### PR TITLE
Implement native scan driven workspace indexing plan

### DIFF
--- a/src-tauri/src/database/mutations.rs
+++ b/src-tauri/src/database/mutations.rs
@@ -173,7 +173,7 @@ fn create_new_row_markdown(note_path: &str, title: &str) -> Result<String, Strin
 
 fn row_by_path(root: &Path, note_path: &str) -> Result<DatabaseRow, String> {
     let conn = open_db(root)?;
-    let mut rows = hydrate_rows_by_paths(&conn, &[note_path.to_string()])?;
+    let mut rows = hydrate_rows_by_paths(root, &conn, &[note_path.to_string()])?;
     rows.pop()
         .ok_or_else(|| "note row not found after update".to_string())
 }

--- a/src-tauri/src/database/query.rs
+++ b/src-tauri/src/database/query.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use rusqlite::{params, Connection};
 
 use crate::index::commands::parse_raw_search_query;
+use crate::index::frontmatter::preview_from_markdown;
 use crate::index::open_db;
 use crate::index::search_advanced::run_search_advanced;
 use crate::notes::frontmatter::split_frontmatter;
@@ -123,15 +124,21 @@ fn tag_source_ids(conn: &Connection, tag: &str, limit: usize) -> Result<Vec<Stri
     Ok(out)
 }
 
-fn search_source_ids(conn: &Connection, query: &str, limit: usize) -> Result<Vec<String>, String> {
+fn search_source_ids(
+    root: &Path,
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<String>, String> {
     let request = parse_raw_search_query(query, Some(limit as u32));
-    Ok(run_search_advanced(conn, request)?
+    Ok(run_search_advanced(root, conn, request)?
         .into_iter()
         .map(|result| result.id)
         .collect())
 }
 
 fn source_ids(
+    root: &Path,
     conn: &Connection,
     kind: &str,
     value: &str,
@@ -141,12 +148,13 @@ fn source_ids(
     match kind {
         "folder" => folder_source_ids(conn, value.trim_matches('/'), recursive, limit),
         "tag" => tag_source_ids(conn, value, limit),
-        "search" => search_source_ids(conn, value, limit),
+        "search" => search_source_ids(root, conn, value, limit),
         other => Err(format!("unsupported database source kind '{other}'")),
     }
 }
 
 pub(crate) fn hydrate_rows_by_paths(
+    root: &Path,
     conn: &Connection,
     note_paths: &[String],
 ) -> Result<Vec<DatabaseRow>, String> {
@@ -160,7 +168,7 @@ pub(crate) fn hydrate_rows_by_paths(
 
     let mut stmt = conn
         .prepare(&format!(
-            "SELECT id, title, created, updated, preview FROM notes WHERE id IN ({placeholders})"
+            "SELECT id, title, created, updated FROM notes WHERE id IN ({placeholders})"
         ))
         .map_err(|e| e.to_string())?;
     let mut rows = stmt
@@ -177,7 +185,7 @@ pub(crate) fn hydrate_rows_by_paths(
                 title: row.get(1).map_err(|e| e.to_string())?,
                 created: row.get(2).map_err(|e| e.to_string())?,
                 updated: row.get(3).map_err(|e| e.to_string())?,
-                preview: row.get(4).map_err(|e| e.to_string())?,
+                preview: String::new(),
                 tags: Vec::new(),
                 properties: BTreeMap::new(),
             },
@@ -226,10 +234,17 @@ pub(crate) fn hydrate_rows_by_paths(
         }
     }
 
-    Ok(note_paths
+    let mut rows = note_paths
         .iter()
         .filter_map(|path| row_map.remove(path))
-        .collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    for row in &mut rows {
+        let abs = paths::join_under(root, Path::new(&row.note_path))?;
+        if let Ok(markdown) = std::fs::read_to_string(&abs) {
+            row.preview = preview_from_markdown(&row.note_path, &markdown);
+        }
+    }
+    Ok(rows)
 }
 
 fn collect_available_properties(rows: &[DatabaseRow]) -> Vec<DatabasePropertyOption> {
@@ -270,6 +285,7 @@ pub fn load_database(
         .unwrap_or(HARD_LIMIT as u32)
         .clamp(1, HARD_LIMIT as u32) as usize;
     let mut ids = source_ids(
+        root,
         &conn,
         &config.source.kind,
         &config.source.value,
@@ -281,7 +297,7 @@ pub fn load_database(
     if truncated {
         ids.truncate(effective_limit);
     }
-    let rows = hydrate_rows_by_paths(&conn, &ids)?;
+    let rows = hydrate_rows_by_paths(root, &conn, &ids)?;
     let available_properties = collect_available_properties(&rows);
     Ok(DatabaseLoadResult {
         config,

--- a/src-tauri/src/glyph_paths.rs
+++ b/src-tauri/src/glyph_paths.rs
@@ -1,13 +1,54 @@
-use crate::paths;
+use crate::{paths, utils};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use tauri::{AppHandle, Manager};
 
 pub const GLYPH_DIR_NAME: &str = ".glyph";
 pub const GLYPH_DB_NAME: &str = "glyph.sqlite";
 pub const GLYPH_APP_DIR_NAME: &str = "Glyph";
 pub const AI_HISTORY_DIR_NAME: &str = "ai_history";
+const SPACES_DIR_NAME: &str = "spaces";
+
+fn app_local_glyph_root_cell() -> &'static OnceLock<PathBuf> {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    &ROOT
+}
+
+pub fn init_app_local_root(app: &AppHandle) -> Result<(), String> {
+    let base = app.path().app_config_dir().map_err(|e| e.to_string())?;
+    let root = base.join(GLYPH_DIR_NAME);
+    std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+    let _ = app_local_glyph_root_cell().set(root);
+    Ok(())
+}
+
+fn app_local_glyph_root() -> Result<&'static PathBuf, String> {
+    #[cfg(test)]
+    if app_local_glyph_root_cell().get().is_none() {
+        let fallback = std::env::temp_dir()
+            .join("glyph-tests-app-config")
+            .join(GLYPH_DIR_NAME);
+        let _ = std::fs::create_dir_all(&fallback);
+        let _ = app_local_glyph_root_cell().set(fallback);
+    }
+    app_local_glyph_root_cell()
+        .get()
+        .ok_or_else(|| "app-local glyph root not initialized".to_string())
+}
+
+pub fn space_id(space_root: &Path) -> String {
+    let normalized = space_root
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>()
+        .join("/");
+    utils::sha256_hex(normalized.as_bytes())
+}
 
 pub fn glyph_dir(space_root: &Path) -> Result<PathBuf, String> {
-    paths::join_under(space_root, Path::new(GLYPH_DIR_NAME))
+    Ok(app_local_glyph_root()?
+        .join(SPACES_DIR_NAME)
+        .join(space_id(space_root)))
 }
 
 pub fn glyph_db_path(space_root: &Path) -> Result<PathBuf, String> {

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -6,6 +6,7 @@ use crate::space::state::mark_recent_local_change;
 use crate::space::SpaceState;
 
 use super::db::open_db;
+use super::frontmatter::preview_from_markdown;
 use super::indexer::index_note;
 use super::indexer::rebuild;
 use super::search_advanced::{run_search_advanced, SearchAdvancedRequest};
@@ -157,25 +158,18 @@ fn rewrite_task_dates(body: &str, scheduled_date: &str, due_date: &str) -> Strin
 }
 
 fn fetch_previews_by_ids(
-    conn: &rusqlite::Connection,
+    root: &Path,
     ids: &[String],
 ) -> Result<std::collections::HashMap<String, String>, String> {
     if ids.is_empty() {
         return Ok(std::collections::HashMap::new());
     }
-    let placeholders = std::iter::repeat_n("?", ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let sql = format!("SELECT id, preview FROM notes WHERE id IN ({placeholders})");
-    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-    let params = rusqlite::params_from_iter(ids.iter());
-    let mut rows = stmt.query(params).map_err(|e| e.to_string())?;
     let mut map = std::collections::HashMap::<String, String>::new();
-    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
-        map.insert(
-            row.get::<_, String>(0).map_err(|e| e.to_string())?,
-            row.get::<_, String>(1).map_err(|e| e.to_string())?,
-        );
+    for id in ids {
+        let abs = root.join(id);
+        if let Ok(markdown) = std::fs::read_to_string(&abs) {
+            map.insert(id.clone(), preview_from_markdown(id, &markdown));
+        }
     }
     Ok(map)
 }
@@ -206,7 +200,7 @@ pub async fn search(
     let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
-        hybrid_search(&conn, &query, &[], 50)
+        hybrid_search(&conn, &root, &query, &[], 50)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -220,7 +214,7 @@ pub async fn search_advanced(
     let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
-        run_search_advanced(&conn, request)
+        run_search_advanced(&root, &conn, request)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -236,7 +230,7 @@ pub async fn search_parse_and_run(
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let req = parse_raw_search_query(&raw_query, limit);
         let conn = open_db(&root)?;
-        run_search_advanced(&conn, req)
+        run_search_advanced(&root, &conn, req)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -252,13 +246,13 @@ pub async fn search_view_data(
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<ViewNotePreview>, String> {
         let lim = limit.unwrap_or(200).clamp(1, 2_000) as usize;
         let conn = open_db(&root)?;
-        let results = hybrid_search(&conn, &query, &[], lim as i64)?;
+        let results = hybrid_search(&conn, &root, &query, &[], lim as i64)?;
         let ids = results
             .iter()
             .map(|r| r.id.clone())
             .filter(|id| !id.trim().is_empty())
             .collect::<Vec<_>>();
-        let preview_by_id = fetch_previews_by_ids(&conn, &ids)?;
+        let preview_by_id = fetch_previews_by_ids(&root, &ids)?;
         Ok(results
             .into_iter()
             .take(lim)
@@ -301,7 +295,7 @@ pub async fn search_with_tags(
 
         if q.is_empty() {
             let mut sql = String::from(
-                "SELECT n.id, n.title, n.preview AS snippet, 0.0 AS score
+                "SELECT n.id, n.title, n.path AS snippet, 0.0 AS score
                  FROM notes n ",
             );
             for i in 0..norm_tags.len() {
@@ -332,7 +326,7 @@ pub async fn search_with_tags(
             }
             return Ok(out);
         }
-        hybrid_search(&conn, &q, &norm_tags, lim)
+        hybrid_search(&conn, &root, &q, &norm_tags, lim)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -349,7 +343,7 @@ pub async fn recent_notes(
         let conn = open_db(&root)?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, title, preview AS snippet, 0.0 AS score
+                "SELECT id, title, path AS snippet, 0.0 AS score
                  FROM notes
                  ORDER BY updated DESC
                  LIMIT ?",
@@ -417,7 +411,7 @@ pub async fn tag_notes(
             let limit = raw_limit.min(100_000) as i64;
             let mut stmt = conn
                 .prepare(
-                    "SELECT n.id, n.title, '' AS snippet, 0.0 AS score
+                    "SELECT n.id, n.title, n.path AS snippet, 0.0 AS score
                      FROM tags t
                      JOIN notes n ON n.id = t.note_id
                      WHERE t.tag = ?
@@ -441,7 +435,7 @@ pub async fn tag_notes(
         } else {
             let mut stmt = conn
                 .prepare(
-                    "SELECT n.id, n.title, '' AS snippet, 0.0 AS score
+                    "SELECT n.id, n.title, n.path AS snippet, 0.0 AS score
                      FROM tags t
                      JOIN notes n ON n.id = t.note_id
                      WHERE t.tag = ?
@@ -480,7 +474,7 @@ pub async fn tag_view_data(
         let conn = open_db(&root)?;
         let mut stmt = conn
             .prepare(
-                "SELECT n.id, n.title, n.preview AS snippet, 0.0 AS score
+                "SELECT n.id, n.title
                  FROM tags t
                  JOIN notes n ON n.id = t.note_id
                  WHERE t.tag = ?
@@ -491,14 +485,22 @@ pub async fn tag_view_data(
         let mut rows = stmt
             .query(rusqlite::params![t, lim as i64])
             .map_err(|e| e.to_string())?;
-        let mut out: Vec<ViewNotePreview> = Vec::new();
+        let mut ids = Vec::<String>::new();
+        let mut titles = std::collections::HashMap::<String, String>::new();
         while let Some(row) = rows.next().map_err(|e| e.to_string())? {
-            out.push(ViewNotePreview {
-                id: row.get(0).map_err(|e| e.to_string())?,
-                title: row.get(1).map_err(|e| e.to_string())?,
-                content: row.get(2).map_err(|e| e.to_string())?,
-            });
+            let id: String = row.get(0).map_err(|e| e.to_string())?;
+            ids.push(id.clone());
+            titles.insert(id, row.get(1).map_err(|e| e.to_string())?);
         }
+        let previews = fetch_previews_by_ids(&root, &ids)?;
+        let out = ids
+            .into_iter()
+            .map(|id| ViewNotePreview {
+                title: titles.remove(&id).unwrap_or_default(),
+                content: previews.get(&id).cloned().unwrap_or_default(),
+                id,
+            })
+            .collect();
         Ok(out)
     })
     .await

--- a/src-tauri/src/index/db.rs
+++ b/src-tauri/src/index/db.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 use super::schema::ensure_schema;
+const SCHEMA_VERSION: i64 = 2;
 
 fn schema_cache() -> &'static Mutex<HashSet<PathBuf>> {
     static CACHE: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
@@ -19,9 +20,21 @@ pub fn open_db(space_root: &Path) -> Result<rusqlite::Connection, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let conn = rusqlite::Connection::open(&path).map_err(|e| e.to_string())?;
+    let mut conn = rusqlite::Connection::open(&path).map_err(|e| e.to_string())?;
     conn.pragma_update(None, "journal_mode", "WAL")
         .map_err(|e| e.to_string())?;
+
+    if !is_schema_compatible(&conn)? {
+        drop(conn);
+        reset_db_family(&path)?;
+        let reopened = rusqlite::Connection::open(&path).map_err(|e| e.to_string())?;
+        reopened
+            .pragma_update(None, "journal_mode", "WAL")
+            .map_err(|e| e.to_string())?;
+        conn = reopened;
+        let mut cache = schema_cache().lock().unwrap_or_else(|p| p.into_inner());
+        cache.remove(&path);
+    }
 
     let mut cache = schema_cache().lock().unwrap_or_else(|p| p.into_inner());
     if !cache.contains(&path) {
@@ -30,6 +43,99 @@ pub fn open_db(space_root: &Path) -> Result<rusqlite::Connection, String> {
     }
 
     Ok(conn)
+}
+
+pub fn db_exists(space_root: &Path) -> Result<bool, String> {
+    Ok(db_path(space_root)?.exists())
+}
+
+pub fn index_ready(space_root: &Path) -> Result<bool, String> {
+    if !db_exists(space_root)? {
+        return Ok(false);
+    }
+    let conn = open_db(space_root)?;
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM index_state WHERE singleton = 1",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(status == "ready")
+}
+
+fn is_schema_compatible(conn: &rusqlite::Connection) -> Result<bool, String> {
+    let notes_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'notes')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    if !notes_exists {
+        return Ok(true);
+    }
+
+    let mut has_preview = false;
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(notes)")
+        .map_err(|e| e.to_string())?;
+    let mut rows = stmt.query([]).map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let name: String = row.get(1).map_err(|e| e.to_string())?;
+        if name == "preview" {
+            has_preview = true;
+            break;
+        }
+    }
+    if has_preview {
+        return Ok(false);
+    }
+
+    let old_fts_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master
+             WHERE type = 'table' AND name IN ('notes_fts', 'tasks_fts')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    if old_fts_count > 0 {
+        return Ok(false);
+    }
+
+    let state_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'index_state')",
+            [],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    if !state_exists {
+        return Ok(false);
+    }
+
+    let version: i64 = conn
+        .query_row(
+            "SELECT schema_version FROM index_state WHERE singleton = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or_default();
+    Ok(version == SCHEMA_VERSION)
+}
+
+fn reset_db_family(path: &Path) -> Result<(), String> {
+    for candidate in [
+        path.to_path_buf(),
+        PathBuf::from(format!("{}-wal", path.to_string_lossy())),
+        PathBuf::from(format!("{}-shm", path.to_string_lossy())),
+    ] {
+        if candidate.exists() {
+            std::fs::remove_file(&candidate).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
 }
 
 pub fn reset_schema_cache() {

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -1,30 +1,39 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
 };
 
-use crate::utils;
+use crate::{glyph_paths, utils};
 
 use super::db::{open_db, resolve_title_to_id};
-use super::frontmatter::{
-    parse_frontmatter_title_created_updated, preview_from_markdown, split_frontmatter,
+use super::frontmatter::parse_frontmatter_title_created_updated;
+use super::helpers::{
+    now_sqlite_compatible_iso8601, path_to_slash_string, sha256_hex, should_skip_entry,
 };
-use super::helpers::{path_to_slash_string, sha256_hex, should_skip_entry};
 use super::links::parse_outgoing_links;
 use super::properties::{delete_note_properties, reindex_note_properties};
 use super::tags::parse_all_tags;
 use super::tasks::{delete_note_tasks, reindex_note_tasks};
 use super::types::IndexRebuildResult;
 
-fn fts_body_with_frontmatter(markdown: &str) -> String {
-    let (yaml, body) = split_frontmatter(markdown);
-    if yaml.is_empty() {
-        body.to_string()
-    } else if body.is_empty() {
-        yaml.to_string()
-    } else {
-        format!("{yaml}\n{body}")
-    }
+fn mark_index_state(
+    conn: &rusqlite::Connection,
+    status: &str,
+    started_at: Option<&str>,
+    completed_at: Option<&str>,
+) -> Result<(), String> {
+    conn.execute(
+        "UPDATE index_state
+         SET schema_version = 2,
+             status = ?,
+             last_rebuild_started_at = COALESCE(?, last_rebuild_started_at),
+             last_rebuild_completed_at = ?
+         WHERE singleton = 1",
+        rusqlite::params![status, started_at, completed_at],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 fn collect_markdown_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, String> {
@@ -76,10 +85,36 @@ fn collect_markdown_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, S
     Ok(out)
 }
 
+fn index_locks() -> &'static Mutex<std::collections::HashMap<String, Arc<Mutex<()>>>> {
+    static LOCKS: OnceLock<Mutex<std::collections::HashMap<String, Arc<Mutex<()>>>>> =
+        OnceLock::new();
+    LOCKS.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+fn with_space_index_lock<T>(
+    space_root: &Path,
+    f: impl FnOnce() -> Result<T, String>,
+) -> Result<T, String> {
+    let key = glyph_paths::space_id(space_root);
+    let lock = {
+        let mut guard = index_locks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _guard = lock.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    f()
+}
+
 pub fn index_note(space_root: &Path, note_id: &str, markdown: &str) -> Result<(), String> {
-    let conn = open_db(space_root)?;
-    let file_path = space_root.join(note_id);
-    index_note_with_conn(&conn, note_id, markdown, &file_path)
+    with_space_index_lock(space_root, || {
+        let conn = open_db(space_root)?;
+        let file_path = space_root.join(note_id);
+        index_note_with_conn(&conn, note_id, markdown, &file_path)
+    })
 }
 
 fn index_note_with_conn(
@@ -102,7 +137,8 @@ fn index_note_with_conn(
 
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
 
-    let (mut title, created, updated) = parse_frontmatter_title_created_updated(markdown, file_path);
+    let (mut title, created, updated) =
+        parse_frontmatter_title_created_updated(markdown, file_path);
     if title == "Untitled" {
         if let Some(stem) = Path::new(note_id)
             .file_stem()
@@ -113,22 +149,11 @@ fn index_note_with_conn(
             title = stem.to_string();
         }
     }
-    let title_for_fts = title.clone();
-    let preview = preview_from_markdown(note_id, markdown);
     let rel_path = note_id.to_string();
 
     tx.execute(
-        "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag, preview) VALUES(?, ?, ?, ?, ?, ?, ?)",
-        rusqlite::params![note_id, title, created, updated, rel_path, etag, preview],
-    )
-    .map_err(|e| e.to_string())?;
-
-    tx.execute("DELETE FROM notes_fts WHERE id = ?", [note_id])
-        .map_err(|e| e.to_string())?;
-    let body = fts_body_with_frontmatter(markdown);
-    tx.execute(
-        "INSERT INTO notes_fts(id, title, body) VALUES(?, ?, ?)",
-        rusqlite::params![note_id, title_for_fts, body],
+        "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag) VALUES(?, ?, ?, ?, ?, ?)",
+        rusqlite::params![note_id, title, created, updated, rel_path, etag],
     )
     .map_err(|e| e.to_string())?;
 
@@ -183,125 +208,118 @@ fn index_note_with_conn(
 }
 
 pub fn remove_note(space_root: &Path, note_id: &str) -> Result<(), String> {
-    let conn = open_db(space_root)?;
-    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM notes WHERE id = ?", [note_id])
+    with_space_index_lock(space_root, || {
+        let conn = open_db(space_root)?;
+        let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM notes WHERE id = ?", [note_id])
+            .map_err(|e| e.to_string())?;
+        tx.execute(
+            "DELETE FROM links WHERE from_id = ? OR to_id = ?",
+            rusqlite::params![note_id, note_id],
+        )
         .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM notes_fts WHERE id = ?", [note_id])
-        .map_err(|e| e.to_string())?;
-    tx.execute(
-        "DELETE FROM links WHERE from_id = ? OR to_id = ?",
-        rusqlite::params![note_id, note_id],
-    )
-    .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM tags WHERE note_id = ?", [note_id])
-        .map_err(|e| e.to_string())?;
-    delete_note_properties(&tx, note_id)?;
-    delete_note_tasks(&tx, note_id)?;
-    tx.commit().map_err(|e| e.to_string())?;
-    Ok(())
+        tx.execute("DELETE FROM tags WHERE note_id = ?", [note_id])
+            .map_err(|e| e.to_string())?;
+        delete_note_properties(&tx, note_id)?;
+        delete_note_tasks(&tx, note_id)?;
+        tx.commit().map_err(|e| e.to_string())?;
+        Ok(())
+    })
 }
 
 pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
-    let mut conn = open_db(space_root)?;
-    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    with_space_index_lock(space_root, || {
+        let mut conn = open_db(space_root)?;
+        let started_at = now_sqlite_compatible_iso8601();
+        mark_index_state(&conn, "building", Some(&started_at), None)?;
+        let tx = conn.transaction().map_err(|e| e.to_string())?;
 
-    tx.execute("DELETE FROM notes", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM notes_fts", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM links", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM tags", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM note_properties", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM tasks", [])
-        .map_err(|e| e.to_string())?;
-    tx.execute("DELETE FROM tasks_fts", [])
-        .map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM notes", [])
+            .map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM links", [])
+            .map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM tags", [])
+            .map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM note_properties", [])
+            .map_err(|e| e.to_string())?;
+        tx.execute("DELETE FROM tasks", [])
+            .map_err(|e| e.to_string())?;
 
-    let note_paths = collect_markdown_files(space_root)?;
-    let mut link_data: Vec<(String, HashSet<String>, HashSet<String>)> =
-        Vec::with_capacity(note_paths.len());
-    let count = note_paths.len();
+        let note_paths = collect_markdown_files(space_root)?;
+        let mut link_data: Vec<(String, HashSet<String>, HashSet<String>)> =
+            Vec::with_capacity(note_paths.len());
+        let count = note_paths.len();
 
-    for (rel, path) in &note_paths {
-        let markdown = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        for (rel, path) in &note_paths {
+            let markdown = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
 
-        let (mut title, created, updated) = parse_frontmatter_title_created_updated(&markdown, path);
-        if title == "Untitled" {
-            if let Some(stem) = Path::new(rel)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-            {
-                title = stem.to_string();
+            let (mut title, created, updated) =
+                parse_frontmatter_title_created_updated(&markdown, path);
+            if title == "Untitled" {
+                if let Some(stem) = Path::new(rel)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                {
+                    title = stem.to_string();
+                }
             }
-        }
-        let etag = sha256_hex(markdown.as_bytes());
-        let preview = preview_from_markdown(rel, &markdown);
+            let etag = sha256_hex(markdown.as_bytes());
 
-        tx.execute(
-            "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag, preview) VALUES(?, ?, ?, ?, ?, ?, ?)",
-            rusqlite::params![rel, title, created, updated, rel, etag, preview],
+            tx.execute(
+            "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag) VALUES(?, ?, ?, ?, ?, ?)",
+            rusqlite::params![rel, title, created, updated, rel, etag],
         )
         .map_err(|e| e.to_string())?;
 
-        tx.execute("DELETE FROM notes_fts WHERE id = ?", [rel])
-            .map_err(|e| e.to_string())?;
-        let body = fts_body_with_frontmatter(&markdown);
-        tx.execute(
-            "INSERT INTO notes_fts(id, title, body) VALUES(?, ?, ?)",
-            rusqlite::params![rel, title, body],
-        )
-        .map_err(|e| e.to_string())?;
-
-        for tag in parse_all_tags(&markdown) {
-            tx.execute(
-                "INSERT OR IGNORE INTO tags(note_id, tag) VALUES(?, ?)",
-                rusqlite::params![rel, tag],
-            )
-            .map_err(|e| e.to_string())?;
-        }
-        if let Err(error) = reindex_note_properties(&tx, rel, &markdown) {
-            tracing::warn!(
-                note_id = rel,
-                rel_path = rel,
-                error = %error,
-                "Skipping note property indexing during rebuild after frontmatter parse error"
-            );
-        }
-        reindex_note_tasks(&tx, rel, rel, &updated, &etag, &markdown)?;
-
-        let (to_ids, to_titles) = parse_outgoing_links(rel, &markdown);
-        link_data.push((rel.clone(), to_ids, to_titles));
-    }
-
-    for (rel, to_ids, to_titles) in &link_data {
-        let mut inserted = HashSet::<(Option<String>, Option<String>, &'static str)>::new();
-        for to_id in to_ids {
-            inserted.insert((Some(to_id.clone()), None, "file"));
-        }
-        for to_title in to_titles {
-            if let Some(to_id) = resolve_title_to_id(&tx, to_title)? {
-                inserted.insert((Some(to_id), None, "file"));
-            } else {
-                inserted.insert((None, Some(to_title.clone()), "wikilink"));
+            for tag in parse_all_tags(&markdown) {
+                tx.execute(
+                    "INSERT OR IGNORE INTO tags(note_id, tag) VALUES(?, ?)",
+                    rusqlite::params![rel, tag],
+                )
+                .map_err(|e| e.to_string())?;
             }
+            if let Err(error) = reindex_note_properties(&tx, rel, &markdown) {
+                tracing::warn!(
+                    note_id = rel,
+                    rel_path = rel,
+                    error = %error,
+                    "Skipping note property indexing during rebuild after frontmatter parse error"
+                );
+            }
+            reindex_note_tasks(&tx, rel, rel, &updated, &etag, &markdown)?;
+
+            let (to_ids, to_titles) = parse_outgoing_links(rel, &markdown);
+            link_data.push((rel.clone(), to_ids, to_titles));
         }
-        for (to_id, to_title, kind) in inserted {
-            tx.execute(
+
+        for (rel, to_ids, to_titles) in &link_data {
+            let mut inserted = HashSet::<(Option<String>, Option<String>, &'static str)>::new();
+            for to_id in to_ids {
+                inserted.insert((Some(to_id.clone()), None, "file"));
+            }
+            for to_title in to_titles {
+                if let Some(to_id) = resolve_title_to_id(&tx, to_title)? {
+                    inserted.insert((Some(to_id), None, "file"));
+                } else {
+                    inserted.insert((None, Some(to_title.clone()), "wikilink"));
+                }
+            }
+            for (to_id, to_title, kind) in inserted {
+                tx.execute(
                 "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, ?, ?)",
                 rusqlite::params![rel, to_id, to_title, kind],
             )
             .map_err(|e| e.to_string())?;
+            }
         }
-    }
 
-    tx.commit().map_err(|e| e.to_string())?;
-    Ok(IndexRebuildResult { indexed: count })
+        tx.commit().map_err(|e| e.to_string())?;
+        let completed_at = now_sqlite_compatible_iso8601();
+        mark_index_state(&conn, "ready", None, Some(&completed_at))?;
+        Ok(IndexRebuildResult { indexed: count })
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -1,6 +1,6 @@
 pub mod commands;
 pub(crate) mod db;
-mod frontmatter;
+pub(crate) mod frontmatter;
 mod helpers;
 mod indexer;
 mod links;
@@ -13,4 +13,4 @@ mod tasks;
 mod types;
 
 pub use db::open_db;
-pub use indexer::{index_note, remove_note};
+pub use indexer::{index_note, rebuild, remove_note};

--- a/src-tauri/src/index/schema.rs
+++ b/src-tauri/src/index/schema.rs
@@ -9,12 +9,21 @@ CREATE TABLE IF NOT EXISTS notes (
   created TEXT NOT NULL,
   updated TEXT NOT NULL,
   path TEXT NOT NULL,
-  etag TEXT NOT NULL,
-  preview TEXT NOT NULL DEFAULT ''
+  etag TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS notes_title_idx ON notes(title);
 CREATE INDEX IF NOT EXISTS notes_title_nocase_idx ON notes(title COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS notes_path_nocase_idx ON notes(path COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS notes_updated_idx ON notes(updated DESC);
+
+CREATE TABLE IF NOT EXISTS index_state (
+  singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+  schema_version INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('building', 'ready')),
+  last_rebuild_started_at TEXT,
+  last_rebuild_completed_at TEXT
+);
 
 CREATE TABLE IF NOT EXISTS links (
   from_id TEXT NOT NULL,
@@ -46,13 +55,6 @@ CREATE TABLE IF NOT EXISTS note_properties (
 
 CREATE INDEX IF NOT EXISTS note_properties_key_idx ON note_properties(key);
 CREATE INDEX IF NOT EXISTS note_properties_lookup_idx ON note_properties(key, value_text);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
-  id UNINDEXED,
-  title,
-  body,
-  tokenize = 'porter'
-);
 
 CREATE TABLE IF NOT EXISTS tasks (
   task_id TEXT PRIMARY KEY,
@@ -91,13 +93,13 @@ CREATE INDEX IF NOT EXISTS tasks_note_idx ON tasks(note_id);
 CREATE INDEX IF NOT EXISTS tasks_schedule_idx ON tasks(scheduled_date);
 CREATE INDEX IF NOT EXISTS tasks_due_idx ON tasks(due_date);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS tasks_fts USING fts5(
-  task_id UNINDEXED,
-  text,
-  tags,
-  project,
-  tokenize = 'porter'
-);
+INSERT OR IGNORE INTO index_state(
+  singleton,
+  schema_version,
+  status,
+  last_rebuild_started_at,
+  last_rebuild_completed_at
+) VALUES (1, 2, 'ready', NULL, NULL);
 "#,
     )
     .map_err(|e| e.to_string())

--- a/src-tauri/src/index/search_advanced.rs
+++ b/src-tauri/src/index/search_advanced.rs
@@ -1,8 +1,10 @@
+use std::path::Path;
+
 use serde::Deserialize;
 
 use rusqlite::Connection;
 
-use super::search_hybrid::hybrid_search;
+use super::search_hybrid::{hybrid_search, metadata_search};
 use super::tags::normalize_tag;
 use super::types::SearchResult;
 
@@ -21,6 +23,7 @@ pub struct SearchAdvancedRequest {
 }
 
 pub fn run_search_advanced(
+    space_root: &Path,
     conn: &Connection,
     req: SearchAdvancedRequest,
 ) -> Result<Vec<SearchResult>, String> {
@@ -43,75 +46,22 @@ pub fn run_search_advanced(
     let mut out = if !query_text.is_empty() && !req.title_only {
         hybrid_search(
             conn,
+            space_root,
             &query_text,
             &tags,
             (limit as i64 * 8).clamp(200, 5_000),
         )?
     } else {
-        select_candidates(
+        metadata_search(
             conn,
             &query_text,
-            req.title_only,
             &tags,
             (limit as i64 * 8).clamp(200, 5_000),
         )?
-        .into_iter()
-        .map(|item| item.result)
-        .collect()
     };
 
     if out.len() > limit {
         out.truncate(limit);
-    }
-    Ok(out)
-}
-
-struct Candidate {
-    result: SearchResult,
-}
-
-fn select_candidates(
-    conn: &Connection,
-    text: &str,
-    title_only: bool,
-    tags: &[String],
-    limit: i64,
-) -> Result<Vec<Candidate>, String> {
-    let mut sql = String::from("SELECT n.id, n.title, n.preview FROM notes n ");
-    for i in 0..tags.len() {
-        sql.push_str(&format!(
-            "JOIN tags t{idx} ON t{idx}.note_id = n.id AND t{idx}.tag = ? ",
-            idx = i
-        ));
-    }
-    let mut params: Vec<rusqlite::types::Value> = tags
-        .iter()
-        .map(|t| rusqlite::types::Value::from(t.clone()))
-        .collect();
-    if title_only && !text.is_empty() {
-        sql.push_str("WHERE lower(n.title) LIKE ? ");
-        params.push(rusqlite::types::Value::from(format!(
-            "%{}%",
-            text.to_lowercase()
-        )));
-    }
-    sql.push_str("ORDER BY n.updated DESC LIMIT ?");
-    params.push(rusqlite::types::Value::from(limit));
-
-    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(params.iter()))
-        .map_err(|e| e.to_string())?;
-    let mut out = Vec::new();
-    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
-        out.push(Candidate {
-            result: SearchResult {
-                id: row.get(0).map_err(|e| e.to_string())?,
-                title: row.get(1).map_err(|e| e.to_string())?,
-                snippet: row.get(2).map_err(|e| e.to_string())?,
-                score: 0.0,
-            },
-        });
     }
     Ok(out)
 }

--- a/src-tauri/src/index/search_hybrid.rs
+++ b/src-tauri/src/index/search_hybrid.rs
@@ -1,10 +1,24 @@
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
 use rusqlite::Connection;
 
+use crate::utils;
+
+use super::frontmatter::{parse_frontmatter_title_created_updated, split_frontmatter};
+use super::helpers::{path_to_slash_string, should_skip_entry};
 use super::types::SearchResult;
 
-const CANDIDATE_LIMIT: i64 = 300;
+const DEFAULT_SCAN_LIMIT: usize = 10_000;
+const MAX_FILE_BYTES: u64 = 1024 * 1024;
+
+#[derive(Clone)]
+struct MetadataCandidate {
+    id: String,
+    title: String,
+    path: String,
+    score: f64,
+}
 
 fn tokenize_query(query: &str) -> Vec<String> {
     query
@@ -15,199 +29,334 @@ fn tokenize_query(query: &str) -> Vec<String> {
         .collect()
 }
 
-fn trigrams(s: &str) -> HashSet<[char; 3]> {
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() < 3 {
-        return HashSet::new();
-    }
-    let mut out = HashSet::new();
-    for i in 0..(chars.len() - 2) {
-        out.insert([chars[i], chars[i + 1], chars[i + 2]]);
-    }
-    out
-}
-
-fn jaccard_trigram(a: &str, b: &str) -> f64 {
-    let ta = trigrams(a);
-    let tb = trigrams(b);
-    if ta.is_empty() || tb.is_empty() {
-        return 0.0;
-    }
-    let inter = ta.intersection(&tb).count() as f64;
-    let union = ta.union(&tb).count() as f64;
-    if union <= 0.0 {
-        0.0
-    } else {
-        inter / union
-    }
-}
-
-fn semantic_score(query_lc: &str, terms: &[String], title: &str, preview: &str) -> f64 {
+fn candidate_match_score(title: &str, path: &str, query_lc: &str, terms: &[String]) -> f64 {
     let title_lc = title.to_lowercase();
-    let preview_lc = preview.to_lowercase();
-    let text = format!("{title_lc} {preview_lc}");
+    let path_lc = path.to_lowercase();
+    let file_name_lc = Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("")
+        .to_lowercase();
 
-    let mut matched = 0usize;
-    for t in terms {
-        if text.contains(t) {
-            matched += 1;
+    if !query_lc.is_empty() {
+        if title_lc == query_lc {
+            return 8.0;
+        }
+        if file_name_lc == query_lc {
+            return 7.5;
+        }
+        if title_lc.starts_with(query_lc) {
+            return 7.0;
+        }
+        if file_name_lc.starts_with(query_lc) {
+            return 6.5;
+        }
+        if path_lc.ends_with(query_lc) {
+            return 6.0;
         }
     }
-    let overlap = if terms.is_empty() {
-        0.0
-    } else {
-        matched as f64 / terms.len() as f64
-    };
 
-    let tri = jaccard_trigram(query_lc, &text);
-    let phrase_bonus = if text.contains(query_lc) { 0.2 } else { 0.0 };
-    let title_bonus = if title_lc.contains(query_lc) {
-        0.1
-    } else {
-        0.0
-    };
-
-    (0.6 * overlap) + (0.4 * tri) + phrase_bonus + title_bonus
+    let mut score = 0.0;
+    for term in terms {
+        if title_lc.contains(term) {
+            score += 2.0;
+        }
+        if file_name_lc.contains(term) {
+            score += 1.7;
+        }
+        if path_lc.contains(term) {
+            score += 1.0;
+        }
+    }
+    score
 }
 
-fn keyword_search(
+fn metadata_candidates(
     conn: &Connection,
     query: &str,
     tags: &[String],
     limit: i64,
-) -> Result<Vec<SearchResult>, String> {
-    let mut sql = String::from(
-        "SELECT notes_fts.id, notes_fts.title,
-                snippet(notes_fts, 2, '⟦', '⟧', '…', 10) AS snip,
-                bm25(notes_fts) AS score
-         FROM notes_fts ",
-    );
-    for i in 0..tags.len() {
-        sql.push_str(&format!(
-            "JOIN tags t{idx} ON t{idx}.note_id = notes_fts.id AND t{idx}.tag = ? ",
-            idx = i
-        ));
-    }
-    sql.push_str("WHERE notes_fts MATCH ? ORDER BY score LIMIT ?");
-
-    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-    let mut params: Vec<rusqlite::types::Value> = tags
-        .iter()
-        .map(|t| rusqlite::types::Value::from(t.clone()))
-        .collect();
-    params.push(rusqlite::types::Value::from(query.to_string()));
-    params.push(rusqlite::types::Value::from(limit));
-
-    let mut rows = stmt
-        .query(rusqlite::params_from_iter(params.iter()))
-        .map_err(|e| e.to_string())?;
-    let mut out = Vec::new();
-    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
-        out.push(SearchResult {
-            id: row.get(0).map_err(|e| e.to_string())?,
-            title: row.get(1).map_err(|e| e.to_string())?,
-            snippet: row.get(2).map_err(|e| e.to_string())?,
-            score: row.get(3).map_err(|e| e.to_string())?,
-        });
-    }
-    Ok(out)
-}
-
-fn semantic_candidates(
-    conn: &Connection,
-    terms: &[String],
-    tags: &[String],
-) -> Result<Vec<(String, String, String)>, String> {
-    let mut sql = String::from("SELECT n.id, n.title, n.preview FROM notes n ");
+) -> Result<Vec<MetadataCandidate>, String> {
+    let query_lc = query.trim().to_lowercase();
+    let terms = tokenize_query(&query_lc);
+    let mut sql = String::from("SELECT n.id, n.title, n.path FROM notes n ");
     for i in 0..tags.len() {
         sql.push_str(&format!(
             "JOIN tags t{idx} ON t{idx}.note_id = n.id AND t{idx}.tag = ? ",
             idx = i
         ));
     }
-    if !terms.is_empty() {
-        sql.push_str("WHERE ");
-        for (i, _) in terms.iter().enumerate() {
-            if i > 0 {
-                sql.push_str(" OR ");
-            }
-            sql.push_str("lower(n.title) LIKE ? OR lower(n.preview) LIKE ?");
-        }
-        sql.push(' ');
-    }
     sql.push_str("ORDER BY n.updated DESC LIMIT ?");
 
     let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
     let mut params: Vec<rusqlite::types::Value> = tags
         .iter()
-        .map(|t| rusqlite::types::Value::from(t.clone()))
+        .map(|tag| rusqlite::types::Value::from(tag.clone()))
         .collect();
-    for t in terms {
-        let like = format!("%{t}%");
-        params.push(rusqlite::types::Value::from(like.clone()));
-        params.push(rusqlite::types::Value::from(like));
-    }
-    params.push(rusqlite::types::Value::from(CANDIDATE_LIMIT));
+    params.push(rusqlite::types::Value::from(limit.max(1)));
 
     let mut rows = stmt
         .query(rusqlite::params_from_iter(params.iter()))
         .map_err(|e| e.to_string())?;
     let mut out = Vec::new();
     while let Some(row) = rows.next().map_err(|e| e.to_string())? {
-        out.push((
-            row.get(0).map_err(|e| e.to_string())?,
-            row.get(1).map_err(|e| e.to_string())?,
-            row.get(2).map_err(|e| e.to_string())?,
-        ));
+        let id: String = row.get(0).map_err(|e| e.to_string())?;
+        let title: String = row.get(1).map_err(|e| e.to_string())?;
+        let path: String = row.get(2).map_err(|e| e.to_string())?;
+        let score = if query_lc.is_empty() {
+            1.0
+        } else {
+            candidate_match_score(&title, &path, &query_lc, &terms)
+        };
+        if query_lc.is_empty() || score > 0.0 {
+            out.push(MetadataCandidate {
+                id,
+                title,
+                path,
+                score,
+            });
+        }
     }
     Ok(out)
 }
 
-pub fn hybrid_search(
+pub fn metadata_note_ids_for_tags(
+    conn: &Connection,
+    tags: &[String],
+) -> Result<Option<HashSet<String>>, String> {
+    if tags.is_empty() {
+        return Ok(None);
+    }
+    let candidates = metadata_candidates(conn, "", tags, 50_000)?;
+    Ok(Some(
+        candidates
+            .into_iter()
+            .map(|candidate| candidate.id)
+            .collect(),
+    ))
+}
+
+fn find_highlight_span(line: &str, query_lc: &str, terms: &[String]) -> Option<(usize, usize)> {
+    let line_lc = line.to_lowercase();
+    if !query_lc.is_empty() {
+        if let Some(idx) = line_lc.find(query_lc) {
+            return Some((idx, idx + query_lc.len()));
+        }
+    }
+    for term in terms {
+        if let Some(idx) = line_lc.find(term) {
+            return Some((idx, idx + term.len()));
+        }
+    }
+    None
+}
+
+fn highlight_line(line: &str, query_lc: &str, terms: &[String]) -> Option<String> {
+    let (start, end) = find_highlight_span(line, query_lc, terms)?;
+    Some(format!(
+        "{}⟦{}⟧{}",
+        &line[..start],
+        &line[start..end],
+        &line[end..]
+    ))
+}
+
+fn content_match(markdown: &str, query_lc: &str, terms: &[String]) -> Option<(String, f64)> {
+    let (_yaml, body) = split_frontmatter(markdown);
+    let body = body.trim();
+    if body.is_empty() {
+        return None;
+    }
+
+    for (idx, line) in body.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Some(snippet) = highlight_line(trimmed, query_lc, terms) else {
+            continue;
+        };
+        let line_penalty = (idx.min(50) as f64) * 0.01;
+        let phrase_bonus = if !query_lc.is_empty() && trimmed.to_lowercase().contains(query_lc) {
+            1.5
+        } else {
+            0.0
+        };
+        let score = 4.0 + phrase_bonus - line_penalty;
+        return Some((snippet, score.max(0.1)));
+    }
+    None
+}
+
+fn collect_markdown_files(
+    space_root: &Path,
+    allowed_ids: Option<&HashSet<String>>,
+    scan_limit: usize,
+) -> Result<Vec<(String, PathBuf)>, String> {
+    if let Some(ids) = allowed_ids {
+        let mut out = Vec::new();
+        for id in ids {
+            let abs = space_root.join(id);
+            if abs.is_file() {
+                out.push((id.clone(), abs));
+            }
+        }
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        return Ok(out);
+    }
+
+    let mut out = Vec::new();
+    let mut stack = vec![space_root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if should_skip_entry(&name) {
+                continue;
+            }
+            let path = entry.path();
+            let meta = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(_) => continue,
+            };
+            if meta.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !meta.is_file() || !utils::is_markdown_path(&path) {
+                continue;
+            }
+            let rel = match path.strip_prefix(space_root) {
+                Ok(rel) => rel,
+                Err(_) => continue,
+            };
+            out.push((path_to_slash_string(rel), path));
+            if out.len() >= scan_limit {
+                return Ok(out);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+fn content_candidates(
+    space_root: &Path,
+    query: &str,
+    allowed_ids: Option<&HashSet<String>>,
+    limit: i64,
+) -> Result<Vec<SearchResult>, String> {
+    let query_lc = query.trim().to_lowercase();
+    if query_lc.is_empty() {
+        return Ok(Vec::new());
+    }
+    let terms = tokenize_query(&query_lc);
+    let files = collect_markdown_files(space_root, allowed_ids, DEFAULT_SCAN_LIMIT)?;
+    let mut out = Vec::new();
+
+    for (rel, path) in files {
+        let meta = match std::fs::metadata(&path) {
+            Ok(meta) => meta,
+            Err(_) => continue,
+        };
+        if meta.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        let markdown = match std::fs::read_to_string(&path) {
+            Ok(markdown) => markdown,
+            Err(_) => continue,
+        };
+        let Some((snippet, score)) = content_match(&markdown, &query_lc, &terms) else {
+            continue;
+        };
+        let (mut title, _created, _updated) =
+            parse_frontmatter_title_created_updated(&markdown, &path);
+        if title == "Untitled" {
+            title = Path::new(&rel)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("Untitled")
+                .to_string();
+        }
+        out.push(SearchResult {
+            id: rel,
+            title,
+            snippet,
+            score,
+        });
+        if out.len() >= limit.max(1) as usize {
+            break;
+        }
+    }
+
+    Ok(out)
+}
+
+pub fn metadata_search(
     conn: &Connection,
     query: &str,
     tags: &[String],
     limit: i64,
 ) -> Result<Vec<SearchResult>, String> {
-    let q = query.trim();
-    if q.is_empty() {
+    Ok(metadata_candidates(conn, query, tags, limit)?
+        .into_iter()
+        .map(|candidate| SearchResult {
+            id: candidate.id,
+            title: candidate.title,
+            snippet: candidate.path,
+            score: candidate.score,
+        })
+        .collect())
+}
+
+pub fn hybrid_search(
+    conn: &Connection,
+    space_root: &Path,
+    query: &str,
+    tags: &[String],
+    limit: i64,
+) -> Result<Vec<SearchResult>, String> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() && tags.is_empty() {
         return Ok(Vec::new());
     }
-    let q_lc = q.to_lowercase();
-    let terms = tokenize_query(&q_lc);
 
-    let keyword = keyword_search(conn, q, tags, limit.max(50)).unwrap_or_default();
-    let candidates = semantic_candidates(conn, &terms, tags)?;
-
-    let mut ranked: HashMap<String, SearchResult> = HashMap::new();
-    let keyword_len = keyword.len().max(1) as f64;
-    for (idx, r) in keyword.into_iter().enumerate() {
-        let rank_score = 1.0 - (idx as f64 / keyword_len);
+    let mut ranked = HashMap::<String, SearchResult>::new();
+    let metadata = metadata_candidates(conn, trimmed, tags, limit.max(200))?;
+    for candidate in metadata {
         ranked.insert(
-            r.id.clone(),
+            candidate.id.clone(),
             SearchResult {
-                score: 0.7 * rank_score,
-                ..r
+                id: candidate.id,
+                title: candidate.title,
+                snippet: candidate.path,
+                score: candidate.score,
             },
         );
     }
 
-    for (id, title, preview) in candidates {
-        let sem = semantic_score(&q_lc, &terms, &title, &preview);
-        if sem <= 0.0 {
-            continue;
+    if !trimmed.is_empty() {
+        let allowed_ids = metadata_note_ids_for_tags(conn, tags)?;
+        for candidate in
+            content_candidates(space_root, trimmed, allowed_ids.as_ref(), limit.max(200))?
+        {
+            if let Some(entry) = ranked.get_mut(&candidate.id) {
+                entry.score += candidate.score;
+                entry.snippet = candidate.snippet;
+                if entry.title.trim().is_empty() {
+                    entry.title = candidate.title;
+                }
+            } else {
+                ranked.insert(candidate.id.clone(), candidate);
+            }
         }
-        let entry = ranked.entry(id.clone()).or_insert_with(|| SearchResult {
-            id,
-            title,
-            snippet: preview,
-            score: 0.0,
-        });
-        entry.score += 0.5 * sem;
     }
 
     let mut out: Vec<SearchResult> = ranked.into_values().collect();
-    out.sort_by(|a, b| b.score.total_cmp(&a.score));
+    out.sort_by(|a, b| b.score.total_cmp(&a.score).then_with(|| a.id.cmp(&b.id)));
     out.truncate(limit.max(1) as usize);
     Ok(out)
 }

--- a/src-tauri/src/index/tasks/store.rs
+++ b/src-tauri/src/index/tasks/store.rs
@@ -21,11 +21,6 @@ fn like_prefix_pattern(folder: &str) -> String {
 }
 
 pub fn delete_note_tasks(conn: &rusqlite::Connection, note_id: &str) -> Result<(), String> {
-    conn.execute(
-        "DELETE FROM tasks_fts WHERE task_id IN (SELECT task_id FROM tasks WHERE note_id = ?)",
-        [note_id],
-    )
-    .map_err(|e| e.to_string())?;
     conn.execute("DELETE FROM tasks WHERE note_id = ?", [note_id])
         .map_err(|e| e.to_string())?;
     Ok(())
@@ -74,12 +69,6 @@ fn insert_task(
     )
     .map_err(|e| e.to_string())?;
 
-    conn.execute(
-        "INSERT OR REPLACE INTO tasks_fts(task_id, text, tags, project) VALUES(?, ?, ?, '')",
-        rusqlite::params![task_id, task.text_norm, task.tags.join(" ")],
-    )
-    .map_err(|e| e.to_string())?;
-
     Ok(())
 }
 
@@ -91,11 +80,6 @@ pub fn reindex_note_tasks(
     note_etag: &str,
     markdown: &str,
 ) -> Result<(), String> {
-    conn.execute(
-        "DELETE FROM tasks_fts WHERE task_id IN (SELECT task_id FROM tasks WHERE note_id = ?)",
-        [note_id],
-    )
-    .map_err(|e| e.to_string())?;
     conn.execute("DELETE FROM tasks WHERE note_id = ?", [note_id])
         .map_err(|e| e.to_string())?;
     for task in parse_tasks(markdown) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,8 @@ mod glyph_fs;
 mod glyph_paths;
 mod index;
 mod io_atomic;
-mod links;
 mod license;
+mod links;
 mod net;
 mod notes;
 mod paths;
@@ -107,13 +107,8 @@ pub fn run() {
                 ],
             )?;
 
-            let open_space = MenuItem::with_id(
-                app,
-                "space.open",
-                "Open Space…",
-                true,
-                Some("CmdOrCtrl+O"),
-            )?;
+            let open_space =
+                MenuItem::with_id(app, "space.open", "Open Space…", true, Some("CmdOrCtrl+O"))?;
             let create_space = MenuItem::with_id(
                 app,
                 "space.create",
@@ -130,20 +125,10 @@ pub fn run() {
                 true,
                 None::<&str>,
             )?;
-            let open_space_settings = MenuItem::with_id(
-                app,
-                "space.settings",
-                "Space Settings…",
-                true,
-                None::<&str>,
-            )?;
-            let new_note = MenuItem::with_id(
-                app,
-                "file.new_note",
-                "New Note",
-                true,
-                Some("CmdOrCtrl+N"),
-            )?;
+            let open_space_settings =
+                MenuItem::with_id(app, "space.settings", "Space Settings…", true, None::<&str>)?;
+            let new_note =
+                MenuItem::with_id(app, "file.new_note", "New Note", true, Some("CmdOrCtrl+N"))?;
             let open_daily_note = MenuItem::with_id(
                 app,
                 "file.open_daily_note",
@@ -151,13 +136,8 @@ pub fn run() {
                 true,
                 Some("CmdOrCtrl+Shift+D"),
             )?;
-            let save_note = MenuItem::with_id(
-                app,
-                "file.save_note",
-                "Save",
-                true,
-                Some("CmdOrCtrl+S"),
-            )?;
+            let save_note =
+                MenuItem::with_id(app, "file.save_note", "Save", true, Some("CmdOrCtrl+S"))?;
             let close_tab = MenuItem::with_id(
                 app,
                 "file.close_tab",
@@ -172,8 +152,7 @@ pub fn run() {
                 true,
                 Some("CmdOrCtrl+Shift+A"),
             )?;
-            let close_ai =
-                MenuItem::with_id(app, "ai.close", "Close AI Pane", true, None::<&str>)?;
+            let close_ai = MenuItem::with_id(app, "ai.close", "Close AI Pane", true, None::<&str>)?;
             let attach_current_note = MenuItem::with_id(
                 app,
                 "ai.attach_current_note",
@@ -188,13 +167,8 @@ pub fn run() {
                 true,
                 Some("CmdOrCtrl+Alt+Shift+A"),
             )?;
-            let open_ai_settings = MenuItem::with_id(
-                app,
-                "ai.settings",
-                "AI Settings…",
-                true,
-                None::<&str>,
-            )?;
+            let open_ai_settings =
+                MenuItem::with_id(app, "ai.settings", "AI Settings…", true, None::<&str>)?;
 
             let file_menu = Submenu::with_items(
                 app,
@@ -342,6 +316,7 @@ pub fn run() {
             _ => {}
         })
         .setup(|app| {
+            glyph_paths::init_app_local_root(&app.handle())?;
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
             if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/license/commands.rs
+++ b/src-tauri/src/license/commands.rs
@@ -1,13 +1,13 @@
 use tauri::AppHandle;
 use tracing::error;
 
+use super::is_official_build;
 use super::service::verify_license_key;
 use super::store::{license_path, read_record, write_record};
 use super::types::{
     build_status, ensure_trial_window, ensure_trial_window_from_activation, hash_license_key,
     mask_license_key, normalize_license_key, LicenseActivateResult,
 };
-use super::is_official_build;
 
 fn now_ms() -> u64 {
     std::time::SystemTime::now()

--- a/src-tauri/src/license/service.rs
+++ b/src-tauri/src/license/service.rs
@@ -53,10 +53,7 @@ pub async fn verify_license_key(license_key: &str) -> Result<(), LicenseServiceE
 
     let response = client
         .post(GUMROAD_VERIFY_URL)
-        .form(&[
-            ("product_id", product_id),
-            ("license_key", license_key),
-        ])
+        .form(&[("product_id", product_id), ("license_key", license_key)])
         .send()
         .await
         .map_err(|e| {
@@ -67,8 +64,7 @@ pub async fn verify_license_key(license_key: &str) -> Result<(), LicenseServiceE
                 "gumroad license verification request failed"
             );
             let message = if e.is_timeout() {
-                "License verification timed out. Check your connection and try again."
-                    .to_string()
+                "License verification timed out. Check your connection and try again.".to_string()
             } else {
                 "Could not reach Gumroad to verify this license key.".to_string()
             };

--- a/src-tauri/src/license/types.rs
+++ b/src-tauri/src/license/types.rs
@@ -105,7 +105,10 @@ pub fn ensure_trial_window(record: &mut LicenseRecord, started_at_ms: u64) -> bo
     true
 }
 
-pub fn ensure_trial_window_from_activation(record: &mut LicenseRecord, fallback_now_ms: u64) -> bool {
+pub fn ensure_trial_window_from_activation(
+    record: &mut LicenseRecord,
+    fallback_now_ms: u64,
+) -> bool {
     let base = record.activated_at_ms.unwrap_or(fallback_now_ms);
     ensure_trial_window(record, base)
 }
@@ -187,8 +190,7 @@ mod tests {
 
     #[test]
     fn normalizes_license_keys() {
-        let normalized =
-            normalize_license_key(" 38b1a8b4-9ae64752-ae8c53e8-08ba26eb \n").unwrap();
+        let normalized = normalize_license_key(" 38b1a8b4-9ae64752-ae8c53e8-08ba26eb \n").unwrap();
         assert_eq!(normalized, "38B1A8B4-9AE64752-AE8C53E8-08BA26EB");
     }
 
@@ -238,7 +240,10 @@ mod tests {
         assert!(status.can_use_app);
         assert_eq!(status.trial_started_at_ms, Some(1_000));
         assert_eq!(status.trial_expires_at_ms, Some(1_000 + TRIAL_DURATION_MS));
-        assert_eq!(status.trial_remaining_seconds, Some((TRIAL_DURATION_MS - 1_000 + 999) / 1000));
+        assert_eq!(
+            status.trial_remaining_seconds,
+            Some((TRIAL_DURATION_MS - 1_000 + 999) / 1000)
+        );
     }
 
     #[test]

--- a/src-tauri/src/links/fetch.rs
+++ b/src-tauri/src/links/fetch.rs
@@ -3,9 +3,9 @@ use serde::Deserialize;
 use std::{fs, io::Read, path::Path};
 use url::Url;
 
-use crate::{io_atomic, net, paths};
+use crate::{io_atomic, net};
 
-use super::helpers::{image_rel_path, now_ms, MAX_HTML_BYTES, MAX_IMAGE_BYTES};
+use super::helpers::{image_cache_path, now_ms, MAX_HTML_BYTES, MAX_IMAGE_BYTES};
 use super::types::LinkPreview;
 
 pub fn extract_meta(html: &str, key: &str) -> Option<String> {
@@ -120,10 +120,9 @@ pub fn download_image(
     image_url: &Url,
 ) -> Result<Option<String>, String> {
     net::validate_url_host(image_url, false)?;
-    let rel = image_rel_path(image_url);
-    let abs = paths::join_under(space_root, &rel)?;
+    let abs = image_cache_path(space_root, image_url)?;
     if abs.exists() {
-        return Ok(Some(rel.to_string_lossy().to_string()));
+        return Ok(Some(abs.to_string_lossy().to_string()));
     }
     if let Some(parent) = abs.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
@@ -146,7 +145,7 @@ pub fn download_image(
         return Ok(None);
     }
     io_atomic::write_atomic(&abs, &buf).map_err(|e| e.to_string())?;
-    Ok(Some(rel.to_string_lossy().to_string()))
+    Ok(Some(abs.to_string_lossy().to_string()))
 }
 
 pub fn build_preview(
@@ -175,7 +174,7 @@ pub fn build_preview(
         ok = true;
     }
 
-    let (image_url, image_cache_rel_path) = match image_url
+    let (image_url, image_cache_path) = match image_url
         .as_deref()
         .and_then(|raw| resolve_image_url_fn(normalized, raw))
     {
@@ -192,7 +191,7 @@ pub fn build_preview(
         title,
         description,
         image_url,
-        image_cache_rel_path,
+        image_cache_path,
         fetched_at_ms: now_ms(),
         ok,
     }

--- a/src-tauri/src/links/helpers.rs
+++ b/src-tauri/src/links/helpers.rs
@@ -27,7 +27,7 @@ pub fn cache_path(space_root: &Path, normalized_url: &str) -> Result<PathBuf, St
     Ok(dir.join(format!("{}.json", sha256_hex(normalized_url))))
 }
 
-pub fn image_rel_path(image_url: &Url) -> PathBuf {
+pub fn image_cache_file_name(image_url: &Url) -> String {
     let mut ext = ".img";
     if let Some(seg) = image_url.path().rsplit('/').next() {
         if let Some(dot) = seg.rfind('.') {
@@ -40,11 +40,11 @@ pub fn image_rel_path(image_url: &Url) -> PathBuf {
             }
         }
     }
-    PathBuf::from(".glyph/cache/link-previews").join(format!(
-        "{}{}",
-        sha256_hex(image_url.as_str()),
-        ext
-    ))
+    format!("{}{}", sha256_hex(image_url.as_str()), ext)
+}
+
+pub fn image_cache_path(space_root: &Path, image_url: &Url) -> Result<PathBuf, String> {
+    Ok(cache_dir(space_root)?.join(image_cache_file_name(image_url)))
 }
 
 pub fn normalize_url(raw: &str) -> Result<Url, String> {

--- a/src-tauri/src/links/types.rs
+++ b/src-tauri/src/links/types.rs
@@ -8,7 +8,7 @@ pub struct LinkPreview {
     pub description: String,
     pub image_url: Option<String>,
     #[serde(default)]
-    pub image_cache_rel_path: Option<String>,
+    pub image_cache_path: Option<String>,
     pub fetched_at_ms: u64,
     #[serde(default)]
     pub ok: bool,

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use tauri::State;
 
-use crate::index::db::reset_schema_cache;
+use crate::index::db::{index_ready, reset_schema_cache};
+use crate::index::rebuild;
 
 use super::helpers::{canonicalize_dir, create_or_open_impl, SpaceInfo};
 use super::state::SpaceState;
@@ -30,6 +31,7 @@ pub async fn space_create(
     *guard = Some(PathBuf::from(&info.root));
     drop(guard);
     let _ = set_notes_watcher(&state, app, PathBuf::from(&info.root));
+    maybe_queue_initial_rebuild(PathBuf::from(&info.root));
     Ok(info)
 }
 
@@ -55,7 +57,18 @@ pub async fn space_open(
     *guard = Some(PathBuf::from(&info.root));
     drop(guard);
     let _ = set_notes_watcher(&state, app, PathBuf::from(&info.root));
+    maybe_queue_initial_rebuild(PathBuf::from(&info.root));
     Ok(info)
+}
+
+fn maybe_queue_initial_rebuild(root: PathBuf) {
+    let needs_rebuild = index_ready(&root).map(|ready| !ready).unwrap_or(true);
+    if !needs_rebuild {
+        return;
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        let _ = rebuild(&root);
+    });
 }
 
 #[tauri::command]

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -100,28 +100,28 @@ pub fn set_notes_watcher(
             }
 
             if utils::is_markdown_path(&path) {
-	                if !has_recent_local_change(&recent_local_changes, &rel_s) {
-	                    let _ = idx_tx.send((rel_s.clone(), is_remove));
+                if !has_recent_local_change(&recent_local_changes, &rel_s) {
+                    let _ = idx_tx.send((rel_s.clone(), is_remove));
 
-	                    let _ = app2.emit(
-	                        "notes:external_changed",
-	                        ExternalChangeEvent {
-	                            rel_path: rel_s.clone(),
-	                            removed: is_remove,
-	                        },
-	                    );
-	                }
-	            }
+                    let _ = app2.emit(
+                        "notes:external_changed",
+                        ExternalChangeEvent {
+                            rel_path: rel_s.clone(),
+                            removed: is_remove,
+                        },
+                    );
+                }
+            }
 
-	            let _ = app2.emit(
-	                "space:fs_changed",
-	                ExternalChangeEvent {
-	                    rel_path: rel_s,
-	                    removed: is_remove,
-	                },
-	            );
-	        }
-	    })
+            let _ = app2.emit(
+                "space:fs_changed",
+                ExternalChangeEvent {
+                    rel_path: rel_s,
+                    removed: is_remove,
+                },
+            );
+        }
+    })
     .map_err(|e| e.to_string())?;
 
     let mut watcher = watcher;

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -103,7 +103,14 @@ pub async fn space_rename_path(
         }
         let is_dir = from_abs.is_dir();
         std::fs::rename(&from_abs, &to_abs).map_err(|e| e.to_string())?;
-        reindex_after_rename(&root, &from_path, &to_path, &to_abs, is_dir, &recent_local_changes);
+        reindex_after_rename(
+            &root,
+            &from_path,
+            &to_path,
+            &to_abs,
+            is_dir,
+            &recent_local_changes,
+        );
         Ok(())
     })
     .await
@@ -173,13 +180,7 @@ pub async fn space_delete_path(
         deny_hidden_rel_path(&rel)?;
         let abs = paths::join_under(&root, &rel)?;
         let meta = std::fs::metadata(&abs).map_err(|e| e.to_string())?;
-        remove_markdown_notes_from_index(
-            &root,
-            &path,
-            &abs,
-            &recent_local_changes,
-            meta.is_dir(),
-        );
+        remove_markdown_notes_from_index(&root, &path, &abs, &recent_local_changes, meta.is_dir());
         if meta.is_dir() {
             if recursive.unwrap_or(false) {
                 move_path_to_trash(&abs)

--- a/src-tauri/src/space_fs/view_data.rs
+++ b/src-tauri/src/space_fs/view_data.rs
@@ -6,7 +6,9 @@ use std::{
 };
 use tauri::State;
 
-use crate::{index::open_db, paths, space::SpaceState, utils};
+use crate::{
+    index::frontmatter::preview_from_markdown, index::open_db, paths, space::SpaceState, utils,
+};
 
 use super::{
     helpers::{deny_hidden_rel_path, should_hide},
@@ -160,17 +162,22 @@ pub async fn space_folder_view_data(
             let placeholders = std::iter::repeat_n("?", ids.len())
                 .collect::<Vec<_>>()
                 .join(", ");
-            let sql = format!("SELECT id, title, preview FROM notes WHERE id IN ({placeholders})");
+            let sql = format!("SELECT id, title FROM notes WHERE id IN ({placeholders})");
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
             let mut rows = stmt
                 .query(rusqlite::params_from_iter(ids.iter()))
                 .map_err(|e| e.to_string())?;
             let mut out = Vec::new();
             while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+                let id: String = row.get(0).map_err(|e| e.to_string())?;
+                let abs = root.join(&id);
+                let content = std::fs::read_to_string(&abs)
+                    .map(|markdown| preview_from_markdown(&id, &markdown))
+                    .unwrap_or_default();
                 out.push(FolderViewNotePreview {
-                    id: row.get(0).map_err(|e| e.to_string())?,
                     title: row.get(1).map_err(|e| e.to_string())?,
-                    content: row.get(2).map_err(|e| e.to_string())?,
+                    id,
+                    content,
                 });
             }
             out

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -52,8 +52,12 @@ export function CommandPalette({
 	const selectedSearchPathRef = useRef<string | null>(null);
 	const [previewPath, setPreviewPath] = useState<string | null>(null);
 
-	const { recentFiles, isSearching, titleMatches, contentMatches, reset } =
-		useCommandSearch(open, activeTab, query, spacePath);
+	const { searchResults, recentFiles, isSearching, reset } = useCommandSearch(
+		open,
+		activeTab,
+		query,
+		spacePath,
+	);
 
 	const filtered = useMemo(() => {
 		if (activeTab !== "commands") return [];
@@ -75,13 +79,13 @@ export function CommandPalette({
 		activeTab === "commands"
 			? filtered.length
 			: query.trim()
-				? titleMatches.length + contentMatches.length
+				? searchResults.length
 				: recentFiles.length;
 	const parsedSearch = useMemo(() => parseSearchQuery(query), [query]);
 	const searchEntries = useMemo(
 		() =>
 			query.trim()
-				? [...titleMatches, ...contentMatches].map((result) => ({
+				? searchResults.map((result) => ({
 						path: result.id,
 						title: result.title,
 					}))
@@ -89,7 +93,7 @@ export function CommandPalette({
 						path: file.path,
 						title: null,
 					})),
-		[contentMatches, query, recentFiles, titleMatches],
+		[query, recentFiles, searchResults],
 	);
 	const selectedSearchEntry =
 		activeTab === "search" ? (searchEntries[selectedIndex] ?? null) : null;
@@ -196,20 +200,13 @@ export function CommandPalette({
 	const selectSearchResult = useCallback(
 		(index: number) => {
 			const resultId = query.trim()
-				? [...titleMatches, ...contentMatches][index]?.id
+				? searchResults[index]?.id
 				: recentFiles[index]?.path;
 			if (!resultId) return;
 			onClose();
 			onSelectSearchResult(resultId);
 		},
-		[
-			titleMatches,
-			contentMatches,
-			recentFiles,
-			query,
-			onClose,
-			onSelectSearchResult,
-		],
+		[searchResults, recentFiles, query, onClose, onSelectSearchResult],
 	);
 
 	const handleSelect = useCallback(
@@ -379,14 +376,13 @@ export function CommandPalette({
 											>
 												{isSearching
 													? "Searching..."
-													: `${(titleMatches.length + contentMatches.length).toLocaleString()} results`}
+													: `${searchResults.length.toLocaleString()} results`}
 											</div>
 										) : null}
 										<SearchResultsList
 											query={query}
 											isSearching={isSearching}
-											titleMatches={titleMatches}
-											contentMatches={contentMatches}
+											searchResults={searchResults}
 											recentFiles={recentFiles}
 											selectedIndex={selectedIndex}
 											onSetSelectedIndex={(index) =>

--- a/src/components/app/CommandSearchResults.tsx
+++ b/src/components/app/CommandSearchResults.tsx
@@ -69,8 +69,7 @@ export function SearchResultItem({
 interface SearchResultsListProps {
 	query: string;
 	isSearching: boolean;
-	titleMatches: SearchResult[];
-	contentMatches: SearchResult[];
+	searchResults: SearchResult[];
 	recentFiles: RecentFile[];
 	selectedIndex: number;
 	onSetSelectedIndex: (index: number) => void;
@@ -93,8 +92,7 @@ function recentDisplayFolder(relPath: string): string {
 export function SearchResultsList({
 	query,
 	isSearching,
-	titleMatches,
-	contentMatches,
+	searchResults,
 	recentFiles,
 	selectedIndex,
 	onSetSelectedIndex,
@@ -146,49 +144,22 @@ export function SearchResultsList({
 
 	return (
 		<>
-			{titleMatches.length > 0 && (
-				<>
-					<div className="commandPaletteGroupLabel">
-						{trimmed.startsWith("#") ? "Tagged Notes" : "Notes"}
-					</div>
-					{titleMatches.map((r, index) => (
-						<SearchResultItem
-							key={r.id}
-							result={r}
-							index={index}
-							isSelected={index === selectedIndex}
-							onMouseEnter={() => onSetSelectedIndex(index)}
-							onSelect={() => onSelectResult(index)}
-						/>
-					))}
-				</>
+			{searchResults.map((result, index) => (
+				<SearchResultItem
+					key={result.id}
+					result={result}
+					index={index}
+					isSelected={index === selectedIndex}
+					onMouseEnter={() => onSetSelectedIndex(index)}
+					onSelect={() => onSelectResult(index)}
+				/>
+			))}
+			{searchResults.length === 0 && !isSearching && (
+				<div className="commandPaletteEmpty">No results</div>
 			)}
-			{contentMatches.length > 0 && (
-				<>
-					<div className="commandPaletteGroupLabel">Content</div>
-					{contentMatches.map((r, index) => {
-						const globalIndex = titleMatches.length + index;
-						return (
-							<SearchResultItem
-								key={r.id}
-								result={r}
-								index={globalIndex}
-								isSelected={globalIndex === selectedIndex}
-								onMouseEnter={() => onSetSelectedIndex(globalIndex)}
-								onSelect={() => onSelectResult(globalIndex)}
-							/>
-						);
-					})}
-				</>
+			{isSearching && searchResults.length === 0 && (
+				<div className="commandPaletteEmpty">Searching…</div>
 			)}
-			{titleMatches.length === 0 &&
-				contentMatches.length === 0 &&
-				!isSearching && <div className="commandPaletteEmpty">No results</div>}
-			{isSearching &&
-				titleMatches.length === 0 &&
-				contentMatches.length === 0 && (
-					<div className="commandPaletteEmpty">Searching…</div>
-				)}
 		</>
 	);
 }

--- a/src/components/app/useCommandSearch.ts
+++ b/src/components/app/useCommandSearch.ts
@@ -81,26 +81,6 @@ export function useCommandSearch(
 		};
 	}, [query, activeTab, spacePath]);
 
-	const { titleMatches, contentMatches } = useMemo(() => {
-		if (activeTab !== "search" || !query.trim())
-			return { titleMatches: [], contentMatches: [] };
-		const parsed = parseSearchQuery(query.trim());
-		const q = parsed.text.toLowerCase();
-		if (parsed.request.tag_only) {
-			return { titleMatches: searchResults, contentMatches: [] };
-		}
-		const title: SearchResult[] = [];
-		const content: SearchResult[] = [];
-		for (const r of searchResults) {
-			if (!q || r.title.toLowerCase().includes(q)) {
-				title.push(r);
-			} else {
-				content.push(r);
-			}
-		}
-		return { titleMatches: title, contentMatches: content };
-	}, [searchResults, query, activeTab]);
-
 	const reset = useCallback(() => {
 		requestIdRef.current += 1;
 		setSearchResults([]);
@@ -111,8 +91,6 @@ export function useCommandSearch(
 		searchResults,
 		recentFiles: recentMarkdownFiles,
 		isSearching,
-		titleMatches,
-		contentMatches,
 		reset,
 	};
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -336,7 +336,7 @@ export interface LinkPreview {
 	title: string;
 	description: string;
 	image_url: string | null;
-	image_cache_rel_path: string | null;
+	image_cache_path: string | null;
 	fetched_at_ms: number;
 	ok: boolean;
 }


### PR DESCRIPTION
Summary
- document the new split between metadata-only SQLite storage and native scan body-text search, covering schema, storage paths, and indexing coordination
- describe the app-support directory layout, mutex-protected rebuilds, and watcher behavior for the hard-cutover flow
- outline the separate metadata search, native content scan, and quick-open designs so the plan captures all moving parts
Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic index rebuilding when opening spaces for the first time
  * Enhanced search with content-based scoring of markdown files
  * Unified search results display in the command palette

* **Bug Fixes**
  * Added schema compatibility validation to prevent database corruption
  * Improved file path resolution and caching for linked content

* **Improvements**
  * Preview generation now reads directly from markdown files for accuracy
  * Streamlined search results presentation with consolidated result list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->