### PR TITLE
Add configurable vertical tab layout for note tabs

### DIFF
--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -283,7 +283,7 @@ export const MainContent = memo(function MainContent({
 		onContinueLastSpace,
 		onCreateSpace,
 	} = useSpace();
-	const { dailyNotesFolder } = useUILayoutContext();
+	const { dailyNotesFolder, tabLayout } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
 	const [onboarding, setOnboarding] = useState<OnboardingSettings>(
 		DEFAULT_ONBOARDING_SETTINGS,
@@ -466,7 +466,7 @@ export const MainContent = memo(function MainContent({
 	return (
 		<main className="mainArea">
 			<div className="canvasWrapper">
-				<div className="canvasPaneHost">
+				<div className="canvasPaneHost" data-tab-layout={tabLayout}>
 					<DailyNotesSetupToast
 						visible={dailyNoteSetupToastVisible}
 						onDismiss={() => setDailyNoteSetupToastVisible(false)}
@@ -477,6 +477,7 @@ export const MainContent = memo(function MainContent({
 					/>
 					{showTabBar && (
 						<TabBar
+							layout={tabLayout}
 							openTabs={openTabs}
 							activeTabPath={activeTabPath}
 							dragTabPath={dragTabPath}
@@ -492,33 +493,35 @@ export const MainContent = memo(function MainContent({
 							onReorder={reorderTabs}
 						/>
 					)}
-					{content ?? (
-						<div className="mainEmptyState">
-							{showStarterPane ? (
-								<GettingStartedPane
-									commandShortcutParts={commandShortcutParts}
-									showDailyNoteAction={Boolean(dailyNotesFolder)}
-									onCreateNote={onCreateNote}
-									onOpenCommandPalette={onOpenCommandPalette}
-									onOpenDailyNote={onOpenDailyNote}
-									onOpenTasks={onOpenTasks}
-									onDismiss={() => {
-										setStarterOverrideVisible(false);
-										void updateOnboardingSettings({ starterDismissed: true });
-									}}
-								/>
-							) : (
-								<ContextualEmptyState
-									onboarding={onboarding}
-									commandShortcutParts={commandShortcutParts}
-									showDailyNoteAction={Boolean(dailyNotesFolder)}
-									onCreateNote={onCreateNote}
-									onOpenCommandPalette={onOpenCommandPalette}
-									onOpenDailyNote={onOpenDailyNote}
-								/>
-							)}
-						</div>
-					)}
+					<div className="canvasContentHost">
+						{content ?? (
+							<div className="mainEmptyState">
+								{showStarterPane ? (
+									<GettingStartedPane
+										commandShortcutParts={commandShortcutParts}
+										showDailyNoteAction={Boolean(dailyNotesFolder)}
+										onCreateNote={onCreateNote}
+										onOpenCommandPalette={onOpenCommandPalette}
+										onOpenDailyNote={onOpenDailyNote}
+										onOpenTasks={onOpenTasks}
+										onDismiss={() => {
+											setStarterOverrideVisible(false);
+											void updateOnboardingSettings({ starterDismissed: true });
+										}}
+									/>
+								) : (
+									<ContextualEmptyState
+										onboarding={onboarding}
+										commandShortcutParts={commandShortcutParts}
+										showDailyNoteAction={Boolean(dailyNotesFolder)}
+										onCreateNote={onCreateNote}
+										onOpenCommandPalette={onOpenCommandPalette}
+										onOpenDailyNote={onOpenDailyNote}
+									/>
+								)}
+							</div>
+						)}
+					</div>
 				</div>
 			</div>
 		</main>

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -6,6 +6,7 @@ import { getShortcutTooltip } from "../../lib/shortcuts";
 import { TASKS_TAB_ID } from "../../lib/tasks";
 
 interface TabBarProps {
+	layout: "horizontal" | "vertical";
 	openTabs: string[];
 	activeTabPath: string | null;
 	dragTabPath: string | null;
@@ -22,6 +23,7 @@ interface TabBarProps {
 }
 
 export function TabBar({
+	layout,
 	openTabs,
 	activeTabPath,
 	dragTabPath,
@@ -62,11 +64,13 @@ export function TabBar({
 	return (
 		<div
 			className="mainTabsBarWrap"
+			data-layout={layout}
 			onPointerEnter={() => setHovered(true)}
 			onPointerLeave={() => setHovered(false)}
 		>
 			<div
 				className="mainTabsBar"
+				data-layout={layout}
 				data-empty-state={useWindowBackground ? "true" : "false"}
 			>
 				<div className="mainTabsSide" />
@@ -115,7 +119,7 @@ export function TabBar({
 					) : null}
 				</div>
 			</div>
-			{breadcrumbSegments.length > 0 && (
+			{layout === "horizontal" && breadcrumbSegments.length > 0 && (
 				<div className={`mainTabsBreadcrumb ${hovered ? "is-visible" : ""}`}>
 					{breadcrumbSegments.map((segment, i, arr) => (
 						// biome-ignore lint/suspicious/noArrayIndexKey: breadcrumb segments are derived from a static path split and never reorder

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -13,6 +13,7 @@ import {
 	type UiFontFamily,
 	type UiFontSize,
 	type UiLightThemeId,
+	type UiTabLayout,
 	loadSettings,
 	setThemeMode,
 	setUiAccent,
@@ -22,6 +23,7 @@ import {
 	setUiFontSize,
 	setUiLightThemeId,
 	setUiMonoFontFamily,
+	setUiTabLayout,
 	setUiTranslucentApp,
 } from "../../lib/settings";
 import {
@@ -57,6 +59,7 @@ export function AppearanceSettingsPane() {
 		GLYPH_DEFAULT_DARK_THEME_ID,
 	);
 	const [accent, setAccentState] = useState<UiAccent>("neutral");
+	const [tabLayout, setTabLayoutState] = useState<UiTabLayout>("horizontal");
 	const [fontFamily, setFontFamilyState] =
 		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
 	const [monoFontFamily, setMonoFontFamilyState] =
@@ -86,6 +89,7 @@ export function AppearanceSettingsPane() {
 				setLightThemeIdState(settings.ui.lightThemeId);
 				setDarkThemeIdState(settings.ui.darkThemeId);
 				setAccentState(settings.ui.accent);
+				setTabLayoutState(settings.ui.tabLayout);
 				setFontFamilyState(settings.ui.fontFamily);
 				setMonoFontFamilyState(settings.ui.monoFontFamily);
 				setUiFontSizeState(settings.ui.fontSize);
@@ -246,6 +250,16 @@ export function AppearanceSettingsPane() {
 		}
 	}, []);
 
+	const onTabLayoutChange = useCallback(async (next: UiTabLayout) => {
+		setError("");
+		setTabLayoutState(next);
+		try {
+			await setUiTabLayout(next);
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Failed to save settings");
+		}
+	}, []);
+
 	const onTranslucentAppChange = useCallback(async (next: boolean) => {
 		setError("");
 		setTranslucentAppState(next);
@@ -282,10 +296,12 @@ export function AppearanceSettingsPane() {
 					lightOptions={LIGHT_THEME_OPTIONS}
 					darkOptions={DARK_THEME_OPTIONS}
 					translucentApp={translucentApp}
+					tabLayout={tabLayout}
 					onThemeModeChange={onThemeModeChange}
 					onLightThemeChange={onLightThemeChange}
 					onDarkThemeChange={onDarkThemeChange}
 					onTranslucentAppChange={onTranslucentAppChange}
+					onTabLayoutChange={onTabLayoutChange}
 				/>
 				{showAccentCard ? (
 					<AppearanceAccentCard

--- a/src/components/settings/AppearanceThemeCard.tsx
+++ b/src/components/settings/AppearanceThemeCard.tsx
@@ -6,9 +6,17 @@ import type {
 	UiAccent,
 	UiDarkThemeId,
 	UiLightThemeId,
+	UiTabLayout,
 } from "../../lib/settings";
 import type { UiThemeOption, UiThemePreview } from "../../lib/uiThemes";
-import { ChevronDown, Computer, Moon, Sun } from "../Icons";
+import {
+	ChevronDown,
+	Computer,
+	Layout,
+	LayoutAlignLeft,
+	Moon,
+	Sun,
+} from "../Icons";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
 import {
 	SettingsRow,
@@ -26,10 +34,12 @@ interface AppearanceThemeCardProps {
 	lightOptions: readonly UiThemeOption<UiLightThemeId>[];
 	darkOptions: readonly UiThemeOption<UiDarkThemeId>[];
 	translucentApp: boolean;
+	tabLayout: UiTabLayout;
 	onThemeModeChange: (mode: ThemeMode) => Promise<void>;
 	onLightThemeChange: (themeId: UiLightThemeId) => Promise<void>;
 	onDarkThemeChange: (themeId: UiDarkThemeId) => Promise<void>;
 	onTranslucentAppChange: (enabled: boolean) => Promise<void>;
+	onTabLayoutChange: (layout: UiTabLayout) => Promise<void>;
 }
 
 function resolvePreview<T extends string>(
@@ -243,10 +253,12 @@ export function AppearanceThemeCard({
 	lightOptions,
 	darkOptions,
 	translucentApp,
+	tabLayout,
 	onThemeModeChange,
 	onLightThemeChange,
 	onDarkThemeChange,
 	onTranslucentAppChange,
+	onTabLayoutChange,
 }: AppearanceThemeCardProps) {
 	const resolvedLightTheme = {
 		...lightTheme,
@@ -323,6 +335,29 @@ export function AppearanceThemeCard({
 					ariaLabel="Translucent app"
 					checked={translucentApp}
 					onCheckedChange={(checked) => void onTranslucentAppChange(checked)}
+				/>
+			</SettingsRow>
+
+			<SettingsRow
+				label="Tab layout"
+				description="Choose whether note tabs appear across the top or in a left-side rail."
+			>
+				<SettingsSegmented<UiTabLayout>
+					ariaLabel="Tab layout"
+					value={tabLayout}
+					onChange={(value) => void onTabLayoutChange(value)}
+					options={[
+						{
+							label: "Horizontal",
+							value: "horizontal",
+							icon: <Layout size={16} strokeWidth={1.7} />,
+						},
+						{
+							label: "Vertical",
+							value: "vertical",
+							icon: <LayoutAlignLeft size={16} strokeWidth={1.7} />,
+						},
+					]}
 				/>
 			</SettingsRow>
 		</SettingsSection>

--- a/src/components/shadcn-studio/tabs/tabs-15.tsx
+++ b/src/components/shadcn-studio/tabs/tabs-15.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+	Tabs,
+	TabsContent,
+	TabsList,
+	TabsTrigger,
+} from "@/components/ui/shadcn/tabs";
+
+const tabs = [
+	{
+		name: "Explore",
+		value: "explore",
+		content: (
+			<>
+				Discover{" "}
+				<span className="font-semibold text-foreground">fresh ideas</span>,
+				trending topics, and hidden gems curated just for you. Start exploring
+				and let your curiosity lead the way!
+			</>
+		),
+	},
+	{
+		name: "Favorites",
+		value: "favorites",
+		content: (
+			<>
+				All your{" "}
+				<span className="font-semibold text-foreground">favorites</span> are
+				saved here. Revisit articles, collections, and moments you love, any
+				time you want a little inspiration.
+			</>
+		),
+	},
+	{
+		name: "Surprise Me",
+		value: "surprise",
+		content: (
+			<>
+				<span className="font-semibold text-foreground">Surprise!</span>{" "}
+				Here&apos;s something unexpected-a fun fact, a quirky tip, or a daily
+				challenge. Come back for a new surprise every day!
+			</>
+		),
+	},
+];
+
+const TabsVerticalDemo = () => {
+	return (
+		<div className="w-full max-w-md">
+			<Tabs defaultValue="explore" orientation="vertical">
+				<TabsList className="h-full flex-col">
+					{tabs.map((tab) => (
+						<TabsTrigger key={tab.value} value={tab.value} className="w-full">
+							{tab.name}
+						</TabsTrigger>
+					))}
+				</TabsList>
+
+				{tabs.map((tab) => (
+					<TabsContent key={tab.value} value={tab.value}>
+						<p className="text-sm text-muted-foreground">{tab.content}</p>
+					</TabsContent>
+				))}
+			</Tabs>
+		</div>
+	);
+};
+
+export default TabsVerticalDemo;

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -13,6 +13,7 @@ import {
 import { useSearch } from "../hooks/useSearch";
 import {
 	type AiAssistantMode,
+	type UiTabLayout,
 	loadSettings,
 	reloadFromDisk,
 	setAiAssistantMode as saveAiAssistantMode,
@@ -42,6 +43,7 @@ export interface UILayoutContextValue {
 	templateFolder: string | null;
 	dailyNoteTemplatePath: string | null;
 	showToc: boolean;
+	tabLayout: UiTabLayout;
 	setShowToc: (show: boolean) => void;
 }
 
@@ -85,6 +87,7 @@ type UIState = {
 	templateFolder: string | null;
 	dailyNoteTemplatePath: string | null;
 	showToc: boolean;
+	tabLayout: UiTabLayout;
 	aiEnabled: boolean;
 	aiPanelOpen: boolean;
 	aiPanelWidth: number;
@@ -103,6 +106,7 @@ type UIAction =
 	| { type: "setTemplateFolder"; value: string | null }
 	| { type: "setDailyNoteTemplatePath"; value: string | null }
 	| { type: "setShowToc"; value: boolean }
+	| { type: "setTabLayout"; value: UiTabLayout }
 	| { type: "setAiEnabled"; value: boolean }
 	| { type: "setAiPanelOpen"; value: SetStateAction<boolean> }
 	| { type: "setAiPanelWidth"; value: number }
@@ -117,6 +121,7 @@ type UIAction =
 			templateFolder: string | null;
 			dailyNoteTemplatePath: string | null;
 			showToc: boolean;
+			tabLayout: UiTabLayout;
 	  };
 
 const initialUIState: UIState = {
@@ -131,6 +136,7 @@ const initialUIState: UIState = {
 	templateFolder: null,
 	dailyNoteTemplatePath: null,
 	showToc: true,
+	tabLayout: "horizontal",
 	aiEnabled: true,
 	aiPanelOpen: false,
 	aiPanelWidth: 380,
@@ -167,6 +173,8 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 			return { ...state, dailyNoteTemplatePath: action.value };
 		case "setShowToc":
 			return { ...state, showToc: action.value };
+		case "setTabLayout":
+			return { ...state, tabLayout: action.value };
 		case "setAiEnabled":
 			return {
 				...state,
@@ -201,6 +209,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				templateFolder: action.templateFolder,
 				dailyNoteTemplatePath: action.dailyNoteTemplatePath,
 				showToc: action.showToc,
+				tabLayout: action.tabLayout,
 			};
 		default:
 			return state;
@@ -222,6 +231,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		templateFolder,
 		dailyNoteTemplatePath,
 		showToc,
+		tabLayout,
 		aiEnabled,
 		aiPanelOpen,
 		aiPanelWidth,
@@ -248,6 +258,10 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		const nextShowToc = payload.ui?.showToc;
 		if (typeof nextShowToc === "boolean") {
 			dispatch({ type: "setShowToc", value: nextShowToc });
+		}
+		const nextTabLayout = payload.ui?.tabLayout;
+		if (nextTabLayout === "horizontal" || nextTabLayout === "vertical") {
+			dispatch({ type: "setTabLayout", value: nextTabLayout });
 		}
 		if (payload.dailyNotes && "folder" in payload.dailyNotes) {
 			dispatch({
@@ -287,6 +301,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					templateFolder: s.templates?.folder ?? null,
 					dailyNoteTemplatePath: s.templates?.dailyNoteTemplate ?? null,
 					showToc: s.ui.showToc,
+					tabLayout: s.ui.tabLayout,
 				});
 			} catch {
 				// best-effort settings hydration
@@ -437,6 +452,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			templateFolder,
 			dailyNoteTemplatePath,
 			showToc,
+			tabLayout,
 			setShowToc,
 		}),
 		[
@@ -458,6 +474,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			templateFolder,
 			dailyNoteTemplatePath,
 			showToc,
+			tabLayout,
 			setShowToc,
 		],
 	);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -28,6 +28,8 @@ async function getStore(): Promise<LazyStore> {
 
 export type ThemeMode = "system" | "light" | "dark";
 const THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
+export type UiTabLayout = "horizontal" | "vertical";
+const UI_TAB_LAYOUTS = new Set<UiTabLayout>(["horizontal", "vertical"]);
 export type UiAccent =
 	| "neutral"
 	| "cerulean"
@@ -44,6 +46,7 @@ const UI_ACCENTS = new Set<UiAccent>([
 	"vibrant-coral",
 ]);
 const DEFAULT_UI_ACCENT: UiAccent = "neutral";
+const DEFAULT_UI_TAB_LAYOUT: UiTabLayout = "horizontal";
 const DEFAULT_UI_FONT_FAMILY = "Inter";
 const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
 export const MIN_UI_FONT_SIZE = 7;
@@ -97,6 +100,12 @@ function asUiAccent(value: unknown): UiAccent {
 		: DEFAULT_UI_ACCENT;
 }
 
+function asUiTabLayout(value: unknown): UiTabLayout {
+	return typeof value === "string" && UI_TAB_LAYOUTS.has(value as UiTabLayout)
+		? (value as UiTabLayout)
+		: DEFAULT_UI_TAB_LAYOUT;
+}
+
 function asUiFontFamily(value: unknown): UiFontFamily {
 	if (typeof value !== "string") return DEFAULT_UI_FONT_FAMILY;
 	const trimmed = value.trim();
@@ -140,6 +149,7 @@ async function emitSettingsUpdated(payload: {
 		lightThemeId?: UiLightThemeId;
 		darkThemeId?: UiDarkThemeId;
 		accent?: UiAccent;
+		tabLayout?: UiTabLayout;
 		fontFamily?: UiFontFamily;
 		monoFontFamily?: UiFontFamily;
 		fontSize?: UiFontSize;
@@ -187,6 +197,7 @@ interface AppSettings {
 		lightThemeId: UiLightThemeId;
 		darkThemeId: UiDarkThemeId;
 		accent: UiAccent;
+		tabLayout: UiTabLayout;
 		fontFamily: UiFontFamily;
 		monoFontFamily: UiFontFamily;
 		fontSize: UiFontSize;
@@ -218,6 +229,7 @@ const KEYS = {
 	lightThemeId: "ui.lightThemeId",
 	darkThemeId: "ui.darkThemeId",
 	accent: "ui.accent",
+	tabLayout: "ui.tabLayout",
 	fontFamily: "ui.fontFamily",
 	monoFontFamily: "ui.monoFontFamily",
 	fontSize: "ui.fontSize",
@@ -324,6 +336,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawLightThemeId,
 		rawDarkThemeId,
 		rawAccent,
+		rawTabLayout,
 		rawFontFamily,
 		rawMonoFontFamily,
 		rawFontSize,
@@ -350,6 +363,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<unknown>(KEYS.lightThemeId),
 		store.get<unknown>(KEYS.darkThemeId),
 		store.get<unknown>(KEYS.accent),
+		store.get<unknown>(KEYS.tabLayout),
 		store.get<unknown>(KEYS.fontFamily),
 		store.get<unknown>(KEYS.monoFontFamily),
 		store.get<unknown>(KEYS.fontSize),
@@ -379,6 +393,7 @@ export async function loadSettings(): Promise<AppSettings> {
 	const lightThemeId = asUiLightThemeId(rawLightThemeId);
 	const darkThemeId = asUiDarkThemeId(rawDarkThemeId);
 	const accent = asUiAccent(rawAccent);
+	const tabLayout = asUiTabLayout(rawTabLayout);
 	const fontFamily = asUiFontFamily(rawFontFamily);
 	const monoFontFamily = asUiMonoFontFamily(rawMonoFontFamily);
 	const fontSize = asUiFontSize(rawFontSize);
@@ -419,6 +434,7 @@ export async function loadSettings(): Promise<AppSettings> {
 			lightThemeId,
 			darkThemeId,
 			accent,
+			tabLayout,
 			fontFamily,
 			monoFontFamily,
 			fontSize,
@@ -535,6 +551,14 @@ export async function setUiAccent(accent: UiAccent): Promise<void> {
 	await store.set(KEYS.accent, next);
 	await store.save();
 	void emitSettingsUpdated({ ui: { accent: next } });
+}
+
+export async function setUiTabLayout(tabLayout: UiTabLayout): Promise<void> {
+	const store = await getStore();
+	const next = asUiTabLayout(tabLayout);
+	await store.set(KEYS.tabLayout, next);
+	await store.save();
+	void emitSettingsUpdated({ ui: { tabLayout: next } });
 }
 
 export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -64,6 +64,7 @@ type TauriEventMap = {
 				| "light-yellow"
 				| "soft-apricot"
 				| "vibrant-coral";
+			tabLayout?: "horizontal" | "vertical";
 			fontFamily?: string;
 			monoFontFamily?: string;
 			fontSize?: number;

--- a/src/styles/app/05-main-area.css
+++ b/src/styles/app/05-main-area.css
@@ -506,8 +506,28 @@
 	position: relative;
 }
 
+.canvasPaneHost[data-tab-layout="vertical"] {
+	flex-direction: row;
+}
+
+.canvasContentHost {
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+}
+
 .mainTabsBarWrap {
 	flex-shrink: 0;
+}
+
+.canvasPaneHost[data-tab-layout="vertical"] .mainTabsBarWrap {
+	width: 220px;
+	min-width: 220px;
+	min-height: 0;
+	border-right: 1px solid
+		color-mix(in srgb, var(--border-light) 54%, transparent);
 }
 
 .mainTabsBar {
@@ -518,6 +538,14 @@
 	padding: 0 var(--space-3);
 	border-bottom: 0;
 	background: var(--bg-primary);
+}
+
+.mainTabsBar[data-layout="vertical"] {
+	height: 100%;
+	flex-direction: column;
+	align-items: stretch;
+	gap: var(--space-3);
+	padding: var(--space-3);
 }
 
 .mainTabsBar[data-empty-state="true"] {
@@ -574,10 +602,22 @@
 	min-width: 0;
 }
 
+.mainTabsBar[data-layout="vertical"] .mainTabsSide {
+	display: none;
+}
+
 .mainTabsSideEnd {
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
+}
+
+.mainTabsBar[data-layout="vertical"] .mainTabsSideEnd {
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 8px;
 }
 
 .mainTabsCenter {
@@ -585,6 +625,11 @@
 	min-width: 0;
 	display: flex;
 	align-items: center;
+}
+
+.mainTabsBar[data-layout="vertical"] .mainTabsCenter {
+	flex: 1 1 auto;
+	align-items: stretch;
 }
 
 .mainTabsStrip {
@@ -600,10 +645,24 @@
 	overflow: hidden;
 }
 
+.mainTabsBar[data-layout="vertical"] .mainTabsStrip {
+	flex-direction: column;
+	align-items: stretch;
+	gap: 8px;
+	padding: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+}
+
 .mainTabWrap {
 	position: relative;
 	min-width: 78px;
 	flex: 1 1 0%;
+}
+
+.mainTabsBar[data-layout="vertical"] .mainTabWrap {
+	min-width: 0;
+	flex: 0 0 auto;
 }
 
 .mainTab {
@@ -624,6 +683,12 @@
 	transition: background var(--transition-fast), border-color
 		var(--transition-fast), color var(--transition-fast), box-shadow
 		var(--transition-fast);
+}
+
+.mainTabsBar[data-layout="vertical"] .mainTab {
+	height: 36px;
+	justify-content: flex-start;
+	padding-right: 12px;
 }
 
 .mainTab:hover {
@@ -726,6 +791,13 @@
 	transition: background var(--transition-fast), color var(--transition-fast);
 }
 
+.mainTabsBar[data-layout="vertical"] .mainTabAdd,
+.mainTabsBar[data-layout="vertical"] .mainTabsAiToggle {
+	height: 32px;
+	width: 100%;
+	border-radius: var(--radius-xl);
+}
+
 .mainTabAdd:hover {
 	color: var(--text-primary);
 }
@@ -778,6 +850,70 @@
 	outline: 2px solid
 		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
 	outline-offset: 1px;
+}
+
+@media (max-width: 960px) {
+	.canvasPaneHost[data-tab-layout="vertical"] {
+		flex-direction: column;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsBarWrap {
+		width: auto;
+		min-width: 0;
+		min-height: auto;
+		border-right: 0;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsBar {
+		height: 44px;
+		flex-direction: row;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 0 var(--space-3);
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsSide {
+		display: block;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsSideEnd {
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 0;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsCenter {
+		flex: 0 1 1120px;
+		align-items: center;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsStrip {
+		flex-direction: row;
+		align-items: center;
+		gap: 6px;
+		padding: 3px 0;
+		overflow-x: auto;
+		overflow-y: hidden;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabWrap {
+		min-width: 78px;
+		flex: 1 1 0%;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTab {
+		height: 28px;
+		justify-content: center;
+		padding-right: 10px;
+	}
+
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabAdd,
+	.canvasPaneHost[data-tab-layout="vertical"] .mainTabsAiToggle {
+		height: 28px;
+		width: 28px;
+		border-radius: var(--radius-md);
+	}
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- add a persisted `ui.tabLayout` setting and sync it through the UI context and Tauri settings events
- add an Appearance setting to switch between horizontal and vertical note tab layouts
- update the main tab bar and canvas layout to render a left-side vertical rail on larger screens with a responsive fallback on smaller screens
- include a shadcn studio vertical tabs demo component for reuse and reference

## Testing
- `pnpm check`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab layout setting in appearance preferences, allowing users to choose between horizontal and vertical tab arrangements.
  * Tab interface dynamically adapts to selected layout with responsive optimizations for narrower viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->