### PR TITLE
Polish 0.2.7 UI and space switching

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -13,7 +13,13 @@ fn read_dotenv_value(path: &Path, key: &str) -> Option<String> {
         if entry_key.trim() != key {
             continue;
         }
-        return Some(raw_value.trim().trim_matches('"').trim_matches('\'').to_string());
+        return Some(
+            raw_value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string(),
+        );
     }
     None
 }

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -1313,8 +1313,7 @@ fn local_note_graph_for_conn(
     }
 
     let node_ids = nodes_by_id.keys().cloned().collect::<Vec<_>>();
-    let placeholders = std::iter::repeat("?")
-        .take(node_ids.len())
+    let placeholders = std::iter::repeat_n("?", node_ids.len())
         .collect::<Vec<_>>()
         .join(", ");
     let edge_query = format!(
@@ -1345,7 +1344,11 @@ fn local_note_graph_for_conn(
             .then_with(|| left.id.cmp(&right.id))
     });
 
-    Ok(LocalNoteGraph { center, nodes, edges })
+    Ok(LocalNoteGraph {
+        center,
+        nodes,
+        edges,
+    })
 }
 
 #[tauri::command(rename_all = "snake_case")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,7 +118,8 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         None::<&str>,
     )?;
     #[cfg(target_os = "macos")]
-    let app_settings = MenuItem::with_id(app, "app.settings", "Settings…", true, Some("CmdOrCtrl+,"))?;
+    let app_settings =
+        MenuItem::with_id(app, "app.settings", "Settings…", true, Some("CmdOrCtrl+,"))?;
 
     #[cfg(target_os = "macos")]
     let app_menu = Submenu::with_items(
@@ -138,7 +139,8 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         ],
     )?;
 
-    let open_space = MenuItem::with_id(app, "space.open", "Open Space…", true, Some("CmdOrCtrl+O"))?;
+    let open_space =
+        MenuItem::with_id(app, "space.open", "Open Space…", true, Some("CmdOrCtrl+O"))?;
     let create_space = MenuItem::with_id(
         app,
         "space.create",
@@ -220,23 +222,16 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         None::<&str>,
     )?;
-    let editor_link_clear = MenuItem::with_id(
-        app,
-        "editor.link_clear",
-        "Remove Link",
-        true,
-        None::<&str>,
-    )?;
-    let editor_heading_1 = MenuItem::with_id(app, "editor.heading_1", "Heading 1", true, None::<&str>)?;
-    let editor_heading_2 = MenuItem::with_id(app, "editor.heading_2", "Heading 2", true, None::<&str>)?;
-    let editor_heading_3 = MenuItem::with_id(app, "editor.heading_3", "Heading 3", true, None::<&str>)?;
-    let editor_bullet_list = MenuItem::with_id(
-        app,
-        "editor.bullet_list",
-        "Bullet List",
-        true,
-        None::<&str>,
-    )?;
+    let editor_link_clear =
+        MenuItem::with_id(app, "editor.link_clear", "Remove Link", true, None::<&str>)?;
+    let editor_heading_1 =
+        MenuItem::with_id(app, "editor.heading_1", "Heading 1", true, None::<&str>)?;
+    let editor_heading_2 =
+        MenuItem::with_id(app, "editor.heading_2", "Heading 2", true, None::<&str>)?;
+    let editor_heading_3 =
+        MenuItem::with_id(app, "editor.heading_3", "Heading 3", true, None::<&str>)?;
+    let editor_bullet_list =
+        MenuItem::with_id(app, "editor.bullet_list", "Bullet List", true, None::<&str>)?;
     let editor_numbered_list = MenuItem::with_id(
         app,
         "editor.numbered_list",
@@ -244,15 +239,11 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         None::<&str>,
     )?;
-    let editor_todo_list = MenuItem::with_id(app, "editor.todo_list", "To-do List", true, None::<&str>)?;
+    let editor_todo_list =
+        MenuItem::with_id(app, "editor.todo_list", "To-do List", true, None::<&str>)?;
     let editor_quote = MenuItem::with_id(app, "editor.quote", "Quote", true, None::<&str>)?;
-    let editor_code_block = MenuItem::with_id(
-        app,
-        "editor.code_block",
-        "Code Block",
-        true,
-        None::<&str>,
-    )?;
+    let editor_code_block =
+        MenuItem::with_id(app, "editor.code_block", "Code Block", true, None::<&str>)?;
     let editor_mermaid_chart = MenuItem::with_id(
         app,
         "editor.mermaid_chart",
@@ -262,7 +253,13 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
     )?;
     let editor_table = MenuItem::with_id(app, "editor.table", "Table", true, None::<&str>)?;
     let editor_divider = MenuItem::with_id(app, "editor.divider", "Divider", true, None::<&str>)?;
-    let editor_callout_info = MenuItem::with_id(app, "editor.callout_info", "Info Callout", true, None::<&str>)?;
+    let editor_callout_info = MenuItem::with_id(
+        app,
+        "editor.callout_info",
+        "Info Callout",
+        true,
+        None::<&str>,
+    )?;
     let editor_callout_warning = MenuItem::with_id(
         app,
         "editor.callout_warning",
@@ -284,23 +281,33 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         None::<&str>,
     )?;
-    let editor_callout_tip = MenuItem::with_id(app, "editor.callout_tip", "Tip Callout", true, None::<&str>)?;
-    let editor_color_gray = MenuItem::with_id(app, "editor.color_gray", "Gray", true, None::<&str>)?;
-    let editor_color_brown = MenuItem::with_id(app, "editor.color_brown", "Brown", true, None::<&str>)?;
-    let editor_color_orange = MenuItem::with_id(app, "editor.color_orange", "Orange", true, None::<&str>)?;
-    let editor_color_yellow = MenuItem::with_id(app, "editor.color_yellow", "Yellow", true, None::<&str>)?;
-    let editor_color_green = MenuItem::with_id(app, "editor.color_green", "Green", true, None::<&str>)?;
-    let editor_color_blue = MenuItem::with_id(app, "editor.color_blue", "Blue", true, None::<&str>)?;
-    let editor_color_purple = MenuItem::with_id(app, "editor.color_purple", "Purple", true, None::<&str>)?;
+    let editor_callout_tip =
+        MenuItem::with_id(app, "editor.callout_tip", "Tip Callout", true, None::<&str>)?;
+    let editor_color_gray =
+        MenuItem::with_id(app, "editor.color_gray", "Gray", true, None::<&str>)?;
+    let editor_color_brown =
+        MenuItem::with_id(app, "editor.color_brown", "Brown", true, None::<&str>)?;
+    let editor_color_orange =
+        MenuItem::with_id(app, "editor.color_orange", "Orange", true, None::<&str>)?;
+    let editor_color_yellow =
+        MenuItem::with_id(app, "editor.color_yellow", "Yellow", true, None::<&str>)?;
+    let editor_color_green =
+        MenuItem::with_id(app, "editor.color_green", "Green", true, None::<&str>)?;
+    let editor_color_blue =
+        MenuItem::with_id(app, "editor.color_blue", "Blue", true, None::<&str>)?;
+    let editor_color_purple =
+        MenuItem::with_id(app, "editor.color_purple", "Purple", true, None::<&str>)?;
     let editor_color_red = MenuItem::with_id(app, "editor.color_red", "Red", true, None::<&str>)?;
     let editor_color_clear =
         MenuItem::with_id(app, "editor.color_clear", "Clear Color", true, None::<&str>)?;
     let editor_highlight_yellow =
         MenuItem::with_id(app, "editor.highlight_yellow", "Yellow", true, None::<&str>)?;
-    let editor_highlight_blue = MenuItem::with_id(app, "editor.highlight_blue", "Blue", true, None::<&str>)?;
+    let editor_highlight_blue =
+        MenuItem::with_id(app, "editor.highlight_blue", "Blue", true, None::<&str>)?;
     let editor_highlight_green =
         MenuItem::with_id(app, "editor.highlight_green", "Green", true, None::<&str>)?;
-    let editor_highlight_red = MenuItem::with_id(app, "editor.highlight_red", "Red", true, None::<&str>)?;
+    let editor_highlight_red =
+        MenuItem::with_id(app, "editor.highlight_red", "Red", true, None::<&str>)?;
     let editor_highlight_clear = MenuItem::with_id(
         app,
         "editor.highlight_clear",
@@ -323,7 +330,8 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         Some("CmdOrCtrl+Alt+Shift+A"),
     )?;
-    let open_ai_settings = MenuItem::with_id(app, "ai.settings", "AI Settings…", true, None::<&str>)?;
+    let open_ai_settings =
+        MenuItem::with_id(app, "ai.settings", "AI Settings…", true, None::<&str>)?;
 
     let file_menu = Submenu::with_items(
         app,

--- a/src-tauri/src/license/commands.rs
+++ b/src-tauri/src/license/commands.rs
@@ -1,13 +1,13 @@
 use tauri::AppHandle;
 use tracing::error;
 
-use super::{is_dev_force_licensed, is_official_build};
 use super::service::verify_license_key;
 use super::store::{license_path, read_record, write_record};
 use super::types::{
     build_status, build_status_for, ensure_trial_window, ensure_trial_window_from_activation,
     hash_license_key, mask_license_key, normalize_license_key, LicenseActivateResult,
 };
+use super::{is_dev_force_licensed, is_official_build};
 
 fn now_ms() -> u64 {
     std::time::SystemTime::now()

--- a/src/components/calendar/CalendarPane.tsx
+++ b/src/components/calendar/CalendarPane.tsx
@@ -517,7 +517,7 @@ export function CalendarPane({
 								type="button"
 								size="sm"
 								variant="outline"
-								className="calendarTaskAddIcon calendarTaskBtn"
+								className="calendarTaskBtn"
 								onClick={() => void submitTask()}
 								disabled={isSubmittingTask || !taskDraft.trim()}
 								aria-label="Add task"
@@ -532,7 +532,8 @@ export function CalendarPane({
 								type="button"
 								variant="outline"
 								size="sm"
-								className="calendarTaskBtn calendarOpenNoteBtn"
+								className="calendarTaskBtn"
+								data-size="sm"
 								onClick={openSelectedDailyNote}
 							>
 								<HugeiconsIcon
@@ -581,11 +582,6 @@ export function CalendarPane({
 									{renderTaskGroup("For this day", agendaTasks)}
 									{renderTaskGroup("Overdue", overdueTasks)}
 									{renderTaskGroup("Ongoing", ongoingTasks)}
-									{!hasAnyTasks ? (
-										<div className="calendarEmptyText">
-											No tasks for this day.
-										</div>
-									) : null}
 								</div>
 							</div>
 						</div>
@@ -601,7 +597,8 @@ export function CalendarPane({
 										type="button"
 										size="sm"
 										variant="outline"
-										className="calendarTaskBtn calendarToolbarIconBtn"
+										className="calendarTaskBtn"
+										data-size="icon"
 										onClick={() => stepRange(-1)}
 										aria-label="Previous month"
 									>
@@ -616,7 +613,8 @@ export function CalendarPane({
 										type="button"
 										size="sm"
 										variant="outline"
-										className="calendarTaskBtn calendarOpenNoteBtn"
+										className="calendarTaskBtn"
+										data-size="sm"
 										onClick={goToToday}
 									>
 										Today
@@ -625,7 +623,8 @@ export function CalendarPane({
 										type="button"
 										size="sm"
 										variant="outline"
-										className="calendarTaskBtn calendarToolbarIconBtn"
+										className="calendarTaskBtn"
+										data-size="icon"
 										onClick={() => stepRange(1)}
 										aria-label="Next month"
 									>

--- a/src/components/calendar/CalendarPane.tsx
+++ b/src/components/calendar/CalendarPane.tsx
@@ -434,10 +434,6 @@ export function CalendarPane({
 	const agendaTasks = selectedTasks?.for_day ?? [];
 	const overdueTasks = selectedTasks?.overdue ?? [];
 	const ongoingTasks = selectedTasks?.ongoing ?? [];
-	const hasAnyTasks =
-		agendaTasks.length > 0 ||
-		overdueTasks.length > 0 ||
-		ongoingTasks.length > 0;
 	const noteActivity = data?.detail.note_activity ?? [];
 
 	const effectiveSelectedRecentNotePath = useMemo(() => {

--- a/src/components/calendar/RecentNotesBoardStrip.tsx
+++ b/src/components/calendar/RecentNotesBoardStrip.tsx
@@ -35,9 +35,7 @@ export function RecentNotesBoardStrip({
 	return (
 		<ul className="calendarRecentList">
 			{notes.length === 0 ? (
-				<li className="calendarRecentListEmpty">
-					No activity notes for this day.
-				</li>
+				<li className="calendarRecentListEmpty">No notes for this day</li>
 			) : null}
 			{notes.map((note) => {
 				const title = noteTitle(note);

--- a/src/components/database/DatabaseSourceDialog.tsx
+++ b/src/components/database/DatabaseSourceDialog.tsx
@@ -480,11 +480,11 @@ export function DatabaseSourceDropdown({
 			>
 				<div className="flex items-center gap-3">
 					<span className="w-20 shrink-0 text-xs font-medium text-muted-foreground">
-						Save new files in
+						Save Files In
 					</span>
 					<DatabaseFolderPicker
 						value={config.new_note.folder}
-						placeholder="Choose a folder"
+						placeholder="Folder"
 						triggerClassName="databaseSourceInlinePicker"
 						onChange={(value) => void handleNewNoteFolder(value)}
 					/>

--- a/src/components/editor/CanvasNoteInlineEditor.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.tsx
@@ -2,8 +2,10 @@ import {
 	ArrowLeft,
 	ArrowRight,
 	Calendar03Icon,
+	Copy01Icon,
 	LocationAdd01Icon,
 	SourceCodeIcon,
+	Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -98,6 +100,7 @@ interface SelectionRibbonPosition {
 interface SelectedCodeBlockState {
 	top: number;
 	controlsLeft: number;
+	controlsRight: number;
 	previewLeft: number;
 	width: number;
 	previewTop: number;
@@ -407,6 +410,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 	const [codeBlockPickerOpen, setCodeBlockPickerOpen] = useState(false);
 	const [selectedCodeBlock, setSelectedCodeBlock] =
 		useState<SelectedCodeBlockState | null>(null);
+	const [codeBlockCopied, setCodeBlockCopied] = useState(false);
 	const [activeMermaidPreviewPos, setActiveMermaidPreviewPos] = useState<
 		number | null
 	>(null);
@@ -1054,6 +1058,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 		if (!editor || mode !== "rich") {
 			setSelectedCodeBlock(null);
 			setCodeBlockPickerOpen(false);
+			setCodeBlockCopied(false);
 			return;
 		}
 		const host = tiptapHostRef.current;
@@ -1065,6 +1070,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 			if (!selection?.anchorNode) {
 				setSelectedCodeBlock(null);
 				setCodeBlockPickerOpen(false);
+				setCodeBlockCopied(false);
 				return;
 			}
 			const anchorElement =
@@ -1074,6 +1080,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 			if (!anchorElement || !host.contains(anchorElement)) {
 				setSelectedCodeBlock(null);
 				setCodeBlockPickerOpen(false);
+				setCodeBlockCopied(false);
 				return;
 			}
 
@@ -1081,6 +1088,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 			if (!codeElement || !host.contains(codeElement)) {
 				setSelectedCodeBlock(null);
 				setCodeBlockPickerOpen(false);
+				setCodeBlockCopied(false);
 				return;
 			}
 
@@ -1088,12 +1096,14 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 			if (parentNode.type.name !== "codeBlock") {
 				setSelectedCodeBlock(null);
 				setCodeBlockPickerOpen(false);
+				setCodeBlockCopied(false);
 				return;
 			}
 
 			const codeOffset = getOffsetWithinAncestor(codeElement, host);
 			const nextTop = codeOffset.top + 8;
 			const nextControlsLeft = codeOffset.left + 10;
+			const nextControlsRight = codeOffset.left + codeElement.offsetWidth - 10;
 			const nextPreviewLeft = codeOffset.left;
 			const nextWidth = Math.max(220, codeElement.offsetWidth);
 			const nextPreviewTop = codeOffset.top + codeElement.offsetHeight + 12;
@@ -1109,6 +1119,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 					prev &&
 					prev.top === nextTop &&
 					prev.controlsLeft === nextControlsLeft &&
+					prev.controlsRight === nextControlsRight &&
 					prev.previewLeft === nextPreviewLeft &&
 					prev.width === nextWidth &&
 					prev.previewTop === nextPreviewTop &&
@@ -1118,9 +1129,11 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 				) {
 					return prev;
 				}
+				setCodeBlockCopied(false);
 				return {
 					top: nextTop,
 					controlsLeft: nextControlsLeft,
+					controlsRight: nextControlsRight,
 					previewLeft: nextPreviewLeft,
 					width: nextWidth,
 					previewTop: nextPreviewTop,
@@ -1593,6 +1606,39 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 									</button>
 								) : null}
 							</div>
+						) : null}
+						{canEdit && selectedCodeBlock ? (
+							<button
+								type="button"
+								className="codeBlockCopyBtn"
+								data-copied={codeBlockCopied || undefined}
+								style={{
+									top: `${selectedCodeBlock.top}px`,
+									left: `${selectedCodeBlock.controlsRight}px`,
+								}}
+								onMouseDown={preventCodeBlockPickerMouseDown}
+								onClick={() => {
+									if (!selectedCodeBlock) return;
+									const clipboard = navigator.clipboard;
+									if (!clipboard?.writeText) {
+										console.error("Clipboard API unavailable");
+										return;
+									}
+									void clipboard
+										.writeText(selectedCodeBlock.source)
+										.then(() => {
+											setCodeBlockCopied(true);
+											window.setTimeout(() => setCodeBlockCopied(false), 1500);
+										});
+								}}
+								title={codeBlockCopied ? "Copied!" : "Copy code to clipboard"}
+							>
+								<HugeiconsIcon
+									icon={codeBlockCopied ? Tick02Icon : Copy01Icon}
+									size={12}
+									strokeWidth={0.9}
+								/>
+							</button>
 						) : null}
 						{canEdit && selectedCodeBlock && isSelectedMermaidPreviewActive ? (
 							<MermaidPreviewPanel

--- a/src/components/editor/CanvasNoteInlineEditor.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.tsx
@@ -109,6 +109,25 @@ interface SelectedCodeBlockState {
 	source: string;
 }
 
+function areSelectedCodeBlocksEqual(
+	a: SelectedCodeBlockState | null,
+	b: SelectedCodeBlockState | null,
+): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	return (
+		a.top === b.top &&
+		a.controlsLeft === b.controlsLeft &&
+		a.controlsRight === b.controlsRight &&
+		a.previewLeft === b.previewLeft &&
+		a.width === b.width &&
+		a.previewTop === b.previewTop &&
+		a.pos === b.pos &&
+		a.language === b.language &&
+		a.source === b.source
+	);
+}
+
 interface SelectedTableState {
 	rowControlLeft: number;
 	rowControlTop: number;
@@ -410,6 +429,8 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 	const [codeBlockPickerOpen, setCodeBlockPickerOpen] = useState(false);
 	const [selectedCodeBlock, setSelectedCodeBlock] =
 		useState<SelectedCodeBlockState | null>(null);
+	const selectedCodeBlockRef = useRef<SelectedCodeBlockState | null>(null);
+	const codeBlockCopyResetTimerRef = useRef<number | null>(null);
 	const [codeBlockCopied, setCodeBlockCopied] = useState(false);
 	const [activeMermaidPreviewPos, setActiveMermaidPreviewPos] = useState<
 		number | null
@@ -1056,6 +1077,11 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 
 	useEffect(() => {
 		if (!editor || mode !== "rich") {
+			selectedCodeBlockRef.current = null;
+			if (codeBlockCopyResetTimerRef.current !== null) {
+				window.clearTimeout(codeBlockCopyResetTimerRef.current);
+				codeBlockCopyResetTimerRef.current = null;
+			}
 			setSelectedCodeBlock(null);
 			setCodeBlockPickerOpen(false);
 			setCodeBlockCopied(false);
@@ -1065,12 +1091,21 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 		const contentRoot = getMountedEditorContentRoot(host);
 		if (!host || !contentRoot) return;
 
+		const clearSelectedCodeBlock = () => {
+			selectedCodeBlockRef.current = null;
+			if (codeBlockCopyResetTimerRef.current !== null) {
+				window.clearTimeout(codeBlockCopyResetTimerRef.current);
+				codeBlockCopyResetTimerRef.current = null;
+			}
+			setSelectedCodeBlock(null);
+			setCodeBlockPickerOpen(false);
+			setCodeBlockCopied(false);
+		};
+
 		const syncSelectedCodeBlock = () => {
 			const selection = window.getSelection();
 			if (!selection?.anchorNode) {
-				setSelectedCodeBlock(null);
-				setCodeBlockPickerOpen(false);
-				setCodeBlockCopied(false);
+				clearSelectedCodeBlock();
 				return;
 			}
 			const anchorElement =
@@ -1078,25 +1113,19 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 					? selection.anchorNode
 					: selection.anchorNode.parentElement;
 			if (!anchorElement || !host.contains(anchorElement)) {
-				setSelectedCodeBlock(null);
-				setCodeBlockPickerOpen(false);
-				setCodeBlockCopied(false);
+				clearSelectedCodeBlock();
 				return;
 			}
 
 			const codeElement = anchorElement.closest("pre") as HTMLElement | null;
 			if (!codeElement || !host.contains(codeElement)) {
-				setSelectedCodeBlock(null);
-				setCodeBlockPickerOpen(false);
-				setCodeBlockCopied(false);
+				clearSelectedCodeBlock();
 				return;
 			}
 
 			const parentNode = editor.state.selection.$from.parent;
 			if (parentNode.type.name !== "codeBlock") {
-				setSelectedCodeBlock(null);
-				setCodeBlockPickerOpen(false);
-				setCodeBlockCopied(false);
+				clearSelectedCodeBlock();
 				return;
 			}
 
@@ -1114,33 +1143,30 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 			const nextPos = editor.state.selection.$from.before();
 			const nextSource = parentNode.textContent ?? "";
 
-			setSelectedCodeBlock((prev) => {
-				if (
-					prev &&
-					prev.top === nextTop &&
-					prev.controlsLeft === nextControlsLeft &&
-					prev.controlsRight === nextControlsRight &&
-					prev.previewLeft === nextPreviewLeft &&
-					prev.width === nextWidth &&
-					prev.previewTop === nextPreviewTop &&
-					prev.pos === nextPos &&
-					prev.language === nextLanguage &&
-					prev.source === nextSource
-				) {
-					return prev;
+			const nextCodeBlock = {
+				top: nextTop,
+				controlsLeft: nextControlsLeft,
+				controlsRight: nextControlsRight,
+				previewLeft: nextPreviewLeft,
+				width: nextWidth,
+				previewTop: nextPreviewTop,
+				pos: nextPos,
+				language: nextLanguage,
+				source: nextSource,
+			} satisfies SelectedCodeBlockState;
+			if (
+				!areSelectedCodeBlocksEqual(selectedCodeBlockRef.current, nextCodeBlock)
+			) {
+				selectedCodeBlockRef.current = nextCodeBlock;
+				if (codeBlockCopyResetTimerRef.current !== null) {
+					window.clearTimeout(codeBlockCopyResetTimerRef.current);
+					codeBlockCopyResetTimerRef.current = null;
 				}
 				setCodeBlockCopied(false);
-				return {
-					top: nextTop,
-					controlsLeft: nextControlsLeft,
-					controlsRight: nextControlsRight,
-					previewLeft: nextPreviewLeft,
-					width: nextWidth,
-					previewTop: nextPreviewTop,
-					pos: nextPos,
-					language: nextLanguage,
-					source: nextSource,
-				};
+			}
+			setSelectedCodeBlock((prev) => {
+				if (areSelectedCodeBlocksEqual(prev, nextCodeBlock)) return prev;
+				return nextCodeBlock;
 			});
 		};
 
@@ -1154,6 +1180,10 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 		editor.on("selectionUpdate", syncSelectedCodeBlock);
 		editor.on("transaction", syncSelectedCodeBlock);
 		return () => {
+			if (codeBlockCopyResetTimerRef.current !== null) {
+				window.clearTimeout(codeBlockCopyResetTimerRef.current);
+				codeBlockCopyResetTimerRef.current = null;
+			}
 			scrollHost?.removeEventListener("scroll", syncSelectedCodeBlock);
 			window.removeEventListener("resize", syncSelectedCodeBlock);
 			document.removeEventListener("selectionchange", syncSelectedCodeBlock);
@@ -1299,6 +1329,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 		const target = event.target instanceof HTMLElement ? event.target : null;
 		if (
 			target?.closest(".codeBlockPreviewBtn") ||
+			target?.closest(".codeBlockCopyBtn") ||
 			target?.closest(".codeBlockLanguageBtn") ||
 			target?.closest(".codeBlockLanguagePopover")
 		) {
@@ -1622,13 +1653,30 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 									const clipboard = navigator.clipboard;
 									if (!clipboard?.writeText) {
 										console.error("Clipboard API unavailable");
+										setCodeBlockCopied(false);
 										return;
 									}
 									void clipboard
 										.writeText(selectedCodeBlock.source)
 										.then(() => {
+											if (codeBlockCopyResetTimerRef.current !== null) {
+												window.clearTimeout(codeBlockCopyResetTimerRef.current);
+											}
 											setCodeBlockCopied(true);
-											window.setTimeout(() => setCodeBlockCopied(false), 1500);
+											codeBlockCopyResetTimerRef.current = window.setTimeout(
+												() => {
+													codeBlockCopyResetTimerRef.current = null;
+													setCodeBlockCopied(false);
+												},
+												1500,
+											);
+										})
+										.catch((error: unknown) => {
+											console.error(
+												"Failed to copy code block contents.",
+												error,
+											);
+											setCodeBlockCopied(false);
 										});
 								}}
 								title={codeBlockCopied ? "Copied!" : "Copy code to clipboard"}

--- a/src/components/editor/CanvasNoteInlineEditor.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.tsx
@@ -128,6 +128,15 @@ function areSelectedCodeBlocksEqual(
 	);
 }
 
+function areSelectedCodeBlocksSameBlock(
+	a: SelectedCodeBlockState | null,
+	b: SelectedCodeBlockState | null,
+): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	return a.pos === b.pos && a.language === b.language && a.source === b.source;
+}
+
 interface SelectedTableState {
 	rowControlLeft: number;
 	rowControlTop: number;
@@ -1155,7 +1164,10 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 				source: nextSource,
 			} satisfies SelectedCodeBlockState;
 			if (
-				!areSelectedCodeBlocksEqual(selectedCodeBlockRef.current, nextCodeBlock)
+				!areSelectedCodeBlocksSameBlock(
+					selectedCodeBlockRef.current,
+					nextCodeBlock,
+				)
 			) {
 				selectedCodeBlockRef.current = nextCodeBlock;
 				if (codeBlockCopyResetTimerRef.current !== null) {

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -1,10 +1,3 @@
-import {
-	Calendar03Icon,
-	FileAttachmentIcon,
-	Globe02Icon,
-	SearchIcon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useState } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
@@ -21,11 +14,7 @@ import { invoke } from "../../lib/tauri";
 import { Trash2 } from "../Icons";
 import { FolderOpen } from "../Icons/NavigationIcons";
 import { Button } from "../ui/shadcn/button";
-import {
-	SettingsRow,
-	SettingsSection,
-	SettingsValueCard,
-} from "./SettingsScaffold";
+import { SettingsRow, SettingsSection } from "./SettingsScaffold";
 import { TemplateSettingsSections } from "./TemplatesSettingsPane";
 
 const DEFAULT_ATTACHMENT_FOLDER = "assets";
@@ -256,20 +245,11 @@ export function SpaceSettingsPane() {
 					>
 						<div className="dailyNotesFolderField">
 							<div className="dailyNotesFolderRow">
-								<SettingsValueCard
-									icon={
-										<HugeiconsIcon
-											icon={Calendar03Icon}
-											size={14}
-											strokeWidth={0.9}
-										/>
-									}
-									value={
-										dailyNotesLoading
-											? "Loading..."
-											: (dailyNotesFolder ?? "Not configured")
-									}
-								/>
+								<div className="dailyNotesFolderPath">
+									{dailyNotesLoading
+										? "Loading..."
+										: (dailyNotesFolder ?? "Not configured")}
+								</div>
 								<div className="settingsActions dailyNotesActions">
 									<Button
 										type="button"
@@ -313,7 +293,7 @@ export function SpaceSettingsPane() {
 				>
 					<SettingsRow
 						label="Location"
-						description="Glyph saves pasted images and other note attachments here, then inserts relative Markdown paths so they still render after reopening the app."
+						description="Where to save images and files you paste into notes."
 						stacked
 						interactive={false}
 					>
@@ -337,27 +317,18 @@ export function SpaceSettingsPane() {
 							</select>
 							<div className="settingsHelp">
 								{attachmentStorageMode === "space-root"
-									? "Attachments are saved directly in the top level of the current space."
+									? "Saved at the top level of your space."
 									: attachmentStorageMode === "note-folder"
-										? "Attachments are saved beside the note that receives them."
-										: "Choose a folder inside the current space for all note attachments."}
+										? "Saved next to the note they are attached to."
+										: "All attachments go in one folder."}
 							</div>
 							{attachmentStorageMode === "specific-folder" ? (
 								<div className="dailyNotesFolderRow">
-									<SettingsValueCard
-										icon={
-											<HugeiconsIcon
-												icon={FileAttachmentIcon}
-												size={14}
-												strokeWidth={0.9}
-											/>
-										}
-										value={
-											attachmentsLoading
-												? "Loading..."
-												: attachmentFolder || DEFAULT_ATTACHMENT_FOLDER
-										}
-									/>
+									<div className="dailyNotesFolderPath">
+										{attachmentsLoading
+											? "Loading..."
+											: attachmentFolder || DEFAULT_ATTACHMENT_FOLDER}
+									</div>
 									<div className="settingsActions dailyNotesActions">
 										<Button
 											type="button"
@@ -400,26 +371,17 @@ export function SpaceSettingsPane() {
 				>
 					<SettingsRow
 						label="Folder"
-						description="Web pages saved from the command palette will be stored here as Markdown files."
+						description="Where saved web pages are stored as Markdown."
 						stacked
 						interactive={false}
 					>
 						<div className="dailyNotesFolderField">
 							<div className="dailyNotesFolderRow">
-								<SettingsValueCard
-									icon={
-										<HugeiconsIcon
-											icon={Globe02Icon}
-											size={14}
-											strokeWidth={0.9}
-										/>
-									}
-									value={
-										webClippingsLoading
-											? "Loading..."
-											: (webClippingsFolder ?? "Space root")
-									}
-								/>
+								<div className="dailyNotesFolderPath">
+									{webClippingsLoading
+										? "Loading..."
+										: (webClippingsFolder ?? "Space root")}
+								</div>
 								<div className="settingsActions dailyNotesActions">
 									<Button
 										type="button"
@@ -481,15 +443,10 @@ export function SpaceSettingsPane() {
 						stacked
 						interactive={false}
 					>
-						<SettingsValueCard
-							icon={
-								<HugeiconsIcon icon={SearchIcon} size={14} strokeWidth={0.9} />
-							}
-							value={
-								reindexStatus ||
-								(!currentSpacePath ? "No space selected." : "Index is ready.")
-							}
-						/>
+						<div className="dailyNotesFolderPath" data-compact>
+							{reindexStatus ||
+								(!currentSpacePath ? "No space selected." : "Index is ready.")}
+						</div>
 					</SettingsRow>
 				</SettingsSection>
 			</div>

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -443,7 +443,7 @@ export function SpaceSettingsPane() {
 						stacked
 						interactive={false}
 					>
-						<div className="dailyNotesFolderPath" data-compact>
+						<div className="settingsCompactStatus">
 							{reindexStatus ||
 								(!currentSpacePath ? "No space selected." : "Index is ready.")}
 						</div>

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { clearAiPanelCaches } from "../components/ai/cache";
 import { clearInlineImageHydrationCache } from "../components/editor/hooks/useHydrateInlineImages";
+import { invalidateNavigationPrefetch } from "../lib/navigationPrefetch";
 import {
 	clearCurrentSpacePath,
 	loadSettings,
@@ -140,6 +141,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 					await clearCurrentSpacePath();
 					clearAiPanelCaches();
 					clearInlineImageHydrationCache();
+					invalidateNavigationPrefetch();
 					setSpacePath(null);
 					setSpaceSchemaVersion(null);
 				}
@@ -174,6 +176,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			await clearCurrentSpacePath();
 			clearAiPanelCaches();
 			clearInlineImageHydrationCache();
+			invalidateNavigationPrefetch();
 			setSpacePath(null);
 			setSpaceSchemaVersion(null);
 		} catch (err) {

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -2,20 +2,23 @@
 	"versions": [
 		{
 			"version": "0.2.7",
-			"publishedAt": "2026-04-10",
+			"publishedAt": "2026-04-14",
 			"sections": [
 				{
 					"category": "Added",
 					"items": [
-						"Introduced a context-aware Markdown menu that surfaces the full rich-formatting toolkit only when editing Markdown, delivering a cleaner, distraction-free menubar everywhere else.",
-						"Refined Calendar Activity into a clean, command-palette-style note list with title-plus-folder scanning for faster daily context"
+						"Cleaner menus — formatting options only appear when you are editing Markdown, keeping the menubar simple the rest of the time.",
+						"Refined Calendar Activity into a clean, command-palette-style note list with title-plus-folder scanning for faster daily context",
+						"Copy button on code blocks — grab code snippets with a single click, with a satisfying checkmark to confirm"
 					]
 				},
 				{
 					"category": "Improved",
 					"items": [
 						"Improved Dark Mode accessibility with refined contrast and readability so every screen feels more comfortable and polished after hours",
-						"Glyph now keeps saving normally on SMB and NAS shares, and only skips the unsupported sync call when the filesystem reports that it cannot handle it"
+						"Glyph now keeps saving normally on SMB and NAS shares, and only skips the unsupported sync call when the filesystem reports that it cannot handle it",
+						"Streamlined calendar button styling for a more consistent and polished appearance across all controls",
+						"Settings UI refresh — cleaner folder paths and simpler descriptions throughout the Space settings"
 					]
 				}
 			]

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -1,4 +1,7 @@
-import { setCachedMarkdownDoc } from "../components/preview/markdownCache";
+import {
+	clearMarkdownDocCache,
+	setCachedMarkdownDoc,
+} from "../components/preview/markdownCache";
 import { buildMonthRange } from "./calendar";
 import type {
 	AllDocsItem,
@@ -43,6 +46,7 @@ const databaseRowsPromiseCache = new Map<
 
 const allDocsCache = new Map<string, AllDocsItem[]>();
 const allDocsPromiseCache = new Map<string, Promise<AllDocsItem[]>>();
+let cacheGeneration = 0;
 
 function trimCache<T>(
 	cache: Map<string, T>,
@@ -72,6 +76,7 @@ async function flushQueuedNotePrefetch() {
 	);
 	if (!missingPaths.length) return;
 
+	const generation = cacheGeneration;
 	const batchPromise = invoke("space_read_texts_batch", {
 		paths: missingPaths,
 	});
@@ -81,6 +86,9 @@ async function flushQueuedNotePrefetch() {
 			path,
 			batchPromise
 				.then((docs) => {
+					if (generation !== cacheGeneration) {
+						return null;
+					}
 					const match = docs.find((entry) => entry.rel_path === path);
 					if (
 						!match ||
@@ -241,6 +249,7 @@ export function prefetchCalendarData(args: {
 	if (existingPromise) return existingPromise;
 
 	const range = buildMonthRange(args.anchorDate);
+	const generation = cacheGeneration;
 	const promise = invoke("calendar_query_range", {
 		start_date: range.start,
 		end_date: range.end,
@@ -248,8 +257,10 @@ export function prefetchCalendarData(args: {
 		daily_notes_folder: args.dailyNotesFolder,
 	})
 		.then((result) => {
-			calendarDataCache.set(key, result);
-			trimCache(calendarDataCache);
+			if (generation === cacheGeneration) {
+				calendarDataCache.set(key, result);
+				trimCache(calendarDataCache);
+			}
 			return result;
 		})
 		.finally(() => {
@@ -280,9 +291,12 @@ export function prefetchDatabaseSummaries() {
 	if (databaseSummariesCache.promise) {
 		return databaseSummariesCache.promise;
 	}
+	const generation = cacheGeneration;
 	const promise = invoke("databases_list")
 		.then((result) => {
-			databaseSummariesCache.data = result;
+			if (generation === cacheGeneration) {
+				databaseSummariesCache.data = result;
+			}
 			return result;
 		})
 		.finally(() => {
@@ -310,10 +324,13 @@ export function prefetchDatabaseDocument(databaseId: string) {
 	if (cached) return Promise.resolve(cached);
 	const existingPromise = databaseDocumentPromiseCache.get(normalized);
 	if (existingPromise) return existingPromise;
+	const generation = cacheGeneration;
 	const promise = invoke("databases_get", { database_id: normalized })
 		.then((result) => {
-			databaseDocumentCache.set(normalized, result);
-			trimCache(databaseDocumentCache);
+			if (generation === cacheGeneration) {
+				databaseDocumentCache.set(normalized, result);
+				trimCache(databaseDocumentCache);
+			}
 			return result;
 		})
 		.finally(() => {
@@ -342,10 +359,13 @@ export function prefetchDatabaseRows(databaseId: string, viewId: string) {
 	if (cached) return Promise.resolve(cached);
 	const existingPromise = databaseRowsPromiseCache.get(key);
 	if (existingPromise) return existingPromise;
+	const generation = cacheGeneration;
 	const promise = loadAllDatabaseRows(databaseId, viewId)
 		.then((result) => {
-			databaseRowsCache.set(key, result);
-			trimCache(databaseRowsCache);
+			if (generation === cacheGeneration) {
+				databaseRowsCache.set(key, result);
+				trimCache(databaseRowsCache);
+			}
 			return result;
 		})
 		.finally(() => {
@@ -418,6 +438,7 @@ export function prefetchAllDocs(folderPrefix?: string | null) {
 	if (cached) return Promise.resolve(cached);
 	const existingPromise = allDocsPromiseCache.get(key);
 	if (existingPromise) return existingPromise;
+	const generation = cacheGeneration;
 	const promise = invoke("all_docs_list", {
 		limit: 2000,
 		folder_prefix: folderPrefix?.trim() ? folderPrefix : null,
@@ -437,8 +458,10 @@ export function prefetchAllDocs(folderPrefix?: string | null) {
 								normalizedPath.startsWith(`${normalized}/`)
 							);
 						});
-			allDocsCache.set(key, nextItems);
-			trimCache(allDocsCache);
+			if (generation === cacheGeneration) {
+				allDocsCache.set(key, nextItems);
+				trimCache(allDocsCache);
+			}
 			return nextItems;
 		})
 		.finally(() => {
@@ -461,4 +484,14 @@ export function invalidateAllDocsPrefetch(folderPrefix?: string | null) {
 	}
 	allDocsCache.clear();
 	allDocsPromiseCache.clear();
+}
+
+export function invalidateNavigationPrefetch() {
+	cacheGeneration += 1;
+	invalidatePrefetchedNote();
+	clearMarkdownDocCache();
+	invalidateCalendarPrefetch();
+	invalidateDatabaseSummariesPrefetch();
+	invalidateDatabasePrefetch();
+	invalidateAllDocsPrefetch();
 }

--- a/src/styles/app/11-settings-misc.css
+++ b/src/styles/app/11-settings-misc.css
@@ -170,6 +170,11 @@
 	border-radius: var(--radius-lg);
 }
 
+.dailyNotesFolderPath[data-compact] {
+	flex: 0 0 auto;
+	align-self: flex-end;
+}
+
 .dailyNotesError {
 	margin-top: 0;
 }

--- a/src/styles/app/11-settings-misc.css
+++ b/src/styles/app/11-settings-misc.css
@@ -175,6 +175,19 @@
 	align-self: flex-end;
 }
 
+.settingsCompactStatus {
+	align-self: flex-end;
+	padding: 8px 10px;
+	font-size: var(--text-xs);
+	line-height: 1.45;
+	color: var(--text-secondary);
+	word-break: normal;
+	overflow-wrap: normal;
+	border: 1px solid color-mix(in srgb, var(--border-light) 70%, transparent);
+	background: var(--settings-surface-soft);
+	border-radius: var(--radius-lg);
+}
+
 .dailyNotesError {
 	margin-top: 0;
 }

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -310,11 +310,11 @@
 			(2 * var(--readable-content-gutter-compact))
 		)
 	);
-	margin: 0 auto var(--space-1);
+	margin: 0 auto var(--space-2);
 	border: none;
-	border-radius: 0;
-	padding: 0 14px;
-	background: transparent;
+	border-radius: 10px;
+	padding: 10px 14px;
+	background: var(--bg-secondary);
 	color: var(--text-secondary);
 	font-size: var(--text-xs);
 }

--- a/src/styles/app/24-node-note-editor-b.css
+++ b/src/styles/app/24-node-note-editor-b.css
@@ -1613,6 +1613,36 @@ input.notePropertyValue {
 	white-space: nowrap;
 }
 
+.codeBlockCopyBtn {
+	position: absolute;
+	z-index: 15;
+	width: 22px;
+	height: 18px;
+	padding: 0;
+	border: none;
+	border-radius: var(--radius-sm);
+	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
+	color: color-mix(in srgb, var(--text-tertiary) 88%, transparent);
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 10px;
+	font-weight: var(--font-medium);
+	backdrop-filter: blur(4px);
+	cursor: pointer;
+	transition: color 150ms ease, background-color 150ms ease;
+	transform: translateX(-100%);
+}
+
+.codeBlockCopyBtn:hover {
+	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-hover));
+	color: var(--text-primary);
+}
+
+.codeBlockCopyBtn[data-copied] {
+	color: var(--success);
+}
+
 .codeBlockLanguagePopover {
 	width: 176px;
 	padding: 8px;

--- a/src/styles/app/37-database-pickers.css
+++ b/src/styles/app/37-database-pickers.css
@@ -575,6 +575,10 @@
 	padding: 2px 4px 2px 8px;
 }
 
+.databaseColumnDropdownRow:hover {
+	background: transparent;
+}
+
 .databaseColumnDropdownButton {
 	display: flex;
 	align-items: center;
@@ -588,6 +592,11 @@
 	color: var(--text-secondary);
 	text-align: left;
 	cursor: pointer;
+}
+
+.databaseColumnDropdownButton:hover {
+	background: transparent;
+	color: var(--text-secondary);
 }
 
 .databaseColumnDropdownMain {

--- a/src/styles/app/42-calendar.css
+++ b/src/styles/app/42-calendar.css
@@ -148,17 +148,10 @@
 	padding: 0;
 }
 
-.calendarToolbarIconBtn {
-	flex: 0 0 auto;
-	width: 28px;
-	height: 28px;
-	padding: 0;
-}
-
 .calendarTaskBtn {
 	border: 1px solid
 		color-mix(in srgb, var(--interactive-accent) 72%, var(--border-strong));
-	border-radius: 10px;
+	border-radius: var(--radius-md);
 	background: var(--interactive-accent);
 	color: var(--text-inverse);
 	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
@@ -169,26 +162,14 @@
 	color: var(--text-inverse);
 }
 
-.calendarTaskAddIcon.calendarTaskBtn {
-	border: 1px solid
-		color-mix(in srgb, var(--interactive-accent) 72%, var(--border-strong));
-	border-radius: 10px;
-	background: var(--interactive-accent);
+.calendarTaskBtn[data-size="icon"] {
+	flex: 0 0 auto;
+	width: 28px;
+	height: 28px;
+	padding: 0;
 }
 
-.calendarTaskAddIcon.calendarTaskBtn:disabled {
-	background: var(--interactive-accent);
-	border-color: color-mix(
-		in srgb,
-		var(--interactive-accent) 72%,
-		var(--border-strong)
-	);
-	color: var(--text-inverse);
-	opacity: 1;
-	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
-}
-
-.calendarOpenNoteBtn {
+.calendarTaskBtn[data-size="sm"] {
 	height: 28px;
 	padding-top: 0;
 	padding-bottom: 0;
@@ -641,7 +622,6 @@
 	padding: 8px 12px;
 	font-size: 0.8rem;
 	color: var(--text-tertiary, var(--text-secondary));
-	font-style: italic;
 }
 
 /* ── Empty / error / loading ── */

--- a/website/src/pages/manifesto.astro
+++ b/website/src/pages/manifesto.astro
@@ -1,0 +1,233 @@
+---
+import logoG from "../../assets/logo_g.PNG";
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Manifesto - Glyph" description="Why I built Glyph. A quiet place for your thoughts in a noisy world." bodyClass="has-dot-grid">
+	<div class="manifesto-page">
+		<header class="manifesto-header">
+			<a href="/" class="manifesto-logo">
+				<img src={logoG.src} alt="" class="manifesto-logo-icon" />
+				<span>GLYPH</span>
+			</a>
+			<a href="/" class="manifesto-home">Back home</a>
+		</header>
+
+		<main class="manifesto-main">
+			<p class="manifesto-label">MANIFESTO</p>
+			<h1>Reclaiming your thoughts from the noise</h1>
+
+			<div class="manifesto-body">
+				<section class="manifesto-section">
+					<p class="section-numeral">I</p>
+					<p>Where do your ideas go?</p>
+					<p>
+						Into apps that sync to someone else's server. Into feeds that
+						rearrange your words for engagement. Into tools that lock your
+						thinking behind a subscription, an API call, a terms-of-service
+						update you never read.
+					</p>
+					<p>
+						You opened a blank page to think. Somewhere along the way, thinking
+						became a product, and you became the input.
+					</p>
+				</section>
+
+				<section class="manifesto-section">
+					<p class="section-numeral">II</p>
+					<p>Ideas need a home that belongs to you.</p>
+					<p>
+						Not a platform. Not a cloud. Not a workspace with seventeen
+						integrations and a Kanban board. A place as simple and direct as pen
+						on paper, except your paper can link to other paper, search itself,
+						and never run out of room.
+					</p>
+					<p>
+						Your notes should live on your machine, in files you can open with
+						anything, files that will outlast every app that ever claimed to
+						organize your life.
+					</p>
+				</section>
+
+				<section class="manifesto-section">
+					<p class="section-numeral">III</p>
+					<p>Good tools get out of the way.</p>
+					<p>
+						A good notebook does not ping you. It does not suggest you upgrade,
+						collaborate, or share. It does not harvest your half-formed thoughts
+						to train a model. It sits quietly until you need it, and when you do,
+						it opens fast and stays steady.
+					</p>
+					<p>
+						AI can sharpen thinking, when you control it. When you choose the
+						model, own the context, and can pull the plug without losing a word.
+						Intelligence should serve the writer, never surveil them.
+					</p>
+				</section>
+
+				<section class="manifesto-section">
+					<p class="section-numeral">IV</p>
+					<p>Complexity is a slow poison.</p>
+					<p>
+						Every feature you do not need is friction you carry. Every toggle,
+						panel, and permission system is a small tax on your attention. The
+						tools that endure are the ones that do less, and do it so well you
+						forget they are there.
+					</p>
+					<p>
+						I would rather ship fewer things that feel right than many things
+						that feel busy.
+					</p>
+				</section>
+
+				<section class="manifesto-section">
+					<p class="section-numeral">V</p>
+					<p>Your freedom is already here.</p>
+					<p>
+						Markdown files on your disk. A local database only your machine
+						touches. No account required, no internet required, no permission
+						required. If Glyph disappeared tomorrow, your notes would still be
+						yours. Readable, portable, complete.
+					</p>
+					<p>
+						That is not a feature. That is the point.
+					</p>
+				</section>
+
+				<div class="manifesto-coda">
+					<p>Open the page.</p>
+					<p>Write the thought.</p>
+					<p>Own the words.</p>
+				</div>
+			</div>
+		</main>
+	</div>
+</Layout>
+
+<style>
+	.manifesto-page {
+		width: min(680px, 90vw);
+		margin: 0 auto;
+		padding: 2.5rem 0 5rem;
+	}
+
+	.manifesto-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 3rem;
+	}
+
+	.manifesto-logo {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.14em;
+	}
+
+	.manifesto-logo-icon {
+		width: 1.25rem;
+		height: 1.25rem;
+		border-radius: 4px;
+	}
+
+	.manifesto-home {
+		font-size: 0.72rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--muted);
+		border-bottom: 1px solid transparent;
+		transition: color 0.15s ease, border-color 0.15s ease;
+	}
+
+	.manifesto-home:hover {
+		color: var(--ink);
+		border-color: rgba(17, 17, 17, 0.2);
+	}
+
+	.manifesto-label {
+		font-size: 0.68rem;
+		font-weight: 500;
+		letter-spacing: 0.18em;
+		color: var(--faint);
+		margin-bottom: 0.85rem;
+	}
+
+	h1 {
+		font-family: var(--serif);
+		font-size: clamp(2.2rem, 5vw, 3.2rem);
+		font-style: italic;
+		font-weight: 400;
+		letter-spacing: -0.02em;
+		line-height: 1.12;
+		margin-bottom: 2.5rem;
+	}
+
+	.manifesto-body {
+		display: grid;
+		gap: 2.5rem;
+	}
+
+	.manifesto-section {
+		display: grid;
+		gap: 0.9rem;
+	}
+
+	.section-numeral {
+		font-family: var(--serif);
+		font-size: 1.15rem;
+		font-style: italic;
+		color: var(--faint);
+		margin-bottom: 0.15rem;
+	}
+
+	.manifesto-section p:not(.section-numeral) {
+		font-size: 0.95rem;
+		line-height: 1.85;
+		color: var(--muted);
+	}
+
+	.manifesto-section p:not(.section-numeral):first-of-type + p,
+	.manifesto-section p:nth-of-type(2) {
+		color: var(--muted);
+	}
+
+	.manifesto-section > p:nth-child(2) {
+		font-family: var(--sans);
+		font-size: 1.05rem;
+		font-weight: 500;
+		color: var(--ink);
+		line-height: 1.6;
+	}
+
+	.manifesto-coda {
+		margin-top: 1.5rem;
+		padding-top: 2rem;
+		border-top: 1px solid var(--border);
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	.manifesto-coda p {
+		font-family: var(--serif);
+		font-size: 1.3rem;
+		font-style: italic;
+		color: var(--ink);
+		line-height: 1.5;
+	}
+
+	@media (max-width: 640px) {
+		.manifesto-page {
+			padding-top: 1.75rem;
+		}
+
+		.manifesto-header {
+			flex-direction: column;
+			align-items: flex-start;
+			margin-bottom: 2.25rem;
+		}
+	}
+</style>

--- a/website/src/sections/FAQ.astro
+++ b/website/src/sections/FAQ.astro
@@ -14,7 +14,7 @@ const faqs = [
 	},
 	{
 		q: "I can't afford it at the listed price. What should I do?",
-		a: `Please reach out on <a href="https://x.com/karat_sidhu" target="_blank" rel="noopener" style="text-decoration:underline">Twitter (I refuse to call it X)</a> or email <a href="mailto:karatsidhu@gmail.com" style="text-decoration:underline">karatsidhu@gmail.com</a>. I built this solo and I know what it's like to stretch a budget. Students, indie devs, anyone who needs a break — just ask. I'll hook you up.`,
+		a: `I offer a 50% discount for students and indie developers. Reach out on <a href="https://x.com/karat_sidhu" target="_blank" rel="noopener" style="text-decoration:underline">Twitter (I refuse to call it X)</a> or email <a href="mailto:karatsidhu@gmail.com" style="text-decoration:underline">karatsidhu@gmail.com</a> — I built this solo and I know what it's like to stretch a budget. We'll work something out.`,
 	},
 	{
 		q: "Is it open source?",

--- a/website/src/sections/Header.astro
+++ b/website/src/sections/Header.astro
@@ -12,9 +12,7 @@ import { downloadUrl } from "../lib/site";
 	<nav class="nav">
 		<a href="#features">Features</a>
 		<a href="#pricing">Pricing</a>
-		<a href="#faq">FAQs</a>
-		<a href="https://docs.glyphformac.com" target="_blank" rel="noopener">Docs</a>
-		<a href="https://github.com/SidhuK/Glyph" target="_blank" rel="noopener">GitHub</a>
+		<a href="/manifesto">Manifesto</a>
 	</nav>
 	<a href={downloadUrl} class="header-cta header-cta--desktop" target="_blank" rel="noopener">Download</a>
 	<button class="header-hamburger" type="button" aria-label="Toggle menu" data-hamburger>
@@ -28,8 +26,6 @@ import { downloadUrl } from "../lib/site";
 <div class="mobile-nav" data-mobile-nav>
 	<a href="#features">Features</a>
 	<a href="#pricing">Pricing</a>
-	<a href="#faq">FAQs</a>
-	<a href="https://docs.glyphformac.com" target="_blank" rel="noopener">Docs</a>
-	<a href="https://github.com/SidhuK/Glyph" target="_blank" rel="noopener">GitHub</a>
+	<a href="/manifesto">Manifesto</a>
 	<a href={downloadUrl} class="header-cta" target="_blank" rel="noopener">Download</a>
 </div>


### PR DESCRIPTION
## Summary
- Polish calendar, settings, database picker, editor code block, and frontmatter styling.
- Clear navigation prefetch caches when switching spaces so special views load the active space’s data.
- Add the website manifesto page and update related website copy/navigation.
- Update release notes for the 0.2.7 work.

## Testing
- `pnpm check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sidhuk/glyph/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy button on code blocks with click-and-confirm feedback.
  * New Manifesto site page and updated site navigation.

* **Improved**
  * Calendar: streamlined button styling and only shows task groups that contain tasks (no empty-state line).
  * Simplified recent-notes empty message.
  * Settings: refreshed UI with more compact folder displays and shorter descriptions.
  * FAQ: clarified student/indie discount wording.

* **Style**
  * Refined frontmatter preview and new code-block copy button styling; improved database picker hover states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->