### PR TITLE
Add optional Vim Mode for the editor

### DIFF
--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -23,6 +23,7 @@ import { MarkdownLinkAutocomplete } from "./markdownLinkAutocomplete";
 import { MermaidPreview } from "./mermaidPreview";
 import { PersonAutocomplete } from "./personAutocomplete";
 import { TagDecorations } from "./tagDecorations";
+import { VimMode } from "./vimMode";
 import { WikiLink } from "./wikiLink";
 import { ZenFocus } from "./zenFocus";
 
@@ -531,6 +532,7 @@ interface CreateEditorExtensionsOptions {
 	enableWikiLinks?: boolean;
 	enableMarkdownLinkAutocomplete?: boolean;
 	enablePeopleMentions?: boolean;
+	enableVimKeybindings?: boolean;
 	currentPath?: string;
 	currentPathResolver?: (() => string) | null;
 	getZenModeEnabled?: (() => boolean) | null;
@@ -544,6 +546,7 @@ export function createEditorExtensions(
 		enableWikiLinks = true,
 		enableMarkdownLinkAutocomplete = true,
 		enablePeopleMentions = false,
+		enableVimKeybindings = false,
 		currentPath = "",
 		currentPathResolver = null,
 		getZenModeEnabled = null,
@@ -597,5 +600,6 @@ export function createEditorExtensions(
 		ZenFocus.configure({
 			getZenModeEnabled: getZenModeEnabled ?? (() => false),
 		}),
+		...(enableVimKeybindings ? [VimMode] : []),
 	];
 }

--- a/src/components/editor/extensions/vimMode.integration.test.ts
+++ b/src/components/editor/extensions/vimMode.integration.test.ts
@@ -4,7 +4,7 @@ import { Editor } from "@tiptap/core";
 import { describe, expect, it } from "vitest";
 import { createEditorExtensions } from "./index";
 
-function createEditor(enableVimKeybindings = true) {
+function createEditor(enableVimKeybindings = true, content = "hello world") {
 	const element = document.createElement("div");
 	document.body.appendChild(element);
 	const editor = new Editor({
@@ -14,7 +14,7 @@ function createEditor(enableVimKeybindings = true) {
 			enableVimKeybindings,
 			enableWikiLinks: false,
 		}),
-		content: "hello world",
+		content,
 		contentType: "markdown",
 		element,
 	});
@@ -39,9 +39,13 @@ function press(editor: Editor, key: string) {
 }
 
 function vimMode(editor: Editor) {
-	const storage = (editor.storage as unknown as Record<string, unknown>)
-		.vimMode as { mode?: string } | undefined;
-	return storage?.mode;
+	return vimStorage(editor)?.mode;
+}
+
+function vimStorage(editor: Editor) {
+	return (editor.storage as unknown as Record<string, unknown>).vimMode as
+		| { mode?: string; pendingExpiresAt?: number; pendingKey?: string | null }
+		| undefined;
 }
 
 describe("Vim mode extension", () => {
@@ -62,12 +66,21 @@ describe("Vim mode extension", () => {
 
 		try {
 			expect(vimMode(harness.editor)).toBe("insert");
+			expect(harness.editor.view.dom.getAttribute("data-vim-mode")).toBe(
+				"insert",
+			);
 
 			expect(press(harness.editor, "Escape")).toBe(true);
 			expect(vimMode(harness.editor)).toBe("normal");
+			expect(harness.editor.view.dom.getAttribute("data-vim-mode")).toBe(
+				"normal",
+			);
 
 			expect(press(harness.editor, "i")).toBe(true);
 			expect(vimMode(harness.editor)).toBe("insert");
+			expect(harness.editor.view.dom.getAttribute("data-vim-mode")).toBe(
+				"insert",
+			);
 		} finally {
 			harness.destroy();
 		}
@@ -94,7 +107,95 @@ describe("Vim mode extension", () => {
 			expect(harness.editor.state.selection.head).toBe(1);
 
 			press(harness.editor, "$");
-			expect(harness.editor.state.selection.head).toBe(12);
+			expect(harness.editor.state.selection.head).toBe(11);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("treats $ as an end-of-line motion so x deletes the last character", () => {
+		const harness = createEditor();
+
+		try {
+			harness.editor.commands.setTextSelection(2);
+			press(harness.editor, "Escape");
+			press(harness.editor, "$");
+			press(harness.editor, "x");
+
+			expect(harness.editor.getText()).toBe("hello worl");
+			expect(vimMode(harness.editor)).toBe("normal");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("uses A as an append-at-end command", () => {
+		const harness = createEditor();
+
+		try {
+			harness.editor.commands.setTextSelection(2);
+			press(harness.editor, "Escape");
+			press(harness.editor, "A");
+			harness.editor.commands.insertContent("!");
+
+			expect(harness.editor.getText()).toBe("hello world!");
+			expect(vimMode(harness.editor)).toBe("insert");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("clears pending operators on unrelated keydown", () => {
+		const harness = createEditor();
+
+		try {
+			press(harness.editor, "Escape");
+			press(harness.editor, "d");
+			expect(vimStorage(harness.editor)?.pendingKey).toBe("d");
+
+			press(harness.editor, "ArrowRight");
+			expect(vimStorage(harness.editor)?.pendingKey).toBeNull();
+			expect(vimStorage(harness.editor)?.pendingExpiresAt).toBe(0);
+
+			press(harness.editor, "d");
+			expect(harness.editor.getText()).toBe("hello world");
+			expect(vimStorage(harness.editor)?.pendingKey).toBe("d");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("clears pending operators on blur", () => {
+		const harness = createEditor();
+
+		try {
+			press(harness.editor, "Escape");
+			press(harness.editor, "g");
+			expect(vimStorage(harness.editor)?.pendingKey).toBe("g");
+
+			harness.editor.view.dom.dispatchEvent(
+				new FocusEvent("blur", { bubbles: true }),
+			);
+
+			expect(vimStorage(harness.editor)?.pendingKey).toBeNull();
+			expect(vimStorage(harness.editor)?.pendingExpiresAt).toBe(0);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("clears pending operators on selection changes", () => {
+		const harness = createEditor();
+
+		try {
+			press(harness.editor, "Escape");
+			press(harness.editor, "d");
+			expect(vimStorage(harness.editor)?.pendingKey).toBe("d");
+
+			harness.editor.commands.setTextSelection(5);
+
+			expect(vimStorage(harness.editor)?.pendingKey).toBeNull();
+			expect(vimStorage(harness.editor)?.pendingExpiresAt).toBe(0);
 		} finally {
 			harness.destroy();
 		}
@@ -115,6 +216,72 @@ describe("Vim mode extension", () => {
 
 			expect(harness.editor.getText()).toBe("");
 			expect(vimMode(harness.editor)).toBe("normal");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("removes the whole paragraph with dd when another paragraph remains", () => {
+		const harness = createEditor(true, "alpha\n\nbeta");
+
+		try {
+			harness.editor.commands.setTextSelection(3);
+			press(harness.editor, "Escape");
+			press(harness.editor, "d");
+			press(harness.editor, "d");
+
+			expect(harness.editor.getMarkdown()).toBe("beta");
+			expect(vimMode(harness.editor)).toBe("normal");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("keeps the required empty paragraph when dd deletes the only paragraph", () => {
+		const harness = createEditor(true, "alpha");
+
+		try {
+			harness.editor.commands.setTextSelection(3);
+			press(harness.editor, "Escape");
+			press(harness.editor, "d");
+			press(harness.editor, "d");
+
+			expect(harness.editor.getText()).toBe("");
+			expect(vimMode(harness.editor)).toBe("normal");
+		} finally {
+			harness.destroy();
+		}
+	});
+});
+
+describe("Vim mode line opening", () => {
+	it("opens an empty line above and leaves the cursor there with O", () => {
+		const harness = createEditor(true, "hello world");
+
+		try {
+			harness.editor.commands.setTextSelection(7);
+			press(harness.editor, "Escape");
+			press(harness.editor, "O");
+			harness.editor.commands.insertContent("above");
+
+			expect(harness.editor.getMarkdown()).toBe("above\n\nhello world");
+			expect(vimMode(harness.editor)).toBe("insert");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("opens an empty line below and leaves the cursor there with o", () => {
+		const harness = createEditor(true, "hello world");
+
+		try {
+			harness.editor.commands.setTextSelection(7);
+			press(harness.editor, "Escape");
+			press(harness.editor, "o");
+			harness.editor.commands.insertContent("below");
+
+			expect(harness.editor.getMarkdown()).toBe("hello world\n\nbelow");
+			expect(vimMode(harness.editor)).toBe("insert");
 		} finally {
 			harness.destroy();
 		}

--- a/src/components/editor/extensions/vimMode.integration.test.ts
+++ b/src/components/editor/extensions/vimMode.integration.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { Editor } from "@tiptap/core";
+import { describe, expect, it } from "vitest";
+import { createEditorExtensions } from "./index";
+
+function createEditor(enableVimKeybindings = true) {
+	const element = document.createElement("div");
+	document.body.appendChild(element);
+	const editor = new Editor({
+		extensions: createEditorExtensions({
+			enableMarkdownLinkAutocomplete: false,
+			enableSlashCommand: false,
+			enableVimKeybindings,
+			enableWikiLinks: false,
+		}),
+		content: "hello world",
+		contentType: "markdown",
+		element,
+	});
+
+	return {
+		editor,
+		destroy() {
+			editor.destroy();
+			element.remove();
+		},
+	};
+}
+
+function press(editor: Editor, key: string) {
+	const event = new KeyboardEvent("keydown", {
+		bubbles: true,
+		cancelable: true,
+		key,
+	});
+	editor.view.dom.dispatchEvent(event);
+	return event.defaultPrevented;
+}
+
+function vimMode(editor: Editor) {
+	const storage = (editor.storage as unknown as Record<string, unknown>)
+		.vimMode as { mode?: string } | undefined;
+	return storage?.mode;
+}
+
+describe("Vim mode extension", () => {
+	it("is not registered when Vim keybindings are disabled", () => {
+		const harness = createEditor(false);
+
+		try {
+			expect(
+				(harness.editor.storage as unknown as Record<string, unknown>).vimMode,
+			).toBeUndefined();
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("starts in insert mode and toggles between Vim normal and insert modes", () => {
+		const harness = createEditor();
+
+		try {
+			expect(vimMode(harness.editor)).toBe("insert");
+
+			expect(press(harness.editor, "Escape")).toBe(true);
+			expect(vimMode(harness.editor)).toBe("normal");
+
+			expect(press(harness.editor, "i")).toBe(true);
+			expect(vimMode(harness.editor)).toBe("insert");
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("moves the cursor with basic Vim motions in normal mode", () => {
+		const harness = createEditor();
+
+		try {
+			harness.editor.commands.setTextSelection(8);
+
+			press(harness.editor, "Escape");
+			const afterEscape = harness.editor.state.selection.head;
+			press(harness.editor, "h");
+			expect(harness.editor.state.selection.head).toBeLessThan(afterEscape);
+
+			press(harness.editor, "l");
+			expect(harness.editor.state.selection.head).toBe(afterEscape);
+
+			press(harness.editor, "b");
+			expect(harness.editor.state.selection.head).toBe(1);
+
+			press(harness.editor, "0");
+			expect(harness.editor.state.selection.head).toBe(1);
+
+			press(harness.editor, "$");
+			expect(harness.editor.state.selection.head).toBe(12);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("supports x and dd edits in normal mode", () => {
+		const harness = createEditor();
+
+		try {
+			harness.editor.commands.setTextSelection(2);
+			press(harness.editor, "Escape");
+			press(harness.editor, "x");
+
+			expect(harness.editor.getText()).toBe("ello world");
+
+			press(harness.editor, "d");
+			press(harness.editor, "d");
+
+			expect(harness.editor.getText()).toBe("");
+			expect(vimMode(harness.editor)).toBe("normal");
+		} finally {
+			harness.destroy();
+		}
+	});
+});

--- a/src/components/editor/extensions/vimMode.ts
+++ b/src/components/editor/extensions/vimMode.ts
@@ -15,10 +15,12 @@ interface TextBlockContext {
 	end: number;
 	node: EditorState["doc"];
 	offset: number;
+	parentChildCount: number;
 	start: number;
 }
 
 const PENDING_KEY_TIMEOUT_MS = 800;
+const VIM_MODE_DATA_ATTRIBUTE = "data-vim-mode";
 const SWALLOWED_NORMAL_KEYS = ["Backspace", "Delete", "Enter", "Space", "Tab"];
 const PRINTABLE_NORMAL_KEYS = Array.from(
 	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;',./~!@#%^&*()_+{}|:\"<>?",
@@ -39,6 +41,28 @@ function hasOpenSuggestionMenu() {
 	);
 }
 
+function syncVimModeAttribute(editor: Editor, mode: VimInputMode | null) {
+	if (!mode || !editor.isEditable) {
+		editor.view.dom.removeAttribute(VIM_MODE_DATA_ATTRIBUTE);
+		return;
+	}
+	editor.view.dom.setAttribute(VIM_MODE_DATA_ATTRIBUTE, mode);
+}
+
+function clearPendingOperator(storage: VimModeStorage) {
+	storage.pendingKey = null;
+	storage.pendingExpiresAt = 0;
+}
+
+function armPendingOperator(
+	storage: VimModeStorage,
+	key: string,
+	timestamp: number,
+) {
+	storage.pendingKey = key;
+	storage.pendingExpiresAt = timestamp + PENDING_KEY_TIMEOUT_MS;
+}
+
 function getTextBlockContext(state: EditorState): TextBlockContext | null {
 	const { $head } = state.selection;
 
@@ -52,6 +76,7 @@ function getTextBlockContext(state: EditorState): TextBlockContext | null {
 			end,
 			node,
 			offset: Math.max(0, Math.min($head.pos - start, node.textContent.length)),
+			parentChildCount: $head.node(depth - 1).childCount,
 			start,
 		};
 	}
@@ -104,6 +129,13 @@ function moveToTextBlockStart(editor: Editor) {
 function moveToTextBlockEnd(editor: Editor) {
 	const context = getTextBlockContext(editor.state);
 	if (!context) return true;
+	setSelection(editor, Math.max(context.start, context.end - 1));
+	return true;
+}
+
+function moveToTextBlockAppend(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
 	setSelection(editor, context.end);
 	return true;
 }
@@ -152,8 +184,16 @@ function moveToWordEnd(editor: Editor) {
 function openLine(editor: Editor, placement: "above" | "below") {
 	const context = getTextBlockContext(editor.state);
 	if (!context) return true;
-	const pos = placement === "above" ? context.start : context.end;
-	editor.chain().focus().setTextSelection(pos).splitBlock().run();
+	if (placement === "below") {
+		editor.chain().focus().setTextSelection(context.end).splitBlock().run();
+	} else {
+		editor
+			.chain()
+			.focus()
+			.insertContentAt(context.start - 1, { type: "paragraph" })
+			.setTextSelection(context.start)
+			.run();
+	}
 	editor.commands.enterVimInsertMode();
 	return true;
 }
@@ -177,13 +217,19 @@ function deleteCharacter(editor: Editor) {
 }
 
 function deleteTextBlockContents(editor: Editor) {
-	const context = getTextBlockContext(editor.state);
+	const { state } = editor;
+	const context = getTextBlockContext(state);
 	if (!context) return true;
-	editor
-		.chain()
-		.focus()
-		.deleteRange({ from: context.start, to: context.end })
-		.run();
+	const nodeFrom = context.start - 1;
+	const nodeTo = context.end + 1;
+	const canDeleteNode =
+		context.parentChildCount > 1 &&
+		nodeFrom >= 0 &&
+		nodeTo <= state.doc.content.size;
+	const range = canDeleteNode
+		? { from: nodeFrom, to: nodeTo }
+		: { from: context.start, to: context.end };
+	editor.chain().focus().deleteRange(range).run();
 	return true;
 }
 
@@ -193,13 +239,13 @@ function runNormalModeCommand(
 	command: () => boolean,
 ) {
 	if (!editor.isEditable || storage.mode !== "normal") return false;
-	storage.pendingKey = null;
+	clearPendingOperator(storage);
 	return command();
 }
 
 function swallowNormalModeKey(storage: VimModeStorage, editor: Editor) {
 	if (!editor.isEditable || storage.mode !== "normal") return false;
-	storage.pendingKey = null;
+	clearPendingOperator(storage);
 	return true;
 }
 
@@ -215,23 +261,35 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 		};
 	},
 
+	onCreate() {
+		syncVimModeAttribute(this.editor, this.storage.mode);
+	},
+
+	onDestroy() {
+		syncVimModeAttribute(this.editor, null);
+	},
+
 	addCommands() {
 		return {
 			enterVimInsertMode: () => (): boolean => {
 				this.storage.mode = "insert";
-				this.storage.pendingKey = null;
+				clearPendingOperator(this.storage);
+				syncVimModeAttribute(this.editor, this.storage.mode);
 				return true;
 			},
 			enterVimNormalMode:
 				() =>
 				({ state, tr, dispatch }): boolean => {
 					this.storage.mode = "normal";
-					this.storage.pendingKey = null;
+					clearPendingOperator(this.storage);
+					syncVimModeAttribute(this.editor, this.storage.mode);
 					if (!dispatch) return true;
 
 					const context = getTextBlockContext(state);
 					const minPos = context?.start ?? 0;
-					const maxPos = context?.end ?? state.doc.content.size;
+					const maxPos = context
+						? Math.max(context.start, context.end - 1)
+						: state.doc.content.size;
 					const head = state.selection.head;
 					const nextPos = Math.max(minPos, Math.min(head - 1, maxPos));
 					const selection = Selection.near(state.doc.resolve(nextPos));
@@ -254,7 +312,7 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 			$: normal(() => moveToTextBlockEnd(this.editor)),
 			0: normal(() => moveToTextBlockStart(this.editor)),
 			A: normal(() => {
-				moveToTextBlockEnd(this.editor);
+				moveToTextBlockAppend(this.editor);
 				return this.editor.commands.enterVimInsertMode();
 			}),
 			G: normal(() => {
@@ -279,11 +337,11 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 					this.storage.pendingKey === "d" &&
 					this.storage.pendingExpiresAt > now
 				) {
-					this.storage.pendingKey = null;
+					clearPendingOperator(this.storage);
 					return deleteTextBlockContents(this.editor);
 				}
-				this.storage.pendingKey = "d";
-				this.storage.pendingExpiresAt = now + PENDING_KEY_TIMEOUT_MS;
+				clearPendingOperator(this.storage);
+				armPendingOperator(this.storage, "d", now);
 				return true;
 			},
 			e: normal(() => moveToWordEnd(this.editor)),
@@ -295,12 +353,12 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 					this.storage.pendingKey === "g" &&
 					this.storage.pendingExpiresAt > now
 				) {
-					this.storage.pendingKey = null;
+					clearPendingOperator(this.storage);
 					setSelection(this.editor, 0);
 					return true;
 				}
-				this.storage.pendingKey = "g";
-				this.storage.pendingExpiresAt = now + PENDING_KEY_TIMEOUT_MS;
+				clearPendingOperator(this.storage);
+				armPendingOperator(this.storage, "g", now);
 				return true;
 			},
 			h: normal(() => moveBy(this.editor, -1)),
@@ -328,8 +386,43 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 		return [
 			new Plugin({
 				props: {
+					handleDOMEvents: {
+						blur: () => {
+							clearPendingOperator(this.storage);
+							return false;
+						},
+						mouseup: () => {
+							clearPendingOperator(this.storage);
+							return false;
+						},
+					},
+					handleKeyDown: (_view, event) => {
+						if (
+							this.storage.mode === "normal" &&
+							this.storage.pendingKey &&
+							event.key !== this.storage.pendingKey
+						) {
+							clearPendingOperator(this.storage);
+						}
+						return false;
+					},
 					handleTextInput: () =>
 						this.editor.isEditable && this.storage.mode === "normal",
+				},
+				view: () => {
+					syncVimModeAttribute(this.editor, this.storage.mode);
+					return {
+						update: (view, previousState) => {
+							syncVimModeAttribute(this.editor, this.storage.mode);
+							if (!previousState.selection.eq(view.state.selection)) {
+								clearPendingOperator(this.storage);
+							}
+						},
+						destroy: () => {
+							clearPendingOperator(this.storage);
+							syncVimModeAttribute(this.editor, null);
+						},
+					};
 				},
 			}),
 		];

--- a/src/components/editor/extensions/vimMode.ts
+++ b/src/components/editor/extensions/vimMode.ts
@@ -1,0 +1,337 @@
+import { type Editor, Extension } from "@tiptap/core";
+import type { EditorState } from "@tiptap/pm/state";
+import { Plugin, Selection } from "@tiptap/pm/state";
+
+type VimInputMode = "insert" | "normal";
+
+interface VimModeStorage {
+	mode: VimInputMode;
+	pendingKey: string | null;
+	pendingExpiresAt: number;
+}
+
+interface TextBlockContext {
+	depth: number;
+	end: number;
+	node: EditorState["doc"];
+	offset: number;
+	start: number;
+}
+
+const PENDING_KEY_TIMEOUT_MS = 800;
+const SWALLOWED_NORMAL_KEYS = ["Backspace", "Delete", "Enter", "Space", "Tab"];
+const PRINTABLE_NORMAL_KEYS = Array.from(
+	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`-=[]\\;',./~!@#%^&*()_+{}|:\"<>?",
+);
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		vimMode: {
+			enterVimInsertMode: () => ReturnType;
+			enterVimNormalMode: () => ReturnType;
+		};
+	}
+}
+
+function hasOpenSuggestionMenu() {
+	return Boolean(
+		document.querySelector(".slashCommandMenu, .wikiLinkSuggestionMenu"),
+	);
+}
+
+function getTextBlockContext(state: EditorState): TextBlockContext | null {
+	const { $head } = state.selection;
+
+	for (let depth = $head.depth; depth > 0; depth -= 1) {
+		const node = $head.node(depth);
+		if (!node.isTextblock) continue;
+		const start = $head.start(depth);
+		const end = $head.end(depth);
+		return {
+			depth,
+			end,
+			node,
+			offset: Math.max(0, Math.min($head.pos - start, node.textContent.length)),
+			start,
+		};
+	}
+
+	return null;
+}
+
+function clampPosition(state: EditorState, pos: number) {
+	return Math.max(0, Math.min(state.doc.content.size, pos));
+}
+
+function setSelection(editor: Editor, pos: number) {
+	const { state, view } = editor;
+	const nextPos = clampPosition(state, pos);
+	const selection = Selection.near(state.doc.resolve(nextPos));
+	view.dispatch(state.tr.setSelection(selection).scrollIntoView());
+}
+
+function moveBy(editor: Editor, delta: number) {
+	setSelection(editor, editor.state.selection.head + delta);
+	return true;
+}
+
+function moveVertically(editor: Editor, direction: -1 | 1) {
+	const { state, view } = editor;
+	const head = state.selection.head;
+	const coords = view.coordsAtPos(head);
+	const lineHeight = Number.parseFloat(getComputedStyle(view.dom).lineHeight);
+	const distance = Number.isFinite(lineHeight) ? lineHeight : 20;
+	const target = view.posAtCoords({
+		left: coords.left,
+		top:
+			direction > 0 ? coords.bottom + distance / 2 : coords.top - distance / 2,
+	});
+
+	if (target) {
+		setSelection(editor, target.pos);
+	}
+
+	return true;
+}
+
+function moveToTextBlockStart(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	setSelection(editor, context.start);
+	return true;
+}
+
+function moveToTextBlockEnd(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	setSelection(editor, context.end);
+	return true;
+}
+
+function moveToNextWordStart(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	const text = context.node.textContent;
+	let offset = context.offset;
+
+	while (offset < text.length && !/\s/.test(text[offset] ?? "")) offset += 1;
+	while (offset < text.length && /\s/.test(text[offset] ?? "")) offset += 1;
+
+	setSelection(editor, context.start + offset);
+	return true;
+}
+
+function moveToPreviousWordStart(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	const text = context.node.textContent;
+	let offset = Math.max(0, context.offset - 1);
+
+	while (offset > 0 && /\s/.test(text[offset] ?? "")) offset -= 1;
+	while (offset > 0 && !/\s/.test(text[offset - 1] ?? "")) offset -= 1;
+
+	setSelection(editor, context.start + offset);
+	return true;
+}
+
+function moveToWordEnd(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	const text = context.node.textContent;
+	let offset = Math.min(text.length, context.offset + 1);
+
+	while (offset < text.length && /\s/.test(text[offset] ?? "")) offset += 1;
+	while (offset < text.length - 1 && !/\s/.test(text[offset + 1] ?? "")) {
+		offset += 1;
+	}
+
+	setSelection(editor, context.start + offset);
+	return true;
+}
+
+function openLine(editor: Editor, placement: "above" | "below") {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	const pos = placement === "above" ? context.start : context.end;
+	editor.chain().focus().setTextSelection(pos).splitBlock().run();
+	editor.commands.enterVimInsertMode();
+	return true;
+}
+
+function deleteCharacter(editor: Editor) {
+	const { state } = editor;
+	const context = getTextBlockContext(state);
+	if (!context) return true;
+	if (!state.selection.empty) {
+		editor.chain().focus().deleteSelection().run();
+		return true;
+	}
+	const pos = state.selection.head;
+	if (pos >= context.end) return true;
+	editor
+		.chain()
+		.focus()
+		.deleteRange({ from: pos, to: pos + 1 })
+		.run();
+	return true;
+}
+
+function deleteTextBlockContents(editor: Editor) {
+	const context = getTextBlockContext(editor.state);
+	if (!context) return true;
+	editor
+		.chain()
+		.focus()
+		.deleteRange({ from: context.start, to: context.end })
+		.run();
+	return true;
+}
+
+function runNormalModeCommand(
+	storage: VimModeStorage,
+	editor: Editor,
+	command: () => boolean,
+) {
+	if (!editor.isEditable || storage.mode !== "normal") return false;
+	storage.pendingKey = null;
+	return command();
+}
+
+function swallowNormalModeKey(storage: VimModeStorage, editor: Editor) {
+	if (!editor.isEditable || storage.mode !== "normal") return false;
+	storage.pendingKey = null;
+	return true;
+}
+
+export const VimMode = Extension.create<object, VimModeStorage>({
+	name: "vimMode",
+	priority: 1000,
+
+	addStorage() {
+		return {
+			mode: "insert",
+			pendingExpiresAt: 0,
+			pendingKey: null,
+		};
+	},
+
+	addCommands() {
+		return {
+			enterVimInsertMode: () => (): boolean => {
+				this.storage.mode = "insert";
+				this.storage.pendingKey = null;
+				return true;
+			},
+			enterVimNormalMode:
+				() =>
+				({ state, tr, dispatch }): boolean => {
+					this.storage.mode = "normal";
+					this.storage.pendingKey = null;
+					if (!dispatch) return true;
+
+					const context = getTextBlockContext(state);
+					const minPos = context?.start ?? 0;
+					const maxPos = context?.end ?? state.doc.content.size;
+					const head = state.selection.head;
+					const nextPos = Math.max(minPos, Math.min(head - 1, maxPos));
+					const selection = Selection.near(state.doc.resolve(nextPos));
+					dispatch(tr.setSelection(selection).scrollIntoView());
+					return true;
+				},
+		};
+	},
+
+	addKeyboardShortcuts() {
+		const normal = (command: () => boolean) => () =>
+			runNormalModeCommand(this.storage, this.editor, command);
+		const swallow = () => swallowNormalModeKey(this.storage, this.editor);
+		const shortcuts: Record<string, () => boolean> = {
+			Escape: () => {
+				if (!this.editor.isEditable || hasOpenSuggestionMenu()) return false;
+				return this.editor.commands.enterVimNormalMode();
+			},
+			"Control-r": normal(() => this.editor.commands.redo()),
+			$: normal(() => moveToTextBlockEnd(this.editor)),
+			0: normal(() => moveToTextBlockStart(this.editor)),
+			A: normal(() => {
+				moveToTextBlockEnd(this.editor);
+				return this.editor.commands.enterVimInsertMode();
+			}),
+			G: normal(() => {
+				setSelection(this.editor, this.editor.state.doc.content.size);
+				return true;
+			}),
+			I: normal(() => {
+				moveToTextBlockStart(this.editor);
+				return this.editor.commands.enterVimInsertMode();
+			}),
+			O: normal(() => openLine(this.editor, "above")),
+			a: normal(() => {
+				moveBy(this.editor, 1);
+				return this.editor.commands.enterVimInsertMode();
+			}),
+			b: normal(() => moveToPreviousWordStart(this.editor)),
+			d: () => {
+				if (!this.editor.isEditable || this.storage.mode !== "normal")
+					return false;
+				const now = Date.now();
+				if (
+					this.storage.pendingKey === "d" &&
+					this.storage.pendingExpiresAt > now
+				) {
+					this.storage.pendingKey = null;
+					return deleteTextBlockContents(this.editor);
+				}
+				this.storage.pendingKey = "d";
+				this.storage.pendingExpiresAt = now + PENDING_KEY_TIMEOUT_MS;
+				return true;
+			},
+			e: normal(() => moveToWordEnd(this.editor)),
+			g: () => {
+				if (!this.editor.isEditable || this.storage.mode !== "normal")
+					return false;
+				const now = Date.now();
+				if (
+					this.storage.pendingKey === "g" &&
+					this.storage.pendingExpiresAt > now
+				) {
+					this.storage.pendingKey = null;
+					setSelection(this.editor, 0);
+					return true;
+				}
+				this.storage.pendingKey = "g";
+				this.storage.pendingExpiresAt = now + PENDING_KEY_TIMEOUT_MS;
+				return true;
+			},
+			h: normal(() => moveBy(this.editor, -1)),
+			i: normal(() => this.editor.commands.enterVimInsertMode()),
+			j: normal(() => moveVertically(this.editor, 1)),
+			k: normal(() => moveVertically(this.editor, -1)),
+			l: normal(() => moveBy(this.editor, 1)),
+			o: normal(() => openLine(this.editor, "below")),
+			u: normal(() => this.editor.commands.undo()),
+			w: normal(() => moveToNextWordStart(this.editor)),
+			x: normal(() => deleteCharacter(this.editor)),
+		};
+
+		for (const key of SWALLOWED_NORMAL_KEYS) {
+			shortcuts[key] = swallow;
+		}
+		for (const key of PRINTABLE_NORMAL_KEYS) {
+			shortcuts[key] ??= swallow;
+		}
+
+		return shortcuts;
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				props: {
+					handleTextInput: () =>
+						this.editor.isEditable && this.storage.mode === "normal",
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -414,6 +414,7 @@ export function useNoteEditor({
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
 	const [peopleMentionsEnabled, setPeopleMentionsEnabled] = useState(false);
+	const [vimKeybindingsEnabled, setVimKeybindingsEnabled] = useState(false);
 	const extensions = useMemo(
 		() =>
 			createEditorExtensions({
@@ -421,9 +422,14 @@ export function useNoteEditor({
 				currentPathResolver: () => relPathRef.current,
 				enableMarkdownLinkAutocomplete,
 				enablePeopleMentions: peopleMentionsEnabled,
+				enableVimKeybindings: vimKeybindingsEnabled,
 				getZenModeEnabled: () => zenModeActiveRef.current,
 			}),
-		[enableMarkdownLinkAutocomplete, peopleMentionsEnabled],
+		[
+			enableMarkdownLinkAutocomplete,
+			peopleMentionsEnabled,
+			vimKeybindingsEnabled,
+		],
 	);
 	const markdownManager = useMemo(
 		() =>
@@ -447,6 +453,7 @@ export function useNoteEditor({
 				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
 				setColorfulHeadings(settings.editor.colorfulHeadings);
 				setPeopleMentionsEnabled(settings.editor.enablePeopleMentionsAsTags);
+				setVimKeybindingsEnabled(settings.editor.vimKeybindings === true);
 				attachmentStorageModeRef.current =
 					settings.editor.attachmentStorageMode;
 				attachmentFolderRef.current = settings.editor.attachmentFolder;
@@ -456,6 +463,7 @@ export function useNoteEditor({
 				setShowCollapsibleHeadings(false);
 				setColorfulHeadings(false);
 				setPeopleMentionsEnabled(false);
+				setVimKeybindingsEnabled(false);
 				attachmentStorageModeRef.current = "note-folder";
 				attachmentFolderRef.current = DEFAULT_ATTACHMENT_FOLDER;
 			});
@@ -473,6 +481,9 @@ export function useNoteEditor({
 		}
 		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
 			setPeopleMentionsEnabled(payload.editor.enablePeopleMentionsAsTags);
+		}
+		if (typeof payload.editor?.vimKeybindings === "boolean") {
+			setVimKeybindingsEnabled(payload.editor.vimKeybindings);
 		}
 		if (payload.editor?.attachmentStorageMode) {
 			attachmentStorageModeRef.current = payload.editor.attachmentStorageMode;
@@ -648,7 +659,11 @@ export function useNoteEditor({
 				onChange(nextMarkdown);
 			},
 		},
-		[peopleMentionsEnabled, enableMarkdownLinkAutocomplete],
+		[
+			peopleMentionsEnabled,
+			enableMarkdownLinkAutocomplete,
+			vimKeybindingsEnabled,
+		],
 	);
 	editorRef.current = editor;
 

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -15,6 +15,7 @@ const {
 	setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowCollapsibleHeadingsMock,
+	setEditorVimKeybindingsMock,
 	setShowFileTreeFolderCountsMock,
 	setShowTocMock,
 } = vi.hoisted(() => ({
@@ -26,6 +27,7 @@ const {
 	setEditorColorfulHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleHeadingsMock: vi.fn(() => Promise.resolve()),
+	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
 	setShowTocMock: vi.fn(() => Promise.resolve()),
 }));
@@ -46,6 +48,7 @@ vi.mock("../../lib/settings", () => ({
 	setEditorColorfulHeadings: setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTags: setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowCollapsibleHeadings: setEditorShowCollapsibleHeadingsMock,
+	setEditorVimKeybindings: setEditorVimKeybindingsMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
 	setShowToc: setShowTocMock,
 }));
@@ -113,12 +116,13 @@ vi.mock("./SettingsScaffold", () => ({
 	}
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-function makeSettings(colorfulHeadings: boolean) {
+function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
 	return {
 		editor: {
 			colorfulHeadings,
 			enablePeopleMentionsAsTags: false,
 			showCollapsibleHeadings: false,
+			vimKeybindings,
 		},
 		ui: {
 			aiAssistantMode: "create" as const,
@@ -194,5 +198,49 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setEditorColorfulHeadingsMock).toHaveBeenCalledWith(true);
+	});
+
+	it("shows Vim Mode off by default", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Vim Mode"]',
+		) as HTMLInputElement | null;
+
+		expect(container.textContent).toContain("Vim Mode");
+		expect(toggle?.checked).toBe(false);
+	});
+
+	it("reflects stored Vim keybinding state", async () => {
+		loadSettingsMock.mockResolvedValue(makeSettings(false, true));
+
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Vim Mode"]',
+		) as HTMLInputElement | null;
+
+		expect(toggle?.checked).toBe(true);
+	});
+
+	it("saves Vim keybinding changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Vim Mode"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setEditorVimKeybindingsMock).toHaveBeenCalledWith(true);
 	});
 });

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -1,3 +1,5 @@
+import { BadgeInfoIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useState } from "react";
 import { useSpace } from "../../contexts";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -11,22 +13,89 @@ import {
 	setEditorColorfulHeadings,
 	setEditorEnablePeopleMentionsAsTags,
 	setEditorShowCollapsibleHeadings,
+	setEditorVimKeybindings,
 	setShowFileTreeFolderCounts,
 	setShowToc,
 } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
 import {
 	SettingsRow,
 	SettingsSection,
 	SettingsToggle,
 } from "./SettingsScaffold";
 
+const VIM_KEYBINDING_HELP = [
+	{ key: "Esc", action: "Enter Vim command mode." },
+	{ key: "i", action: "Type at the cursor." },
+	{ key: "a", action: "Type after the cursor." },
+	{ key: "I", action: "Go to the start of the line and type." },
+	{ key: "A", action: "Go to the end of the line and type." },
+	{ key: "o", action: "Open a new line below and type." },
+	{ key: "O", action: "Open a new line above and type." },
+	{ key: "h / j / k / l", action: "Move left, down, up, and right." },
+	{ key: "w", action: "Jump to the next word." },
+	{ key: "b", action: "Jump back to the previous word." },
+	{ key: "e", action: "Jump to the end of the word." },
+	{ key: "0", action: "Jump to the start of the line." },
+	{ key: "$", action: "Jump to the end of the line." },
+	{ key: "gg", action: "Jump to the start of the note." },
+	{ key: "G", action: "Jump to the end of the note." },
+	{ key: "x", action: "Delete the character under or near the cursor." },
+	{ key: "dd", action: "Delete the current line's contents." },
+	{ key: "u", action: "Undo." },
+	{ key: "Control-r", action: "Redo." },
+] as const;
+
+function VimKeybindingsHelp() {
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className="vimKeybindingsInfoButton"
+					aria-label="Vim keybindings help"
+				>
+					<HugeiconsIcon icon={BadgeInfoIcon} size={14} strokeWidth={0.9} />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="start"
+				side="right"
+				sideOffset={8}
+				className="vimKeybindingsPopover"
+			>
+				<div className="vimKeybindingsPopoverTitle">Vim keybindings</div>
+				<div className="vimKeybindingsModes">
+					<div>
+						<strong>insert</strong> means normal typing mode. You type and text
+						appears, like the editor already does.
+					</div>
+					<div>
+						<strong>normal</strong> means command mode. Your keys move around or
+						edit text instead of typing letters.
+					</div>
+				</div>
+				<div className="vimKeybindingsList">
+					{VIM_KEYBINDING_HELP.map((item) => (
+						<div className="vimKeybindingsItem" key={item.key}>
+							<kbd>{item.key}</kbd>
+							<span>{item.action}</span>
+						</div>
+					))}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
 export function AdvancedSettingsPane() {
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
 	const [enablePeopleMentionsAsTags, setEnablePeopleMentionsAsTags] =
 		useState(false);
+	const [vimKeybindings, setVimKeybindings] = useState(false);
 	const [showToc, setShowTocState] = useState(true);
 	const [aiAssistantMode, setAiAssistantModeState] =
 		useState<AiAssistantMode>("create");
@@ -45,6 +114,7 @@ export function AdvancedSettingsPane() {
 		isSavingEnablePeopleMentionsAsTags,
 		setIsSavingEnablePeopleMentionsAsTags,
 	] = useState(false);
+	const [isSavingVimKeybindings, setIsSavingVimKeybindings] = useState(false);
 	const [isSavingAiAssistantMode, setIsSavingAiAssistantMode] = useState(false);
 	const [isSavingDelightfulGlyph, setIsSavingDelightfulGlyph] = useState(false);
 	const [
@@ -64,6 +134,7 @@ export function AdvancedSettingsPane() {
 			setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
 			setColorfulHeadings(settings.editor.colorfulHeadings);
 			setEnablePeopleMentionsAsTags(settings.editor.enablePeopleMentionsAsTags);
+			setVimKeybindings(settings.editor.vimKeybindings === true);
 			setShowTocState(settings.ui.showToc);
 			setAiAssistantModeState(settings.ui.aiAssistantMode);
 			setDelightfulGlyphState(settings.ui.delightfulGlyph);
@@ -88,6 +159,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
 			setEnablePeopleMentionsAsTags(payload.editor.enablePeopleMentionsAsTags);
+		}
+		if (typeof payload.editor?.vimKeybindings === "boolean") {
+			setVimKeybindings(payload.editor.vimKeybindings);
 		}
 		if (typeof payload.ui?.showToc === "boolean") {
 			setShowTocState(payload.ui.showToc);
@@ -224,6 +298,35 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingShowCollapsibleHeadings(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label={
+							<span className="settingsLabelWithHelp">
+								Vim Mode
+								<VimKeybindingsHelp />
+							</span>
+						}
+						description="Do NOT Turn this ON if you don't know what it means."
+					>
+						<SettingsToggle
+							checked={vimKeybindings}
+							disabled={isSavingVimKeybindings}
+							ariaLabel="Vim Mode"
+							onCheckedChange={(checked) => {
+								const previous = vimKeybindings;
+								setError("");
+								setVimKeybindings(checked);
+								setIsSavingVimKeybindings(true);
+								void setEditorVimKeybindings(checked)
+									.catch((cause) => {
+										setVimKeybindings(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingVimKeybindings(false);
 									});
 							}}
 						/>

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -1,6 +1,18 @@
 {
 	"versions": [
 		{
+			"version": "0.2.8",
+			"publishedAt": "2026-04-14",
+			"sections": [
+				{
+					"category": "Added",
+					"items": [
+						"Optional Vim keybindings — power users can now move through notes, edit faster, and stay in flow with familiar Vim-style controls"
+					]
+				}
+			]
+		},
+		{
 			"version": "0.2.7",
 			"publishedAt": "2026-04-13",
 			"sections": [

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -77,6 +77,42 @@ describe("settings colorful headings", () => {
 	});
 });
 
+describe("settings Vim keybindings", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults Vim keybindings to false", async () => {
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.vimKeybindings).toBe(false);
+	});
+
+	it("loads Vim keybindings from the store", async () => {
+		storeState.set("editor.vimKeybindings", true);
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.vimKeybindings).toBe(true);
+	});
+
+	it("persists and emits Vim keybinding changes", async () => {
+		const { setEditorVimKeybindings } = await import("./settings");
+
+		await setEditorVimKeybindings(true);
+
+		expect(storeState.get("editor.vimKeybindings")).toBe(true);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			editor: { vimKeybindings: true },
+		});
+	});
+});
+
 describe("attachment storage settings", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -102,6 +102,7 @@ export interface EditorSettings {
 	attachmentStorageMode: AttachmentStorageMode;
 	attachmentFolder: string | null;
 	enablePeopleMentionsAsTags: boolean;
+	vimKeybindings: boolean;
 }
 
 export interface FileTreeSettings {
@@ -119,6 +120,7 @@ export const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	attachmentStorageMode: "note-folder",
 	attachmentFolder: DEFAULT_ATTACHMENT_FOLDER,
 	enablePeopleMentionsAsTags: false,
+	vimKeybindings: false,
 };
 
 export const DEFAULT_FILE_TREE_SETTINGS: FileTreeSettings = {
@@ -240,6 +242,7 @@ async function emitSettingsUpdated(payload: {
 		attachmentStorageMode?: AttachmentStorageMode;
 		attachmentFolder?: string | null;
 		enablePeopleMentionsAsTags?: boolean;
+		vimKeybindings?: boolean;
 	};
 	onboarding?: Partial<OnboardingSettings>;
 }): Promise<void> {
@@ -322,6 +325,7 @@ const KEYS = {
 	editorAttachmentFolder: "editor.attachmentFolder",
 	editorPastedMediaFolder: "editor.pastedMediaFolder",
 	editorEnablePeopleMentionsAsTags: "editor.enablePeopleMentionsAsTags",
+	editorVimKeybindings: "editor.vimKeybindings",
 	autoUpdateLastCheckedAt: "updates.lastCheckedAt",
 	dailyNotesFolder: "dailyNotes.folder",
 	webClippingsFolder: "webClippings.folder",
@@ -446,6 +450,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawEditorAttachmentFolder,
 		rawEditorPastedMediaFolder,
 		rawEditorEnablePeopleMentionsAsTags,
+		rawEditorVimKeybindings,
 		rawDatabaseShowColumnColor,
 		rawDatabaseShowNoteCount,
 	] = await Promise.all([
@@ -484,6 +489,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<string | null>(KEYS.editorAttachmentFolder),
 		store.get<string | null>(KEYS.editorPastedMediaFolder),
 		store.get<boolean | null>(KEYS.editorEnablePeopleMentionsAsTags),
+		store.get<boolean | null>(KEYS.editorVimKeybindings),
 		store.get<boolean | null>(KEYS.databaseShowColumnColor),
 		store.get<boolean | null>(KEYS.databaseShowNoteCount),
 	]);
@@ -602,6 +608,10 @@ export async function loadSettings(): Promise<AppSettings> {
 			typeof rawEditorEnablePeopleMentionsAsTags === "boolean"
 				? rawEditorEnablePeopleMentionsAsTags
 				: DEFAULT_EDITOR_SETTINGS.enablePeopleMentionsAsTags,
+		vimKeybindings:
+			typeof rawEditorVimKeybindings === "boolean"
+				? rawEditorVimKeybindings
+				: DEFAULT_EDITOR_SETTINGS.vimKeybindings,
 	};
 	const database: DatabaseSettings = {
 		showColumnColor:
@@ -887,6 +897,15 @@ export async function setEditorEnablePeopleMentionsAsTags(
 	await store.save();
 	void emitSettingsUpdated({
 		editor: { enablePeopleMentionsAsTags: enabled },
+	});
+}
+
+export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.editorVimKeybindings, enabled);
+	await store.save();
+	void emitSettingsUpdated({
+		editor: { vimKeybindings: enabled },
 	});
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -103,6 +103,7 @@ type TauriEventMap = {
 			attachmentStorageMode?: AttachmentStorageMode;
 			attachmentFolder?: string | null;
 			enablePeopleMentionsAsTags?: boolean;
+			vimKeybindings?: boolean;
 		};
 		onboarding?: {
 			launcherSeen?: boolean;

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -336,6 +336,109 @@
 	color: var(--text-primary);
 }
 
+.settingsLabelWithHelp {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+}
+
+.vimKeybindingsInfoButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	flex-shrink: 0;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-secondary);
+	line-height: 0;
+	cursor: pointer;
+	transition: all var(--transition-base);
+}
+
+.vimKeybindingsInfoButton:hover {
+	color: var(--text-primary);
+	border-color: color-mix(in srgb, var(--border-default) 75%, transparent);
+	background: color-mix(in srgb, var(--bg-secondary) 85%, transparent);
+}
+
+.vimKeybindingsInfoButton svg {
+	display: block;
+	width: 14px;
+	height: 14px;
+	color: currentcolor;
+	flex-shrink: 0;
+}
+
+.vimKeybindingsPopover {
+	width: min(360px, calc(100vw - 32px));
+	max-height: min(520px, calc(100vh - 48px));
+	overflow-y: auto;
+	padding: 14px;
+	border-radius: var(--radius-md);
+}
+
+.vimKeybindingsPopoverTitle {
+	font-size: 13px;
+	font-weight: var(--font-semibold);
+	color: var(--text-primary);
+	margin-bottom: 10px;
+}
+
+.vimKeybindingsModes {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding-bottom: 12px;
+	margin-bottom: 12px;
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 76%, transparent);
+	font-size: 12px;
+	line-height: 1.45;
+	color: var(--text-secondary);
+}
+
+.vimKeybindingsModes strong {
+	color: var(--text-primary);
+	font-weight: var(--font-semibold);
+}
+
+.vimKeybindingsList {
+	display: flex;
+	flex-direction: column;
+	gap: 7px;
+}
+
+.vimKeybindingsItem {
+	display: grid;
+	grid-template-columns: minmax(58px, max-content) 1fr;
+	align-items: baseline;
+	gap: 10px;
+	font-size: 12px;
+	line-height: 1.35;
+	color: var(--text-secondary);
+}
+
+.vimKeybindingsItem kbd {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 22px;
+	width: fit-content;
+	padding: 2px 6px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 80%, transparent);
+	border-radius: var(--radius-sm);
+	background: var(--settings-control-surface-strong);
+	color: var(--text-primary);
+	font-size: 11px;
+	font-family: var(--font-mono);
+	font-weight: var(--font-medium);
+	white-space: nowrap;
+}
+
 .settingsValue {
 	max-width: 100%;
 	font-size: 12px;

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -180,6 +180,36 @@
 	transition: color 180ms ease, background-color 180ms ease;
 }
 
+.markdownEditorStatsPill::before {
+	display: none;
+	align-items: center;
+	gap: 6px;
+	padding: 0 8px;
+	min-height: 25px;
+	border-right: 1px solid
+		color-mix(in srgb, var(--border-light) 72%, transparent);
+	font-size: 10.5px;
+	font-weight: var(--font-medium);
+	line-height: 1;
+	color: var(--text-secondary);
+	transition: color 180ms ease, background-color 180ms ease;
+}
+
+.markdownEditorPane:has(.tiptapContentInline[data-vim-mode])
+	.markdownEditorStatsPill::before {
+	content: "INSERT";
+	display: inline-flex;
+	cursor: default;
+}
+
+.markdownEditorPane:has(.tiptapContentInline[data-vim-mode="normal"])
+	.markdownEditorStatsPill::before {
+	content: "NORMAL";
+	color: color-mix(in srgb, var(--interactive-accent) 78%, var(--text-primary));
+	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+	border-radius: var(--radius-full);
+}
+
 .markdownEditorStatsItem + .markdownEditorStatsItem {
 	border-left: 1px solid
 		color-mix(in srgb, var(--border-light) 72%, transparent);
@@ -475,6 +505,16 @@
 	}
 
 	.markdownEditorStatsItem {
+		padding: 0 7px;
+		gap: 4px;
+		font-size: 10px;
+		max-width: 32vw;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.markdownEditorStatsPill::before {
 		padding: 0 7px;
 		gap: 4px;
 		font-size: 10px;


### PR DESCRIPTION
## Summary
- Add a local TipTap Vim Mode extension with basic insert/normal state, navigation, editing, undo, and redo bindings.
- Add a persisted Advanced settings toggle for Vim Mode, off by default.
- Add inline Vim Mode help popover and release notes entry for 0.2.8.

## Testing
- `pnpm test -- src/components/editor/extensions/vimMode.integration.test.ts src/lib/settings.test.ts src/components/settings/AdvancedSettingsPane.test.tsx`
- `pnpm test -- src/components/settings/AdvancedSettingsPane.test.tsx`
- `pnpm check`
- `pnpm build`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sidhuk/glyph/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Vim Mode for the editor featuring Vim keybindings for cursor movement and text editing
  * Enable/disable Vim Mode from Advanced Settings (disabled by default)
  * Supports common Vim motions, mode switching, and editing operations
  * Includes in-app help documentation explaining available Vim keybindings and commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->