### PR TITLE
Add wiki image linking, task rings, and editor polish for v0.2.9

### DIFF
--- a/docs/image-wikilink-resolution.md
+++ b/docs/image-wikilink-resolution.md
@@ -1,0 +1,35 @@
+# Image Wikilink Resolution (`![[...]]`)
+
+This document defines how embedded image wikilinks are parsed and rendered in Glyph.
+
+## Parsing and Rendering Decisions
+
+- `![[...]]` is parsed as a `wikiLink` node with `embed: true`.
+- Image-like embed targets (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.svg`, `.bmp`, `.avif`, `.tif`, `.tiff`) are rendered as `<img data-wikilink-embed="true" ...>`.
+- The initial `<img src>` is the raw wikilink target, then hydration resolves it to a preview data URL.
+- Markdown serialization preserves wikilink syntax (`![[...]]`) instead of converting to `![...](...)`.
+
+## Resolution Rules (Space-Root Semantics)
+
+Image wikilinks are resolved by backend command `space_resolve_image_wikilink`:
+
+1. Root-relative path:
+   - `![[/images/cover.png]]` resolves only to `images/cover.png` at space root.
+2. Nested path (contains `/`):
+   - `![[assets/cover.png]]` is treated as space-root relative and must match that exact path.
+   - No basename fallback is applied when an explicit nested path does not exist.
+3. Filename-only target:
+   - `![[cover.png]]` searches by basename across image files in the space.
+   - If exactly one match exists, use it.
+4. Ambiguous filename fallback:
+   - If multiple basename matches exist, prefer the single root-level match if there is exactly one.
+   - Otherwise choose the lexicographically smallest relative path (case-insensitive deterministic fallback).
+5. Extensionless filename:
+   - `![[cover]]` can match a unique image basename stem.
+
+## Frontend Hydration Behavior
+
+- Inline image hydration uses:
+  - `space_resolve_image_wikilink` for `data-wikilink-embed="true"` images.
+  - `space_resolve_markdown_link` for standard Markdown images.
+- If resolution fails, the image remains unresolved (raw source is kept), which is the explicit fallback.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1043,6 +1043,7 @@ pub fn run() {
             space_fs::list::space_list_markdown_files,
             space_fs::list::space_list_files,
             space_fs::link_ops::space_resolve_wikilink,
+            space_fs::link_ops::space_resolve_image_wikilink,
             space_fs::link_ops::space_resolve_markdown_link,
             space_fs::link_ops::space_suggest_links,
             space_fs::summary::space_dir_children_summary,

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -194,7 +194,9 @@ fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<
         return None;
     }
 
-    let normalized = normalize_segments(raw.trim_start_matches("./"));
+    let pre_normalized = raw.trim_start_matches("./");
+    let is_explicit_path = pre_normalized.starts_with('/') || pre_normalized.contains('/');
+    let normalized = normalize_segments(pre_normalized);
     if normalized.is_empty() {
         return None;
     }
@@ -204,7 +206,7 @@ fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<
         .filter(|entry| is_image_rel_path(&entry.rel_path))
         .collect::<Vec<_>>();
 
-    let explicit_path_query = if raw.starts_with('/') || normalized.contains('/') {
+    let explicit_path_query = if is_explicit_path {
         Some(normalized.trim_start_matches('/').to_string())
     } else {
         None
@@ -418,6 +420,13 @@ mod tests {
     fn image_wikilink_does_not_fallback_for_missing_explicit_nested_path() {
         let entries = vec![entry("images/photo.png"), entry("photo.png")];
         let resolved = resolve_image_wikilink_target(&entries, "assets/photo.png");
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn image_wikilink_does_not_fallback_for_normalized_explicit_path() {
+        let entries = vec![entry("images/photo.png"), entry("docs/note.md")];
+        let resolved = resolve_image_wikilink_target(&entries, "assets/../photo.png");
         assert_eq!(resolved, None);
     }
 

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -45,6 +45,14 @@ fn basename(path: &str) -> String {
     path.rsplit('/').next().unwrap_or(path).to_string()
 }
 
+fn basename_without_extension(path: &str) -> String {
+    let name = basename(path);
+    match name.rsplit_once('.') {
+        Some((stem, _)) => stem.to_string(),
+        None => name,
+    }
+}
+
 fn title_from_rel(path: &str) -> String {
     basename(path)
         .trim_end_matches(".md")
@@ -138,6 +146,105 @@ fn list_files(root: &Path, markdown_only: bool, limit: usize) -> Result<Vec<File
     Ok(out)
 }
 
+fn is_image_rel_path(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".webp")
+        || lower.ends_with(".gif")
+        || lower.ends_with(".svg")
+        || lower.ends_with(".bmp")
+        || lower.ends_with(".avif")
+        || lower.ends_with(".tif")
+        || lower.ends_with(".tiff")
+}
+
+fn choose_ambiguous_image_match(matches: Vec<String>) -> Option<String> {
+    if matches.is_empty() {
+        return None;
+    }
+    if matches.len() == 1 {
+        return matches.into_iter().next();
+    }
+    let mut root_only = matches
+        .iter()
+        .filter(|path| !path.contains('/'))
+        .cloned()
+        .collect::<Vec<_>>();
+    if root_only.len() == 1 {
+        return root_only.pop();
+    }
+    let mut sorted = matches;
+    sorted.sort_by_cached_key(|path| path.to_lowercase());
+    sorted.into_iter().next()
+}
+
+fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<String> {
+    let raw = target
+        .split('#')
+        .next()
+        .unwrap_or("")
+        .split('|')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .replace('\\', "/");
+    if raw.is_empty() {
+        return None;
+    }
+
+    let normalized = normalize_segments(raw.trim_start_matches("./"));
+    if normalized.is_empty() {
+        return None;
+    }
+
+    let image_entries = entries
+        .iter()
+        .filter(|entry| is_image_rel_path(&entry.rel_path))
+        .collect::<Vec<_>>();
+
+    let explicit_path_query = if raw.starts_with('/') || normalized.contains('/') {
+        Some(normalized.trim_start_matches('/').to_string())
+    } else {
+        None
+    };
+
+    if let Some(path_query) = explicit_path_query {
+        if let Some(hit) = image_entries
+            .iter()
+            .find(|entry| normalize_path(&entry.rel_path).eq_ignore_ascii_case(&path_query))
+        {
+            return Some(hit.rel_path.clone());
+        }
+        return None;
+    }
+
+    let file_name_query = normalized.trim_start_matches('/');
+    let exact_name_matches = image_entries
+        .iter()
+        .filter(|entry| basename(&entry.rel_path).eq_ignore_ascii_case(file_name_query))
+        .map(|entry| entry.rel_path.clone())
+        .collect::<Vec<_>>();
+    if !exact_name_matches.is_empty() {
+        return choose_ambiguous_image_match(exact_name_matches);
+    }
+
+    let has_explicit_extension = file_name_query.rsplit_once('.').is_some();
+    if has_explicit_extension {
+        return None;
+    }
+
+    let stem_matches = image_entries
+        .iter()
+        .filter(|entry| {
+            basename_without_extension(&entry.rel_path).eq_ignore_ascii_case(file_name_query)
+        })
+        .map(|entry| entry.rel_path.clone())
+        .collect::<Vec<_>>();
+    choose_ambiguous_image_match(stem_matches)
+}
+
 #[tauri::command]
 pub async fn space_resolve_wikilink(
     state: State<'_, SpaceState>,
@@ -169,6 +276,20 @@ pub async fn space_resolve_wikilink(
             return Ok(Some(hit.rel_path.clone()));
         }
         Ok(None)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn space_resolve_image_wikilink(
+    state: State<'_, SpaceState>,
+    target: String,
+) -> Result<Option<String>, String> {
+    let root = state.current_root()?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let entries = list_files(&root, false, 80_000)?;
+        Ok(resolve_image_wikilink_target(&entries, &target))
     })
     .await
     .map_err(|e| e.to_string())?
@@ -221,6 +342,91 @@ pub async fn space_resolve_markdown_link(
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_image_wikilink_target, FileEntry};
+
+    fn entry(path: &str) -> FileEntry {
+        FileEntry {
+            rel_path: path.to_string(),
+            is_markdown: path.to_ascii_lowercase().ends_with(".md"),
+        }
+    }
+
+    #[test]
+    fn image_wikilink_resolves_root_relative_path() {
+        let entries = vec![entry("images/cover.png"), entry("docs/note.md")];
+        let resolved = resolve_image_wikilink_target(&entries, "/images/cover.png");
+        assert_eq!(resolved, Some("images/cover.png".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_resolves_nested_path_from_space_root() {
+        let entries = vec![
+            entry("assets/logo.png"),
+            entry("docs/assets/logo.png"),
+            entry("docs/note.md"),
+        ];
+        let resolved = resolve_image_wikilink_target(&entries, "assets/logo.png");
+        assert_eq!(resolved, Some("assets/logo.png".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_resolves_unique_filename() {
+        let entries = vec![entry("images/hero.webp"), entry("docs/note.md")];
+        let resolved = resolve_image_wikilink_target(&entries, "hero.webp");
+        assert_eq!(resolved, Some("images/hero.webp".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_resolves_extensionless_unique_stem() {
+        let entries = vec![
+            entry("images/diagram.png"),
+            entry("images/other.jpg"),
+            entry("docs/note.md"),
+        ];
+        let resolved = resolve_image_wikilink_target(&entries, "diagram");
+        assert_eq!(resolved, Some("images/diagram.png".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_ambiguous_filename_prefers_single_root_file() {
+        let entries = vec![
+            entry("photo.png"),
+            entry("assets/photo.png"),
+            entry("z/photo.png"),
+            entry("docs/note.md"),
+        ];
+        let resolved = resolve_image_wikilink_target(&entries, "photo.png");
+        assert_eq!(resolved, Some("photo.png".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_ambiguous_filename_falls_back_to_lexicographic() {
+        let entries = vec![
+            entry("zeta/photo.png"),
+            entry("alpha/photo.png"),
+            entry("docs/note.md"),
+        ];
+        let resolved = resolve_image_wikilink_target(&entries, "photo.png");
+        assert_eq!(resolved, Some("alpha/photo.png".to_string()));
+    }
+
+    #[test]
+    fn image_wikilink_does_not_fallback_for_missing_explicit_nested_path() {
+        let entries = vec![entry("images/photo.png"), entry("photo.png")];
+        let resolved = resolve_image_wikilink_target(&entries, "assets/photo.png");
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn image_wikilink_ignores_non_images() {
+        let entries = vec![entry("image.md"), entry("docs/note.md")];
+        let resolved = resolve_image_wikilink_target(&entries, "image");
+        assert_eq!(resolved, None);
+    }
 }
 
 #[tauri::command]

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1171,10 +1171,8 @@ export function AppShell() {
 				for (const dir of ancestorDirs) next.add(dir);
 				return next;
 			});
-			for (const dir of ancestorDirs) {
-				await fileTree.loadDir(dir);
-			}
-			await fileTree.loadDir(parentPath || "");
+			const dirsToLoad = parentPath ? ancestorDirs : [""];
+			await Promise.all(dirsToLoad.map((dir) => fileTree.loadDir(dir)));
 			window.requestAnimationFrame(() => {
 				window.requestAnimationFrame(() => {
 					dispatchFileTreeStartRename({ path: nextPath });

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -138,6 +138,34 @@ const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 600;
 const PRINT_EDITOR_BODY_CLASS = "glyphPrintEditorMode";
 const PRINT_EDITOR_TARGET_CLASS = "glyphPrintEditorTarget";
+const IMAGE_EXTENSIONS = new Set([
+	"png",
+	"jpg",
+	"jpeg",
+	"webp",
+	"gif",
+	"svg",
+	"bmp",
+	"avif",
+	"tif",
+	"tiff",
+]);
+
+function fileExtension(path: string): string {
+	const name = path.split("/").pop() ?? path;
+	const dot = name.lastIndexOf(".");
+	if (dot <= 0 || dot === name.length - 1) return "";
+	return name.slice(dot + 1).toLowerCase();
+}
+
+function isImageWikiTarget(target: string): boolean {
+	return IMAGE_EXTENSIONS.has(fileExtension(target));
+}
+
+function isMarkdownWikiTarget(target: string): boolean {
+	const ext = fileExtension(target);
+	return !ext || ext === "md";
+}
 
 export function AppShell() {
 	const space = useSpace();
@@ -527,6 +555,10 @@ export function AppShell() {
 			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 			if (!normalizedTarget) return;
+			if (!isMarkdownWikiTarget(normalizedTarget)) {
+				setError(`Only markdown notes are creatable via [[...]]: ${rawTarget}`);
+				return;
+			}
 
 			const resolved = await invoke("space_resolve_wikilink", {
 				target: normalizedTarget,
@@ -579,6 +611,29 @@ export function AppShell() {
 			if (!detail?.target) return;
 			void (async () => {
 				try {
+					const targetWithoutAnchor =
+						detail.target.split("#", 1)[0] ?? detail.target;
+					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
+					if (!normalizedTarget) return;
+
+					if (detail.embed || isImageWikiTarget(normalizedTarget)) {
+						const resolvedImage = await invoke("space_resolve_image_wikilink", {
+							target: normalizedTarget,
+						});
+						if (resolvedImage) {
+							await openWorkspaceFile(resolvedImage);
+							return;
+						}
+						setError(`Could not resolve image wikilink: ${detail.target}`);
+						return;
+					}
+
+					if (!isMarkdownWikiTarget(normalizedTarget)) {
+						setError(
+							`Unsupported non-markdown wikilink target: ${detail.target}`,
+						);
+						return;
+					}
 					await openOrCreateWikiLinkTarget(detail.target);
 				} catch (e) {
 					setError(
@@ -1097,6 +1152,42 @@ export function AppShell() {
 		setSidebarCollapsed,
 		setSidebarViewMode,
 	]);
+
+	const handleStartRenameFromTab = useCallback(
+		async (path: string) => {
+			const nextPath = path.trim();
+			if (!nextPath || !isMarkdownPath(nextPath)) return;
+			setSidebarCollapsed(false);
+			setSidebarViewMode("files");
+			const parentPath = parentDir(nextPath);
+			const ancestorDirs: string[] = [];
+			let current = parentPath;
+			while (current) {
+				ancestorDirs.unshift(current);
+				current = parentDir(current);
+			}
+			updateExpandedDirs((prev) => {
+				const next = new Set(prev);
+				for (const dir of ancestorDirs) next.add(dir);
+				return next;
+			});
+			for (const dir of ancestorDirs) {
+				await fileTree.loadDir(dir);
+			}
+			await fileTree.loadDir(parentPath || "");
+			window.requestAnimationFrame(() => {
+				window.requestAnimationFrame(() => {
+					dispatchFileTreeStartRename({ path: nextPath });
+				});
+			});
+		},
+		[
+			fileTree.loadDir,
+			setSidebarCollapsed,
+			setSidebarViewMode,
+			updateExpandedDirs,
+		],
+	);
 
 	const handleGitSyncFailure = useCallback(
 		(cause: unknown) => {
@@ -1788,6 +1879,7 @@ export function AppShell() {
 				renameTabsForPath={renameTabsForPath}
 				reorderTabs={reorderTabs}
 				openBlankTab={openBlankTab}
+				onStartRenamePath={handleStartRenameFromTab}
 				replaceActiveTabWithBlank={replaceActiveTabWithBlank}
 				showGettingStartedRequest={showGettingStartedRequest}
 				openDatabasesId={openDatabasesId}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -291,6 +291,7 @@ interface MainContentProps {
 	) => void;
 	reorderTabs: (fromTabId: string, toTabId: string) => void;
 	openBlankTab: () => void;
+	onStartRenamePath: (path: string) => void;
 	replaceActiveTabWithBlank: () => void;
 	showGettingStartedRequest: number;
 	openDatabasesId: string | null;
@@ -384,6 +385,7 @@ export const MainContent = memo(function MainContent({
 	renameTabsForPath,
 	reorderTabs,
 	openBlankTab,
+	onStartRenamePath,
 	replaceActiveTabWithBlank,
 	showGettingStartedRequest,
 	openDatabasesId,
@@ -822,6 +824,7 @@ export const MainContent = memo(function MainContent({
 								onPrefetchTab={handlePrefetchTab}
 								onSelectTab={setActiveTabId}
 								onCloseTab={closeTab}
+								onStartRenamePath={onStartRenamePath}
 								onDragStart={setDragTabId}
 								onDragEnd={() => setDragTabId(null)}
 								onReorder={reorderTabs}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -147,17 +147,18 @@ export const SidebarContent = memo(function SidebarContent({
 		const tryCenterRenameTarget = () => {
 			if (cancelled) return;
 			attempts += 1;
-			const nodes = document.querySelectorAll<HTMLElement>(
-				"[data-file-tree-path]",
-			);
-			const target = Array.from(nodes).find(
-				(node) => node.dataset.fileTreePath === renamingPath,
+			const escapedPath =
+				typeof CSS !== "undefined" && typeof CSS.escape === "function"
+					? CSS.escape(renamingPath)
+					: renamingPath;
+			const target = document.querySelector<HTMLElement>(
+				`[data-file-tree-path="${escapedPath}"]`,
 			);
 			if (target) {
 				target.scrollIntoView({
 					block: "center",
 					inline: "nearest",
-					behavior: "smooth",
+					behavior: "auto",
 				});
 				return;
 			}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -136,6 +136,49 @@ export const SidebarContent = memo(function SidebarContent({
 			);
 	}, [handleStartRename]);
 
+	useEffect(() => {
+		if (!renamingPath) return;
+		let cancelled = false;
+		let retryTimer: number | null = null;
+		let firstFrame: number | null = null;
+		let secondFrame: number | null = null;
+		let attempts = 0;
+
+		const tryCenterRenameTarget = () => {
+			if (cancelled) return;
+			attempts += 1;
+			const nodes = document.querySelectorAll<HTMLElement>(
+				"[data-file-tree-path]",
+			);
+			const target = Array.from(nodes).find(
+				(node) => node.dataset.fileTreePath === renamingPath,
+			);
+			if (target) {
+				target.scrollIntoView({
+					block: "center",
+					inline: "nearest",
+					behavior: "smooth",
+				});
+				return;
+			}
+			if (attempts >= 10) return;
+			retryTimer = window.setTimeout(tryCenterRenameTarget, 45);
+		};
+
+		firstFrame = window.requestAnimationFrame(() => {
+			secondFrame = window.requestAnimationFrame(() => {
+				tryCenterRenameTarget();
+			});
+		});
+
+		return () => {
+			cancelled = true;
+			if (firstFrame !== null) window.cancelAnimationFrame(firstFrame);
+			if (secondFrame !== null) window.cancelAnimationFrame(secondFrame);
+			if (retryTimer !== null) window.clearTimeout(retryTimer);
+		};
+	}, [renamingPath]);
+
 	const handleCancelRename = useCallback(() => {
 		setRenamingPath(null);
 		setPendingNewNotePath(null);

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -18,6 +18,7 @@ interface TabBarProps {
 	onPrefetchTab: (target: string | null) => void;
 	onSelectTab: (tabId: string) => void;
 	onCloseTab: (tabId: string) => void;
+	onStartRenamePath: (path: string) => void;
 	onDragStart: (tabId: string) => void;
 	onDragEnd: () => void;
 	onReorder: (fromTabId: string, toTabId: string) => void;
@@ -43,6 +44,7 @@ export function TabBar({
 	onPrefetchTab,
 	onSelectTab,
 	onCloseTab,
+	onStartRenamePath,
 	onDragStart,
 	onDragEnd,
 	onReorder,
@@ -53,19 +55,25 @@ export function TabBar({
 		return withoutExt || name;
 	}, []);
 
+	const compactLabel = useCallback((value: string) => {
+		const text = value.trim();
+		if (text.length <= 20) return text;
+		return `${text.slice(0, 17)}...`;
+	}, []);
+
 	const tabLabel = useCallback(
 		(tab: WorkspaceTab) => {
 			if (tab.kind === "blank") return "New Tab";
-			if (tab.target === AI_AGENT_TAB_ID) return "AI Agent";
-			if (tab.target === ALL_DOCS_TAB_ID) return "All Notes";
-			if (tab.target === CALENDAR_TAB_ID) return "Calendar";
-			if (tab.target === DATABASES_TAB_ID) return "Collections";
-			if (tab.target === TEMPLATES_TAB_ID) return "Templates";
+			if (tab.target === AI_AGENT_TAB_ID) return compactLabel("AI Agent");
+			if (tab.target === ALL_DOCS_TAB_ID) return compactLabel("All Notes");
+			if (tab.target === CALENDAR_TAB_ID) return compactLabel("Calendar");
+			if (tab.target === DATABASES_TAB_ID) return compactLabel("Collections");
+			if (tab.target === TEMPLATES_TAB_ID) return compactLabel("Templates");
 			const parts = (tab.target ?? "").split("/").filter(Boolean);
 			const rawName = parts[parts.length - 1] ?? tab.target ?? "Untitled";
-			return stripFileExtension(rawName);
+			return compactLabel(stripFileExtension(rawName));
 		},
-		[stripFileExtension],
+		[compactLabel, stripFileExtension],
 	);
 
 	const [hovered, setHovered] = useState(false);
@@ -84,36 +92,33 @@ export function TabBar({
 				className="mainTabsBar"
 				data-empty-state={useWindowBackground ? "true" : "false"}
 			>
-				<div className="mainTabsSide" />
-				<div className="mainTabsCenter">
-					<div className="mainTabsStrip">
-						{tabs.map((tab) => (
-							<TabItem
-								key={tab.id}
-								tab={tab}
-								label={tabLabel(tab)}
-								isActive={tab.id === activeTabId}
-								dragTabId={dragTabId}
-								onPrefetchTab={onPrefetchTab}
-								onSelectTab={onSelectTab}
-								onCloseTab={onCloseTab}
-								onDragStart={onDragStart}
-								onDragEnd={onDragEnd}
-								onReorder={onReorder}
-							/>
-						))}
-						<button
-							type="button"
-							className="mainTabAdd"
-							onClick={onOpenBlankTab}
-							title={`Open blank tab (${getShortcutTooltip({ meta: true, key: "t" })})`}
-							aria-label="Open blank tab"
-						>
-							+
-						</button>
-					</div>
+				<div className="mainTabsStrip">
+					{tabs.map((tab) => (
+						<TabItem
+							key={tab.id}
+							tab={tab}
+							label={tabLabel(tab)}
+							isActive={tab.id === activeTabId}
+							dragTabId={dragTabId}
+							onPrefetchTab={onPrefetchTab}
+							onSelectTab={onSelectTab}
+							onCloseTab={onCloseTab}
+							onStartRenamePath={onStartRenamePath}
+							onDragStart={onDragStart}
+							onDragEnd={onDragEnd}
+							onReorder={onReorder}
+						/>
+					))}
 				</div>
-				<div className="mainTabsSide mainTabsSideEnd" />
+				<button
+					type="button"
+					className="mainTabAdd"
+					onClick={onOpenBlankTab}
+					title={`Open blank tab (${getShortcutTooltip({ meta: true, key: "t" })})`}
+					aria-label="Open blank tab"
+				>
+					+
+				</button>
 			</div>
 			{breadcrumbSegments.length > 0 && (
 				<div className={`mainTabsBreadcrumb ${hovered ? "is-visible" : ""}`}>
@@ -154,6 +159,7 @@ const TabItem = memo(function TabItem({
 	onSelectTab,
 	onPrefetchTab,
 	onCloseTab,
+	onStartRenamePath,
 	onDragStart,
 	onDragEnd,
 	onReorder,
@@ -165,6 +171,7 @@ const TabItem = memo(function TabItem({
 	onSelectTab: (tabId: string) => void;
 	onPrefetchTab: (target: string | null) => void;
 	onCloseTab: (tabId: string) => void;
+	onStartRenamePath: (path: string) => void;
 	onDragStart: (tabId: string) => void;
 	onDragEnd: () => void;
 	onReorder: (fromTabId: string, toTabId: string) => void;
@@ -195,6 +202,11 @@ const TabItem = memo(function TabItem({
 		},
 		[onCloseTab, tab.id],
 	);
+	const handleDoubleClick = useCallback(() => {
+		if (!tab.target || tab.kind === "blank" || isPathSpecial(tab.target))
+			return;
+		onStartRenamePath(tab.target);
+	}, [onStartRenamePath, tab.kind, tab.target]);
 
 	const title =
 		tab.kind === "blank"
@@ -227,6 +239,7 @@ const TabItem = memo(function TabItem({
 				onDragEnd={onDragEnd}
 				onDragOver={handleDragOver}
 				onDrop={handleDrop}
+				onDoubleClick={handleDoubleClick}
 			>
 				<span className="mainTabText">
 					<span className="mainTabLabel">{label}</span>

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -64,11 +64,11 @@ export function TabBar({
 	const tabLabel = useCallback(
 		(tab: WorkspaceTab) => {
 			if (tab.kind === "blank") return "New Tab";
-			if (tab.target === AI_AGENT_TAB_ID) return compactLabel("AI Agent");
-			if (tab.target === ALL_DOCS_TAB_ID) return compactLabel("All Notes");
-			if (tab.target === CALENDAR_TAB_ID) return compactLabel("Calendar");
-			if (tab.target === DATABASES_TAB_ID) return compactLabel("Collections");
-			if (tab.target === TEMPLATES_TAB_ID) return compactLabel("Templates");
+			if (tab.target === AI_AGENT_TAB_ID) return "AI Agent";
+			if (tab.target === ALL_DOCS_TAB_ID) return "All Notes";
+			if (tab.target === CALENDAR_TAB_ID) return "Calendar";
+			if (tab.target === DATABASES_TAB_ID) return "Collections";
+			if (tab.target === TEMPLATES_TAB_ID) return "Templates";
 			const parts = (tab.target ?? "").split("/").filter(Boolean);
 			const rawName = parts[parts.length - 1] ?? tab.target ?? "Untitled";
 			return compactLabel(stripFileExtension(rawName));

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -17,7 +17,9 @@ import {
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
+import { loadSettings } from "../../lib/settings";
 import { type NoteTaskSummary, invoke } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
 import { parentDir } from "../../utils/path";
 import {
 	EDITOR_TEXT_COLORS,
@@ -275,6 +277,8 @@ export function DatabaseBoard({
 	const [taskSummariesByPath, setTaskSummariesByPath] = useState<
 		Record<string, NoteTaskSummary>
 	>({});
+	const [showTaskProgressIndicator, setShowTaskProgressIndicator] =
+		useState(true);
 	const boardCardColumns = useMemo(
 		() => cardCandidateColumns(columns, groupColumnId),
 		[columns, groupColumnId],
@@ -296,6 +300,10 @@ export function DatabaseBoard({
 	}, []);
 
 	useEffect(() => {
+		if (!showTaskProgressIndicator) {
+			setTaskSummariesByPath({});
+			return;
+		}
 		const notePaths = Array.from(
 			new Set(rows.map((row) => row.note_path).filter(Boolean)),
 		);
@@ -326,7 +334,26 @@ export function DatabaseBoard({
 		return () => {
 			cancelled = true;
 		};
-	}, [rows]);
+	}, [rows, showTaskProgressIndicator]);
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (cancelled) return;
+				setShowTaskProgressIndicator(settings.ui.showTaskProgressIndicator);
+			})
+			.catch(() => undefined);
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
+			setShowTaskProgressIndicator(payload.ui.showTaskProgressIndicator);
+		}
+	});
 
 	const handleLaneDrop = useCallback(
 		async (
@@ -689,7 +716,8 @@ export function DatabaseBoard({
 																	<span className="databaseBoardCardTitle">
 																		{title}
 																	</span>
-																	{taskSummary.total_count > 0 ? (
+																	{showTaskProgressIndicator &&
+																	taskSummary.total_count > 0 ? (
 																		<TaskProgressIndicator
 																			summary={taskSummary}
 																			className="databaseBoardCardTaskProgress"

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -277,8 +277,10 @@ export function DatabaseBoard({
 	const [taskSummariesByPath, setTaskSummariesByPath] = useState<
 		Record<string, NoteTaskSummary>
 	>({});
-	const [showTaskProgressIndicator, setShowTaskProgressIndicator] =
-		useState(true);
+	const [showTaskProgressIndicator, setShowTaskProgressIndicator] = useState<
+		boolean | null
+	>(null);
+	const taskProgressSettingVersionRef = useRef(0);
 	const boardCardColumns = useMemo(
 		() => cardCandidateColumns(columns, groupColumnId),
 		[columns, groupColumnId],
@@ -300,7 +302,7 @@ export function DatabaseBoard({
 	}, []);
 
 	useEffect(() => {
-		if (!showTaskProgressIndicator) {
+		if (showTaskProgressIndicator !== true) {
 			setTaskSummariesByPath({});
 			return;
 		}
@@ -338,9 +340,12 @@ export function DatabaseBoard({
 
 	useEffect(() => {
 		let cancelled = false;
+		const requestedAtVersion = taskProgressSettingVersionRef.current;
 		void loadSettings()
 			.then((settings) => {
 				if (cancelled) return;
+				if (taskProgressSettingVersionRef.current !== requestedAtVersion)
+					return;
 				setShowTaskProgressIndicator(settings.ui.showTaskProgressIndicator);
 			})
 			.catch(() => undefined);
@@ -351,6 +356,7 @@ export function DatabaseBoard({
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
+			taskProgressSettingVersionRef.current += 1;
 			setShowTaskProgressIndicator(payload.ui.showTaskProgressIndicator);
 		}
 	});

--- a/src/components/editor/CanvasNoteInlineEditor.test.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.test.tsx
@@ -11,10 +11,16 @@ const {
 	getColorfulHeadings,
 	mockEditor,
 	setColorfulHeadings,
+	setShowFrontmatterInEditor,
+	getShowFrontmatterInEditor,
+	setFrontmatter,
+	getFrontmatter,
 	useNoteEditorMock,
 } = vi.hoisted(() => {
 	const listeners = new Map<string, Set<() => void>>();
 	let colorfulHeadings = false;
+	let showFrontmatterInEditor = false;
+	let frontmatter: string | null = null;
 	const chainCommands = {
 		addColumnAfter: vi.fn(() => chainCommands),
 		addRowAfter: vi.fn(() => chainCommands),
@@ -52,9 +58,21 @@ const {
 		setColorfulHeadings(value: boolean) {
 			colorfulHeadings = value;
 		},
+		setShowFrontmatterInEditor(value: boolean) {
+			showFrontmatterInEditor = value;
+		},
+		getShowFrontmatterInEditor() {
+			return showFrontmatterInEditor;
+		},
+		setFrontmatter(value: string | null) {
+			frontmatter = value;
+		},
 		useNoteEditorMock: vi.fn(),
 		getColorfulHeadings() {
 			return colorfulHeadings;
+		},
+		getFrontmatter() {
+			return frontmatter;
 		},
 	};
 });
@@ -222,14 +240,17 @@ describe("CanvasNoteInlineEditor table controls", () => {
 			unobserve() {}
 		} as typeof ResizeObserver;
 		setColorfulHeadings(false);
+		setShowFrontmatterInEditor(false);
+		setFrontmatter(null);
 		mockEditor.isEditable = true;
 		chainCommands.run.mockReturnValue(true);
 		useNoteEditorMock.mockImplementation(() => ({
 			body: "",
 			colorfulHeadings: getColorfulHeadings(),
 			editor: mockEditor,
-			frontmatter: null,
-			frontmatterRef: { current: null },
+			frontmatter: getFrontmatter(),
+			showFrontmatterInEditor: getShowFrontmatterInEditor(),
+			frontmatterRef: { current: getFrontmatter() },
 			lastAppliedBodyRef: { current: "" },
 			lastEmittedMarkdownRef: { current: "" },
 		}));
@@ -379,5 +400,48 @@ describe("CanvasNoteInlineEditor table controls", () => {
 		});
 		expect(chainCommands.addColumnAfter).toHaveBeenCalled();
 		expect(chainCommands.run).toHaveBeenCalled();
+	});
+
+	it("keeps frontmatter hidden by default for new notes", () => {
+		setShowFrontmatterInEditor(false);
+		setFrontmatter(null);
+
+		render("rich");
+
+		expect(container.querySelector(".frontmatterPreview")).toBeNull();
+	});
+
+	it("shows and hides existing frontmatter based on the toggle without reload", () => {
+		setFrontmatter("---\ntitle: Existing\n---\n");
+		setShowFrontmatterInEditor(false);
+
+		render("rich");
+		expect(container.querySelector(".frontmatterPreview")).toBeNull();
+
+		setShowFrontmatterInEditor(true);
+		render("rich");
+		expect(container.querySelector(".frontmatterPreview")).toBeInstanceOf(
+			HTMLDivElement,
+		);
+	});
+
+	it("applies persisted frontmatter visibility after restart remount", () => {
+		setFrontmatter("---\ntitle: Persisted\n---\n");
+		setShowFrontmatterInEditor(true);
+
+		render("rich");
+		expect(container.querySelector(".frontmatterPreview")).toBeInstanceOf(
+			HTMLDivElement,
+		);
+
+		act(() => {
+			root.unmount();
+		});
+		root = createRoot(container);
+
+		render("rich");
+		expect(container.querySelector(".frontmatterPreview")).toBeInstanceOf(
+			HTMLDivElement,
+		);
 	});
 });

--- a/src/components/editor/CanvasNoteInlineEditor.test.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.test.tsx
@@ -411,7 +411,7 @@ describe("CanvasNoteInlineEditor table controls", () => {
 		expect(container.querySelector(".frontmatterPreview")).toBeNull();
 	});
 
-	it("shows and hides existing frontmatter based on the toggle without reload", () => {
+	it("shows and hides existing frontmatter based on the toggle across rerender", () => {
 		setFrontmatter("---\ntitle: Existing\n---\n");
 		setShowFrontmatterInEditor(false);
 

--- a/src/components/editor/CanvasNoteInlineEditor.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.tsx
@@ -387,6 +387,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 		lastAppliedBodyRef,
 		lastEmittedMarkdownRef,
 		colorfulHeadings,
+		showFrontmatterInEditor,
 	} = useNoteEditor({
 		markdown,
 		mode,
@@ -862,6 +863,7 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 									anchorKind: parsed.anchorKind,
 									anchor: parsed.anchor,
 									unresolved: parsed.unresolved,
+									embed: parsed.embed,
 								});
 							}}
 						>
@@ -1482,14 +1484,17 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 						spellCheck={false}
 					/>
 				) : null}
-				{mode === "rich" && frontmatterDraft && !zenModeActive ? (
+				{mode === "rich" &&
+				showFrontmatterInEditor &&
+				frontmatterDraft &&
+				!zenModeActive ? (
 					<div className="frontmatterPreview mono">
 						<NotePropertiesPanel
 							frontmatter={frontmatterDraft}
 							onChange={handleFrontmatterChange}
 						/>
 					</div>
-				) : frontmatter && !zenModeActive ? (
+				) : showFrontmatterInEditor && frontmatter && !zenModeActive ? (
 					<div className="frontmatterPreview mono">
 						<pre>{renderFrontmatterWithLinks(frontmatter.trimEnd())}</pre>
 					</div>

--- a/src/components/editor/CanvasNoteInlineEditor.tsx
+++ b/src/components/editor/CanvasNoteInlineEditor.tsx
@@ -1494,7 +1494,10 @@ export const CanvasNoteInlineEditor = memo(function CanvasNoteInlineEditor({
 							onChange={handleFrontmatterChange}
 						/>
 					</div>
-				) : showFrontmatterInEditor && frontmatter && !zenModeActive ? (
+				) : mode === "rich" &&
+					showFrontmatterInEditor &&
+					frontmatter &&
+					!zenModeActive ? (
 					<div className="frontmatterPreview mono">
 						<pre>{renderFrontmatterWithLinks(frontmatter.trimEnd())}</pre>
 					</div>

--- a/src/components/editor/extensions/wikiLink.integration.test.ts
+++ b/src/components/editor/extensions/wikiLink.integration.test.ts
@@ -4,6 +4,23 @@ import { describe, expect, it } from "vitest";
 import { WikiLink } from "./wikiLink";
 
 describe("WikiLink markdown manager integration", () => {
+	function findWikiLinkNode(
+		value: unknown,
+	): { type?: string; attrs?: Record<string, unknown> } | null {
+		if (!value || typeof value !== "object") return null;
+		const node = value as {
+			type?: string;
+			attrs?: Record<string, unknown>;
+			content?: unknown[];
+		};
+		if (node.type === "wikiLink") return node;
+		for (const child of node.content ?? []) {
+			const found = findWikiLinkNode(child);
+			if (found) return found;
+		}
+		return null;
+	}
+
 	it("round-trips wikilinks through parse/serialize", () => {
 		const manager = new MarkdownManager({
 			extensions: [StarterKit, WikiLink],
@@ -27,6 +44,10 @@ describe("WikiLink markdown manager integration", () => {
 			extensions: [StarterKit, WikiLink],
 		});
 		const json = manager.parse("Hero ![[assets/cover.png]]");
+		const wikiLinkNode = findWikiLinkNode(json);
+		expect(wikiLinkNode).not.toBeNull();
+		expect(wikiLinkNode?.attrs?.target).toBe("assets/cover.png");
+		expect(wikiLinkNode?.attrs?.embed).toBe(true);
 		const out = manager.serialize(json);
 		expect(out).toContain("![[assets/cover.png]]");
 	});

--- a/src/components/editor/extensions/wikiLink.integration.test.ts
+++ b/src/components/editor/extensions/wikiLink.integration.test.ts
@@ -21,4 +21,13 @@ describe("WikiLink markdown manager integration", () => {
 		const out = manager.serialize(json);
 		expect(out).toContain("[[#Heading]]");
 	});
+
+	it("round-trips embedded image wikilinks", () => {
+		const manager = new MarkdownManager({
+			extensions: [StarterKit, WikiLink],
+		});
+		const json = manager.parse("Hero ![[assets/cover.png]]");
+		const out = manager.serialize(json);
+		expect(out).toContain("![[assets/cover.png]]");
+	});
 });

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -50,6 +50,45 @@ function isImageTarget(target: string): boolean {
 	);
 }
 
+function isImagePath(path: string): boolean {
+	return isImageTarget(path);
+}
+
+function isEmbedSuggestionContext(
+	editor: SuggestionProps<WikiLinkSuggestionItem>["editor"],
+	rangeFrom: number,
+): boolean {
+	if (rangeFrom <= 1) return false;
+	try {
+		const previous = editor.state.doc.textBetween(
+			rangeFrom - 1,
+			rangeFrom,
+			"",
+			"",
+		);
+		return previous === "!";
+	} catch {
+		return false;
+	}
+}
+
+function getEmbedReplacementFrom(
+	editor: SuggestionProps<WikiLinkSuggestionItem>["editor"],
+	rangeFrom: number,
+): number {
+	if (!isEmbedSuggestionContext(editor, rangeFrom)) return rangeFrom;
+	return Math.max(0, rangeFrom - 1);
+}
+
+function isEmbedSuggestionContextFromQuery(
+	editor: SuggestionProps<WikiLinkSuggestionItem>["editor"],
+	query: string,
+): boolean {
+	const cursor = editor.state.selection.from;
+	const startOfOpenBrackets = cursor - query.length - 2;
+	return isEmbedSuggestionContext(editor, startOfOpenBrackets);
+}
+
 declare module "@tiptap/core" {
 	interface Commands<ReturnType> {
 		wikiLink: {
@@ -228,17 +267,21 @@ export const WikiLink = Node.create({
 	addProseMirrorPlugins() {
 		const getSuggestions = async (
 			query: string,
+			includeImagesOnly: boolean,
 		): Promise<WikiLinkSuggestionItem[]> => {
 			const results = await invoke("space_suggest_links", {
 				request: {
 					query,
-					markdown_only: true,
-					strip_markdown_ext: true,
+					markdown_only: includeImagesOnly ? false : true,
+					strip_markdown_ext: includeImagesOnly ? false : true,
 					relative_to_source: false,
 					limit: this.options.suggestionLimit,
 				},
 			});
-			return results.map((item) => ({
+			const filtered = includeImagesOnly
+				? results.filter((item) => isImagePath(item.path))
+				: results;
+			return filtered.map((item) => ({
 				path: item.path,
 				title: item.title || titleFromRelPath(item.path),
 				insertText: item.insert_text,
@@ -252,15 +295,27 @@ export const WikiLink = Node.create({
 				char: "[[",
 				allowedPrefixes: null,
 				startOfLine: false,
-				items: async ({ query }) => getSuggestions(query),
+				items: async ({ editor, query }) => {
+					const asEmbed = isEmbedSuggestionContextFromQuery(editor, query);
+					return getSuggestions(query, asEmbed);
+				},
 				command: ({ editor, range, props }) => {
-					const raw = `[[${props.insertText}]]`;
+					const asEmbed = isEmbedSuggestionContext(editor, range.from);
+					const replaceFrom = asEmbed
+						? getEmbedReplacementFrom(editor, range.from)
+						: range.from;
+					const raw = asEmbed
+						? `![[${props.insertText}]]`
+						: `[[${props.insertText}]]`;
 					const parsed = parseWikiLink(raw);
 					if (!parsed) return;
 					editor
 						.chain()
 						.focus()
-						.deleteRange(range)
+						.deleteRange({
+							from: replaceFrom,
+							to: range.to,
+						})
 						.insertContent({
 							type: "wikiLink",
 							attrs: parsed,

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -56,13 +56,21 @@ function isEmbedSuggestionContext(
 ): boolean {
 	if (rangeFrom <= 1) return false;
 	try {
-		const previous = editor.state.doc.textBetween(
+		const previousChar = editor.state.doc.textBetween(
 			rangeFrom - 1,
 			rangeFrom,
 			"",
 			"",
 		);
-		return previous === "!";
+		if (previousChar !== "!") return false;
+		if (rangeFrom <= 2) return true;
+		const beforePreviousChar = editor.state.doc.textBetween(
+			rangeFrom - 2,
+			rangeFrom - 1,
+			"",
+			"",
+		);
+		return beforePreviousChar !== "!";
 	} catch {
 		return false;
 	}
@@ -265,19 +273,22 @@ export const WikiLink = Node.create({
 			query: string,
 			includeImagesOnly: boolean,
 		): Promise<WikiLinkSuggestionItem[]> => {
+			const requestLimit = includeImagesOnly
+				? Math.min(this.options.suggestionLimit * 4, 200)
+				: this.options.suggestionLimit;
 			const results = await invoke("space_suggest_links", {
 				request: {
 					query,
 					markdown_only: !includeImagesOnly,
 					strip_markdown_ext: !includeImagesOnly,
 					relative_to_source: false,
-					limit: this.options.suggestionLimit,
+					limit: requestLimit,
 				},
 			});
 			const filtered = includeImagesOnly
 				? results.filter((item) => isImageTarget(item.path))
 				: results;
-			return filtered.map((item) => ({
+			return filtered.slice(0, this.options.suggestionLimit).map((item) => ({
 				path: item.path,
 				title: item.title || titleFromRelPath(item.path),
 				insertText: item.insert_text,

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -50,10 +50,6 @@ function isImageTarget(target: string): boolean {
 	);
 }
 
-function isImagePath(path: string): boolean {
-	return isImageTarget(path);
-}
-
 function isEmbedSuggestionContext(
 	editor: SuggestionProps<WikiLinkSuggestionItem>["editor"],
 	rangeFrom: number,
@@ -272,14 +268,14 @@ export const WikiLink = Node.create({
 			const results = await invoke("space_suggest_links", {
 				request: {
 					query,
-					markdown_only: includeImagesOnly ? false : true,
-					strip_markdown_ext: includeImagesOnly ? false : true,
+					markdown_only: !includeImagesOnly,
+					strip_markdown_ext: !includeImagesOnly,
 					relative_to_source: false,
 					limit: this.options.suggestionLimit,
 				},
 			});
 			const filtered = includeImagesOnly
-				? results.filter((item) => isImagePath(item.path))
+				? results.filter((item) => isImageTarget(item.path))
 				: results;
 			return filtered.map((item) => ({
 				path: item.path,

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -82,6 +82,8 @@ function maybeDeleteSourceGeneration(sourcePath: string) {
 function clearInlineImageHydrationCacheForSource(sourcePath: string) {
 	sourceGeneration.set(sourcePath, getSourceGeneration(sourcePath) + 1);
 	const prefix = `${sourcePath}::`;
+	// Wiki image-link keys are global (`wiki-image-link::...`) and intentionally
+	// survive per-source invalidation because they do not depend on sourcePath.
 	for (const key of [...dataUrlCache.keys()]) {
 		if (key.startsWith(prefix)) dataUrlCache.delete(key);
 	}
@@ -128,6 +130,17 @@ function dedupeCandidates(href: string): string[] {
 
 type InlineImageResolverKind = "markdown-link" | "wiki-image-link";
 
+function getInlineImageCacheKey(
+	sourcePath: string,
+	rawSrc: string,
+	kind: InlineImageResolverKind,
+): string {
+	if (kind === "wiki-image-link") {
+		return `${kind}::${rawSrc}`;
+	}
+	return `${sourcePath}::${kind}::${rawSrc}`;
+}
+
 function getResolverKindForImage(image: Element): InlineImageResolverKind {
 	return image.getAttribute("data-wikilink-embed") === "true"
 		? "wiki-image-link"
@@ -163,7 +176,7 @@ async function resolveInlineImageDataUrl(
 	rawSrc: string,
 	kind: InlineImageResolverKind,
 ): Promise<string | null> {
-	const key = `${sourcePath}::${kind}::${rawSrc}`;
+	const key = getInlineImageCacheKey(sourcePath, rawSrc, kind);
 	if (dataUrlCache.has(key)) return dataUrlCache.get(key) ?? null;
 	if (missCache.has(key)) return null;
 	if (inFlightCache.has(key)) return inFlightCache.get(key) ?? null;
@@ -295,16 +308,22 @@ export function useHydrateInlineImages(
 					image.setAttribute("data-glyph-origin-src", originalSrc);
 				}
 				const resolverKind = getResolverKindForImage(image);
-				const key = `${sourcePath}::${resolverKind}::${originalSrc}`;
-				if (image.getAttribute("data-glyph-hydrated-key") === key) continue;
-				void resolveInlineImageDataUrl(sourcePath, originalSrc, resolverKind).then(
-					(dataUrl) => {
-						if (cancelled || !dataUrl || !image.isConnected) return;
-						hydrateImageNodesInDocument(editor, originalSrc, dataUrl);
-						image.setAttribute("data-glyph-hydrated-key", key);
-						image.setAttribute("src", dataUrl);
-					},
+				const key = getInlineImageCacheKey(
+					sourcePath,
+					originalSrc,
+					resolverKind,
 				);
+				if (image.getAttribute("data-glyph-hydrated-key") === key) continue;
+				void resolveInlineImageDataUrl(
+					sourcePath,
+					originalSrc,
+					resolverKind,
+				).then((dataUrl) => {
+					if (cancelled || !dataUrl || !image.isConnected) return;
+					hydrateImageNodesInDocument(editor, originalSrc, dataUrl);
+					image.setAttribute("data-glyph-hydrated-key", key);
+					image.setAttribute("src", dataUrl);
+				});
 			}
 		};
 

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -126,10 +126,28 @@ function dedupeCandidates(href: string): string[] {
 	return Array.from(new Set(out));
 }
 
+type InlineImageResolverKind = "markdown-link" | "wiki-image-link";
+
+function getResolverKindForImage(image: Element): InlineImageResolverKind {
+	return image.getAttribute("data-wikilink-embed") === "true"
+		? "wiki-image-link"
+		: "markdown-link";
+}
+
 async function resolveSpaceImagePath(
 	sourcePath: string,
 	href: string,
+	kind: InlineImageResolverKind,
 ): Promise<string | null> {
+	if (kind === "wiki-image-link") {
+		for (const candidate of dedupeCandidates(href)) {
+			const resolved = await invoke("space_resolve_image_wikilink", {
+				target: candidate,
+			});
+			if (resolved) return resolved;
+		}
+		return null;
+	}
 	for (const candidate of dedupeCandidates(href)) {
 		const resolved = await invoke("space_resolve_markdown_link", {
 			href: candidate,
@@ -143,8 +161,9 @@ async function resolveSpaceImagePath(
 async function resolveInlineImageDataUrl(
 	sourcePath: string,
 	rawSrc: string,
+	kind: InlineImageResolverKind,
 ): Promise<string | null> {
-	const key = `${sourcePath}::${rawSrc}`;
+	const key = `${sourcePath}::${kind}::${rawSrc}`;
 	if (dataUrlCache.has(key)) return dataUrlCache.get(key) ?? null;
 	if (missCache.has(key)) return null;
 	if (inFlightCache.has(key)) return inFlightCache.get(key) ?? null;
@@ -154,7 +173,7 @@ async function resolveInlineImageDataUrl(
 
 	const promise = (async () => {
 		try {
-			const relPath = await resolveSpaceImagePath(sourcePath, rawSrc);
+			const relPath = await resolveSpaceImagePath(sourcePath, rawSrc, kind);
 			if (
 				!matchesGeneration(
 					sourcePath,
@@ -275,9 +294,10 @@ export function useHydrateInlineImages(
 				if (image.getAttribute("data-glyph-origin-src") !== originalSrc) {
 					image.setAttribute("data-glyph-origin-src", originalSrc);
 				}
-				const key = `${sourcePath}::${originalSrc}`;
+				const resolverKind = getResolverKindForImage(image);
+				const key = `${sourcePath}::${resolverKind}::${originalSrc}`;
 				if (image.getAttribute("data-glyph-hydrated-key") === key) continue;
-				void resolveInlineImageDataUrl(sourcePath, originalSrc).then(
+				void resolveInlineImageDataUrl(sourcePath, originalSrc, resolverKind).then(
 					(dataUrl) => {
 						if (cancelled || !dataUrl || !image.isConnected) return;
 						hydrateImageNodesInDocument(editor, originalSrc, dataUrl);

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -27,6 +27,7 @@ const {
 					attachmentStorageMode?: AttachmentStorageMode;
 					colorfulHeadings?: boolean;
 					enablePeopleMentionsAsTags?: boolean;
+					showFrontmatterInEditor?: boolean;
 					showCollapsibleHeadings?: boolean;
 				};
 		  }) => void)
@@ -115,6 +116,7 @@ const {
 				attachmentStorageMode?: AttachmentStorageMode;
 				colorfulHeadings?: boolean;
 				enablePeopleMentionsAsTags?: boolean;
+				showFrontmatterInEditor?: boolean;
 				showCollapsibleHeadings?: boolean;
 			};
 		}) => settingsUpdatedHandler?.(payload),
@@ -127,6 +129,7 @@ const {
 					attachmentStorageMode: "specific-folder",
 					colorfulHeadings: false,
 					showCollapsibleHeadings: false,
+					showFrontmatterInEditor: false,
 					enablePeopleMentionsAsTags: false,
 				},
 			}),
@@ -188,6 +191,7 @@ vi.mock("../../../lib/tauriEvents", () => ({
 				attachmentStorageMode?: AttachmentStorageMode;
 				colorfulHeadings?: boolean;
 				enablePeopleMentionsAsTags?: boolean;
+				showFrontmatterInEditor?: boolean;
 				showCollapsibleHeadings?: boolean;
 			};
 		}) => void,
@@ -208,7 +212,10 @@ function Harness({
 	pasteMarkdownBehavior = "plain-text",
 }: {
 	onChange: (nextMarkdown: string) => void;
-	onState?: (state: { colorfulHeadings: boolean }) => void;
+	onState?: (state: {
+		colorfulHeadings: boolean;
+		showFrontmatterInEditor: boolean;
+	}) => void;
 	pasteMarkdownBehavior?: "plain-text" | "smart-markdown";
 }) {
 	const state = useNoteEditor({
@@ -219,8 +226,11 @@ function Harness({
 		onChange,
 	});
 	useEffect(() => {
-		onState?.({ colorfulHeadings: state.colorfulHeadings });
-	}, [onState, state.colorfulHeadings]);
+		onState?.({
+			colorfulHeadings: state.colorfulHeadings,
+			showFrontmatterInEditor: state.showFrontmatterInEditor,
+		});
+	}, [onState, state.colorfulHeadings, state.showFrontmatterInEditor]);
 	return null;
 }
 
@@ -329,6 +339,7 @@ describe("useNoteEditor", () => {
 				attachmentStorageMode: "specific-folder",
 				colorfulHeadings: false,
 				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: false,
 				enablePeopleMentionsAsTags: false,
 			},
 		});
@@ -428,7 +439,10 @@ describe("useNoteEditor", () => {
 			root.render(<Harness onChange={onChange} onState={onState} />);
 		});
 
-		expect(onState).toHaveBeenLastCalledWith({ colorfulHeadings: false });
+		expect(onState).toHaveBeenLastCalledWith({
+			colorfulHeadings: false,
+			showFrontmatterInEditor: false,
+		});
 
 		await act(async () => {
 			emitSettingsUpdated({
@@ -436,7 +450,59 @@ describe("useNoteEditor", () => {
 			});
 		});
 
-		expect(onState).toHaveBeenLastCalledWith({ colorfulHeadings: true });
+		expect(onState).toHaveBeenLastCalledWith({
+			colorfulHeadings: true,
+			showFrontmatterInEditor: false,
+		});
+	});
+
+	it("tracks frontmatter visibility from settings and live updates", async () => {
+		const onChange = vi.fn();
+		const onState = vi.fn();
+
+		await act(async () => {
+			root.render(<Harness onChange={onChange} onState={onState} />);
+		});
+
+		expect(onState).toHaveBeenLastCalledWith({
+			colorfulHeadings: false,
+			showFrontmatterInEditor: false,
+		});
+
+		await act(async () => {
+			emitSettingsUpdated({
+				editor: { showFrontmatterInEditor: true },
+			});
+		});
+
+		expect(onState).toHaveBeenLastCalledWith({
+			colorfulHeadings: false,
+			showFrontmatterInEditor: true,
+		});
+	});
+
+	it("hydrates frontmatter visibility from persisted settings on mount", async () => {
+		const onChange = vi.fn();
+		const onState = vi.fn();
+		loadSettingsMock.mockResolvedValue({
+			editor: {
+				attachmentFolder: "assets",
+				attachmentStorageMode: "specific-folder",
+				colorfulHeadings: false,
+				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: true,
+				enablePeopleMentionsAsTags: false,
+			},
+		});
+
+		await act(async () => {
+			root.render(<Harness onChange={onChange} onState={onState} />);
+		});
+
+		expect(onState).toHaveBeenLastCalledWith({
+			colorfulHeadings: false,
+			showFrontmatterInEditor: true,
+		});
 	});
 
 	it("intercepts Markdown text paste when smart paste is enabled", async () => {
@@ -705,6 +771,7 @@ describe("useNoteEditor", () => {
 				attachmentStorageMode: "specific-folder",
 				colorfulHeadings: false,
 				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: false,
 				enablePeopleMentionsAsTags: false,
 			},
 		});
@@ -743,6 +810,7 @@ describe("useNoteEditor", () => {
 				attachmentStorageMode: "space-root",
 				colorfulHeadings: false,
 				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: false,
 				enablePeopleMentionsAsTags: false,
 			},
 		});
@@ -781,6 +849,7 @@ describe("useNoteEditor", () => {
 				attachmentStorageMode: "note-folder",
 				colorfulHeadings: false,
 				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: false,
 				enablePeopleMentionsAsTags: false,
 			},
 		});

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -340,7 +340,7 @@ function handleEditorClick(
 		}
 		event.preventDefault();
 		dispatchWikiLinkClick({
-			raw: wikiLink.textContent ?? "",
+			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
 			target: wikiLink.getAttribute("data-target") ?? "",
 			alias: wikiLink.getAttribute("data-alias") || null,
 			anchorKind:
@@ -350,6 +350,7 @@ function handleEditorClick(
 					| "block") ?? "none",
 			anchor: wikiLink.getAttribute("data-anchor") || null,
 			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
+			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
 		});
 		return true;
 	}
@@ -412,6 +413,7 @@ export function useNoteEditor({
 	const attachmentFolderRef = useRef<string | null>(DEFAULT_ATTACHMENT_FOLDER);
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
+	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
 	const [peopleMentionsEnabled, setPeopleMentionsEnabled] = useState(false);
 	const [vimKeybindingsEnabled, setVimKeybindingsEnabled] = useState(false);
@@ -451,6 +453,9 @@ export function useNoteEditor({
 			.then((settings) => {
 				if (cancelled) return;
 				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
+				setShowFrontmatterInEditor(
+					settings.editor.showFrontmatterInEditor === true,
+				);
 				setColorfulHeadings(settings.editor.colorfulHeadings);
 				setPeopleMentionsEnabled(settings.editor.enablePeopleMentionsAsTags);
 				setVimKeybindingsEnabled(settings.editor.vimKeybindings === true);
@@ -461,6 +466,7 @@ export function useNoteEditor({
 			.catch(() => {
 				if (cancelled) return;
 				setShowCollapsibleHeadings(false);
+				setShowFrontmatterInEditor(false);
 				setColorfulHeadings(false);
 				setPeopleMentionsEnabled(false);
 				setVimKeybindingsEnabled(false);
@@ -475,6 +481,9 @@ export function useNoteEditor({
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 			setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+		}
+		if (typeof payload.editor?.showFrontmatterInEditor === "boolean") {
+			setShowFrontmatterInEditor(payload.editor.showFrontmatterInEditor);
 		}
 		if (typeof payload.editor?.colorfulHeadings === "boolean") {
 			setColorfulHeadings(payload.editor.colorfulHeadings);
@@ -700,6 +709,7 @@ export function useNoteEditor({
 		frontmatter,
 		body,
 		colorfulHeadings,
+		showFrontmatterInEditor,
 		frontmatterRef,
 		lastAppliedBodyRef,
 		lastEmittedMarkdownRef,

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -10,6 +10,7 @@ export interface WikiLinkClickDetail {
 	anchorKind: "none" | "heading" | "block";
 	anchor: string | null;
 	unresolved: boolean;
+	embed?: boolean;
 }
 
 export interface TagClickDetail {

--- a/src/components/editor/markdown/wikiLinkCodec.test.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.test.ts
@@ -11,6 +11,19 @@ describe("wikiLinkCodec", () => {
 		expect(parseWikiLink("[[Daily Note|Today]]")?.alias).toBe("Today");
 	});
 
+	it("parses embed image wikilinks", () => {
+		expect(parseWikiLink("![[image.png]]")).toMatchObject({
+			target: "image.png",
+			embed: true,
+			alias: null,
+		});
+		expect(parseWikiLink("![[assets/cover.webp|Cover]]")).toMatchObject({
+			target: "assets/cover.webp",
+			embed: true,
+			alias: "Cover",
+		});
+	});
+
 	it("parses heading and block anchors", () => {
 		expect(parseWikiLink("[[Note#Section]]")).toMatchObject({
 			target: "Note",
@@ -47,6 +60,14 @@ describe("wikiLinkCodec", () => {
 				anchor: "x1",
 			}),
 		).toBe("[[Note#^x1]]");
+		expect(
+			wikiLinkAttrsToMarkdown({
+				target: "image.png",
+				embed: true,
+				anchorKind: "none",
+				anchor: null,
+			}),
+		).toBe("![[image.png]]");
 	});
 
 	it("falls back to raw when attrs are incomplete", () => {

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -11,10 +11,15 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import type { KeyboardEvent } from "react";
 import { memo, useEffect, useRef, useState } from "react";
-import type { FileTreeAppearance, FsEntry } from "../../lib/tauri";
+import type {
+	FileTreeAppearance,
+	FsEntry,
+	NoteTaskSummary,
+} from "../../lib/tauri";
 import { FolderPlus, Trash2 } from "../Icons";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { isEditorTextColor } from "../editor/textColors";
+import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -121,6 +126,7 @@ interface FileTreeFileItemProps {
 		direction: -1 | 1,
 		currentTarget: HTMLButtonElement,
 	) => void;
+	taskSummary: NoteTaskSummary | null;
 }
 
 export const FileTreeFileItem = memo(function FileTreeFileItem({
@@ -145,6 +151,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	isPinned,
 	onTogglePinned,
 	onArrowNavigate,
+	taskSummary,
 }: FileTreeFileItemProps) {
 	const customColor =
 		appearance?.color && isEditorTextColor(appearance.color)
@@ -182,7 +189,11 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 		<li className={isActive ? "fileTreeItem active" : "fileTreeItem"}>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (
-					<div className="fileTreeRow fileTreeRowEditing" style={rowStyle}>
+					<div
+						className="fileTreeRow fileTreeRowEditing"
+						style={rowStyle}
+						data-file-tree-path={entry.rel_path}
+					>
 						<span className="fileTreeLeadingSpacer" aria-hidden="true" />
 						<FileRenameInput
 							key={`${entry.rel_path}:${entry.name}`}
@@ -230,6 +241,12 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 									/>
 								)}
 								<span className="fileTreeName">{displayStem}</span>
+								{(taskSummary?.total_count ?? 0) > 0 ? (
+									<TaskProgressIndicator
+										summary={taskSummary}
+										className="fileTreeTaskProgress"
+									/>
+								) : null}
 								{extBadge && (
 									<span className="fileTreeExtBadge">{extBadge}</span>
 								)}

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -7,11 +7,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileTreePane } from "./FileTreePane";
 
 const {
+	invokeMock,
 	loadSettingsMock,
 	useFileTreeContextMock,
 	useSpaceMock,
 	useTauriEventMock,
 } = vi.hoisted(() => ({
+	invokeMock: vi.fn(() => Promise.resolve([])),
 	loadSettingsMock: vi.fn(),
 	useFileTreeContextMock: vi.fn(),
 	useSpaceMock: vi.fn(),
@@ -79,7 +81,7 @@ vi.mock("../../lib/tauriEvents", () => ({
 }));
 
 vi.mock("../../lib/tauri", () => ({
-	invoke: vi.fn(),
+	invoke: invokeMock,
 }));
 
 (
@@ -95,7 +97,10 @@ describe("FileTreePane", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		loadSettingsMock.mockResolvedValue({
-			ui: { showFileTreeFolderCounts: false },
+			ui: {
+				showFileTreeFolderCounts: false,
+				showTaskProgressIndicator: true,
+			},
 		});
 		useFileTreeContextMock.mockReturnValue({
 			itemAppearance: {},

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -10,6 +10,7 @@ import type {
 	DirChildSummary,
 	FileTreeAppearance,
 	FsEntry,
+	NoteTaskSummary,
 } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
@@ -18,6 +19,7 @@ import {
 	parentDir,
 	basename as relBasename,
 } from "../../utils/path";
+import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
 import { FileTreeDirItem } from "./FileTreeDirItem";
 import { FileTreeFileItem } from "./FileTreeFileItem";
@@ -86,6 +88,8 @@ interface TreeEntriesProps {
 		direction: -1 | 1,
 		currentTarget: HTMLButtonElement,
 	) => void;
+	showTaskProgressIndicator: boolean;
+	taskSummariesByPath: Record<string, NoteTaskSummary>;
 }
 
 function TreeEntries({
@@ -117,6 +121,8 @@ function TreeEntries({
 	pinnedFiles,
 	onTogglePinnedFile,
 	onArrowNavigate,
+	showTaskProgressIndicator,
+	taskSummariesByPath,
 }: TreeEntriesProps) {
 	if (entries.length === 0) return null;
 
@@ -190,6 +196,8 @@ function TreeEntries({
 									pinnedFiles={pinnedFiles}
 									onTogglePinnedFile={onTogglePinnedFile}
 									onArrowNavigate={onArrowNavigate}
+									showTaskProgressIndicator={showTaskProgressIndicator}
+									taskSummariesByPath={taskSummariesByPath}
 								/>
 							)}
 						</FileTreeDirItem>
@@ -222,6 +230,11 @@ function TreeEntries({
 						isPinned={pinnedFiles.includes(e.rel_path)}
 						onTogglePinned={onTogglePinnedFile}
 						onArrowNavigate={onArrowNavigate}
+						taskSummary={
+							showTaskProgressIndicator
+								? (taskSummariesByPath[e.rel_path] ?? null)
+								: null
+						}
 					/>
 				);
 			})}
@@ -256,8 +269,13 @@ export const FileTreePane = memo(function FileTreePane({
 	const { itemAppearance, setItemAppearance } = useFileTreeContext();
 	const { spacePath, setError } = useSpace();
 	const [showFolderFileCounts, setShowFolderFileCounts] = useState(false);
+	const [showTaskProgressIndicator, setShowTaskProgressIndicator] =
+		useState(true);
 	const [folderFileCounts, setFolderFileCounts] = useState<
 		Record<string, number>
+	>({});
+	const [taskSummariesByPath, setTaskSummariesByPath] = useState<
+		Record<string, NoteTaskSummary>
 	>({});
 
 	useEffect(() => {
@@ -265,6 +283,7 @@ export const FileTreePane = memo(function FileTreePane({
 		void loadSettings().then((settings) => {
 			if (!cancelled) {
 				setShowFolderFileCounts(settings.ui.showFileTreeFolderCounts);
+				setShowTaskProgressIndicator(settings.ui.showTaskProgressIndicator);
 			}
 		});
 		return () => {
@@ -275,6 +294,9 @@ export const FileTreePane = memo(function FileTreePane({
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFolderFileCounts(payload.ui.showFileTreeFolderCounts);
+		}
+		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
+			setShowTaskProgressIndicator(payload.ui.showTaskProgressIndicator);
 		}
 	});
 
@@ -354,6 +376,63 @@ export const FileTreePane = memo(function FileTreePane({
 		summaryParentDirs,
 		folderCountTreeRevision,
 	]);
+
+	const taskSummaryPaths = useMemo(() => {
+		const paths = new Set<string>();
+		const collectEntries = (entries: FsEntry[] | undefined) => {
+			for (const entry of entries ?? []) {
+				if (entry.kind === "file" && entry.is_markdown) {
+					paths.add(entry.rel_path);
+				}
+			}
+		};
+
+		collectEntries(rootEntries);
+		for (const dirPath of Object.keys(childrenByDir)) {
+			collectEntries(childrenByDir[dirPath]);
+		}
+		for (const pinnedPath of pinnedFiles) {
+			if (isMarkdownPath(pinnedPath)) {
+				paths.add(pinnedPath);
+			}
+		}
+
+		return [...paths].sort();
+	}, [childrenByDir, pinnedFiles, rootEntries]);
+
+	useEffect(() => {
+		if (
+			!spacePath ||
+			!showTaskProgressIndicator ||
+			taskSummaryPaths.length === 0
+		) {
+			setTaskSummariesByPath({});
+			return;
+		}
+
+		let cancelled = false;
+		void invoke("task_summaries_for_paths", { note_paths: taskSummaryPaths })
+			.then((items) => {
+				if (cancelled) return;
+				const next: Record<string, NoteTaskSummary> = {};
+				for (const item of items) {
+					next[item.note_path] = {
+						total_count: item.total_count,
+						completed_count: item.completed_count,
+						open_count: item.open_count,
+					};
+				}
+				setTaskSummariesByPath(next);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setTaskSummariesByPath({});
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [showTaskProgressIndicator, spacePath, taskSummaryPaths]);
 
 	const handleCreateFolder = useCallback(
 		async (dirPath: string) => {
@@ -527,6 +606,14 @@ export const FileTreePane = memo(function FileTreePane({
 													<span className="fileTreeName">
 														{file.displayName}
 													</span>
+													{showTaskProgressIndicator &&
+													(taskSummariesByPath[file.path]?.total_count ?? 0) >
+														0 ? (
+														<TaskProgressIndicator
+															summary={taskSummariesByPath[file.path]}
+															className="fileTreeTaskProgress"
+														/>
+													) : null}
 													{file.parent ? (
 														<span className="fileTreePinnedPath">
 															{file.parent}
@@ -570,6 +657,8 @@ export const FileTreePane = memo(function FileTreePane({
 							pinnedFiles={pinnedFiles}
 							onTogglePinnedFile={onTogglePinnedFile}
 							onArrowNavigate={handleArrowNavigate}
+							showTaskProgressIndicator={showTaskProgressIndicator}
+							taskSummariesByPath={taskSummariesByPath}
 						/>
 					) : null}
 				</div>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -388,7 +388,7 @@ export const FileTreePane = memo(function FileTreePane({
 		};
 
 		collectEntries(rootEntries);
-		for (const dirPath of Object.keys(childrenByDir)) {
+		for (const dirPath of expandedDirs) {
 			collectEntries(childrenByDir[dirPath]);
 		}
 		for (const pinnedPath of pinnedFiles) {
@@ -398,7 +398,7 @@ export const FileTreePane = memo(function FileTreePane({
 		}
 
 		return [...paths].sort();
-	}, [childrenByDir, pinnedFiles, rootEntries]);
+	}, [childrenByDir, expandedDirs, pinnedFiles, rootEntries]);
 
 	useEffect(() => {
 		if (

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -32,6 +32,7 @@ import {
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { setPrefetchedNote } from "../../lib/navigationPrefetch";
 import { splitYamlFrontmatter } from "../../lib/notePreview";
+import { loadSettings } from "../../lib/settings";
 import {
 	type NoteTaskSummary,
 	type TextFileDoc,
@@ -130,6 +131,8 @@ export function MarkdownEditorPane({
 	const [syncPulse, setSyncPulse] = useState<SyncPulse>(null);
 	const [taskSummary, setTaskSummary] =
 		useState<NoteTaskSummary>(EMPTY_TASK_SUMMARY);
+	const [showTaskProgressIndicator, setShowTaskProgressIndicator] =
+		useState(true);
 	const calloutInserterRef = useRef<((type: string) => void) | null>(null);
 	const savedTextRef = useRef(savedText);
 	const textRef = useRef(text);
@@ -543,6 +546,24 @@ export function MarkdownEditorPane({
 	);
 
 	useTauriEvent("notes:external_changed", handleExternalNoteChanged);
+	useTauriEvent("settings:updated", (payload) => {
+		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
+			setShowTaskProgressIndicator(payload.ui.showTaskProgressIndicator);
+		}
+	});
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (cancelled) return;
+				setShowTaskProgressIndicator(settings.ui.showTaskProgressIndicator);
+			})
+			.catch(() => undefined);
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	useEffect(() => {
 		const handleForceEditMode = (event: Event) => {
@@ -687,6 +708,9 @@ export function MarkdownEditorPane({
 			taskSummaryTimerRef.current = null;
 		}
 		setTaskSummary(EMPTY_TASK_SUMMARY);
+		if (!showTaskProgressIndicator) {
+			return;
+		}
 
 		const requestToken = taskSummaryRequestTokenRef.current + 1;
 		taskSummaryRequestTokenRef.current = requestToken;
@@ -725,7 +749,7 @@ export function MarkdownEditorPane({
 				taskSummaryTimerRef.current = null;
 			}
 		};
-	}, [text]);
+	}, [showTaskProgressIndicator, text]);
 
 	useEffect(() => {
 		if (mode === "preview") return;
@@ -1032,7 +1056,7 @@ export function MarkdownEditorPane({
 							/>
 							<span>{stats.readingTime}</span>
 						</div>
-						{visibleTaskSummary.total_count > 0 ? (
+						{showTaskProgressIndicator && visibleTaskSummary.total_count > 0 ? (
 							<div
 								className="markdownEditorStatsItem markdownEditorTaskProgressItem"
 								data-metric="task-progress"

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -14,10 +14,12 @@ const {
 	setDelightfulGlyphMock,
 	setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTagsMock,
+	setEditorShowFrontmatterInEditorMock,
 	setEditorShowCollapsibleHeadingsMock,
 	setEditorWidthModeMock,
 	setEditorVimKeybindingsMock,
 	setShowFileTreeFolderCountsMock,
+	setShowTaskProgressIndicatorMock,
 	setShowTocMock,
 } = vi.hoisted(() => ({
 	loadSettingsMock: vi.fn(),
@@ -27,10 +29,12 @@ const {
 	setDelightfulGlyphMock: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
+	setEditorShowFrontmatterInEditorMock: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorWidthModeMock: vi.fn(() => Promise.resolve()),
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
+	setShowTaskProgressIndicatorMock: vi.fn(() => Promise.resolve()),
 	setShowTocMock: vi.fn(() => Promise.resolve()),
 }));
 
@@ -49,10 +53,12 @@ vi.mock("../../lib/settings", () => ({
 	setDelightfulGlyph: setDelightfulGlyphMock,
 	setEditorColorfulHeadings: setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTags: setEditorEnablePeopleMentionsAsTagsMock,
+	setEditorShowFrontmatterInEditor: setEditorShowFrontmatterInEditorMock,
 	setEditorShowCollapsibleHeadings: setEditorShowCollapsibleHeadingsMock,
 	setEditorWidthMode: setEditorWidthModeMock,
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
+	setShowTaskProgressIndicator: setShowTaskProgressIndicatorMock,
 	setShowToc: setShowTocMock,
 }));
 
@@ -152,12 +158,14 @@ function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
 			editorWidthMode: "compact" as const,
 			enablePeopleMentionsAsTags: false,
 			showCollapsibleHeadings: false,
+			showFrontmatterInEditor: false,
 			vimKeybindings,
 		},
 		ui: {
 			aiAssistantMode: "create" as const,
 			delightfulGlyph: false,
 			showFileTreeFolderCounts: false,
+			showTaskProgressIndicator: true,
 			showToc: true,
 		},
 		database: {
@@ -230,6 +238,23 @@ describe("AdvancedSettingsPane", () => {
 		expect(setEditorColorfulHeadingsMock).toHaveBeenCalledWith(true);
 	});
 
+	it("saves show frontmatter in editor changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Show frontmatter in editor"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setEditorShowFrontmatterInEditorMock).toHaveBeenCalledWith(true);
+	});
+
 	it("saves editor width mode changes", async () => {
 		await act(async () => {
 			root.render(<AdvancedSettingsPane />);
@@ -291,5 +316,22 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setEditorVimKeybindingsMock).toHaveBeenCalledWith(true);
+	});
+
+	it("saves task progress indicator visibility changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Show task progress indicators"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setShowTaskProgressIndicatorMock).toHaveBeenCalledWith(false);
 	});
 });

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -14,9 +14,11 @@ import {
 	setEditorColorfulHeadings,
 	setEditorEnablePeopleMentionsAsTags,
 	setEditorShowCollapsibleHeadings,
+	setEditorShowFrontmatterInEditor,
 	setEditorVimKeybindings,
 	setEditorWidthMode,
 	setShowFileTreeFolderCounts,
+	setShowTaskProgressIndicator,
 	setShowToc,
 } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
@@ -101,6 +103,7 @@ function VimKeybindingsHelp() {
 
 export function AdvancedSettingsPane() {
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
+	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
 	const [editorWidthMode, setEditorWidthModeState] =
 		useState<EditorWidthMode>("compact");
@@ -113,11 +116,15 @@ export function AdvancedSettingsPane() {
 	const [delightfulGlyph, setDelightfulGlyphState] = useState(false);
 	const [showFileTreeFolderCounts, setShowFileTreeFolderCountsState] =
 		useState(false);
+	const [showTaskProgressIndicator, setShowTaskProgressIndicatorState] =
+		useState(true);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
 	const [showDatabaseNoteCount, setShowDatabaseNoteCount] = useState(false);
 	const [error, setError] = useState("");
 	const [isSavingShowToc, setIsSavingShowToc] = useState(false);
 	const [isSavingShowCollapsibleHeadings, setIsSavingShowCollapsibleHeadings] =
+		useState(false);
+	const [isSavingShowFrontmatterInEditor, setIsSavingShowFrontmatterInEditor] =
 		useState(false);
 	const [isSavingColorfulHeadings, setIsSavingColorfulHeadings] =
 		useState(false);
@@ -133,6 +140,10 @@ export function AdvancedSettingsPane() {
 		isSavingShowFileTreeFolderCounts,
 		setIsSavingShowFileTreeFolderCounts,
 	] = useState(false);
+	const [
+		isSavingShowTaskProgressIndicator,
+		setIsSavingShowTaskProgressIndicator,
+	] = useState(false);
 	const [isSavingDatabaseColumnColor, setIsSavingDatabaseColumnColor] =
 		useState(false);
 	const [isSavingDatabaseNoteCount, setIsSavingDatabaseNoteCount] =
@@ -144,6 +155,7 @@ export function AdvancedSettingsPane() {
 		try {
 			const settings = await loadSettings();
 			setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
+			setShowFrontmatterInEditor(settings.editor.showFrontmatterInEditor);
 			setColorfulHeadings(settings.editor.colorfulHeadings);
 			setEditorWidthModeState(settings.editor.editorWidthMode);
 			setEnablePeopleMentionsAsTags(settings.editor.enablePeopleMentionsAsTags);
@@ -152,6 +164,7 @@ export function AdvancedSettingsPane() {
 			setAiAssistantModeState(settings.ui.aiAssistantMode);
 			setDelightfulGlyphState(settings.ui.delightfulGlyph);
 			setShowFileTreeFolderCountsState(settings.ui.showFileTreeFolderCounts);
+			setShowTaskProgressIndicatorState(settings.ui.showTaskProgressIndicator);
 			setShowDatabaseColumnColor(settings.database.showColumnColor);
 			setShowDatabaseNoteCount(settings.database.showNoteCount);
 		} catch (cause) {
@@ -166,6 +179,9 @@ export function AdvancedSettingsPane() {
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 			setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+		}
+		if (typeof payload.editor?.showFrontmatterInEditor === "boolean") {
+			setShowFrontmatterInEditor(payload.editor.showFrontmatterInEditor);
 		}
 		if (typeof payload.editor?.colorfulHeadings === "boolean") {
 			setColorfulHeadings(payload.editor.colorfulHeadings);
@@ -197,6 +213,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFileTreeFolderCountsState(payload.ui.showFileTreeFolderCounts);
+		}
+		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
+			setShowTaskProgressIndicatorState(payload.ui.showTaskProgressIndicator);
 		}
 		if (typeof payload.database?.showColumnColor === "boolean") {
 			setShowDatabaseColumnColor(payload.database.showColumnColor);
@@ -270,6 +289,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingEnablePeopleMentionsAsTags(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Show frontmatter in editor"
+						description="Display YAML frontmatter at the top of notes while editing. Turning this off keeps frontmatter available to indexing and databases."
+					>
+						<SettingsToggle
+							checked={showFrontmatterInEditor}
+							disabled={isSavingShowFrontmatterInEditor}
+							ariaLabel="Show frontmatter in editor"
+							onCheckedChange={(checked) => {
+								const previous = showFrontmatterInEditor;
+								setError("");
+								setShowFrontmatterInEditor(checked);
+								setIsSavingShowFrontmatterInEditor(true);
+								void setEditorShowFrontmatterInEditor(checked)
+									.catch((cause) => {
+										setShowFrontmatterInEditor(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingShowFrontmatterInEditor(false);
 									});
 							}}
 						/>
@@ -434,6 +477,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingDelightfulGlyph(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Show task progress indicators"
+						description="Show task completion rings across the app, including the editor ribbon, sidebar file tree, and database cards."
+					>
+						<SettingsToggle
+							checked={showTaskProgressIndicator}
+							disabled={isSavingShowTaskProgressIndicator}
+							ariaLabel="Show task progress indicators"
+							onCheckedChange={(checked) => {
+								const previous = showTaskProgressIndicator;
+								setError("");
+								setShowTaskProgressIndicatorState(checked);
+								setIsSavingShowTaskProgressIndicator(true);
+								void setShowTaskProgressIndicator(checked)
+									.catch((cause) => {
+										setShowTaskProgressIndicatorState(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingShowTaskProgressIndicator(false);
 									});
 							}}
 						/>

--- a/src/components/settings/accentOptions.ts
+++ b/src/components/settings/accentOptions.ts
@@ -1,7 +1,7 @@
 import type { UiAccent } from "../../lib/settings";
 
 const ACCENT_COLOR_MAP: Record<Exclude<UiAccent, "neutral">, string> = {
-	"glyph-orange": "#ff9f0a",
+	"glyph-orange": "#de7356",
 	cerulean: "#0081a7",
 	"tropical-teal": "#00afb9",
 	"light-yellow": "#fdfcdc",

--- a/src/components/tasks/TaskProgressIndicator.tsx
+++ b/src/components/tasks/TaskProgressIndicator.tsx
@@ -5,6 +5,9 @@ interface TaskProgressIndicatorProps {
 	className?: string;
 }
 
+const RING_RADIUS = 4;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
 export function TaskProgressIndicator({
 	summary,
 	className = "",
@@ -12,8 +15,6 @@ export function TaskProgressIndicator({
 	const { completed_count, total_count } = summary;
 	const ratio = total_count > 0 ? completed_count / total_count : 0;
 	const clampedRatio = Math.max(0, Math.min(1, ratio));
-	const RING_RADIUS = 4;
-	const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 	return (
 		<div

--- a/src/components/tasks/TaskProgressIndicator.tsx
+++ b/src/components/tasks/TaskProgressIndicator.tsx
@@ -12,14 +12,8 @@ export function TaskProgressIndicator({
 	const { completed_count, total_count } = summary;
 	const ratio = total_count > 0 ? completed_count / total_count : 0;
 	const clampedRatio = Math.max(0, Math.min(1, ratio));
-	const tone =
-		clampedRatio >= 1
-			? "green"
-			: clampedRatio >= 0.66
-				? "blue"
-				: clampedRatio >= 0.25
-					? "yellow"
-					: "red";
+	const RING_RADIUS = 4;
+	const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 	return (
 		<div
@@ -29,15 +23,26 @@ export function TaskProgressIndicator({
 			title={`${completed_count}/${total_count} tasks completed`}
 			aria-label={`${completed_count} of ${total_count} tasks completed`}
 		>
-			<div
-				className={`markdownEditorTaskProgressBar is-${tone}`}
+			<svg
+				className="markdownEditorTaskProgressRing"
+				viewBox="0 0 12 12"
 				aria-hidden="true"
 			>
-				<div
-					className="markdownEditorTaskProgressFill"
-					style={{ transform: `scaleX(${clampedRatio})` }}
+				<circle
+					className="markdownEditorTaskProgressTrack"
+					cx="6"
+					cy="6"
+					r={RING_RADIUS}
 				/>
-			</div>
+				<circle
+					className="markdownEditorTaskProgressStroke"
+					cx="6"
+					cy="6"
+					r={RING_RADIUS}
+					strokeDasharray={RING_CIRCUMFERENCE}
+					strokeDashoffset={RING_CIRCUMFERENCE * (1 - clampedRatio)}
+				/>
+			</svg>
 		</div>
 	);
 }

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -1,6 +1,38 @@
 {
 	"versions": [
 		{
+			"version": "0.2.9",
+			"publishedAt": "2026-04-20",
+			"sections": [
+				{
+					"category": "Added",
+					"items": [
+						"Option to show or hide YAML frontmatter in notes",
+						"Toggle setting for task indicators across the app (enabled by default)",
+						"Rename files directly from the tab bar by double-clicking a tab"
+					]
+				},
+				{
+					"category": "Improved",
+					"items": [
+						"Refined heading styling so H1 and H2 are more in line with editor heading visuals",
+						"Updated orange accent to a more pleasant hex tone for better visual comfort",
+						"Improved image handling for wiki-style images and image linking",
+						"Switched task progress from bars to rings for clearer progress at a glance",
+						"Added task progress rings in the sidebar",
+						"Compact tab bar layout for a cleaner, denser UI"
+					]
+				},
+				{
+					"category": "Fixed",
+					"items": [
+						"Fixed and cleaned up issues with smaller font sizes",
+						"Tightened sidebar spacing and recent spaces button UI alignment"
+					]
+				}
+			]
+		},
+		{
 			"version": "0.2.8",
 			"publishedAt": "2026-04-17",
 			"sections": [

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -24,6 +24,23 @@ const BASE_TEXT_SIZES = {
 	"3xl": 30,
 } as const;
 
+const BASE_SPACE_SIZES = {
+	1: 4,
+	2: 8,
+	3: 12,
+	4: 16,
+	5: 20,
+	6: 24,
+	8: 32,
+} as const;
+
+const BASE_LAYOUT_SIZES = {
+	headerHeight: 48,
+	buttonHeight: 32,
+	buttonHeightSm: 26,
+	inputHeight: 32,
+} as const;
+
 const BASE_EDITOR_TEXT_SIZES = {
 	body: 16,
 	inline: 13,
@@ -38,7 +55,7 @@ const BASE_EDITOR_TEXT_SIZES = {
 
 const UI_ACCENT_COLORS: Record<UiAccent, string> = {
 	neutral: "#2f2f2f",
-	"glyph-orange": "#ff9f0a",
+	"glyph-orange": "#de7356",
 	cerulean: "#0081a7",
 	"tropical-teal": "#00afb9",
 	"light-yellow": "#fdfcdc",
@@ -69,6 +86,15 @@ function scaledEditorPx(px: number, scale: number): string {
 	return `${Math.round(px * scale * 100) / 100}px`;
 }
 
+function getCompactDisplayBoost(): number {
+	if (typeof window === "undefined" || !window.screen) return 1;
+	const availableWidth = Number(window.screen.availWidth);
+	if (!Number.isFinite(availableWidth) || availableWidth <= 0) return 1;
+	if (availableWidth <= 1366) return 1.12;
+	if (availableWidth <= 1512) return 1.08;
+	return 1;
+}
+
 export function applyUiTypography(
 	fontFamily: UiFontFamily,
 	monoFontFamily: UiFontFamily,
@@ -79,6 +105,11 @@ export function applyUiTypography(
 	const safeFamily = fontFamily.trim() || "Satoshi";
 	const safeMonoFamily = monoFontFamily.trim() || "JetBrains Mono";
 	const uiScale = Math.max(0.5, Math.min(3, uiFontSize / 14));
+	const compactDisplayBoost = getCompactDisplayBoost();
+	const effectiveUiScale = Math.max(
+		0.5,
+		Math.min(3, uiScale * compactDisplayBoost),
+	);
 	const editorScale = Math.max(
 		MIN_EDITOR_FONT_SIZE / BASE_EDITOR_TEXT_SIZES.body,
 		Math.min(
@@ -86,7 +117,7 @@ export function applyUiTypography(
 			editorFontSize / 16,
 		),
 	);
-	const rootRemPx = 16 * uiScale;
+	const rootRemPx = 16 * effectiveUiScale;
 
 	// Scale rem-based typography globally so Tailwind/shadcn text sizes follow too.
 	root.style.fontSize = `${Math.round(rootRemPx * 100) / 100}px`;
@@ -98,22 +129,81 @@ export function applyUiTypography(
 		"--font-mono",
 		`"${safeMonoFamily}", ui-monospace, SFMono-Regular, Menlo, monospace`,
 	);
-	root.style.setProperty("--text-xs", scaledPx(BASE_TEXT_SIZES.xs, uiScale));
-	root.style.setProperty("--text-sm", scaledPx(BASE_TEXT_SIZES.sm, uiScale));
+	root.style.setProperty(
+		"--text-xs",
+		scaledPx(BASE_TEXT_SIZES.xs, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--text-sm",
+		scaledPx(BASE_TEXT_SIZES.sm, effectiveUiScale),
+	);
 	root.style.setProperty(
 		"--text-base",
-		scaledPx(BASE_TEXT_SIZES.base, uiScale),
+		scaledPx(BASE_TEXT_SIZES.base, effectiveUiScale),
 	);
-	root.style.setProperty("--text-md", scaledPx(BASE_TEXT_SIZES.md, uiScale));
-	root.style.setProperty("--text-lg", scaledPx(BASE_TEXT_SIZES.lg, uiScale));
-	root.style.setProperty("--text-xl", scaledPx(BASE_TEXT_SIZES.xl, uiScale));
+	root.style.setProperty(
+		"--text-md",
+		scaledPx(BASE_TEXT_SIZES.md, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--text-lg",
+		scaledPx(BASE_TEXT_SIZES.lg, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--text-xl",
+		scaledPx(BASE_TEXT_SIZES.xl, effectiveUiScale),
+	);
 	root.style.setProperty(
 		"--text-2xl",
-		scaledPx(BASE_TEXT_SIZES["2xl"], uiScale),
+		scaledPx(BASE_TEXT_SIZES["2xl"], effectiveUiScale),
 	);
 	root.style.setProperty(
 		"--text-3xl",
-		scaledPx(BASE_TEXT_SIZES["3xl"], uiScale),
+		scaledPx(BASE_TEXT_SIZES["3xl"], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-1",
+		scaledPx(BASE_SPACE_SIZES[1], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-2",
+		scaledPx(BASE_SPACE_SIZES[2], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-3",
+		scaledPx(BASE_SPACE_SIZES[3], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-4",
+		scaledPx(BASE_SPACE_SIZES[4], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-5",
+		scaledPx(BASE_SPACE_SIZES[5], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-6",
+		scaledPx(BASE_SPACE_SIZES[6], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--space-8",
+		scaledPx(BASE_SPACE_SIZES[8], effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--header-height",
+		scaledPx(BASE_LAYOUT_SIZES.headerHeight, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--button-height",
+		scaledPx(BASE_LAYOUT_SIZES.buttonHeight, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--button-height-sm",
+		scaledPx(BASE_LAYOUT_SIZES.buttonHeightSm, effectiveUiScale),
+	);
+	root.style.setProperty(
+		"--input-height",
+		scaledPx(BASE_LAYOUT_SIZES.inputHeight, effectiveUiScale),
 	);
 	root.style.setProperty(
 		"--editor-font-size",

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -90,6 +90,8 @@ function getCompactDisplayBoost(): number {
 	if (typeof window === "undefined" || !window.screen) return 1;
 	const availableWidth = Number(window.screen.availWidth);
 	if (!Number.isFinite(availableWidth) || availableWidth <= 0) return 1;
+	// 1366 and 1512 are practical breakpoints for common laptop and compact
+	// desktop display widths where slightly larger UI text improves readability.
 	if (availableWidth <= 1366) return 1.12;
 	if (availableWidth <= 1512) return 1.08;
 	return 1;

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -113,6 +113,36 @@ describe("settings Vim keybindings", () => {
 	});
 });
 
+describe("settings task progress indicator", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults task progress indicator visibility to on", async () => {
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.showTaskProgressIndicator).toBe(true);
+	});
+
+	it("loads task progress indicator visibility from the store", async () => {
+		storeState.set("ui.taskProgressIndicator.enabled", false);
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.showTaskProgressIndicator).toBe(false);
+	});
+
+	it("persists and emits task progress indicator visibility changes", async () => {
+		const { setShowTaskProgressIndicator } = await import("./settings");
+		await setShowTaskProgressIndicator(false);
+		expect(storeState.get("ui.taskProgressIndicator.enabled")).toBe(false);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { showTaskProgressIndicator: false },
+		});
+	});
+});
+
 describe("settings editor width mode", () => {
 	beforeEach(() => {
 		vi.resetModules();
@@ -145,6 +175,42 @@ describe("settings editor width mode", () => {
 		expect(storeState.get("editor.editorWidthMode")).toBe("comfortable");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			editor: { editorWidthMode: "comfortable" },
+		});
+	});
+});
+
+describe("settings show frontmatter in editor", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults frontmatter visibility to off", async () => {
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.showFrontmatterInEditor).toBe(false);
+	});
+
+	it("loads frontmatter visibility from the store", async () => {
+		storeState.set("editor.showFrontmatterInEditor", true);
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.showFrontmatterInEditor).toBe(true);
+	});
+
+	it("persists and emits frontmatter visibility changes", async () => {
+		const { setEditorShowFrontmatterInEditor } = await import("./settings");
+
+		await setEditorShowFrontmatterInEditor(true);
+
+		expect(storeState.get("editor.showFrontmatterInEditor")).toBe(true);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			editor: { showFrontmatterInEditor: true },
 		});
 	});
 });

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -127,6 +127,13 @@ describe("settings task progress indicator", () => {
 	});
 
 	it("loads task progress indicator visibility from the store", async () => {
+		storeState.set("ui.showTaskProgressIndicator", false);
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.showTaskProgressIndicator).toBe(false);
+	});
+
+	it("loads task progress indicator visibility from the legacy store key", async () => {
 		storeState.set("ui.taskProgressIndicator.enabled", false);
 		const { loadSettings } = await import("./settings");
 		const settings = await loadSettings();
@@ -136,7 +143,7 @@ describe("settings task progress indicator", () => {
 	it("persists and emits task progress indicator visibility changes", async () => {
 		const { setShowTaskProgressIndicator } = await import("./settings");
 		await setShowTaskProgressIndicator(false);
-		expect(storeState.get("ui.taskProgressIndicator.enabled")).toBe(false);
+		expect(storeState.get("ui.showTaskProgressIndicator")).toBe(false);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			ui: { showTaskProgressIndicator: false },
 		});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -342,7 +342,7 @@ const KEYS = {
 	delightfulGlyph: "ui.delightfulGlyph",
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
-	showTaskProgressIndicator: "ui.taskProgressIndicator.enabled",
+	showTaskProgressIndicator: "ui.showTaskProgressIndicator",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
@@ -365,6 +365,10 @@ const KEYS = {
 	onboardingUsedCommandPalette: "onboarding.usedCommandPalette",
 	onboardingOpenedDailyNote: "onboarding.openedDailyNote",
 } as const;
+
+// Legacy key from older builds; kept as a read-only fallback during migration.
+const LEGACY_SHOW_TASK_PROGRESS_INDICATOR_KEY =
+	"ui.taskProgressIndicator.enabled";
 
 const ONBOARDING_KEYS = {
 	launcherSeen: KEYS.onboardingLauncherSeen,
@@ -449,6 +453,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawShowToc,
 		rawShowFileTreeFolderCounts,
 		rawShowTaskProgressIndicator,
+		rawShowTaskProgressIndicatorLegacy,
 		dailyNotesFolderRaw,
 		rawWebClippingsFolder,
 		templatesFolderRaw,
@@ -489,6 +494,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.showToc),
 		store.get<boolean | null>(KEYS.showFileTreeFolderCounts),
 		store.get<boolean | null>(KEYS.showTaskProgressIndicator),
+		store.get<boolean | null>(LEGACY_SHOW_TASK_PROGRESS_INDICATOR_KEY),
 		store.get<string | null>(KEYS.dailyNotesFolder),
 		store.get<string | null>(KEYS.webClippingsFolder),
 		store.get<string | null>(KEYS.templatesFolder),
@@ -544,7 +550,9 @@ export async function loadSettings(): Promise<AppSettings> {
 	const showTaskProgressIndicator =
 		typeof rawShowTaskProgressIndicator === "boolean"
 			? rawShowTaskProgressIndicator
-			: DEFAULT_SHOW_TASK_PROGRESS_INDICATOR;
+			: typeof rawShowTaskProgressIndicatorLegacy === "boolean"
+				? rawShowTaskProgressIndicatorLegacy
+				: DEFAULT_SHOW_TASK_PROGRESS_INDICATOR;
 	const dailyNotesFolder =
 		typeof dailyNotesFolderRaw === "string"
 			? normalizeRelPath(dailyNotesFolderRaw) || null

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -64,6 +64,7 @@ const DEFAULT_UI_ACCENT: UiAccent = "cerulean";
 const DEFAULT_UI_FONT_FAMILY = "Satoshi";
 const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
 const DEFAULT_AUTO_UPDATE_CHECK_INTERVAL: AutoUpdateCheckInterval = "3h";
+const DEFAULT_SHOW_TASK_PROGRESS_INDICATOR = true;
 export const MIN_UI_FONT_SIZE = 7;
 export const MAX_UI_FONT_SIZE = 40;
 const DEFAULT_UI_FONT_SIZE = 14;
@@ -110,6 +111,7 @@ export interface DatabaseSettings {
 
 export interface EditorSettings {
 	showCollapsibleHeadings: boolean;
+	showFrontmatterInEditor: boolean;
 	colorfulHeadings: boolean;
 	editorWidthMode: EditorWidthMode;
 	attachmentStorageMode: AttachmentStorageMode;
@@ -129,6 +131,7 @@ const DEFAULT_DATABASE_SETTINGS: DatabaseSettings = {
 
 const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	showCollapsibleHeadings: false,
+	showFrontmatterInEditor: false,
 	colorfulHeadings: false,
 	editorWidthMode: "compact",
 	attachmentStorageMode: "note-folder",
@@ -234,6 +237,7 @@ async function emitSettingsUpdated(payload: {
 		delightfulGlyph?: boolean;
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
+		showTaskProgressIndicator?: boolean;
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
 	};
@@ -256,6 +260,7 @@ async function emitSettingsUpdated(payload: {
 	};
 	editor?: {
 		showCollapsibleHeadings?: boolean;
+		showFrontmatterInEditor?: boolean;
 		colorfulHeadings?: boolean;
 		editorWidthMode?: EditorWidthMode;
 		attachmentStorageMode?: AttachmentStorageMode;
@@ -298,6 +303,7 @@ interface AppSettings {
 		delightfulGlyph: boolean;
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
+		showTaskProgressIndicator: boolean;
 		aiAssistantMode: AiAssistantMode;
 	};
 	dailyNotes: {
@@ -336,7 +342,9 @@ const KEYS = {
 	delightfulGlyph: "ui.delightfulGlyph",
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
+	showTaskProgressIndicator: "ui.taskProgressIndicator.enabled",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
+	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
 	editorEditorWidthMode: "editor.editorWidthMode",
 	editorAttachmentStorageMode: "editor.attachmentStorageMode",
@@ -440,12 +448,14 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawDelightfulGlyph,
 		rawShowToc,
 		rawShowFileTreeFolderCounts,
+		rawShowTaskProgressIndicator,
 		dailyNotesFolderRaw,
 		rawWebClippingsFolder,
 		templatesFolderRaw,
 		templatesDailyNoteTemplateRaw,
 		taskSourceRaw,
 		rawEditorShowCollapsibleHeadings,
+		rawEditorShowFrontmatterInEditor,
 		rawEditorColorfulHeadings,
 		rawEditorWidthMode,
 		rawEditorAttachmentStorageMode,
@@ -478,12 +488,14 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.delightfulGlyph),
 		store.get<boolean | null>(KEYS.showToc),
 		store.get<boolean | null>(KEYS.showFileTreeFolderCounts),
+		store.get<boolean | null>(KEYS.showTaskProgressIndicator),
 		store.get<string | null>(KEYS.dailyNotesFolder),
 		store.get<string | null>(KEYS.webClippingsFolder),
 		store.get<string | null>(KEYS.templatesFolder),
 		store.get<string | null>(KEYS.templatesDailyNoteTemplate),
 		store.get<unknown>(KEYS.taskSource),
 		store.get<boolean | null>(KEYS.editorShowCollapsibleHeadings),
+		store.get<boolean | null>(KEYS.editorShowFrontmatterInEditor),
 		store.get<boolean | null>(KEYS.editorColorfulHeadings),
 		store.get<unknown>(KEYS.editorEditorWidthMode),
 		store.get<unknown>(KEYS.editorAttachmentStorageMode),
@@ -529,6 +541,10 @@ export async function loadSettings(): Promise<AppSettings> {
 		typeof rawShowFileTreeFolderCounts === "boolean"
 			? rawShowFileTreeFolderCounts
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
+	const showTaskProgressIndicator =
+		typeof rawShowTaskProgressIndicator === "boolean"
+			? rawShowTaskProgressIndicator
+			: DEFAULT_SHOW_TASK_PROGRESS_INDICATOR;
 	const dailyNotesFolder =
 		typeof dailyNotesFolderRaw === "string"
 			? normalizeRelPath(dailyNotesFolderRaw) || null
@@ -558,6 +574,10 @@ export async function loadSettings(): Promise<AppSettings> {
 			typeof rawEditorShowCollapsibleHeadings === "boolean"
 				? rawEditorShowCollapsibleHeadings
 				: DEFAULT_EDITOR_SETTINGS.showCollapsibleHeadings,
+		showFrontmatterInEditor:
+			typeof rawEditorShowFrontmatterInEditor === "boolean"
+				? rawEditorShowFrontmatterInEditor
+				: DEFAULT_EDITOR_SETTINGS.showFrontmatterInEditor,
 		colorfulHeadings:
 			typeof rawEditorColorfulHeadings === "boolean"
 				? rawEditorColorfulHeadings
@@ -604,6 +624,7 @@ export async function loadSettings(): Promise<AppSettings> {
 			delightfulGlyph,
 			showToc,
 			showFileTreeFolderCounts,
+			showTaskProgressIndicator,
 			aiAssistantMode,
 		},
 		dailyNotes: {
@@ -770,6 +791,15 @@ export async function setShowFileTreeFolderCounts(
 	void emitSettingsUpdated({ ui: { showFileTreeFolderCounts: enabled } });
 }
 
+export async function setShowTaskProgressIndicator(
+	enabled: boolean,
+): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.showTaskProgressIndicator, enabled);
+	await store.save();
+	void emitSettingsUpdated({ ui: { showTaskProgressIndicator: enabled } });
+}
+
 export async function setEditorShowCollapsibleHeadings(
 	enabled: boolean,
 ): Promise<void> {
@@ -789,6 +819,17 @@ export async function setEditorColorfulHeadings(
 	await store.save();
 	void emitSettingsUpdated({
 		editor: { colorfulHeadings: enabled },
+	});
+}
+
+export async function setEditorShowFrontmatterInEditor(
+	enabled: boolean,
+): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.editorShowFrontmatterInEditor, enabled);
+	await store.save();
+	void emitSettingsUpdated({
+		editor: { showFrontmatterInEditor: enabled },
 	});
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -828,6 +828,7 @@ interface TauriCommands {
 	space_resolve_abs_path: CommandDef<{ path: string }, string>;
 	space_relativize_path: CommandDef<{ abs_path: string }, string>;
 	space_resolve_wikilink: CommandDef<{ target: string }, string | null>;
+	space_resolve_image_wikilink: CommandDef<{ target: string }, string | null>;
 	space_resolve_markdown_link: CommandDef<
 		{ href: string; sourcePath: string },
 		string | null

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -76,6 +76,7 @@ type TauriEventMap = {
 			delightfulGlyph?: boolean;
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
+			showTaskProgressIndicator?: boolean;
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
 		};
@@ -95,6 +96,7 @@ type TauriEventMap = {
 		};
 		editor?: {
 			showCollapsibleHeadings?: boolean;
+			showFrontmatterInEditor?: boolean;
 			colorfulHeadings?: boolean;
 			editorWidthMode?: EditorWidthMode;
 			attachmentStorageMode?: AttachmentStorageMode;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -164,7 +164,14 @@ function ThemeAndTypographyBridge() {
 		) {
 			return;
 		}
-		applyUiTypography(fontFamily, monoFontFamily, uiFontSize, editorFontSize);
+		const applyTypography = () => {
+			applyUiTypography(fontFamily, monoFontFamily, uiFontSize, editorFontSize);
+		};
+		applyTypography();
+		window.addEventListener("resize", applyTypography);
+		return () => {
+			window.removeEventListener("resize", applyTypography);
+		};
 	}, [editorFontSize, fontFamily, monoFontFamily, uiFontSize]);
 
 	React.useEffect(() => {

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -60,7 +60,7 @@
 .sidebarHeader {
 	display: flex;
 	align-items: center;
-	height: calc(var(--header-height) - 4px);
+	height: calc(var(--header-height) - 6px);
 	padding: 0;
 	border-bottom: none;
 	flex-shrink: 0;
@@ -92,7 +92,7 @@
 	align-items: center;
 	gap: 6px;
 	position: absolute;
-	top: 50%;
+	top: calc(50% - 4px);
 	left: var(--window-control-toggle-offset, 90px);
 	transform: translateY(-50%);
 }

--- a/src/styles/app/05-main-area.css
+++ b/src/styles/app/05-main-area.css
@@ -730,10 +730,11 @@
 }
 
 .mainTabsBar {
-	height: 44px;
+	height: 40px;
 	display: flex;
 	align-items: center;
-	gap: var(--space-2);
+	justify-content: flex-start;
+	gap: 8px;
 	padding: 0 var(--space-3);
 	border-bottom: 0;
 	background: var(--bg-primary);
@@ -788,41 +789,31 @@
 	font-weight: var(--font-medium);
 }
 
-.mainTabsSide {
-	flex: 1;
-	min-width: 0;
-}
-
-.mainTabsSideEnd {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-}
-
-.mainTabsCenter {
-	flex: 0 1 1120px;
-	min-width: 0;
-	display: flex;
-	align-items: center;
-}
-
 .mainTabsStrip {
-	flex: 1;
+	flex: 0 1 auto;
+	width: fit-content;
+	max-width: calc(100% - 40px);
 	min-width: 0;
 	display: flex;
 	align-items: center;
-	gap: 6px;
-	padding: 3px 0;
-	border-radius: var(--radius-3xl);
-	border: 0;
-	background: transparent;
-	overflow: hidden;
+	gap: 5px;
+	padding: 2px 6px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 24%, transparent);
+	background: color-mix(in srgb, var(--bg-tertiary) 66%, transparent);
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.mainTabsStrip::-webkit-scrollbar {
+	display: none;
 }
 
 .mainTabWrap {
 	position: relative;
-	min-width: 78px;
-	flex: 1 1 0%;
+	flex: 0 0 auto;
+	width: clamp(96px, 12vw, 178px);
+	min-width: 0;
 }
 
 .mainTab {
@@ -836,7 +827,7 @@
 	gap: 7px;
 	padding: 0 10px 0 26px;
 	border-radius: var(--radius-2xl);
-	border: 1px solid color-mix(in srgb, var(--border-light) 28%, transparent);
+	border: 1px solid transparent;
 	background: transparent;
 	color: var(--text-tertiary);
 	cursor: pointer;
@@ -870,7 +861,7 @@
 }
 
 .mainTabLabel {
-	font-size: 11px;
+	font-size: 12px;
 	line-height: 1.2;
 	font-weight: var(--font-medium);
 }

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -346,6 +346,17 @@
 	white-space: nowrap;
 }
 
+.fileTreeTaskProgress {
+	flex-shrink: 0;
+	width: 12px;
+	height: 12px;
+}
+
+.fileTreeTaskProgress .markdownEditorTaskProgressRing {
+	width: 12px;
+	height: 12px;
+}
+
 .fileTreeRow[data-has-custom-color="true"] .fileTreeExtBadge {
 	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-hover));
 	color: var(--pill-contrast-fg);

--- a/src/styles/app/24-node-note-editor-b.css
+++ b/src/styles/app/24-node-note-editor-b.css
@@ -783,10 +783,10 @@ input.notePropertyValue {
 .tiptapContentInline h4,
 .tiptapContentInline h5,
 .tiptapContentInline h6 {
-	margin: calc(var(--space-5) + 2px) 0 var(--space-3);
-	font-weight: var(--font-semibold);
-	line-height: 1.22;
-	letter-spacing: -0.018em;
+	margin: calc(var(--space-4) + 2px) 0 calc(var(--space-2) + 2px);
+	font-weight: var(--font-medium);
+	line-height: 1.32;
+	letter-spacing: -0.014em;
 	text-wrap: balance;
 }
 
@@ -797,19 +797,24 @@ input.notePropertyValue {
 .tiptapContentInline
 	:is(p, ul, ol, blockquote, pre, table)
 	+ :is(h1, h2, h3, h4, h5, h6) {
-	margin-top: calc(var(--space-6) + 2px);
+	margin-top: calc(var(--space-5) + 2px);
 }
 
 .tiptapContentInline h1 {
 	font-size: var(--editor-h1-font-size);
+	font-weight: var(--font-semibold);
+	line-height: 1.26;
 }
 
 .tiptapContentInline h2 {
 	font-size: var(--editor-h2-font-size);
+	font-weight: var(--font-semibold);
+	line-height: 1.3;
 }
 
 .tiptapContentInline h3 {
 	font-size: var(--editor-h3-font-size);
+	line-height: 1.36;
 }
 
 .tiptapContentInline h4 {
@@ -908,6 +913,7 @@ input.notePropertyValue {
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h5::before,
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h6::before {
 	position: absolute;
+	top: auto;
 	bottom: 0;
 	left: calc(
 		-1 *
@@ -915,6 +921,7 @@ input.notePropertyValue {
 		2px
 	);
 	font-size: 11px;
+	line-height: 1;
 	font-weight: var(--font-medium);
 	letter-spacing: 0.025em;
 	color: color-mix(in srgb, var(--text-tertiary) 86%, transparent);
@@ -923,14 +930,17 @@ input.notePropertyValue {
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h1::before {
 	content: "H1";
+	bottom: 6px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h2::before {
 	content: "H2";
+	bottom: 5px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h3::before {
 	content: "H3";
+	bottom: 4px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h4::before {
@@ -1441,6 +1451,32 @@ input.notePropertyValue {
 }
 
 @media (max-width: 760px) {
+	.tiptapContentInline h1,
+	.tiptapContentInline h2,
+	.tiptapContentInline h3,
+	.tiptapContentInline h4,
+	.tiptapContentInline h5,
+	.tiptapContentInline h6 {
+		margin-top: var(--space-4);
+		margin-bottom: var(--space-2);
+		letter-spacing: -0.012em;
+	}
+
+	.tiptapContentInline h1 {
+		font-size: 23px;
+		line-height: 1.28;
+	}
+
+	.tiptapContentInline h2 {
+		font-size: 19px;
+		line-height: 1.32;
+	}
+
+	.tiptapContentInline h3 {
+		font-size: 16.5px;
+		line-height: 1.38;
+	}
+
 	.tiptapHostInline:not(.is-preview) .tiptapContentInline {
 		padding-left: var(--editor-readable-content-gutter-compact);
 	}

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -236,47 +236,31 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
+	width: 16px;
 	height: 12px;
 }
 
-.markdownEditorTaskProgressBar {
-	position: relative;
-	display: flex;
-	align-items: stretch;
-	justify-content: flex-start;
-	width: 18px;
-	height: 9px;
-	border: 1px solid color-mix(in srgb, var(--border-default) 68%, transparent);
-	border-radius: 2px;
-	background: color-mix(in srgb, var(--bg-secondary) 92%, var(--bg-primary));
-	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--border-light) 28%, transparent);
-	overflow: hidden;
+.markdownEditorTaskProgressRing {
+	width: 12px;
+	height: 12px;
+	display: block;
+	transform: rotate(-90deg);
 }
 
-.markdownEditorTaskProgressFill {
-	width: 100%;
-	height: 100%;
-	border-radius: 0;
-	transform-origin: left center;
-	transition: transform 180ms ease;
+.markdownEditorTaskProgressTrack,
+.markdownEditorTaskProgressStroke {
+	fill: none;
+	stroke-width: 2;
 }
 
-.markdownEditorTaskProgressBar.is-red .markdownEditorTaskProgressFill {
-	background: var(--glyph-inline-highlight-red, rgba(249, 112, 102, 0.2));
+.markdownEditorTaskProgressTrack {
+	stroke: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
 }
 
-.markdownEditorTaskProgressBar.is-yellow .markdownEditorTaskProgressFill {
-	background: var(--glyph-inline-highlight-yellow, rgba(240, 180, 41, 0.26));
-}
-
-.markdownEditorTaskProgressBar.is-blue .markdownEditorTaskProgressFill {
-	background: var(--glyph-inline-highlight-blue, rgba(59, 155, 220, 0.22));
-}
-
-.markdownEditorTaskProgressBar.is-green .markdownEditorTaskProgressFill {
-	background: var(--glyph-inline-highlight-green, rgba(60, 207, 142, 0.24));
+.markdownEditorTaskProgressStroke {
+	stroke: var(--interactive-accent);
+	stroke-linecap: round;
+	transition: stroke-dashoffset 180ms ease;
 }
 
 .markdownEditorSaveState {
@@ -325,7 +309,7 @@
 }
 
 .markdownEditorStatsDock.is-collapsed .markdownEditorTaskProgress {
-	width: 24px;
+	width: 16px;
 	height: 12px;
 }
 


### PR DESCRIPTION
## Summary
- Improve wiki image resolution and linking, with supporting Tauri link ops and editor hydration updates
- Add task progress rings in the sidebar and expose a global task indicator toggle enabled by default
- Refine editor and layout UX with cleaner heading styling, compact tabs, sidebar spacing updates, and file rename from tabs
- Update accent options, font-size handling, YAML frontmatter visibility, and release notes for `0.2.9`

## Testing
- Updated and added targeted tests for wiki links, note editor behavior, file tree, settings, and inline image/editor flows
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embedded image wikilinks using `![[...]]` syntax
  * Editor setting to toggle frontmatter visibility
  * UI setting to toggle task progress indicators
  * Tab rename capability via double-click

* **Improved**
  * Redesigned task progress visualization from horizontal bar to circular ring format
  * Refined tab bar layout with responsive sizing
  * Enhanced UI spacing and heading typography in editor
  * Improved sidebar and layout alignment

* **Fixed**
  * Corrected sidebar header and action vertical alignment
  * Adjusted accent color styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->