### PR TITLE
Add per-tab note back and forward navigation

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -353,6 +353,10 @@ export function AppShell() {
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
+		canGoBack,
+		canGoForward,
+		goBack,
+		goForward,
 	} = useTabManager(spacePath);
 
 	useEffect(() => {
@@ -1535,6 +1539,26 @@ export function AppShell() {
 				action: () => setActivePreviewPath(null),
 			},
 			{
+				id: "go-back-note",
+				label: "Go back",
+				icon: <HugeiconsIcon icon={MoveIcon} size={16} strokeWidth={0.9} />,
+				category: "Navigation",
+				shortcut: { meta: true, key: "[" },
+				enabled: canGoBack,
+				allowInEditable: true,
+				action: goBack,
+			},
+			{
+				id: "go-forward-note",
+				label: "Go forward",
+				icon: <HugeiconsIcon icon={MoveIcon} size={16} strokeWidth={0.9} />,
+				category: "Navigation",
+				shortcut: { meta: true, key: "]" },
+				enabled: canGoForward,
+				allowInEditable: true,
+				action: goForward,
+			},
+			{
 				id: "quick-open",
 				label: "Quick open",
 				icon: <HugeiconsIcon icon={SearchIcon} size={16} strokeWidth={0.9} />,
@@ -1772,6 +1796,10 @@ export function AppShell() {
 		openSettings,
 		refreshMoveTargetDirs,
 		openPalette,
+		canGoBack,
+		canGoForward,
+		goBack,
+		goForward,
 	]);
 
 	useCommandShortcuts({
@@ -1879,6 +1907,10 @@ export function AppShell() {
 				openBlankTab={openBlankTab}
 				onStartRenamePath={handleStartRenameFromTab}
 				replaceActiveTabWithBlank={replaceActiveTabWithBlank}
+				canGoBack={canGoBack}
+				canGoForward={canGoForward}
+				onGoBack={goBack}
+				onGoForward={goForward}
 				showGettingStartedRequest={showGettingStartedRequest}
 				openDatabasesId={openDatabasesId}
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 import {
 	AiChat02Icon,
+	ArrowLeft,
+	ArrowRight,
 	Calendar03Icon,
 	CalendarAdd01Icon,
 	ColorsIcon,
@@ -1541,7 +1543,7 @@ export function AppShell() {
 			{
 				id: "go-back-note",
 				label: "Go back",
-				icon: <HugeiconsIcon icon={MoveIcon} size={16} strokeWidth={0.9} />,
+				icon: <HugeiconsIcon icon={ArrowLeft} size={16} strokeWidth={0.9} />,
 				category: "Navigation",
 				shortcut: { meta: true, key: "[" },
 				enabled: canGoBack,
@@ -1551,7 +1553,7 @@ export function AppShell() {
 			{
 				id: "go-forward-note",
 				label: "Go forward",
-				icon: <HugeiconsIcon icon={MoveIcon} size={16} strokeWidth={0.9} />,
+				icon: <HugeiconsIcon icon={ArrowRight} size={16} strokeWidth={0.9} />,
 				category: "Navigation",
 				shortcut: { meta: true, key: "]" },
 				enabled: canGoForward,

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -293,6 +293,10 @@ interface MainContentProps {
 	openBlankTab: () => void;
 	onStartRenamePath: (path: string) => void;
 	replaceActiveTabWithBlank: () => void;
+	canGoBack: boolean;
+	canGoForward: boolean;
+	onGoBack: () => void;
+	onGoForward: () => void;
 	showGettingStartedRequest: number;
 	openDatabasesId: string | null;
 	dailyNoteSetupNoticeRequest: number;
@@ -387,6 +391,10 @@ export const MainContent = memo(function MainContent({
 	openBlankTab,
 	onStartRenamePath,
 	replaceActiveTabWithBlank,
+	canGoBack,
+	canGoForward,
+	onGoBack,
+	onGoForward,
 	showGettingStartedRequest,
 	openDatabasesId,
 	dailyNoteSetupNoticeRequest,
@@ -477,7 +485,7 @@ export const MainContent = memo(function MainContent({
 	const showStarterPane =
 		Boolean(spacePath) &&
 		(showStarterByDefault || (starterOverrideVisible && !activeTabPath));
-	const showTabBar = tabs.length > 1;
+	const showTabBar = tabs.length > 0;
 
 	useEffect(() => {
 		let cancelled = false;
@@ -820,6 +828,10 @@ export const MainContent = memo(function MainContent({
 								activeTabPath={activeTabPath}
 								dragTabId={dragTabId}
 								useWindowBackground={!content}
+								canGoBack={canGoBack}
+								canGoForward={canGoForward}
+								onGoBack={onGoBack}
+								onGoForward={onGoForward}
 								onOpenBlankTab={openBlankTab}
 								onPrefetchTab={handlePrefetchTab}
 								onSelectTab={setActiveTabId}

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -14,6 +14,10 @@ interface TabBarProps {
 	activeTabPath: string | null;
 	dragTabId: string | null;
 	useWindowBackground?: boolean;
+	canGoBack: boolean;
+	canGoForward: boolean;
+	onGoBack: () => void;
+	onGoForward: () => void;
 	onOpenBlankTab: () => void;
 	onPrefetchTab: (target: string | null) => void;
 	onSelectTab: (tabId: string) => void;
@@ -40,6 +44,10 @@ export function TabBar({
 	activeTabPath,
 	dragTabId,
 	useWindowBackground = false,
+	canGoBack,
+	canGoForward,
+	onGoBack,
+	onGoForward,
 	onOpenBlankTab,
 	onPrefetchTab,
 	onSelectTab,
@@ -92,6 +100,28 @@ export function TabBar({
 				className="mainTabsBar"
 				data-empty-state={useWindowBackground ? "true" : "false"}
 			>
+				<div className="mainTabNavControls">
+					<button
+						type="button"
+						className="mainTabNavBtn"
+						onClick={onGoBack}
+						disabled={!canGoBack}
+						title="Go back"
+						aria-label="Go back"
+					>
+						←
+					</button>
+					<button
+						type="button"
+						className="mainTabNavBtn"
+						onClick={onGoForward}
+						disabled={!canGoForward}
+						title="Go forward"
+						aria-label="Go forward"
+					>
+						→
+					</button>
+				</div>
 				<div className="mainTabsStrip">
 					{tabs.map((tab) => (
 						<TabItem

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -85,6 +85,7 @@ export function TabBar({
 	);
 
 	const [hovered, setHovered] = useState(false);
+	const showTabs = tabs.length > 1;
 	const breadcrumbSegments =
 		activeTabPath && !isPathSpecial(activeTabPath)
 			? activeTabPath.split("/").filter(Boolean)
@@ -122,33 +123,37 @@ export function TabBar({
 						→
 					</button>
 				</div>
-				<div className="mainTabsStrip">
-					{tabs.map((tab) => (
-						<TabItem
-							key={tab.id}
-							tab={tab}
-							label={tabLabel(tab)}
-							isActive={tab.id === activeTabId}
-							dragTabId={dragTabId}
-							onPrefetchTab={onPrefetchTab}
-							onSelectTab={onSelectTab}
-							onCloseTab={onCloseTab}
-							onStartRenamePath={onStartRenamePath}
-							onDragStart={onDragStart}
-							onDragEnd={onDragEnd}
-							onReorder={onReorder}
-						/>
-					))}
-				</div>
-				<button
-					type="button"
-					className="mainTabAdd"
-					onClick={onOpenBlankTab}
-					title={`Open blank tab (${getShortcutTooltip({ meta: true, key: "t" })})`}
-					aria-label="Open blank tab"
-				>
-					+
-				</button>
+				{showTabs ? (
+					<>
+						<div className="mainTabsStrip">
+							{tabs.map((tab) => (
+								<TabItem
+									key={tab.id}
+									tab={tab}
+									label={tabLabel(tab)}
+									isActive={tab.id === activeTabId}
+									dragTabId={dragTabId}
+									onPrefetchTab={onPrefetchTab}
+									onSelectTab={onSelectTab}
+									onCloseTab={onCloseTab}
+									onStartRenamePath={onStartRenamePath}
+									onDragStart={onDragStart}
+									onDragEnd={onDragEnd}
+									onReorder={onReorder}
+								/>
+							))}
+						</div>
+						<button
+							type="button"
+							className="mainTabAdd"
+							onClick={onOpenBlankTab}
+							title={`Open blank tab (${getShortcutTooltip({ meta: true, key: "t" })})`}
+							aria-label="Open blank tab"
+						>
+							+
+						</button>
+					</>
+				) : null}
 			</div>
 			{breadcrumbSegments.length > 0 && (
 				<div className={`mainTabsBreadcrumb ${hovered ? "is-visible" : ""}`}>

--- a/src/components/app/useTabManager.test.tsx
+++ b/src/components/app/useTabManager.test.tsx
@@ -160,4 +160,265 @@ describe("useTabManager", () => {
 		expect(latestValue.tabs[2]).toMatchObject({ kind: "blank", target: null });
 		expect(latestValue.activeTabPath).toBe("notes/first.md");
 	});
+
+	it("pushes note history when opening markdown notes in the same tab", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		expect(latestValue.canGoBack).toBe(true);
+		expect(latestValue.canGoForward).toBe(false);
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+		expect(latestValue.canGoBack).toBe(false);
+		expect(latestValue.canGoForward).toBe(true);
+	});
+
+	it("supports repeated back presses before React re-renders", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/c.md");
+		});
+
+		act(() => {
+			latestValue.goBack();
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+		expect(latestValue.canGoBack).toBe(false);
+		expect(latestValue.canGoForward).toBe(true);
+	});
+
+	it("does not push consecutive duplicate entries", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		expect(latestValue.canGoBack).toBe(true);
+		expect(latestValue.canGoForward).toBe(false);
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+	});
+
+	it("truncates forward history after a new note is opened from a back state", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/c.md");
+		});
+		act(() => {
+			latestValue.goBack();
+		});
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+		expect(latestValue.canGoForward).toBe(true);
+
+		act(() => {
+			latestValue.openFileTab("notes/d.md");
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/d.md");
+		expect(latestValue.canGoForward).toBe(false);
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+	});
+
+	it("keeps history isolated per tab", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openBlankTab();
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		// Switch to first tab
+		act(() => {
+			latestValue.setActiveTabId(latestValue.tabs[0]?.id ?? null);
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+		expect(latestValue.canGoBack).toBe(false);
+		expect(latestValue.canGoForward).toBe(false);
+
+		// Switch back to second tab
+		act(() => {
+			latestValue.setActiveTabId(latestValue.tabs[1]?.id ?? null);
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/b.md");
+		expect(latestValue.canGoBack).toBe(false);
+	});
+
+	it("preserves current behavior when target note is already open in another tab", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openBlankTab();
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		const secondTabId = latestValue.activeTabId;
+
+		// Jump to existing tab a.md
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+
+		// Switch back to second tab — it should still have its own history
+		act(() => {
+			latestValue.setActiveTabId(secondTabId);
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/b.md");
+		expect(latestValue.canGoBack).toBe(false);
+	});
+
+	it("ignores preview/special-tab opens for history creation", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+		act(() => {
+			latestValue.openSpecialTab("all-docs");
+		});
+
+		expect(latestValue.activeTabPath).toBe("all-docs");
+		expect(latestValue.canGoBack).toBe(true);
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+	});
+
+	it("removes tab history on close", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		const tabId = latestValue.activeTabId;
+
+		act(() => {
+			latestValue.closeTab(tabId ?? "");
+		});
+
+		expect(latestValue.canGoBack).toBe(false);
+		expect(latestValue.canGoForward).toBe(false);
+	});
+
+	it("rewrites history entries on rename", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		act(() => {
+			latestValue.renameTabsForPath("notes/a.md", "notes/renamed.md");
+		});
+
+		act(() => {
+			latestValue.goForward();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/b.md");
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/renamed.md");
+	});
+
+	it("prunes history entries on delete / recursive delete", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+		act(() => {
+			latestValue.openFileTab("notes/c.md");
+		});
+
+		act(() => {
+			latestValue.closeTabsForPathRemoval("notes/b.md");
+		});
+
+		expect(latestValue.canGoForward).toBe(false);
+
+		act(() => {
+			latestValue.goBack();
+		});
+
+		expect(latestValue.activeTabPath).toBe("notes/a.md");
+	});
+
+	it("clears history when replacing a blank tab", () => {
+		act(() => {
+			latestValue.openFileTab("notes/a.md");
+		});
+		act(() => {
+			latestValue.openBlankTab();
+		});
+		act(() => {
+			latestValue.openFileTab("notes/b.md");
+		});
+
+		expect(latestValue.canGoBack).toBe(false);
+		expect(latestValue.canGoForward).toBe(false);
+	});
 });

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -2,12 +2,24 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useRecentFiles } from "../../hooks/useRecentFiles";
 import { isInAppPreviewable } from "../../utils/filePreview";
+import { isMarkdownPath } from "../../utils/path";
 
 export interface WorkspaceTab {
 	id: string;
 	kind: "blank" | "file" | "special";
 	target: string | null;
 }
+
+type NoteHistoryEntry = {
+	path: string;
+};
+
+type TabNoteHistory = {
+	entries: NoteHistoryEntry[];
+	index: number;
+};
+
+type TabHistoryById = Record<string, TabNoteHistory>;
 
 function matchesRemovedPath(
 	tab: WorkspaceTab,
@@ -34,12 +46,15 @@ export function useTabManager(spacePath: string | null) {
 	const [activeTabId, setActiveTabIdState] = useState<string | null>(null);
 	const [dragTabId, setDragTabId] = useState<string | null>(null);
 	const [dirtyByPath, setDirtyByPath] = useState<Record<string, boolean>>({});
+	const [historyByTabId, setHistoryByTabId] = useState<TabHistoryById>({});
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
+	const historyByTabIdRef = useRef<TabHistoryById>({});
 
 	tabsRef.current = tabs;
 	activeTabIdRef.current = activeTabId;
+	historyByTabIdRef.current = historyByTabId;
 
 	const createTab = useCallback(
 		(kind: WorkspaceTab["kind"], target: string | null): WorkspaceTab => ({
@@ -61,7 +76,7 @@ export function useTabManager(spacePath: string | null) {
 		(
 			nextTabs: WorkspaceTab[],
 			nextActiveTabId: string | null,
-			previousActiveTabId: string | null,
+			previousActiveTarget: string | null,
 		) => {
 			const nextActiveTab =
 				nextTabs.find((tab) => tab.id === nextActiveTabId) ?? null;
@@ -92,11 +107,9 @@ export function useTabManager(spacePath: string | null) {
 			setOpenMarkdownTabs(nextMarkdownTabs);
 			setActiveMarkdownTabPath(nextActiveMarkdownPath);
 
-			if (
-				zenModeActive &&
-				!nextActiveMarkdownPath &&
-				previousActiveTabId !== nextActiveTabId
-			) {
+			const targetChanged = previousActiveTarget !== nextActiveTab?.target;
+
+			if (zenModeActive && !nextActiveMarkdownPath && targetChanged) {
 				setZenModeActive(false);
 			}
 
@@ -104,7 +117,7 @@ export function useTabManager(spacePath: string | null) {
 				nextActiveTab?.kind === "file" &&
 				nextActiveTab.target &&
 				spacePath &&
-				previousActiveTabId !== nextActiveTabId
+				targetChanged
 			) {
 				void addRecentFile(nextActiveTab.target, spacePath);
 			}
@@ -124,11 +137,15 @@ export function useTabManager(spacePath: string | null) {
 	const commitTabsChange = useCallback(
 		(nextTabs: WorkspaceTab[], nextActiveTabId: string | null) => {
 			const previousActiveTabId = activeTabIdRef.current;
+			const previousActiveTab = tabsRef.current.find(
+				(t) => t.id === previousActiveTabId,
+			);
+			const previousActiveTarget = previousActiveTab?.target ?? null;
 			tabsRef.current = nextTabs;
 			activeTabIdRef.current = nextActiveTabId;
 			setTabs(nextTabs);
 			setActiveTabIdState(nextActiveTabId);
-			syncWorkspaceState(nextTabs, nextActiveTabId, previousActiveTabId);
+			syncWorkspaceState(nextTabs, nextActiveTabId, previousActiveTarget);
 		},
 		[syncWorkspaceState],
 	);
@@ -140,14 +157,16 @@ export function useTabManager(spacePath: string | null) {
 		[commitTabsChange],
 	);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset tab state when the active space changes.
 	useEffect(() => {
-		void spacePath;
 		tabsRef.current = [];
 		activeTabIdRef.current = null;
+		historyByTabIdRef.current = {};
 		setTabs([]);
 		setActiveTabIdState(null);
 		setDragTabId(null);
 		setDirtyByPath({});
+		setHistoryByTabId({});
 	}, [spacePath]);
 
 	const focusExistingTab = useCallback(
@@ -170,33 +189,139 @@ export function useTabManager(spacePath: string | null) {
 		});
 	}, []);
 
-	const replaceActiveTab = useCallback(
-		(kind: WorkspaceTab["kind"], target: string | null) => {
-			const nextTab = createTab(kind, target);
-			const previousActiveTabId = activeTabIdRef.current;
+	const updateHistoryState = useCallback(
+		(updater: (prev: TabHistoryById) => TabHistoryById) => {
+			const prev = historyByTabIdRef.current;
+			const next = updater(prev);
+			if (next === prev) return prev;
+			historyByTabIdRef.current = next;
+			setHistoryByTabId(next);
+			return next;
+		},
+		[],
+	);
+
+	const updateActiveTabInPlace = useCallback(
+		(kind: WorkspaceTab["kind"], target: string | null): string => {
 			const currentTabs = tabsRef.current;
-			let nextTabs = currentTabs;
+			const previousActiveTabId = activeTabIdRef.current;
+
 			if (!previousActiveTabId) {
-				nextTabs = [nextTab];
-			} else {
-				const activeIndex = currentTabs.findIndex(
-					(tab) => tab.id === previousActiveTabId,
-				);
-				if (activeIndex === -1) {
-					nextTabs = [...currentTabs, nextTab];
-				} else {
-					const current = currentTabs[activeIndex];
-					if (current?.kind === "file") {
-						clearDirtyForTarget(current.target);
-					}
-					nextTabs = [...currentTabs];
-					nextTabs[activeIndex] = nextTab;
-				}
+				const nextTab = createTab(kind, target);
+				commitTabsChange([...currentTabs, nextTab], nextTab.id);
+				return nextTab.id;
 			}
-			commitTabsChange(nextTabs, nextTab.id);
+
+			const activeIndex = currentTabs.findIndex(
+				(tab) => tab.id === previousActiveTabId,
+			);
+
+			if (activeIndex === -1) {
+				const nextTab = createTab(kind, target);
+				commitTabsChange([...currentTabs, nextTab], nextTab.id);
+				return nextTab.id;
+			}
+
+			const currentTab = currentTabs[activeIndex];
+			if (currentTab?.kind === "file") {
+				clearDirtyForTarget(currentTab.target);
+			}
+
+			const nextTabs = [...currentTabs];
+			nextTabs[activeIndex] = { ...currentTab, kind, target };
+			commitTabsChange(nextTabs, previousActiveTabId);
+			return previousActiveTabId;
 		},
 		[clearDirtyForTarget, commitTabsChange, createTab],
 	);
+
+	const pushNoteHistory = useCallback(
+		(tabId: string, path: string) => {
+			if (!isMarkdownPath(path)) return;
+			updateHistoryState((prev) => {
+				const current = prev[tabId] ?? { entries: [], index: -1 };
+				const entries = current.entries;
+				const currentIndex = current.index;
+
+				if (currentIndex >= 0 && entries[currentIndex]?.path === path) {
+					return prev;
+				}
+
+				const newEntries = entries.slice(0, currentIndex + 1);
+				newEntries.push({ path });
+
+				return {
+					...prev,
+					[tabId]: {
+						entries: newEntries,
+						index: newEntries.length - 1,
+					},
+				};
+			});
+		},
+		[updateHistoryState],
+	);
+
+	const clearHistoryForTab = useCallback(
+		(tabId: string) => {
+			updateHistoryState((prev) => {
+				if (!(tabId in prev)) return prev;
+				const next = { ...prev };
+				delete next[tabId];
+				return next;
+			});
+		},
+		[updateHistoryState],
+	);
+
+	const stepHistory = useCallback(
+		(tabId: string, delta: -1 | 1): string | null => {
+			const history = historyByTabIdRef.current[tabId];
+			if (!history) return null;
+
+			const nextIndex = history.index + delta;
+			if (nextIndex < 0 || nextIndex >= history.entries.length) return null;
+
+			const entry = history.entries[nextIndex];
+			if (!entry) return null;
+
+			updateHistoryState((prev) => {
+				const current = prev[tabId];
+				if (!current) return prev;
+				return {
+					...prev,
+					[tabId]: { ...current, index: nextIndex },
+				};
+			});
+
+			return entry.path;
+		},
+		[updateHistoryState],
+	);
+
+	const goBack = useCallback(() => {
+		const activeId = activeTabIdRef.current;
+		if (!activeId) return;
+		const path = stepHistory(activeId, -1);
+		if (!path) return;
+		updateActiveTabInPlace("file", path);
+	}, [stepHistory, updateActiveTabInPlace]);
+
+	const goForward = useCallback(() => {
+		const activeId = activeTabIdRef.current;
+		if (!activeId) return;
+		const path = stepHistory(activeId, 1);
+		if (!path) return;
+		updateActiveTabInPlace("file", path);
+	}, [stepHistory, updateActiveTabInPlace]);
+
+	const activeHistory =
+		activeTabId !== null ? (historyByTabId[activeTabId] ?? null) : null;
+
+	const canGoBack = (activeHistory?.index ?? -1) > 0;
+
+	const canGoForward =
+		(activeHistory?.index ?? -1) < (activeHistory?.entries.length ?? 0) - 1;
 
 	const canOpenInMainPane = useCallback(
 		(path: string) =>
@@ -208,18 +333,55 @@ export function useTabManager(spacePath: string | null) {
 		(path: string) => {
 			if (!canOpenInMainPane(path)) return false;
 			if (focusExistingTab(path)) return true;
-			replaceActiveTab("file", path);
+
+			const currentActiveId = activeTabIdRef.current;
+			const currentTabs = tabsRef.current;
+			const activeIndex = currentTabs.findIndex(
+				(t) => t.id === currentActiveId,
+			);
+			const isReplacingBlank =
+				activeIndex >= 0 && currentTabs[activeIndex]?.kind === "blank";
+
+			if (isReplacingBlank && currentActiveId) {
+				clearHistoryForTab(currentActiveId);
+			}
+
+			const tabId = updateActiveTabInPlace("file", path);
+
+			if (isMarkdownPath(path)) {
+				pushNoteHistory(tabId, path);
+			}
+
 			return true;
 		},
-		[canOpenInMainPane, focusExistingTab, replaceActiveTab],
+		[
+			canOpenInMainPane,
+			clearHistoryForTab,
+			focusExistingTab,
+			pushNoteHistory,
+			updateActiveTabInPlace,
+		],
 	);
 
 	const openSpecialTab = useCallback(
 		(target: string) => {
 			if (focusExistingTab(target)) return;
-			replaceActiveTab("special", target);
+
+			const currentActiveId = activeTabIdRef.current;
+			const currentTabs = tabsRef.current;
+			const activeIndex = currentTabs.findIndex(
+				(t) => t.id === currentActiveId,
+			);
+			const isReplacingBlank =
+				activeIndex >= 0 && currentTabs[activeIndex]?.kind === "blank";
+
+			if (isReplacingBlank && currentActiveId) {
+				clearHistoryForTab(currentActiveId);
+			}
+
+			updateActiveTabInPlace("special", target);
 		},
-		[focusExistingTab, replaceActiveTab],
+		[clearHistoryForTab, focusExistingTab, updateActiveTabInPlace],
 	);
 
 	const openBlankTab = useCallback(() => {
@@ -229,8 +391,12 @@ export function useTabManager(spacePath: string | null) {
 
 	const replaceActiveTabWithBlank = useCallback(() => {
 		if (activeTab?.kind === "blank") return;
-		replaceActiveTab("blank", null);
-	}, [activeTab?.kind, replaceActiveTab]);
+		const currentActiveId = activeTabIdRef.current;
+		if (currentActiveId) {
+			clearHistoryForTab(currentActiveId);
+		}
+		updateActiveTabInPlace("blank", null);
+	}, [activeTab?.kind, clearHistoryForTab, updateActiveTabInPlace]);
 
 	const closeTab = useCallback(
 		(tabId: string) => {
@@ -252,6 +418,12 @@ export function useTabManager(spacePath: string | null) {
 					return next;
 				});
 			}
+			updateHistoryState((prev) => {
+				if (!(tabId in prev)) return prev;
+				const next = { ...prev };
+				delete next[tabId];
+				return next;
+			});
 			commitTabsChange(nextTabs, nextActiveTabId);
 			setDirtyByPath((prev) => {
 				let changed = false;
@@ -270,12 +442,14 @@ export function useTabManager(spacePath: string | null) {
 				return changed ? next : prev;
 			});
 		},
-		[commitTabsChange],
+		[commitTabsChange, updateHistoryState],
 	);
 
 	const closeAllTabs = useCallback(() => {
 		commitTabsChange([], null);
 		setDirtyByPath({});
+		historyByTabIdRef.current = {};
+		setHistoryByTabId({});
 	}, [commitTabsChange]);
 
 	const closeActiveTab = useCallback(() => {
@@ -289,10 +463,16 @@ export function useTabManager(spacePath: string | null) {
 			const nextTabs = currentTabs.filter(
 				(tab) => !matchesRemovedPath(tab, path, recursive),
 			);
-			if (nextTabs.length === currentTabs.length) return;
+			const tabsRemoved = nextTabs.length < currentTabs.length;
+			const removedTabIds = new Set(
+				currentTabs
+					.filter((tab) => matchesRemovedPath(tab, path, recursive))
+					.map((tab) => tab.id),
+			);
+
 			const currentActiveTabId = activeTabIdRef.current;
 			let nextActiveTabId = currentActiveTabId;
-			if (currentActiveTabId) {
+			if (tabsRemoved && currentActiveTabId) {
 				const removedIndex = currentTabs.findIndex(
 					(tab) => tab.id === currentActiveTabId,
 				);
@@ -320,7 +500,45 @@ export function useTabManager(spacePath: string | null) {
 					}
 				}
 			}
-			commitTabsChange(nextTabs, nextActiveTabId);
+			updateHistoryState((prev) => {
+				let changed = false;
+				const next: TabHistoryById = {};
+				for (const [tabId, history] of Object.entries(prev)) {
+					if (removedTabIds.has(tabId)) {
+						changed = true;
+						continue;
+					}
+					const survivingEntries: NoteHistoryEntry[] = [];
+					let newIndex = history.index;
+					for (let i = 0; i < history.entries.length; i++) {
+						const entry = history.entries[i];
+						const matches =
+							entry.path === path ||
+							(recursive && entry.path.startsWith(`${path}/`));
+						if (!matches) {
+							survivingEntries.push(entry);
+						} else {
+							changed = true;
+							if (i <= history.index && newIndex > 0) {
+								newIndex--;
+							}
+						}
+					}
+					if (survivingEntries.length > 0) {
+						next[tabId] = {
+							entries: survivingEntries,
+							index: Math.max(
+								-1,
+								Math.min(newIndex, survivingEntries.length - 1),
+							),
+						};
+					}
+				}
+				return changed ? next : prev;
+			});
+			if (tabsRemoved) {
+				commitTabsChange(nextTabs, nextActiveTabId);
+			}
 			setDirtyByPath((prev) => {
 				let changed = false;
 				const next: Record<string, boolean> = {};
@@ -337,7 +555,7 @@ export function useTabManager(spacePath: string | null) {
 				return changed ? next : prev;
 			});
 		},
-		[commitTabsChange],
+		[commitTabsChange, updateHistoryState],
 	);
 
 	const renameTabsForPath = useCallback(
@@ -358,6 +576,27 @@ export function useTabManager(spacePath: string | null) {
 					};
 				}
 				return tab;
+			});
+			updateHistoryState((prev) => {
+				let historyChanged = false;
+				const nextHistory: TabHistoryById = {};
+				for (const [tabId, history] of Object.entries(prev)) {
+					const newEntries = history.entries.map((entry) => {
+						if (entry.path === fromPath) {
+							historyChanged = true;
+							return { path: toPath };
+						}
+						if (recursive && entry.path.startsWith(`${fromPath}/`)) {
+							historyChanged = true;
+							return {
+								path: `${toPath}${entry.path.slice(fromPath.length)}`,
+							};
+						}
+						return entry;
+					});
+					nextHistory[tabId] = { ...history, entries: newEntries };
+				}
+				return historyChanged ? nextHistory : prev;
 			});
 			if (changed) {
 				commitTabsChange(next, activeTabIdRef.current);
@@ -381,7 +620,7 @@ export function useTabManager(spacePath: string | null) {
 				return dirtyChanged ? nextDirty : prev;
 			});
 		},
-		[commitTabsChange],
+		[commitTabsChange, updateHistoryState],
 	);
 
 	const reorderTabs = useCallback(
@@ -457,5 +696,9 @@ export function useTabManager(spacePath: string | null) {
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
+		canGoBack,
+		canGoForward,
+		goBack,
+		goForward,
 	};
 }

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.test.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.test.ts
@@ -46,14 +46,14 @@ describe("wikiLinkMarkdownBridge", () => {
 	it("preserves extra blank lines through editor bridge round-trip", () => {
 		const md = "alpha\n\n\nbeta";
 		const preprocessed = preprocessMarkdownForEditor(md);
-		expect(preprocessed).toBe(`alpha\n\n\u200b\nbeta`);
+		expect(preprocessed).toBe("alpha\n\n\u200b\nbeta");
 		expect(postprocessMarkdownFromEditor(preprocessed)).toBe(md);
 	});
 
 	it("preserves whitespace-only separator lines through editor bridge round-trip", () => {
 		const md = "alpha\n \n\t\nbeta";
 		const preprocessed = preprocessMarkdownForEditor(md);
-		expect(preprocessed).toBe(`alpha\n\u2060\u2061\n\u2060\u2062\nbeta`);
+		expect(preprocessed).toBe("alpha\n\u2060\u2061\n\u2060\u2062\nbeta");
 		expect(postprocessMarkdownFromEditor(preprocessed)).toBe(md);
 	});
 

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
@@ -121,7 +121,8 @@ function postprocessHighlightedText(input: string): string {
 function encodeWhitespaceLine(line: string): string {
 	let encoded = WHITESPACE_LINE_SENTINEL;
 	for (const char of line) {
-		encoded += char === " " ? WHITESPACE_SPACE_SENTINEL : WHITESPACE_TAB_SENTINEL;
+		encoded +=
+			char === " " ? WHITESPACE_SPACE_SENTINEL : WHITESPACE_TAB_SENTINEL;
 	}
 	return encoded;
 }

--- a/src/lib/shortcuts/registry.ts
+++ b/src/lib/shortcuts/registry.ts
@@ -148,6 +148,22 @@ export const SHORTCUTS = [
 		category: "file",
 		context: "space",
 	},
+	{
+		id: "go-back-note",
+		shortcut: { meta: true, key: "[" },
+		label: "Go Back",
+		description: "Go back to the previous note in the current tab",
+		category: "navigation",
+		context: "space",
+	},
+	{
+		id: "go-forward-note",
+		shortcut: { meta: true, key: "]" },
+		label: "Go Forward",
+		description: "Go forward to the next note in the current tab",
+		category: "navigation",
+		context: "space",
+	},
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Search & Command Palette

--- a/src/styles/app/05-main-area.css
+++ b/src/styles/app/05-main-area.css
@@ -744,6 +744,47 @@
 	background: var(--bg-primary);
 }
 
+.mainTabNavControls {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+}
+
+.mainTabNavBtn {
+	height: 28px;
+	width: 28px;
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: var(--radius-md);
+	border: 1px solid transparent;
+	background: transparent;
+	color: var(--text-secondary);
+	font-size: 13px;
+	font-weight: var(--font-medium);
+	line-height: 1;
+	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast),
+		opacity var(--transition-fast);
+}
+
+.mainTabNavBtn:hover:not(:disabled) {
+	color: var(--text-primary);
+	background: color-mix(in srgb, var(--bg-hover) 82%, transparent);
+}
+
+.mainTabNavBtn:disabled {
+	opacity: 0.35;
+	cursor: not-allowed;
+	color: var(--text-tertiary);
+}
+
+.mainTabNavBtn:active:not(:disabled) {
+	opacity: 0.85;
+}
+
 .mainTabsBreadcrumb {
 	display: flex;
 	align-items: center;
@@ -1007,6 +1048,7 @@
 .mainTab:focus-visible,
 .mainTabClose:focus-visible,
 .mainTabAdd:focus-visible,
+.mainTabNavBtn:focus-visible,
 .mainTabsAiToggle:focus-visible,
 .mainAiFloatingToggle:focus-visible {
 	outline: 2px solid

--- a/website/src/styles/components.css
+++ b/website/src/styles/components.css
@@ -448,8 +448,6 @@
 		flex-direction: column;
 		align-items: flex-start;
 	}
-
-
 }
 
 @media (max-width: 720px) {
@@ -457,8 +455,6 @@
 	.faq-summary {
 		align-items: flex-start;
 	}
-
-
 }
 
 @media (max-width: 640px) {
@@ -507,6 +503,4 @@
 		gap: 0.5rem;
 		letter-spacing: 0.08em;
 	}
-
-
 }


### PR DESCRIPTION
## Summary
- Add browser-style Back/Forward navigation for markdown notes within each workspace tab
- Keep note history attached to the active tab, with support for opening existing tabs, blank tab replacement, rename/delete cleanup, and session-only reset
- Surface navigation through the tab bar, command palette, and keyboard shortcuts

## Testing
- Added and updated unit coverage for tab history behavior, including repeated back presses, forward truncation, rename/delete handling, and blank-tab replacement
- Validated the app with lint/format checks and a production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added back/forward navigation to traverse through previously opened notes within each tab
- Added keyboard shortcuts (Meta+[ for back, Meta+]) for quick note navigation
- Added visual back/forward buttons in the tab bar

## Improvements
- Enhanced tab navigation controls and visibility behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->