### PR TITLE
Add app deep links and sidebar copy actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@hugeicons/react": "^1.1.6",
 		"@tanstack/react-table": "^8.21.3",
 		"@tauri-apps/api": "^2.10.1",
+		"@tauri-apps/plugin-deep-link": "^2.4.8",
 		"@tauri-apps/plugin-dialog": "^2",
 		"@tauri-apps/plugin-opener": "^2",
 		"@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
+      '@tauri-apps/plugin-deep-link':
+        specifier: ^2.4.8
+        version: 2.4.8
       '@tauri-apps/plugin-dialog':
         specifier: ^2
         version: 2.6.0
@@ -1675,6 +1678,9 @@ packages:
     resolution: {integrity: sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.4.8':
+    resolution: {integrity: sha512-Cd2Cs960MGuGONeIwxOPx9wqwedetAHOGlwK5boJ/SMTfAtAyfErpfVPEn+EJzgXsJun8EKzsEumHjr+64V4fw==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -4474,6 +4480,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.9.6
       '@tauri-apps/cli-win32-ia32-msvc': 2.9.6
       '@tauri-apps/cli-win32-x64-msvc': 2.9.6
+
+  '@tauri-apps/plugin-deep-link@2.4.8':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -524,6 +524,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +686,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -905,6 +931,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1569,10 +1604,12 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "time",
@@ -1871,7 +1908,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -2979,6 +3016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,6 +3954,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4843,6 +4900,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,6 +5009,22 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5207,6 +5301,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -6139,6 +6242,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,8 @@ rig-core = { version = "0.24.0", features = ["derive"] }
 schemars = "0.8"
 tauri-plugin-process = "2"
 htmd = "0.5.4"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "20"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
 		"core:window:allow-start-dragging",
 		"core:window:allow-set-focus",
 		"core:window:allow-show",
+		"deep-link:default",
 		"dialog:default",
 		"notification:default",
 		{

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1151,6 +1151,14 @@ fn set_window_vibrancy_theme(window: tauri::WebviewWindow, theme: String) -> Res
     }
 }
 
+fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     init_tracing();
@@ -1253,6 +1261,12 @@ pub fn run() {
         .setup(|app| {
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
+            #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                app.deep_link().register_all()?;
+            }
+
             if let Some(window) = app.get_webview_window("main") {
                 if let Ok(Some(monitor)) = window.current_monitor() {
                     let monitor_size = monitor.size();
@@ -1301,6 +1315,10 @@ pub fn run() {
         .manage(git_sync::GitSyncState::default())
         .manage(space::SpaceState::default())
         .manage(MenuState::default())
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            focus_main_window(app);
+        }))
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
@@ -1435,11 +1453,7 @@ pub fn run() {
         .run(|app_handle, event| {
             #[cfg(target_os = "macos")]
             if let RunEvent::Reopen { .. } = event {
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.unminimize();
-                    let _ = window.set_focus();
-                }
+                focus_main_window(app_handle);
             }
         });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,6 +43,11 @@
 		}
 	},
 	"plugins": {
+		"deep-link": {
+			"desktop": {
+				"schemes": ["glyph"]
+			}
+		},
 		"updater": {
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUzMDlDQjRBQkM2ODYzMEMKUldRTVkyaThTc3NKNHpsV1pzbXpnMFZPSXFKdnhWU082eFpjYU1nVlRWZjhuRVpQZXl5ekF6cGoK",
 			"endpoints": [

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -72,6 +72,7 @@ import {
 } from "../../lib/appEvents";
 import { CALENDAR_TAB_ID } from "../../lib/calendar";
 import { DATABASES_TAB_ID } from "../../lib/databases";
+import type { GlyphDeepLink } from "../../lib/deeplinks";
 import { promptNoteExportPath } from "../../lib/export";
 import { getLicenseStatus } from "../../lib/license";
 import {
@@ -124,6 +125,7 @@ import {
 	loadCalendarPane,
 	loadDatabasesPane,
 } from "./prefetchablePanes";
+import { useDeepLinks } from "./useDeepLinks";
 import { useTabManager } from "./useTabManager";
 
 const loadCommandPalette = () =>
@@ -183,6 +185,7 @@ export function AppShell() {
 		onCreateSpace,
 		closeSpace,
 		recentSpaces,
+		settingsLoaded,
 	} = space;
 	const fileTreeCtx = useFileTreeContext();
 	const {
@@ -228,6 +231,7 @@ export function AppShell() {
 	>("commands");
 	const [paletteInitialQuery, setPaletteInitialQuery] = useState("");
 	const [openDatabasesId, setOpenDatabasesId] = useState<string | null>(null);
+	const [openDatabasesRequestNonce, setOpenDatabasesRequestNonce] = useState(0);
 	const [showGettingStartedRequest, setShowGettingStartedRequest] = useState(0);
 	const [dailyNoteSetupNoticeRequest, setDailyNoteSetupNoticeRequest] =
 		useState(0);
@@ -922,6 +926,7 @@ export function AppShell() {
 	const openDatabasesTab = useCallback(
 		(databaseId?: string | null) => {
 			setOpenDatabasesId(databaseId ?? null);
+			setOpenDatabasesRequestNonce((value) => value + 1);
 			openSpecialTab(DATABASES_TAB_ID);
 		},
 		[openSpecialTab],
@@ -982,6 +987,83 @@ export function AppShell() {
 	const openGettingStarted = useCallback(() => {
 		setShowGettingStartedRequest((prev) => prev + 1);
 	}, []);
+
+	const revealFileTreePath = useCallback(
+		async (path: string) => {
+			setSidebarCollapsed(false);
+			setSidebarViewMode("files");
+			const parentPath = parentDir(path);
+			const ancestorDirs: string[] = [];
+			let current = parentPath;
+			while (current) {
+				ancestorDirs.unshift(current);
+				current = parentDir(current);
+			}
+			updateExpandedDirs((prev) => {
+				const next = new Set(prev);
+				for (const dir of ancestorDirs) next.add(dir);
+				return next;
+			});
+			await Promise.all(ancestorDirs.map((dir) => fileTree.loadDir(dir)));
+		},
+		[
+			fileTree.loadDir,
+			setSidebarCollapsed,
+			setSidebarViewMode,
+			updateExpandedDirs,
+		],
+	);
+
+	const openDeepLinkedWorkspaceFile = useCallback(
+		async (path: string) => {
+			await revealFileTreePath(path);
+			await openWorkspaceFile(path);
+		},
+		[openWorkspaceFile, revealFileTreePath],
+	);
+
+	const handleOpenDeepLink = useCallback(
+		async (link: GlyphDeepLink) => {
+			setError("");
+			switch (link.kind) {
+				case "note":
+				case "file":
+					await openDeepLinkedWorkspaceFile(link.path);
+					return;
+				case "daily-note":
+					requestOpenDailyNote();
+					return;
+				case "all-docs":
+					openAllDocsTab();
+					return;
+				case "calendar":
+					openCalendarTab();
+					return;
+				case "databases":
+					openDatabasesTab(link.databaseId);
+					return;
+				case "settings":
+					openSettings(link.tab);
+					return;
+			}
+		},
+		[
+			openAllDocsTab,
+			openCalendarTab,
+			openDatabasesTab,
+			openDeepLinkedWorkspaceFile,
+			openSettings,
+			requestOpenDailyNote,
+			setError,
+		],
+	);
+
+	useDeepLinks({
+		settingsLoaded,
+		spacePath,
+		onOpenDeepLink: handleOpenDeepLink,
+		onError: setError,
+	});
 
 	const handleCreateNoteFromStarter = useCallback(async () => {
 		if (!spacePath) return;
@@ -2150,6 +2232,7 @@ export function AppShell() {
 				onGoForward={goForward}
 				showGettingStartedRequest={showGettingStartedRequest}
 				openDatabasesId={openDatabasesId}
+				openDatabasesRequestNonce={openDatabasesRequestNonce}
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}
 				onOpenDailyNotesSettings={() => openSettings("general")}
 			/>

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -305,6 +305,7 @@ interface MainContentProps {
 	onGoForward: () => void;
 	showGettingStartedRequest: number;
 	openDatabasesId: string | null;
+	openDatabasesRequestNonce: number;
 	dailyNoteSetupNoticeRequest: number;
 	onOpenDailyNotesSettings: () => void;
 }
@@ -403,6 +404,7 @@ export const MainContent = memo(function MainContent({
 	onGoForward,
 	showGettingStartedRequest,
 	openDatabasesId,
+	openDatabasesRequestNonce,
 	dailyNoteSetupNoticeRequest,
 	onOpenDailyNotesSettings,
 }: MainContentProps) {
@@ -697,6 +699,7 @@ export const MainContent = memo(function MainContent({
 						initialDatabaseId={initialDatabaseId}
 						initialDocument={initialDocument}
 						initialRows={initialRows}
+						openRequestNonce={openDatabasesRequestNonce}
 					/>
 				</Suspense>
 			);
@@ -737,6 +740,7 @@ export const MainContent = memo(function MainContent({
 		onOpenDailyNotesSettings,
 		onCreateNote,
 		openDatabasesId,
+		openDatabasesRequestNonce,
 		dailyNotesFolder,
 		templateFolder,
 		viewerPath,

--- a/src/components/app/useDeepLinks.test.tsx
+++ b/src/components/app/useDeepLinks.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GlyphDeepLink } from "../../lib/deeplinks";
+import { useDeepLinks } from "./useDeepLinks";
+
+let currentUrls: string[] | null = null;
+let openUrlHandler: ((urls: string[]) => void) | null = null;
+const unlistenMock = vi.fn();
+
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+	getCurrent: vi.fn(() => Promise.resolve(currentUrls)),
+	onOpenUrl: vi.fn((handler: (urls: string[]) => void) => {
+		openUrlHandler = handler;
+		return Promise.resolve(unlistenMock);
+	}),
+}));
+
+(
+	globalThis as typeof globalThis & {
+		IS_REACT_ACT_ENVIRONMENT?: boolean;
+	}
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Harness({
+	settingsLoaded,
+	spacePath,
+	onOpenDeepLink,
+	onError,
+}: {
+	settingsLoaded: boolean;
+	spacePath: string | null;
+	onOpenDeepLink: (link: GlyphDeepLink) => void;
+	onError: (message: string) => void;
+}) {
+	useDeepLinks({
+		settingsLoaded,
+		spacePath,
+		onOpenDeepLink,
+		onError,
+	});
+
+	return null;
+}
+
+function flushPromises() {
+	return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+describe("useDeepLinks", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let openedLinks: GlyphDeepLink[];
+	let errors: string[];
+	let onOpenDeepLink: (link: GlyphDeepLink) => void;
+	let onError: (message: string) => void;
+
+	beforeEach(() => {
+		currentUrls = null;
+		openUrlHandler = null;
+		unlistenMock.mockClear();
+		openedLinks = [];
+		errors = [];
+		onOpenDeepLink = (link) => {
+			openedLinks.push(link);
+		};
+		onError = (message) => {
+			errors.push(message);
+		};
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+	});
+
+	it("opens startup deeplinks after settings and a space are ready", async () => {
+		currentUrls = ["glyph://note/notes/Today.md"];
+
+		await act(async () => {
+			root.render(
+				<Harness
+					settingsLoaded={false}
+					spacePath={null}
+					onOpenDeepLink={onOpenDeepLink}
+					onError={onError}
+				/>,
+			);
+			await flushPromises();
+		});
+
+		expect(openedLinks).toEqual([]);
+
+		await act(async () => {
+			root.render(
+				<Harness
+					settingsLoaded
+					spacePath="/tmp/space"
+					onOpenDeepLink={onOpenDeepLink}
+					onError={onError}
+				/>,
+			);
+			await flushPromises();
+		});
+
+		expect(openedLinks).toEqual([
+			{
+				kind: "note",
+				path: "notes/Today.md",
+			},
+		]);
+		expect(errors).toEqual([]);
+	});
+
+	it("allows settings links without an open space", async () => {
+		currentUrls = ["glyph://settings/ai"];
+
+		await act(async () => {
+			root.render(
+				<Harness
+					settingsLoaded
+					spacePath={null}
+					onOpenDeepLink={onOpenDeepLink}
+					onError={onError}
+				/>,
+			);
+			await flushPromises();
+		});
+
+		expect(openedLinks).toEqual([
+			{
+				kind: "settings",
+				tab: "ai",
+			},
+		]);
+		expect(errors).toEqual([]);
+	});
+
+	it("reports current-space links when startup finishes without a space", async () => {
+		currentUrls = ["glyph://calendar"];
+
+		await act(async () => {
+			root.render(
+				<Harness
+					settingsLoaded
+					spacePath={null}
+					onOpenDeepLink={onOpenDeepLink}
+					onError={onError}
+				/>,
+			);
+			await flushPromises();
+		});
+
+		expect(openedLinks).toEqual([]);
+		expect(errors).toEqual(["Open a space before using this Glyph link."]);
+	});
+
+	it("dedupes live URL events", async () => {
+		await act(async () => {
+			root.render(
+				<Harness
+					settingsLoaded
+					spacePath="/tmp/space"
+					onOpenDeepLink={onOpenDeepLink}
+					onError={onError}
+				/>,
+			);
+			await flushPromises();
+		});
+
+		await act(async () => {
+			openUrlHandler?.(["glyph://all-docs", "glyph://all-docs"]);
+			await flushPromises();
+		});
+
+		expect(openedLinks).toEqual([{ kind: "all-docs" }]);
+	});
+});

--- a/src/components/app/useDeepLinks.ts
+++ b/src/components/app/useDeepLinks.ts
@@ -1,0 +1,99 @@
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
+import { useCallback, useEffect, useRef } from "react";
+import { type GlyphDeepLink, parseGlyphDeepLink } from "../../lib/deeplinks";
+
+export interface UseDeepLinksOptions {
+	settingsLoaded: boolean;
+	spacePath: string | null;
+	onOpenDeepLink: (link: GlyphDeepLink) => void | Promise<void>;
+	onError: (message: string) => void;
+}
+
+const needsOpenSpace = (link: GlyphDeepLink): boolean =>
+	link.kind !== "settings";
+
+export function useDeepLinks({
+	settingsLoaded,
+	spacePath,
+	onOpenDeepLink,
+	onError,
+}: UseDeepLinksOptions): void {
+	const pendingRef = useRef<GlyphDeepLink[]>([]);
+	const seenRawUrlsRef = useRef(new Set<string>());
+	const settingsLoadedRef = useRef(settingsLoaded);
+	const spacePathRef = useRef(spacePath);
+	const onOpenDeepLinkRef = useRef(onOpenDeepLink);
+	const onErrorRef = useRef(onError);
+
+	settingsLoadedRef.current = settingsLoaded;
+	spacePathRef.current = spacePath;
+	onOpenDeepLinkRef.current = onOpenDeepLink;
+	onErrorRef.current = onError;
+
+	const flushPending = useCallback(() => {
+		if (!settingsLoadedRef.current) return;
+		const pending = pendingRef.current;
+		pendingRef.current = [];
+		for (const link of pending) {
+			if (needsOpenSpace(link) && !spacePathRef.current) {
+				onErrorRef.current("Open a space before using this Glyph link.");
+				continue;
+			}
+			void onOpenDeepLinkRef.current(link);
+		}
+	}, []);
+
+	const handleUrls = useCallback(
+		(urls: string[] | null) => {
+			if (!urls?.length) return;
+			for (const rawUrl of urls) {
+				if (seenRawUrlsRef.current.has(rawUrl)) continue;
+				seenRawUrlsRef.current.add(rawUrl);
+				const link = parseGlyphDeepLink(rawUrl);
+				if (!link) {
+					onErrorRef.current("Glyph could not open that link.");
+					continue;
+				}
+				pendingRef.current.push(link);
+			}
+			flushPending();
+		},
+		[flushPending],
+	);
+
+	useEffect(() => {
+		let cancelled = false;
+		let cleanup: (() => void) | null = null;
+
+		void getCurrent()
+			.then((urls) => {
+				if (!cancelled) handleUrls(urls);
+			})
+			.catch(() => {
+				// Deep links are best-effort during app startup.
+			});
+
+		void onOpenUrl((urls) => {
+			handleUrls(urls);
+		})
+			.then((unlisten) => {
+				if (cancelled) {
+					unlisten();
+					return;
+				}
+				cleanup = unlisten;
+			})
+			.catch(() => {
+				// Some non-Tauri test/browser contexts cannot subscribe.
+			});
+
+		return () => {
+			cancelled = true;
+			cleanup?.();
+		};
+	}, [handleUrls]);
+
+	useEffect(() => {
+		flushPending();
+	});
+}

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -121,6 +121,7 @@ describe("FileTreeFileItem", () => {
 					onNewDatabaseInDir={vi.fn()}
 					onNewFolderInDir={vi.fn()}
 					onDuplicateFile={vi.fn()}
+					onCopyDeeplink={vi.fn()}
 					onStartRename={vi.fn()}
 					onCommitRename={vi.fn()}
 					onCancelRename={vi.fn()}
@@ -148,6 +149,22 @@ describe("FileTreeFileItem", () => {
 
 		expect(container.textContent).toContain("Unpin file");
 		expect(container.textContent).not.toContain("Pin file");
+	});
+
+	it("calls copy deeplink from the context menu", async () => {
+		const onCopyDeeplink = vi.fn();
+		await renderFileTreeFileItem({ onCopyDeeplink });
+
+		const copyButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.includes("Copy deeplink"),
+		);
+		expect(copyButton).toBeDefined();
+
+		await act(async () => {
+			copyButton?.click();
+		});
+
+		expect(onCopyDeeplink).toHaveBeenCalledWith("notes/alpha.md");
 	});
 
 	it("calls arrow navigation when pressing the up or down keys", async () => {

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -112,6 +112,7 @@ interface FileTreeFileItemProps {
 	onNewDatabaseInDir: (dirPath: string) => unknown;
 	onNewFolderInDir: (dirPath: string) => unknown;
 	onDuplicateFile: (path: string) => unknown;
+	onCopyDeeplink: (path: string) => unknown;
 	onStartRename: () => void;
 	onCommitRename: (path: string, nextName: string) => Promise<void> | void;
 	onCancelRename: () => void;
@@ -141,6 +142,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	onNewDatabaseInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
+	onCopyDeeplink,
 	onStartRename,
 	onCommitRename,
 	onCancelRename,
@@ -285,6 +287,13 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 							>
 								<HugeiconsIcon icon={Copy01Icon} size={14} strokeWidth={0.9} />
 								Duplicate file
+							</ContextMenuItem>
+							<ContextMenuItem
+								className="fileTreeCreateMenuItem"
+								onSelect={() => void onCopyDeeplink(entry.rel_path)}
+							>
+								<HugeiconsIcon icon={Copy01Icon} size={14} strokeWidth={0.9} />
+								Copy deeplink
 							</ContextMenuItem>
 							<ContextMenuItem
 								className="fileTreeCreateMenuItem"

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -4,6 +4,7 @@ import { m } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useFileTreeContext, useSpace } from "../../contexts";
+import { glyphDeepLinkForFile } from "../../lib/deeplinks";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { loadSettings } from "../../lib/settings";
 import type {
@@ -69,6 +70,7 @@ interface TreeEntriesProps {
 	onNewDatabaseInDir: (dirPath: string) => Promise<string | null>;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
+	onCopyDeeplink: (path: string) => Promise<void>;
 	onDeletePath: (path: string, kind: "dir" | "file") => Promise<void>;
 	onStartRename: (path: string) => void;
 	onCommitDirRename: (dirPath: string, nextName: string) => Promise<void>;
@@ -109,6 +111,7 @@ function TreeEntries({
 	onNewDatabaseInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
+	onCopyDeeplink,
 	onDeletePath,
 	onStartRename,
 	onCommitDirRename,
@@ -184,6 +187,7 @@ function TreeEntries({
 									onNewDatabaseInDir={onNewDatabaseInDir}
 									onNewFolderInDir={onNewFolderInDir}
 									onDuplicateFile={onDuplicateFile}
+									onCopyDeeplink={onCopyDeeplink}
 									onDeletePath={onDeletePath}
 									onStartRename={onStartRename}
 									onCommitDirRename={onCommitDirRename}
@@ -217,6 +221,7 @@ function TreeEntries({
 						onNewDatabaseInDir={onNewDatabaseInDir}
 						onNewFolderInDir={onNewFolderInDir}
 						onDuplicateFile={onDuplicateFile}
+						onCopyDeeplink={onCopyDeeplink}
 						isRenaming={renamingPath === e.rel_path}
 						onStartRename={() => onStartRename(e.rel_path)}
 						onCommitRename={onCommitFileRename}
@@ -471,6 +476,24 @@ export const FileTreePane = memo(function FileTreePane({
 		[onDuplicateFile, onStartRename],
 	);
 
+	const handleCopyDeeplink = useCallback(
+		async (path: string) => {
+			const deeplink = glyphDeepLinkForFile(path);
+			if (!deeplink) return;
+			try {
+				await navigator.clipboard.writeText(deeplink);
+				toast.success("Copied deeplink.");
+			} catch (error) {
+				const message = extractErrorMessage(error);
+				setError(message);
+				toast.error("Could not copy deeplink", {
+					description: message,
+				});
+			}
+		},
+		[setError],
+	);
+
 	const handleChangeAppearance = useCallback(
 		async (entry: FsEntry, appearance: FileTreeAppearance) => {
 			try {
@@ -645,6 +668,7 @@ export const FileTreePane = memo(function FileTreePane({
 							onNewDatabaseInDir={onNewDatabaseInDir}
 							onNewFolderInDir={handleCreateFolder}
 							onDuplicateFile={handleDuplicateFile}
+							onCopyDeeplink={handleCopyDeeplink}
 							onDeletePath={handleDeletePath}
 							onStartRename={onStartRename}
 							onCommitDirRename={onCommitDirRename}

--- a/src/lib/deeplinks.test.ts
+++ b/src/lib/deeplinks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { glyphDeepLinkForFile, parseGlyphDeepLink } from "./deeplinks";
+
+describe("parseGlyphDeepLink", () => {
+	it("parses workspace targets", () => {
+		expect(parseGlyphDeepLink("glyph://note/notes/Today.md")).toEqual({
+			kind: "note",
+			path: "notes/Today.md",
+		});
+		expect(parseGlyphDeepLink("glyph://file/assets/cover.png")).toEqual({
+			kind: "file",
+			path: "assets/cover.png",
+		});
+		expect(parseGlyphDeepLink("glyph://daily-note")).toEqual({
+			kind: "daily-note",
+		});
+	});
+
+	it("parses app surface targets", () => {
+		expect(parseGlyphDeepLink("glyph://all-docs")).toEqual({
+			kind: "all-docs",
+		});
+		expect(parseGlyphDeepLink("glyph://calendar")).toEqual({
+			kind: "calendar",
+		});
+		expect(parseGlyphDeepLink("glyph://databases")).toEqual({
+			kind: "databases",
+			databaseId: null,
+		});
+		expect(parseGlyphDeepLink("glyph://database/db_123")).toEqual({
+			kind: "databases",
+			databaseId: "db_123",
+		});
+	});
+
+	it("parses settings targets", () => {
+		expect(parseGlyphDeepLink("glyph://settings")).toEqual({
+			kind: "settings",
+			tab: "general",
+		});
+		expect(parseGlyphDeepLink("glyph://settings/ai")).toEqual({
+			kind: "settings",
+			tab: "ai",
+		});
+	});
+
+	it("rejects invalid links", () => {
+		expect(parseGlyphDeepLink("https://glyph.local/note/a.md")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://unknown/a.md")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://settings/nope")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://note/assets/cover.png")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://file/../secret.md")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://file/%2Fsecret.md")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://file/C:/secret.md")).toBeNull();
+		expect(parseGlyphDeepLink("glyph://database/db/extra")).toBeNull();
+	});
+
+	it("decodes encoded relative paths", () => {
+		expect(parseGlyphDeepLink("glyph://note/Meeting%20Notes.md")).toEqual({
+			kind: "note",
+			path: "Meeting Notes.md",
+		});
+	});
+
+	it("builds file deeplinks", () => {
+		expect(glyphDeepLinkForFile("Meeting Notes.md")).toBe(
+			"glyph://note/Meeting%20Notes.md",
+		);
+		expect(glyphDeepLinkForFile("assets/cover image.png")).toBe(
+			"glyph://file/assets/cover%20image.png",
+		);
+		expect(glyphDeepLinkForFile("")).toBeNull();
+	});
+});

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -1,0 +1,132 @@
+import type { SettingsTab } from "../components/settings/settingsConfig";
+import { isMarkdownPath, normalizeRelPath } from "../utils/path";
+
+export type GlyphDeepLink =
+	| { kind: "note"; path: string }
+	| { kind: "file"; path: string }
+	| { kind: "daily-note" }
+	| { kind: "all-docs" }
+	| { kind: "calendar" }
+	| { kind: "databases"; databaseId: string | null }
+	| { kind: "settings"; tab: SettingsTab };
+
+const SETTINGS_TABS = new Set<SettingsTab>([
+	"general",
+	"appearance",
+	"ai",
+	"space",
+	"git",
+	"advanced",
+	"about",
+]);
+
+function decodeSegment(value: string): string | null {
+	try {
+		return decodeURIComponent(value);
+	} catch {
+		return null;
+	}
+}
+
+function hasTraversal(rawUrl: string): boolean {
+	const decoded = decodeSegment(rawUrl);
+	const value = decoded ?? rawUrl;
+	return /(^|[/\\])\.\.([/\\]|$)/.test(value);
+}
+
+function decodePath(pathname: string): string | null {
+	const trimmed = pathname.replace(/^\/+/, "");
+	const decoded = decodeSegment(trimmed);
+	if (decoded === null) return null;
+	if (decoded.startsWith("/") || /^[a-z]:/i.test(decoded)) return null;
+	const normalized = normalizeRelPath(decoded);
+	if (
+		!normalized ||
+		normalized.startsWith("../") ||
+		normalized.includes("/../")
+	) {
+		return null;
+	}
+	if (normalized === ".." || /^[a-z]:/i.test(normalized)) return null;
+	return normalized;
+}
+
+function decodeRequiredValue(pathname: string): string | null {
+	const decoded = decodePath(pathname);
+	return decoded?.trim() || null;
+}
+
+function decodeRequiredSegment(pathname: string): string | null {
+	const value = decodeRequiredValue(pathname);
+	if (!value || value.includes("/")) return null;
+	return value;
+}
+
+export function parseGlyphDeepLink(rawUrl: string): GlyphDeepLink | null {
+	if (hasTraversal(rawUrl)) return null;
+
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+
+	if (url.protocol !== "glyph:") return null;
+
+	switch (url.hostname) {
+		case "note": {
+			const path = decodePath(url.pathname);
+			if (!path || !isMarkdownPath(path)) return null;
+			return { kind: "note", path };
+		}
+		case "file": {
+			const path = decodePath(url.pathname);
+			if (!path) return null;
+			return { kind: "file", path };
+		}
+		case "daily-note":
+			return url.pathname === "" || url.pathname === "/"
+				? { kind: "daily-note" }
+				: null;
+		case "all-docs":
+			return url.pathname === "" || url.pathname === "/"
+				? { kind: "all-docs" }
+				: null;
+		case "calendar":
+			return url.pathname === "" || url.pathname === "/"
+				? { kind: "calendar" }
+				: null;
+		case "databases":
+			if (url.pathname !== "" && url.pathname !== "/") return null;
+			return { kind: "databases", databaseId: null };
+		case "database": {
+			const databaseId = decodeRequiredSegment(url.pathname);
+			return databaseId ? { kind: "databases", databaseId } : null;
+		}
+		case "settings": {
+			if (url.pathname === "" || url.pathname === "/") {
+				return { kind: "settings", tab: "general" };
+			}
+			const tab = decodeRequiredValue(url.pathname);
+			if (!tab || !SETTINGS_TABS.has(tab as SettingsTab)) return null;
+			return { kind: "settings", tab: tab as SettingsTab };
+		}
+		default:
+			return null;
+	}
+}
+
+function encodeRelPath(path: string): string {
+	return normalizeRelPath(path)
+		.split("/")
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+}
+
+export function glyphDeepLinkForFile(path: string): string | null {
+	const normalized = normalizeRelPath(path);
+	if (!normalized) return null;
+	const host = isMarkdownPath(normalized) ? "note" : "file";
+	return `glyph://${host}/${encodeRelPath(normalized)}`;
+}


### PR DESCRIPTION
## Summary
- Add app-level `glyph://` deeplink support for notes, files, daily note, all docs, calendar, databases, database records, and settings
- Wire deeplink handling into app startup so links open the right view and focus the main window
- Add a sidebar file-tree context menu action to copy a file deeplink, with clipboard feedback and path encoding
- Cover parsing, launch handling, and file-tree menu behavior with tests

## Testing
- `pnpm check`
- `pnpm build`
- `pnpm test -- src/lib/deeplinks.test.ts src/components/filetree/FileTreeFileItem.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deep-link support enabling users to open the app via custom URLs pointing to workspace items, daily notes, app views, databases, and settings.
  * Added "Copy deeplink" option in the file tree context menu to generate shareable links to files and folders.
  * App now brings the main window to foreground when opened via deep-link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->