### PR TITLE
Add extract-selection-to-note workflow

### DIFF
--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/utils";
 import {
 	AiEditingIcon,
 	ChatAdd01Icon,
-	Logout01Icon,
+	Logout05Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -346,7 +346,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 						title="Minimize"
 						onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
 					>
-						<HugeiconsIcon icon={Logout01Icon} size={13} strokeWidth={0.9} />
+						<HugeiconsIcon icon={Logout05Icon} size={13} strokeWidth={0.9} />
 					</Button>
 				</div>
 			</div>

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { BadgeInfoIcon } from "@hugeicons/core-free-icons";
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	type MouseEvent as ReactMouseEvent,
@@ -320,7 +320,7 @@ export function ModelSelector({
 														aria-pressed={infoActive}
 													>
 														<HugeiconsIcon
-															icon={BadgeInfoIcon}
+															icon={InformationCircleIcon}
 															size={14}
 															strokeWidth={0.9}
 														/>

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -365,6 +365,15 @@ export function AppShell() {
 		[fileTree, openFileTab, setActiveDirPath],
 	);
 
+	const openWorkspaceFileInNewTab = useCallback(
+		async (path: string) => {
+			if (!path) return;
+			openBlankTab();
+			await openWorkspaceFile(path);
+		},
+		[openBlankTab, openWorkspaceFile],
+	);
+
 	const openQuickNoteWindow = useCallback(() => {
 		void invoke("show_quick_note_window").catch((cause) => {
 			const message = cause instanceof Error ? cause.message : String(cause);
@@ -1320,6 +1329,7 @@ export function AppShell() {
 			<MainContent
 				fileTree={fileTree}
 				onOpenFile={openWorkspaceFile}
+				onOpenFileInNewTab={openWorkspaceFileInNewTab}
 				onOpenCommandPalette={openCommandPalette}
 				onCreateNote={handleCreateNoteFromStarter}
 				onOpenDailyNote={requestOpenDailyNote}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -368,10 +368,18 @@ export function AppShell() {
 	const openWorkspaceFileInNewTab = useCallback(
 		async (path: string) => {
 			if (!path) return;
+			if (!isMarkdownPath(path) && !isInAppPreviewable(path)) {
+				await openWorkspaceFile(path);
+				return;
+			}
+			if (tabs.some((tab) => tab.target === path)) {
+				await openWorkspaceFile(path);
+				return;
+			}
 			openBlankTab();
 			await openWorkspaceFile(path);
 		},
-		[openBlankTab, openWorkspaceFile],
+		[openBlankTab, openWorkspaceFile, tabs],
 	);
 
 	const openQuickNoteWindow = useCallback(() => {

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -56,6 +56,10 @@ import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { isInAppPreviewable } from "../../utils/filePreview";
 import { Calendar, FileText, Settings } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
+import type {
+	CreateMarkdownFileOptions,
+	ExtractToNoteActions,
+} from "../editor/types";
 import { FilePreviewPane } from "../preview/FilePreviewPane";
 import { NotePane } from "../preview/NotePane";
 import { AboutSettingsPane } from "../settings/AboutSettingsPane";
@@ -252,6 +256,9 @@ function ContextualEmptyState({
 
 interface MainContentProps {
 	fileTree: {
+		createMarkdownFileAtPath: (
+			options: CreateMarkdownFileOptions,
+		) => Promise<string | null>;
 		openNonMarkdownExternally: (relPath: string) => Promise<void>;
 		onRenameDir: (
 			path: string,
@@ -260,6 +267,7 @@ interface MainContentProps {
 		) => Promise<string | null>;
 	};
 	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFileInNewTab: (relPath: string) => Promise<void>;
 	onOpenCommandPalette: () => void;
 	onCreateNote: () => void;
 	onOpenDailyNote: () => void;
@@ -360,6 +368,7 @@ function DailyNotesSetupToast({
 export const MainContent = memo(function MainContent({
 	fileTree,
 	onOpenFile,
+	onOpenFileInNewTab,
 	onOpenCommandPalette,
 	onCreateNote,
 	onOpenDailyNote,
@@ -682,10 +691,16 @@ export const MainContent = memo(function MainContent({
 		}
 		if (viewerPath.toLowerCase().endsWith(".md")) {
 			const initialDoc = getPrefetchedNote(viewerPath);
+			const extractToNoteActions = {
+				createMarkdownFile: fileTree.createMarkdownFileAtPath,
+				openNote: onOpenFile,
+				openNoteInNewTab: onOpenFileInNewTab,
+			} satisfies ExtractToNoteActions;
 			return (
 				<NotePane
 					relPath={viewerPath}
 					initialDoc={initialDoc}
+					extractToNoteActions={extractToNoteActions}
 					onDirtyChange={(dirty) =>
 						setDirtyByPath((prev) =>
 							prev[viewerPath] === dirty
@@ -713,6 +728,7 @@ export const MainContent = memo(function MainContent({
 		closeTab,
 		fileTree,
 		onOpenFile,
+		onOpenFileInNewTab,
 		onOpenDailyNotesSettings,
 		onCreateNote,
 		openDatabasesId,

--- a/src/components/editor/EditorRibbon.tsx
+++ b/src/components/editor/EditorRibbon.tsx
@@ -1,3 +1,5 @@
+import { NoteAddIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { m } from "motion/react";
 import { type CSSProperties, memo } from "react";
@@ -17,6 +19,7 @@ interface EditorRibbonProps {
 	editor: Editor;
 	canEdit: boolean;
 	className?: string;
+	onExtractSelectionToNote?: () => void;
 	style?: CSSProperties;
 }
 
@@ -52,6 +55,7 @@ export const EditorRibbon = memo(function EditorRibbon({
 	editor,
 	canEdit,
 	className,
+	onExtractSelectionToNote,
 	style,
 }: EditorRibbonProps) {
 	const focusChain = () =>
@@ -114,6 +118,20 @@ export const EditorRibbon = memo(function EditorRibbon({
 						focusChain={focusChain}
 						preventMouseDown={preventMouseDown}
 					/>
+					{onExtractSelectionToNote ? (
+						<m.button
+							type="button"
+							className="ribbonBtn"
+							title="Extract to note"
+							disabled={!canEdit}
+							onMouseDown={preventMouseDown}
+							onClick={() => canEdit && onExtractSelectionToNote()}
+							whileTap={canEdit ? { scale: 0.97 } : undefined}
+							transition={springPresets.snappy}
+						>
+							<HugeiconsIcon icon={NoteAddIcon} size={15} strokeWidth={0.9} />
+						</m.button>
+					) : null}
 					<span className="ribbonDivider" />
 					<RibbonButtonList
 						buttons={getHeadingButtons(editor, runCommand, focusChain)}

--- a/src/components/editor/ExtractToNoteDialog.tsx
+++ b/src/components/editor/ExtractToNoteDialog.tsx
@@ -1,0 +1,106 @@
+import { useRef } from "react";
+import { DatabaseFolderPicker } from "../database/DatabaseFolderPicker";
+import { Button } from "../ui/shadcn/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../ui/shadcn/dialog";
+import { Input } from "../ui/shadcn/input";
+import type { ExtractToNoteDialogState } from "./extractSelectionToNote";
+
+interface ExtractToNoteDialogProps {
+	onClose: () => void;
+	onDestinationDirChange: (destinationDir: string) => void;
+	onSubmit: () => Promise<void> | void;
+	onTitleChange: (title: string) => void;
+	state: ExtractToNoteDialogState | null;
+}
+
+export function ExtractToNoteDialog({
+	onClose,
+	onDestinationDirChange,
+	onSubmit,
+	onTitleChange,
+	state,
+}: ExtractToNoteDialogProps) {
+	const titleInputRef = useRef<HTMLInputElement | null>(null);
+
+	return (
+		<Dialog
+			open={state !== null}
+			onOpenChange={(open) => {
+				if (!open) onClose();
+			}}
+		>
+			<DialogContent
+				className="extractToNoteDialog databaseDialogCompact"
+				onOpenAutoFocus={(event) => {
+					const input = titleInputRef.current;
+					if (!input) return;
+					event.preventDefault();
+					input.focus();
+					input.select();
+				}}
+			>
+				<DialogHeader className="extractToNoteHeader">
+					<DialogTitle>Extract to Note</DialogTitle>
+				</DialogHeader>
+				<form
+					className="extractToNoteForm"
+					onSubmit={(event) => {
+						event.preventDefault();
+						void onSubmit();
+					}}
+				>
+					<div className="extractToNoteField">
+						<label
+							className="extractToNoteLabel"
+							htmlFor="extract-to-note-title"
+						>
+							Title
+						</label>
+						<Input
+							ref={titleInputRef}
+							id="extract-to-note-title"
+							className="extractToNoteInput extractToNoteTitleInput"
+							value={state?.title ?? ""}
+							onChange={(event) => onTitleChange(event.target.value)}
+							placeholder="Note title"
+							disabled={state?.loading}
+						/>
+					</div>
+					<div className="extractToNoteField">
+						<div className="extractToNoteLabel">Destination</div>
+						{state ? (
+							<DatabaseFolderPicker
+								value={state.destinationDir}
+								onChange={onDestinationDirChange}
+								placeholder="Space root"
+								triggerClassName="extractToNoteFolderTrigger"
+							/>
+						) : null}
+					</div>
+					<DialogFooter className="extractToNoteActions">
+						<Button
+							type="button"
+							variant="ghost"
+							onClick={onClose}
+							disabled={state?.loading}
+						>
+							Cancel
+						</Button>
+						<Button
+							type="submit"
+							disabled={state?.loading || !state?.title.trim()}
+						>
+							{state?.loading ? "Creating" : "Create"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -148,6 +148,7 @@ export interface NoteEditorSurfaceProps {
 	onPointerDownCapture: (event: React.PointerEvent<HTMLDivElement>) => void;
 
 	selectionRibbon: SelectionRibbonPosition | null;
+	onExtractSelectionToNote?: () => void;
 
 	table: {
 		selected: SelectedTableState | null;
@@ -217,6 +218,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 	hostRef,
 	onPointerDownCapture,
 	selectionRibbon,
+	onExtractSelectionToNote,
 	table,
 	codeBlock,
 	task,
@@ -247,6 +249,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 					<EditorRibbon
 						editor={editor}
 						canEdit={canEdit}
+						onExtractSelectionToNote={onExtractSelectionToNote}
 						style={{
 							top: `${selectionRibbon.top}px`,
 							left: `${selectionRibbon.left}px`,

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -28,6 +28,7 @@ import {
 	DialogTitle,
 } from "../ui/shadcn/dialog";
 import { Input } from "../ui/shadcn/input";
+import { ExtractToNoteDialog } from "./ExtractToNoteDialog";
 import { NoteEditorSurface } from "./NoteEditorSurface";
 import { NotePropertiesPanel } from "./NotePropertiesPanel";
 import {
@@ -40,6 +41,7 @@ import {
 	getOffsetWithinAncestor,
 	isVisibleEditorHost,
 } from "./hooks/editorDomUtils";
+import { useExtractSelectionToNote } from "./hooks/useExtractSelectionToNote";
 import { useNoteEditor } from "./hooks/useNoteEditor";
 import { useResetScrollOnChange } from "./hooks/useResetScrollOnChange";
 import { useSelectionRibbon } from "./hooks/useSelectionRibbon";
@@ -168,6 +170,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	onEditorReady,
 	onChange,
 	onFrontmatterCommit,
+	extractToNoteActions,
 }: NoteInlineEditorProps) {
 	const {
 		editor,
@@ -294,6 +297,13 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		mode,
 		onChange,
 	});
+	const extractToNote = useExtractSelectionToNote({
+		actions: extractToNoteActions,
+		canEdit,
+		editor,
+		hostRef: tiptapHostRef,
+		relPath,
+	});
 
 	useEffect(() => {
 		if (!editor || mode !== "rich") return;
@@ -371,6 +381,9 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 							.run();
 					case "divider":
 						return chain.setHorizontalRule().run();
+					case "extract_selection_to_note":
+						extractToNote.openExtractDialog();
+						return true;
 					case "callout_info":
 						return chain
 							.insertContent({
@@ -493,7 +506,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		return () => {
 			window.removeEventListener(EDITOR_MENU_ACTION_EVENT, onEditorMenuAction);
 		};
-	}, [canEdit, editor, mode]);
+	}, [canEdit, editor, extractToNote.openExtractDialog, mode]);
 
 	useEffect(() => {
 		if (!onRegisterCalloutInserter) return;
@@ -951,6 +964,11 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 						hostRef={handleTiptapHostRef}
 						onPointerDownCapture={handleEditorPointerDownCapture}
 						selectionRibbon={selectionRibbon}
+						onExtractSelectionToNote={
+							extractToNote.canExtractToNote
+								? extractToNote.openExtractDialog
+								: undefined
+						}
 						table={{
 							selected: selectedTable,
 							onControlMouseDown: preventTableControlMouseDown,
@@ -1031,6 +1049,13 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					/>
 				) : null}
 			</div>
+			<ExtractToNoteDialog
+				state={extractToNote.dialogState}
+				onClose={extractToNote.closeExtractDialog}
+				onSubmit={extractToNote.submitExtractDialog}
+				onTitleChange={extractToNote.setExtractTitle}
+				onDestinationDirChange={extractToNote.setExtractDestinationDir}
+			/>
 			<Dialog
 				open={linkDialog !== null}
 				onOpenChange={(open) => {

--- a/src/components/editor/editorActions.ts
+++ b/src/components/editor/editorActions.ts
@@ -9,14 +9,15 @@ type EditorActionCategory =
 	| "callout"
 	| "color"
 	| "highlight"
-	| "link";
+	| "link"
+	| "note";
 
 interface EditorActionDefinition {
 	id: EditorActionId;
 	label: string;
 	description: string;
 	category: EditorActionCategory;
-	menuId: string;
+	menuId?: string;
 }
 
 const BASE_EDITOR_ACTIONS: EditorActionDefinition[] = [
@@ -187,6 +188,12 @@ const BASE_EDITOR_ACTIONS: EditorActionDefinition[] = [
 		description: "Remove the current link from the selection.",
 		category: "link",
 		menuId: "editor.link_clear",
+	},
+	{
+		id: "extract_selection_to_note",
+		label: "Extract to Note",
+		description: "Create a note from the current selection.",
+		category: "note",
 	},
 	{
 		id: "color_clear",

--- a/src/components/editor/extractSelectionToNote.ts
+++ b/src/components/editor/extractSelectionToNote.ts
@@ -1,0 +1,243 @@
+import type { Editor, JSONContent } from "@tiptap/core";
+import { postprocessMarkdownFromEditor } from "./markdown/wikiLinkMarkdownBridge";
+
+export interface ExtractSelectionDraft {
+	markdown: string;
+	range: { from: number; to: number };
+	suggestedTitle: string;
+	text: string;
+}
+
+export interface ExtractToNoteDialogState extends ExtractSelectionDraft {
+	destinationDir: string;
+	loading: boolean;
+	title: string;
+}
+
+const FALLBACK_TITLE = "Untitled";
+const MAX_TITLE_LENGTH = 80;
+const INVALID_FILENAME_CHARS = /[<>:"/\\|?*]/g;
+const MARKDOWN_LINK_RE = /(!?)\[([^\]\n]*)\]\(([^)\n]+)\)/g;
+
+function normalizeRelPath(path: string): string {
+	return path
+		.trim()
+		.replace(/\u200b/g, "")
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+}
+
+function parentDir(relPath: string): string {
+	const normalized = normalizeRelPath(relPath);
+	const idx = normalized.lastIndexOf("/");
+	return idx === -1 ? "" : normalized.slice(0, idx);
+}
+
+function normalizeSegments(path: string): string {
+	const out: string[] = [];
+	for (const part of path.replace(/\\/g, "/").split("/")) {
+		if (!part || part === ".") continue;
+		if (part === "..") {
+			out.pop();
+			continue;
+		}
+		out.push(part);
+	}
+	return out.join("/");
+}
+
+function relativePath(fromDir: string, toPath: string): string {
+	const from = normalizeRelPath(fromDir).split("/").filter(Boolean);
+	const to = normalizeRelPath(toPath).split("/").filter(Boolean);
+	let index = 0;
+	while (
+		index < from.length &&
+		index < to.length &&
+		from[index] === to[index]
+	) {
+		index += 1;
+	}
+	const parts = [
+		...Array.from({ length: from.length - index }, () => ".."),
+		...to.slice(index),
+	];
+	return parts.join("/") || to[to.length - 1] || "";
+}
+
+function stripInlineMarkdown(value: string): string {
+	return value
+		.replace(/!\[([^\]\n]*)\]\(([^)\n]+)\)/g, "$1")
+		.replace(/\[([^\]\n]+)\]\(([^)\n]+)\)/g, "$1")
+		.replace(
+			/!?\[\[([^\]\n|#]+)(?:#[^\]\n|]+)?(?:\|([^\]\n]+))?\]\]/g,
+			(_match, target: string, alias: string | undefined) => alias ?? target,
+		)
+		.replace(/`([^`\n]+)`/g, "$1")
+		.replace(/[*_~>#-]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function truncateTitle(value: string): string {
+	const normalized = value.replace(/\s+/g, " ").trim();
+	if (normalized.length <= MAX_TITLE_LENGTH) return normalized;
+	return normalized.slice(0, MAX_TITLE_LENGTH).trim();
+}
+
+export function suggestExtractedNoteTitle(
+	markdown: string,
+	text: string,
+): string {
+	const heading = markdown.match(/^#{1,6}\s+(.+)$/m)?.[1];
+	if (heading) {
+		const title = truncateTitle(stripInlineMarkdown(heading));
+		if (title) return title;
+	}
+
+	for (const line of markdown.split("\n")) {
+		const title = truncateTitle(stripInlineMarkdown(line));
+		if (title) return title;
+	}
+
+	const fallback = truncateTitle(stripInlineMarkdown(text));
+	return fallback || FALLBACK_TITLE;
+}
+
+export function sanitizeExtractedNoteTitle(title: string): string {
+	const sanitized = title
+		.replace(INVALID_FILENAME_CHARS, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		.replace(/\.+$/g, "");
+	return sanitized || FALLBACK_TITLE;
+}
+
+export function uniqueExtractedNoteTitle(
+	title: string,
+	siblingNames: Iterable<string>,
+): string {
+	const base = sanitizeExtractedNoteTitle(title);
+	const unavailable = new Set(
+		Array.from(siblingNames, (name) => name.toLowerCase()),
+	);
+	if (!unavailable.has(`${base}.md`.toLowerCase())) return base;
+	let index = 2;
+	while (unavailable.has(`${base} ${index}.md`.toLowerCase())) {
+		index += 1;
+	}
+	return `${base} ${index}`;
+}
+
+export function buildExtractedNotePath(title: string, destinationDir: string) {
+	const safeTitle = sanitizeExtractedNoteTitle(title);
+	const dir = normalizeRelPath(destinationDir);
+	return dir ? `${dir}/${safeTitle}.md` : `${safeTitle}.md`;
+}
+
+function splitDestination(raw: string): {
+	destination: string;
+	suffix: string;
+	wrapper: "<" | "";
+} {
+	const trimmed = raw.trim();
+	const wrapper = trimmed.startsWith("<") && trimmed.includes(">") ? "<" : "";
+	const wrappedEnd = wrapper ? trimmed.indexOf(">") : -1;
+	const rawValue = wrapper ? trimmed.slice(1, wrappedEnd) : trimmed;
+	const wrapperSuffix = wrapper ? trimmed.slice(wrappedEnd + 1) : "";
+	const titleMatch = wrapper ? null : rawValue.match(/^(\S+)(\s+["'][\s\S]*)$/);
+	const value = titleMatch ? (titleMatch[1] ?? "") : rawValue;
+	const titleSuffix = titleMatch ? (titleMatch[2] ?? "") : "";
+	const baseSuffix = `${titleSuffix}${wrapperSuffix}`;
+	const hashIndex = value.indexOf("#");
+	if (hashIndex === -1)
+		return { destination: value, suffix: baseSuffix, wrapper };
+	return {
+		destination: value.slice(0, hashIndex),
+		suffix: `${value.slice(hashIndex)}${baseSuffix}`,
+		wrapper,
+	};
+}
+
+function isRewritableDestination(destination: string): boolean {
+	const lower = destination.trim().toLowerCase();
+	return (
+		Boolean(lower) &&
+		!lower.startsWith("#") &&
+		!lower.startsWith("http://") &&
+		!lower.startsWith("https://") &&
+		!lower.startsWith("mailto:") &&
+		!lower.startsWith("tel:") &&
+		!lower.startsWith("data:")
+	);
+}
+
+function decodeDestination(destination: string): string {
+	try {
+		return decodeURI(destination);
+	} catch {
+		return destination;
+	}
+}
+
+function encodeDestination(destination: string): string {
+	try {
+		return encodeURI(destination);
+	} catch {
+		return destination;
+	}
+}
+
+export function rewriteRelativeMarkdownLinks(
+	markdown: string,
+	sourcePath: string,
+	destinationDir: string,
+): string {
+	const sourceDir = parentDir(sourcePath);
+	const nextDir = normalizeRelPath(destinationDir);
+	if (sourceDir === nextDir) return markdown;
+
+	return markdown.replace(
+		MARKDOWN_LINK_RE,
+		(match, embed: string, label: string, rawDestination: string) => {
+			const { destination, suffix, wrapper } = splitDestination(rawDestination);
+			if (!isRewritableDestination(destination)) return match;
+			const decoded = decodeDestination(destination);
+			const absoluteTarget = decoded.startsWith("/")
+				? normalizeSegments(decoded)
+				: normalizeSegments(`${sourceDir}/${decoded}`);
+			const nextDestination = encodeDestination(
+				relativePath(nextDir, absoluteTarget),
+			);
+			const wrappedDestination =
+				wrapper === "<" ? `<${nextDestination}>` : nextDestination;
+			return `${embed}[${label}](${wrappedDestination}${suffix})`;
+		},
+	);
+}
+
+function normalizeSelectedMarkdown(markdown: string): string {
+	return postprocessMarkdownFromEditor(markdown)
+		.replace(/^\n+/, "")
+		.replace(/\n+$/, "");
+}
+
+export function buildExtractSelectionDraft(
+	editor: Editor,
+): ExtractSelectionDraft | null {
+	if (!editor.markdown) return null;
+	const { selection } = editor.state;
+	if (selection.empty) return null;
+	const slice = selection.content();
+	const content = slice.content.toJSON() as JSONContent[] | null;
+	if (!content?.length) return null;
+	const rawMarkdown = editor.markdown.serialize(content);
+	const markdown = normalizeSelectedMarkdown(rawMarkdown);
+	const text = slice.content.textBetween(0, slice.content.size, "\n").trim();
+	if (!markdown.trim() && !text) return null;
+	return {
+		markdown,
+		range: { from: selection.from, to: selection.to },
+		suggestedTitle: suggestExtractedNoteTitle(markdown, text),
+		text,
+	};
+}

--- a/src/components/editor/hooks/useExtractSelectionToNote.ts
+++ b/src/components/editor/hooks/useExtractSelectionToNote.ts
@@ -1,0 +1,187 @@
+import type { Editor } from "@tiptap/core";
+import { type RefObject, useCallback, useState } from "react";
+import { toast } from "sonner";
+import { invoke } from "../../../lib/tauri";
+import {
+	type ExtractToNoteDialogState,
+	buildExtractSelectionDraft,
+	buildExtractedNotePath,
+	rewriteRelativeMarkdownLinks,
+	sanitizeExtractedNoteTitle,
+	uniqueExtractedNoteTitle,
+} from "../extractSelectionToNote";
+import type { ExtractToNoteActions } from "../types";
+
+interface UseExtractSelectionToNoteArgs {
+	actions?: ExtractToNoteActions;
+	canEdit: boolean;
+	editor: Editor | null;
+	hostRef: RefObject<HTMLDivElement | null>;
+	relPath?: string;
+}
+
+export function useExtractSelectionToNote({
+	actions,
+	canEdit,
+	editor,
+	hostRef,
+	relPath,
+}: UseExtractSelectionToNoteArgs) {
+	const [dialogState, setDialogState] =
+		useState<ExtractToNoteDialogState | null>(null);
+
+	const canExtractToNote = canEdit && Boolean(relPath) && Boolean(actions);
+
+	const loadUniqueExtractTitle = useCallback(
+		async (title: string, destinationDir: string) => {
+			const siblings = await invoke("space_list_dir", {
+				dir: destinationDir || null,
+			});
+			return uniqueExtractedNoteTitle(
+				title,
+				siblings
+					.filter((entry) => entry.kind === "file")
+					.map((entry) => entry.name),
+			);
+		},
+		[],
+	);
+
+	const openExtractDialog = useCallback(() => {
+		if (!editor || !canExtractToNote || !relPath) {
+			toast.error("Select text in an editable note first.");
+			return;
+		}
+		const draft = buildExtractSelectionDraft(editor);
+		if (!draft) {
+			toast.error("Select text to extract.");
+			return;
+		}
+		const destinationDir = relPath.includes("/")
+			? relPath.slice(0, relPath.lastIndexOf("/"))
+			: "";
+		setDialogState({
+			...draft,
+			destinationDir,
+			loading: true,
+			title: sanitizeExtractedNoteTitle(draft.suggestedTitle),
+		});
+		void loadUniqueExtractTitle(draft.suggestedTitle, destinationDir)
+			.then((title) => {
+				setDialogState((current) =>
+					current && current.range.from === draft.range.from
+						? { ...current, loading: false, title }
+						: current,
+				);
+			})
+			.catch((error) => {
+				console.error("Failed to suggest extracted note name", error);
+				setDialogState((current) =>
+					current && current.range.from === draft.range.from
+						? { ...current, loading: false }
+						: current,
+				);
+			});
+	}, [canExtractToNote, editor, loadUniqueExtractTitle, relPath]);
+
+	const closeExtractDialog = useCallback(() => {
+		setDialogState(null);
+	}, []);
+
+	const setExtractTitle = useCallback((title: string) => {
+		setDialogState((current) => (current ? { ...current, title } : current));
+	}, []);
+
+	const setExtractDestinationDir = useCallback((destinationDir: string) => {
+		setDialogState((current) =>
+			current ? { ...current, destinationDir } : current,
+		);
+	}, []);
+
+	const submitExtractDialog = useCallback(async () => {
+		if (!editor || !dialogState || !actions || !relPath) return;
+		const requestedTitle = sanitizeExtractedNoteTitle(dialogState.title);
+		if (!requestedTitle) return;
+		setDialogState((current) =>
+			current ? { ...current, loading: true } : current,
+		);
+		try {
+			const finalTitle = await loadUniqueExtractTitle(
+				requestedTitle,
+				dialogState.destinationDir,
+			);
+			const notePath = buildExtractedNotePath(
+				finalTitle,
+				dialogState.destinationDir,
+			);
+			const noteMarkdown = rewriteRelativeMarkdownLinks(
+				dialogState.markdown,
+				relPath,
+				dialogState.destinationDir,
+			);
+			const createdPath = await actions.createMarkdownFile({
+				path: notePath,
+				text: `${noteMarkdown.trimEnd()}\n`,
+				openParentDir: dialogState.destinationDir,
+			});
+			if (!createdPath) {
+				throw new Error("Could not create the extracted note.");
+			}
+			const scrollHost = hostRef.current?.closest(
+				".rfNodeNoteEditorBody",
+			) as HTMLElement | null;
+			const scrollTop = scrollHost?.scrollTop ?? 0;
+			const inserted = editor
+				.chain()
+				.focus(null, { scrollIntoView: false })
+				.insertContentAt(dialogState.range, `[[${finalTitle}]]`, {
+					contentType: "markdown",
+				})
+				.run();
+			if (!inserted) {
+				throw new Error(
+					"Created the note, but could not replace the selection.",
+				);
+			}
+			if (scrollHost) {
+				requestAnimationFrame(() => {
+					scrollHost.scrollTop = scrollTop;
+				});
+			}
+			setDialogState(null);
+			toast.success("Extracted to note", {
+				className: "extractToNoteToast",
+				description: finalTitle,
+				action: {
+					label: "Open",
+					onClick: () => {
+						void actions.openNote(createdPath);
+					},
+				},
+				cancel: {
+					label: "New Tab",
+					onClick: () => {
+						void actions.openNoteInNewTab(createdPath);
+					},
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error("Failed to extract selection to note", error);
+			toast.error("Could not extract to note", { description: message });
+			setDialogState((current) =>
+				current ? { ...current, loading: false } : current,
+			);
+		}
+	}, [actions, dialogState, editor, hostRef, loadUniqueExtractTitle, relPath]);
+
+	return {
+		canExtractToNote,
+		closeExtractDialog,
+		dialogState,
+		openExtractDialog,
+		setExtractDestinationDir,
+		setExtractTitle,
+		submitExtractDialog,
+	};
+}

--- a/src/components/editor/hooks/useExtractSelectionToNote.ts
+++ b/src/components/editor/hooks/useExtractSelectionToNote.ts
@@ -139,9 +139,18 @@ export function useExtractSelectionToNote({
 				})
 				.run();
 			if (!inserted) {
-				throw new Error(
-					"Created the note, but could not replace the selection.",
-				);
+				setDialogState(null);
+				toast.error("Note created, but selection was not replaced.", {
+					className: "extractToNoteToast",
+					description: finalTitle,
+					action: {
+						label: "Open",
+						onClick: () => {
+							void actions.openNote(createdPath);
+						},
+					},
+				});
+				return;
 			}
 			if (scrollHost) {
 				requestAnimationFrame(() => {
@@ -156,12 +165,6 @@ export function useExtractSelectionToNote({
 					label: "Open",
 					onClick: () => {
 						void actions.openNote(createdPath);
-					},
-				},
-				cancel: {
-					label: "New Tab",
-					onClick: () => {
-						void actions.openNoteInNewTab(createdPath);
 					},
 				},
 			});

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -3,6 +3,20 @@ import type { Editor } from "@tiptap/core";
 export type NoteInlineEditorMode = "plain" | "rich" | "preview";
 export type PasteMarkdownBehavior = "plain-text" | "smart-markdown";
 
+export interface CreateMarkdownFileOptions {
+	openParentDir?: string | null;
+	path: string;
+	text: string;
+}
+
+export interface ExtractToNoteActions {
+	createMarkdownFile: (
+		options: CreateMarkdownFileOptions,
+	) => Promise<string | null>;
+	openNote: (path: string) => Promise<void> | void;
+	openNoteInNewTab: (path: string) => Promise<void> | void;
+}
+
 export interface NoteInlineEditorProps {
 	markdown: string;
 	relPath?: string;
@@ -10,6 +24,7 @@ export interface NoteInlineEditorProps {
 	zenModeActive?: boolean;
 	onChange: (nextMarkdown: string) => void;
 	onFrontmatterCommit?: () => void;
+	extractToNoteActions?: ExtractToNoteActions;
 	interactive?: boolean;
 	showBacklinks?: boolean;
 	deferHeavyFeatures?: boolean;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1,7 +1,7 @@
 import {
 	AiEditingIcon,
-	BadgeInfoIcon,
 	FlowConnectionIcon,
+	InformationCircleIcon,
 	SlidersHorizontalIcon,
 	SourceCodeIcon,
 } from "@hugeicons/core-free-icons";
@@ -54,7 +54,10 @@ import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
-import type { NoteInlineEditorMode } from "../editor/types";
+import type {
+	ExtractToNoteActions,
+	NoteInlineEditorMode,
+} from "../editor/types";
 import { LocalNoteGraphDialog } from "../graph/LocalNoteGraphDialog";
 import { Button } from "../ui/shadcn/button";
 import { LinkedNotePreviewSheet } from "./LinkedNotePreviewSheet";
@@ -70,6 +73,7 @@ interface MarkdownEditorPaneProps {
 	onDirtyChange?: (dirty: boolean) => void;
 	initialDoc?: TextFileDoc | null;
 	initialError?: string;
+	extractToNoteActions?: ExtractToNoteActions;
 }
 
 type SyncPulse = "saved" | "reloaded" | null;
@@ -170,6 +174,7 @@ export function MarkdownEditorPane({
 	onDirtyChange,
 	initialDoc = null,
 	initialError = "",
+	extractToNoteActions,
 }: MarkdownEditorPaneProps) {
 	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
 	const [text, setText] = useState(() => initialText);
@@ -921,7 +926,7 @@ export function MarkdownEditorPane({
 										}}
 									>
 										<HugeiconsIcon
-											icon={BadgeInfoIcon}
+											icon={InformationCircleIcon}
 											size={12}
 											strokeWidth={0.9}
 										/>
@@ -1049,6 +1054,7 @@ export function MarkdownEditorPane({
 							}}
 							onFrontmatterCommit={runAutosave}
 							onEditorReady={setTocEditor}
+							extractToNoteActions={extractToNoteActions}
 						/>
 					</div>
 				</div>

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -1,22 +1,26 @@
 import type { TextFileDoc } from "../../lib/tauri";
+import type { ExtractToNoteActions } from "../editor/types";
 import { MarkdownEditorPane } from "./MarkdownEditorPane";
 
 interface NotePaneProps {
 	relPath: string;
 	onDirtyChange?: (dirty: boolean) => void;
 	initialDoc?: TextFileDoc | null;
+	extractToNoteActions?: ExtractToNoteActions;
 }
 
 export function NotePane({
 	relPath,
 	onDirtyChange,
 	initialDoc = null,
+	extractToNoteActions,
 }: NotePaneProps) {
 	return (
 		<MarkdownEditorPane
 			relPath={relPath}
 			initialDoc={initialDoc}
 			onDirtyChange={onDirtyChange}
+			extractToNoteActions={extractToNoteActions}
 		/>
 	);
 }

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -1,4 +1,4 @@
-import { BadgeInfoIcon } from "@hugeicons/core-free-icons";
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useState } from "react";
 import { useSpace } from "../../contexts";
@@ -68,7 +68,11 @@ function VimKeybindingsHelp() {
 					className="vimKeybindingsInfoButton"
 					aria-label="Vim keybindings help"
 				>
-					<HugeiconsIcon icon={BadgeInfoIcon} size={14} strokeWidth={0.9} />
+					<HugeiconsIcon
+						icon={InformationCircleIcon}
+						size={14}
+						strokeWidth={0.9}
+					/>
 				</button>
 			</PopoverTrigger>
 			<PopoverContent

--- a/src/components/ui/shadcn/sonner.tsx
+++ b/src/components/ui/shadcn/sonner.tsx
@@ -3,7 +3,7 @@
 import {
 	Alert02Icon,
 	CheckCircle,
-	Info,
+	InformationCircleIcon,
 	LoaderCircle,
 	OctagonIcon,
 } from "@hugeicons/core-free-icons";
@@ -27,7 +27,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
 					/>
 				),
 				info: (
-					<HugeiconsIcon icon={Info} className="size-4" strokeWidth={0.9} />
+					<HugeiconsIcon
+						icon={InformationCircleIcon}
+						className="size-4"
+						strokeWidth={0.9}
+					/>
 				),
 				warning: (
 					<HugeiconsIcon

--- a/src/styles/app/26-node-note-overlays.css
+++ b/src/styles/app/26-node-note-overlays.css
@@ -485,3 +485,77 @@
 .editorLinkDialogActions {
 	margin-top: 4px;
 }
+
+.extractToNoteDialog {
+	max-width: min(440px, calc(100vw - 32px));
+	gap: 16px;
+	padding: 20px;
+	border-radius: var(--radius-lg);
+}
+
+.extractToNoteDialog [data-slot="dialog-close"] {
+	top: 18px;
+	right: 18px;
+}
+
+.extractToNoteHeader {
+	padding-right: 34px;
+	gap: 0;
+}
+
+.extractToNoteForm {
+	display: grid;
+	gap: 14px;
+}
+
+.extractToNoteField {
+	display: grid;
+	gap: 6px;
+}
+
+.extractToNoteLabel {
+	font-size: 0.75rem;
+	font-weight: var(--font-medium);
+	color: var(--text-secondary);
+}
+
+.extractToNoteInput {
+	height: 38px;
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-secondary));
+	box-shadow: none;
+}
+
+.extractToNoteFolderTrigger {
+	width: 100%;
+	max-width: none;
+	align-self: stretch;
+}
+
+.extractToNoteActions {
+	margin-top: 4px;
+}
+
+.extractToNoteToast[data-sonner-toast][data-styled="true"] {
+	gap: 10px;
+}
+
+.extractToNoteToast[data-sonner-toast][data-styled="true"] [data-content] {
+	min-width: 0;
+	flex: 1 1 auto;
+}
+
+.extractToNoteToast[data-sonner-toast][data-styled="true"] [data-title],
+.extractToNoteToast[data-sonner-toast][data-styled="true"] [data-description] {
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.extractToNoteToast[data-sonner-toast][data-styled="true"] [data-button] {
+	height: 28px;
+	padding-inline: 10px;
+	margin-left: 0;
+	white-space: nowrap;
+}

--- a/website/src/pages/changelog.astro
+++ b/website/src/pages/changelog.astro
@@ -6,8 +6,7 @@ import { downloadUrl } from "../lib/site";
 
 const changelog = getChangelogPageData(10);
 const pageTitle = "Glyph Changelog";
-const pageDescription =
-	"What shipped in Glyph and what's in progress.";
+const pageDescription = "What shipped in Glyph and what's in progress.";
 const repositoryUrl = changelog.repositoryUrl;
 
 function getCommitHref(hash: string): string | undefined {


### PR DESCRIPTION
## Summary
- Add a new extract-selection-to-note flow with command wiring, dialog UI, and editor integration.
- Update note/editor surfaces and related app shell paths so the action is available from the relevant places.
- Refresh a few info/logout icons for consistency and fix the changelog page formatting issue.

## Testing
- `pnpm check` passed.
- `pnpm build` passed.
- `cd src-tauri && cargo check` passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sidhuk/glyph/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Extract to Note" functionality enabling users to extract editor selections into standalone notes with customizable titles and destination folders.
  * Added extract-to-note dialog and action button to the editor ribbon.

* **Style**
  * Updated various UI icons across components for visual consistency and improved information representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->