### PR TITLE
[codex] Folio mode implementation

### DIFF
--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -49,6 +49,7 @@ pub struct AllDocsItem {
     pub updated: String,
     pub created: String,
     pub tags: Vec<String>,
+    pub people: Vec<String>,
 }
 
 #[derive(Serialize)]
@@ -375,6 +376,16 @@ pub async fn all_docs_list(
                                   AND tag NOT LIKE 'people/%'
                                 ORDER BY is_explicit DESC, tag COLLATE NOCASE ASC
                             ) ordered_tags
+                        ), ''),
+                        COALESCE((
+                            SELECT GROUP_CONCAT(ordered_people.tag, '\n')
+                            FROM (
+                                SELECT tag
+                                FROM tags
+                                WHERE note_id = n.id
+                                  AND tag LIKE 'people/%'
+                                ORDER BY tag COLLATE NOCASE ASC
+                            ) ordered_people
                         ), '')
                  FROM notes n ",
         );
@@ -395,6 +406,7 @@ pub async fn all_docs_list(
         let mut out = Vec::new();
         while let Some(row) = rows.next().map_err(|e| e.to_string())? {
             let tag_blob: String = row.get(5).map_err(|e| e.to_string())?;
+            let people_blob: String = row.get(6).map_err(|e| e.to_string())?;
             out.push(AllDocsItem {
                 note_path: row.get(0).map_err(|e| e.to_string())?,
                 title: row.get(1).map_err(|e| e.to_string())?,
@@ -406,6 +418,10 @@ pub async fn all_docs_list(
                     .map(str::trim)
                     .filter(|tag| !tag.is_empty())
                     .map(ToOwned::to_owned)
+                    .collect(),
+                people: people_blob
+                    .split('\n')
+                    .filter_map(people_tag_to_handle)
                     .collect(),
             });
         }

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -366,27 +366,8 @@ pub async fn all_docs_list(
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<AllDocsItem>, String> {
         let conn = open_db(&root)?;
         let mut sql = String::from(
-            "SELECT n.path, n.title, n.preview, n.updated, n.created,
-                        COALESCE((
-                            SELECT GROUP_CONCAT(ordered_tags.tag, '\n')
-                            FROM (
-                                SELECT tag
-                                FROM tags
-                                WHERE note_id = n.id
-                                  AND tag NOT LIKE 'people/%'
-                                ORDER BY is_explicit DESC, tag COLLATE NOCASE ASC
-                            ) ordered_tags
-                        ), ''),
-                        COALESCE((
-                            SELECT GROUP_CONCAT(ordered_people.tag, '\n')
-                            FROM (
-                                SELECT tag
-                                FROM tags
-                                WHERE note_id = n.id
-                                  AND tag LIKE 'people/%'
-                                ORDER BY tag COLLATE NOCASE ASC
-                            ) ordered_people
-                        ), '')
+            "WITH visible_notes AS (
+                 SELECT n.id, n.path, n.title, n.preview, n.updated, n.created
                  FROM notes n ",
         );
         let mut params: Vec<rusqlite::types::Value> = Vec::new();
@@ -397,7 +378,38 @@ pub async fn all_docs_list(
                 escape_like(prefix)
             )));
         }
-        sql.push_str("ORDER BY n.updated DESC LIMIT ?");
+        sql.push_str(
+            "ORDER BY n.updated DESC LIMIT ?
+             ),
+             tag_blob AS (
+                 SELECT ordered_tags.note_id, GROUP_CONCAT(ordered_tags.tag, '\n') AS tags
+                 FROM (
+                     SELECT t.note_id, t.tag, t.is_explicit
+                     FROM tags t
+                     JOIN visible_notes vn ON vn.id = t.note_id
+                     WHERE t.tag NOT LIKE 'people/%'
+                     ORDER BY t.note_id, t.is_explicit DESC, t.tag COLLATE NOCASE ASC
+                 ) ordered_tags
+                 GROUP BY ordered_tags.note_id
+             ),
+             people_blob AS (
+                 SELECT ordered_people.note_id, GROUP_CONCAT(ordered_people.tag, '\n') AS people
+                 FROM (
+                     SELECT t.note_id, t.tag
+                     FROM tags t
+                     JOIN visible_notes vn ON vn.id = t.note_id
+                     WHERE t.tag LIKE 'people/%'
+                     ORDER BY t.note_id, t.tag COLLATE NOCASE ASC
+                 ) ordered_people
+                 GROUP BY ordered_people.note_id
+             )
+             SELECT vn.path, vn.title, vn.preview, vn.updated, vn.created,
+                    COALESCE(tag_blob.tags, ''), COALESCE(people_blob.people, '')
+             FROM visible_notes vn
+             LEFT JOIN tag_blob ON tag_blob.note_id = vn.id
+             LEFT JOIN people_blob ON people_blob.note_id = vn.id
+             ORDER BY vn.updated DESC",
+        );
         params.push(rusqlite::types::Value::from(limit));
         let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
         let mut rows = stmt

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -1,8 +1,9 @@
+use serde::Serialize;
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
 };
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
 use crate::{index, paths, space::SpaceState, utils};
@@ -11,6 +12,12 @@ use super::super::helpers::deny_hidden_rel_path;
 use super::super::link_rewrite::{self, LinkRewriteResult};
 use super::super::types::FsEntry;
 use super::trash::move_path_to_trash;
+
+#[derive(Serialize, Clone)]
+struct NoteChangeEvent {
+    rel_path: String,
+    removed: bool,
+}
 
 fn split_duplicate_name(file_name: &str) -> (&str, &str) {
     match file_name.rfind('.') {
@@ -221,16 +228,27 @@ pub async fn space_create_dir(state: State<'_, SpaceState>, path: String) -> Res
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_duplicate_path(
+    app: tauri::AppHandle,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<FsEntry, String> {
     let root = state.current_root()?;
     let recent_local_changes = state.recent_local_changes();
-    tauri::async_runtime::spawn_blocking(move || {
+    let entry = tauri::async_runtime::spawn_blocking(move || {
         duplicate_file_under_root(&root, Path::new(&path), &recent_local_changes)
     })
     .await
-    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())??;
+    if entry.is_markdown {
+        let _ = app.emit(
+            "notes:external_changed",
+            NoteChangeEvent {
+                rel_path: entry.rel_path.clone(),
+                removed: false,
+            },
+        );
+    }
+    Ok(entry)
 }
 
 #[tauri::command]

--- a/src/App.css
+++ b/src/App.css
@@ -42,6 +42,7 @@
 @import "./styles/app/37-database.css";
 @import "./styles/app/41-database-board.css";
 @import "./styles/app/47-database-table-dialogs.css";
+@import "./styles/app/49-folio-mode.css";
 @import "./styles/app/38-licensing.css";
 @import "./styles/app/39-floating-toc.css";
 @import "./styles/app/40-template-picker.css";

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -132,6 +132,7 @@ export function AppShell() {
 		setSidebarCollapsed,
 		zenModeActive,
 		setZenModeActive,
+		folioMode,
 		paletteOpen,
 		setPaletteOpen,
 		activePreviewPath,
@@ -1259,6 +1260,7 @@ export function AppShell() {
 				"appShell",
 				sidebarCollapsed && "appShellSidebarCollapsed",
 				zenModeActive && "appShellZenMode",
+				folioMode && "appShellFolioMode",
 			)}
 		>
 			<div
@@ -1335,7 +1337,12 @@ export function AppShell() {
 				/>
 			) : null}
 			<MainContent
-				fileTree={fileTree}
+				fileTree={{
+					createMarkdownFileAtPath: fileTree.createMarkdownFileAtPath,
+					openNonMarkdownExternally: fileTree.openNonMarkdownExternally,
+					onRenameDir: fileTree.onRenameDir,
+					onDeletePath: fileTree.onDeletePath,
+				}}
 				onOpenFile={openWorkspaceFile}
 				onOpenFileInNewTab={openWorkspaceFileInNewTab}
 				onOpenCommandPalette={openCommandPalette}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -60,6 +60,7 @@ import type {
 	CreateMarkdownFileOptions,
 	ExtractToNoteActions,
 } from "../editor/types";
+import { FolioWorkspace } from "../folio/FolioWorkspace";
 import { FilePreviewPane } from "../preview/FilePreviewPane";
 import { NotePane } from "../preview/NotePane";
 import { AboutSettingsPane } from "../settings/AboutSettingsPane";
@@ -265,6 +266,7 @@ interface MainContentProps {
 			nextName: string,
 			kind: "dir" | "file",
 		) => Promise<string | null>;
+		onDeletePath: (path: string, kind: "dir" | "file") => Promise<boolean>;
 	};
 	onOpenFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
@@ -400,6 +402,7 @@ export const MainContent = memo(function MainContent({
 		dailyNotesFolder,
 		templateFolder,
 		zenModeActive,
+		folioMode,
 		settingsMode,
 		settingsTab,
 	} = useUILayoutContext();
@@ -798,6 +801,93 @@ export const MainContent = memo(function MainContent({
 			SETTINGS_TABS.find((tab) => tab.id === settingsTab) ?? SETTINGS_TABS[0],
 		[settingsTab],
 	);
+	const showFolioWorkspace = folioMode && !zenModeActive;
+	const editorSurface = (
+		<>
+			<div className="canvasPaneHost">
+				<DailyNotesSetupToast
+					visible={dailyNoteSetupToastVisible}
+					onDismiss={() => setDailyNoteSetupToastVisible(false)}
+					onOpenSettings={() => {
+						setDailyNoteSetupToastVisible(false);
+						onOpenDailyNotesSettings();
+					}}
+				/>
+				{showTabBar ? (
+					<div
+						className={`mainTabBarTransition${zenModeActive ? " is-zen-hidden" : ""}`}
+						aria-hidden={zenModeActive}
+						inert={zenModeActive ? true : undefined}
+					>
+						<TabBar
+							tabs={tabs}
+							activeTabId={activeTabId}
+							activeTabPath={activeTabPath}
+							useWindowBackground={!content}
+							canGoBack={canGoBack}
+							canGoForward={canGoForward}
+							onGoBack={onGoBack}
+							onGoForward={onGoForward}
+							onOpenBlankTab={openBlankTab}
+							onPrefetchTab={handlePrefetchTab}
+							onSelectTab={setActiveTabId}
+							onCloseTab={closeTab}
+							onStartRenamePath={onStartRenamePath}
+							onReorder={reorderTabs}
+						/>
+					</div>
+				) : null}
+				{content ?? (
+					<div className="mainEmptyState">
+						{showStarterPane ? (
+							<GettingStartedPane
+								commandShortcutParts={commandShortcutParts}
+								showDailyNoteAction={Boolean(dailyNotesFolder)}
+								onCreateNote={onCreateNote}
+								onOpenCommandPalette={onOpenCommandPalette}
+								onOpenDailyNote={onOpenDailyNote}
+								onDismiss={() => {
+									setStarterOverrideVisible(false);
+									void updateOnboardingSettings({ starterDismissed: true });
+								}}
+							/>
+						) : (
+							<ContextualEmptyState
+								onboarding={onboarding}
+								commandShortcutParts={commandShortcutParts}
+								showDailyNoteAction={Boolean(dailyNotesFolder)}
+								onCreateNote={onCreateNote}
+								onOpenCommandPalette={onOpenCommandPalette}
+								onOpenDailyNote={onOpenDailyNote}
+							/>
+						)}
+					</div>
+				)}
+				{aiEnabled && !zenModeActive ? (
+					<AIFloatingHost
+						isOpen={aiPanelOpen}
+						onToggle={() => setAiPanelOpen((open) => !open)}
+					/>
+				) : null}
+			</div>
+			<div
+				ref={infoSidebarResize.resizeRef}
+				className="notesInfoSidebarResizeHandle"
+				onPointerDown={handleInfoSidebarResizePointerDown}
+				onPointerMove={infoSidebarResize.handlePointerMove}
+				onPointerUp={infoSidebarResize.handlePointerUp}
+				data-window-drag-ignore
+				style={{ cursor: zenModeActive ? "default" : "col-resize" }}
+			/>
+			<div
+				id="notes-info-sidebar-root"
+				ref={notesInfoSidebarHostRef}
+				className="notesInfoSidebarHost"
+				aria-live="polite"
+				style={notesInfoSidebarHostStyle}
+			/>
+		</>
+	);
 
 	if (settingsMode) {
 		return (
@@ -848,88 +938,21 @@ export const MainContent = memo(function MainContent({
 	return (
 		<main className={zenModeActive ? "mainArea mainAreaZen" : "mainArea"}>
 			<div className="canvasWrapper">
-				<div className="canvasPaneHost">
-					<DailyNotesSetupToast
-						visible={dailyNoteSetupToastVisible}
-						onDismiss={() => setDailyNoteSetupToastVisible(false)}
-						onOpenSettings={() => {
-							setDailyNoteSetupToastVisible(false);
-							onOpenDailyNotesSettings();
-						}}
-					/>
-					{showTabBar ? (
-						<div
-							className={`mainTabBarTransition${zenModeActive ? " is-zen-hidden" : ""}`}
-							aria-hidden={zenModeActive}
-							inert={zenModeActive ? true : undefined}
-						>
-							<TabBar
-								tabs={tabs}
-								activeTabId={activeTabId}
-								activeTabPath={activeTabPath}
-								useWindowBackground={!content}
-								canGoBack={canGoBack}
-								canGoForward={canGoForward}
-								onGoBack={onGoBack}
-								onGoForward={onGoForward}
-								onOpenBlankTab={openBlankTab}
-								onPrefetchTab={handlePrefetchTab}
-								onSelectTab={setActiveTabId}
-								onCloseTab={closeTab}
-								onStartRenamePath={onStartRenamePath}
-								onReorder={reorderTabs}
-							/>
-						</div>
-					) : null}
-					{content ?? (
-						<div className="mainEmptyState">
-							{showStarterPane ? (
-								<GettingStartedPane
-									commandShortcutParts={commandShortcutParts}
-									showDailyNoteAction={Boolean(dailyNotesFolder)}
-									onCreateNote={onCreateNote}
-									onOpenCommandPalette={onOpenCommandPalette}
-									onOpenDailyNote={onOpenDailyNote}
-									onDismiss={() => {
-										setStarterOverrideVisible(false);
-										void updateOnboardingSettings({ starterDismissed: true });
-									}}
-								/>
-							) : (
-								<ContextualEmptyState
-									onboarding={onboarding}
-									commandShortcutParts={commandShortcutParts}
-									showDailyNoteAction={Boolean(dailyNotesFolder)}
-									onCreateNote={onCreateNote}
-									onOpenCommandPalette={onOpenCommandPalette}
-									onOpenDailyNote={onOpenDailyNote}
-								/>
-							)}
-						</div>
-					)}
-					{aiEnabled && !zenModeActive ? (
-						<AIFloatingHost
-							isOpen={aiPanelOpen}
-							onToggle={() => setAiPanelOpen((open) => !open)}
-						/>
-					) : null}
-				</div>
-				<div
-					ref={infoSidebarResize.resizeRef}
-					className="notesInfoSidebarResizeHandle"
-					onPointerDown={handleInfoSidebarResizePointerDown}
-					onPointerMove={infoSidebarResize.handlePointerMove}
-					onPointerUp={infoSidebarResize.handlePointerUp}
-					data-window-drag-ignore
-					style={{ cursor: zenModeActive ? "default" : "col-resize" }}
-				/>
-				<div
-					id="notes-info-sidebar-root"
-					ref={notesInfoSidebarHostRef}
-					className="notesInfoSidebarHost"
-					aria-live="polite"
-					style={notesInfoSidebarHostStyle}
-				/>
+				{showFolioWorkspace ? (
+					<FolioWorkspace
+						activeTabPath={activeTabPath}
+						onOpenFile={onOpenFile}
+						onOpenFileInNewTab={onOpenFileInNewTab}
+						onRenameFile={(path, nextName) =>
+							fileTree.onRenameDir(path, nextName, "file")
+						}
+						onDeleteFile={(path) => fileTree.onDeletePath(path, "file")}
+					>
+						{editorSurface}
+					</FolioWorkspace>
+				) : (
+					editorSurface
+				)}
 			</div>
 		</main>
 	);

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -943,9 +943,6 @@ export const MainContent = memo(function MainContent({
 						activeTabPath={activeTabPath}
 						onOpenFile={onOpenFile}
 						onOpenFileInNewTab={onOpenFileInNewTab}
-						onRenameFile={(path, nextName) =>
-							fileTree.onRenameDir(path, nextName, "file")
-						}
 						onDeleteFile={(path) => fileTree.onDeletePath(path, "file")}
 					>
 						{editorSurface}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -9,12 +9,12 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useFileTreeContext } from "../../contexts";
+import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
 import { shouldShowGitSync } from "../../lib/gitSyncUi";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
-import { type GitSyncStatus, invoke } from "../../lib/tauri";
+import { type FsEntry, type GitSyncStatus, invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
@@ -74,6 +74,34 @@ function spaceInitial(label: string): string {
 	return trimmed.slice(0, 1).toUpperCase();
 }
 
+function isSpaceContainerEntry(entry: FsEntry, spaceLabel: string): boolean {
+	const normalizedSpaceLabel = spaceLabel.trim().toLocaleLowerCase();
+	return (
+		entry.kind === "dir" &&
+		normalizedSpaceLabel.length > 0 &&
+		entry.name.trim().toLocaleLowerCase() === normalizedSpaceLabel
+	);
+}
+
+function folderEntries(entries: FsEntry[] | undefined): FsEntry[] {
+	return (entries ?? []).filter((entry) => entry.kind === "dir");
+}
+
+function folioTreeRootEntries(
+	rootEntries: FsEntry[],
+	childrenByDir: Record<string, FsEntry[] | undefined>,
+	spaceLabel: string,
+): FsEntry[] {
+	const spaceContainer = rootEntries.find((entry) =>
+		isSpaceContainerEntry(entry, spaceLabel),
+	);
+	if (!spaceContainer) return folderEntries(rootEntries);
+	return folderEntries([
+		...rootEntries.filter((entry) => entry !== spaceContainer),
+		...(childrenByDir[spaceContainer.rel_path] ?? []),
+	]);
+}
+
 export const SidebarContent = memo(function SidebarContent({
 	onToggleDir,
 	onLoadDir,
@@ -118,6 +146,7 @@ export const SidebarContent = memo(function SidebarContent({
 		tags,
 		people,
 	} = useFileTreeContext();
+	const { folioMode, folioScope, setFolioScope } = useUILayoutContext();
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
 	const [pendingNewNotePath, setPendingNewNotePath] = useState<string | null>(
 		null,
@@ -133,12 +162,38 @@ export const SidebarContent = memo(function SidebarContent({
 	const showGitButton = shouldShowGitSync(gitSyncStatus);
 	const effectiveGitExpanded = showGitButton && gitExpanded;
 	const showAllNotesCount = allNotesCount !== null;
+	const activeFolioFolder =
+		folioScope.kind === "folder" ? folioScope.folderPrefix : null;
 	const spaceLabel = spacePath ? formatSpaceLabel(spacePath) : "Glyph";
+	const folioSpaceContainerPath = useMemo(() => {
+		if (!folioMode) return null;
+		return (
+			rootEntries.find((entry) => isSpaceContainerEntry(entry, spaceLabel))
+				?.rel_path ?? null
+		);
+	}, [folioMode, rootEntries, spaceLabel]);
+	const folioRootEntries = useMemo(
+		() => folioTreeRootEntries(rootEntries, childrenByDir, spaceLabel),
+		[rootEntries, childrenByDir, spaceLabel],
+	);
+	const folioChildrenByDir = useMemo(() => {
+		const next: Record<string, FsEntry[] | undefined> = {};
+		for (const [dirPath, entries] of Object.entries(childrenByDir)) {
+			next[dirPath] = entries ? folderEntries(entries) : entries;
+		}
+		return next;
+	}, [childrenByDir]);
 	const displayRecentSpaces = useMemo(
 		() =>
 			recentSpaces.filter((path) => path && path !== spacePath).slice(0, 10),
 		[recentSpaces, spacePath],
 	);
+
+	useEffect(() => {
+		if (!folioMode || !folioSpaceContainerPath) return;
+		if (childrenByDir[folioSpaceContainerPath] !== undefined) return;
+		void onLoadDir(folioSpaceContainerPath);
+	}, [childrenByDir, folioMode, folioSpaceContainerPath, onLoadDir]);
 
 	const handleStartRename = useCallback((path: string) => {
 		const nextPath = path.trim();
@@ -300,6 +355,41 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 		[onOpenRecentSpaceAtPath],
 	);
+	const handleOpenAllNotes = useCallback(() => {
+		if (!folioMode) {
+			onOpenAllDocs();
+			return;
+		}
+		setFolioScope({ kind: "all" });
+		onPrefetchAllDocs();
+	}, [folioMode, onOpenAllDocs, onPrefetchAllDocs, setFolioScope]);
+	const handleNotesHeaderClick = useCallback(() => {
+		setNotesExpanded((value) => !value);
+		if (!folioMode) return;
+		setFolioScope({ kind: "all" });
+		onPrefetchAllDocs();
+	}, [folioMode, onPrefetchAllDocs, setFolioScope]);
+	const handleSelectFolioFolder = useCallback(
+		(dirPath: string) => {
+			onSelectDir(dirPath);
+			if (!dirPath) {
+				setFolioScope({ kind: "all" });
+				return;
+			}
+			setFolioScope({ kind: "folder", folderPrefix: dirPath });
+		},
+		[onSelectDir, setFolioScope],
+	);
+	const handleSelectTag = useCallback(
+		(tag: string) => {
+			if (!folioMode) {
+				onSelectTag(tag);
+				return;
+			}
+			setFolioScope({ kind: "tag", tag });
+		},
+		[folioMode, onSelectTag, setFolioScope],
+	);
 
 	if (!spacePath) {
 		return (
@@ -459,7 +549,7 @@ export const SidebarContent = memo(function SidebarContent({
 							aria-current={
 								activeTopSection === "all-notes" ? "page" : undefined
 							}
-							onClick={onOpenAllDocs}
+							onClick={handleOpenAllNotes}
 							onMouseEnter={onPrefetchAllDocs}
 							onFocus={onPrefetchAllDocs}
 							title="Open All Notes"
@@ -503,7 +593,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<button
 								type="button"
 								className="sidebarStackHeader sidebarStackHeaderToggle"
-								onClick={() => setNotesExpanded((v) => !v)}
+								onClick={handleNotesHeaderClick}
 								aria-expanded={notesExpanded}
 								aria-label={notesExpanded ? "Collapse Notes" : "Expand Notes"}
 							>
@@ -522,14 +612,16 @@ export const SidebarContent = memo(function SidebarContent({
 							</button>
 							{notesExpanded ? (
 								<FileTreePane
-									rootEntries={rootEntries}
-									childrenByDir={childrenByDir}
+									rootEntries={folioMode ? folioRootEntries : rootEntries}
+									childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
 									expandedDirs={expandedDirs}
-									activeFilePath={activeFilePath}
-									activeDirPath={activeDirPath}
+									activeFilePath={folioMode ? null : activeFilePath}
+									activeDirPath={folioMode ? activeFolioFolder : activeDirPath}
 									onToggleDir={onToggleDir}
 									onLoadDir={onLoadDir}
-									onSelectDir={onSelectDir}
+									onSelectDir={
+										folioMode ? handleSelectFolioFolder : onSelectDir
+									}
 									onOpenFile={onOpenFile}
 									onPrefetchFile={onPrefetchFile}
 									onNewFileInDir={onNewFileInDir}
@@ -544,7 +636,7 @@ export const SidebarContent = memo(function SidebarContent({
 									onCommitFileRename={handleCommitFileRename}
 									onCommitDirRename={handleCommitDirRename}
 									onMovePath={onMovePath}
-									pinnedFiles={pinnedFiles}
+									pinnedFiles={folioMode ? [] : pinnedFiles}
 									onTogglePinnedFile={togglePinnedFile}
 								/>
 							) : null}
@@ -553,8 +645,8 @@ export const SidebarContent = memo(function SidebarContent({
 							<TagsPane
 								tags={tags}
 								people={people}
-								onSelectTag={onSelectTag}
-								onSelectPerson={onSelectTag}
+								onSelectTag={handleSelectTag}
+								onSelectPerson={handleSelectTag}
 							/>
 						</section>
 					</div>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -356,12 +356,11 @@ export const SidebarContent = memo(function SidebarContent({
 		[onOpenRecentSpaceAtPath],
 	);
 	const handleOpenAllNotes = useCallback(() => {
-		if (!folioMode) {
-			onOpenAllDocs();
-			return;
+		onOpenAllDocs();
+		if (folioMode) {
+			setFolioScope({ kind: "all" });
+			onPrefetchAllDocs();
 		}
-		setFolioScope({ kind: "all" });
-		onPrefetchAllDocs();
 	}, [folioMode, onOpenAllDocs, onPrefetchAllDocs, setFolioScope]);
 	const handleNotesHeaderClick = useCallback(() => {
 		setNotesExpanded((value) => !value);

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -390,6 +390,16 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 		[folioMode, onSelectTag, setFolioScope],
 	);
+	const handleSelectPerson = useCallback(
+		(handle: string) => {
+			if (!folioMode) {
+				onSelectTag(handle);
+				return;
+			}
+			setFolioScope({ kind: "person", handle });
+		},
+		[folioMode, onSelectTag, setFolioScope],
+	);
 
 	if (!spacePath) {
 		return (
@@ -646,7 +656,7 @@ export const SidebarContent = memo(function SidebarContent({
 								tags={tags}
 								people={people}
 								onSelectTag={handleSelectTag}
-								onSelectPerson={handleSelectTag}
+								onSelectPerson={handleSelectPerson}
 							/>
 						</section>
 					</div>

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -1,9 +1,10 @@
 import { memo, useMemo } from "react";
 import { databaseValueToneStyle } from "../../lib/database/palette";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
-import type { AllDocsItem } from "../../lib/tauri";
+import type { AllDocsItem, NoteTaskSummary } from "../../lib/tauri";
 import { basename, parentDir } from "../../utils/path";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
+import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import {
 	ContextMenu,
 	ContextMenuContent,
@@ -21,6 +22,7 @@ interface FolioNoteListItemProps {
 	onRename: (path: string) => void;
 	onDelete: (path: string) => void;
 	onFocus: () => void;
+	taskSummary?: NoteTaskSummary | null;
 }
 
 function titleFromPath(notePath: string): string {
@@ -76,6 +78,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	onRename,
 	onDelete,
 	onFocus,
+	taskSummary = null,
 }: FolioNoteListItemProps) {
 	const title = note.title.trim() || titleFromPath(note.note_path);
 	const preview = useMemo(() => {
@@ -116,6 +119,12 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 					>
 						<span className="folioNoteRowTop">
 							<span className="folioNoteTitle">{title}</span>
+							{taskSummary && taskSummary.total_count > 0 ? (
+								<TaskProgressIndicator
+									summary={taskSummary}
+									className="folioNoteTaskProgress"
+								/>
+							) : null}
 						</span>
 						<span className="folioNotePreview">{preview}</span>
 						<span className="folioNoteFooter">

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -1,0 +1,183 @@
+import { memo, useMemo } from "react";
+import { databaseValueToneStyle } from "../../lib/database/palette";
+import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
+import type { AllDocsItem } from "../../lib/tauri";
+import { basename, parentDir } from "../../utils/path";
+import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuTrigger,
+} from "../ui/shadcn/context-menu";
+
+interface FolioNoteListItemProps {
+	note: AllDocsItem;
+	selected: boolean;
+	onOpen: (path: string) => void;
+	onOpenInNewTab: (path: string) => void;
+	onPrefetch: (path: string) => void;
+	onRename: (path: string) => void;
+	onDelete: (path: string) => void;
+	onFocus: () => void;
+}
+
+function titleFromPath(notePath: string): string {
+	return basename(notePath).replace(/\.md$/i, "") || "Untitled";
+}
+
+function dateLabel(iso: string): string {
+	try {
+		return new Intl.DateTimeFormat(undefined, {
+			month: "short",
+			day: "numeric",
+		}).format(new Date(iso));
+	} catch {
+		return "";
+	}
+}
+
+function previewText(preview: string, title: string): string {
+	const lowerTitle = title.trim().toLowerCase();
+	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
+	const previewLines: string[] = [];
+
+	for (const rawLine of lines) {
+		const line = rawLine.trim();
+		if (!line || /^#\s+/.test(line)) continue;
+
+		const withoutMarkdownPrefix = line
+			.replace(/^#{2,6}\s+/, "")
+			.replace(/^>\s?/, "")
+			.replace(/^(?:[-*+]|\d+\.)\s+/, "")
+			.replace(/^\[(?: |x|X)\]\s+/, "");
+		const normalized = normalizeInlineMarkdown(withoutMarkdownPrefix);
+		if (!normalized) continue;
+
+		if (lowerTitle && normalized.toLowerCase().startsWith(lowerTitle)) {
+			const withoutTitle = normalized.slice(title.length).trim();
+			if (withoutTitle) previewLines.push(withoutTitle);
+			continue;
+		}
+
+		previewLines.push(normalized);
+	}
+
+	return previewLines.join(" ") || "No preview";
+}
+
+export const FolioNoteListItem = memo(function FolioNoteListItem({
+	note,
+	selected,
+	onOpen,
+	onOpenInNewTab,
+	onPrefetch,
+	onRename,
+	onDelete,
+	onFocus,
+}: FolioNoteListItemProps) {
+	const title = note.title.trim() || titleFromPath(note.note_path);
+	const preview = useMemo(() => {
+		return previewText(note.preview, title);
+	}, [note.preview, title]);
+	const updated = dateLabel(note.updated);
+	const visibleTags = note.tags.slice(0, 2);
+	const hiddenTagCount = Math.max(0, note.tags.length - visibleTags.length);
+	const folder = parentDir(note.note_path);
+
+	return (
+		<li className="folioNoteListItem">
+			<ContextMenu>
+				<ContextMenuTrigger asChild>
+					<button
+						type="button"
+						className="folioNoteRow"
+						data-state={selected ? "selected" : "idle"}
+						data-folio-note-path={note.note_path}
+						aria-current={selected ? "page" : undefined}
+						onClick={(event) => {
+							if (event.metaKey || event.ctrlKey) {
+								onOpenInNewTab(note.note_path);
+								return;
+							}
+							onOpen(note.note_path);
+						}}
+						onDoubleClick={() => onOpenInNewTab(note.note_path)}
+						onAuxClick={(event) => {
+							if (event.button === 1) onOpenInNewTab(note.note_path);
+						}}
+						onMouseEnter={() => onPrefetch(note.note_path)}
+						onFocus={() => {
+							onFocus();
+							onPrefetch(note.note_path);
+						}}
+						title={note.note_path}
+					>
+						<span className="folioNoteRowTop">
+							<span className="folioNoteTitle">{title}</span>
+						</span>
+						<span className="folioNotePreview">{preview}</span>
+						<span className="folioNoteFooter">
+							<span className="folioNoteTags">
+								{visibleTags.length > 0 ? (
+									visibleTags.map((tag) => (
+										<span
+											key={tag}
+											className="databaseCellPill folioNoteTag"
+											style={databaseValueToneStyle(tag)}
+											title={formatDatabaseTagLabel(tag)}
+										>
+											{formatDatabaseTagLabel(tag)}
+										</span>
+									))
+								) : (
+									<span className="folioNoteFolder">
+										{folder || "No folder"}
+									</span>
+								)}
+								{hiddenTagCount > 0 ? (
+									<span className="databaseCellPill databaseCellPillMore folioNoteTag">
+										+{hiddenTagCount}
+									</span>
+								) : null}
+							</span>
+							<span className="folioNoteDates">{updated}</span>
+						</span>
+					</button>
+				</ContextMenuTrigger>
+				<ContextMenuContent
+					className="fileTreeCreateMenu"
+					onCloseAutoFocus={(event) => event.preventDefault()}
+				>
+					<ContextMenuItem
+						className="fileTreeCreateMenuItem"
+						onSelect={() => onOpen(note.note_path)}
+					>
+						Open
+					</ContextMenuItem>
+					<ContextMenuItem
+						className="fileTreeCreateMenuItem"
+						onSelect={() => onOpenInNewTab(note.note_path)}
+					>
+						Open in New Tab
+					</ContextMenuItem>
+					<ContextMenuSeparator className="fileTreeCreateMenuSeparator" />
+					<ContextMenuItem
+						className="fileTreeCreateMenuItem"
+						onSelect={() => onRename(note.note_path)}
+					>
+						Rename
+					</ContextMenuItem>
+					<ContextMenuItem
+						variant="destructive"
+						className="fileTreeCreateMenuItem"
+						onSelect={() => onDelete(note.note_path)}
+					>
+						Delete
+					</ContextMenuItem>
+				</ContextMenuContent>
+			</ContextMenu>
+		</li>
+	);
+});

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -125,12 +125,9 @@ describe("FolioNotesListPane", () => {
 	let queryClient: QueryClient;
 	let onOpenFile: (relPath: string) => Promise<void>;
 	let onOpenFileInNewTab: (relPath: string) => Promise<void>;
-	let onRenameFile: (
-		relPath: string,
-		nextName: string,
-	) => Promise<string | null>;
 	let onDeleteFile: (relPath: string) => Promise<boolean>;
 	let scrollIntoViewArgs: Array<boolean | ScrollIntoViewOptions | undefined>;
+	let originalScrollIntoView: HTMLElement["scrollIntoView"];
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -143,8 +140,8 @@ describe("FolioNotesListPane", () => {
 		});
 		onOpenFile = vi.fn(async () => {});
 		onOpenFileInNewTab = vi.fn(async () => {});
-		onRenameFile = vi.fn(async () => null);
 		onDeleteFile = vi.fn(async () => true);
+		originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
 		scrollIntoViewArgs = [];
 		HTMLElement.prototype.scrollIntoView = (
 			arg?: boolean | ScrollIntoViewOptions,
@@ -162,6 +159,8 @@ describe("FolioNotesListPane", () => {
 		});
 		container.remove();
 		queryClient.clear();
+		HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+		scrollIntoViewArgs = [];
 	});
 
 	function renderPane(activeTabPath: string | null = null) {
@@ -171,7 +170,6 @@ describe("FolioNotesListPane", () => {
 					activeTabPath={activeTabPath}
 					onOpenFile={onOpenFile}
 					onOpenFileInNewTab={onOpenFileInNewTab}
-					onRenameFile={onRenameFile}
 					onDeleteFile={onDeleteFile}
 				/>
 			</QueryClientProvider>,

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -7,10 +7,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FolioNotesListPane } from "./FolioNotesListPane";
 import type { FolioScope } from "./folioScopes";
 
-const { loadAllDocsMock, prefetchNoteMock, scopeRef } = vi.hoisted(() => ({
+const {
+	loadAllDocsMock,
+	prefetchNoteMock,
+	scopeRef,
+	taskSummariesRef,
+	showTaskProgressIndicatorRef,
+} = vi.hoisted(() => ({
 	loadAllDocsMock: vi.fn(),
 	prefetchNoteMock: vi.fn(),
 	scopeRef: { current: { kind: "all" } as FolioScope },
+	taskSummariesRef: {
+		current: {} as Record<
+			string,
+			{ total_count: number; completed_count: number; open_count: number }
+		>,
+	},
+	showTaskProgressIndicatorRef: { current: true as boolean | null },
 }));
 
 vi.mock("../../contexts", () => ({
@@ -32,6 +45,14 @@ vi.mock("../../lib/navigationPrefetch", async () => {
 
 vi.mock("../../lib/tauriEvents", () => ({
 	useTauriEvent: () => {},
+}));
+
+vi.mock("../../hooks/useTaskProgressIndicatorSetting", () => ({
+	useTaskProgressIndicatorSetting: () => showTaskProgressIndicatorRef.current,
+}));
+
+vi.mock("../../hooks/useTaskSummariesForPaths", () => ({
+	useTaskSummariesForPaths: () => taskSummariesRef.current,
 }));
 
 vi.mock("../ui/shadcn/context-menu", () => ({
@@ -114,6 +135,8 @@ describe("FolioNotesListPane", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		scopeRef.current = { kind: "all" };
+		taskSummariesRef.current = {};
+		showTaskProgressIndicatorRef.current = true;
 		loadAllDocsMock.mockResolvedValue(notes);
 		queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false, gcTime: 0 } },
@@ -196,6 +219,30 @@ describe("FolioNotesListPane", () => {
 
 		expect(container.textContent).toContain("Roadmap");
 		expect(container.textContent).not.toContain("Sketch");
+	});
+
+	it("renders task progress rings on note cards", async () => {
+		taskSummariesRef.current = {
+			"Projects/Roadmap.md": {
+				total_count: 4,
+				completed_count: 3,
+				open_count: 1,
+			},
+		};
+
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Roadmap") ?? false);
+
+		expect(
+			container.querySelector(
+				'[data-folio-note-path="Projects/Roadmap.md"] [aria-label="3 of 4 tasks completed"]',
+			),
+		).toBeTruthy();
+		expect(
+			container.querySelector(
+				'[data-folio-note-path="Ideas/Sketch.md"] .folioNoteTaskProgress',
+			),
+		).toBeNull();
 	});
 
 	it("sorts by edited time when selected", async () => {

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FolioNotesListPane } from "./FolioNotesListPane";
+import type { FolioScope } from "./folioScopes";
+
+const { loadAllDocsMock, prefetchNoteMock, scopeRef } = vi.hoisted(() => ({
+	loadAllDocsMock: vi.fn(),
+	prefetchNoteMock: vi.fn(),
+	scopeRef: { current: { kind: "all" } as FolioScope },
+}));
+
+vi.mock("../../contexts", () => ({
+	useUILayoutContext: () => ({
+		folioScope: scopeRef.current,
+	}),
+}));
+
+vi.mock("../../lib/navigationPrefetch", async () => {
+	const actual = await vi.importActual<
+		typeof import("../../lib/navigationPrefetch")
+	>("../../lib/navigationPrefetch");
+	return {
+		...actual,
+		loadAllDocs: loadAllDocsMock,
+		prefetchNote: prefetchNoteMock,
+	};
+});
+
+vi.mock("../../lib/tauriEvents", () => ({
+	useTauriEvent: () => {},
+}));
+
+vi.mock("../ui/shadcn/context-menu", () => ({
+	ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+	ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
+	ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	ContextMenuItem: ({
+		children,
+		onSelect,
+	}: {
+		children: React.ReactNode;
+		onSelect?: () => void;
+	}) => (
+		<button type="button" onClick={onSelect}>
+			{children}
+		</button>
+	),
+	ContextMenuSeparator: () => <hr />,
+}));
+
+(
+	globalThis as typeof globalThis & {
+		IS_REACT_ACT_ENVIRONMENT?: boolean;
+	}
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const notes = [
+	{
+		note_path: "Projects/Roadmap.md",
+		title: "Roadmap",
+		preview: "# Roadmap\n\nLaunch   planning\nand milestones",
+		updated: "2026-05-01T10:00:00.000Z",
+		created: "2026-05-01T09:00:00.000Z",
+		tags: ["planning"],
+	},
+	{
+		note_path: "Ideas/Sketch.md",
+		title: "Sketch",
+		preview: "A fast idea",
+		updated: "2026-05-02T10:00:00.000Z",
+		created: "2026-05-02T09:00:00.000Z",
+		tags: ["ideas"],
+	},
+];
+
+async function waitFor(check: () => boolean) {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		if (check()) return;
+		await act(async () => {
+			await new Promise((resolve) => window.setTimeout(resolve, 0));
+		});
+	}
+}
+
+describe("FolioNotesListPane", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let queryClient: QueryClient;
+	let onOpenFile: (relPath: string) => Promise<void>;
+	let onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	let onRenameFile: (
+		relPath: string,
+		nextName: string,
+	) => Promise<string | null>;
+	let onDeleteFile: (relPath: string) => Promise<boolean>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		scopeRef.current = { kind: "all" };
+		loadAllDocsMock.mockResolvedValue(notes);
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false, gcTime: 0 } },
+		});
+		onOpenFile = vi.fn(async () => {});
+		onOpenFileInNewTab = vi.fn(async () => {});
+		onRenameFile = vi.fn(async () => null);
+		onDeleteFile = vi.fn(async () => true);
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+		queryClient.clear();
+	});
+
+	function renderPane(activeTabPath: string | null = null) {
+		root.render(
+			<QueryClientProvider client={queryClient}>
+				<FolioNotesListPane
+					activeTabPath={activeTabPath}
+					onOpenFile={onOpenFile}
+					onOpenFileInNewTab={onOpenFileInNewTab}
+					onRenameFile={onRenameFile}
+					onDeleteFile={onDeleteFile}
+				/>
+			</QueryClientProvider>,
+		);
+	}
+
+	it("renders dense note rows from all docs", async () => {
+		await act(async () => renderPane("Projects/Roadmap.md"));
+		await waitFor(() => container.textContent?.includes("Roadmap") ?? false);
+
+		expect(container.textContent).toContain("All Notes");
+		expect(container.textContent).toContain("Roadmap");
+		expect(container.textContent).toContain("Launch planning and milestones");
+		expect(container.textContent).toContain("Sketch");
+		expect(loadAllDocsMock).toHaveBeenCalledWith(null);
+		expect(
+			container
+				.querySelector('[data-folio-note-path="Projects/Roadmap.md"]')
+				?.getAttribute("data-state"),
+		).toBe("selected");
+	});
+
+	it("filters rows locally", async () => {
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		const input = container.querySelector(
+			'input[aria-label="Filter notes"]',
+		) as HTMLInputElement | null;
+		expect(input).toBeTruthy();
+
+		await act(async () => {
+			if (!input) return;
+			const valueSetter = Object.getOwnPropertyDescriptor(
+				HTMLInputElement.prototype,
+				"value",
+			)?.set;
+			valueSetter?.call(input, "road");
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+		});
+
+		expect(container.textContent).toContain("Roadmap");
+		expect(container.textContent).not.toContain("Sketch");
+	});
+
+	it("opens a note on row click", async () => {
+		await act(async () => renderPane());
+		await waitFor(
+			() =>
+				container.querySelector(
+					'[data-folio-note-path="Projects/Roadmap.md"]',
+				) !== null,
+		);
+
+		const row = container.querySelector(
+			'[data-folio-note-path="Projects/Roadmap.md"]',
+		);
+		expect(row).toBeTruthy();
+
+		await act(async () => {
+			row?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(vi.mocked(onOpenFile)).toHaveBeenCalledWith("Projects/Roadmap.md");
+	});
+
+	it("opens adjacent notes with arrow keys", async () => {
+		await act(async () => renderPane("Projects/Roadmap.md"));
+		await waitFor(
+			() =>
+				container.querySelector(
+					'[data-folio-note-path="Projects/Roadmap.md"]',
+				) !== null,
+		);
+
+		const row = container.querySelector(
+			'[data-folio-note-path="Projects/Roadmap.md"]',
+		) as HTMLButtonElement | null;
+		expect(row).toBeTruthy();
+
+		await act(async () => {
+			row?.focus();
+			row?.dispatchEvent(
+				new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+			);
+		});
+
+		expect(vi.mocked(onOpenFile)).toHaveBeenCalledWith("Ideas/Sketch.md");
+	});
+
+	it("uses arrow keys for navigation instead of list scrolling", async () => {
+		await act(async () => renderPane("Projects/Roadmap.md"));
+		await waitFor(() => container.querySelector(".folioNotesList") !== null);
+
+		const list = container.querySelector(".folioNotesList");
+		expect(list).toBeTruthy();
+
+		const event = new KeyboardEvent("keydown", {
+			key: "ArrowDown",
+			bubbles: true,
+			cancelable: true,
+		});
+		await act(async () => {
+			list?.dispatchEvent(event);
+		});
+
+		expect(event.defaultPrevented).toBe(true);
+		expect(vi.mocked(onOpenFile)).toHaveBeenCalledWith("Ideas/Sketch.md");
+	});
+});

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -64,20 +64,22 @@ vi.mock("../ui/shadcn/context-menu", () => ({
 
 const notes = [
 	{
+		note_path: "Ideas/Sketch.md",
+		title: "Sketch",
+		preview: "A fast idea",
+		updated: "2026-05-02T10:00:00.000Z",
+		created: "2026-04-30T09:00:00.000Z",
+		tags: ["ideas"],
+		people: ["mira"],
+	},
+	{
 		note_path: "Projects/Roadmap.md",
 		title: "Roadmap",
 		preview: "# Roadmap\n\nLaunch   planning\nand milestones",
 		updated: "2026-05-01T10:00:00.000Z",
 		created: "2026-05-01T09:00:00.000Z",
 		tags: ["planning"],
-	},
-	{
-		note_path: "Ideas/Sketch.md",
-		title: "Sketch",
-		preview: "A fast idea",
-		updated: "2026-05-02T10:00:00.000Z",
-		created: "2026-05-02T09:00:00.000Z",
-		tags: ["ideas"],
+		people: ["alex"],
 	},
 ];
 
@@ -88,6 +90,12 @@ async function waitFor(check: () => boolean) {
 			await new Promise((resolve) => window.setTimeout(resolve, 0));
 		});
 	}
+}
+
+function renderedNotePaths(container: Element): string[] {
+	return Array.from(container.querySelectorAll("[data-folio-note-path]")).map(
+		(row) => row.getAttribute("data-folio-note-path") ?? "",
+	);
 }
 
 describe("FolioNotesListPane", () => {
@@ -101,6 +109,7 @@ describe("FolioNotesListPane", () => {
 		nextName: string,
 	) => Promise<string | null>;
 	let onDeleteFile: (relPath: string) => Promise<boolean>;
+	let scrollIntoViewArgs: Array<boolean | ScrollIntoViewOptions | undefined>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -113,6 +122,12 @@ describe("FolioNotesListPane", () => {
 		onOpenFileInNewTab = vi.fn(async () => {});
 		onRenameFile = vi.fn(async () => null);
 		onDeleteFile = vi.fn(async () => true);
+		scrollIntoViewArgs = [];
+		HTMLElement.prototype.scrollIntoView = (
+			arg?: boolean | ScrollIntoViewOptions,
+		) => {
+			scrollIntoViewArgs.push(arg);
+		};
 		container = document.createElement("div");
 		document.body.appendChild(container);
 		root = createRoot(container);
@@ -149,6 +164,10 @@ describe("FolioNotesListPane", () => {
 		expect(container.textContent).toContain("Launch planning and milestones");
 		expect(container.textContent).toContain("Sketch");
 		expect(loadAllDocsMock).toHaveBeenCalledWith(null);
+		expect(renderedNotePaths(container)).toEqual([
+			"Projects/Roadmap.md",
+			"Ideas/Sketch.md",
+		]);
 		expect(
 			container
 				.querySelector('[data-folio-note-path="Projects/Roadmap.md"]')
@@ -177,6 +196,91 @@ describe("FolioNotesListPane", () => {
 
 		expect(container.textContent).toContain("Roadmap");
 		expect(container.textContent).not.toContain("Sketch");
+	});
+
+	it("sorts by edited time when selected", async () => {
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		const select = container.querySelector(
+			'select[aria-label="Sort notes"]',
+		) as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+		expect(
+			Array.from(select?.options ?? []).map((option) => option.textContent),
+		).toEqual(["Alphabetically", "Edited", "Created"]);
+
+		await act(async () => {
+			if (!select) return;
+			const valueSetter = Object.getOwnPropertyDescriptor(
+				HTMLSelectElement.prototype,
+				"value",
+			)?.set;
+			valueSetter?.call(select, "edited");
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+
+		expect(renderedNotePaths(container)).toEqual([
+			"Ideas/Sketch.md",
+			"Projects/Roadmap.md",
+		]);
+	});
+
+	it("sorts by created time when selected", async () => {
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		const select = container.querySelector(
+			'select[aria-label="Sort notes"]',
+		) as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+
+		await act(async () => {
+			if (!select) return;
+			const valueSetter = Object.getOwnPropertyDescriptor(
+				HTMLSelectElement.prototype,
+				"value",
+			)?.set;
+			valueSetter?.call(select, "created");
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+
+		expect(renderedNotePaths(container)).toEqual([
+			"Projects/Roadmap.md",
+			"Ideas/Sketch.md",
+		]);
+	});
+
+	it("keeps sort control arrow keys inside the select", async () => {
+		await act(async () => renderPane("Projects/Roadmap.md"));
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		const select = container.querySelector(
+			'select[aria-label="Sort notes"]',
+		) as HTMLSelectElement | null;
+		expect(select).toBeTruthy();
+
+		const event = new KeyboardEvent("keydown", {
+			key: "ArrowDown",
+			bubbles: true,
+			cancelable: true,
+		});
+		await act(async () => {
+			select?.dispatchEvent(event);
+		});
+
+		expect(event.defaultPrevented).toBe(false);
+		expect(vi.mocked(onOpenFile)).not.toHaveBeenCalled();
+	});
+
+	it("filters person scopes by indexed people metadata", async () => {
+		scopeRef.current = { kind: "person", handle: "@mira" };
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		expect(container.textContent).toContain("@mira");
+		expect(renderedNotePaths(container)).toEqual(["Ideas/Sketch.md"]);
+		expect(container.textContent).not.toContain("Roadmap");
 	});
 
 	it("opens a note on row click", async () => {
@@ -241,6 +345,32 @@ describe("FolioNotesListPane", () => {
 		});
 
 		expect(event.defaultPrevented).toBe(true);
+		expect(vi.mocked(onOpenFile)).toHaveBeenCalledWith("Ideas/Sketch.md");
+	});
+
+	it("scrolls the selected row into view during keyboard navigation", async () => {
+		await act(async () => renderPane("Projects/Roadmap.md"));
+		await waitFor(
+			() =>
+				container.querySelector(
+					'[data-folio-note-path="Projects/Roadmap.md"]',
+				) !== null,
+		);
+		scrollIntoViewArgs = [];
+
+		const list = container.querySelector(".folioNotesList");
+		await act(async () => {
+			list?.dispatchEvent(
+				new KeyboardEvent("keydown", {
+					key: "ArrowDown",
+					bubbles: true,
+					cancelable: true,
+				}),
+			);
+			await new Promise((resolve) => window.requestAnimationFrame(resolve));
+		});
+
+		expect(scrollIntoViewArgs).toContainEqual({ block: "nearest" });
 		expect(vi.mocked(onOpenFile)).toHaveBeenCalledWith("Ideas/Sketch.md");
 	});
 });

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUILayoutContext } from "../../contexts";
 import { prefetchNote } from "../../lib/navigationPrefetch";
 import type { AllDocsItem } from "../../lib/tauri";
@@ -15,6 +15,8 @@ interface FolioNotesListPaneProps {
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
 
+type FolioNotesSortMode = "alphabetical" | "edited" | "created";
+
 function noteTitle(note: AllDocsItem): string {
 	return note.title.trim() || basename(note.note_path).replace(/\.md$/i, "");
 }
@@ -28,6 +30,34 @@ function noteMatchesFilter(note: AllDocsItem, query: string): boolean {
 	return haystack.includes(normalized);
 }
 
+function compareNotes(
+	left: AllDocsItem,
+	right: AllDocsItem,
+	sortMode: FolioNotesSortMode,
+): number {
+	if (sortMode === "edited") {
+		return Date.parse(right.updated) - Date.parse(left.updated);
+	}
+	if (sortMode === "created") {
+		return Date.parse(right.created) - Date.parse(left.created);
+	}
+	return (
+		noteTitle(left).localeCompare(noteTitle(right), undefined, {
+			sensitivity: "base",
+			numeric: true,
+		}) || left.note_path.localeCompare(right.note_path)
+	);
+}
+
+function isFolioHeaderControl(target: EventTarget | null): boolean {
+	return (
+		target instanceof HTMLInputElement ||
+		target instanceof HTMLSelectElement ||
+		target instanceof HTMLTextAreaElement ||
+		(target instanceof HTMLElement && target.isContentEditable)
+	);
+}
+
 export const FolioNotesListPane = memo(function FolioNotesListPane({
 	activeTabPath,
 	onOpenFile,
@@ -39,10 +69,15 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	const { notes, isLoading, error, title, missingFolder } =
 		useFolioNotes(folioScope);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [sortMode, setSortMode] = useState<FolioNotesSortMode>("alphabetical");
 	const paneRef = useRef<HTMLElement | null>(null);
 	const visibleNotes = useMemo(
-		() => notes.filter((note) => noteMatchesFilter(note, searchQuery)),
-		[notes, searchQuery],
+		() =>
+			notes
+				.filter((note) => noteMatchesFilter(note, searchQuery))
+				.slice()
+				.sort((left, right) => compareNotes(left, right, sortMode)),
+		[notes, searchQuery, sortMode],
 	);
 	const selectedIndex = useMemo(
 		() =>
@@ -55,6 +90,19 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		requestAnimationFrame(() =>
 			paneRef.current?.focus({ preventScroll: true }),
 		);
+	}, []);
+	const scrollNoteIntoView = useCallback((path: string) => {
+		requestAnimationFrame(() => {
+			const rows =
+				paneRef.current?.querySelectorAll<HTMLElement>(
+					"[data-folio-note-path]",
+				) ?? [];
+			for (const row of rows) {
+				if (row.dataset.folioNotePath !== path) continue;
+				row.scrollIntoView?.({ block: "nearest" });
+				return;
+			}
+		});
 	}, []);
 	const openNote = useCallback(
 		(path: string) => {
@@ -96,10 +144,17 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			const nextIndex =
 				(selectedIndex + direction + visibleNotes.length) % visibleNotes.length;
 			const nextNote = visibleNotes[nextIndex];
-			if (nextNote) openNote(nextNote.note_path);
+			if (!nextNote) return;
+			scrollNoteIntoView(nextNote.note_path);
+			openNote(nextNote.note_path);
 		},
-		[openNote, selectedIndex, visibleNotes],
+		[openNote, scrollNoteIntoView, selectedIndex, visibleNotes],
 	);
+
+	useEffect(() => {
+		if (!activeTabPath) return;
+		scrollNoteIntoView(activeTabPath);
+	}, [activeTabPath, scrollNoteIntoView]);
 
 	const body = (() => {
 		if (missingFolder) {
@@ -153,7 +208,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			aria-label="Notes list"
 			tabIndex={-1}
 			onKeyDown={(event) => {
-				if (event.target instanceof HTMLInputElement) return;
+				if (isFolioHeaderControl(event.target)) return;
 				if (event.key === "ArrowDown" || event.key === "ArrowUp") {
 					event.preventDefault();
 					openAdjacentNote(event.key === "ArrowDown" ? 1 : -1);
@@ -170,7 +225,9 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				title={title}
 				count={visibleNotes.length}
 				searchQuery={searchQuery}
+				sortMode={sortMode}
 				onSearchQueryChange={setSearchQuery}
+				onSortModeChange={setSortMode}
 			/>
 			{body}
 		</aside>

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,0 +1,178 @@
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { useUILayoutContext } from "../../contexts";
+import { prefetchNote } from "../../lib/navigationPrefetch";
+import type { AllDocsItem } from "../../lib/tauri";
+import { basename } from "../../utils/path";
+import { FolioNoteListItem } from "./FolioNoteListItem";
+import { FolioScopeHeader } from "./FolioScopeHeader";
+import { useFolioNotes } from "./useFolioNotes";
+
+interface FolioNotesListPaneProps {
+	activeTabPath: string | null;
+	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onRenameFile: (relPath: string, nextName: string) => Promise<string | null>;
+	onDeleteFile: (relPath: string) => Promise<boolean>;
+}
+
+function noteTitle(note: AllDocsItem): string {
+	return note.title.trim() || basename(note.note_path).replace(/\.md$/i, "");
+}
+
+function noteMatchesFilter(note: AllDocsItem, query: string): boolean {
+	const normalized = query.trim().toLowerCase();
+	if (!normalized) return true;
+	const haystack = [noteTitle(note), note.preview, note.note_path, ...note.tags]
+		.join(" ")
+		.toLowerCase();
+	return haystack.includes(normalized);
+}
+
+export const FolioNotesListPane = memo(function FolioNotesListPane({
+	activeTabPath,
+	onOpenFile,
+	onOpenFileInNewTab,
+	onRenameFile,
+	onDeleteFile,
+}: FolioNotesListPaneProps) {
+	const { folioScope } = useUILayoutContext();
+	const { notes, isLoading, error, title, missingFolder } =
+		useFolioNotes(folioScope);
+	const [searchQuery, setSearchQuery] = useState("");
+	const paneRef = useRef<HTMLElement | null>(null);
+	const visibleNotes = useMemo(
+		() => notes.filter((note) => noteMatchesFilter(note, searchQuery)),
+		[notes, searchQuery],
+	);
+	const selectedIndex = useMemo(
+		() =>
+			activeTabPath
+				? visibleNotes.findIndex((note) => note.note_path === activeTabPath)
+				: -1,
+		[activeTabPath, visibleNotes],
+	);
+	const focusPane = useCallback(() => {
+		requestAnimationFrame(() =>
+			paneRef.current?.focus({ preventScroll: true }),
+		);
+	}, []);
+	const openNote = useCallback(
+		(path: string) => {
+			void onOpenFile(path);
+			focusPane();
+		},
+		[focusPane, onOpenFile],
+	);
+	const openNoteInNewTab = useCallback(
+		(path: string) => {
+			void onOpenFileInNewTab(path);
+		},
+		[onOpenFileInNewTab],
+	);
+	const renameNote = useCallback(
+		(path: string) => {
+			const currentName = basename(path);
+			const nextName = window.prompt("Rename note", currentName);
+			if (!nextName || nextName.trim() === currentName) return;
+			const trimmed = nextName.trim();
+			const normalizedName =
+				currentName.toLowerCase().endsWith(".md") &&
+				!trimmed.toLowerCase().endsWith(".md")
+					? `${trimmed}.md`
+					: trimmed;
+			void onRenameFile(path, normalizedName);
+		},
+		[onRenameFile],
+	);
+	const deleteNote = useCallback(
+		(path: string) => {
+			void onDeleteFile(path);
+		},
+		[onDeleteFile],
+	);
+	const openAdjacentNote = useCallback(
+		(direction: 1 | -1) => {
+			if (!visibleNotes.length || selectedIndex < 0) return;
+			const nextIndex =
+				(selectedIndex + direction + visibleNotes.length) % visibleNotes.length;
+			const nextNote = visibleNotes[nextIndex];
+			if (nextNote) openNote(nextNote.note_path);
+		},
+		[openNote, selectedIndex, visibleNotes],
+	);
+
+	const body = (() => {
+		if (missingFolder) {
+			return (
+				<div className="folioNotesState">
+					Set a folder in Settings to browse this scope.
+				</div>
+			);
+		}
+		if (isLoading) {
+			return <div className="folioNotesState">Loading notes…</div>;
+		}
+		if (error) {
+			return (
+				<div className="folioNotesState">
+					Could not load notes:{" "}
+					{error instanceof Error ? error.message : String(error)}
+				</div>
+			);
+		}
+		if (!visibleNotes.length) {
+			return (
+				<div className="folioNotesState">
+					{searchQuery.trim() ? "No matching notes." : "No notes found."}
+				</div>
+			);
+		}
+		return (
+			<ul className="folioNotesList">
+				{visibleNotes.map((note) => (
+					<FolioNoteListItem
+						key={note.note_path}
+						note={note}
+						selected={activeTabPath === note.note_path}
+						onOpen={openNote}
+						onOpenInNewTab={openNoteInNewTab}
+						onPrefetch={prefetchNote}
+						onRename={renameNote}
+						onDelete={deleteNote}
+						onFocus={focusPane}
+					/>
+				))}
+			</ul>
+		);
+	})();
+
+	return (
+		<aside
+			ref={paneRef}
+			className="folioNotesPane"
+			aria-label="Notes list"
+			tabIndex={-1}
+			onKeyDown={(event) => {
+				if (event.target instanceof HTMLInputElement) return;
+				if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+					event.preventDefault();
+					openAdjacentNote(event.key === "ArrowDown" ? 1 : -1);
+					return;
+				}
+				if (event.key === "Enter") {
+					event.preventDefault();
+					const note = selectedIndex >= 0 ? visibleNotes[selectedIndex] : null;
+					if (note) openNote(note.note_path);
+				}
+			}}
+		>
+			<FolioScopeHeader
+				title={title}
+				count={visibleNotes.length}
+				searchQuery={searchQuery}
+				onSearchQueryChange={setSearchQuery}
+			/>
+			{body}
+		</aside>
+	);
+});

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,7 +1,10 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUILayoutContext } from "../../contexts";
+import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
+import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { prefetchNote } from "../../lib/navigationPrefetch";
 import type { AllDocsItem } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename } from "../../utils/path";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
@@ -70,6 +73,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		useFolioNotes(folioScope);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [sortMode, setSortMode] = useState<FolioNotesSortMode>("alphabetical");
+	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const paneRef = useRef<HTMLElement | null>(null);
 	const visibleNotes = useMemo(
 		() =>
@@ -86,6 +90,22 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				: -1,
 		[activeTabPath, visibleNotes],
 	);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(null);
+	const taskSummaryPaths = useMemo(
+		() => visibleNotes.map((note) => note.note_path),
+		[visibleNotes],
+	);
+	const taskSummariesByPath = useTaskSummariesForPaths(
+		taskSummaryPaths,
+		showTaskProgressIndicator,
+		taskSummaryRefreshKey,
+	);
+
+	useTauriEvent("notes:external_changed", (payload) => {
+		if (!payload.rel_path || !taskSummaryPaths.includes(payload.rel_path))
+			return;
+		setTaskSummaryRefreshKey((key) => key + 1);
+	});
 	const focusPane = useCallback(() => {
 		requestAnimationFrame(() =>
 			paneRef.current?.focus({ preventScroll: true }),
@@ -195,6 +215,11 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 						onRename={renameNote}
 						onDelete={deleteNote}
 						onFocus={focusPane}
+						taskSummary={
+							showTaskProgressIndicator
+								? (taskSummariesByPath[note.note_path] ?? null)
+								: null
+						}
 					/>
 				))}
 			</ul>

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -2,23 +2,22 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useUILayoutContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
+import { dispatchFileTreeStartRename } from "../../lib/appEvents";
 import { prefetchNote } from "../../lib/navigationPrefetch";
 import type { AllDocsItem } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename } from "../../utils/path";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
+import type { FolioNotesSortMode } from "./folioScopes";
 import { useFolioNotes } from "./useFolioNotes";
 
 interface FolioNotesListPaneProps {
 	activeTabPath: string | null;
 	onOpenFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
-	onRenameFile: (relPath: string, nextName: string) => Promise<string | null>;
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
-
-type FolioNotesSortMode = "alphabetical" | "edited" | "created";
 
 function noteTitle(note: AllDocsItem): string {
 	return note.title.trim() || basename(note.note_path).replace(/\.md$/i, "");
@@ -65,7 +64,6 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	activeTabPath,
 	onOpenFile,
 	onOpenFileInNewTab,
-	onRenameFile,
 	onDeleteFile,
 }: FolioNotesListPaneProps) {
 	const { folioScope } = useUILayoutContext();
@@ -137,24 +135,19 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		},
 		[onOpenFileInNewTab],
 	);
-	const renameNote = useCallback(
-		(path: string) => {
-			const currentName = basename(path);
-			const nextName = window.prompt("Rename note", currentName);
-			if (!nextName || nextName.trim() === currentName) return;
-			const trimmed = nextName.trim();
-			const normalizedName =
-				currentName.toLowerCase().endsWith(".md") &&
-				!trimmed.toLowerCase().endsWith(".md")
-					? `${trimmed}.md`
-					: trimmed;
-			void onRenameFile(path, normalizedName);
-		},
-		[onRenameFile],
-	);
+	const renameNote = useCallback((path: string) => {
+		dispatchFileTreeStartRename({ path });
+	}, []);
 	const deleteNote = useCallback(
-		(path: string) => {
-			void onDeleteFile(path);
+		async (path: string) => {
+			const { confirm } = await import("@tauri-apps/plugin-dialog");
+			const confirmed = await confirm("Delete this note?", {
+				title: "Confirm delete",
+				okLabel: "Delete",
+				cancelLabel: "Cancel",
+			});
+			if (!confirmed) return;
+			await onDeleteFile(path);
 		},
 		[onDeleteFile],
 	);

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -1,0 +1,39 @@
+import { SearchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { memo } from "react";
+
+interface FolioScopeHeaderProps {
+	title: string;
+	count: number;
+	searchQuery: string;
+	onSearchQueryChange: (query: string) => void;
+}
+
+export const FolioScopeHeader = memo(function FolioScopeHeader({
+	title,
+	count,
+	searchQuery,
+	onSearchQueryChange,
+}: FolioScopeHeaderProps) {
+	return (
+		<header className="folioNotesHeader">
+			<div className="folioNotesTitleRow">
+				<h2 className="folioNotesTitle">{title}</h2>
+				<span className="folioNotesCount">
+					{count} {count === 1 ? "note" : "notes"}
+				</span>
+			</div>
+			<label className="folioNotesSearch">
+				<HugeiconsIcon icon={SearchIcon} size={14} strokeWidth={0.9} />
+				<input
+					type="text"
+					inputMode="search"
+					value={searchQuery}
+					placeholder="Filter notes"
+					aria-label="Filter notes"
+					onChange={(event) => onSearchQueryChange(event.currentTarget.value)}
+				/>
+			</label>
+		</header>
+	);
+});

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -6,8 +6,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo } from "react";
-
-type FolioNotesSortMode = "alphabetical" | "edited" | "created";
+import type { FolioNotesSortMode } from "./folioScopes";
 
 interface FolioScopeHeaderProps {
 	title: string;

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -1,20 +1,38 @@
-import { SearchIcon } from "@hugeicons/core-free-icons";
+import {
+	ArrangeByLettersAZIcon,
+	Calendar03Icon,
+	Clock01Icon,
+	SearchIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo } from "react";
+
+type FolioNotesSortMode = "alphabetical" | "edited" | "created";
 
 interface FolioScopeHeaderProps {
 	title: string;
 	count: number;
 	searchQuery: string;
+	sortMode: FolioNotesSortMode;
 	onSearchQueryChange: (query: string) => void;
+	onSortModeChange: (sortMode: FolioNotesSortMode) => void;
 }
 
 export const FolioScopeHeader = memo(function FolioScopeHeader({
 	title,
 	count,
 	searchQuery,
+	sortMode,
 	onSearchQueryChange,
+	onSortModeChange,
 }: FolioScopeHeaderProps) {
+	const sortIcon =
+		sortMode === "alphabetical"
+			? ArrangeByLettersAZIcon
+			: sortMode === "created"
+				? Calendar03Icon
+				: Clock01Icon;
+
 	return (
 		<header className="folioNotesHeader">
 			<div className="folioNotesTitleRow">
@@ -23,17 +41,39 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 					{count} {count === 1 ? "note" : "notes"}
 				</span>
 			</div>
-			<label className="folioNotesSearch">
-				<HugeiconsIcon icon={SearchIcon} size={14} strokeWidth={0.9} />
-				<input
-					type="text"
-					inputMode="search"
-					value={searchQuery}
-					placeholder="Filter notes"
-					aria-label="Filter notes"
-					onChange={(event) => onSearchQueryChange(event.currentTarget.value)}
-				/>
-			</label>
+			<div className="folioNotesControls">
+				<label className="folioNotesSearch">
+					<HugeiconsIcon icon={SearchIcon} size={14} strokeWidth={0.9} />
+					<input
+						type="text"
+						inputMode="search"
+						value={searchQuery}
+						placeholder="Filter notes"
+						aria-label="Filter notes"
+						onChange={(event) => onSearchQueryChange(event.currentTarget.value)}
+					/>
+				</label>
+				<label className="folioNotesSort">
+					<HugeiconsIcon icon={sortIcon} size={14} strokeWidth={1} />
+					<select
+						className="folioNotesSortSelect"
+						value={sortMode}
+						aria-label="Sort notes"
+						onChange={(event) => {
+							const value = event.currentTarget.value;
+							onSortModeChange(
+								value === "edited" || value === "created"
+									? value
+									: "alphabetical",
+							);
+						}}
+					>
+						<option value="alphabetical">Alphabetically</option>
+						<option value="edited">Edited</option>
+						<option value="created">Created</option>
+					</select>
+				</label>
+			</div>
 		</header>
 	);
 });

--- a/src/components/folio/FolioWorkspace.tsx
+++ b/src/components/folio/FolioWorkspace.tsx
@@ -13,7 +13,6 @@ interface FolioWorkspaceProps {
 	activeTabPath: string | null;
 	onOpenFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
-	onRenameFile: (relPath: string, nextName: string) => Promise<string | null>;
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
 
@@ -22,7 +21,6 @@ export const FolioWorkspace = memo(function FolioWorkspace({
 	activeTabPath,
 	onOpenFile,
 	onOpenFileInNewTab,
-	onRenameFile,
 	onDeleteFile,
 }: FolioWorkspaceProps) {
 	const [notesWidth, setNotesWidth] = useState(320);
@@ -47,7 +45,6 @@ export const FolioWorkspace = memo(function FolioWorkspace({
 				activeTabPath={activeTabPath}
 				onOpenFile={onOpenFile}
 				onOpenFileInNewTab={onOpenFileInNewTab}
-				onRenameFile={onRenameFile}
 				onDeleteFile={onDeleteFile}
 			/>
 			<div

--- a/src/components/folio/FolioWorkspace.tsx
+++ b/src/components/folio/FolioWorkspace.tsx
@@ -1,0 +1,64 @@
+import {
+	type CSSProperties,
+	type ReactNode,
+	memo,
+	useMemo,
+	useState,
+} from "react";
+import { useResizablePanel } from "../../hooks/useResizablePanel";
+import { FolioNotesListPane } from "./FolioNotesListPane";
+
+interface FolioWorkspaceProps {
+	children: ReactNode;
+	activeTabPath: string | null;
+	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onRenameFile: (relPath: string, nextName: string) => Promise<string | null>;
+	onDeleteFile: (relPath: string) => Promise<boolean>;
+}
+
+export const FolioWorkspace = memo(function FolioWorkspace({
+	children,
+	activeTabPath,
+	onOpenFile,
+	onOpenFileInNewTab,
+	onRenameFile,
+	onDeleteFile,
+}: FolioWorkspaceProps) {
+	const [notesWidth, setNotesWidth] = useState(320);
+	const resize = useResizablePanel({
+		min: 260,
+		max: 420,
+		direction: "right",
+		currentWidth: notesWidth,
+		onResize: setNotesWidth,
+	});
+	const style = useMemo(
+		() =>
+			({
+				"--folio-notes-width": `${notesWidth}px`,
+			}) as CSSProperties,
+		[notesWidth],
+	);
+
+	return (
+		<div className="folioWorkspace" style={style}>
+			<FolioNotesListPane
+				activeTabPath={activeTabPath}
+				onOpenFile={onOpenFile}
+				onOpenFileInNewTab={onOpenFileInNewTab}
+				onRenameFile={onRenameFile}
+				onDeleteFile={onDeleteFile}
+			/>
+			<div
+				ref={resize.resizeRef}
+				className="folioNotesResizeHandle"
+				onPointerDown={resize.handlePointerDown}
+				onPointerMove={resize.handlePointerMove}
+				onPointerUp={resize.handlePointerUp}
+				data-window-drag-ignore
+			/>
+			<div className="folioEditorHost">{children}</div>
+		</div>
+	);
+});

--- a/src/components/folio/folioScopes.ts
+++ b/src/components/folio/folioScopes.ts
@@ -2,6 +2,7 @@ export type FolioScope =
 	| { kind: "all" }
 	| { kind: "folder"; folderPrefix: string }
 	| { kind: "tag"; tag: string }
+	| { kind: "person"; handle: string }
 	| { kind: "daily"; folderPrefix: string | null }
 	| { kind: "templates"; folderPrefix: string | null }
 	| { kind: "search"; query: string };
@@ -25,6 +26,8 @@ export function folioScopeTitle(scope: FolioScope): string {
 			return scope.tag.startsWith("#") || scope.tag.startsWith("@")
 				? scope.tag
 				: `#${scope.tag}`;
+		case "person":
+			return scope.handle.startsWith("@") ? scope.handle : `@${scope.handle}`;
 		case "daily":
 			return "Daily Notes";
 		case "templates":

--- a/src/components/folio/folioScopes.ts
+++ b/src/components/folio/folioScopes.ts
@@ -7,6 +7,8 @@ export type FolioScope =
 	| { kind: "templates"; folderPrefix: string | null }
 	| { kind: "search"; query: string };
 
+export type FolioNotesSortMode = "alphabetical" | "edited" | "created";
+
 export const DEFAULT_FOLIO_SCOPE: FolioScope = { kind: "all" };
 
 export function normalizeFolioPath(value: string | null | undefined): string {
@@ -21,7 +23,12 @@ export function folioScopeTitle(scope: FolioScope): string {
 		case "all":
 			return "All Notes";
 		case "folder":
-			return scope.folderPrefix.split("/").filter(Boolean).pop() ?? "Folder";
+			return (
+				normalizeFolioPath(scope.folderPrefix)
+					.split("/")
+					.filter(Boolean)
+					.pop() ?? "Folder"
+			);
 		case "tag":
 			return scope.tag.startsWith("#") || scope.tag.startsWith("@")
 				? scope.tag

--- a/src/components/folio/folioScopes.ts
+++ b/src/components/folio/folioScopes.ts
@@ -1,0 +1,35 @@
+export type FolioScope =
+	| { kind: "all" }
+	| { kind: "folder"; folderPrefix: string }
+	| { kind: "tag"; tag: string }
+	| { kind: "daily"; folderPrefix: string | null }
+	| { kind: "templates"; folderPrefix: string | null }
+	| { kind: "search"; query: string };
+
+export const DEFAULT_FOLIO_SCOPE: FolioScope = { kind: "all" };
+
+export function normalizeFolioPath(value: string | null | undefined): string {
+	return (value ?? "")
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+}
+
+export function folioScopeTitle(scope: FolioScope): string {
+	switch (scope.kind) {
+		case "all":
+			return "All Notes";
+		case "folder":
+			return scope.folderPrefix.split("/").filter(Boolean).pop() ?? "Folder";
+		case "tag":
+			return scope.tag.startsWith("#") || scope.tag.startsWith("@")
+				? scope.tag
+				: `#${scope.tag}`;
+		case "daily":
+			return "Daily Notes";
+		case "templates":
+			return "Templates";
+		case "search":
+			return scope.query.trim() ? `Search: ${scope.query.trim()}` : "Search";
+	}
+}

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -1,0 +1,89 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
+import type { AllDocsItem } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
+import {
+	type FolioScope,
+	folioScopeTitle,
+	normalizeFolioPath,
+} from "./folioScopes";
+
+function folderForScope(scope: FolioScope): string | null {
+	switch (scope.kind) {
+		case "folder":
+			return normalizeFolioPath(scope.folderPrefix) || null;
+		case "daily":
+		case "templates":
+			return normalizeFolioPath(scope.folderPrefix) || null;
+		default:
+			return null;
+	}
+}
+
+function tagMatches(noteTags: string[], tag: string): boolean {
+	const normalizedTag = tag.trim().replace(/^[#@]/, "").toLowerCase();
+	if (!normalizedTag) return false;
+	return noteTags.some(
+		(noteTag) =>
+			noteTag.trim().replace(/^[#@]/, "").toLowerCase() === normalizedTag,
+	);
+}
+
+function filterNotesForScope(
+	notes: AllDocsItem[],
+	scope: FolioScope,
+): AllDocsItem[] {
+	switch (scope.kind) {
+		case "tag":
+			return notes.filter((note) => tagMatches(note.tags, scope.tag));
+		case "search": {
+			const query = scope.query.trim().toLowerCase();
+			if (!query) return notes;
+			return notes.filter((note) => {
+				const haystack = [
+					note.title,
+					note.preview,
+					note.note_path,
+					...note.tags,
+				]
+					.join(" ")
+					.toLowerCase();
+				return haystack.includes(query);
+			});
+		}
+		default:
+			return notes;
+	}
+}
+
+export function useFolioNotes(scope: FolioScope) {
+	const queryClient = useQueryClient();
+	const folderPrefix = folderForScope(scope);
+	const folderRequired =
+		(scope.kind === "daily" || scope.kind === "templates") && !folderPrefix;
+	const query = useQuery({
+		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		queryFn: () => loadAllDocs(folderPrefix),
+		enabled: !folderRequired,
+	});
+
+	useTauriEvent("notes:external_changed", () => {
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		});
+	});
+
+	const notes = useMemo(
+		() => filterNotesForScope(query.data ?? [], scope),
+		[query.data, scope],
+	);
+
+	return {
+		notes,
+		isLoading: query.isLoading,
+		error: query.error,
+		title: folioScopeTitle(scope),
+		missingFolder: folderRequired,
+	};
+}

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -30,6 +30,18 @@ function tagMatches(noteTags: string[], tag: string): boolean {
 	);
 }
 
+function personMatches(
+	notePeople: string[] | undefined,
+	handle: string,
+): boolean {
+	const normalizedHandle = handle.trim().replace(/^@/, "").toLowerCase();
+	if (!normalizedHandle) return false;
+	return (notePeople ?? []).some(
+		(notePerson) =>
+			notePerson.trim().replace(/^@/, "").toLowerCase() === normalizedHandle,
+	);
+}
+
 function filterNotesForScope(
 	notes: AllDocsItem[],
 	scope: FolioScope,
@@ -37,6 +49,8 @@ function filterNotesForScope(
 	switch (scope.kind) {
 		case "tag":
 			return notes.filter((note) => tagMatches(note.tags, scope.tag));
+		case "person":
+			return notes.filter((note) => personMatches(note.people, scope.handle));
 		case "search": {
 			const query = scope.query.trim().toLowerCase();
 			if (!query) return notes;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1066,6 +1066,7 @@ export function MarkdownEditorPane({
 				>
 					<div className="markdownEditorCenter">
 						<NoteInlineEditor
+							key={relPath}
 							markdown={text}
 							relPath={relPath}
 							mode={mode}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1066,7 +1066,6 @@ export function MarkdownEditorPane({
 				>
 					<div className="markdownEditorCenter">
 						<NoteInlineEditor
-							key={relPath}
 							markdown={text}
 							relPath={relPath}
 							mode={mode}

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -17,7 +17,6 @@ export function NotePane({
 }: NotePaneProps) {
 	return (
 		<MarkdownEditorPane
-			key={relPath}
 			relPath={relPath}
 			initialDoc={initialDoc}
 			onDirtyChange={onDirtyChange}

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -17,6 +17,7 @@ export function NotePane({
 }: NotePaneProps) {
 	return (
 		<MarkdownEditorPane
+			key={relPath}
 			relPath={relPath}
 			initialDoc={initialDoc}
 			onDirtyChange={onDirtyChange}

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -18,6 +18,7 @@ const {
 	setEditorShowCollapsibleHeadingsMock,
 	setEditorWidthModeMock,
 	setEditorVimKeybindingsMock,
+	setFolioModeMock,
 	setShowFileTreeFolderCountsMock,
 	setShowTaskProgressIndicatorMock,
 	setShowTocMock,
@@ -33,6 +34,7 @@ const {
 	setEditorShowCollapsibleHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorWidthModeMock: vi.fn(() => Promise.resolve()),
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
+	setFolioModeMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
 	setShowTaskProgressIndicatorMock: vi.fn(() => Promise.resolve()),
 	setShowTocMock: vi.fn(() => Promise.resolve()),
@@ -57,6 +59,7 @@ vi.mock("../../lib/settings", () => ({
 	setEditorShowCollapsibleHeadings: setEditorShowCollapsibleHeadingsMock,
 	setEditorWidthMode: setEditorWidthModeMock,
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
+	setFolioMode: setFolioModeMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
 	setShowTaskProgressIndicator: setShowTaskProgressIndicatorMock,
 	setShowToc: setShowTocMock,
@@ -164,6 +167,7 @@ function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
 		ui: {
 			aiAssistantMode: "create" as const,
 			delightfulGlyph: false,
+			folioMode: false,
 			showFileTreeFolderCounts: false,
 			showTaskProgressIndicator: true,
 			showToc: true,
@@ -333,5 +337,22 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setShowTaskProgressIndicatorMock).toHaveBeenCalledWith(false);
+	});
+
+	it("saves Folio Mode changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Folio Mode"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setFolioModeMock).toHaveBeenCalledWith(true);
 	});
 });

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -17,6 +17,7 @@ import {
 	setEditorShowFrontmatterInEditor,
 	setEditorVimKeybindings,
 	setEditorWidthMode,
+	setFolioMode,
 	setShowFileTreeFolderCounts,
 	setShowTaskProgressIndicator,
 	setShowToc,
@@ -118,6 +119,7 @@ export function AdvancedSettingsPane() {
 	const [aiAssistantMode, setAiAssistantModeState] =
 		useState<AiAssistantMode>("create");
 	const [delightfulGlyph, setDelightfulGlyphState] = useState(false);
+	const [folioMode, setFolioModeState] = useState(false);
 	const [showFileTreeFolderCounts, setShowFileTreeFolderCountsState] =
 		useState(false);
 	const [showTaskProgressIndicator, setShowTaskProgressIndicatorState] =
@@ -140,6 +142,7 @@ export function AdvancedSettingsPane() {
 	const [isSavingVimKeybindings, setIsSavingVimKeybindings] = useState(false);
 	const [isSavingAiAssistantMode, setIsSavingAiAssistantMode] = useState(false);
 	const [isSavingDelightfulGlyph, setIsSavingDelightfulGlyph] = useState(false);
+	const [isSavingFolioMode, setIsSavingFolioMode] = useState(false);
 	const [
 		isSavingShowFileTreeFolderCounts,
 		setIsSavingShowFileTreeFolderCounts,
@@ -167,6 +170,7 @@ export function AdvancedSettingsPane() {
 			setShowTocState(settings.ui.showToc);
 			setAiAssistantModeState(settings.ui.aiAssistantMode);
 			setDelightfulGlyphState(settings.ui.delightfulGlyph);
+			setFolioModeState(settings.ui.folioMode);
 			setShowFileTreeFolderCountsState(settings.ui.showFileTreeFolderCounts);
 			setShowTaskProgressIndicatorState(settings.ui.showTaskProgressIndicator);
 			setShowDatabaseColumnColor(settings.database.showColumnColor);
@@ -214,6 +218,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.ui?.delightfulGlyph === "boolean") {
 			setDelightfulGlyphState(payload.ui.delightfulGlyph);
+		}
+		if (typeof payload.ui?.folioMode === "boolean") {
+			setFolioModeState(payload.ui.folioMode);
 		}
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFileTreeFolderCountsState(payload.ui.showFileTreeFolderCounts);
@@ -481,6 +488,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingDelightfulGlyph(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Folio Mode"
+						description="Use a Bear-style three-pane layout with a navigation sidebar, rich notes list, and editor."
+					>
+						<SettingsToggle
+							checked={folioMode}
+							disabled={isSavingFolioMode}
+							ariaLabel="Folio Mode"
+							onCheckedChange={(checked) => {
+								const previous = folioMode;
+								setError("");
+								setFolioModeState(checked);
+								setIsSavingFolioMode(true);
+								void setFolioMode(checked)
+									.catch((cause) => {
+										setFolioModeState(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingFolioMode(false);
 									});
 							}}
 						/>

--- a/src/contexts/UIContext.test.tsx
+++ b/src/contexts/UIContext.test.tsx
@@ -21,12 +21,14 @@ vi.mock("../lib/settings", () => ({
 			aiEnabled: true,
 			aiAssistantMode: "create",
 			showToc: true,
+			folioMode: false,
 		},
 		dailyNotes: { folder: null },
 		templates: { folder: null, dailyNoteTemplate: null },
 	})),
 	reloadFromDisk: vi.fn(async () => {}),
 	setAiAssistantMode: vi.fn(),
+	setFolioMode: vi.fn(),
 	setShowToc: vi.fn(),
 }));
 
@@ -48,6 +50,7 @@ interface CapturedContext {
 	sidebarCollapsed: boolean;
 	zenModeActive: boolean;
 	aiPanelOpen: boolean;
+	folioMode: boolean;
 	setSidebarCollapsed: (collapsed: boolean) => void;
 	setZenModeActive: (active: boolean) => void;
 	setAiPanelOpen: (open: boolean | ((prev: boolean) => boolean)) => void;
@@ -66,6 +69,7 @@ function Harness({
 			sidebarCollapsed: layout.sidebarCollapsed,
 			zenModeActive: layout.zenModeActive,
 			aiPanelOpen: ai.aiPanelOpen,
+			folioMode: layout.folioMode,
 			setSidebarCollapsed: layout.setSidebarCollapsed,
 			setZenModeActive: layout.setZenModeActive,
 			setAiPanelOpen: ai.setAiPanelOpen,

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -10,12 +10,17 @@ import {
 	useMemo,
 	useReducer,
 } from "react";
+import {
+	DEFAULT_FOLIO_SCOPE,
+	type FolioScope,
+} from "../components/folio/folioScopes";
 import type { SettingsTab } from "../components/settings/settingsConfig";
 import {
 	type AiAssistantMode,
 	loadSettings,
 	reloadFromDisk,
 	setAiAssistantMode as saveAiAssistantMode,
+	setFolioMode as saveFolioMode,
 	setShowToc as saveShowToc,
 } from "../lib/settings";
 import { useTauriEvent } from "../lib/tauriEvents";
@@ -41,6 +46,10 @@ export interface UILayoutContextValue {
 	dailyNoteTemplatePath: string | null;
 	showToc: boolean;
 	setShowToc: (show: boolean) => void;
+	folioMode: boolean;
+	setFolioMode: (enabled: boolean) => void;
+	folioScope: FolioScope;
+	setFolioScope: (scope: FolioScope) => void;
 	settingsMode: boolean;
 	settingsTab: SettingsTab;
 	openSettings: (tab?: SettingsTab) => void;
@@ -71,6 +80,8 @@ type UIState = {
 	templateFolder: string | null;
 	dailyNoteTemplatePath: string | null;
 	showToc: boolean;
+	folioMode: boolean;
+	folioScope: FolioScope;
 	settingsMode: boolean;
 	settingsTab: SettingsTab;
 	aiEnabled: boolean;
@@ -94,6 +105,8 @@ type UIAction =
 	| { type: "setTemplateFolder"; value: string | null }
 	| { type: "setDailyNoteTemplatePath"; value: string | null }
 	| { type: "setShowToc"; value: boolean }
+	| { type: "setFolioMode"; value: boolean }
+	| { type: "setFolioScope"; value: FolioScope }
 	| { type: "setAiEnabled"; value: boolean }
 	| { type: "setAiPanelOpen"; value: SetStateAction<boolean> }
 	| { type: "setAiAssistantMode"; value: AiAssistantMode }
@@ -109,6 +122,7 @@ type UIAction =
 			templateFolder: string | null;
 			dailyNoteTemplatePath: string | null;
 			showToc: boolean;
+			folioMode: boolean;
 	  };
 
 const initialUIState: UIState = {
@@ -123,6 +137,8 @@ const initialUIState: UIState = {
 	templateFolder: null,
 	dailyNoteTemplatePath: null,
 	showToc: true,
+	folioMode: false,
+	folioScope: DEFAULT_FOLIO_SCOPE,
 	settingsMode: false,
 	settingsTab: "general" as SettingsTab,
 	aiEnabled: true,
@@ -183,6 +199,14 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 			return { ...state, dailyNoteTemplatePath: action.value };
 		case "setShowToc":
 			return { ...state, showToc: action.value };
+		case "setFolioMode":
+			return {
+				...state,
+				folioMode: action.value,
+				folioScope: action.value ? DEFAULT_FOLIO_SCOPE : state.folioScope,
+			};
+		case "setFolioScope":
+			return { ...state, folioScope: action.value };
 		case "setAiEnabled":
 			return {
 				...state,
@@ -252,6 +276,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				templateFolder: action.templateFolder,
 				dailyNoteTemplatePath: action.dailyNoteTemplatePath,
 				showToc: action.showToc,
+				folioMode: action.folioMode,
 			};
 		default:
 			return state;
@@ -273,6 +298,8 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		templateFolder,
 		dailyNoteTemplatePath,
 		showToc,
+		folioMode,
+		folioScope,
 		settingsMode,
 		settingsTab,
 		aiEnabled,
@@ -296,6 +323,10 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		const nextShowToc = payload.ui?.showToc;
 		if (typeof nextShowToc === "boolean") {
 			dispatch({ type: "setShowToc", value: nextShowToc });
+		}
+		const nextFolioMode = payload.ui?.folioMode;
+		if (typeof nextFolioMode === "boolean") {
+			dispatch({ type: "setFolioMode", value: nextFolioMode });
 		}
 		if (payload.dailyNotes && "folder" in payload.dailyNotes) {
 			dispatch({
@@ -331,6 +362,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					templateFolder: s.templates?.folder ?? null,
 					dailyNoteTemplatePath: s.templates?.dailyNoteTemplate ?? null,
 					showToc: s.ui.showToc,
+					folioMode: s.ui.folioMode,
 				});
 			} catch {
 				// best-effort settings hydration
@@ -397,6 +429,16 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		dispatch({ type: "setShowToc", value: show });
 		void saveShowToc(show);
 	}, []);
+
+	const setFolioMode = useCallback((enabled: boolean) => {
+		dispatch({ type: "setFolioMode", value: enabled });
+		void saveFolioMode(enabled);
+	}, []);
+
+	const setFolioScope = useCallback(
+		(scope: FolioScope) => dispatch({ type: "setFolioScope", value: scope }),
+		[],
+	);
 
 	const setSidebarCollapsed = useCallback(
 		(collapsed: boolean) =>
@@ -479,6 +521,10 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			dailyNoteTemplatePath,
 			showToc,
 			setShowToc,
+			folioMode,
+			setFolioMode,
+			folioScope,
+			setFolioScope,
 			settingsMode,
 			settingsTab,
 			openSettings,
@@ -505,6 +551,10 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			dailyNoteTemplatePath,
 			showToc,
 			setShowToc,
+			folioMode,
+			setFolioMode,
+			folioScope,
+			setFolioScope,
 			settingsMode,
 			settingsTab,
 			openSettings,

--- a/src/hooks/useFileTreeCRUD.ts
+++ b/src/hooks/useFileTreeCRUD.ts
@@ -7,6 +7,12 @@ import {
 } from "../lib/appEvents";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { isMissingFileError } from "../lib/fsErrors";
+import {
+	invalidateAllDocsPrefetch,
+	optimisticallyAddAllDocsNote,
+	optimisticallyRemoveAllDocsPath,
+	optimisticallyRenameAllDocsPath,
+} from "../lib/navigationPrefetch";
 import { updateOnboardingSettings } from "../lib/settings";
 import type { FsEntry, LinkRewriteResult } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
@@ -178,6 +184,7 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 					kind: "file",
 					is_markdown: true,
 				});
+				optimisticallyAddAllDocsNote({ path: markdownRel, text });
 				const nextOpenParentDir =
 					typeof openParentDir === "string"
 						? openParentDir
@@ -304,6 +311,12 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 				const duplicatedPath = normalizeRelPath(duplicated.rel_path);
 				if (!duplicatedPath) return null;
 				insertEntryOptimistic(parentDir(duplicatedPath), duplicated);
+				if (duplicated.is_markdown) {
+					optimisticallyAddAllDocsNote({
+						path: duplicatedPath,
+						sourcePath: target,
+					});
+				}
 				await ensureDirChainLoaded(parentDir(duplicatedPath));
 				return duplicatedPath;
 			} catch (error) {
@@ -397,6 +410,8 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 					toPath: nextPath,
 					recursive: kind === "dir",
 				});
+				optimisticallyRenameAllDocsPath(dirPath, nextPath, kind === "dir");
+				invalidateAllDocsPrefetch();
 				await refreshAfterCreate(parent);
 				if (kind === "dir") await loadDir(nextPath, true);
 				await runPinnedSync("rename", () =>
@@ -491,6 +506,8 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 					path: target,
 					recursive: kind === "dir",
 				});
+				optimisticallyRemoveAllDocsPath(target, kind === "dir");
+				invalidateAllDocsPrefetch();
 				await runPinnedSync("delete", () => deletePinnedPath(target));
 				try {
 					await deleteItemAppearance(target);
@@ -623,6 +640,8 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 					toPath: nextPath,
 					recursive: kind === "dir",
 				});
+				optimisticallyRenameAllDocsPath(from, nextPath, kind === "dir");
+				invalidateAllDocsPrefetch();
 				await runPinnedSync("move", () => renamePinnedPath(from, nextPath));
 				try {
 					await renameItemAppearance(from, nextPath);

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -4,6 +4,7 @@ import {
 } from "../components/preview/markdownCache";
 import { buildMonthRange } from "./calendar";
 import { readStoredSelectedViewId } from "./database/selectedViewStorage";
+import { parseNotePreview } from "./notePreview";
 import { queryClient } from "./queryClient";
 import type {
 	AllDocsItem,
@@ -23,6 +24,29 @@ const normalizeAllDocsFolder = (folderPrefix?: string | null) => {
 		.replace(/^\/+|\/+$/g, "");
 	return normalized || "__all__";
 };
+
+const normalizeAllDocsPath = (path: string) =>
+	path
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+
+const titleFromAllDocsPath = (path: string) => {
+	const name = normalizeAllDocsPath(path).split("/").pop() ?? "Untitled";
+	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
+};
+
+const allDocsFolderContainsPath = (folderKey: string, path: string) => {
+	if (folderKey === "__all__") return true;
+	const normalizedPath = normalizeAllDocsPath(path);
+	return (
+		normalizedPath === folderKey || normalizedPath.startsWith(`${folderKey}/`)
+	);
+};
+
+const compareAllDocsItems = (left: AllDocsItem, right: AllDocsItem) =>
+	Date.parse(right.updated) - Date.parse(left.updated) ||
+	left.note_path.localeCompare(right.note_path);
 
 export const navigationQueryKeys = {
 	all: ["navigation"] as const,
@@ -336,6 +360,136 @@ export function getPrefetchedAllDocs(folderPrefix?: string | null) {
 		queryClient.getQueryData<AllDocsItem[]>(
 			navigationQueryKeys.allDocsList(folderPrefix),
 		) ?? null
+	);
+}
+
+function updateAllDocsListCaches(
+	updater: (current: AllDocsItem[], folderKey: string) => AllDocsItem[],
+) {
+	const queries = queryClient
+		.getQueryCache()
+		.findAll({ queryKey: navigationQueryKeys.allDocs() });
+	for (const query of queries) {
+		const folderKey = Array.isArray(query.queryKey)
+			? String(query.queryKey[2] ?? "__all__")
+			: "__all__";
+		const current = queryClient.getQueryData<AllDocsItem[]>(query.queryKey);
+		if (!current) continue;
+		queryClient.setQueryData<AllDocsItem[]>(
+			query.queryKey,
+			updater(current, folderKey),
+		);
+	}
+}
+
+function findCachedAllDocsItem(path: string): AllDocsItem | null {
+	const normalizedPath = normalizeAllDocsPath(path);
+	const queries = queryClient
+		.getQueryCache()
+		.findAll({ queryKey: navigationQueryKeys.allDocs() });
+	for (const query of queries) {
+		const current = queryClient.getQueryData<AllDocsItem[]>(query.queryKey);
+		const item = current?.find(
+			(note) => normalizeAllDocsPath(note.note_path) === normalizedPath,
+		);
+		if (item) return item;
+	}
+	return null;
+}
+
+export function upsertAllDocsPrefetchItem(item: AllDocsItem) {
+	const normalizedPath = normalizeAllDocsPath(item.note_path);
+	if (!normalizedPath) return;
+	updateAllDocsListCaches((current, folderKey) => {
+		const withoutItem = current.filter(
+			(note) => normalizeAllDocsPath(note.note_path) !== normalizedPath,
+		);
+		if (!allDocsFolderContainsPath(folderKey, normalizedPath))
+			return withoutItem;
+		return [...withoutItem, { ...item, note_path: normalizedPath }].sort(
+			compareAllDocsItems,
+		);
+	});
+}
+
+export function optimisticallyAddAllDocsNote(args: {
+	path: string;
+	text?: string;
+	sourcePath?: string;
+}) {
+	const normalizedPath = normalizeAllDocsPath(args.path);
+	if (!normalizedPath.toLowerCase().endsWith(".md")) return;
+	const source = args.sourcePath
+		? findCachedAllDocsItem(args.sourcePath)
+		: null;
+	const preview = parseNotePreview(normalizedPath, args.text ?? "");
+	const now = new Date().toISOString();
+	upsertAllDocsPrefetchItem({
+		note_path: normalizedPath,
+		title:
+			source?.title ??
+			(args.text !== undefined
+				? preview.title
+				: titleFromAllDocsPath(normalizedPath)),
+		preview:
+			source?.preview ?? (args.text !== undefined ? preview.content : ""),
+		updated: now,
+		created: now,
+		tags: source?.tags ?? [],
+		people: source?.people ?? [],
+	});
+}
+
+export function optimisticallyRenameAllDocsPath(
+	fromPath: string,
+	toPath: string,
+	recursive = false,
+) {
+	const from = normalizeAllDocsPath(fromPath);
+	const to = normalizeAllDocsPath(toPath);
+	if (!from || !to) return;
+	const fromTitle = titleFromAllDocsPath(from);
+	const toTitle = titleFromAllDocsPath(to);
+	updateAllDocsListCaches((current, folderKey) => {
+		const next: AllDocsItem[] = [];
+		for (const note of current) {
+			const notePath = normalizeAllDocsPath(note.note_path);
+			const matches =
+				notePath === from || (recursive && notePath.startsWith(`${from}/`));
+			const renamedPath = matches
+				? notePath === from
+					? to
+					: `${to}${notePath.slice(from.length)}`
+				: notePath;
+			if (!allDocsFolderContainsPath(folderKey, renamedPath)) continue;
+			next.push(
+				matches
+					? {
+							...note,
+							note_path: renamedPath,
+							title: note.title === fromTitle ? toTitle : note.title,
+						}
+					: note,
+			);
+		}
+		return next.sort(compareAllDocsItems);
+	});
+}
+
+export function optimisticallyRemoveAllDocsPath(
+	path: string,
+	recursive = false,
+) {
+	const normalizedPath = normalizeAllDocsPath(path);
+	if (!normalizedPath) return;
+	updateAllDocsListCaches((current) =>
+		current.filter((note) => {
+			const notePath = normalizeAllDocsPath(note.note_path);
+			return (
+				notePath !== normalizedPath &&
+				(!recursive || !notePath.startsWith(`${normalizedPath}/`))
+			);
+		}),
 	);
 }
 

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -150,6 +150,36 @@ describe("settings task progress indicator", () => {
 	});
 });
 
+describe("settings Folio Mode", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults Folio Mode to false", async () => {
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.folioMode).toBe(false);
+	});
+
+	it("loads Folio Mode from the store", async () => {
+		storeState.set("ui.folioMode", true);
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.folioMode).toBe(true);
+	});
+
+	it("persists and emits Folio Mode changes", async () => {
+		const { setFolioMode } = await import("./settings");
+		await setFolioMode(true);
+		expect(storeState.get("ui.folioMode")).toBe(true);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { folioMode: true },
+		});
+	});
+});
+
 describe("settings editor width mode", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -272,6 +272,7 @@ async function emitSettingsUpdated(payload: {
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
 		showTaskProgressIndicator?: boolean;
+		folioMode?: boolean;
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
 	};
@@ -344,6 +345,7 @@ interface AppSettings {
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
 		showTaskProgressIndicator: boolean;
+		folioMode: boolean;
 		aiAssistantMode: AiAssistantMode;
 	};
 	dailyNotes: {
@@ -385,6 +387,7 @@ const KEYS = {
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
 	showTaskProgressIndicator: "ui.showTaskProgressIndicator",
+	folioMode: "ui.folioMode",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
@@ -621,6 +624,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawShowFileTreeFolderCounts,
 		rawShowTaskProgressIndicator,
 		rawShowTaskProgressIndicatorLegacy,
+		rawFolioMode,
 		dailyNotesFolderRaw,
 		rawWebClippingsFolder,
 		rawQuickNotesFolder,
@@ -665,6 +669,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.showFileTreeFolderCounts),
 		store.get<boolean | null>(KEYS.showTaskProgressIndicator),
 		store.get<boolean | null>(LEGACY_SHOW_TASK_PROGRESS_INDICATOR_KEY),
+		store.get<boolean | null>(KEYS.folioMode),
 		store.get<string | null>(KEYS.dailyNotesFolder),
 		store.get<string | null>(KEYS.webClippingsFolder),
 		store.get<unknown>(KEYS.quickNotesFolder),
@@ -733,6 +738,7 @@ export async function loadSettings(): Promise<AppSettings> {
 			: typeof rawShowTaskProgressIndicatorLegacy === "boolean"
 				? rawShowTaskProgressIndicatorLegacy
 				: DEFAULT_SHOW_TASK_PROGRESS_INDICATOR;
+	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
 	const dailyNotesFolder =
 		typeof dailyNotesFolderRaw === "string"
 			? normalizeRelPath(dailyNotesFolderRaw) || null
@@ -820,6 +826,7 @@ export async function loadSettings(): Promise<AppSettings> {
 			showToc,
 			showFileTreeFolderCounts,
 			showTaskProgressIndicator,
+			folioMode,
 			aiAssistantMode,
 		},
 		dailyNotes: {
@@ -1100,6 +1107,13 @@ export async function setShowTaskProgressIndicator(
 	await store.set(KEYS.showTaskProgressIndicator, enabled);
 	await store.save();
 	void emitSettingsUpdated({ ui: { showTaskProgressIndicator: enabled } });
+}
+
+export async function setFolioMode(enabled: boolean): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.folioMode, enabled);
+	await store.save();
+	void emitSettingsUpdated({ ui: { folioMode: enabled } });
 }
 
 export async function setEditorShowCollapsibleHeadings(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -297,6 +297,7 @@ export interface AllDocsItem {
 	updated: string;
 	created: string;
 	tags: string[];
+	people?: string[];
 }
 
 export interface SearchAdvancedRequest {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -79,6 +79,7 @@ type TauriEventMap = {
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
 			showTaskProgressIndicator?: boolean;
+			folioMode?: boolean;
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
 		};

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -1,0 +1,269 @@
+.folioWorkspace {
+	display: flex;
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	background: var(--bg-primary);
+}
+
+.folioNotesPane {
+	flex: 0 0 var(--folio-notes-width, 320px);
+	width: var(--folio-notes-width, 320px);
+	min-width: 260px;
+	max-width: 420px;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	border-right: 1px solid
+		color-mix(in srgb, var(--border-light) 76%, transparent);
+	background: var(--bg-primary);
+}
+
+.folioNotesHeader {
+	flex: 0 0 auto;
+	padding: 12px 12px 9px;
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 58%, transparent);
+}
+
+.folioNotesTitleRow {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	margin-bottom: 8px;
+}
+
+.folioNotesTitle {
+	min-width: 0;
+	margin: 0;
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	font-weight: var(--font-semibold);
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.folioNotesCount {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+	font-size: 11px;
+}
+
+.folioNotesSearch {
+	height: 28px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 9px;
+	border: 1px solid var(--border-light);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-tertiary);
+	cursor: text;
+}
+
+.folioNotesSearch svg {
+	flex: 0 0 auto;
+}
+
+.folioNotesSearch input {
+	height: 18px;
+	min-width: 0;
+	flex: 1;
+	border: 0;
+	outline: 0;
+	box-shadow: none;
+	padding: 0;
+	appearance: none;
+	background: transparent;
+	border-radius: 0;
+	caret-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 70%,
+		var(--text-secondary)
+	);
+	color: var(--text-primary);
+	font: inherit;
+	font-size: var(--text-sm);
+	line-height: 18px;
+}
+
+.folioNotesSearch input:focus,
+.folioNotesSearch input:focus-visible {
+	outline: none;
+	border-color: transparent;
+	box-shadow: none;
+}
+
+.folioNotesList {
+	flex: 1;
+	min-height: 0;
+	overflow: auto;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.folioNoteListItem {
+	margin: 0;
+	padding: 0;
+}
+
+.folioNoteRow {
+	width: 100%;
+	min-height: 116px;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	justify-content: flex-start;
+	gap: 6px;
+	padding: 10px 16px 9px;
+	border: 0;
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 58%, transparent);
+	border-radius: 0;
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+	cursor: default;
+}
+
+.folioNoteRow:hover,
+.folioNoteRow:focus-visible {
+	background: var(--bg-hover);
+	outline: none;
+}
+
+.folioNoteRow[data-state="selected"] {
+	background: color-mix(in srgb, var(--interactive-accent) 8%, var(--bg-hover));
+}
+
+.folioNoteRowTop {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	min-width: 0;
+}
+
+.folioNoteTitle {
+	min-width: 0;
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-primary);
+	font-size: 13px;
+	font-weight: var(--font-medium);
+	line-height: 1.25;
+}
+
+.folioNotePreview {
+	min-width: 0;
+	flex: 0 0 auto;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
+	font-size: 12px;
+	line-height: 1.38;
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
+.folioNoteFooter {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	min-width: 0;
+	margin-top: auto;
+}
+
+.folioNoteTags {
+	min-width: 0;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	overflow: hidden;
+}
+
+.folioNoteTag {
+	max-width: 104px;
+	min-height: 18px;
+	padding: 1px 7px;
+	font-size: 10px;
+	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.folioNoteFolder {
+	min-width: 0;
+	overflow: hidden;
+	color: var(--text-tertiary);
+	font-size: 10px;
+	line-height: 16px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.folioNoteDates {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--text-tertiary);
+	font-size: 10px;
+	white-space: nowrap;
+}
+
+.folioNotesState {
+	margin: 14px 12px;
+	color: var(--text-tertiary);
+	font-size: var(--text-sm);
+	line-height: 1.4;
+	text-align: left;
+}
+
+.folioNotesResizeHandle {
+	position: relative;
+	flex: 0 0 7px;
+	margin-left: -3px;
+	margin-right: -3px;
+	cursor: col-resize;
+	user-select: none;
+	background: transparent;
+	z-index: 2;
+}
+
+.folioNotesResizeHandle::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 50%;
+	width: 1px;
+	transform: translateX(-50%);
+	background: transparent;
+}
+
+.folioNotesResizeHandle:hover::before {
+	background: color-mix(in srgb, var(--border-medium) 64%, transparent);
+}
+
+.folioEditorHost {
+	flex: 1;
+	min-width: 0;
+	min-height: 0;
+	display: flex;
+	background: var(--bg-primary);
+}

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -216,6 +216,30 @@
 	line-height: 1.25;
 }
 
+.folioNoteTaskProgress {
+	flex: 0 0 auto;
+	width: 16px;
+	height: 16px;
+	margin-left: auto;
+	opacity: 0.9;
+}
+
+.folioNoteTaskProgress .markdownEditorTaskProgressRing {
+	width: 14px;
+	height: 14px;
+	border-width: 2px;
+}
+
+.folioNoteTaskProgress .markdownEditorTaskProgressPie {
+	width: 7px;
+	height: 7px;
+}
+
+.folioNoteRow:hover .folioNoteTaskProgress,
+.folioNoteRow[data-state="selected"] .folioNoteTaskProgress {
+	opacity: 1;
+}
+
 .folioNotePreview {
 	min-width: 0;
 	flex: 0 0 auto;

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -52,8 +52,16 @@
 	font-size: 11px;
 }
 
+.folioNotesControls {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
 .folioNotesSearch {
 	height: 28px;
+	flex: 1 1 auto;
+	min-width: 0;
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -95,6 +103,52 @@
 .folioNotesSearch input:focus-visible {
 	outline: none;
 	border-color: transparent;
+	box-shadow: none;
+}
+
+.folioNotesSort {
+	position: relative;
+	flex: 0 0 auto;
+	width: 30px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid var(--border-light);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-secondary);
+}
+
+.folioNotesSort svg {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+}
+
+.folioNotesSortSelect {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	background: transparent;
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: var(--text-xs);
+	opacity: 0;
+	cursor: pointer;
+}
+
+.folioNotesSort:focus-within {
+	border-color: var(--border-focus);
+}
+
+.folioNotesSortSelect:focus,
+.folioNotesSortSelect:focus-visible {
+	outline: none;
 	box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- add Folio mode's three-pane workspace and notes list controls
- preserve native keyboard behavior for Folio header form controls
- support Folio people scopes with indexed people metadata from all_docs_list

## Validation
- pnpm test -- src/components/folio/FolioNotesListPane.test.tsx
- pnpm check
- pnpm build
- cargo check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Folio Mode: Optional workspace layout with a resizable notes pane alongside the editor, featuring search, tag and person filtering, and sorting options (alphabetical, edited, created date). Includes keyboard navigation support.

**Tests**
- Added comprehensive test coverage for folio mode components and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->