### PR TITLE
[codex] Polish note navigation and in-note find

### DIFF
--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -78,7 +78,7 @@ export const TagsPane = memo(function TagsPane({
 		[onSelectPerson],
 	);
 	const [tagsExpanded, setTagsExpanded] = useState(false);
-	const [sectionExpanded, setSectionExpanded] = useState(true);
+	const [sectionExpanded, setSectionExpanded] = useState(false);
 	const rows = buildTagTreeRows(tags);
 	const peopleRows = buildPeopleRows(people);
 

--- a/src/components/ai/AIFloatingHost.tsx
+++ b/src/components/ai/AIFloatingHost.tsx
@@ -1,13 +1,5 @@
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import {
-	type PointerEvent as ReactPointerEvent,
-	Suspense,
-	lazy,
-	useCallback,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
+import { Suspense, lazy, useEffect } from "react";
 
 const importAIPanel = () => import("./AIPanel");
 
@@ -23,106 +15,8 @@ interface AIFloatingHostProps {
 	onToggle: () => void;
 }
 
-type ResizeDirection =
-	| "top"
-	| "right"
-	| "bottom"
-	| "left"
-	| "top-left"
-	| "top-right"
-	| "bottom-left"
-	| "bottom-right";
-
-const FLOATING_PANEL_MIN_WIDTH = 360;
-const FLOATING_PANEL_MIN_HEIGHT = 360;
-const FLOATING_PANEL_DEFAULT_WIDTH = 460;
-const FLOATING_PANEL_DEFAULT_HEIGHT = 620;
-const FLOATING_PANEL_VIEWPORT_GAP = 32;
-
 export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 	const shouldReduceMotion = useReducedMotion();
-	const [panelSize, setPanelSize] = useState({
-		width: FLOATING_PANEL_DEFAULT_WIDTH,
-		height: FLOATING_PANEL_DEFAULT_HEIGHT,
-	});
-	const resizeStateRef = useRef<{
-		direction: ResizeDirection;
-		startX: number;
-		startY: number;
-		startWidth: number;
-		startHeight: number;
-	} | null>(null);
-	const stopResizeRef = useRef<() => void>(() => {});
-
-	const clampSize = useCallback((width: number, height: number) => {
-		const maxWidth = Math.max(
-			FLOATING_PANEL_MIN_WIDTH,
-			window.innerWidth - FLOATING_PANEL_VIEWPORT_GAP,
-		);
-		const maxHeight = Math.max(
-			FLOATING_PANEL_MIN_HEIGHT,
-			window.innerHeight - FLOATING_PANEL_VIEWPORT_GAP,
-		);
-		return {
-			width: Math.max(FLOATING_PANEL_MIN_WIDTH, Math.min(maxWidth, width)),
-			height: Math.max(FLOATING_PANEL_MIN_HEIGHT, Math.min(maxHeight, height)),
-		};
-	}, []);
-
-	const handlePointerMove = useCallback(
-		(event: PointerEvent) => {
-			const resizeState = resizeStateRef.current;
-			if (!resizeState) return;
-			const deltaX = event.clientX - resizeState.startX;
-			const deltaY = event.clientY - resizeState.startY;
-
-			let nextWidth = resizeState.startWidth;
-			let nextHeight = resizeState.startHeight;
-
-			if (resizeState.direction.includes("left")) {
-				nextWidth = resizeState.startWidth - deltaX;
-			} else if (resizeState.direction.includes("right")) {
-				nextWidth = resizeState.startWidth + deltaX;
-			}
-
-			if (resizeState.direction.includes("top")) {
-				nextHeight = resizeState.startHeight - deltaY;
-			} else if (resizeState.direction.includes("bottom")) {
-				nextHeight = resizeState.startHeight + deltaY;
-			}
-
-			setPanelSize(clampSize(nextWidth, nextHeight));
-		},
-		[clampSize],
-	);
-
-	const handlePointerUp = useCallback(() => {
-		stopResizeRef.current();
-	}, []);
-
-	const stopResize = useCallback(() => {
-		resizeStateRef.current = null;
-		window.removeEventListener("pointermove", handlePointerMove);
-		window.removeEventListener("pointerup", handlePointerUp);
-	}, [handlePointerMove, handlePointerUp]);
-	stopResizeRef.current = stopResize;
-
-	const startResize = useCallback(
-		(direction: ResizeDirection, event: ReactPointerEvent<HTMLDivElement>) => {
-			event.preventDefault();
-			event.stopPropagation();
-			resizeStateRef.current = {
-				direction,
-				startX: event.clientX,
-				startY: event.clientY,
-				startWidth: panelSize.width,
-				startHeight: panelSize.height,
-			};
-			window.addEventListener("pointermove", handlePointerMove);
-			window.addEventListener("pointerup", handlePointerUp);
-		},
-		[handlePointerMove, handlePointerUp, panelSize.height, panelSize.width],
-	);
 
 	useEffect(() => {
 		if (!isOpen) return;
@@ -140,17 +34,6 @@ export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 		};
 	}, [isOpen]);
 
-	useEffect(() => {
-		const onWindowResize = () => {
-			setPanelSize((current) => clampSize(current.width, current.height));
-		};
-		window.addEventListener("resize", onWindowResize);
-		return () => {
-			window.removeEventListener("resize", onWindowResize);
-			stopResizeRef.current();
-		};
-	}, [clampSize]);
-
 	return (
 		<div className="aiFloatingWindowHost" data-window-drag-ignore>
 			<AnimatePresence>
@@ -158,12 +41,11 @@ export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 					<m.div
 						key="ai-floating-window"
 						className="aiFloatingWindow"
-						style={{ width: panelSize.width, height: panelSize.height }}
 						initial={
-							shouldReduceMotion ? false : { opacity: 0, y: 10, scale: 0.98 }
+							shouldReduceMotion ? false : { opacity: 0, x: 8, scale: 0.99 }
 						}
-						animate={{ opacity: 1, y: 0, scale: 1 }}
-						exit={shouldReduceMotion ? {} : { opacity: 0, y: 8, scale: 0.98 }}
+						animate={{ opacity: 1, x: 0, scale: 1 }}
+						exit={shouldReduceMotion ? {} : { opacity: 0, x: 8, scale: 0.99 }}
 						transition={
 							shouldReduceMotion
 								? { duration: 0 }
@@ -175,38 +57,6 @@ export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 								<LazyAIPanel isOpen={isOpen} onClose={onToggle} />
 							</div>
 						</Suspense>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-top"
-							onPointerDown={(event) => startResize("top", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-right"
-							onPointerDown={(event) => startResize("right", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-bottom"
-							onPointerDown={(event) => startResize("bottom", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-left"
-							onPointerDown={(event) => startResize("left", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-top-left"
-							onPointerDown={(event) => startResize("top-left", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-top-right"
-							onPointerDown={(event) => startResize("top-right", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-bottom-left"
-							onPointerDown={(event) => startResize("bottom-left", event)}
-						/>
-						<div
-							className="aiFloatingResizeHandle aiFloatingResizeHandle-bottom-right"
-							onPointerDown={(event) => startResize("bottom-right", event)}
-						/>
 					</m.div>
 				)}
 			</AnimatePresence>

--- a/src/components/ai/AIFloatingHost.tsx
+++ b/src/components/ai/AIFloatingHost.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { Suspense, lazy, useEffect } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 
 const importAIPanel = () => import("./AIPanel");
 
@@ -17,9 +17,11 @@ interface AIFloatingHostProps {
 
 export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 	const shouldReduceMotion = useReducedMotion();
+	const [shouldRenderHost, setShouldRenderHost] = useState(isOpen);
 
 	useEffect(() => {
 		if (!isOpen) return;
+		setShouldRenderHost(true);
 		let cancelled = false;
 		void importAIPanel()
 			.then((module) => {
@@ -34,9 +36,15 @@ export function AIFloatingHost({ isOpen, onToggle }: AIFloatingHostProps) {
 		};
 	}, [isOpen]);
 
+	if (!isOpen && !shouldRenderHost) return null;
+
 	return (
 		<div className="aiFloatingWindowHost" data-window-drag-ignore>
-			<AnimatePresence>
+			<AnimatePresence
+				onExitComplete={() => {
+					if (!isOpen) setShouldRenderHost(false);
+				}}
+			>
 				{isOpen && (
 					<m.div
 						key="ai-floating-window"

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/lib/utils";
 import {
-	AiEditingIcon,
 	ChatAdd01Icon,
 	Logout05Icon,
+	SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -295,7 +295,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 			<div className="aiPanelHeader">
 				<div className="aiPanelHeaderLeft">
 					<div className="aiPanelTitle">
-						<HugeiconsIcon icon={AiEditingIcon} size={18} strokeWidth={0.9} />
+						<HugeiconsIcon icon={SparklesIcon} size={18} strokeWidth={0.9} />
 					</div>
 					<button
 						type="button"

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -112,6 +112,8 @@ export function AppShell() {
 	} = space;
 	const fileTreeCtx = useFileTreeContext();
 	const {
+		rootEntries,
+		childrenByDir,
 		expandedDirs,
 		activeDirPath,
 		setActiveDirPath,
@@ -1031,6 +1033,36 @@ export function AppShell() {
 		setSidebarCollapsed,
 	]);
 
+	const handleNavigateBreadcrumbPath = useCallback(
+		(dirPath: string) => {
+			const nextPath = normalizeRelPath(dirPath);
+			setSidebarCollapsed(false);
+			setActiveDirPath(nextPath);
+
+			const ancestorDirs: string[] = [];
+			let current = nextPath;
+			while (current) {
+				ancestorDirs.unshift(current);
+				current = parentDir(current);
+			}
+
+			updateExpandedDirs((prev) => {
+				const next = new Set(prev);
+				for (const dir of ancestorDirs) next.add(dir);
+				return next;
+			});
+
+			const dirsToLoad = nextPath ? ancestorDirs : [""];
+			void Promise.all(dirsToLoad.map((dir) => fileTree.loadDir(dir)));
+		},
+		[
+			fileTree.loadDir,
+			setActiveDirPath,
+			setSidebarCollapsed,
+			updateExpandedDirs,
+		],
+	);
+
 	const handleStartRenameFromTab = useCallback(
 		async (path: string) => {
 			const nextPath = path.trim();
@@ -1349,6 +1381,8 @@ export function AppShell() {
 				onCreateNote={handleCreateNoteFromStarter}
 				onOpenDailyNote={requestOpenDailyNote}
 				tabs={tabs}
+				rootEntries={rootEntries}
+				childrenByDir={childrenByDir}
 				activeTabId={activeTabId}
 				activeTabPath={activeTabPath}
 				setActiveTabId={setActiveTabId}
@@ -1360,6 +1394,8 @@ export function AppShell() {
 				reorderTabs={reorderTabs}
 				openBlankTab={openBlankTab}
 				onStartRenamePath={handleStartRenameFromTab}
+				onNavigateBreadcrumbPath={handleNavigateBreadcrumbPath}
+				onLoadBreadcrumbDir={fileTree.loadDir}
 				replaceActiveTabWithBlank={replaceActiveTabWithBlank}
 				canGoBack={canGoBack}
 				canGoForward={canGoForward}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -51,6 +51,7 @@ import {
 } from "../../lib/settings";
 import { formatShortcutPartsForPlatform } from "../../lib/shortcuts/platform";
 import { todayIsoDateLocal } from "../../lib/tasks";
+import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { isInAppPreviewable } from "../../utils/filePreview";
@@ -274,6 +275,8 @@ interface MainContentProps {
 	onCreateNote: () => void;
 	onOpenDailyNote: () => void;
 	tabs: WorkspaceTab[];
+	rootEntries: FsEntry[];
+	childrenByDir: Record<string, FsEntry[] | undefined>;
 	activeTabId: string | null;
 	activeTabPath: string | null;
 	setActiveTabId: (tabId: string | null) => void;
@@ -289,6 +292,8 @@ interface MainContentProps {
 	reorderTabs: (fromTabId: string, toTabId: string) => void;
 	openBlankTab: () => void;
 	onStartRenamePath: (path: string) => void;
+	onNavigateBreadcrumbPath: (dirPath: string) => void;
+	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
 	replaceActiveTabWithBlank: () => void;
 	canGoBack: boolean;
 	canGoForward: boolean;
@@ -375,6 +380,8 @@ export const MainContent = memo(function MainContent({
 	onCreateNote,
 	onOpenDailyNote,
 	tabs,
+	rootEntries,
+	childrenByDir,
 	activeTabId,
 	activeTabPath,
 	setActiveTabId,
@@ -386,6 +393,8 @@ export const MainContent = memo(function MainContent({
 	reorderTabs,
 	openBlankTab,
 	onStartRenamePath,
+	onNavigateBreadcrumbPath,
+	onLoadBreadcrumbDir,
 	replaceActiveTabWithBlank,
 	canGoBack,
 	canGoForward,
@@ -820,6 +829,8 @@ export const MainContent = memo(function MainContent({
 				>
 					<TabBar
 						tabs={tabs}
+						rootEntries={rootEntries}
+						childrenByDir={childrenByDir}
 						activeTabId={activeTabId}
 						activeTabPath={activeTabPath}
 						useWindowBackground={!content}
@@ -829,6 +840,9 @@ export const MainContent = memo(function MainContent({
 						onGoForward={onGoForward}
 						onOpenBlankTab={openBlankTab}
 						onPrefetchTab={handlePrefetchTab}
+						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
+						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
+						onOpenBreadcrumbFile={onOpenFile}
 						onSelectTab={setActiveTabId}
 						onCloseTab={closeTab}
 						onStartRenamePath={onStartRenamePath}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -802,74 +802,70 @@ export const MainContent = memo(function MainContent({
 		[settingsTab],
 	);
 	const showFolioWorkspace = folioMode && !zenModeActive;
-	const editorSurface = (
-		<>
-			<div className="canvasPaneHost">
-				<DailyNotesSetupToast
-					visible={dailyNoteSetupToastVisible}
-					onDismiss={() => setDailyNoteSetupToastVisible(false)}
-					onOpenSettings={() => {
-						setDailyNoteSetupToastVisible(false);
-						onOpenDailyNotesSettings();
-					}}
-				/>
-				{showTabBar ? (
-					<div
-						className={`mainTabBarTransition${zenModeActive ? " is-zen-hidden" : ""}`}
-						aria-hidden={zenModeActive}
-						inert={zenModeActive ? true : undefined}
-					>
-						<TabBar
-							tabs={tabs}
-							activeTabId={activeTabId}
-							activeTabPath={activeTabPath}
-							useWindowBackground={!content}
-							canGoBack={canGoBack}
-							canGoForward={canGoForward}
-							onGoBack={onGoBack}
-							onGoForward={onGoForward}
-							onOpenBlankTab={openBlankTab}
-							onPrefetchTab={handlePrefetchTab}
-							onSelectTab={setActiveTabId}
-							onCloseTab={closeTab}
-							onStartRenamePath={onStartRenamePath}
-							onReorder={reorderTabs}
-						/>
-					</div>
-				) : null}
-				{content ?? (
-					<div className="mainEmptyState">
-						{showStarterPane ? (
-							<GettingStartedPane
-								commandShortcutParts={commandShortcutParts}
-								showDailyNoteAction={Boolean(dailyNotesFolder)}
-								onCreateNote={onCreateNote}
-								onOpenCommandPalette={onOpenCommandPalette}
-								onOpenDailyNote={onOpenDailyNote}
-								onDismiss={() => {
-									setStarterOverrideVisible(false);
-									void updateOnboardingSettings({ starterDismissed: true });
-								}}
-							/>
-						) : (
-							<ContextualEmptyState
-								onboarding={onboarding}
-								commandShortcutParts={commandShortcutParts}
-								showDailyNoteAction={Boolean(dailyNotesFolder)}
-								onCreateNote={onCreateNote}
-								onOpenCommandPalette={onOpenCommandPalette}
-								onOpenDailyNote={onOpenDailyNote}
-							/>
-						)}
-					</div>
-				)}
-				{aiEnabled && !zenModeActive ? (
-					<AIFloatingHost
-						isOpen={aiPanelOpen}
-						onToggle={() => setAiPanelOpen((open) => !open)}
+	const editorCanvas = (
+		<div className="canvasPaneHost">
+			<DailyNotesSetupToast
+				visible={dailyNoteSetupToastVisible}
+				onDismiss={() => setDailyNoteSetupToastVisible(false)}
+				onOpenSettings={() => {
+					setDailyNoteSetupToastVisible(false);
+					onOpenDailyNotesSettings();
+				}}
+			/>
+			{showTabBar ? (
+				<div
+					className={`mainTabBarTransition${zenModeActive ? " is-zen-hidden" : ""}`}
+					aria-hidden={zenModeActive}
+					inert={zenModeActive ? true : undefined}
+				>
+					<TabBar
+						tabs={tabs}
+						activeTabId={activeTabId}
+						activeTabPath={activeTabPath}
+						useWindowBackground={!content}
+						canGoBack={canGoBack}
+						canGoForward={canGoForward}
+						onGoBack={onGoBack}
+						onGoForward={onGoForward}
+						onOpenBlankTab={openBlankTab}
+						onPrefetchTab={handlePrefetchTab}
+						onSelectTab={setActiveTabId}
+						onCloseTab={closeTab}
+						onStartRenamePath={onStartRenamePath}
+						onReorder={reorderTabs}
 					/>
-				) : null}
-			</div>
+				</div>
+			) : null}
+			{content ?? (
+				<div className="mainEmptyState">
+					{showStarterPane ? (
+						<GettingStartedPane
+							commandShortcutParts={commandShortcutParts}
+							showDailyNoteAction={Boolean(dailyNotesFolder)}
+							onCreateNote={onCreateNote}
+							onOpenCommandPalette={onOpenCommandPalette}
+							onOpenDailyNote={onOpenDailyNote}
+							onDismiss={() => {
+								setStarterOverrideVisible(false);
+								void updateOnboardingSettings({ starterDismissed: true });
+							}}
+						/>
+					) : (
+						<ContextualEmptyState
+							onboarding={onboarding}
+							commandShortcutParts={commandShortcutParts}
+							showDailyNoteAction={Boolean(dailyNotesFolder)}
+							onCreateNote={onCreateNote}
+							onOpenCommandPalette={onOpenCommandPalette}
+							onOpenDailyNote={onOpenDailyNote}
+						/>
+					)}
+				</div>
+			)}
+		</div>
+	);
+	const rightSidebarSurface = (
+		<>
 			<div
 				ref={infoSidebarResize.resizeRef}
 				className="notesInfoSidebarResizeHandle"
@@ -885,7 +881,14 @@ export const MainContent = memo(function MainContent({
 				className="notesInfoSidebarHost"
 				aria-live="polite"
 				style={notesInfoSidebarHostStyle}
-			/>
+			>
+				{aiEnabled && aiPanelOpen && !zenModeActive ? (
+					<AIFloatingHost
+						isOpen={aiPanelOpen}
+						onToggle={() => setAiPanelOpen((open) => !open)}
+					/>
+				) : null}
+			</div>
 		</>
 	);
 
@@ -936,21 +939,24 @@ export const MainContent = memo(function MainContent({
 	}
 
 	return (
-		<main className={zenModeActive ? "mainArea mainAreaZen" : "mainArea"}>
-			<div className="canvasWrapper">
-				{showFolioWorkspace ? (
-					<FolioWorkspace
-						activeTabPath={activeTabPath}
-						onOpenFile={onOpenFile}
-						onOpenFileInNewTab={onOpenFileInNewTab}
-						onDeleteFile={(path) => fileTree.onDeletePath(path, "file")}
-					>
-						{editorSurface}
-					</FolioWorkspace>
-				) : (
-					editorSurface
-				)}
-			</div>
-		</main>
+		<>
+			<main className={zenModeActive ? "mainArea mainAreaZen" : "mainArea"}>
+				<div className="canvasWrapper">
+					{showFolioWorkspace ? (
+						<FolioWorkspace
+							activeTabPath={activeTabPath}
+							onOpenFile={onOpenFile}
+							onOpenFileInNewTab={onOpenFileInNewTab}
+							onDeleteFile={(path) => fileTree.onDeletePath(path, "file")}
+						>
+							{editorCanvas}
+						</FolioWorkspace>
+					) : (
+						editorCanvas
+					)}
+				</div>
+			</main>
+			{rightSidebarSurface}
+		</>
 	);
 });

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -896,7 +896,7 @@ export const MainContent = memo(function MainContent({
 				aria-live="polite"
 				style={notesInfoSidebarHostStyle}
 			>
-				{aiEnabled && aiPanelOpen && !zenModeActive ? (
+				{aiEnabled && !zenModeActive ? (
 					<AIFloatingHost
 						isOpen={aiPanelOpen}
 						onToggle={() => setAiPanelOpen((open) => !open)}

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -13,11 +13,23 @@ import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { CALENDAR_TAB_ID } from "../../lib/calendar";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
+import type { FsEntry } from "../../lib/tauri";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
+import { ChevronRight, File, FileText, FolderOpen } from "../Icons";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
 import type { WorkspaceTab } from "./useTabManager";
 
 interface TabBarProps {
 	tabs: WorkspaceTab[];
+	rootEntries: FsEntry[];
+	childrenByDir: Record<string, FsEntry[] | undefined>;
 	activeTabId: string | null;
 	activeTabPath: string | null;
 	useWindowBackground?: boolean;
@@ -27,6 +39,9 @@ interface TabBarProps {
 	onGoForward: () => void;
 	onOpenBlankTab: () => void;
 	onPrefetchTab: (target: string | null) => void;
+	onNavigateBreadcrumbPath: (dirPath: string) => void;
+	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
+	onOpenBreadcrumbFile: (relPath: string) => Promise<void>;
 	onSelectTab: (tabId: string) => void;
 	onCloseTab: (tabId: string) => void;
 	onStartRenamePath: (path: string) => void;
@@ -35,6 +50,7 @@ interface TabBarProps {
 
 const MAIN_TAB_DND_TYPE = "main-tab";
 const MAIN_TAB_DND_GROUP = "main-tabs";
+const ROOT_PATH_KEY = "__root__";
 const MAIN_TAB_SENSORS = [
 	PointerSensor.configure({
 		activationConstraints: [
@@ -42,6 +58,25 @@ const MAIN_TAB_SENSORS = [
 		],
 	}),
 ];
+
+interface BreadcrumbPart {
+	label: string;
+	path: string;
+	kind: "folder" | "file";
+}
+
+function sortBreadcrumbEntries(entries: FsEntry[]) {
+	return [...entries].sort((a, b) => {
+		if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+		return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+	});
+}
+
+function menuTitleForDir(path: string) {
+	if (!path) return "Space";
+	const parts = path.split("/").filter(Boolean);
+	return parts[parts.length - 1] ?? "Space";
+}
 
 function isPathSpecial(path: string): boolean {
 	return (
@@ -55,6 +90,8 @@ function isPathSpecial(path: string): boolean {
 
 export function TabBar({
 	tabs,
+	rootEntries,
+	childrenByDir,
 	activeTabId,
 	activeTabPath,
 	useWindowBackground = false,
@@ -64,6 +101,9 @@ export function TabBar({
 	onGoForward,
 	onOpenBlankTab,
 	onPrefetchTab,
+	onNavigateBreadcrumbPath,
+	onLoadBreadcrumbDir,
+	onOpenBreadcrumbFile,
 	onSelectTab,
 	onCloseTab,
 	onStartRenamePath,
@@ -98,12 +138,27 @@ export function TabBar({
 		[compactLabel, stripFileExtension],
 	);
 
-	const [hovered, setHovered] = useState(false);
 	const showTabs = tabs.length > 1;
 	const newTabShortcut = getBinding("new-tab");
-	const breadcrumbSegments =
+	const [openBreadcrumbMenuKey, setOpenBreadcrumbMenuKey] = useState<
+		string | null
+	>(null);
+	const breadcrumbParts: BreadcrumbPart[] =
 		activeTabPath && !isPathSpecial(activeTabPath)
-			? activeTabPath.split("/").filter(Boolean)
+			? [
+					{ label: "Space", path: "", kind: "folder" },
+					...activeTabPath
+						.split("/")
+						.filter(Boolean)
+						.map((segment, index, segments): BreadcrumbPart => {
+							const isFile = index === segments.length - 1;
+							return {
+								label: isFile ? stripFileExtension(segment) : segment,
+								path: segments.slice(0, index + 1).join("/"),
+								kind: isFile ? "file" : "folder",
+							};
+						}),
+				]
 			: [];
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {
@@ -156,11 +211,7 @@ export function TabBar({
 				{showTabs ? (
 					<>
 						<DragDropProvider onDragEnd={handleDragEnd}>
-							<div
-								className="mainTabsStrip"
-								onPointerEnter={() => setHovered(true)}
-								onPointerLeave={() => setHovered(false)}
-							>
+							<div className="mainTabsStrip">
 								{tabs.map((tab, index) => (
 									<TabItem
 										key={tab.id}
@@ -193,34 +244,170 @@ export function TabBar({
 					</>
 				) : null}
 			</div>
-			{breadcrumbSegments.length > 0 && (
-				<div className={`mainTabsBreadcrumb ${hovered ? "is-visible" : ""}`}>
-					{breadcrumbSegments.map((segment, i, arr) => (
-						<span
-							key={breadcrumbSegments.slice(0, i + 1).join("/")}
-							className="mainTabsBreadcrumbItem"
-						>
-							{i > 0 && (
-								<span className="mainTabsBreadcrumbSep" aria-hidden>
-									/
-								</span>
-							)}
+			{breadcrumbParts.length > 0 && (
+				<nav className="mainTabsBreadcrumb" aria-label="Current file path">
+					{breadcrumbParts.map((part, index) => {
+						const isCurrent = index === breadcrumbParts.length - 1;
+						const dirPath =
+							part.kind === "folder"
+								? part.path
+								: part.path.split("/").slice(0, -1).join("/");
+						const menuDirPath = breadcrumbParts[index - 1]?.path ?? "";
+						const menuEntries =
+							menuDirPath === "" ? rootEntries : childrenByDir[menuDirPath];
+						const menuItems = sortBreadcrumbEntries(menuEntries ?? []);
+						const key = part.path || ROOT_PATH_KEY;
+						const menuKey = `${index}:${menuDirPath || ROOT_PATH_KEY}`;
+
+						return (
 							<span
-								className={
-									i === arr.length - 1
-										? "mainTabsBreadcrumbCurrent"
-										: "mainTabsBreadcrumbSegment"
-								}
+								key={key}
+								className="mainTabsBreadcrumbItem"
+								data-current={isCurrent ? "true" : undefined}
 							>
-								{i === arr.length - 1
-									? segment.replace(/\.[^.]+$/, "")
-									: segment}
+								{index > 0 ? (
+									<BreadcrumbEntryMenu
+										open={openBreadcrumbMenuKey === menuKey}
+										dirPath={menuDirPath}
+										entries={menuItems}
+										loading={menuEntries === undefined}
+										onOpenChange={(open) => {
+											setOpenBreadcrumbMenuKey(open ? menuKey : null);
+										}}
+										onLoadDir={onLoadBreadcrumbDir}
+										onNavigateDir={onNavigateBreadcrumbPath}
+										onOpenFile={onOpenBreadcrumbFile}
+									/>
+								) : null}
+								<button
+									type="button"
+									className="mainTabsBreadcrumbButton"
+									aria-current={isCurrent ? "page" : undefined}
+									disabled={isCurrent}
+									title={
+										isCurrent
+											? (activeTabPath ?? undefined)
+											: `Show ${dirPath || "root"}`
+									}
+									onClick={() => onNavigateBreadcrumbPath(dirPath)}
+								>
+									{part.kind === "folder" ? (
+										<FolderOpen
+											size={12}
+											className="mainTabsBreadcrumbIcon"
+											aria-hidden="true"
+										/>
+									) : (
+										<FileText
+											size={12}
+											className="mainTabsBreadcrumbIcon"
+											aria-hidden="true"
+										/>
+									)}
+									<span className="mainTabsBreadcrumbLabel">{part.label}</span>
+								</button>
 							</span>
-						</span>
-					))}
-				</div>
+						);
+					})}
+				</nav>
 			)}
 		</div>
+	);
+}
+
+function BreadcrumbEntryMenu({
+	open,
+	dirPath,
+	entries,
+	loading,
+	onOpenChange,
+	onLoadDir,
+	onNavigateDir,
+	onOpenFile,
+}: {
+	open: boolean;
+	dirPath: string;
+	entries: FsEntry[];
+	loading: boolean;
+	onOpenChange: (open: boolean) => void;
+	onLoadDir: (dirPath: string) => Promise<void>;
+	onNavigateDir: (dirPath: string) => void;
+	onOpenFile: (relPath: string) => Promise<void>;
+}) {
+	const displayEntries = entries.slice(0, 40);
+	const hiddenCount = Math.max(0, entries.length - displayEntries.length);
+
+	return (
+		<DropdownMenu
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (nextOpen) void onLoadDir(dirPath);
+				onOpenChange(nextOpen);
+			}}
+		>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className="mainTabsBreadcrumbSepButton"
+					aria-label={`Browse ${menuTitleForDir(dirPath)}`}
+				>
+					<ChevronRight
+						size={10}
+						className="mainTabsBreadcrumbSep"
+						aria-hidden="true"
+					/>
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				side="bottom"
+				className="mainTabsBreadcrumbMenu"
+			>
+				<DropdownMenuLabel className="mainTabsBreadcrumbMenuLabel">
+					{menuTitleForDir(dirPath)}
+				</DropdownMenuLabel>
+				<DropdownMenuSeparator className="mainTabsBreadcrumbMenuSeparator" />
+				{loading ? (
+					<div className="mainTabsBreadcrumbMenuState">Loading...</div>
+				) : displayEntries.length ? (
+					<>
+						{displayEntries.map((entry) => (
+							<DropdownMenuItem
+								key={entry.rel_path || ROOT_PATH_KEY}
+								className="mainTabsBreadcrumbMenuItem"
+								onSelect={() => {
+									if (entry.kind === "dir") {
+										onNavigateDir(entry.rel_path);
+										return;
+									}
+									void onOpenFile(entry.rel_path);
+								}}
+							>
+								{entry.kind === "dir" ? (
+									<FolderOpen size={13} aria-hidden="true" />
+								) : entry.is_markdown ? (
+									<FileText size={13} aria-hidden="true" />
+								) : (
+									<File size={13} aria-hidden="true" />
+								)}
+								<span className="mainTabsBreadcrumbMenuItemLabel">
+									{entry.is_markdown
+										? entry.name.replace(/\.[^./]+$/, "")
+										: entry.name}
+								</span>
+							</DropdownMenuItem>
+						))}
+						{hiddenCount > 0 ? (
+							<div className="mainTabsBreadcrumbMenuState">
+								+{hiddenCount} more
+							</div>
+						) : null}
+					</>
+				) : (
+					<div className="mainTabsBreadcrumbMenuState">Empty folder</div>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -1,5 +1,4 @@
 import {
-	AiEditingIcon,
 	ArrowLeft,
 	ArrowRight,
 	Calendar03Icon,
@@ -26,6 +25,7 @@ import {
 	SearchIcon,
 	Settings01Icon,
 	SidebarLeftIcon,
+	SparklesIcon,
 	SquareLock02Icon,
 	TableIcon,
 } from "@hugeicons/core-free-icons";
@@ -209,7 +209,7 @@ function buildAiCommands({
 		{
 			id: "toggle-ai",
 			label: "Toggle AI",
-			icon: <HugeiconsIcon icon={AiEditingIcon} size={16} strokeWidth={0.9} />,
+			icon: <HugeiconsIcon icon={SparklesIcon} size={16} strokeWidth={0.9} />,
 			category: "AI",
 			shortcut: { meta: true, shift: true, key: "a" },
 			enabled: Boolean(spacePath),
@@ -218,7 +218,7 @@ function buildAiCommands({
 		{
 			id: "close-ai-pane",
 			label: "Close AI",
-			icon: <HugeiconsIcon icon={AiEditingIcon} size={16} strokeWidth={0.9} />,
+			icon: <HugeiconsIcon icon={SparklesIcon} size={16} strokeWidth={0.9} />,
 			category: "AI",
 			enabled: Boolean(spacePath),
 			action: handleCloseAiPaneFromMenu,
@@ -244,7 +244,7 @@ function buildAiCommands({
 		{
 			id: "open-ai-agent",
 			label: "Open AI Agent",
-			icon: <HugeiconsIcon icon={AiEditingIcon} size={16} strokeWidth={0.9} />,
+			icon: <HugeiconsIcon icon={SparklesIcon} size={16} strokeWidth={0.9} />,
 			category: "AI",
 			enabled: Boolean(spacePath),
 			action: () => openSpecialTab(AI_AGENT_TAB_ID),

--- a/src/components/editor/NoteFindBar.tsx
+++ b/src/components/editor/NoteFindBar.tsx
@@ -1,0 +1,80 @@
+import type { KeyboardEvent, RefObject } from "react";
+import { Search } from "../Icons";
+import { Input } from "../ui/shadcn/input";
+
+interface NoteFindBarProps {
+	countLabel: string;
+	inputRef: RefObject<HTMLInputElement | null>;
+	matchCount: number;
+	query: string;
+	onClose: () => void;
+	onInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+	onNext: () => void;
+	onPrevious: () => void;
+	onQueryChange: (query: string) => void;
+}
+
+export function NoteFindBar({
+	countLabel,
+	inputRef,
+	matchCount,
+	query,
+	onClose,
+	onInputKeyDown,
+	onNext,
+	onPrevious,
+	onQueryChange,
+}: NoteFindBarProps) {
+	return (
+		<div className="noteFindBar nodrag nopan nowheel">
+			<Search size={13} className="noteFindIcon" aria-hidden />
+			<Input
+				ref={inputRef}
+				className="noteFindInput"
+				value={query}
+				onChange={(event) => onQueryChange(event.target.value)}
+				onKeyDown={onInputKeyDown}
+				placeholder="Find in note"
+				aria-label="Find in note"
+			/>
+			<span className="noteFindCount" aria-live="polite">
+				{countLabel}
+			</span>
+			<button
+				type="button"
+				className="noteFindIconButton"
+				onClick={onPrevious}
+				disabled={!matchCount}
+				aria-label="Previous match"
+				title="Previous match"
+			>
+				<span className="noteFindButtonGlyph" aria-hidden>
+					↑
+				</span>
+			</button>
+			<button
+				type="button"
+				className="noteFindIconButton"
+				onClick={onNext}
+				disabled={!matchCount}
+				aria-label="Next match"
+				title="Next match"
+			>
+				<span className="noteFindButtonGlyph" aria-hidden>
+					↓
+				</span>
+			</button>
+			<button
+				type="button"
+				className="noteFindIconButton"
+				onClick={onClose}
+				aria-label="Close find"
+				title="Close find"
+			>
+				<span className="noteFindButtonGlyph" aria-hidden>
+					×
+				</span>
+			</button>
+		</div>
+	);
+}

--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -34,6 +34,7 @@ const {
 		commands: {
 			refreshMermaidPreviews: vi.fn(),
 			setActiveMermaidPreview: vi.fn(),
+			setNoteSearch: vi.fn(),
 			setRichMermaidPreviewHeight: vi.fn(),
 		},
 		off: vi.fn((event: string, callback: () => void) => {

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -30,6 +30,7 @@ import {
 import { Input } from "../ui/shadcn/input";
 import { ExtractToNoteDialog } from "./ExtractToNoteDialog";
 import { NoteEditorSurface } from "./NoteEditorSurface";
+import { NoteFindBar } from "./NoteFindBar";
 import { NotePropertiesPanel } from "./NotePropertiesPanel";
 import {
 	type SupportedCodeBlockLanguage,
@@ -43,6 +44,7 @@ import {
 } from "./hooks/editorDomUtils";
 import { useExtractSelectionToNote } from "./hooks/useExtractSelectionToNote";
 import { useNoteEditor } from "./hooks/useNoteEditor";
+import { useNoteFind } from "./hooks/useNoteFind";
 import { useResetScrollOnChange } from "./hooks/useResetScrollOnChange";
 import { useSelectionRibbon } from "./hooks/useSelectionRibbon";
 import { useTableInlineControls } from "./hooks/useTableInlineControls";
@@ -212,6 +214,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	const [activeMermaidPreviewHeight, setActiveMermaidPreviewHeight] =
 		useState(0);
 	const [linkDialog, setLinkDialog] = useState<LinkDialogState | null>(null);
+	const rawTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const previousRelPathRef = useRef(relPath);
 
 	useEffect(() => {
@@ -303,6 +306,14 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		editor,
 		hostRef: tiptapHostRef,
 		relPath,
+	});
+	const noteFind = useNoteFind({
+		editor,
+		markdown,
+		mode,
+		relPath,
+		rawTextareaRef,
+		tiptapHostRef,
 	});
 
 	useEffect(() => {
@@ -925,10 +936,25 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			]
 				.filter(Boolean)
 				.join(" ")}
+			onKeyDownCapture={noteFind.handleEditorKeyDownCapture}
 		>
 			<div className="rfNodeNoteEditorBody nodrag nopan nowheel">
+				{noteFind.findOpen ? (
+					<NoteFindBar
+						countLabel={noteFind.findCountLabel}
+						inputRef={noteFind.findInputRef}
+						matchCount={noteFind.findMatchCount}
+						query={noteFind.findQuery}
+						onClose={noteFind.closeFind}
+						onInputKeyDown={noteFind.handleFindInputKeyDown}
+						onNext={() => noteFind.moveFindMatch(1)}
+						onPrevious={() => noteFind.moveFindMatch(-1)}
+						onQueryChange={noteFind.updateFindQuery}
+					/>
+				) : null}
 				{mode === "plain" ? (
 					<textarea
+						ref={rawTextareaRef}
 						className="rfNodeNoteEditorRaw mono"
 						value={markdown}
 						onChange={(event) => onChange(event.target.value)}

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -21,6 +21,7 @@ import { HighlightedText } from "./highlightedText";
 import { MarkdownImage } from "./markdownImage";
 import { MarkdownLinkAutocomplete } from "./markdownLinkAutocomplete";
 import { MermaidPreview } from "./mermaidPreview";
+import { NoteSearch } from "./noteSearch";
 import { PersonAutocomplete } from "./personAutocomplete";
 import { TagDecorations } from "./tagDecorations";
 import { VimMode } from "./vimMode";
@@ -665,6 +666,7 @@ export function createEditorExtensions(
 		TaskDetailShortcut,
 		MarkdownLinkSyntaxCollapse,
 		MarkdownImageShortcut,
+		NoteSearch,
 		TableEnterNavigation,
 		Table.configure({ resizable: true }),
 		TableRow,

--- a/src/components/editor/extensions/noteSearch.ts
+++ b/src/components/editor/extensions/noteSearch.ts
@@ -1,0 +1,125 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+export interface NoteSearchRange {
+	from: number;
+	to: number;
+}
+
+interface NoteSearchState {
+	query: string;
+	activeIndex: number;
+}
+
+const noteSearchPluginKey = new PluginKey<NoteSearchState>("note-search");
+
+export function findPlainTextSearchRanges(
+	text: string,
+	query: string,
+	offset = 0,
+) {
+	const ranges: NoteSearchRange[] = [];
+	if (!query) return ranges;
+
+	const haystack = text.toLocaleLowerCase();
+	const needle = query.toLocaleLowerCase();
+	let startIndex = 0;
+
+	while (startIndex <= haystack.length - needle.length) {
+		const index = haystack.indexOf(needle, startIndex);
+		if (index === -1) break;
+		ranges.push({
+			from: offset + index,
+			to: offset + index + query.length,
+		});
+		startIndex = index + query.length;
+	}
+
+	return ranges;
+}
+
+export function findNoteSearchRanges(
+	doc: ProseMirrorNode,
+	query: string,
+): NoteSearchRange[] {
+	const ranges: NoteSearchRange[] = [];
+	if (!query) return ranges;
+
+	doc.descendants((node, pos) => {
+		if (!node.isText || !node.text) return;
+		ranges.push(...findPlainTextSearchRanges(node.text, query, pos));
+	});
+
+	return ranges;
+}
+
+function buildSearchDecorations(
+	doc: ProseMirrorNode,
+	{ activeIndex, query }: NoteSearchState,
+) {
+	const ranges = findNoteSearchRanges(doc, query);
+	if (!ranges.length) return DecorationSet.empty;
+
+	return DecorationSet.create(
+		doc,
+		ranges.map((range, index) =>
+			Decoration.inline(range.from, range.to, {
+				class:
+					index === activeIndex
+						? "noteSearchMatch noteSearchMatchActive"
+						: "noteSearchMatch",
+			}),
+		),
+	);
+}
+
+declare module "@tiptap/core" {
+	interface Commands<ReturnType> {
+		noteSearch: {
+			setNoteSearch: (state: NoteSearchState) => ReturnType;
+		};
+	}
+}
+
+export const NoteSearch = Extension.create({
+	name: "note-search",
+
+	addCommands() {
+		return {
+			setNoteSearch:
+				(state: NoteSearchState) =>
+				({ tr, dispatch }) => {
+					dispatch?.(tr.setMeta(noteSearchPluginKey, state));
+					return true;
+				},
+		};
+	},
+
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<NoteSearchState>({
+				key: noteSearchPluginKey,
+				state: {
+					init: () => ({ query: "", activeIndex: 0 }),
+					apply(tr, value) {
+						const next = tr.getMeta(noteSearchPluginKey);
+						return next &&
+							typeof next.query === "string" &&
+							typeof next.activeIndex === "number"
+							? next
+							: value;
+					},
+				},
+				props: {
+					decorations(state) {
+						const searchState = noteSearchPluginKey.getState(state);
+						if (!searchState?.query) return DecorationSet.empty;
+						return buildSearchDecorations(state.doc, searchState);
+					},
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -1,0 +1,324 @@
+import { TextSelection } from "@tiptap/pm/state";
+import type { Editor } from "@tiptap/react";
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import {
+	findNoteSearchRanges,
+	findPlainTextSearchRanges,
+} from "../extensions/noteSearch";
+import type { NoteInlineEditorMode } from "../types";
+
+const MAX_SELECTION_QUERY_LENGTH = 120;
+
+interface UseNoteFindOptions {
+	editor: Editor | null;
+	markdown: string;
+	mode: NoteInlineEditorMode;
+	relPath?: string;
+	rawTextareaRef: RefObject<HTMLTextAreaElement | null>;
+	tiptapHostRef: RefObject<HTMLDivElement | null>;
+}
+
+function isPrimaryFindShortcut(event: ReactKeyboardEvent | KeyboardEvent) {
+	return (
+		(event.metaKey || event.ctrlKey) &&
+		!event.altKey &&
+		!event.shiftKey &&
+		event.key.toLowerCase() === "f"
+	);
+}
+
+function selectedTextForQuery(text: string): string {
+	const normalized = text.replace(/\s+/g, " ").trim();
+	if (!normalized || normalized.length > MAX_SELECTION_QUERY_LENGTH) return "";
+	return normalized;
+}
+
+function centerElementInScrollHost(element: Element, scrollHost: HTMLElement) {
+	const elementRect = element.getBoundingClientRect();
+	const hostRect = scrollHost.getBoundingClientRect();
+	const elementCenter = elementRect.top + elementRect.height / 2;
+	const hostCenter = hostRect.top + hostRect.height / 2;
+	scrollHost.scrollTo({
+		top: scrollHost.scrollTop + elementCenter - hostCenter,
+		behavior: "smooth",
+	});
+}
+
+function centerEditorPosition(editor: Editor, pos: number) {
+	const scrollHost = editor.view.dom.closest(
+		".rfNodeNoteEditorBody",
+	) as HTMLElement | null;
+	if (!scrollHost) return;
+
+	try {
+		const coords = editor.view.coordsAtPos(pos);
+		const hostRect = scrollHost.getBoundingClientRect();
+		const matchCenter = coords.top + (coords.bottom - coords.top) / 2;
+		const hostCenter = hostRect.top + hostRect.height / 2;
+		scrollHost.scrollTo({
+			top: scrollHost.scrollTop + matchCenter - hostCenter,
+			behavior: "smooth",
+		});
+	} catch {
+		const activeMatch = scrollHost.querySelector(".noteSearchMatchActive");
+		if (activeMatch) centerElementInScrollHost(activeMatch, scrollHost);
+	}
+}
+
+function centerTextareaRange(textarea: HTMLTextAreaElement, index: number) {
+	const textBeforeMatch = textarea.value.slice(0, index);
+	const lineIndex = textBeforeMatch.split("\n").length - 1;
+	const computed = window.getComputedStyle(textarea);
+	const parsedLineHeight = Number.parseFloat(computed.lineHeight);
+	const fontSize = Number.parseFloat(computed.fontSize);
+	const lineHeight = Number.isFinite(parsedLineHeight)
+		? parsedLineHeight
+		: fontSize * 1.5;
+	const matchTop = lineIndex * lineHeight;
+	textarea.scrollTo({
+		top: Math.max(matchTop - textarea.clientHeight / 2 + lineHeight, 0),
+		behavior: "smooth",
+	});
+}
+
+export function useNoteFind({
+	editor,
+	markdown,
+	mode,
+	relPath,
+	rawTextareaRef,
+	tiptapHostRef,
+}: UseNoteFindOptions) {
+	const [findOpen, setFindOpen] = useState(false);
+	const [findQuery, setFindQuery] = useState("");
+	const [findActiveIndex, setFindActiveIndex] = useState(0);
+	const findInputRef = useRef<HTMLInputElement | null>(null);
+	const previousRelPathRef = useRef(relPath);
+
+	const findMatches = useMemo(() => {
+		if (!findQuery) return [];
+		if (mode === "plain") {
+			return findPlainTextSearchRanges(markdown, findQuery);
+		}
+		if (!editor) return [];
+		return findNoteSearchRanges(editor.state.doc, findQuery);
+	}, [editor, findQuery, markdown, mode]);
+	const effectiveFindActiveIndex = findMatches.length
+		? Math.min(findActiveIndex, findMatches.length - 1)
+		: 0;
+	const findCountLabel =
+		findQuery && findMatches.length
+			? `${effectiveFindActiveIndex + 1} / ${findMatches.length}`
+			: "0 / 0";
+
+	const selectRichFindMatch = useCallback(
+		(index: number) => {
+			if (!editor) return;
+			const match = findMatches[index];
+			if (!match) return;
+			try {
+				const selection = TextSelection.create(
+					editor.state.doc,
+					match.from,
+					match.to,
+				);
+				editor.view.dispatch(editor.state.tr.setSelection(selection));
+				centerEditorPosition(editor, match.from);
+			} catch {
+				const activeMatch = tiptapHostRef.current?.querySelector(
+					".noteSearchMatchActive",
+				);
+				const scrollHost = tiptapHostRef.current?.closest(
+					".rfNodeNoteEditorBody",
+				) as HTMLElement | null;
+				if (activeMatch && scrollHost) {
+					centerElementInScrollHost(activeMatch, scrollHost);
+				}
+			}
+		},
+		[editor, findMatches, tiptapHostRef],
+	);
+
+	const selectPlainFindMatch = useCallback(
+		(index: number) => {
+			const textarea = rawTextareaRef.current;
+			const match = findMatches[index];
+			if (!textarea || !match) return;
+			textarea.focus();
+			textarea.setSelectionRange(match.from, match.to);
+			centerTextareaRange(textarea, match.from);
+		},
+		[findMatches, rawTextareaRef],
+	);
+
+	const selectFindMatch = useCallback(
+		(index: number) => {
+			if (mode === "plain") {
+				selectPlainFindMatch(index);
+				return;
+			}
+			selectRichFindMatch(index);
+		},
+		[mode, selectPlainFindMatch, selectRichFindMatch],
+	);
+
+	const moveFindMatch = useCallback(
+		(direction: 1 | -1) => {
+			if (!findMatches.length) return;
+			const nextIndex =
+				(effectiveFindActiveIndex + direction + findMatches.length) %
+				findMatches.length;
+			setFindActiveIndex(nextIndex);
+			selectFindMatch(nextIndex);
+		},
+		[effectiveFindActiveIndex, findMatches.length, selectFindMatch],
+	);
+
+	const getSelectedSearchText = useCallback(() => {
+		if (mode === "plain") {
+			const textarea = rawTextareaRef.current;
+			if (!textarea || textarea.selectionStart === textarea.selectionEnd) {
+				return "";
+			}
+			return selectedTextForQuery(
+				textarea.value.slice(textarea.selectionStart, textarea.selectionEnd),
+			);
+		}
+		if (!editor || editor.state.selection.empty) return "";
+		const selected = editor.state.doc.textBetween(
+			editor.state.selection.from,
+			editor.state.selection.to,
+			" ",
+		);
+		return selectedTextForQuery(selected);
+	}, [editor, mode, rawTextareaRef]);
+
+	const openFind = useCallback(() => {
+		const selected = getSelectedSearchText();
+		if (selected) {
+			setFindQuery(selected);
+			setFindActiveIndex(0);
+		}
+		setFindOpen(true);
+	}, [getSelectedSearchText]);
+
+	const closeFind = useCallback(() => {
+		setFindOpen(false);
+		if (mode === "plain") {
+			requestAnimationFrame(() => rawTextareaRef.current?.focus());
+			return;
+		}
+		if (editor) {
+			requestAnimationFrame(() => editor.view.focus());
+		}
+	}, [editor, mode, rawTextareaRef]);
+
+	const handleFindInputKeyDown = useCallback(
+		(event: ReactKeyboardEvent<HTMLInputElement>) => {
+			if (isPrimaryFindShortcut(event)) {
+				event.preventDefault();
+				event.currentTarget.select();
+				return;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				closeFind();
+				return;
+			}
+			if (event.key === "Enter") {
+				event.preventDefault();
+				moveFindMatch(event.shiftKey ? -1 : 1);
+			}
+		},
+		[closeFind, moveFindMatch],
+	);
+
+	const handleEditorKeyDownCapture = useCallback(
+		(event: ReactKeyboardEvent<HTMLDivElement>) => {
+			if (!isPrimaryFindShortcut(event)) return;
+			const target = event.target instanceof Element ? event.target : null;
+			if (target?.closest(".noteFindBar")) return;
+			event.preventDefault();
+			openFind();
+		},
+		[openFind],
+	);
+
+	const updateFindQuery = useCallback((nextQuery: string) => {
+		setFindQuery(nextQuery);
+		setFindActiveIndex(0);
+	}, []);
+
+	useEffect(() => {
+		if (previousRelPathRef.current === relPath) return;
+		previousRelPathRef.current = relPath;
+		setFindOpen(false);
+		setFindQuery("");
+		setFindActiveIndex(0);
+	});
+
+	useEffect(() => {
+		if (!findOpen) return;
+		const frame = requestAnimationFrame(() => {
+			findInputRef.current?.focus();
+			findInputRef.current?.select();
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [findOpen]);
+
+	useEffect(() => {
+		if (!editor) return;
+		if (mode === "plain" || !findOpen) {
+			editor.commands.setNoteSearch({ query: "", activeIndex: 0 });
+			return;
+		}
+		editor.commands.setNoteSearch({
+			query: findQuery,
+			activeIndex: effectiveFindActiveIndex,
+		});
+	}, [editor, effectiveFindActiveIndex, findOpen, findQuery, mode]);
+
+	useEffect(() => {
+		if (!findOpen || !findQuery || !findMatches.length) return;
+		if (mode === "plain") return;
+		const frame = requestAnimationFrame(() => {
+			const scrollHost = tiptapHostRef.current?.closest(
+				".rfNodeNoteEditorBody",
+			) as HTMLElement | null;
+			const activeMatch = tiptapHostRef.current?.querySelector(
+				".noteSearchMatchActive",
+			);
+			if (activeMatch && scrollHost) {
+				centerElementInScrollHost(activeMatch, scrollHost);
+			}
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [findMatches.length, findOpen, findQuery, mode, tiptapHostRef]);
+
+	useEffect(() => {
+		if (!findMatches.length && findActiveIndex === 0) return;
+		if (findActiveIndex <= effectiveFindActiveIndex) return;
+		setFindActiveIndex(effectiveFindActiveIndex);
+	}, [effectiveFindActiveIndex, findActiveIndex, findMatches.length]);
+
+	return {
+		closeFind,
+		findCountLabel,
+		findInputRef,
+		findMatchCount: findMatches.length,
+		findOpen,
+		findQuery,
+		handleEditorKeyDownCapture,
+		handleFindInputKeyDown,
+		moveFindMatch,
+		updateFindQuery,
+	};
+}

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -101,7 +101,6 @@ export function useNoteFind({
 	const [findQuery, setFindQuery] = useState("");
 	const [findActiveIndex, setFindActiveIndex] = useState(0);
 	const findInputRef = useRef<HTMLInputElement | null>(null);
-	const previousRelPathRef = useRef(relPath);
 
 	const findMatches = useMemo(() => {
 		if (!findQuery) return [];
@@ -114,8 +113,9 @@ export function useNoteFind({
 	const effectiveFindActiveIndex = findMatches.length
 		? Math.min(findActiveIndex, findMatches.length - 1)
 		: 0;
-	const findCountLabel =
-		findQuery && findMatches.length
+	const findCountLabel = !findQuery
+		? ""
+		: findMatches.length
 			? `${effectiveFindActiveIndex + 1} / ${findMatches.length}`
 			: "0 / 0";
 
@@ -258,12 +258,11 @@ export function useNoteFind({
 	}, []);
 
 	useEffect(() => {
-		if (previousRelPathRef.current === relPath) return;
-		previousRelPathRef.current = relPath;
+		void relPath;
 		setFindOpen(false);
 		setFindQuery("");
 		setFindActiveIndex(0);
-	});
+	}, [relPath]);
 
 	useEffect(() => {
 		if (!findOpen) return;

--- a/src/components/preview/MarkdownEditorPane.test.tsx
+++ b/src/components/preview/MarkdownEditorPane.test.tsx
@@ -26,7 +26,11 @@ const {
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("../../contexts", () => ({
-	useAISidebarContext: () => ({ aiEnabled: false, aiPanelOpen: false }),
+	useAISidebarContext: () => ({
+		aiEnabled: false,
+		aiPanelOpen: false,
+		setAiPanelOpen: vi.fn(),
+	}),
 	useEditorRegistration: () => {},
 	useSpace: () => ({ spacePath: "/spaces/test" }),
 	useUILayoutContext: () => ({

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -636,7 +636,11 @@ export function MarkdownEditorPane({
 		const handleToggleInfoSidebar = (event: Event) => {
 			const detail = (event as CustomEvent<ToggleNoteInfoSidebarDetail>).detail;
 			if (!detail?.path || detail.path !== relPath) return;
-			setInfoPanelOpen((open) => !open);
+			setInfoPanelOpen((open) => {
+				const nextOpen = !open;
+				if (nextOpen) setAiPanelOpen(false);
+				return nextOpen;
+			});
 		};
 		window.addEventListener(FORCE_NOTE_EDIT_MODE_EVENT, handleForceEditMode);
 		window.addEventListener(OPEN_LOCAL_GRAPH_EVENT, handleOpenLocalGraph);
@@ -655,7 +659,11 @@ export function MarkdownEditorPane({
 				handleToggleInfoSidebar,
 			);
 		};
-	}, [relPath]);
+	}, [relPath, setAiPanelOpen]);
+
+	useEffect(() => {
+		if (aiPanelOpen) setInfoPanelOpen(false);
+	}, [aiPanelOpen]);
 
 	const captureZenViewportAnchor = useCallback(() => {
 		const scrollEl = contentScrollRef.current;
@@ -873,7 +881,11 @@ export function MarkdownEditorPane({
 								openSettings("ai");
 								return;
 							}
-							setAiPanelOpen((open) => !open);
+							setAiPanelOpen((open) => {
+								const nextOpen = !open;
+								if (nextOpen) setInfoPanelOpen(false);
+								return nextOpen;
+							});
 						}}
 						aria-label={
 							aiEnabled
@@ -945,7 +957,11 @@ export function MarkdownEditorPane({
 										className="markdownEditorActionItem"
 										data-active={infoPanelOpen}
 										onClick={() => {
-											setInfoPanelOpen((open) => !open);
+											setInfoPanelOpen((open) => {
+												const nextOpen = !open;
+												if (nextOpen) setAiPanelOpen(false);
+												return nextOpen;
+											});
 											setActionsOpen(false);
 										}}
 									>

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1,9 +1,9 @@
 import {
-	AiEditingIcon,
 	FlowConnectionIcon,
 	InformationCircleIcon,
 	SlidersHorizontalIcon,
 	SourceCodeIcon,
+	SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/react";
@@ -903,7 +903,7 @@ export function MarkdownEditorPane({
 						}
 						aria-pressed={aiEnabled ? aiPanelOpen : undefined}
 					>
-						<HugeiconsIcon icon={AiEditingIcon} size={15} strokeWidth={0.9} />
+						<HugeiconsIcon icon={SparklesIcon} size={15} strokeWidth={0.9} />
 					</button>
 					<div className="markdownEditorActionsMenu">
 						<button

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -1,10 +1,10 @@
 import {
-	AiEditingIcon,
 	Archive02Icon,
 	CommandIcon,
 	ConstructionIcon,
 	GitBranchIcon,
 	Settings01Icon,
+	SparklesIcon,
 	Sun03Icon,
 	ToolsIcon,
 } from "@hugeicons/core-free-icons";
@@ -62,7 +62,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		id: "ai",
 		label: "Glyph AI",
 		renderIcon: () => (
-			<HugeiconsIcon icon={AiEditingIcon} size={14} strokeWidth={0.9} />
+			<HugeiconsIcon icon={SparklesIcon} size={14} strokeWidth={0.9} />
 		),
 	},
 	{

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -395,13 +395,7 @@ describe("shortcut settings", () => {
 			shift: false,
 			key: "k",
 		});
-		expect(effective["open-search-palette"]).toEqual({
-			meta: true,
-			ctrl: false,
-			alt: false,
-			shift: false,
-			key: "f",
-		});
+		expect(effective["open-search-palette"]).toBeNull();
 	});
 
 	it("resets all shortcut overrides back to defaults", async () => {

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -930,10 +930,7 @@
 			"description": "Open search in the command palette.",
 			"category": "search",
 			"context": "global",
-			"defaultBinding": {
-				"meta": true,
-				"key": "f"
-			},
+			"defaultBinding": null,
 			"allowInEditable": false,
 			"commandPalette": false
 		},

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -3,7 +3,7 @@
    ───────────────────────────────────────────────────────────────────────────── */
 .appShell {
 	--app-frame-inline: var(--space-1);
-	--app-frame-block: 0px;
+	--app-frame-block: 4px;
 	--app-radius: var(--radius-15);
 	--window-control-toggle-offset: 90px;
 	isolation: isolate;
@@ -20,6 +20,10 @@
 	box-shadow: inset 1px 0 0 0
 		color-mix(in srgb, var(--text-inverse) 22%, transparent);
 	overflow: hidden;
+}
+
+.appShell:not(:has(.notesInfoSidebarHost:not(:empty))) {
+	padding-right: var(--app-frame-inline);
 }
 
 /* Native macOS vibrancy is applied via window-vibrancy crate in Rust.

--- a/src/styles/app/07-ai-panel.css
+++ b/src/styles/app/07-ai-panel.css
@@ -1,26 +1,30 @@
 /* AI FLOATING WINDOW */
 
 .aiFloatingWindowHost {
-	position: absolute;
-	inset: 0;
-	z-index: 24;
-	pointer-events: none;
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	pointer-events: auto;
 }
 
 .aiFloatingWindow {
-	position: absolute;
-	right: 20px;
-	bottom: 20px;
-	max-width: calc(100% - 32px);
-	max-height: calc(100% - 32px);
-	border-radius: calc(var(--radius-xl) + 2px);
-	border: 1px solid color-mix(in srgb, var(--border-light) 62%, transparent);
-	background: color-mix(in srgb, var(--bg-primary) 70%, transparent);
-	backdrop-filter: blur(var(--glass-blur));
-	-webkit-backdrop-filter: blur(var(--glass-blur));
-	box-shadow: 0 18px 36px
-		color-mix(in srgb, var(--shadow-color, #000) 18%, transparent), 0 6px 16px
-		color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+	min-height: 0;
+	border-radius: var(--right-sidebar-island-radius, var(--radius-xl));
+	border: 1px solid
+		var(
+			--right-sidebar-island-border,
+			color-mix(in srgb, var(--border-light) 88%, transparent)
+		);
+	background: var(--right-sidebar-island-bg, var(--bg-primary));
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+	box-shadow: none;
 	overflow: hidden;
 	pointer-events: auto;
 }
@@ -31,78 +35,6 @@
 	height: 100%;
 	min-height: 0;
 	background: transparent;
-}
-
-.aiFloatingResizeHandle {
-	position: absolute;
-	z-index: 5;
-	user-select: none;
-	-webkit-user-select: none;
-	touch-action: none;
-}
-
-.aiFloatingResizeHandle-top {
-	top: -4px;
-	left: 12px;
-	right: 12px;
-	height: 8px;
-	cursor: ns-resize;
-}
-
-.aiFloatingResizeHandle-right {
-	top: 12px;
-	right: -4px;
-	bottom: 12px;
-	width: 8px;
-	cursor: ew-resize;
-}
-
-.aiFloatingResizeHandle-bottom {
-	right: 12px;
-	bottom: -4px;
-	left: 12px;
-	height: 8px;
-	cursor: ns-resize;
-}
-
-.aiFloatingResizeHandle-left {
-	top: 12px;
-	bottom: 12px;
-	left: -4px;
-	width: 8px;
-	cursor: ew-resize;
-}
-
-.aiFloatingResizeHandle-top-left {
-	top: -4px;
-	left: -4px;
-	width: 12px;
-	height: 12px;
-	cursor: nwse-resize;
-}
-
-.aiFloatingResizeHandle-top-right {
-	top: -4px;
-	right: -4px;
-	width: 12px;
-	height: 12px;
-	cursor: nesw-resize;
-}
-
-.aiFloatingResizeHandle-bottom-left {
-	bottom: -4px;
-	left: -4px;
-	width: 12px;
-	height: 12px;
-	cursor: nesw-resize;
-}
-
-.aiFloatingResizeHandle-bottom-right {
-	right: -4px;
-	bottom: -4px;
-	width: 12px;
-	height: 12px;
-	cursor: nwse-resize;
 }
 
 :root[data-translucent-ai-panel="false"] .aiFloatingWindow {

--- a/src/styles/app/07-ai-panel.css
+++ b/src/styles/app/07-ai-panel.css
@@ -43,6 +43,14 @@
 	-webkit-backdrop-filter: none;
 }
 
+:root[data-translucent-sidebar="false"]
+	.notesInfoSidebarHost
+	.aiFloatingWindow {
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+}
+
 .aiPanel {
 	display: flex;
 	flex-direction: column;

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -1,3 +1,13 @@
+.appShell {
+	--right-sidebar-island-bg: var(--bg-primary);
+	--right-sidebar-island-border: color-mix(
+		in srgb,
+		var(--border-light) 88%,
+		transparent
+	);
+	--right-sidebar-island-radius: var(--radius-xl);
+}
+
 .canvasWrapper {
 	flex: 1;
 	position: relative;
@@ -21,7 +31,7 @@
 	transition: border-radius 180ms ease;
 }
 
-.canvasWrapper:has(.notesInfoSidebarHost:not(:empty)) .canvasPaneHost {
+.appShell:has(.notesInfoSidebarHost:not(:empty)) .canvasPaneHost {
 	border-top-right-radius: calc(
 		var(--app-radius) -
 		var(--app-frame-inline) +
@@ -44,8 +54,10 @@
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 	border-left: 0 solid transparent;
-	transition: width 180ms ease, flex-basis 180ms ease, border-color 180ms ease,
-		background-color 180ms ease;
+	box-sizing: border-box;
+	transition:
+		width 180ms ease, flex-basis 180ms ease, padding 180ms ease,
+		border-color 180ms ease, background-color 180ms ease;
 }
 
 .notesInfoSidebarResizeHandle {
@@ -66,7 +78,7 @@
 	margin-right: -4px;
 }
 
-.canvasWrapper:not(:has(.notesInfoSidebarHost:not(:empty)))
+.appShell:not(:has(.notesInfoSidebarHost:not(:empty)))
 	.notesInfoSidebarResizeHandle {
 	width: 0;
 	margin-left: 0;
@@ -95,6 +107,7 @@
 .notesInfoSidebarHost:not(:empty) {
 	flex-basis: var(--markdown-info-sidebar-width, 340px);
 	width: var(--markdown-info-sidebar-width, 340px);
+	padding: 4px 4px 4px 0;
 	background: transparent;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
@@ -107,4 +120,8 @@
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 	border-left-color: var(--border-light);
+}
+
+.notesInfoSidebarHost:has(.notesInfoSidebarPanel) .aiFloatingWindowHost {
+	display: none;
 }

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -116,6 +116,7 @@
 }
 
 :root[data-translucent-sidebar="false"] .notesInfoSidebarHost:not(:empty) {
+	padding: 0;
 	background: var(--bg-sidebar);
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -67,30 +67,35 @@
 	align-items: center;
 	justify-content: safe center;
 	gap: 0;
-	min-height: 0;
-	max-height: 0;
-	padding: 0 calc(var(--space-3) + var(--main-tabs-right-reserve, 78px));
+	width: fit-content;
+	max-width: calc(
+		100% -
+		var(--main-tabs-right-reserve, 78px) -
+		var(--main-tabs-right-reserve, 78px)
+	);
+	min-height: 8px;
+	max-height: 8px;
+	margin: 0 auto;
+	padding: 0 8px;
 	font-size: var(--text-xs);
 	color: var(--text-tertiary);
 	overflow: hidden;
 	opacity: 0;
-	pointer-events: none;
+	pointer-events: auto;
 	scrollbar-width: none;
 	transition: max-height 140ms ease, min-height 140ms ease, opacity 140ms ease,
 		padding 140ms ease;
 }
 
-.mainTabsBarWrap:hover .mainTabsBreadcrumb,
-.mainTabsBarWrap:focus-within .mainTabsBreadcrumb,
-.mainTabsBarWrap:has(.mainTabsBreadcrumbSepButton[data-state="open"])
-	.mainTabsBreadcrumb {
+.mainTabsBreadcrumb:hover,
+.mainTabsBreadcrumb:focus-within,
+.mainTabsBreadcrumb:has(.mainTabsBreadcrumbSepButton[data-state="open"]) {
 	min-height: 32px;
 	max-height: 32px;
-	padding-bottom: 6px;
+	padding: 0 8px 6px;
 	overflow-x: auto;
 	overflow-y: hidden;
 	opacity: 1;
-	pointer-events: auto;
 }
 
 .mainTabsBreadcrumb::-webkit-scrollbar {
@@ -145,7 +150,7 @@
 .mainTabsBreadcrumbSepButton:hover .mainTabsBreadcrumbSep,
 .mainTabsBreadcrumbSepButton:focus-visible .mainTabsBreadcrumbSep,
 .mainTabsBreadcrumbSepButton[data-state="open"] .mainTabsBreadcrumbSep {
-	color: currentColor;
+	color: currentcolor;
 	opacity: 1;
 	transform: translateX(1px);
 }
@@ -198,7 +203,7 @@
 	width: 12px;
 	height: 12px;
 	flex-shrink: 0;
-	color: currentColor;
+	color: currentcolor;
 	opacity: 0.82;
 }
 

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -1,5 +1,6 @@
 .mainTabsBarWrap {
 	flex-shrink: 0;
+	background: var(--bg-primary);
 }
 
 .mainTabsBar {
@@ -64,46 +65,210 @@
 .mainTabsBreadcrumb {
 	display: flex;
 	align-items: center;
-	justify-content: center;
-	gap: 2px;
-	padding: 4px var(--space-3);
+	justify-content: safe center;
+	gap: 0;
+	min-height: 0;
+	max-height: 0;
+	padding: 0 calc(var(--space-3) + var(--main-tabs-right-reserve, 78px));
 	font-size: var(--text-xs);
 	color: var(--text-tertiary);
 	overflow: hidden;
-	max-height: 0;
 	opacity: 0;
-	transition: max-height 140ms ease, opacity 140ms ease, padding 140ms ease;
-	padding-top: 0;
-	padding-bottom: 0;
+	pointer-events: none;
+	scrollbar-width: none;
+	transition: max-height 140ms ease, min-height 140ms ease, opacity 140ms ease,
+		padding 140ms ease;
 }
 
-.mainTabsBreadcrumb.is-visible {
-	max-height: 24px;
+.mainTabsBarWrap:hover .mainTabsBreadcrumb,
+.mainTabsBarWrap:focus-within .mainTabsBreadcrumb,
+.mainTabsBarWrap:has(.mainTabsBreadcrumbSepButton[data-state="open"])
+	.mainTabsBreadcrumb {
+	min-height: 32px;
+	max-height: 32px;
+	padding-bottom: 6px;
+	overflow-x: auto;
+	overflow-y: hidden;
 	opacity: 1;
-	padding-top: 4px;
-	padding-bottom: 4px;
+	pointer-events: auto;
+}
+
+.mainTabsBreadcrumb::-webkit-scrollbar {
+	display: none;
 }
 
 .mainTabsBreadcrumbItem {
 	display: inline-flex;
 	align-items: center;
-	gap: 2px;
-	white-space: nowrap;
+	gap: 4px;
+	min-width: 0;
+	flex-shrink: 0;
 }
 
 .mainTabsBreadcrumbSep {
-	color: var(--text-tertiary);
-	opacity: 0.4;
-	margin: 0 2px;
+	width: 10px;
+	height: 10px;
+	color: var(--text-quaternary);
+	opacity: 0.74;
+	flex-shrink: 0;
+	margin: 0;
+	transition: color var(--transition-fast), transform var(--transition-fast),
+		opacity var(--transition-fast);
 }
 
-.mainTabsBreadcrumbSegment {
-	color: var(--text-tertiary);
+.mainTabsBreadcrumbSepButton {
+	width: 20px;
+	height: 22px;
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-quaternary);
+	cursor: pointer;
+	transition: background var(--transition-fast), border-color
+		var(--transition-fast), color var(--transition-fast);
 }
 
-.mainTabsBreadcrumbCurrent {
-	color: var(--text-secondary);
+.mainTabsBreadcrumbSepButton:hover,
+.mainTabsBreadcrumbSepButton:focus-visible,
+.mainTabsBreadcrumbSepButton[data-state="open"] {
+	background: transparent;
+	border-color: transparent;
+	color: var(--text-primary);
+	outline: none;
+}
+
+.mainTabsBreadcrumbSepButton:hover .mainTabsBreadcrumbSep,
+.mainTabsBreadcrumbSepButton:focus-visible .mainTabsBreadcrumbSep,
+.mainTabsBreadcrumbSepButton[data-state="open"] .mainTabsBreadcrumbSep {
+	color: currentColor;
+	opacity: 1;
+	transform: translateX(1px);
+}
+
+.mainTabsBreadcrumbButton {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: min(28vw, 220px);
+	height: 24px;
+	min-width: 0;
+	padding: 0 7px;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-tertiary);
+	font-size: 11px;
 	font-weight: var(--font-medium);
+	line-height: 1;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: background var(--transition-fast), border-color
+		var(--transition-fast), color var(--transition-fast), box-shadow
+		var(--transition-fast);
+}
+
+.mainTabsBreadcrumbButton:hover:not(:disabled),
+.mainTabsBreadcrumbButton:focus-visible {
+	background: transparent;
+	border-color: transparent;
+	color: var(--text-primary);
+	box-shadow: none;
+}
+
+.mainTabsBreadcrumbButton:focus-visible {
+	outline: none;
+}
+
+.mainTabsBreadcrumbButton[aria-current="page"] {
+	color: var(--text-primary);
+	cursor: default;
+}
+
+.mainTabsBreadcrumbButton:disabled {
+	opacity: 1;
+}
+
+.mainTabsBreadcrumbIcon {
+	width: 12px;
+	height: 12px;
+	flex-shrink: 0;
+	color: currentColor;
+	opacity: 0.82;
+}
+
+.mainTabsBreadcrumbLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.mainTabsBreadcrumbMenu {
+	width: min(280px, calc(100vw - 28px));
+	max-height: min(340px, var(--radix-dropdown-menu-content-available-height));
+	padding: 6px;
+	border-color: color-mix(in srgb, var(--border-light) 68%, transparent);
+	border-radius: var(--radius-lg);
+	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+	box-shadow: 0 12px 32px
+		color-mix(in srgb, var(--shadow-color, #000) 16%, transparent);
+}
+
+.mainTabsBreadcrumbMenuLabel {
+	padding: 6px 7px 5px;
+	color: var(--text-tertiary);
+	font-size: 10px;
+	font-weight: var(--font-semibold);
+	line-height: 1;
+	letter-spacing: 0;
+	text-transform: uppercase;
+}
+
+.mainTabsBreadcrumbMenuSeparator {
+	margin: 3px 0 5px;
+	background: color-mix(in srgb, var(--border-light) 54%, transparent);
+}
+
+.mainTabsBreadcrumbMenuItem {
+	min-height: 30px;
+	padding: 0 8px;
+	border-radius: var(--radius-md);
+	color: var(--text-secondary);
+	font-size: 12px;
+	font-weight: var(--font-medium);
+	cursor: pointer;
+}
+
+.mainTabsBreadcrumbMenuItem:focus,
+.mainTabsBreadcrumbMenuItem[data-highlighted] {
+	background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+	color: var(--text-primary);
+}
+
+.mainTabsBreadcrumbMenuItem svg {
+	width: 13px;
+	height: 13px;
+	color: var(--text-tertiary);
+}
+
+.mainTabsBreadcrumbMenuItemLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.mainTabsBreadcrumbMenuState {
+	padding: 8px;
+	color: var(--text-tertiary);
+	font-size: 12px;
+	line-height: 1.3;
 }
 
 .mainTabsStrip {
@@ -274,7 +439,10 @@
 	.mainTab,
 	.mainTab::before,
 	.mainTabClose,
-	.mainTabAdd {
+	.mainTabAdd,
+	.mainTabsBreadcrumbSep,
+	.mainTabsBreadcrumbSepButton,
+	.mainTabsBreadcrumbButton {
 		transition: none;
 		transform: none;
 	}

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -224,6 +224,85 @@
 	background: var(--bg-primary);
 }
 
+.noteFindBar {
+	position: sticky;
+	top: 8px;
+	z-index: 24;
+	width: min(430px, calc(100% - 20px));
+	margin: 8px auto 0;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 6px 5px 9px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 82%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-secondary));
+	box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+}
+
+.noteFindIcon {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+}
+
+.noteFindInput {
+	min-width: 0;
+	height: 26px;
+	flex: 1 1 auto;
+	border: 0;
+	padding: 0 2px;
+	background: transparent;
+	box-shadow: none;
+	font-size: 12px;
+}
+
+.noteFindInput:focus-visible {
+	box-shadow: none;
+}
+
+.noteFindCount {
+	min-width: 48px;
+	flex: 0 0 auto;
+	text-align: right;
+	font-size: 11px;
+	font-variant-numeric: tabular-nums;
+	color: var(--text-tertiary);
+}
+
+.noteFindIconButton {
+	width: 24px;
+	height: 24px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-secondary);
+	cursor: pointer;
+	transition: background-color 120ms ease, color 120ms ease;
+}
+
+.noteFindButtonGlyph {
+	display: block;
+	font-size: 14px;
+	line-height: 1;
+	font-weight: var(--font-medium);
+}
+
+.noteFindIconButton:hover:not(:disabled),
+.noteFindIconButton:focus-visible {
+	background: transparent;
+	color: var(--text-primary);
+	outline: none;
+}
+
+.noteFindIconButton:disabled {
+	opacity: 0.5;
+	cursor: default;
+}
+
 .rfNodeNoteEditorLoading {
 	flex: 1;
 	min-height: 0;

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -174,6 +174,19 @@
 	);
 }
 
+.noteSearchMatch {
+	border-radius: 3px;
+	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+}
+
+.noteSearchMatchActive {
+	background: color-mix(in srgb, var(--interactive-accent) 34%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 46%, transparent);
+}
+
 .tiptapContentInline h1,
 .tiptapContentInline h2,
 .tiptapContentInline h3,

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -458,7 +458,17 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	background: transparent;
+	overflow: hidden;
+	border: 1px solid
+		var(
+			--right-sidebar-island-border,
+			color-mix(in srgb, var(--border-light) 88%, transparent)
+		);
+	border-radius: var(--right-sidebar-island-radius, var(--radius-xl));
+	background: var(--right-sidebar-island-bg, var(--bg-primary));
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+	box-shadow: none;
 }
 
 .markdownEditorInfoHeader {
@@ -477,7 +487,13 @@
 }
 
 :root[data-translucent-sidebar="false"] .markdownEditorInfoHeader {
-	background: var(--bg-sidebar);
+	background: var(--bg-primary);
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+}
+
+:root[data-translucent-sidebar="false"] .notesInfoSidebarPanel {
+	background: var(--bg-primary);
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 }

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -487,13 +487,15 @@
 }
 
 :root[data-translucent-sidebar="false"] .markdownEditorInfoHeader {
-	background: var(--bg-primary);
+	background: transparent;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 }
 
 :root[data-translucent-sidebar="false"] .notesInfoSidebarPanel {
-	background: var(--bg-primary);
+	border: 0;
+	border-radius: 0;
+	background: transparent;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 }


### PR DESCRIPTION
## What changed

This PR bundles the `0.2.21/improvements` UI work into one reviewable branch. It focuses on making note navigation feel faster, moving the AI panel into the right sidebar model, and adding an editor-local find flow that no longer conflicts with the global command palette search shortcut.

### In-note find

- Adds a `Cmd/Ctrl + F` find bar inside `NoteInlineEditor` for both rich TipTap editing and plain markdown editing.
- Adds a TipTap `NoteSearch` extension that decorates rich-editor matches and tracks the active match separately from the editor content.
- Adds `useNoteFind` to manage opening, closing, keyboard handling, selected-text prefill, match counts, next/previous navigation, active-match scrolling, and reset-on-note-change behavior.
- Updates the global `open-search-palette` command so it no longer claims `Cmd + F`, letting the focused note editor own native find behavior.

### Tab bar and breadcrumbs

- Reworks the tab bar breadcrumb path from passive hover text into an interactive breadcrumb nav.
- Adds breadcrumb folder/file icons, current-file labeling, and Radix dropdown menus for browsing sibling files/folders directly from each breadcrumb separator.
- Wires breadcrumb folder navigation back into the sidebar state so selecting a folder expands and loads the relevant file tree ancestors.
- Preserves existing tab drag/reorder, close, rename, prefetch, and back/forward behavior while passing the file tree entries needed for breadcrumb browsing.

### AI and right sidebar layout

- Moves the AI panel out of the canvas overlay and into the right sidebar surface used by note info panels.
- Removes the floating AI panel resize handles and fixed overlay sizing now that the panel lives in the sidebar region.
- Keeps AI and note info sidebar mutually exclusive in the markdown editor so opening one closes the other.
- Updates AI entry points and settings to use the Sparkles icon for a lighter visual treatment.

### UI polish and defaults

- Makes the tags section collapsed by default.
- Adds right-sidebar island styling, canvas border-radius adjustments, breadcrumb menu styling, and note find match styling.
- Tweaks markdown editor tests/settings expectations around the `Cmd + F` shortcut change.

## Why

The previous `Cmd + F` binding opened the global command/search palette even when users were actively editing a note. That made a common writing workflow feel surprising. This branch gives notes their own focused find experience while keeping command search available through its other command paths.

The AI panel also behaved like a floating canvas overlay with its own resize model. Moving it into the same right sidebar surface as note info makes panel behavior more predictable and keeps the editor canvas cleaner.

Breadcrumbs were already visible as path context, but they were not very actionable. Turning them into lightweight navigation gives users a faster way to jump across nearby files without returning to the sidebar first.

## User impact

- Users can search within the current note with `Cmd/Ctrl + F`, navigate matches with Enter/Shift+Enter or the find controls, and close the find UI with Escape.
- Users can browse the current file's surrounding folder hierarchy from the tab bar breadcrumbs.
- The AI panel opens as a sidebar-style panel instead of a floating resizable overlay.
- Tags start collapsed, reducing visual noise in that pane.

## Developer impact

- Note find behavior is isolated in `useNoteFind` and the `NoteSearch` TipTap extension instead of being mixed into the editor component.
- Breadcrumb browsing uses existing file tree state and loader APIs rather than adding a second filesystem pathway.
- The right sidebar host now owns both note info and AI surfaces, simplifying the canvas overlay model.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

All validation passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Find in notes: search and navigate text matches within documents with visual highlighting
  * Breadcrumb navigation with folder/file menus for quick directory traversal

* **UI Changes**
  * AI panel icon updated and repositioned within sidebar
  * Tags section now collapsed by default
  * App shell and sidebar styling refinements

* **Bug Fixes**
  * AI panel closes info sidebar when opened
  * Search palette default keyboard binding removed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->