### PR TITLE
[codex] Improve Folio file previews and welcome onboarding

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1491,6 +1491,7 @@ pub fn run() {
             space::commands::space_create,
             space::commands::space_open,
             space::commands::space_get_current,
+            space::commands::space_show_onboarding_note,
             space::commands::space_close,
             web_clip::web_clip_save
         ])

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1462,6 +1462,7 @@ pub fn run() {
             index::commands::note_local_graph,
             space_fs::list::space_list_dir,
             space_fs::list::space_list_markdown_files,
+            space_fs::list::space_list_non_markdown_files,
             space_fs::link_ops::space_resolve_wikilink,
             space_fs::link_ops::space_resolve_image_wikilink,
             space_fs::link_ops::space_resolve_markdown_link,

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,7 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::State;
 
-use crate::index::{self, db::reset_schema_cache};
+use crate::{
+    index::{self, db::reset_schema_cache},
+    paths,
+};
 
 use super::helpers::{
     canonicalize_dir, create_or_open_impl, ensure_onboarding_note_for_command, SpaceInfo,
@@ -73,7 +76,7 @@ pub async fn space_show_onboarding_note(state: State<'_, SpaceState>) -> Result<
     let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let note_path = ensure_onboarding_note_for_command(&root)?;
-        let abs = root.join(&note_path);
+        let abs = paths::join_under(&root, Path::new(&note_path))?;
         if let Ok(markdown) = std::fs::read_to_string(&abs) {
             let _ = index::index_note(&root, &note_path, &markdown);
         }

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 use tauri::State;
 
-use crate::index::db::reset_schema_cache;
+use crate::index::{self, db::reset_schema_cache};
 
-use super::helpers::{canonicalize_dir, create_or_open_impl, SpaceInfo};
+use super::helpers::{
+    canonicalize_dir, create_or_open_impl, ensure_onboarding_note_for_command, SpaceInfo,
+};
 use super::state::SpaceState;
 use super::watcher::set_notes_watcher;
 
@@ -64,6 +66,21 @@ pub async fn space_open(
 pub fn space_get_current(state: State<'_, SpaceState>) -> Option<String> {
     let guard = state.current.lock().ok()?;
     guard.as_ref().map(|p| p.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn space_show_onboarding_note(state: State<'_, SpaceState>) -> Result<String, String> {
+    let root = state.current_root()?;
+    tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
+        let note_path = ensure_onboarding_note_for_command(&root)?;
+        let abs = root.join(&note_path);
+        if let Ok(markdown) = std::fs::read_to_string(&abs) {
+            let _ = index::index_note(&root, &note_path, &markdown);
+        }
+        Ok(note_path)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/space/helpers.rs
+++ b/src-tauri/src/space/helpers.rs
@@ -1,15 +1,77 @@
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
-use crate::glyph_paths;
+use crate::{glyph_paths, io_atomic, paths};
 
 #[derive(Serialize)]
 pub struct SpaceInfo {
     pub root: String,
     pub schema_version: u32,
+    pub onboarding_note_path: Option<String>,
 }
 
 pub const VAULT_SCHEMA_VERSION: u32 = 1;
+const ONBOARDING_NOTE_PATH: &str = "Welcome to Glyph.md";
+const ONBOARDING_MARKER_NAME: &str = "onboarding-note-v2.json";
+const ONBOARDING_NOTE_CONTENT: &str = r#"# Welcome to Glyph
+
+Is Glyph the first notes app you have ever opened? Almost certainly not. Is it going to claim that writing things down was invented five minutes ago? Also no.
+
+Glyph is a local-first desktop space for notes, tasks, collections, previews, and AI-assisted thinking. The important part is boring in the best way: your notes are plain Markdown files in the folder you chose. Use the same notes in Obsidian, VS Code, Typora, iA Writer, Logseq, or any app that understands Markdown.
+
+This note is fully editable. Try things here, make a mess, or delete it when it has done its job.
+
+## Learn `Cmd+K` first
+
+If you remember one shortcut, make it `Cmd+K`. It opens the command palette, where you can create notes, jump to views, open settings, run editor actions, and find features without hunting through the UI.
+
+## Write notes
+
+- Create a note with `Cmd+N`.
+- Create folders from the sidebar.
+- Type `/` for headings, lists, tasks, callouts, tables, and code blocks.
+- Type `[[` to link another note.
+- Add `#tags` anywhere in your text.
+
+## Find your way around
+
+- Use `Cmd+P` to open files by name.
+- Pin notes you open often.
+- Open All Notes to scan everything in the space.
+- Use the local graph to see links around the current note.
+
+## Plan your day
+
+- Open today's note with `Cmd+Shift+D`.
+- Use Calendar to move between daily notes.
+- Add tasks with checkboxes and finish them from the task views.
+
+## Add structure
+
+- Open Collections for notes that work better as a table or board.
+- Use properties to track status, dates, owners, or tags.
+- Switch views when you want a different angle on the same notes.
+
+## Use AI with context
+
+- Open the AI panel with `Cmd+Shift+A`.
+- Attach the current note, all open notes, or selected files.
+- Pick the provider/account you want from AI settings.
+
+## Try this first
+
+- [ ] Create a new note
+- [ ] Create a folder
+- [ ] Link two notes with `[[`
+- [ ] Add a `#tag`
+- [ ] Pin a note
+- [ ] Open today's daily note
+- [ ] Create a Collection
+- [ ] Run a command with `Cmd+K`
+- [ ] Open Settings with `Cmd+,`
+- [ ] Delete this note
+- [x] Start writing
+"#;
 
 pub fn ensure_glyph_dirs(root: &Path) -> Result<(), String> {
     let _ = glyph_paths::ensure_glyph_dir(root)?;
@@ -29,10 +91,56 @@ pub fn canonicalize_dir(path: &Path) -> Result<PathBuf, String> {
 pub fn create_or_open_impl(root: &Path) -> Result<SpaceInfo, String> {
     ensure_glyph_dirs(root)?;
     let _ = cleanup_tmp_files(root);
+    let onboarding_note_path = ensure_onboarding_note_for_launch(root);
     Ok(SpaceInfo {
         root: root.to_string_lossy().to_string(),
         schema_version: VAULT_SCHEMA_VERSION,
+        onboarding_note_path,
     })
+}
+
+pub fn onboarding_note_path() -> String {
+    ONBOARDING_NOTE_PATH.to_string()
+}
+
+pub fn ensure_onboarding_note_for_command(root: &Path) -> Result<String, String> {
+    ensure_onboarding_note_file(root)?;
+    write_onboarding_marker(root);
+    Ok(onboarding_note_path())
+}
+
+fn ensure_onboarding_note_for_launch(root: &Path) -> Option<String> {
+    let marker = glyph_paths::glyph_app_dir(root)
+        .ok()?
+        .join(ONBOARDING_MARKER_NAME);
+    if marker.exists() {
+        return None;
+    }
+
+    ensure_onboarding_note_file(root).ok()?;
+    write_onboarding_marker(root);
+    Some(onboarding_note_path())
+}
+
+fn ensure_onboarding_note_file(root: &Path) -> Result<(), String> {
+    let rel = Path::new(ONBOARDING_NOTE_PATH);
+    let abs = paths::join_under(root, rel)?;
+    if abs.exists() {
+        return Ok(());
+    }
+    io_atomic::write_atomic(&abs, ONBOARDING_NOTE_CONTENT.as_bytes()).map_err(|e| e.to_string())
+}
+
+fn write_onboarding_marker(root: &Path) {
+    let marker = match glyph_paths::glyph_app_dir(root) {
+        Ok(dir) => dir.join(ONBOARDING_MARKER_NAME),
+        Err(_) => return,
+    };
+    let marker_body = format!(
+        "{{\"version\":2,\"welcome_note_path\":\"{}\"}}\n",
+        ONBOARDING_NOTE_PATH
+    );
+    let _ = io_atomic::write_atomic(&marker, marker_body.as_bytes());
 }
 
 fn cleanup_tmp_files(root: &Path) -> Result<(), String> {

--- a/src-tauri/src/space/helpers.rs
+++ b/src-tauri/src/space/helpers.rs
@@ -73,6 +73,12 @@ If you remember one shortcut, make it `Cmd+K`. It opens the command palette, whe
 - [x] Start writing
 "#;
 
+#[derive(Serialize)]
+struct OnboardingMarker<'a> {
+    version: u32,
+    welcome_note_path: &'a str,
+}
+
 pub fn ensure_glyph_dirs(root: &Path) -> Result<(), String> {
     let _ = glyph_paths::ensure_glyph_dir(root)?;
     let _ = glyph_paths::ensure_glyph_cache_dir(root)?;
@@ -136,11 +142,14 @@ fn write_onboarding_marker(root: &Path) {
         Ok(dir) => dir.join(ONBOARDING_MARKER_NAME),
         Err(_) => return,
     };
-    let marker_body = format!(
-        "{{\"version\":2,\"welcome_note_path\":\"{}\"}}\n",
-        ONBOARDING_NOTE_PATH
-    );
-    let _ = io_atomic::write_atomic(&marker, marker_body.as_bytes());
+    let marker_body = match serde_json::to_vec(&OnboardingMarker {
+        version: 2,
+        welcome_note_path: ONBOARDING_NOTE_PATH,
+    }) {
+        Ok(body) => body,
+        Err(_) => return,
+    };
+    let _ = io_atomic::write_atomic(&marker, &marker_body);
 }
 
 fn cleanup_tmp_files(root: &Path) -> Result<(), String> {

--- a/src-tauri/src/space_fs/list.rs
+++ b/src-tauri/src/space_fs/list.rs
@@ -4,7 +4,19 @@ use tauri::State;
 use crate::{paths, space::SpaceState, utils};
 
 use super::helpers::{deny_hidden_rel_path, should_hide};
-use super::types::FsEntry;
+use super::types::{FsEntry, FsEntryList};
+
+fn metadata_timestamps(metadata: &std::fs::Metadata) -> (Option<String>, Option<String>) {
+    let created = metadata
+        .created()
+        .ok()
+        .and_then(utils::system_time_to_rfc3339);
+    let updated = metadata
+        .modified()
+        .ok()
+        .and_then(utils::system_time_to_rfc3339);
+    (created, updated)
+}
 
 #[tauri::command]
 pub async fn space_list_markdown_files(
@@ -46,11 +58,18 @@ pub async fn space_list_markdown_files(
                     continue;
                 }
                 let rel_path = start_rel.join(&name);
+                let (created, updated) = entry
+                    .metadata()
+                    .ok()
+                    .map(|metadata| metadata_timestamps(&metadata))
+                    .unwrap_or((None, None));
                 out.push(FsEntry {
                     name,
                     rel_path: rel_path.to_string_lossy().to_string(),
                     kind: "file".to_string(),
                     is_markdown: true,
+                    created,
+                    updated,
                 });
                 if out.len() >= limit {
                     break;
@@ -88,11 +107,14 @@ pub async fn space_list_markdown_files(
                     if !utils::is_markdown_path(Path::new(&name)) {
                         continue;
                     }
+                    let (created, updated) = metadata_timestamps(&meta);
                     out.push(FsEntry {
                         name,
                         rel_path: child_rel.to_string_lossy().to_string(),
                         kind: "file".to_string(),
                         is_markdown: true,
+                        created,
+                        updated,
                     });
                     if out.len() >= limit {
                         break;
@@ -106,6 +128,89 @@ pub async fn space_list_markdown_files(
 
         out.sort_by_cached_key(|e| e.rel_path.to_lowercase());
         Ok(out)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn space_list_non_markdown_files(
+    state: State<'_, SpaceState>,
+    dir: Option<String>,
+    limit: Option<u32>,
+) -> Result<FsEntryList, String> {
+    let root = state.current_root()?;
+    let dir = dir.unwrap_or_default();
+    let limit = limit.unwrap_or(5_000).min(50_000) as usize;
+
+    tauri::async_runtime::spawn_blocking(move || -> Result<FsEntryList, String> {
+        let start_rel = if dir.trim().is_empty() {
+            PathBuf::new()
+        } else {
+            PathBuf::from(&dir)
+        };
+        deny_hidden_rel_path(&start_rel)?;
+        let start_abs = paths::join_under(&root, &start_rel)?;
+        if !start_abs.exists() {
+            return Ok(FsEntryList {
+                files: Vec::new(),
+                truncated: false,
+            });
+        }
+
+        let mut out: Vec<FsEntry> = Vec::new();
+        let mut stack: Vec<PathBuf> = vec![start_rel];
+        while let Some(rel_dir) = stack.pop() {
+            let abs_dir = paths::join_under(&root, &rel_dir)?;
+            let entries = match std::fs::read_dir(&abs_dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            for entry in entries {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                let name = entry.file_name().to_string_lossy().to_string();
+                if should_hide(&name) {
+                    continue;
+                }
+                let meta = match entry.metadata() {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                let child_rel = rel_dir.join(&name);
+                if meta.is_dir() {
+                    stack.push(child_rel);
+                    continue;
+                }
+                if !meta.is_file() || utils::is_markdown_path(&child_rel) {
+                    continue;
+                }
+                let (created, updated) = metadata_timestamps(&meta);
+                out.push(FsEntry {
+                    name,
+                    rel_path: child_rel.to_string_lossy().to_string(),
+                    kind: "file".to_string(),
+                    is_markdown: false,
+                    created,
+                    updated,
+                });
+                if out.len() >= limit {
+                    out.sort_by_cached_key(|e| e.rel_path.to_lowercase());
+                    return Ok(FsEntryList {
+                        files: out,
+                        truncated: true,
+                    });
+                }
+            }
+        }
+
+        out.sort_by_cached_key(|e| e.rel_path.to_lowercase());
+        Ok(FsEntryList {
+            files: out,
+            truncated: false,
+        })
     })
     .await
     .map_err(|e| e.to_string())?
@@ -144,11 +249,14 @@ pub async fn space_list_dir(
             };
             let rel_path = rel.join(&name);
             let is_markdown = utils::is_markdown_path(&rel_path);
+            let (created, updated) = metadata_timestamps(&meta);
             entries.push(FsEntry {
                 name,
                 rel_path: rel_path.to_string_lossy().to_string(),
                 kind: kind.to_string(),
                 is_markdown,
+                created,
+                updated,
             });
         }
 

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -95,6 +95,8 @@ fn build_file_entry(rel_path: &Path, is_markdown: bool) -> Result<FsEntry, Strin
         rel_path: utils::to_slash(rel_path),
         kind: "file".to_string(),
         is_markdown,
+        created: None,
+        updated: None,
     })
 }
 

--- a/src-tauri/src/space_fs/types.rs
+++ b/src-tauri/src/space_fs/types.rs
@@ -6,6 +6,14 @@ pub struct FsEntry {
     pub rel_path: String,
     pub kind: String,
     pub is_markdown: bool,
+    pub created: Option<String>,
+    pub updated: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct FsEntryList {
+    pub files: Vec<FsEntry>,
+    pub truncated: bool,
 }
 
 #[derive(Serialize)]

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -109,6 +109,8 @@ export function AppShell() {
 		onCreateSpace,
 		closeSpace,
 		recentSpaces,
+		onboardingNotePath,
+		consumeOnboardingNotePath,
 	} = space;
 	const fileTreeCtx = useFileTreeContext();
 	const {
@@ -368,6 +370,33 @@ export function AppShell() {
 		},
 		[fileTree, openFileTab, setActiveDirPath],
 	);
+
+	useEffect(() => {
+		if (!spacePath || !onboardingNotePath) return;
+		consumeOnboardingNotePath();
+		void openWorkspaceFile(onboardingNotePath).catch((cause) => {
+			setError(cause instanceof Error ? cause.message : String(cause));
+		});
+	}, [
+		consumeOnboardingNotePath,
+		onboardingNotePath,
+		openWorkspaceFile,
+		setError,
+		spacePath,
+	]);
+
+	const showWelcomeNote = useCallback(async () => {
+		if (!spacePath) return;
+		try {
+			const notePath = await invoke("space_show_onboarding_note");
+			await fileTree.loadDir("", true);
+			await openWorkspaceFile(notePath);
+		} catch (cause) {
+			const message = cause instanceof Error ? cause.message : String(cause);
+			setError(message);
+			toast.error("Could not open the welcome note", { description: message });
+		}
+	}, [fileTree, openWorkspaceFile, setError, spacePath]);
 
 	const openFolioWorkspaceFile = useCallback(
 		async (path: string) => {
@@ -1222,6 +1251,7 @@ export function AppShell() {
 		openSpecialTab,
 		openTemplatesTab,
 		openWorkspaceFile,
+		showWelcomeNote,
 		pinnedFiles,
 		requestOpenDailyNote,
 		saveCurrentEditor,

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -368,6 +368,15 @@ export function AppShell() {
 		[fileTree, openFileTab, setActiveDirPath],
 	);
 
+	const openFolioWorkspaceFile = useCallback(
+		async (path: string) => {
+			if (!path) return;
+			setActiveDirPath(parentDir(path));
+			openFileTab(path);
+		},
+		[openFileTab, setActiveDirPath],
+	);
+
 	const openWorkspaceFileInNewTab = useCallback(
 		async (path: string) => {
 			if (!path) return;
@@ -383,6 +392,19 @@ export function AppShell() {
 			await openWorkspaceFile(path);
 		},
 		[openBlankTab, openWorkspaceFile, tabs],
+	);
+
+	const openFolioWorkspaceFileInNewTab = useCallback(
+		async (path: string) => {
+			if (!path) return;
+			if (tabs.some((tab) => tab.target === path)) {
+				await openFolioWorkspaceFile(path);
+				return;
+			}
+			openBlankTab();
+			await openFolioWorkspaceFile(path);
+		},
+		[openBlankTab, openFolioWorkspaceFile, tabs],
 	);
 
 	const openQuickNoteWindow = useCallback(() => {
@@ -1376,7 +1398,9 @@ export function AppShell() {
 					onDeletePath: fileTree.onDeletePath,
 				}}
 				onOpenFile={openWorkspaceFile}
+				onOpenFolioFile={openFolioWorkspaceFile}
 				onOpenFileInNewTab={openWorkspaceFileInNewTab}
+				onOpenFolioFileInNewTab={openFolioWorkspaceFileInNewTab}
 				onOpenCommandPalette={openCommandPalette}
 				onCreateNote={handleCreateNoteFromStarter}
 				onOpenDailyNote={requestOpenDailyNote}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -174,6 +174,7 @@ export function AppShell() {
 	>([]);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
 	const [commandPaletteSessionId, setCommandPaletteSessionId] = useState(0);
+	const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
 	const [htmlExportRequest, setHtmlExportRequest] = useState<{
 		id: string;
 		relPath: string;
@@ -1315,6 +1316,7 @@ export function AppShell() {
 				sidebarCollapsed && "appShellSidebarCollapsed",
 				zenModeActive && "appShellZenMode",
 				folioMode && "appShellFolioMode",
+				rightSidebarOpen && "appShellRightSidebarOpen",
 			)}
 		>
 			<div
@@ -1429,6 +1431,7 @@ export function AppShell() {
 				openDatabasesId={openDatabasesId}
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}
 				onOpenDailyNotesSettings={() => openSettings("general")}
+				onRightSidebarOpenChange={setRightSidebarOpen}
 			/>
 			<AnimatePresence>
 				{error && <div className="appError">{error}</div>}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -505,7 +505,8 @@ export const MainContent = memo(function MainContent({
 		Boolean(spacePath) &&
 		(showStarterByDefault || (starterOverrideVisible && !activeTabPath));
 	const showTabBar = tabs.length > 0;
-	const aiSidebarVisible = aiEnabled && !zenModeActive && aiPanelOpen;
+	const aiSidebarVisible =
+		aiEnabled && !zenModeActive && aiPanelOpen && !infoSidebarOpen;
 	const rightSidebarOpen =
 		Boolean(spacePath) &&
 		!settingsMode &&
@@ -909,7 +910,7 @@ export const MainContent = memo(function MainContent({
 				data-open={rightSidebarOpen ? "true" : undefined}
 				style={notesInfoSidebarHostStyle}
 			>
-				{aiEnabled && !zenModeActive ? (
+				{aiSidebarVisible ? (
 					<AIFloatingHost
 						isOpen={aiPanelOpen}
 						onToggle={() => setAiPanelOpen((open) => !open)}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -54,6 +54,7 @@ import { todayIsoDateLocal } from "../../lib/tasks";
 import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
+import { cn } from "../../lib/utils";
 import { Calendar, FileText, Settings } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
 import type {
@@ -304,6 +305,7 @@ interface MainContentProps {
 	openDatabasesId: string | null;
 	dailyNoteSetupNoticeRequest: number;
 	onOpenDailyNotesSettings: () => void;
+	onRightSidebarOpenChange?: (open: boolean) => void;
 }
 
 function DailyNotesSetupToast({
@@ -407,6 +409,7 @@ export const MainContent = memo(function MainContent({
 	openDatabasesId,
 	dailyNoteSetupNoticeRequest,
 	onOpenDailyNotesSettings,
+	onRightSidebarOpenChange,
 }: MainContentProps) {
 	const { spacePath, settingsLoaded, onOpenSpace } = useSpace();
 	const { getBinding } = useShortcutBindings();
@@ -427,8 +430,8 @@ export const MainContent = memo(function MainContent({
 	const [dailyNoteSetupToastVisible, setDailyNoteSetupToastVisible] =
 		useState(false);
 	const [infoSidebarWidth, setInfoSidebarWidth] = useState(340);
+	const [infoSidebarOpen, setInfoSidebarOpen] = useState(false);
 	const handledShowGettingStartedRequestRef = useRef(0);
-	const notesInfoSidebarHostRef = useRef<HTMLDivElement | null>(null);
 	const activeTab = useMemo(
 		() => tabs.find((tab) => tab.id === activeTabId) ?? null,
 		[tabs, activeTabId],
@@ -502,6 +505,11 @@ export const MainContent = memo(function MainContent({
 		Boolean(spacePath) &&
 		(showStarterByDefault || (starterOverrideVisible && !activeTabPath));
 	const showTabBar = tabs.length > 0;
+	const aiSidebarVisible = aiEnabled && !zenModeActive && aiPanelOpen;
+	const rightSidebarOpen =
+		Boolean(spacePath) &&
+		!settingsMode &&
+		(aiSidebarVisible || infoSidebarOpen);
 	const infoSidebarResize = useResizablePanel({
 		min: 260,
 		max: 620,
@@ -516,6 +524,16 @@ export const MainContent = memo(function MainContent({
 				"--markdown-info-sidebar-width": `${infoSidebarWidth}px`,
 			}) as CSSProperties,
 		[infoSidebarWidth],
+	);
+	useEffect(() => {
+		onRightSidebarOpenChange?.(rightSidebarOpen);
+	}, [onRightSidebarOpenChange, rightSidebarOpen]);
+
+	useEffect(
+		() => () => {
+			onRightSidebarOpenChange?.(false);
+		},
+		[onRightSidebarOpenChange],
 	);
 
 	useEffect(() => {
@@ -585,11 +603,10 @@ export const MainContent = memo(function MainContent({
 
 	const handleInfoSidebarResizePointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>) => {
-			const host = notesInfoSidebarHostRef.current;
-			if (!host || host.childElementCount === 0 || zenModeActive) return;
+			if (!rightSidebarOpen || zenModeActive) return;
 			infoSidebarResize.handlePointerDown(event);
 		},
-		[infoSidebarResize, zenModeActive],
+		[infoSidebarResize, rightSidebarOpen, zenModeActive],
 	);
 
 	const content = useMemo(() => {
@@ -709,6 +726,7 @@ export const MainContent = memo(function MainContent({
 					relPath={viewerPath}
 					initialDoc={initialDoc}
 					extractToNoteActions={extractToNoteActions}
+					onInfoSidebarOpenChange={setInfoSidebarOpen}
 					onDirtyChange={(dirty) =>
 						setDirtyByPath((prev) =>
 							prev[viewerPath] === dirty
@@ -874,7 +892,10 @@ export const MainContent = memo(function MainContent({
 		<>
 			<div
 				ref={infoSidebarResize.resizeRef}
-				className="notesInfoSidebarResizeHandle"
+				className={cn(
+					"notesInfoSidebarResizeHandle",
+					!rightSidebarOpen && "is-hidden",
+				)}
 				onPointerDown={handleInfoSidebarResizePointerDown}
 				onPointerMove={infoSidebarResize.handlePointerMove}
 				onPointerUp={infoSidebarResize.handlePointerUp}
@@ -883,9 +904,9 @@ export const MainContent = memo(function MainContent({
 			/>
 			<div
 				id="notes-info-sidebar-root"
-				ref={notesInfoSidebarHostRef}
 				className="notesInfoSidebarHost"
 				aria-live="polite"
+				data-open={rightSidebarOpen ? "true" : undefined}
 				style={notesInfoSidebarHostStyle}
 			>
 				{aiEnabled && !zenModeActive ? (
@@ -946,7 +967,10 @@ export const MainContent = memo(function MainContent({
 
 	return (
 		<>
-			<main className={zenModeActive ? "mainArea mainAreaZen" : "mainArea"}>
+			<main
+				className={zenModeActive ? "mainArea mainAreaZen" : "mainArea"}
+				data-right-sidebar-open={rightSidebarOpen ? "true" : undefined}
+			>
 				<div className="canvasWrapper">
 					{showFolioWorkspace ? (
 						<FolioWorkspace

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -54,7 +54,6 @@ import { todayIsoDateLocal } from "../../lib/tasks";
 import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
-import { isInAppPreviewable } from "../../utils/filePreview";
 import { Calendar, FileText, Settings } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
 import type {
@@ -270,7 +269,9 @@ interface MainContentProps {
 		onDeletePath: (path: string, kind: "dir" | "file") => Promise<boolean>;
 	};
 	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFolioFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onOpenFolioFileInNewTab: (relPath: string) => Promise<void>;
 	onOpenCommandPalette: () => void;
 	onCreateNote: () => void;
 	onOpenDailyNote: () => void;
@@ -375,7 +376,9 @@ function DailyNotesSetupToast({
 export const MainContent = memo(function MainContent({
 	fileTree,
 	onOpenFile,
+	onOpenFolioFile,
 	onOpenFileInNewTab,
+	onOpenFolioFileInNewTab,
 	onOpenCommandPalette,
 	onCreateNote,
 	onOpenDailyNote,
@@ -716,18 +719,15 @@ export const MainContent = memo(function MainContent({
 				/>
 			);
 		}
-		if (isInAppPreviewable(viewerPath)) {
-			return (
-				<FilePreviewPane
-					relPath={viewerPath}
-					onClose={() => {
-						if (activeTabId) closeTab(activeTabId);
-					}}
-					onOpenExternally={(path) => fileTree.openNonMarkdownExternally(path)}
-				/>
-			);
-		}
-		return null;
+		return (
+			<FilePreviewPane
+				relPath={viewerPath}
+				onClose={() => {
+					if (activeTabId) closeTab(activeTabId);
+				}}
+				onOpenExternally={(path) => fileTree.openNonMarkdownExternally(path)}
+			/>
+		);
 	}, [
 		activeTabId,
 		closeTab,
@@ -951,8 +951,8 @@ export const MainContent = memo(function MainContent({
 					{showFolioWorkspace ? (
 						<FolioWorkspace
 							activeTabPath={activeTabPath}
-							onOpenFile={onOpenFile}
-							onOpenFileInNewTab={onOpenFileInNewTab}
+							onOpenFile={onOpenFolioFile}
+							onOpenFileInNewTab={onOpenFolioFileInNewTab}
 							onRenameFile={(path, nextName) =>
 								fileTree.onRenameDir(path, nextName, "file")
 							}

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -108,6 +108,7 @@ interface UseAppCommandsDeps {
 	openSpecialTab: (id: string) => void;
 	openTemplatesTab: () => void;
 	openWorkspaceFile: (path: string) => Promise<void>;
+	showWelcomeNote: () => Promise<void>;
 	openMarkdownTabsLength: number;
 	pinnedFiles: string[];
 	requestOpenDailyNote: () => void;
@@ -324,6 +325,7 @@ export function useAppCommands({
 	openSpecialTab,
 	openTemplatesTab,
 	openWorkspaceFile,
+	showWelcomeNote,
 	openMarkdownTabsLength,
 	pinnedFiles,
 	requestOpenDailyNote,
@@ -898,6 +900,14 @@ export function useAppCommands({
 				enabled: Boolean(spacePath),
 				action: openGettingStarted,
 			},
+			{
+				id: "show-welcome-note",
+				label: "Show welcome note",
+				icon: <HugeiconsIcon icon={NoteIcon} size={16} strokeWidth={0.9} />,
+				category: "Help",
+				enabled: Boolean(spacePath),
+				action: () => void showWelcomeNote(),
+			},
 		];
 		return resolveCommandShortcuts(
 			[...baseCommands, ...aiCommands, ...editorCommands],
@@ -952,6 +962,7 @@ export function useAppCommands({
 		openBlankTab,
 		openQuickNoteWindow,
 		openWorkspaceFile,
+		showWelcomeNote,
 		gitSync,
 		getBinding,
 		moveTargetDirs,

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -322,8 +322,7 @@ export function useTabManager(spacePath: string | null) {
 		(activeHistory?.index ?? -1) < (activeHistory?.entries.length ?? 0) - 1;
 
 	const canOpenInMainPane = useCallback(
-		(path: string) =>
-			path.toLowerCase().endsWith(".md") || isInAppPreviewable(path),
+		(path: string) => Boolean(path.trim()),
 		[],
 	);
 

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -72,14 +72,15 @@ function titleFromPath(notePath: string): string {
 	return basename(notePath).replace(/\.md$/i, "") || "Untitled";
 }
 
-function dateLabel(iso: string): string {
+function dateLabel(iso: string | null): string {
+	if (!iso) return "No date";
 	try {
 		return new Intl.DateTimeFormat(undefined, {
 			month: "short",
 			day: "numeric",
 		}).format(new Date(iso));
 	} catch {
-		return "";
+		return "No date";
 	}
 }
 
@@ -350,7 +351,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	const preview = useMemo(() => {
 		return previewText(note.preview, title);
 	}, [note.preview, title]);
-	const updated = isMarkdown && note.updated ? dateLabel(note.updated) : "";
+	const updated = isMarkdown ? dateLabel(note.updated) : "";
 	const visibleTags = note.tags.slice(0, 2);
 	const hiddenTagCount = Math.max(0, note.tags.length - visibleTags.length);
 	const folder = parentDir(note.note_path);

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -1,10 +1,25 @@
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type CSSProperties,
+	memo,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { databaseValueToneStyle } from "../../lib/database/palette";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
-import type { AllDocsItem, NoteTaskSummary } from "../../lib/tauri";
+import type { FileTreeAppearance, NoteTaskSummary } from "../../lib/tauri";
+import { invoke } from "../../lib/tauri";
 import { basename, parentDir } from "../../utils/path";
+import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
+import {
+	getEditorTextColorOption,
+	isEditorTextColor,
+} from "../editor/textColors";
+import { FileTreeAppearanceMenu } from "../filetree/FileTreeAppearanceMenu";
 import { splitEditableFileName } from "../filetree/fileTreeItemHelpers";
+import { getFileTypeInfo } from "../filetree/fileTypeUtils";
 import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import {
 	ContextMenu,
@@ -13,9 +28,10 @@ import {
 	ContextMenuSeparator,
 	ContextMenuTrigger,
 } from "../ui/shadcn/context-menu";
+import type { FolioItem } from "./useFolioNotes";
 
 interface FolioNoteListItemProps {
-	note: AllDocsItem;
+	note: FolioItem;
 	selected: boolean;
 	onOpen: (path: string) => void;
 	onOpenInNewTab: (path: string) => void;
@@ -30,6 +46,26 @@ interface FolioNoteListItemProps {
 		nextName: string,
 	) => Promise<boolean> | boolean;
 	onCancelRename: () => void;
+	appearance?: FileTreeAppearance | null;
+	onChangeAppearance: (
+		path: string,
+		appearance: FileTreeAppearance,
+	) => Promise<void> | void;
+}
+
+type FolioImageRef =
+	| { kind: "markdown-link"; href: string }
+	| { kind: "wiki-image-link"; href: string }
+	| { kind: "direct"; src: string };
+
+const FOLIO_THUMBNAIL_MAX_BYTES = 4 * 1024 * 1024;
+const FOLIO_NOTE_IMAGE_SCAN_MAX_BYTES = 2 * 1024 * 1024;
+const IMAGE_EXT_RE = /\.(?:png|jpe?g|webp|gif|svg|bmp|avif|tiff?)(?:[#?].*)?$/i;
+const DIRECT_IMAGE_SRC_RE = /^(?:https?:|data:|blob:)/i;
+
+interface FolioImageCandidate {
+	index: number;
+	ref: FolioImageRef;
 }
 
 function titleFromPath(notePath: string): string {
@@ -74,6 +110,147 @@ function previewText(preview: string, title: string): string {
 	}
 
 	return previewLines.join(" ") || "No preview";
+}
+
+function markdownImageHref(rawHref: string): string {
+	const href = rawHref.trim().replace(/^<|>$/g, "");
+	const titleMatch = href.match(/^(.+?)(?:\s+["'][^"'\n]*["'])$/);
+	return (titleMatch?.[1] ?? href).trim();
+}
+
+function imageRefFromHref(href: string): FolioImageRef | null {
+	if (!href) return null;
+	if (DIRECT_IMAGE_SRC_RE.test(href)) return { kind: "direct", src: href };
+	if (IMAGE_EXT_RE.test(href)) return { kind: "markdown-link", href };
+	return null;
+}
+
+function referenceImageDefinitions(markdown: string): Map<string, string> {
+	const definitions = new Map<string, string>();
+	for (const match of markdown.matchAll(/^\s*\[([^\]\n]+)\]:\s*(\S+)/gm)) {
+		const label = (match[1] ?? "").trim().toLowerCase();
+		const href = markdownImageHref(match[2] ?? "");
+		if (label && href) definitions.set(label, href);
+	}
+	return definitions;
+}
+
+function extractFirstImageRef(markdown: string): FolioImageRef | null {
+	const candidates: FolioImageCandidate[] = [];
+
+	for (const match of markdown.matchAll(/!\[\[([^\]\n]+)\]\]/g)) {
+		const target = (match[1] ?? "").split("|")[0]?.split("#")[0]?.trim() ?? "";
+		if (target && IMAGE_EXT_RE.test(target)) {
+			candidates.push({
+				index: match.index ?? Number.MAX_SAFE_INTEGER,
+				ref: { kind: "wiki-image-link", href: target },
+			});
+		}
+	}
+
+	for (const match of markdown.matchAll(/!\[[^\]\n]*\]\(([^)\n]+)\)/g)) {
+		const href = markdownImageHref(match[1] ?? "");
+		const ref = imageRefFromHref(href);
+		if (ref) {
+			candidates.push({
+				index: match.index ?? Number.MAX_SAFE_INTEGER,
+				ref,
+			});
+		}
+	}
+
+	for (const match of markdown.matchAll(
+		/<img\b[^>]*\bsrc=(["'])(.*?)\1[^>]*>/gi,
+	)) {
+		const ref = imageRefFromHref((match[2] ?? "").trim());
+		if (ref) {
+			candidates.push({
+				index: match.index ?? Number.MAX_SAFE_INTEGER,
+				ref,
+			});
+		}
+	}
+
+	const definitions = referenceImageDefinitions(markdown);
+	for (const match of markdown.matchAll(/!\[[^\]\n]*\]\[([^\]\n]+)\]/g)) {
+		const label = (match[1] ?? "").trim().toLowerCase();
+		const href = definitions.get(label);
+		const ref = href ? imageRefFromHref(href) : null;
+		if (ref) {
+			candidates.push({
+				index: match.index ?? Number.MAX_SAFE_INTEGER,
+				ref,
+			});
+		}
+	}
+
+	for (const match of markdown.matchAll(/https?:\/\/[^\s<>)"]+/gi)) {
+		const href = (match[0] ?? "").trim();
+		if (!IMAGE_EXT_RE.test(href)) continue;
+		candidates.push({
+			index: match.index ?? Number.MAX_SAFE_INTEGER,
+			ref: { kind: "direct", src: href },
+		});
+	}
+
+	candidates.sort((left, right) => left.index - right.index);
+	return candidates[0]?.ref ?? null;
+}
+
+function useFolioThumbnail(note: FolioItem): string {
+	const previewImageRef = useMemo(
+		() => (note.is_markdown ? extractFirstImageRef(note.preview) : null),
+		[note.is_markdown, note.preview],
+	);
+	const [src, setSrc] = useState("");
+
+	useEffect(() => {
+		let cancelled = false;
+		setSrc("");
+		if (!note.is_markdown) return;
+		void (async () => {
+			try {
+				let imageRef = previewImageRef;
+				if (!imageRef) {
+					const doc = await invoke("space_read_text_preview", {
+						path: note.note_path,
+						max_bytes: FOLIO_NOTE_IMAGE_SCAN_MAX_BYTES,
+					});
+					if (cancelled) return;
+					imageRef = extractFirstImageRef(doc.text);
+				}
+				if (!imageRef) return;
+				if (imageRef.kind === "direct") {
+					setSrc(imageRef.src);
+					return;
+				}
+				const relPath =
+					imageRef.kind === "wiki-image-link"
+						? await invoke("space_resolve_image_wikilink", {
+								target: imageRef.href,
+							})
+						: await invoke("space_resolve_markdown_link", {
+								href: imageRef.href,
+								sourcePath: note.note_path,
+							});
+				if (!relPath || cancelled) return;
+				const preview = await invoke("space_read_binary_preview", {
+					path: relPath,
+					max_bytes: FOLIO_THUMBNAIL_MAX_BYTES,
+				});
+				if (!cancelled && !preview.truncated) {
+					setSrc(preview.data_url);
+				}
+			} catch {
+				if (!cancelled) setSrc("");
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [note.is_markdown, note.note_path, previewImageRef]);
+
+	return src;
 }
 
 function FolioRenameInput({
@@ -150,18 +327,34 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	isRenaming = false,
 	onCommitRename,
 	onCancelRename,
+	appearance = null,
+	onChangeAppearance,
 }: FolioNoteListItemProps) {
 	const title = note.title.trim() || titleFromPath(note.note_path);
+	const isMarkdown = note.is_markdown;
 	const { stem: fileStem, ext: fileExt } = splitEditableFileName(
 		basename(note.note_path),
 	);
+	const { Icon, color } = getFileTypeInfo(note.note_path, isMarkdown);
+	const customColor =
+		appearance?.color && isEditorTextColor(appearance.color)
+			? appearance.color
+			: null;
+	const rowStyle = customColor
+		? ({
+				"--folio-file-color": `var(${getEditorTextColorOption(customColor).cssVar})`,
+			} as CSSProperties)
+		: undefined;
+	const iconColor = customColor ? "var(--folio-file-color)" : color;
+	const extBadge = !isMarkdown && fileExt ? fileExt.slice(1) : "";
 	const preview = useMemo(() => {
 		return previewText(note.preview, title);
 	}, [note.preview, title]);
-	const updated = dateLabel(note.updated);
+	const updated = isMarkdown && note.updated ? dateLabel(note.updated) : "";
 	const visibleTags = note.tags.slice(0, 2);
 	const hiddenTagCount = Math.max(0, note.tags.length - visibleTags.length);
 	const folder = parentDir(note.note_path);
+	const thumbnailSrc = useFolioThumbnail(note);
 	const taskProgress =
 		taskSummary && taskSummary.total_count > 0 ? (
 			<TaskProgressIndicator
@@ -169,9 +362,30 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 				className="folioNoteTaskProgress"
 			/>
 		) : null;
+	const leadingIcon = appearance?.icon ? (
+		<DatabaseColumnIcon
+			iconName={appearance.icon}
+			size={15}
+			className="folioNoteFileIcon"
+		/>
+	) : (
+		<Icon
+			size={15}
+			className="folioNoteFileIcon"
+			style={{ color: iconColor }}
+			aria-hidden="true"
+		/>
+	);
 	const rowDetails = (
-		<>
-			<span className="folioNotePreview">{preview}</span>
+		<div className="folioNoteBody">
+			<span className="folioNoteCopy">
+				<span className="folioNotePreview">{preview}</span>
+			</span>
+			{thumbnailSrc ? (
+				<span className="folioNoteThumbnail" aria-hidden="true">
+					<img src={thumbnailSrc} alt="" />
+				</span>
+			) : null}
 			<span className="folioNoteFooter">
 				<span className="folioNoteTags">
 					{visibleTags.length > 0 ? (
@@ -196,7 +410,14 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 				</span>
 				<span className="folioNoteDates">{updated}</span>
 			</span>
-		</>
+		</div>
+	);
+	const fileDetails = (
+		<span className="folioFileLine">
+			{leadingIcon}
+			<span className="folioFileName">{fileStem || title}</span>
+			{extBadge ? <span className="fileTreeExtBadge">{extBadge}</span> : null}
+		</span>
 	);
 
 	return (
@@ -205,8 +426,10 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 				<div
 					className="folioNoteRow"
 					data-state={selected ? "selected" : "idle"}
+					data-kind={isMarkdown ? "markdown" : "file"}
 					data-folio-note-path={note.note_path}
 					title={note.note_path}
+					style={rowStyle}
 				>
 					<span className="folioNoteRowTop">
 						<FolioRenameInput
@@ -220,7 +443,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 						/>
 						{taskProgress}
 					</span>
-					{rowDetails}
+					{isMarkdown ? rowDetails : fileDetails}
 				</div>
 			) : (
 				<ContextMenu>
@@ -229,6 +452,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							type="button"
 							className="folioNoteRow"
 							data-state={selected ? "selected" : "idle"}
+							data-kind={isMarkdown ? "markdown" : "file"}
 							data-folio-note-path={note.note_path}
 							aria-current={selected ? "page" : undefined}
 							onClick={(event) => {
@@ -242,18 +466,27 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							onAuxClick={(event) => {
 								if (event.button === 1) onOpenInNewTab(note.note_path);
 							}}
-							onMouseEnter={() => onPrefetch(note.note_path)}
+							onMouseEnter={() => {
+								if (isMarkdown) onPrefetch(note.note_path);
+							}}
 							onFocus={() => {
 								onFocus();
-								onPrefetch(note.note_path);
+								if (isMarkdown) onPrefetch(note.note_path);
 							}}
 							title={note.note_path}
+							style={rowStyle}
 						>
-							<span className="folioNoteRowTop">
-								<span className="folioNoteTitle">{title}</span>
-								{taskProgress}
-							</span>
-							{rowDetails}
+							{isMarkdown ? (
+								<>
+									<span className="folioNoteRowTop">
+										<span className="folioNoteTitle">{title}</span>
+										{taskProgress}
+									</span>
+									{rowDetails}
+								</>
+							) : (
+								fileDetails
+							)}
 						</button>
 					</ContextMenuTrigger>
 					<ContextMenuContent
@@ -281,6 +514,13 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 								Rename
 							</ContextMenuItem>
 						) : null}
+						<FileTreeAppearanceMenu
+							itemKind="file"
+							appearance={appearance}
+							onChangeAppearance={(nextAppearance) =>
+								onChangeAppearance(note.note_path, nextAppearance)
+							}
+						/>
 						<ContextMenuItem
 							variant="destructive"
 							className="fileTreeCreateMenuItem"

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -10,12 +10,14 @@ import type { FolioScope } from "./folioScopes";
 const {
 	loadAllDocsMock,
 	prefetchNoteMock,
+	invokeMock,
 	scopeRef,
 	taskSummariesRef,
 	showTaskProgressIndicatorRef,
 } = vi.hoisted(() => ({
 	loadAllDocsMock: vi.fn(),
 	prefetchNoteMock: vi.fn(),
+	invokeMock: vi.fn(),
 	scopeRef: { current: { kind: "all" } as FolioScope },
 	taskSummariesRef: {
 		current: {} as Record<
@@ -30,7 +32,20 @@ vi.mock("../../contexts", () => ({
 	useUILayoutContext: () => ({
 		folioScope: scopeRef.current,
 	}),
+	useFileTreeContext: () => ({
+		itemAppearance: {},
+		setItemAppearance: vi.fn(),
+	}),
 }));
+
+vi.mock("../../lib/tauri", async () => {
+	const actual =
+		await vi.importActual<typeof import("../../lib/tauri")>("../../lib/tauri");
+	return {
+		...actual,
+		invoke: invokeMock,
+	};
+});
 
 vi.mock("../../lib/navigationPrefetch", async () => {
 	const actual = await vi.importActual<
@@ -75,6 +90,10 @@ vi.mock("../ui/shadcn/context-menu", () => ({
 		</button>
 	),
 	ContextMenuSeparator: () => <hr />,
+}));
+
+vi.mock("../filetree/FileTreeAppearanceMenu", () => ({
+	FileTreeAppearanceMenu: () => null,
 }));
 
 (
@@ -135,6 +154,7 @@ describe("FolioNotesListPane", () => {
 		taskSummariesRef.current = {};
 		showTaskProgressIndicatorRef.current = true;
 		loadAllDocsMock.mockResolvedValue(notes);
+		invokeMock.mockResolvedValue([]);
 		queryClient = new QueryClient({
 			defaultOptions: { queries: { retry: false, gcTime: 0 } },
 		});

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -37,6 +37,33 @@ function noteMatchesFilter(note: FolioItem, query: string): boolean {
 	return haystack.includes(normalized);
 }
 
+function timestampMs(value: string | null): number | null {
+	if (!value) return null;
+	const parsed = Date.parse(value);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+function compareNullableDates(
+	left: string | null,
+	right: string | null,
+): number {
+	const leftMs = timestampMs(left);
+	const rightMs = timestampMs(right);
+	if (leftMs === null && rightMs === null) return 0;
+	if (leftMs === null) return 1;
+	if (rightMs === null) return -1;
+	return rightMs - leftMs;
+}
+
+function compareTitles(left: FolioItem, right: FolioItem): number {
+	return (
+		noteTitle(left).localeCompare(noteTitle(right), undefined, {
+			sensitivity: "base",
+			numeric: true,
+		}) || left.note_path.localeCompare(right.note_path)
+	);
+}
+
 function compareNotes(
 	left: FolioItem,
 	right: FolioItem,
@@ -44,28 +71,17 @@ function compareNotes(
 ): number {
 	if (sortMode === "edited") {
 		return (
-			(Date.parse(right.updated) || 0) - (Date.parse(left.updated) || 0) ||
-			noteTitle(left).localeCompare(noteTitle(right), undefined, {
-				sensitivity: "base",
-				numeric: true,
-			})
+			compareNullableDates(left.updated, right.updated) ||
+			compareTitles(left, right)
 		);
 	}
 	if (sortMode === "created") {
 		return (
-			(Date.parse(right.created) || 0) - (Date.parse(left.created) || 0) ||
-			noteTitle(left).localeCompare(noteTitle(right), undefined, {
-				sensitivity: "base",
-				numeric: true,
-			})
+			compareNullableDates(left.created, right.created) ||
+			compareTitles(left, right)
 		);
 	}
-	return (
-		noteTitle(left).localeCompare(noteTitle(right), undefined, {
-			sensitivity: "base",
-			numeric: true,
-		}) || left.note_path.localeCompare(right.note_path)
-	);
+	return compareTitles(left, right);
 }
 
 function isFolioHeaderControl(target: EventTarget | null): boolean {

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -86,8 +86,15 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 }: FolioNotesListPaneProps) {
 	const { folioScope } = useUILayoutContext();
 	const { itemAppearance, setItemAppearance } = useFileTreeContext();
-	const { notes, isLoading, error, title, missingFolder } =
-		useFolioNotes(folioScope);
+	const {
+		notes,
+		filesTruncated,
+		isLoading,
+		error,
+		title,
+		nonMarkdownFileLimit,
+		missingFolder,
+	} = useFolioNotes(folioScope);
 	const [searchQuery, setSearchQuery] = useState("");
 	const [sortMode, setSortMode] = useState<FolioNotesSortMode>("alphabetical");
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
@@ -247,33 +254,40 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			);
 		}
 		return (
-			<ul className="folioNotesList">
-				{visibleNotes.map((note) => (
-					<FolioNoteListItem
-						key={note.note_path}
-						note={note}
-						selected={activeTabPath === note.note_path}
-						onOpen={openNote}
-						onOpenInNewTab={openNoteInNewTab}
-						onPrefetch={prefetchNote}
-						onRename={onRenameFile ? renameNote : undefined}
-						onDelete={deleteNote}
-						onFocus={focusPane}
-						isRenaming={
-							Boolean(onRenameFile) && renamingPath === note.note_path
-						}
-						onCommitRename={commitRename}
-						onCancelRename={cancelRename}
-						appearance={itemAppearance[note.note_path] ?? null}
-						onChangeAppearance={changeAppearance}
-						taskSummary={
-							showTaskProgressIndicator && note.is_markdown
-								? (taskSummariesByPath[note.note_path] ?? null)
-								: null
-						}
-					/>
-				))}
-			</ul>
+			<>
+				{filesTruncated ? (
+					<div className="folioNotesState">
+						Showing the first {nonMarkdownFileLimit.toLocaleString()} files.
+					</div>
+				) : null}
+				<ul className="folioNotesList">
+					{visibleNotes.map((note) => (
+						<FolioNoteListItem
+							key={note.note_path}
+							note={note}
+							selected={activeTabPath === note.note_path}
+							onOpen={openNote}
+							onOpenInNewTab={openNoteInNewTab}
+							onPrefetch={prefetchNote}
+							onRename={onRenameFile ? renameNote : undefined}
+							onDelete={deleteNote}
+							onFocus={focusPane}
+							isRenaming={
+								Boolean(onRenameFile) && renamingPath === note.note_path
+							}
+							onCommitRename={commitRename}
+							onCancelRename={cancelRename}
+							appearance={itemAppearance[note.note_path] ?? null}
+							onChangeAppearance={changeAppearance}
+							taskSummary={
+								showTaskProgressIndicator && note.is_markdown
+									? (taskSummariesByPath[note.note_path] ?? null)
+									: null
+							}
+						/>
+					))}
+				</ul>
+			</>
 		);
 	})();
 

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,15 +1,16 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useUILayoutContext } from "../../contexts";
+import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
+import { extractErrorMessage } from "../../lib/errorUtils";
 import { prefetchNote } from "../../lib/navigationPrefetch";
-import type { AllDocsItem } from "../../lib/tauri";
+import type { FileTreeAppearance } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename } from "../../utils/path";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
 import type { FolioNotesSortMode } from "./folioScopes";
-import { useFolioNotes } from "./useFolioNotes";
+import { type FolioItem, useFolioNotes } from "./useFolioNotes";
 
 interface FolioNotesListPaneProps {
 	activeTabPath: string | null;
@@ -19,11 +20,15 @@ interface FolioNotesListPaneProps {
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
 
-function noteTitle(note: AllDocsItem): string {
-	return note.title.trim() || basename(note.note_path).replace(/\.md$/i, "");
+function noteTitle(note: FolioItem): string {
+	const fallback = basename(note.note_path);
+	return (
+		note.title.trim() ||
+		(note.is_markdown ? fallback.replace(/\.md$/i, "") : fallback)
+	);
 }
 
-function noteMatchesFilter(note: AllDocsItem, query: string): boolean {
+function noteMatchesFilter(note: FolioItem, query: string): boolean {
 	const normalized = query.trim().toLowerCase();
 	if (!normalized) return true;
 	const haystack = [noteTitle(note), note.preview, note.note_path, ...note.tags]
@@ -33,15 +38,27 @@ function noteMatchesFilter(note: AllDocsItem, query: string): boolean {
 }
 
 function compareNotes(
-	left: AllDocsItem,
-	right: AllDocsItem,
+	left: FolioItem,
+	right: FolioItem,
 	sortMode: FolioNotesSortMode,
 ): number {
 	if (sortMode === "edited") {
-		return Date.parse(right.updated) - Date.parse(left.updated);
+		return (
+			(Date.parse(right.updated) || 0) - (Date.parse(left.updated) || 0) ||
+			noteTitle(left).localeCompare(noteTitle(right), undefined, {
+				sensitivity: "base",
+				numeric: true,
+			})
+		);
 	}
 	if (sortMode === "created") {
-		return Date.parse(right.created) - Date.parse(left.created);
+		return (
+			(Date.parse(right.created) || 0) - (Date.parse(left.created) || 0) ||
+			noteTitle(left).localeCompare(noteTitle(right), undefined, {
+				sensitivity: "base",
+				numeric: true,
+			})
+		);
 	}
 	return (
 		noteTitle(left).localeCompare(noteTitle(right), undefined, {
@@ -68,6 +85,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	onDeleteFile,
 }: FolioNotesListPaneProps) {
 	const { folioScope } = useUILayoutContext();
+	const { itemAppearance, setItemAppearance } = useFileTreeContext();
 	const { notes, isLoading, error, title, missingFolder } =
 		useFolioNotes(folioScope);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -92,7 +110,10 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	);
 	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(null);
 	const taskSummaryPaths = useMemo(
-		() => visibleNotes.map((note) => note.note_path),
+		() =>
+			visibleNotes
+				.filter((note) => note.is_markdown)
+				.map((note) => note.note_path),
 		[visibleNotes],
 	);
 	const taskSummariesByPath = useTaskSummariesForPaths(
@@ -168,6 +189,19 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		},
 		[onDeleteFile],
 	);
+	const changeAppearance = useCallback(
+		async (path: string, appearance: FileTreeAppearance) => {
+			try {
+				await setItemAppearance(path, appearance);
+			} catch (error) {
+				console.error(
+					"Failed to update folio file appearance",
+					extractErrorMessage(error),
+				);
+			}
+		},
+		[setItemAppearance],
+	);
 	const openAdjacentNote = useCallback(
 		(direction: 1 | -1) => {
 			if (!visibleNotes.length || selectedIndex < 0) return;
@@ -230,8 +264,10 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 						}
 						onCommitRename={commitRename}
 						onCancelRename={cancelRename}
+						appearance={itemAppearance[note.note_path] ?? null}
+						onChangeAppearance={changeAppearance}
 						taskSummary={
-							showTaskProgressIndicator
+							showTaskProgressIndicator && note.is_markdown
 								? (taskSummariesByPath[note.note_path] ?? null)
 								: null
 						}

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -11,7 +11,9 @@ import {
 	normalizeFolioPath,
 } from "./folioScopes";
 
-export interface FolioItem extends AllDocsItem {
+export interface FolioItem extends Omit<AllDocsItem, "created" | "updated"> {
+	created: string | null;
+	updated: string | null;
 	is_markdown: boolean;
 }
 
@@ -103,8 +105,8 @@ function fileEntryToFolioItem(entry: FsEntry): FolioItem {
 		note_path: normalizeRelPath(entry.rel_path),
 		title: titleFromFilePath(entry.rel_path),
 		preview: "",
-		updated: "",
-		created: "",
+		updated: entry.updated ?? null,
+		created: entry.created ?? null,
 		tags: [],
 		people: [],
 		is_markdown: entry.is_markdown,
@@ -112,33 +114,14 @@ function fileEntryToFolioItem(entry: FsEntry): FolioItem {
 }
 
 async function listNonMarkdownFiles(folderPrefix: string | null) {
-	const startDir = folderPrefix ?? "";
-	const queue = [startDir];
-	const files: FolioItem[] = [];
-
-	while (queue.length > 0) {
-		const dir = queue.shift() ?? "";
-		let entries: FsEntry[] = [];
-		try {
-			entries = await invoke("space_list_dir", dir ? { dir } : {});
-		} catch {
-			continue;
-		}
-		for (const entry of entries) {
-			if (entry.kind === "dir") {
-				queue.push(normalizeRelPath(entry.rel_path));
-				continue;
-			}
-			if (!entry.is_markdown) {
-				files.push(fileEntryToFolioItem(entry));
-				if (files.length >= FOLIO_NON_MARKDOWN_FILE_LIMIT) {
-					return { files, truncated: true };
-				}
-			}
-		}
-	}
-
-	return { files, truncated: false };
+	const result = await invoke("space_list_non_markdown_files", {
+		dir: folderPrefix,
+		limit: FOLIO_NON_MARKDOWN_FILE_LIMIT,
+	});
+	return {
+		files: result.files.map(fileEntryToFolioItem),
+		truncated: result.truncated,
+	};
 }
 
 function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -15,6 +15,8 @@ export interface FolioItem extends AllDocsItem {
 	is_markdown: boolean;
 }
 
+const FOLIO_NON_MARKDOWN_FILE_LIMIT = 5_000;
+
 const folioFilesQueryKey = (folderPrefix: string | null) =>
 	["navigation", "folio-files", folderPrefix ?? "__all__"] as const;
 
@@ -129,11 +131,14 @@ async function listNonMarkdownFiles(folderPrefix: string | null) {
 			}
 			if (!entry.is_markdown) {
 				files.push(fileEntryToFolioItem(entry));
+				if (files.length >= FOLIO_NON_MARKDOWN_FILE_LIMIT) {
+					return { files, truncated: true };
+				}
 			}
 		}
 	}
 
-	return files;
+	return { files, truncated: false };
 }
 
 function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {
@@ -155,6 +160,8 @@ export function useFolioNotes(scope: FolioScope) {
 	const folderPrefix = folderForScope(scope);
 	const folderRequired =
 		(scope.kind === "daily" || scope.kind === "templates") && !folderPrefix;
+	const includesNonMarkdownFiles =
+		scope.kind !== "tag" && scope.kind !== "person";
 	const query = useQuery({
 		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
 		queryFn: () => loadAllDocs(folderPrefix),
@@ -163,7 +170,7 @@ export function useFolioNotes(scope: FolioScope) {
 	const filesQuery = useQuery({
 		queryKey: folioFilesQueryKey(folderPrefix),
 		queryFn: () => listNonMarkdownFiles(folderPrefix),
-		enabled: !folderRequired,
+		enabled: !folderRequired && includesNonMarkdownFiles,
 	});
 
 	useTauriEvent("notes:external_changed", () => {
@@ -183,17 +190,20 @@ export function useFolioNotes(scope: FolioScope) {
 	const items = useMemo(
 		() =>
 			filterNotesForScope(
-				mergeFolioItems(query.data ?? [], filesQuery.data ?? []),
+				mergeFolioItems(query.data ?? [], filesQuery.data?.files ?? []),
 				scope,
 			),
-		[filesQuery.data, query.data, scope],
+		[filesQuery.data?.files, query.data, scope],
 	);
 
 	return {
 		notes: items,
+		filesTruncated:
+			includesNonMarkdownFiles && (filesQuery.data?.truncated ?? false),
 		isLoading: query.isLoading || filesQuery.isLoading,
 		error: query.error ?? filesQuery.error,
 		title: folioScopeTitle(scope),
+		nonMarkdownFileLimit: FOLIO_NON_MARKDOWN_FILE_LIMIT,
 		missingFolder: folderRequired,
 	};
 }

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -1,13 +1,22 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
-import type { AllDocsItem } from "../../lib/tauri";
+import type { AllDocsItem, FsEntry } from "../../lib/tauri";
+import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { basename } from "../../utils/path";
 import {
 	type FolioScope,
 	folioScopeTitle,
 	normalizeFolioPath,
 } from "./folioScopes";
+
+export interface FolioItem extends AllDocsItem {
+	is_markdown: boolean;
+}
+
+const folioFilesQueryKey = (folderPrefix: string | null) =>
+	["navigation", "folio-files", folderPrefix ?? "__all__"] as const;
 
 function folderForScope(scope: FolioScope): string | null {
 	switch (scope.kind) {
@@ -43,14 +52,18 @@ function personMatches(
 }
 
 function filterNotesForScope(
-	notes: AllDocsItem[],
+	notes: FolioItem[],
 	scope: FolioScope,
-): AllDocsItem[] {
+): FolioItem[] {
 	switch (scope.kind) {
 		case "tag":
-			return notes.filter((note) => tagMatches(note.tags, scope.tag));
+			return notes.filter(
+				(note) => note.is_markdown && tagMatches(note.tags, scope.tag),
+			);
 		case "person":
-			return notes.filter((note) => personMatches(note.people, scope.handle));
+			return notes.filter(
+				(note) => note.is_markdown && personMatches(note.people, scope.handle),
+			);
 		case "search": {
 			const query = scope.query.trim().toLowerCase();
 			if (!query) return notes;
@@ -71,6 +84,72 @@ function filterNotesForScope(
 	}
 }
 
+function normalizeRelPath(path: string): string {
+	return path
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+}
+
+function titleFromFilePath(path: string): string {
+	const name = basename(path);
+	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
+}
+
+function fileEntryToFolioItem(entry: FsEntry): FolioItem {
+	return {
+		note_path: normalizeRelPath(entry.rel_path),
+		title: titleFromFilePath(entry.rel_path),
+		preview: "",
+		updated: "",
+		created: "",
+		tags: [],
+		people: [],
+		is_markdown: entry.is_markdown,
+	};
+}
+
+async function listNonMarkdownFiles(folderPrefix: string | null) {
+	const startDir = folderPrefix ?? "";
+	const queue = [startDir];
+	const files: FolioItem[] = [];
+
+	while (queue.length > 0) {
+		const dir = queue.shift() ?? "";
+		let entries: FsEntry[] = [];
+		try {
+			entries = await invoke("space_list_dir", dir ? { dir } : {});
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			if (entry.kind === "dir") {
+				queue.push(normalizeRelPath(entry.rel_path));
+				continue;
+			}
+			if (!entry.is_markdown) {
+				files.push(fileEntryToFolioItem(entry));
+			}
+		}
+	}
+
+	return files;
+}
+
+function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {
+	const out = new Map<string, FolioItem>();
+	for (const note of notes) {
+		const path = normalizeRelPath(note.note_path);
+		if (!path) continue;
+		out.set(path, { ...note, note_path: path, is_markdown: true });
+	}
+	for (const file of files) {
+		if (!file.note_path || out.has(file.note_path)) continue;
+		out.set(file.note_path, file);
+	}
+	return Array.from(out.values());
+}
+
 export function useFolioNotes(scope: FolioScope) {
 	const queryClient = useQueryClient();
 	const folderPrefix = folderForScope(scope);
@@ -81,22 +160,39 @@ export function useFolioNotes(scope: FolioScope) {
 		queryFn: () => loadAllDocs(folderPrefix),
 		enabled: !folderRequired,
 	});
+	const filesQuery = useQuery({
+		queryKey: folioFilesQueryKey(folderPrefix),
+		queryFn: () => listNonMarkdownFiles(folderPrefix),
+		enabled: !folderRequired,
+	});
 
 	useTauriEvent("notes:external_changed", () => {
 		void queryClient.invalidateQueries({
 			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
 		});
 	});
+	useTauriEvent("space:fs_changed", () => {
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		});
+		void queryClient.invalidateQueries({
+			queryKey: folioFilesQueryKey(folderPrefix),
+		});
+	});
 
-	const notes = useMemo(
-		() => filterNotesForScope(query.data ?? [], scope),
-		[query.data, scope],
+	const items = useMemo(
+		() =>
+			filterNotesForScope(
+				mergeFolioItems(query.data ?? [], filesQuery.data ?? []),
+				scope,
+			),
+		[filesQuery.data, query.data, scope],
 	);
 
 	return {
-		notes,
-		isLoading: query.isLoading,
-		error: query.error,
+		notes: items,
+		isLoading: query.isLoading || filesQuery.isLoading,
+		error: query.error ?? filesQuery.error,
 		title: folioScopeTitle(scope),
 		missingFolder: folderRequired,
 	};

--- a/src/components/preview/FilePreviewPane.tsx
+++ b/src/components/preview/FilePreviewPane.tsx
@@ -4,6 +4,7 @@ import { type TextFilePreviewDoc, invoke } from "../../lib/tauri";
 import { getInAppPreviewKind } from "../../utils/filePreview";
 import { basename } from "../../utils/path";
 import { ExternalLink, X } from "../Icons";
+import { getFileTypeInfo } from "../filetree/fileTypeUtils";
 import { Button } from "../ui/shadcn/button";
 
 interface FilePreviewPaneProps {
@@ -15,6 +16,12 @@ interface FilePreviewPaneProps {
 const TEXT_PREVIEW_MAX_BYTES = 1_048_576;
 const BINARY_PREVIEW_MAX_BYTES = 20 * 1024 * 1024;
 
+function extensionLabel(fileName: string, fallback: string): string {
+	const dot = fileName.lastIndexOf(".");
+	if (dot <= 0 || dot === fileName.length - 1) return fallback;
+	return fileName.slice(dot + 1).toLowerCase();
+}
+
 export function FilePreviewPane({
 	relPath,
 	onClose,
@@ -22,6 +29,8 @@ export function FilePreviewPane({
 }: FilePreviewPaneProps) {
 	const kind = getInAppPreviewKind(relPath);
 	const displayName = basename(relPath);
+	const { Icon, color, label } = getFileTypeInfo(relPath, false);
+	const extLabel = extensionLabel(displayName, label);
 	const [fileSrc, setFileSrc] = useState<string>("");
 	const [textDoc, setTextDoc] = useState<TextFilePreviewDoc | null>(null);
 	const [loading, setLoading] = useState(true);
@@ -31,6 +40,11 @@ export function FilePreviewPane({
 		setLoading(true);
 		setError("");
 		try {
+			if (!kind) {
+				setFileSrc("");
+				setTextDoc(null);
+				return;
+			}
 			if (kind === "text") {
 				setFileSrc("");
 				const next = await invoke("space_read_text_preview", {
@@ -49,7 +63,6 @@ export function FilePreviewPane({
 				setFileSrc(next.data_url);
 				return;
 			}
-			throw new Error("Unsupported preview type");
 		} catch (e) {
 			setError(extractErrorMessage(e));
 		} finally {
@@ -96,6 +109,21 @@ export function FilePreviewPane({
 			{!loading && error ? (
 				<div className="filePreviewMeta">
 					<div className="filePreviewHint">{error}</div>
+				</div>
+			) : null}
+
+			{!loading && !error && !kind ? (
+				<div className="filePreviewFallback">
+					<div className="filePreviewFileLine" title={relPath}>
+						<Icon
+							size={16}
+							className="filePreviewFileIcon"
+							style={{ color }}
+							aria-hidden="true"
+						/>
+						<span className="filePreviewFileName">{displayName}</span>
+						<span className="fileTreeExtBadge">{extLabel}</span>
+					</div>
 				</div>
 			) : null}
 

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -73,6 +73,7 @@ import {
 interface MarkdownEditorPaneProps {
 	relPath: string;
 	onDirtyChange?: (dirty: boolean) => void;
+	onInfoSidebarOpenChange?: (open: boolean) => void;
 	initialDoc?: TextFileDoc | null;
 	initialError?: string;
 	extractToNoteActions?: ExtractToNoteActions;
@@ -174,6 +175,7 @@ function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
 export function MarkdownEditorPane({
 	relPath,
 	onDirtyChange,
+	onInfoSidebarOpenChange,
 	initialDoc = null,
 	initialError = "",
 	extractToNoteActions,
@@ -776,6 +778,17 @@ export function MarkdownEditorPane({
 	useEffect(() => {
 		onDirtyChange?.(isDirty);
 	}, [onDirtyChange, isDirty]);
+
+	useEffect(() => {
+		onInfoSidebarOpenChange?.(infoPanelOpen);
+	}, [infoPanelOpen, onInfoSidebarOpenChange]);
+
+	useEffect(
+		() => () => {
+			onInfoSidebarOpenChange?.(false);
+		},
+		[onInfoSidebarOpenChange],
+	);
 
 	useEffect(() => {
 		if (!infoPanelOpen) return;

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -5,6 +5,7 @@ import { MarkdownEditorPane } from "./MarkdownEditorPane";
 interface NotePaneProps {
 	relPath: string;
 	onDirtyChange?: (dirty: boolean) => void;
+	onInfoSidebarOpenChange?: (open: boolean) => void;
 	initialDoc?: TextFileDoc | null;
 	extractToNoteActions?: ExtractToNoteActions;
 }
@@ -12,6 +13,7 @@ interface NotePaneProps {
 export function NotePane({
 	relPath,
 	onDirtyChange,
+	onInfoSidebarOpenChange,
 	initialDoc = null,
 	extractToNoteActions,
 }: NotePaneProps) {
@@ -20,6 +22,7 @@ export function NotePane({
 			relPath={relPath}
 			initialDoc={initialDoc}
 			onDirtyChange={onDirtyChange}
+			onInfoSidebarOpenChange={onInfoSidebarOpenChange}
 			extractToNoteActions={extractToNoteActions}
 		/>
 	);

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -27,9 +27,11 @@ export interface SpaceContextValue {
 	spacePath: string | null;
 	lastSpacePath: string | null;
 	spaceSchemaVersion: number | null;
+	onboardingNotePath: string | null;
 	recentSpaces: string[];
 	isIndexing: boolean;
 	settingsLoaded: boolean;
+	consumeOnboardingNotePath: () => void;
 	startIndexRebuild: () => Promise<void>;
 	onOpenSpace: () => Promise<void>;
 	onOpenSpaceAtPath: (path: string) => Promise<void>;
@@ -74,6 +76,9 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	const [spacePath, setSpacePath] = useState<string | null>(null);
 	const [lastSpacePath, setLastSpacePath] = useState<string | null>(null);
 	const [spaceSchemaVersion, setSpaceSchemaVersion] = useState<number | null>(
+		null,
+	);
+	const [onboardingNotePath, setOnboardingNotePath] = useState<string | null>(
 		null,
 	);
 	const [recentSpaces, setRecentSpaces] = useState<string[]>([]);
@@ -142,6 +147,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 						if (!cancelled) {
 							setSpacePath(spaceInfo.root);
 							setSpaceSchemaVersion(spaceInfo.schema_version);
+							setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
 						}
 					} catch {}
 				}
@@ -183,6 +189,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 					invalidateNavigationPrefetch();
 					setSpacePath(null);
 					setSpaceSchemaVersion(null);
+					setOnboardingNotePath(null);
 				}
 				const spaceInfo =
 					mode === "create"
@@ -199,6 +206,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				setLastSpacePath(spaceInfo.root);
 				setSpacePath(spaceInfo.root);
 				setSpaceSchemaVersion(spaceInfo.schema_version);
+				setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
 			} catch (err) {
 				setError(extractErrorMessage(err));
 			} finally {
@@ -218,9 +226,14 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			invalidateNavigationPrefetch();
 			setSpacePath(null);
 			setSpaceSchemaVersion(null);
+			setOnboardingNotePath(null);
 		} catch (err) {
 			setError(extractErrorMessage(err));
 		}
+	}, []);
+
+	const consumeOnboardingNotePath = useCallback(() => {
+		setOnboardingNotePath(null);
 	}, []);
 
 	const onOpenSpace = useCallback(async () => {
@@ -264,9 +277,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			spacePath,
 			lastSpacePath,
 			spaceSchemaVersion,
+			onboardingNotePath,
 			recentSpaces,
 			isIndexing,
 			settingsLoaded,
+			consumeOnboardingNotePath,
 			startIndexRebuild,
 			onOpenSpace,
 			onOpenSpaceAtPath,
@@ -280,9 +295,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			spacePath,
 			lastSpacePath,
 			spaceSchemaVersion,
+			onboardingNotePath,
 			recentSpaces,
 			isIndexing,
 			settingsLoaded,
+			consumeOnboardingNotePath,
 			startIndexRebuild,
 			onOpenSpace,
 			onOpenSpaceAtPath,

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -1,6 +1,30 @@
 {
 	"versions": [
 		{
+			"version": "0.2.24",
+			"sections": [
+				{
+					"category": "Added",
+					"items": [
+						"New spaces now include an editable onboarding note to help you get started with Glyph"
+					]
+				},
+				{
+					"category": "Improved",
+					"items": [
+						"Folio mode now shows images, file icons, and file colors more clearly",
+						"Non-Markdown files can now open in the preview pane, with a simple file icon and name when a full preview is not available"
+					]
+				},
+				{
+					"category": "Fixed",
+					"items": [
+						"The right sidebar now centers and cleans up both sides correctly when opening the Info or AI panel"
+					]
+				}
+			]
+		},
+		{
 			"version": "0.2.23",
 			"sections": [
 				{

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -18,6 +18,13 @@ export interface FsEntry {
 	rel_path: string;
 	kind: "dir" | "file";
 	is_markdown: boolean;
+	created?: string | null;
+	updated?: string | null;
+}
+
+export interface FsEntryList {
+	files: FsEntry[];
+	truncated: boolean;
 }
 
 export interface LinkRewriteResult {
@@ -768,6 +775,10 @@ interface TauriCommands {
 	space_list_markdown_files: CommandDef<
 		{ dir?: string | null; recursive?: boolean | null; limit?: number | null },
 		FsEntry[]
+	>;
+	space_list_non_markdown_files: CommandDef<
+		{ dir?: string | null; limit?: number | null },
+		FsEntryList
 	>;
 	space_dir_children_summary: CommandDef<
 		{ dir?: string | null; preview_limit?: number | null },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -10,6 +10,7 @@ export interface AppInfo {
 export interface SpaceInfo {
 	root: string;
 	schema_version: number;
+	onboarding_note_path?: string | null;
 }
 
 export interface FsEntry {
@@ -740,6 +741,7 @@ interface TauriCommands {
 	space_create: CommandDef<{ path: string }, SpaceInfo>;
 	space_open: CommandDef<{ path: string }, SpaceInfo>;
 	space_get_current: CommandDef<void, string | null>;
+	space_show_onboarding_note: CommandDef<void, string>;
 	space_close: CommandDef<void, void>;
 	export_write_text: CommandDef<{ abs_path: string; text: string }, void>;
 	space_list_dir: CommandDef<{ dir?: string | null }, FsEntry[]>;

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -1076,6 +1076,16 @@
 			"allowInEditable": false,
 			"commandPalette": true
 		},
+		"show-welcome-note": {
+			"id": "show-welcome-note",
+			"label": "Show Welcome Note",
+			"description": "Create or open the welcome note in the root of the current space.",
+			"category": "settings",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": true
+		},
 		"strikethrough": {
 			"id": "strikethrough",
 			"label": "Strikethrough",

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -22,7 +22,7 @@
 	overflow: hidden;
 }
 
-.appShell:not(:has(.notesInfoSidebarHost:not(:empty))) {
+.appShell:not(.appShellRightSidebarOpen) {
 	padding-right: var(--app-frame-inline);
 }
 

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -31,7 +31,7 @@
 	transition: border-radius 180ms ease;
 }
 
-.appShell:has(.notesInfoSidebarHost:not(:empty)) .canvasPaneHost {
+.mainArea[data-right-sidebar-open="true"] .canvasPaneHost {
 	border-top-right-radius: calc(
 		var(--app-radius) -
 		var(--app-frame-inline) +
@@ -78,14 +78,6 @@
 	margin-right: -4px;
 }
 
-.appShell:not(:has(.notesInfoSidebarHost:not(:empty)))
-	.notesInfoSidebarResizeHandle {
-	width: 0;
-	margin-left: 0;
-	margin-right: 0;
-	pointer-events: none;
-}
-
 .notesInfoSidebarResizeHandle::before {
 	content: "";
 	position: absolute;
@@ -104,10 +96,11 @@
 	pointer-events: none;
 }
 
-.notesInfoSidebarHost:not(:empty) {
+.notesInfoSidebarHost[data-open="true"] {
 	flex-basis: var(--markdown-info-sidebar-width, 340px);
 	width: var(--markdown-info-sidebar-width, 340px);
-	padding: 4px 4px 4px 0;
+	padding: var(--app-frame-block) var(--app-frame-inline) var(--app-frame-block)
+		0;
 	background: transparent;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
@@ -115,14 +108,11 @@
 	border-left-color: transparent;
 }
 
-:root[data-translucent-sidebar="false"] .notesInfoSidebarHost:not(:empty) {
+:root[data-translucent-sidebar="false"]
+	.notesInfoSidebarHost[data-open="true"] {
 	padding: 0;
 	background: var(--bg-sidebar);
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
 	border-left-color: var(--border-light);
-}
-
-.notesInfoSidebarHost:has(.notesInfoSidebarPanel) .aiFloatingWindowHost {
-	display: none;
 }

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -46,6 +46,41 @@
 	font-size: var(--text-sm);
 }
 
+.filePreviewFallback {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	align-items: flex-start;
+	padding: 18px var(--space-6);
+}
+
+.filePreviewFileLine {
+	width: min(520px, 100%);
+	min-height: 36px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 0 10px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+	border-radius: 6px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+}
+
+.filePreviewFileIcon {
+	flex: 0 0 auto;
+}
+
+.filePreviewFileName {
+	min-width: 0;
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+}
+
 .filePreviewPane {
 	display: flex;
 	flex-direction: column;

--- a/src/styles/app/30-file-preview.css
+++ b/src/styles/app/30-file-preview.css
@@ -909,7 +909,7 @@
 }
 
 @media (max-width: 760px) {
-	.notesInfoSidebarHost:not(:empty) {
+	.notesInfoSidebarHost[data-open="true"] {
 		width: min(92vw, 340px);
 		flex-basis: min(92vw, 340px);
 	}

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -195,6 +195,13 @@
 	background: color-mix(in srgb, var(--interactive-accent) 8%, var(--bg-hover));
 }
 
+.folioNoteRow[data-kind="file"] {
+	min-height: 42px;
+	justify-content: center;
+	padding-top: 9px;
+	padding-bottom: 9px;
+}
+
 .folioNoteRowTop {
 	flex: 0 0 auto;
 	display: flex;
@@ -258,6 +265,22 @@
 	opacity: 1;
 }
 
+.folioNoteBody {
+	min-width: 0;
+	flex: 1;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	grid-template-rows: 1fr auto;
+	column-gap: 10px;
+	row-gap: 6px;
+	align-items: start;
+}
+
+.folioNoteCopy {
+	min-width: 0;
+	display: block;
+}
+
 .folioNotePreview {
 	min-width: 0;
 	flex: 0 0 auto;
@@ -272,8 +295,28 @@
 	overflow-wrap: anywhere;
 }
 
+.folioNoteThumbnail {
+	grid-column: 2;
+	grid-row: 1;
+	width: 58px;
+	height: 58px;
+	overflow: hidden;
+	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+	border-radius: 6px;
+	background: var(--bg-secondary);
+}
+
+.folioNoteThumbnail img {
+	width: 100%;
+	height: 100%;
+	display: block;
+	object-fit: cover;
+}
+
 .folioNoteFooter {
 	flex: 0 0 auto;
+	grid-column: 1 / -1;
+	grid-row: 2;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -320,6 +363,31 @@
 	color: var(--text-tertiary);
 	font-size: 10px;
 	white-space: nowrap;
+}
+
+.folioFileLine {
+	width: 100%;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--text-primary);
+}
+
+.folioNoteFileIcon {
+	flex: 0 0 auto;
+	color: var(--folio-file-color, var(--text-tertiary));
+}
+
+.folioFileName {
+	min-width: 0;
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 13px;
+	font-weight: var(--font-medium);
+	line-height: 1.25;
 }
 
 .folioNotesState {


### PR DESCRIPTION
## Summary

This PR rounds out Folio mode so it behaves like a real workspace surface instead of a Markdown-only note list. It teaches Folio to include non-Markdown files, preview images and other file types in the main pane, show lightweight thumbnails for image-linked notes, and preserve file appearance customization from the existing file tree.

It also adds a first-run welcome note flow for spaces and fixes the right-sidebar layout state so the canvas consistently reserves space when either the AI sidebar or note info sidebar is open.

## What Changed

- Adds non-Markdown files to Folio results by walking the space file tree, merging those files with indexed Markdown notes, and invalidating the Folio file query on filesystem changes.
- Updates Folio rows to render Markdown notes and generic files differently: Markdown keeps previews, tags, dates, and task progress, while files show the shared file-type icon, extension badge, custom color/icon appearance, rename, delete, and open-in-new-tab behavior.
- Extracts the first image reference from Markdown notes for Folio thumbnails, including wiki image links, Markdown image links, reference-style images, inline `<img>` tags, direct image URLs, and resolved local attachments.
- Lets the main content area open any non-empty path in the main pane, showing rich previews for supported image/text files and a clean fallback row for unsupported file types instead of failing as unsupported.
- Adds a Tauri-backed welcome note command and one-time launch marker so new spaces create/open `Welcome to Glyph.md`, with a command palette action to show that note again later.
- Tracks right-sidebar open state explicitly from the AI panel and note info panel, replacing CSS emptiness checks with data/class state so the workspace frame, resize handle, and sidebar padding stay in sync.

## Why

Folio mode was useful for Markdown notes, but real spaces often contain screenshots, PDFs, exports, images, and other supporting files. The old path made Folio feel disconnected from the rest of the app because those files either disappeared from the list or could not be opened smoothly inside the Folio workspace.

The sidebar layout also depended on whether the sidebar host had DOM children. That made the frame sensitive to render timing and panel internals, especially around the AI/info sidebars. Moving to explicit open state makes the layout behavior deterministic.

## User Impact

- Users can browse mixed Folio spaces without leaving the Folio surface.
- Image-heavy notes are easier to scan because Folio can show a thumbnail from the note content.
- Unsupported files now have a useful in-app placeholder with file identity instead of a dead preview state.
- First-time spaces get an editable welcome note that explains key flows through real Markdown content.
- Right sidebar spacing should feel stable when toggling AI, note info, and Folio views.

## Root Cause

Folio was built primarily around `AllDocsItem` data from the note index, so it only naturally represented Markdown documents. Preview routing also still gated main-pane tabs through Markdown or known previewable file checks. On the layout side, CSS used `:has(.notesInfoSidebarHost:not(:empty))` as a proxy for sidebar visibility, which did not model cases where sidebar state and rendered children changed at different moments.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

## Notes

The Vite build still reports the existing large chunk and mixed dynamic/static import warnings; the build completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added onboarding welcome note that can be displayed and accessed via the Help command palette
- Folio view now supports non-markdown files with thumbnail previews and per-note appearance customization
- Enhanced file preview with improved fallback UI for unsupported file types

**Improvements**
- Right sidebar state management for better UI organization
- Markdown notes now better integrate with info sidebar controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->