### PR TITLE
[codex] Simplify database and settings surfaces

### DIFF
--- a/src/components/ai/AIMessageMarkdown.tsx
+++ b/src/components/ai/AIMessageMarkdown.tsx
@@ -13,6 +13,7 @@ type CopyButtonElement = HTMLButtonElement & {
 };
 
 const MARKDOWN_VIEW_EXTENSIONS = createEditorExtensions({
+	enableEditingExtensions: false,
 	enableSlashCommand: false,
 });
 

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -288,7 +288,6 @@ function DatabaseBoardLaneView({
 					</div>
 				)}
 				<div className="databaseBoardLaneHeaderActions">
-					<div className="databaseBoardLaneCount">{lane.cardCount}</div>
 					<ContextMenu>
 						<ContextMenuTrigger asChild>
 							<button

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -427,7 +427,7 @@ export function DatabaseBoard({
 		});
 	const [moveError, setMoveError] = useState("");
 	const suppressClickRef = useRef(false);
-	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(null);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
 	const taskSummaryPaths = useMemo(
 		() => Array.from(new Set(rows.map((row) => row.note_path).filter(Boolean))),
 		[rows],

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -592,7 +592,7 @@ function DatabaseCellEditor({
 					<div className="notePropertySuggestions databaseTagSuggestions">
 						<div className="notePropertySuggestionsLabel">Suggested tags</div>
 						<div className="notePropertySuggestionList">
-							{tagSuggestions.map(({ tag, count }) => (
+							{tagSuggestions.map(({ tag }) => (
 								<button
 									key={tag}
 									type="button"
@@ -611,9 +611,6 @@ function DatabaseCellEditor({
 									}}
 								>
 									<span>{formatDatabaseTagLabel(tag)}</span>
-									<span className="notePropertySuggestionCount mono">
-										{count}
-									</span>
 								</button>
 							))}
 						</div>

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -324,9 +324,8 @@ function DatabaseCellEditor({
 				seenTags.add(normalized);
 				return true;
 			})
-			.map(({ tag, count }) => ({
+			.map(({ tag }) => ({
 				tag: normalizeTagToken(tag) ?? tag,
-				count,
 			}));
 		for (const value of valueOptions) {
 			const normalized = normalizeTagToken(value);
@@ -339,7 +338,7 @@ function DatabaseCellEditor({
 			}
 			if (query && !normalized.includes(query)) continue;
 			seenTags.add(normalized);
-			suggestions.push({ tag: normalized, count: 0 });
+			suggestions.push({ tag: normalized });
 			if (suggestions.length >= DATABASE_CELL_TAG_SUGGESTION_LIMIT) break;
 		}
 		return suggestions.slice(0, DATABASE_CELL_TAG_SUGGESTION_LIMIT);

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -316,10 +316,6 @@ export function DatabaseTable({
 											className="databaseGroupCell"
 										>
 											<span className="databaseGroupLabel">{group.label}</span>
-											<span className="databaseGroupCount">
-												{group.rowCount}{" "}
-												{group.rowCount === 1 ? "note" : "notes"}
-											</span>
 										</td>
 									</tr>
 									{group.rows

--- a/src/components/database/DatabaseTagPicker.test.ts
+++ b/src/components/database/DatabaseTagPicker.test.ts
@@ -31,8 +31,8 @@ const availableTags = [
 describe("DatabaseTagPicker", () => {
 	it("excludes virtual tags when query is empty", () => {
 		expect(buildDatabaseTagPickerOptions(availableTags, "")).toEqual([
-			{ tag: "work", count: 3 },
-			{ tag: "personal", count: 1 },
+			{ tag: "work" },
+			{ tag: "personal" },
 		]);
 	});
 
@@ -42,8 +42,8 @@ describe("DatabaseTagPicker", () => {
 
 	it("treats leading slash queries like an empty prefix", () => {
 		expect(buildDatabaseTagPickerOptions(availableTags, "/work")).toEqual([
-			{ tag: "work", count: 3 },
-			{ tag: "personal", count: 1 },
+			{ tag: "work" },
+			{ tag: "personal" },
 		]);
 	});
 

--- a/src/components/database/DatabaseTagPicker.tsx
+++ b/src/components/database/DatabaseTagPicker.tsx
@@ -36,11 +36,13 @@ export function buildDatabaseTagPickerOptions(
 	tags: ReturnType<typeof useFileTreeContext>["tags"],
 	query: string,
 	limit = Number.POSITIVE_INFINITY,
-): Array<{ tag: string; count: number }> {
+): Array<{ tag: string }> {
 	const trimmed = query.trim();
 	if (trimmed.length >= 2) {
 		const suggestions = buildTagSuggestions(tags, [], trimmed, limit);
-		if (suggestions.length > 0) return suggestions;
+		if (suggestions.length > 0) {
+			return suggestions.map(({ tag }) => ({ tag }));
+		}
 	}
 
 	const normalizedQuery = normalizeTagDraftPrefix(trimmed);
@@ -51,7 +53,7 @@ export function buildDatabaseTagPickerOptions(
 				(normalizedQuery.length === 0 ||
 					tag.toLowerCase().includes(normalizedQuery)),
 		)
-		.map(({ tag, direct_count }) => ({ tag, count: direct_count }))
+		.map(({ tag }) => ({ tag }))
 		.slice(0, limit);
 }
 

--- a/src/components/database/DatabaseTagPicker.tsx
+++ b/src/components/database/DatabaseTagPicker.tsx
@@ -128,7 +128,7 @@ export function DatabaseTagPicker({
 				<ScrollArea className="databasePickerResults">
 					<div className="databasePickerList">
 						{options.length > 0
-							? options.map(({ tag, count }) => {
+							? options.map(({ tag }) => {
 									const normalizedTag = normalizeTagToken(tag) ?? tag;
 									const active = normalizedTag === selectedTag;
 									return (
@@ -147,11 +147,7 @@ export function DatabaseTagPicker({
 												<span className="databasePickerOptionLabel">
 													{formatTagLabel(normalizedTag)}
 												</span>
-												<span className="databasePickerOptionMeta">
-													Used in {count} note{count === 1 ? "" : "s"}
-												</span>
 											</span>
-											<span className="databasePickerOptionBadge">{count}</span>
 										</button>
 									);
 								})

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -197,12 +197,6 @@ function DatabasesPaneContent({
 	const [rows, setRows] = useState<DatabaseRow[]>(
 		() => initialRows?.rows ?? [],
 	);
-	const [totalCount, setTotalCount] = useState(
-		() => initialRows?.total_count ?? 0,
-	);
-	const [isTruncated, setIsTruncated] = useState(
-		() => initialRows?.truncated ?? false,
-	);
 	const [loading, setLoading] = useState(() => !initialDocument);
 	const [rowsLoading, setRowsLoading] = useState(() => !initialRows);
 	const [error, setError] = useState("");
@@ -217,7 +211,6 @@ function DatabasesPaneContent({
 	const fsRowsRefreshTimerRef = useRef<number | null>(null);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
 	const { colors: statusColors, setStatusColor } = useStatusPropertyColors();
-	const [showDatabaseNoteCount, setShowDatabaseNoteCount] = useState(false);
 
 	const loadSummaries = useCallback(async () => {
 		const next = await prefetchDatabaseSummaries();
@@ -246,7 +239,6 @@ function DatabasesPaneContent({
 			.then((settings) => {
 				if (!cancelled) {
 					setShowDatabaseColumnColor(settings.database.showColumnColor);
-					setShowDatabaseNoteCount(settings.database.showNoteCount);
 				}
 			})
 			.catch(() => {
@@ -260,9 +252,6 @@ function DatabasesPaneContent({
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.database?.showColumnColor === "boolean") {
 			setShowDatabaseColumnColor(payload.database.showColumnColor);
-		}
-		if (typeof payload.database?.showNoteCount === "boolean") {
-			setShowDatabaseNoteCount(payload.database.showNoteCount);
 		}
 	});
 
@@ -386,8 +375,6 @@ function DatabasesPaneContent({
 			) {
 				if (rowRequestTokenRef.current === requestToken) {
 					setRows([]);
-					setTotalCount(0);
-					setIsTruncated(false);
 				}
 				return;
 			}
@@ -404,8 +391,6 @@ function DatabasesPaneContent({
 					return;
 				}
 				setRows(next.rows);
-				setTotalCount(next.total_count);
-				setIsTruncated(next.truncated);
 				setPrefetchedDatabaseRows(selectedDatabaseId, selectedViewId, next);
 			} catch (cause) {
 				if (rowRequestTokenRef.current !== requestToken) {
@@ -429,8 +414,6 @@ function DatabasesPaneContent({
 		);
 		if (cachedRows) {
 			setRows(cachedRows.rows);
-			setTotalCount(cachedRows.total_count);
-			setIsTruncated(cachedRows.truncated);
 			setRowsLoading(false);
 			void loadRows({ background: true });
 			return;
@@ -853,18 +836,6 @@ function DatabasesPaneContent({
 
 				{document ? (
 					<div className="databasesTopBarRight">
-						{showDatabaseNoteCount ? (
-							<span className="databasesHeaderSource">
-								{totalCount > rows.length
-									? `Showing ${rows.length} of ${totalCount} notes`
-									: `${rows.length} note${rows.length === 1 ? "" : "s"}`}
-							</span>
-						) : null}
-						{isTruncated ? (
-							<span className="databasesHeaderSource">
-								Limited to the first 200 notes
-							</span>
-						) : null}
 						<Button
 							type="button"
 							variant="ghost"

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -197,6 +197,9 @@ function DatabasesPaneContent({
 	const [rows, setRows] = useState<DatabaseRow[]>(
 		() => initialRows?.rows ?? [],
 	);
+	const [rowsTruncated, setRowsTruncated] = useState(
+		() => initialRows?.truncated ?? false,
+	);
 	const [loading, setLoading] = useState(() => !initialDocument);
 	const [rowsLoading, setRowsLoading] = useState(() => !initialRows);
 	const [error, setError] = useState("");
@@ -375,6 +378,7 @@ function DatabasesPaneContent({
 			) {
 				if (rowRequestTokenRef.current === requestToken) {
 					setRows([]);
+					setRowsTruncated(false);
 				}
 				return;
 			}
@@ -391,6 +395,7 @@ function DatabasesPaneContent({
 					return;
 				}
 				setRows(next.rows);
+				setRowsTruncated(next.truncated);
 				setPrefetchedDatabaseRows(selectedDatabaseId, selectedViewId, next);
 			} catch (cause) {
 				if (rowRequestTokenRef.current !== requestToken) {
@@ -414,6 +419,7 @@ function DatabasesPaneContent({
 		);
 		if (cachedRows) {
 			setRows(cachedRows.rows);
+			setRowsTruncated(cachedRows.truncated);
 			setRowsLoading(false);
 			void loadRows({ background: true });
 			return;
@@ -535,6 +541,7 @@ function DatabasesPaneContent({
 			invalidateDatabaseSummariesPrefetch();
 			setDocument(null);
 			setRows([]);
+			setRowsTruncated(false);
 			await loadSummaries();
 		} catch (cause) {
 			setError(extractErrorMessage(cause));
@@ -1042,6 +1049,11 @@ function DatabasesPaneContent({
 					</div>
 					{error ? (
 						<div className="databaseNotice databaseNoticeError">{error}</div>
+					) : null}
+					{rowsTruncated ? (
+						<div className="databaseNotice">
+							Limited to the first 200 notes.
+						</div>
 					) : null}
 					{rowsLoading ? (
 						<div className="databaseLoadingState">Loading rows…</div>

--- a/src/components/editor/EditorRibbon.tsx
+++ b/src/components/editor/EditorRibbon.tsx
@@ -40,6 +40,7 @@ const RibbonButtonList = memo(function RibbonButtonList({
 			type="button"
 			className={`ribbonBtn ${btn.isActive?.() ? "active" : ""}`}
 			title={btn.title}
+			aria-label={btn.title}
 			disabled={!canEdit}
 			onMouseDown={onPreventMouseDown}
 			onClick={() => canEdit && btn.onClick()}
@@ -123,6 +124,7 @@ export const EditorRibbon = memo(function EditorRibbon({
 							type="button"
 							className="ribbonBtn"
 							title="Extract to note"
+							aria-label="Extract to note"
 							disabled={!canEdit}
 							onMouseDown={preventMouseDown}
 							onClick={() => canEdit && onExtractSelectionToNote()}

--- a/src/components/editor/FloatingTOC.tsx
+++ b/src/components/editor/FloatingTOC.tsx
@@ -1,6 +1,5 @@
-import type { Editor } from "@tiptap/react";
 import { memo, useId, useState } from "react";
-import { useTableOfContents } from "./hooks/useTableOfContents";
+import type { TOCHeading } from "./hooks/useTableOfContents";
 
 const MIN_HEADINGS = 2;
 
@@ -23,13 +22,16 @@ const INDENT: Record<number, number> = {
 };
 
 interface FloatingTOCProps {
-	editor: Editor | null;
+	activeId: string | null;
+	headings: TOCHeading[];
+	onSelectHeading: (heading: TOCHeading) => void;
 }
 
 export const FloatingTOC = memo(function FloatingTOC({
-	editor,
+	activeId,
+	headings,
+	onSelectHeading,
 }: FloatingTOCProps) {
-	const { headings, activeId, scrollToHeading } = useTableOfContents(editor);
 	const [expanded, setExpanded] = useState(false);
 	const panelId = useId();
 
@@ -83,7 +85,7 @@ export const FloatingTOC = memo(function FloatingTOC({
 								data-active={h.id === activeId ? "true" : undefined}
 								data-level={h.level}
 								style={{ paddingLeft: INDENT[h.level] ?? 0 }}
-								onClick={() => scrollToHeading(h)}
+								onClick={() => onSelectHeading(h)}
 								title={h.text}
 							>
 								{h.text}

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -307,6 +307,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 								className="codeBlockLanguageBtn"
 								onMouseDown={codeBlock.onPickerMouseDown}
 								title="Set code block language"
+								aria-label="Set code block language"
 							>
 								<span className="codeBlockLanguageBtnIcon" aria-hidden>
 									<HugeiconsIcon
@@ -356,6 +357,11 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 									? "Stop Mermaid preview"
 									: "Play Mermaid preview"
 							}
+							aria-label={
+								codeBlock.isMermaidPreviewActive
+									? "Stop Mermaid preview"
+									: "Play Mermaid preview"
+							}
 						>
 							<span className="codeBlockPreviewBtnLabel mono">
 								{codeBlock.isMermaidPreviewActive ? "Stop" : "Play"}
@@ -376,6 +382,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 					onMouseDown={codeBlock.onPickerMouseDown}
 					onClick={codeBlock.onCopy}
 					title={codeBlock.copied ? "Copied!" : "Copy code to clipboard"}
+					aria-label={codeBlock.copied ? "Copied code" : "Copy code"}
 				>
 					<HugeiconsIcon
 						icon={codeBlock.copied ? Tick02Icon : Copy01Icon}
@@ -418,6 +425,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 								void task.onOpenPopover(task.selectedAnchor);
 							}}
 							title="Schedule selected task"
+							aria-label="Schedule selected task"
 						>
 							<HugeiconsIcon
 								icon={Calendar03Icon}
@@ -438,10 +446,17 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 									type="date"
 									value={task.scheduledDate}
 									onChange={(event) => {
-										const scheduled = event.currentTarget.value;
-										task.onScheduledDateChange(scheduled);
-										task.onUpdateDates(scheduled, task.dueDate);
+										task.onScheduledDateChange(event.currentTarget.value);
 									}}
+									onBlur={(event) =>
+										task.onUpdateDates(event.currentTarget.value, task.dueDate)
+									}
+									onKeyDown={(event) => {
+										if (event.key !== "Enter") return;
+										event.preventDefault();
+										task.onUpdateDates(event.currentTarget.value, task.dueDate);
+									}}
+									aria-label="Scheduled date"
 								/>
 							</label>
 							<label className="tasksDateNativeField">
@@ -450,10 +465,23 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 									type="date"
 									value={task.dueDate}
 									onChange={(event) => {
-										const due = event.currentTarget.value;
-										task.onDueDateChange(due);
-										task.onUpdateDates(task.scheduledDate, due);
+										task.onDueDateChange(event.currentTarget.value);
 									}}
+									onBlur={(event) =>
+										task.onUpdateDates(
+											task.scheduledDate,
+											event.currentTarget.value,
+										)
+									}
+									onKeyDown={(event) => {
+										if (event.key !== "Enter") return;
+										event.preventDefault();
+										task.onUpdateDates(
+											task.scheduledDate,
+											event.currentTarget.value,
+										);
+									}}
+									aria-label="Due date"
 								/>
 							</label>
 						</div>

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -147,6 +147,23 @@ function normalizeEditorHref(value: string): string {
 	return `https://${trimmed}`;
 }
 
+function normalizeCalloutType(type: string): string {
+	return type.toLowerCase() === "warn" ? "warning" : type.toLowerCase();
+}
+
+function createCalloutContent(type: string) {
+	return {
+		type: "blockquote",
+		content: [
+			{
+				type: "paragraph",
+				content: [{ type: "text", text: `[!${normalizeCalloutType(type)}]` }],
+			},
+			{ type: "paragraph" },
+		],
+	};
+}
+
 async function openFrontmatterHref(
 	href: string,
 	sourcePath: string,
@@ -396,70 +413,15 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 						extractToNote.openExtractDialog();
 						return true;
 					case "callout_info":
-						return chain
-							.insertContent({
-								type: "blockquote",
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "[!info]" }],
-									},
-									{ type: "paragraph" },
-								],
-							})
-							.run();
+						return chain.insertContent(createCalloutContent("info")).run();
 					case "callout_warning":
-						return chain
-							.insertContent({
-								type: "blockquote",
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "[!warning]" }],
-									},
-									{ type: "paragraph" },
-								],
-							})
-							.run();
+						return chain.insertContent(createCalloutContent("warning")).run();
 					case "callout_error":
-						return chain
-							.insertContent({
-								type: "blockquote",
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "[!error]" }],
-									},
-									{ type: "paragraph" },
-								],
-							})
-							.run();
+						return chain.insertContent(createCalloutContent("error")).run();
 					case "callout_success":
-						return chain
-							.insertContent({
-								type: "blockquote",
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "[!success]" }],
-									},
-									{ type: "paragraph" },
-								],
-							})
-							.run();
+						return chain.insertContent(createCalloutContent("success")).run();
 					case "callout_tip":
-						return chain
-							.insertContent({
-								type: "blockquote",
-								content: [
-									{
-										type: "paragraph",
-										content: [{ type: "text", text: "[!tip]" }],
-									},
-									{ type: "paragraph" },
-								],
-							})
-							.run();
+						return chain.insertContent(createCalloutContent("tip")).run();
 					case "link_set": {
 						const linkAttrs = editor.getAttributes("link") as {
 							href?: string;
@@ -526,8 +488,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			return;
 		}
 		onRegisterCalloutInserter((type: string) => {
-			const normalizedType =
-				type.toLowerCase() === "warn" ? "warning" : type.toLowerCase();
 			const host = tiptapHostRef.current?.closest(
 				".rfNodeNoteEditorBody",
 			) as HTMLElement | null;
@@ -535,16 +495,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			editor
 				.chain()
 				.focus(null, { scrollIntoView: false })
-				.insertContent({
-					type: "blockquote",
-					content: [
-						{
-							type: "paragraph",
-							content: [{ type: "text", text: `[!${normalizedType}]` }],
-						},
-						{ type: "paragraph" },
-					],
-				})
+				.insertContent(createCalloutContent(type))
 				.run();
 			if (host) {
 				requestAnimationFrame(() => {
@@ -729,23 +680,35 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 
 		syncSelectedCodeBlock();
 		const scrollHost = host.closest(".rfNodeNoteEditorBody");
-		scrollHost?.addEventListener("scroll", syncSelectedCodeBlock, {
+		let codeBlockFrame = 0;
+		const scheduleSelectedCodeBlockSync = () => {
+			if (codeBlockFrame) return;
+			codeBlockFrame = window.requestAnimationFrame(() => {
+				codeBlockFrame = 0;
+				syncSelectedCodeBlock();
+			});
+		};
+		scrollHost?.addEventListener("scroll", scheduleSelectedCodeBlockSync, {
 			passive: true,
 		});
-		window.addEventListener("resize", syncSelectedCodeBlock);
-		document.addEventListener("selectionchange", syncSelectedCodeBlock);
-		editor.on("selectionUpdate", syncSelectedCodeBlock);
-		editor.on("transaction", syncSelectedCodeBlock);
+		window.addEventListener("resize", scheduleSelectedCodeBlockSync);
+		document.addEventListener("selectionchange", scheduleSelectedCodeBlockSync);
+		editor.on("selectionUpdate", scheduleSelectedCodeBlockSync);
+		editor.on("transaction", scheduleSelectedCodeBlockSync);
 		return () => {
+			if (codeBlockFrame) window.cancelAnimationFrame(codeBlockFrame);
 			if (codeBlockCopyResetTimerRef.current !== null) {
 				window.clearTimeout(codeBlockCopyResetTimerRef.current);
 				codeBlockCopyResetTimerRef.current = null;
 			}
-			scrollHost?.removeEventListener("scroll", syncSelectedCodeBlock);
-			window.removeEventListener("resize", syncSelectedCodeBlock);
-			document.removeEventListener("selectionchange", syncSelectedCodeBlock);
-			editor.off("selectionUpdate", syncSelectedCodeBlock);
-			editor.off("transaction", syncSelectedCodeBlock);
+			scrollHost?.removeEventListener("scroll", scheduleSelectedCodeBlockSync);
+			window.removeEventListener("resize", scheduleSelectedCodeBlockSync);
+			document.removeEventListener(
+				"selectionchange",
+				scheduleSelectedCodeBlockSync,
+			);
+			editor.off("selectionUpdate", scheduleSelectedCodeBlockSync);
+			editor.off("transaction", scheduleSelectedCodeBlockSync);
 		};
 	}, [editor, mode]);
 
@@ -762,66 +725,72 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		isSelectedMermaidCodeBlock &&
 		selectedCodeBlock?.pos === activeMermaidPreviewPos;
 
-	const applyCodeBlockLanguage = (language: SupportedCodeBlockLanguage) => {
-		if (!editor) return;
-		editor
-			.chain()
-			.focus(null, { scrollIntoView: false })
-			.updateAttributes("codeBlock", {
-				language: language === "plaintext" ? null : language,
-			})
-			.run();
-		if (language !== MERMAID_CODE_BLOCK_LANGUAGE) {
-			setActiveMermaidPreviewPos(null);
-		}
-		setCodeBlockPickerOpen(false);
-	};
-	const preventCodeBlockPickerMouseDown = (
-		event: ReactMouseEvent<HTMLElement>,
-	) => {
-		event.preventDefault();
-	};
-	const preventTableControlMouseDown = (
-		event: ReactMouseEvent<HTMLButtonElement>,
-	) => {
-		event.preventDefault();
-	};
-	const addRowToSelectedTable = () => {
+	const applyCodeBlockLanguage = useCallback(
+		(language: SupportedCodeBlockLanguage) => {
+			if (!editor) return;
+			editor
+				.chain()
+				.focus(null, { scrollIntoView: false })
+				.updateAttributes("codeBlock", {
+					language: language === "plaintext" ? null : language,
+				})
+				.run();
+			if (language !== MERMAID_CODE_BLOCK_LANGUAGE) {
+				setActiveMermaidPreviewPos(null);
+			}
+			setCodeBlockPickerOpen(false);
+		},
+		[editor],
+	);
+	const preventCodeBlockPickerMouseDown = useCallback(
+		(event: ReactMouseEvent<HTMLElement>) => {
+			event.preventDefault();
+		},
+		[],
+	);
+	const preventTableControlMouseDown = useCallback(
+		(event: ReactMouseEvent<HTMLButtonElement>) => {
+			event.preventDefault();
+		},
+		[],
+	);
+	const addRowToSelectedTable = useCallback(() => {
 		if (!editor) return;
 		editor.chain().focus(null, { scrollIntoView: false }).addRowAfter().run();
-	};
-	const addColumnToSelectedTable = () => {
+	}, [editor]);
+	const addColumnToSelectedTable = useCallback(() => {
 		if (!editor) return;
 		editor
 			.chain()
 			.focus(null, { scrollIntoView: false })
 			.addColumnAfter()
 			.run();
-	};
-	const handleEditorPointerDownCapture = (
-		event: React.PointerEvent<HTMLDivElement>,
-	) => {
-		if (!canEdit || activeMermaidPreviewPos === null) return;
-		const target = event.target instanceof HTMLElement ? event.target : null;
-		if (
-			target?.closest(".codeBlockPreviewBtn") ||
-			target?.closest(".codeBlockCopyBtn") ||
-			target?.closest(".codeBlockLanguageBtn") ||
-			target?.closest(".codeBlockLanguagePopover")
-		) {
-			return;
-		}
-		flushSync(() => {
-			setActiveMermaidPreviewPos(null);
-			setActiveMermaidPreviewHeight(0);
-		});
-	};
-	const toggleSelectedMermaidPreview = () => {
+	}, [editor]);
+	const handleEditorPointerDownCapture = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			if (!canEdit || activeMermaidPreviewPos === null) return;
+			const target = event.target instanceof HTMLElement ? event.target : null;
+			if (
+				target?.closest(".codeBlockPreviewBtn") ||
+				target?.closest(".codeBlockCopyBtn") ||
+				target?.closest(".codeBlockLanguageBtn") ||
+				target?.closest(".codeBlockLanguagePopover")
+			) {
+				return;
+			}
+			flushSync(() => {
+				setActiveMermaidPreviewPos(null);
+				setActiveMermaidPreviewHeight(0);
+			});
+		},
+		[activeMermaidPreviewPos, canEdit],
+	);
+	const toggleSelectedMermaidPreview = useCallback(() => {
 		if (!selectedCodeBlock || !isSelectedMermaidCodeBlock) return;
 		setActiveMermaidPreviewPos((prev) =>
 			prev === selectedCodeBlock.pos ? null : selectedCodeBlock.pos,
 		);
-	};
+	}, [isSelectedMermaidCodeBlock, selectedCodeBlock]);
 
 	useEffect(() => {
 		if (!editor) return;
@@ -926,6 +895,125 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		setLinkDialog(null);
 	}, [canEdit, editor]);
 
+	const copySelectedCodeBlock = useCallback(() => {
+		if (!selectedCodeBlock) return;
+		const clipboard = navigator.clipboard;
+		if (!clipboard?.writeText) {
+			console.error("Clipboard API unavailable");
+			setCodeBlockCopied(false);
+			return;
+		}
+		void clipboard
+			.writeText(selectedCodeBlock.source)
+			.then(() => {
+				if (codeBlockCopyResetTimerRef.current !== null) {
+					window.clearTimeout(codeBlockCopyResetTimerRef.current);
+				}
+				setCodeBlockCopied(true);
+				codeBlockCopyResetTimerRef.current = window.setTimeout(() => {
+					codeBlockCopyResetTimerRef.current = null;
+					setCodeBlockCopied(false);
+				}, 1500);
+			})
+			.catch((error: unknown) => {
+				console.error("Failed to copy code block contents.", error);
+				setCodeBlockCopied(false);
+			});
+	}, [selectedCodeBlock]);
+
+	const tableControls = useMemo(
+		() => ({
+			selected: selectedTable,
+			onControlMouseDown: preventTableControlMouseDown,
+			onAddRow: addRowToSelectedTable,
+			onAddColumn: addColumnToSelectedTable,
+		}),
+		[
+			addColumnToSelectedTable,
+			addRowToSelectedTable,
+			preventTableControlMouseDown,
+			selectedTable,
+		],
+	);
+
+	const codeBlockControls = useMemo(
+		() => ({
+			selected: selectedCodeBlock,
+			pickerOpen: codeBlockPickerOpen,
+			onPickerOpenChange: setCodeBlockPickerOpen,
+			language: selectedCodeBlockLanguage,
+			languageLabel: selectedCodeBlockLanguageLabel,
+			isMermaid: isSelectedMermaidCodeBlock,
+			isMermaidPreviewActive: isSelectedMermaidPreviewActive,
+			copied: codeBlockCopied,
+			onPickerMouseDown: preventCodeBlockPickerMouseDown,
+			onApplyLanguage: applyCodeBlockLanguage,
+			onToggleMermaidPreview: toggleSelectedMermaidPreview,
+			onCopy: copySelectedCodeBlock,
+			mermaidPreviewHeight: activeMermaidPreviewHeight,
+			onMermaidHeightChange: setActiveMermaidPreviewHeight,
+		}),
+		[
+			activeMermaidPreviewHeight,
+			applyCodeBlockLanguage,
+			codeBlockCopied,
+			codeBlockPickerOpen,
+			copySelectedCodeBlock,
+			isSelectedMermaidCodeBlock,
+			isSelectedMermaidPreviewActive,
+			preventCodeBlockPickerMouseDown,
+			selectedCodeBlock,
+			selectedCodeBlockLanguage,
+			selectedCodeBlockLanguageLabel,
+			toggleSelectedMermaidPreview,
+		],
+	);
+
+	const resetTaskDraftDates = useCallback(() => {
+		void taskInlineDates.resetDraftDates();
+	}, [taskInlineDates.resetDraftDates]);
+	const updateTaskDates = useCallback(
+		(scheduled: string, due: string) => {
+			void taskInlineDates.updateTaskDates(scheduled, due);
+		},
+		[taskInlineDates.updateTaskDates],
+	);
+	const taskControls = useMemo(
+		() => ({
+			selectedAnchor: taskInlineDates.selectedTaskAnchor,
+			scheduleAnchor: taskInlineDates.scheduleAnchor,
+			onScheduleAnchorChange: taskInlineDates.setScheduleAnchor,
+			onOpenPopover: taskInlineDates.openTaskPopover,
+			scheduledDate: taskInlineDates.scheduledDate,
+			dueDate: taskInlineDates.dueDate,
+			onScheduledDateChange: taskInlineDates.setScheduledDate,
+			onDueDateChange: taskInlineDates.setDueDate,
+			onResetDraftDates: resetTaskDraftDates,
+			onUpdateDates: updateTaskDates,
+		}),
+		[
+			resetTaskDraftDates,
+			taskInlineDates.dueDate,
+			taskInlineDates.openTaskPopover,
+			taskInlineDates.scheduleAnchor,
+			taskInlineDates.scheduledDate,
+			taskInlineDates.selectedTaskAnchor,
+			taskInlineDates.setDueDate,
+			taskInlineDates.setScheduleAnchor,
+			taskInlineDates.setScheduledDate,
+			updateTaskDates,
+		],
+	);
+
+	const backlinkControls = useMemo(
+		() => ({
+			show: showBacklinks,
+			items: backlinks,
+			interactive,
+		}),
+		[backlinks, interactive, showBacklinks],
+	);
+
 	return (
 		<div
 			className={[
@@ -995,76 +1083,10 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 								? extractToNote.openExtractDialog
 								: undefined
 						}
-						table={{
-							selected: selectedTable,
-							onControlMouseDown: preventTableControlMouseDown,
-							onAddRow: addRowToSelectedTable,
-							onAddColumn: addColumnToSelectedTable,
-						}}
-						codeBlock={{
-							selected: selectedCodeBlock,
-							pickerOpen: codeBlockPickerOpen,
-							onPickerOpenChange: setCodeBlockPickerOpen,
-							language: selectedCodeBlockLanguage,
-							languageLabel: selectedCodeBlockLanguageLabel,
-							isMermaid: isSelectedMermaidCodeBlock,
-							isMermaidPreviewActive: isSelectedMermaidPreviewActive,
-							copied: codeBlockCopied,
-							onPickerMouseDown: preventCodeBlockPickerMouseDown,
-							onApplyLanguage: applyCodeBlockLanguage,
-							onToggleMermaidPreview: toggleSelectedMermaidPreview,
-							onCopy: () => {
-								if (!selectedCodeBlock) return;
-								const clipboard = navigator.clipboard;
-								if (!clipboard?.writeText) {
-									console.error("Clipboard API unavailable");
-									setCodeBlockCopied(false);
-									return;
-								}
-								void clipboard
-									.writeText(selectedCodeBlock.source)
-									.then(() => {
-										if (codeBlockCopyResetTimerRef.current !== null) {
-											window.clearTimeout(codeBlockCopyResetTimerRef.current);
-										}
-										setCodeBlockCopied(true);
-										codeBlockCopyResetTimerRef.current = window.setTimeout(
-											() => {
-												codeBlockCopyResetTimerRef.current = null;
-												setCodeBlockCopied(false);
-											},
-											1500,
-										);
-									})
-									.catch((error: unknown) => {
-										console.error("Failed to copy code block contents.", error);
-										setCodeBlockCopied(false);
-									});
-							},
-							mermaidPreviewHeight: activeMermaidPreviewHeight,
-							onMermaidHeightChange: setActiveMermaidPreviewHeight,
-						}}
-						task={{
-							selectedAnchor: taskInlineDates.selectedTaskAnchor,
-							scheduleAnchor: taskInlineDates.scheduleAnchor,
-							onScheduleAnchorChange: taskInlineDates.setScheduleAnchor,
-							onOpenPopover: taskInlineDates.openTaskPopover,
-							scheduledDate: taskInlineDates.scheduledDate,
-							dueDate: taskInlineDates.dueDate,
-							onScheduledDateChange: taskInlineDates.setScheduledDate,
-							onDueDateChange: taskInlineDates.setDueDate,
-							onResetDraftDates: () => {
-								void taskInlineDates.resetDraftDates();
-							},
-							onUpdateDates: (scheduled, due) => {
-								void taskInlineDates.updateTaskDates(scheduled, due);
-							},
-						}}
-						backlinks={{
-							show: showBacklinks,
-							items: backlinks,
-							interactive,
-						}}
+						table={tableControls}
+						codeBlock={codeBlockControls}
+						task={taskControls}
+						backlinks={backlinkControls}
 					/>
 				) : null}
 			</div>

--- a/src/components/editor/RibbonColorPopover.tsx
+++ b/src/components/editor/RibbonColorPopover.tsx
@@ -35,6 +35,7 @@ export function RibbonColorPopover({
 					type="button"
 					className={`ribbonBtn ${button.isActive?.() ? "active" : ""}`}
 					title={button.title}
+					aria-label={button.title}
 					disabled={!canEdit}
 					onMouseDown={preventMouseDown}
 					whileTap={canEdit ? { scale: 0.97 } : undefined}

--- a/src/components/editor/RibbonHighlightPopover.tsx
+++ b/src/components/editor/RibbonHighlightPopover.tsx
@@ -35,6 +35,7 @@ export function RibbonHighlightPopover({
 					type="button"
 					className={`ribbonBtn ${button.isActive?.() ? "active" : ""}`}
 					title={button.title}
+					aria-label={button.title}
 					disabled={!canEdit}
 					onMouseDown={preventMouseDown}
 					whileTap={canEdit ? { scale: 0.97 } : undefined}

--- a/src/components/editor/RibbonLinkPopover.tsx
+++ b/src/components/editor/RibbonLinkPopover.tsx
@@ -85,6 +85,7 @@ export function RibbonLinkPopover({
 					type="button"
 					className={`ribbonBtn ${editor.isActive("link") ? "active" : ""}`}
 					title="Link"
+					aria-label="Link"
 					disabled={!canEdit}
 					onMouseDown={preventMouseDown}
 					onClick={() => canEdit && setLinkOpen(true)}

--- a/src/components/editor/editorActions.ts
+++ b/src/components/editor/editorActions.ts
@@ -2,212 +2,120 @@ import { EDITOR_TEXT_COLORS } from "./textColors";
 import { EDITOR_TEXT_HIGHLIGHTS } from "./textHighlights";
 
 type EditorActionId = string;
-type EditorActionCategory =
-	| "format"
-	| "structure"
-	| "insert"
-	| "callout"
-	| "color"
-	| "highlight"
-	| "link"
-	| "note";
 
 interface EditorActionDefinition {
 	id: EditorActionId;
 	label: string;
-	description: string;
-	category: EditorActionCategory;
-	menuId?: string;
 }
 
 const BASE_EDITOR_ACTIONS: EditorActionDefinition[] = [
 	{
 		id: "bold",
 		label: "Bold",
-		description: "Toggle bold formatting for the current selection.",
-		category: "format",
-		menuId: "editor.bold",
 	},
 	{
 		id: "italic",
 		label: "Italic",
-		description: "Toggle italic formatting for the current selection.",
-		category: "format",
-		menuId: "editor.italic",
 	},
 	{
 		id: "underline",
 		label: "Underline",
-		description: "Toggle underline formatting for the current selection.",
-		category: "format",
-		menuId: "editor.underline",
 	},
 	{
 		id: "strikethrough",
 		label: "Strikethrough",
-		description: "Toggle strikethrough formatting for the current selection.",
-		category: "format",
-		menuId: "editor.strikethrough",
 	},
 	{
 		id: "heading_1",
 		label: "Heading 1",
-		description: "Convert the current block to a level 1 heading.",
-		category: "structure",
-		menuId: "editor.heading_1",
 	},
 	{
 		id: "heading_2",
 		label: "Heading 2",
-		description: "Convert the current block to a level 2 heading.",
-		category: "structure",
-		menuId: "editor.heading_2",
 	},
 	{
 		id: "heading_3",
 		label: "Heading 3",
-		description: "Convert the current block to a level 3 heading.",
-		category: "structure",
-		menuId: "editor.heading_3",
 	},
 	{
 		id: "collapse_all_headings",
 		label: "Collapse All Headings",
-		description: "Collapse every heading in the current note.",
-		category: "structure",
-		menuId: "editor.collapse_all_headings",
 	},
 	{
 		id: "expand_all_headings",
 		label: "Expand All Headings",
-		description: "Expand every heading in the current note.",
-		category: "structure",
-		menuId: "editor.expand_all_headings",
 	},
 	{
 		id: "bullet_list",
 		label: "Bullet List",
-		description: "Toggle a bullet list.",
-		category: "structure",
-		menuId: "editor.bullet_list",
 	},
 	{
 		id: "numbered_list",
 		label: "Numbered List",
-		description: "Toggle a numbered list.",
-		category: "structure",
-		menuId: "editor.numbered_list",
 	},
 	{
 		id: "todo_list",
 		label: "To-do List",
-		description: "Toggle a task list.",
-		category: "structure",
-		menuId: "editor.todo_list",
 	},
 	{
 		id: "quote",
 		label: "Quote",
-		description: "Toggle a blockquote.",
-		category: "insert",
-		menuId: "editor.quote",
 	},
 	{
 		id: "code_block",
 		label: "Code Block",
-		description: "Toggle a code block.",
-		category: "insert",
-		menuId: "editor.code_block",
 	},
 	{
 		id: "mermaid_chart",
 		label: "Mermaid Chart",
-		description: "Insert a Mermaid code block.",
-		category: "insert",
-		menuId: "editor.mermaid_chart",
 	},
 	{
 		id: "table",
 		label: "Table",
-		description: "Insert a markdown table.",
-		category: "insert",
-		menuId: "editor.table",
 	},
 	{
 		id: "divider",
 		label: "Divider",
-		description: "Insert a horizontal divider.",
-		category: "insert",
-		menuId: "editor.divider",
 	},
 	{
 		id: "callout_info",
 		label: "Info Callout",
-		description: "Insert an info callout block.",
-		category: "callout",
-		menuId: "editor.callout_info",
 	},
 	{
 		id: "callout_warning",
 		label: "Warning Callout",
-		description: "Insert a warning callout block.",
-		category: "callout",
-		menuId: "editor.callout_warning",
 	},
 	{
 		id: "callout_error",
 		label: "Error Callout",
-		description: "Insert an error callout block.",
-		category: "callout",
-		menuId: "editor.callout_error",
 	},
 	{
 		id: "callout_success",
 		label: "Success Callout",
-		description: "Insert a success callout block.",
-		category: "callout",
-		menuId: "editor.callout_success",
 	},
 	{
 		id: "callout_tip",
 		label: "Tip Callout",
-		description: "Insert a tip callout block.",
-		category: "callout",
-		menuId: "editor.callout_tip",
 	},
 	{
 		id: "link_set",
 		label: "Insert or Edit Link",
-		description: "Insert a link or edit the current link.",
-		category: "link",
-		menuId: "editor.link_set",
 	},
 	{
 		id: "link_clear",
 		label: "Remove Link",
-		description: "Remove the current link from the selection.",
-		category: "link",
-		menuId: "editor.link_clear",
 	},
 	{
 		id: "extract_selection_to_note",
 		label: "Extract to Note",
-		description: "Create a note from the current selection.",
-		category: "note",
 	},
 	{
 		id: "color_clear",
 		label: "Clear Text Color",
-		description: "Remove text color formatting.",
-		category: "color",
-		menuId: "editor.color_clear",
 	},
 	{
 		id: "highlight_clear",
 		label: "Clear Highlight",
-		description: "Remove text highlight formatting.",
-		category: "highlight",
-		menuId: "editor.highlight_clear",
 	},
 ];
 
@@ -216,15 +124,9 @@ export const EDITOR_ACTIONS: EditorActionDefinition[] = [
 	...EDITOR_TEXT_COLORS.map<EditorActionDefinition>((color) => ({
 		id: `color_${color.id}`,
 		label: `Text Color: ${color.label}`,
-		description: `Apply ${color.label.toLowerCase()} text color.`,
-		category: "color",
-		menuId: `editor.color_${color.id}`,
 	})),
 	...EDITOR_TEXT_HIGHLIGHTS.map<EditorActionDefinition>((highlight) => ({
 		id: `highlight_${highlight.id}`,
 		label: `Highlight: ${highlight.label}`,
-		description: `Apply ${highlight.label.toLowerCase()} text highlight.`,
-		category: "highlight",
-		menuId: `editor.highlight_${highlight.id}`,
 	})),
 ];

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -60,92 +60,121 @@ function parseStandaloneMarkdownImage(
 
 const CalloutDecorations = Extension.create({
 	name: "callout-decorations",
+	addOptions() {
+		return {
+			enableShortcutTransform: true,
+		};
+	},
 	addProseMirrorPlugins() {
 		const key = new PluginKey("callout-decorations");
-		return [
-			new Plugin({
-				key: new PluginKey("callout-shortcut-transform"),
-				appendTransaction(transactions, _oldState, newState) {
-					if (!transactions.some((tr) => tr.docChanged)) return null;
+		const plugins = [
+			...(this.options.enableShortcutTransform
+				? [
+						new Plugin({
+							key: new PluginKey("callout-shortcut-transform"),
+							appendTransaction(transactions, _oldState, newState) {
+								if (!transactions.some((tr) => tr.docChanged)) return null;
 
-					const blockquote = newState.schema.nodes.blockquote;
-					const paragraph = newState.schema.nodes.paragraph;
-					const textNode = newState.schema.text.bind(newState.schema);
-					if (!blockquote || !paragraph) return null;
+								const blockquote = newState.schema.nodes.blockquote;
+								const paragraph = newState.schema.nodes.paragraph;
+								const textNode = newState.schema.text.bind(newState.schema);
+								if (!blockquote || !paragraph) return null;
 
-					const replacements: Array<{
-						pos: number;
-						size: number;
-						marker: string;
-					}> = [];
+								const replacements: Array<{
+									pos: number;
+									size: number;
+									marker: string;
+								}> = [];
 
-					visitChangedNodes(transactions, newState, (node, pos) => {
-						if (node.type !== paragraph || node.childCount !== 1) return;
-						const text = node.textContent ?? "";
-						const match = text.match(/^\s*>\s*\[!([A-Za-z_-]+)\]\s*(.*)$/);
-						if (!match) return;
-						const rawKind = (match[1] ?? "note").toLowerCase();
-						const kind = rawKind === "warn" ? "warning" : rawKind;
-						const tail = (match[2] ?? "").trim();
-						const marker = tail.length ? `[!${kind}] ${tail}` : `[!${kind}]`;
-						replacements.push({ pos, size: node.nodeSize, marker });
-					});
+								visitChangedNodes(transactions, newState, (node, pos) => {
+									if (node.type !== paragraph || node.childCount !== 1) return;
+									const text = node.textContent ?? "";
+									const match = text.match(
+										/^\s*>\s*\[!([A-Za-z_-]+)\]\s*(.*)$/,
+									);
+									if (!match) return;
+									const rawKind = (match[1] ?? "note").toLowerCase();
+									const kind = rawKind === "warn" ? "warning" : rawKind;
+									const tail = (match[2] ?? "").trim();
+									const marker = tail.length
+										? `[!${kind}] ${tail}`
+										: `[!${kind}]`;
+									replacements.push({ pos, size: node.nodeSize, marker });
+								});
 
-					if (!replacements.length) return null;
+								if (!replacements.length) return null;
 
-					let tr = newState.tr;
-					for (let i = replacements.length - 1; i >= 0; i -= 1) {
-						const replacement = replacements[i];
-						const calloutNode = blockquote.create(
-							null,
-							[
-								paragraph.create(
-									null,
-									replacement.marker ? textNode(replacement.marker) : null,
-								),
-								paragraph.create(),
-							].filter(Boolean),
-						);
-						tr = tr.replaceWith(
-							replacement.pos,
-							replacement.pos + replacement.size,
-							calloutNode,
-						);
-					}
+								let tr = newState.tr;
+								for (let i = replacements.length - 1; i >= 0; i -= 1) {
+									const replacement = replacements[i];
+									const calloutNode = blockquote.create(
+										null,
+										[
+											paragraph.create(
+												null,
+												replacement.marker
+													? textNode(replacement.marker)
+													: null,
+											),
+											paragraph.create(),
+										].filter(Boolean),
+									);
+									tr = tr.replaceWith(
+										replacement.pos,
+										replacement.pos + replacement.size,
+										calloutNode,
+									);
+								}
 
-					return tr.docChanged ? tr : null;
-				},
-			}),
-			new Plugin({
+								return tr.docChanged ? tr : null;
+							},
+						}),
+					]
+				: []),
+			new Plugin<DecorationSet>({
 				key,
+				state: {
+					init: (_config, state) => buildCalloutDecorations(state.doc),
+					apply(tr, decorations) {
+						if (!tr.docChanged) return decorations;
+						return buildCalloutDecorations(tr.doc);
+					},
+				},
 				props: {
 					decorations(state) {
-						const decorations: Decoration[] = [];
-						state.doc.descendants((node, pos) => {
-							if (node.type.name !== "blockquote") return;
-							let parsed: { kind: string; title: string } | null = null;
-							for (let i = 0; i < node.childCount; i += 1) {
-								const child = node.child(i);
-								const text = child.textContent ?? "";
-								parsed = parseCalloutMarker(text);
-								if (parsed) break;
-							}
-							if (!parsed) return;
-							decorations.push(
-								Decoration.node(pos, pos + node.nodeSize, {
-									class: `callout callout-${parsed.kind}`,
-									"data-callout": parsed.kind,
-									"data-callout-title": parsed.title,
-								}),
-							);
-						});
-						return DecorationSet.create(state.doc, decorations);
+						return key.getState(state) ?? DecorationSet.empty;
 					},
 				},
 			}),
 		];
+		return plugins;
 	},
 });
+
+function buildCalloutDecorations(doc: ProseMirrorNode): DecorationSet {
+	const decorations: Decoration[] = [];
+	doc.descendants((node, pos) => {
+		if (node.type.name !== "blockquote") return;
+		let parsed: { kind: string; title: string } | null = null;
+		for (let i = 0; i < node.childCount; i += 1) {
+			const child = node.child(i);
+			const text = child.textContent ?? "";
+			parsed = parseCalloutMarker(text);
+			if (parsed) break;
+		}
+		if (!parsed) return;
+		decorations.push(
+			Decoration.node(pos, pos + node.nodeSize, {
+				class: `callout callout-${parsed.kind}`,
+				"data-callout": parsed.kind,
+				"data-callout-title": parsed.title,
+			}),
+		);
+	});
+	return decorations.length
+		? DecorationSet.create(doc, decorations)
+		: DecorationSet.empty;
+}
 
 const MARKDOWN_LINK_TEXT_RE = /(?<!!)\[([^\]\n]+)\]\(([^)\n]+)\)/g;
 
@@ -714,6 +743,7 @@ const EditorLink = Link.extend({
 });
 
 interface CreateEditorExtensionsOptions {
+	enableEditingExtensions?: boolean;
 	enableSlashCommand?: boolean;
 	enableWikiLinks?: boolean;
 	enableMarkdownLinkAutocomplete?: boolean;
@@ -729,6 +759,7 @@ export function createEditorExtensions(
 	options?: CreateEditorExtensionsOptions,
 ) {
 	const {
+		enableEditingExtensions = true,
 		enableSlashCommand = true,
 		enableWikiLinks = true,
 		enableMarkdownLinkAutocomplete = true,
@@ -753,13 +784,17 @@ export function createEditorExtensions(
 		EditorLink,
 		TaskList,
 		TaskItem.configure({ nested: true }),
-		TaskListMarkdownShortcut,
-		TaskDetailShortcut,
-		MarkdownLinkSyntaxCollapse,
-		MarkdownImageShortcut,
-		NoteSearch,
-		TableEnterNavigation,
-		Table.configure({ resizable: true }),
+		...(enableEditingExtensions
+			? [
+					TaskListMarkdownShortcut,
+					TaskDetailShortcut,
+					MarkdownLinkSyntaxCollapse,
+					MarkdownImageShortcut,
+					NoteSearch,
+					TableEnterNavigation,
+				]
+			: []),
+		Table.configure({ resizable: enableEditingExtensions }),
 		TableRow,
 		TableHeader,
 		TableCell,
@@ -767,7 +802,7 @@ export function createEditorExtensions(
 			allowBase64: true,
 		}),
 		MermaidPreview,
-		HeadingCollapse,
+		...(enableEditingExtensions ? [HeadingCollapse] : []),
 		Markdown.configure({
 			markedOptions: {
 				gfm: true,
@@ -782,7 +817,7 @@ export function createEditorExtensions(
 				]
 			: []),
 		...(enableWikiLinks ? [WikiLink] : []),
-		...(enableMarkdownLinkAutocomplete
+		...(enableEditingExtensions && enableMarkdownLinkAutocomplete
 			? [
 					MarkdownLinkAutocomplete.configure({
 						currentPath,
@@ -790,13 +825,21 @@ export function createEditorExtensions(
 					}),
 				]
 			: []),
-		...(enablePeopleMentions ? [PersonAutocomplete] : []),
-		...(enableSlashCommand ? [SlashCommand] : []),
-		CalloutDecorations,
-		TagDecorations.configure({ enablePeopleMentions }),
-		ZenFocus.configure({
-			getZenModeEnabled: getZenModeEnabled ?? (() => false),
+		...(enableEditingExtensions && enablePeopleMentions
+			? [PersonAutocomplete]
+			: []),
+		...(enableEditingExtensions && enableSlashCommand ? [SlashCommand] : []),
+		CalloutDecorations.configure({
+			enableShortcutTransform: enableEditingExtensions,
 		}),
-		...(enableVimKeybindings ? [VimMode] : []),
+		TagDecorations.configure({ enablePeopleMentions }),
+		...(enableEditingExtensions
+			? [
+					ZenFocus.configure({
+						getZenModeEnabled: getZenModeEnabled ?? (() => false),
+					}),
+				]
+			: []),
+		...(enableEditingExtensions && enableVimKeybindings ? [VimMode] : []),
 	];
 }

--- a/src/components/editor/extensions/markdownLinkAutocomplete.ts
+++ b/src/components/editor/extensions/markdownLinkAutocomplete.ts
@@ -87,12 +87,21 @@ export const MarkdownLinkAutocomplete = Extension.create({
 
 					const updateMenu = (props: SuggestionProps<LinkSuggestionItem>) => {
 						if (!menu) return;
-						menu.innerHTML = "";
+						menu.replaceChildren();
 						for (const [index, item] of props.items.entries()) {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "wikiLinkSuggestionItem";
-							button.innerHTML = `<span class="wikiLinkSuggestionTitle">${item.title}</span><span class="wikiLinkSuggestionPath">${item.insertText}</span>`;
+
+							const title = document.createElement("span");
+							title.className = "wikiLinkSuggestionTitle";
+							title.textContent = item.title;
+
+							const path = document.createElement("span");
+							path.className = "wikiLinkSuggestionPath";
+							path.textContent = item.insertText;
+
+							button.append(title, path);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
 								props.command(item);

--- a/src/components/editor/extensions/mermaidPreview.ts
+++ b/src/components/editor/extensions/mermaidPreview.ts
@@ -9,6 +9,7 @@ import {
 
 interface MermaidPreviewPluginState {
 	activePreviewPos: number | null;
+	decorations: DecorationSet;
 	refreshKey: number;
 	richPreviewHeight: number;
 }
@@ -88,6 +89,71 @@ function buildMermaidPreviewSpacer(height: number) {
 	return spacer;
 }
 
+function buildMermaidPreviewDecorations(
+	doc: Parameters<typeof DecorationSet.create>[0],
+	pluginState: Omit<MermaidPreviewPluginState, "decorations">,
+	editable: boolean,
+): DecorationSet {
+	const decorations: Decoration[] = [];
+
+	doc.descendants((node, pos) => {
+		if (node.type.name !== "codeBlock") return;
+
+		const language =
+			typeof node.attrs.language === "string" ? node.attrs.language : null;
+		if (!isMermaidCodeBlockLanguage(language)) return;
+
+		const isVisiblePreview = !editable || pluginState.activePreviewPos === pos;
+		if (!isVisiblePreview) return;
+
+		if (editable) {
+			if (pluginState.richPreviewHeight <= 0) return;
+			decorations.push(
+				Decoration.widget(
+					pos + node.nodeSize,
+					() =>
+						buildMermaidPreviewSpacer(
+							pluginState.richPreviewHeight + MERMAID_PREVIEW_SPACER_PADDING,
+						),
+					{
+						side: 1,
+						ignoreSelection: true,
+						key: `mermaid-preview-spacer-${pos}`,
+					},
+				),
+			);
+			return;
+		}
+
+		decorations.push(
+			Decoration.node(pos, pos + node.nodeSize, {
+				class: "mermaidCodeBlockHiddenInPreview",
+			}),
+		);
+
+		decorations.push(
+			Decoration.widget(
+				pos + node.nodeSize,
+				() =>
+					buildMermaidPreviewWidget(
+						node.textContent ?? "",
+						!editable,
+						pluginState.refreshKey,
+					),
+				{
+					side: 1,
+					ignoreSelection: true,
+					key: `mermaid-preview-widget-${pos}-${pluginState.refreshKey}`,
+				},
+			),
+		);
+	});
+
+	return decorations.length
+		? DecorationSet.create(doc, decorations)
+		: DecorationSet.empty;
+}
+
 declare module "@tiptap/core" {
 	interface Commands<ReturnType> {
 		mermaidPreview: {
@@ -146,15 +212,26 @@ export const MermaidPreview = Extension.create({
 	},
 	addProseMirrorPlugins() {
 		const editor = this.editor;
+		const getEditable = () => editor.isEditable;
 		return [
 			new Plugin<MermaidPreviewPluginState>({
 				key: mermaidPreviewPluginKey,
 				state: {
-					init: () => ({
-						activePreviewPos: null,
-						refreshKey: 0,
-						richPreviewHeight: 0,
-					}),
+					init: (_config, state) => {
+						const previewState = {
+							activePreviewPos: null,
+							refreshKey: 0,
+							richPreviewHeight: 0,
+						};
+						return {
+							...previewState,
+							decorations: buildMermaidPreviewDecorations(
+								state.doc,
+								previewState,
+								getEditable(),
+							),
+						};
+					},
 					apply(transaction, value) {
 						const mappedActivePreviewPos =
 							value.activePreviewPos == null
@@ -183,100 +260,46 @@ export const MermaidPreview = Extension.create({
 										}
 										return mapped;
 									})();
-						const nextValue = {
-							...value,
+						let nextValue = {
 							activePreviewPos: mappedActivePreviewPos,
+							refreshKey: value.refreshKey,
+							richPreviewHeight: value.richPreviewHeight,
 						};
 						const meta = transaction.getMeta(mermaidPreviewPluginKey) as
 							| MermaidPreviewMeta
 							| undefined;
-						if (!meta) return nextValue;
-						if (meta.type === "set-active") {
-							return {
+						if (meta?.type === "set-active") {
+							nextValue = {
 								...nextValue,
 								activePreviewPos: meta.pos,
 							};
-						}
-						if (meta.type === "set-rich-height") {
-							return {
+						} else if (meta?.type === "set-rich-height") {
+							nextValue = {
 								...nextValue,
 								richPreviewHeight: meta.height,
 							};
+						} else if (meta?.type === "refresh") {
+							nextValue = {
+								...nextValue,
+								refreshKey: value.refreshKey + 1,
+							};
 						}
+
+						if (!transaction.docChanged && !meta) return value;
 						return {
 							...nextValue,
-							refreshKey: value.refreshKey + 1,
+							decorations: buildMermaidPreviewDecorations(
+								transaction.doc,
+								nextValue,
+								getEditable(),
+							),
 						};
 					},
 				},
 				props: {
 					decorations(state) {
 						const pluginState = mermaidPreviewPluginKey.getState(state);
-						if (!pluginState) return null;
-
-						const decorations: Decoration[] = [];
-						const editable = editor.isEditable;
-
-						state.doc.descendants((node, pos) => {
-							if (node.type.name !== "codeBlock") return;
-
-							const language =
-								typeof node.attrs.language === "string"
-									? node.attrs.language
-									: null;
-							if (!isMermaidCodeBlockLanguage(language)) return;
-
-							const isVisiblePreview =
-								!editable || pluginState.activePreviewPos === pos;
-							if (!isVisiblePreview) return;
-
-							if (editable) {
-								if (pluginState.richPreviewHeight <= 0) return;
-								decorations.push(
-									Decoration.widget(
-										pos + node.nodeSize,
-										() =>
-											buildMermaidPreviewSpacer(
-												pluginState.richPreviewHeight +
-													MERMAID_PREVIEW_SPACER_PADDING,
-											),
-										{
-											side: 1,
-											ignoreSelection: true,
-											key: `mermaid-preview-spacer-${pos}`,
-										},
-									),
-								);
-								return;
-							}
-
-							decorations.push(
-								Decoration.node(pos, pos + node.nodeSize, {
-									class: "mermaidCodeBlockHiddenInPreview",
-								}),
-							);
-
-							decorations.push(
-								Decoration.widget(
-									pos + node.nodeSize,
-									() =>
-										buildMermaidPreviewWidget(
-											node.textContent ?? "",
-											!editable,
-											pluginState.refreshKey,
-										),
-									{
-										side: 1,
-										ignoreSelection: true,
-										key: `mermaid-preview-widget-${pos}-${pluginState.refreshKey}`,
-									},
-								),
-							);
-						});
-
-						return decorations.length
-							? DecorationSet.create(state.doc, decorations)
-							: null;
+						return pluginState?.decorations ?? DecorationSet.empty;
 					},
 				},
 			}),

--- a/src/components/editor/extensions/noteSearch.ts
+++ b/src/components/editor/extensions/noteSearch.ts
@@ -13,7 +13,11 @@ interface NoteSearchState {
 	activeIndex: number;
 }
 
-const noteSearchPluginKey = new PluginKey<NoteSearchState>("note-search");
+interface NoteSearchPluginState extends NoteSearchState {
+	decorations: DecorationSet;
+}
+
+const noteSearchPluginKey = new PluginKey<NoteSearchPluginState>("note-search");
 
 export function findPlainTextSearchRanges(
 	text: string,
@@ -99,24 +103,39 @@ export const NoteSearch = Extension.create({
 
 	addProseMirrorPlugins() {
 		return [
-			new Plugin<NoteSearchState>({
+			new Plugin<NoteSearchPluginState>({
 				key: noteSearchPluginKey,
 				state: {
-					init: () => ({ query: "", activeIndex: 0 }),
+					init: () => ({
+						query: "",
+						activeIndex: 0,
+						decorations: DecorationSet.empty,
+					}),
 					apply(tr, value) {
 						const next = tr.getMeta(noteSearchPluginKey);
-						return next &&
+						if (
+							next &&
 							typeof next.query === "string" &&
 							typeof next.activeIndex === "number"
-							? next
-							: value;
+						) {
+							return {
+								...next,
+								decorations: next.query
+									? buildSearchDecorations(tr.doc, next)
+									: DecorationSet.empty,
+							};
+						}
+						if (!tr.docChanged || !value.query) return value;
+						return {
+							...value,
+							decorations: buildSearchDecorations(tr.doc, value),
+						};
 					},
 				},
 				props: {
 					decorations(state) {
 						const searchState = noteSearchPluginKey.getState(state);
-						if (!searchState?.query) return DecorationSet.empty;
-						return buildSearchDecorations(state.doc, searchState);
+						return searchState?.decorations ?? DecorationSet.empty;
 					},
 				},
 			}),

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -101,7 +101,7 @@ export const PersonAutocomplete = Extension.create({
 
 					const updateMenu = (props: SuggestionProps<PersonSuggestionItem>) => {
 						if (!menu) return;
-						menu.innerHTML = "";
+						menu.replaceChildren();
 						for (const [index, item] of props.items.entries()) {
 							const button = document.createElement("button");
 							button.type = "button";

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -31,10 +31,6 @@ interface WikiLinkSuggestionItem {
 	insertText: string;
 }
 
-function attrsFromRaw(raw: string): WikiLinkAttrs | null {
-	return parseWikiLink(raw);
-}
-
 function titleFromRelPath(path: string): string {
 	const parts = path.split("/").filter(Boolean);
 	const name = parts[parts.length - 1] ?? path;
@@ -207,7 +203,7 @@ export const WikiLink = Node.create({
 	},
 	parseMarkdown(token: MarkdownToken, helpers) {
 		const raw = (token.raw ?? "").trim();
-		const parsed = attrsFromRaw(raw);
+		const parsed = parseWikiLink(raw);
 		if (!parsed) return helpers.createTextNode(raw || token.text || "");
 		return helpers.createNode("wikiLink", parsed);
 	},
@@ -224,7 +220,7 @@ export const WikiLink = Node.create({
 		tokenize(src: string) {
 			const match = src.match(/^!?\[\[[^\]\n]+\]\]/);
 			if (!match) return undefined;
-			const parsed = attrsFromRaw(match[0]);
+			const parsed = parseWikiLink(match[0]);
 			if (!parsed) return undefined;
 			return {
 				type: "wikiLink",
@@ -265,7 +261,7 @@ export const WikiLink = Node.create({
 			nodeInputRule({
 				find: WIKI_LINK_INPUT_REGEX,
 				type: this.type,
-				getAttributes: (match) => attrsFromRaw(match[1]) ?? false,
+				getAttributes: (match) => parseWikiLink(match[1]) ?? false,
 			}),
 		];
 	},
@@ -274,7 +270,7 @@ export const WikiLink = Node.create({
 			nodePasteRule({
 				find: WIKI_LINK_PASTE_REGEX,
 				type: this.type,
-				getAttributes: (match) => attrsFromRaw(match[1]) ?? false,
+				getAttributes: (match) => parseWikiLink(match[1]) ?? false,
 			}),
 		];
 	},
@@ -365,13 +361,22 @@ export const WikiLink = Node.create({
 						props: SuggestionProps<WikiLinkSuggestionItem>,
 					) => {
 						if (!menu) return;
-						menu.innerHTML = "";
+						menu.replaceChildren();
 						if (!props.items.length) return;
 						for (const [index, item] of props.items.entries()) {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "wikiLinkSuggestionItem";
-							button.innerHTML = `<span class="wikiLinkSuggestionTitle">${item.title}</span><span class="wikiLinkSuggestionPath">${item.path}</span>`;
+
+							const title = document.createElement("span");
+							title.className = "wikiLinkSuggestionTitle";
+							title.textContent = item.title;
+
+							const path = document.createElement("span");
+							path.className = "wikiLinkSuggestionPath";
+							path.textContent = item.path;
+
+							button.append(title, path);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
 								props.command(item);

--- a/src/components/editor/extensions/zenFocus.ts
+++ b/src/components/editor/extensions/zenFocus.ts
@@ -3,7 +3,13 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 
-const zenFocusPluginKey = new PluginKey<number>("zen-focus");
+interface ZenFocusPluginState {
+	decorations: DecorationSet;
+	enabled: boolean;
+	refreshKey: number;
+}
+
+const zenFocusPluginKey = new PluginKey<ZenFocusPluginState>("zen-focus");
 
 function buildDecorations(
 	doc: ProseMirrorNode,
@@ -68,7 +74,8 @@ export const ZenFocus = Extension.create<{
 					dispatch(
 						tr.setMeta(
 							zenFocusPluginKey,
-							(zenFocusPluginKey.getState(this.editor.state) ?? 0) + 1,
+							(zenFocusPluginKey.getState(this.editor.state)?.refreshKey ?? 0) +
+								1,
 						),
 					);
 					return true;
@@ -77,23 +84,47 @@ export const ZenFocus = Extension.create<{
 	},
 
 	addProseMirrorPlugins() {
+		const getEnabled = () => this.options.getZenModeEnabled?.() ?? false;
 		return [
 			new Plugin({
 				key: zenFocusPluginKey,
 				state: {
-					init: () => 0,
+					init: (_config, state) => {
+						const enabled = getEnabled();
+						return {
+							decorations: buildDecorations(
+								state.doc,
+								state.selection.from,
+								enabled,
+							),
+							enabled,
+							refreshKey: 0,
+						};
+					},
 					apply(tr, value) {
 						const next = tr.getMeta(zenFocusPluginKey);
-						return typeof next === "number" ? next : value;
+						const enabled = getEnabled();
+						const refreshKey =
+							typeof next === "number" ? next : value.refreshKey;
+						if (
+							!tr.docChanged &&
+							!tr.selectionSet &&
+							enabled === value.enabled &&
+							refreshKey === value.refreshKey
+						) {
+							return value;
+						}
+						return {
+							decorations: buildDecorations(tr.doc, tr.selection.from, enabled),
+							enabled,
+							refreshKey,
+						};
 					},
 				},
 				props: {
 					decorations: (state) =>
-						buildDecorations(
-							state.doc,
-							state.selection.from,
-							this.options.getZenModeEnabled?.() ?? false,
-						),
+						zenFocusPluginKey.getState(state)?.decorations ??
+						DecorationSet.empty,
 				},
 			}),
 		];

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -708,9 +708,7 @@ export function useNoteEditor({
 	return {
 		editor,
 		frontmatter,
-		body,
 		colorfulHeadings,
-		showCollapsibleHeadings,
 		showFrontmatterInEditor,
 		frontmatterRef,
 		lastAppliedBodyRef,

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -101,15 +101,16 @@ export function useNoteFind({
 	const [findQuery, setFindQuery] = useState("");
 	const [findActiveIndex, setFindActiveIndex] = useState(0);
 	const findInputRef = useRef<HTMLInputElement | null>(null);
+	const previousRelPathRef = useRef(relPath);
 
 	const findMatches = useMemo(() => {
-		if (!findQuery) return [];
+		if (!findOpen || !findQuery) return [];
 		if (mode === "plain") {
 			return findPlainTextSearchRanges(markdown, findQuery);
 		}
 		if (!editor) return [];
 		return findNoteSearchRanges(editor.state.doc, findQuery);
-	}, [editor, findQuery, markdown, mode]);
+	}, [editor, findOpen, findQuery, markdown, mode]);
 	const effectiveFindActiveIndex = findMatches.length
 		? Math.min(findActiveIndex, findMatches.length - 1)
 		: 0;
@@ -258,7 +259,8 @@ export function useNoteFind({
 	}, []);
 
 	useEffect(() => {
-		void relPath;
+		if (previousRelPathRef.current === relPath) return;
+		previousRelPathRef.current = relPath;
 		setFindOpen(false);
 		setFindQuery("");
 		setFindActiveIndex(0);

--- a/src/components/editor/hooks/useTaskInlineDates.ts
+++ b/src/components/editor/hooks/useTaskInlineDates.ts
@@ -157,7 +157,15 @@ export function useTaskInlineDates({
 
 		syncAnchors();
 		syncSelectedTask();
-		const observer = new MutationObserver(() => syncAnchors());
+		let anchorFrame = 0;
+		const scheduleSyncAnchors = () => {
+			if (anchorFrame) return;
+			anchorFrame = window.requestAnimationFrame(() => {
+				anchorFrame = 0;
+				syncAnchors();
+			});
+		};
+		const observer = new MutationObserver(scheduleSyncAnchors);
 		observer.observe(contentRoot, {
 			childList: true,
 			subtree: true,
@@ -166,6 +174,7 @@ export function useTaskInlineDates({
 		document.addEventListener("selectionchange", syncSelectedTask);
 		editor.on("selectionUpdate", syncSelectedTask);
 		return () => {
+			if (anchorFrame) window.cancelAnimationFrame(anchorFrame);
 			observer.disconnect();
 			document.removeEventListener("selectionchange", syncSelectedTask);
 			editor.off("selectionUpdate", syncSelectedTask);

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 import { X } from "../../Icons";
 import { Button } from "../../ui/shadcn/button";
@@ -41,6 +42,17 @@ export function NotePropertyRow({
 	onSetTagInputRef,
 	tagInputRef,
 }: NotePropertyRowProps) {
+	const [keyDraft, setKeyDraft] = useState(property.key);
+
+	useEffect(() => {
+		setKeyDraft(property.key);
+	}, [property.key]);
+
+	const commitKeyDraft = () => {
+		if (keyDraft === property.key) return;
+		onUpdate(index, { key: keyDraft });
+	};
+
 	return (
 		<div className="notePropertyRow">
 			{readOnly ? (
@@ -77,10 +89,18 @@ export function NotePropertyRow({
 							onSelect={(kind) => onUpdate(index, { kind })}
 						/>
 						<Input
-							value={property.key}
+							value={keyDraft}
 							className="notePropertyKeyInput"
 							placeholder="Property"
-							onChange={(event) => onUpdate(index, { key: event.target.value })}
+							aria-label="Property name"
+							onChange={(event) => setKeyDraft(event.target.value)}
+							onBlur={commitKeyDraft}
+							onKeyDown={(event) => {
+								if (event.key !== "Enter") return;
+								event.preventDefault();
+								commitKeyDraft();
+								event.currentTarget.blur();
+							}}
 						/>
 					</div>
 					<div className="notePropertyValue">

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -98,7 +98,6 @@ export function NotePropertyRow({
 							onKeyDown={(event) => {
 								if (event.key !== "Enter") return;
 								event.preventDefault();
-								commitKeyDraft();
 								event.currentTarget.blur();
 							}}
 						/>

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { useEffect, useState } from "react";
 import {
 	statusColorKey,
 	statusOptionsWithCustomValues,
@@ -51,6 +52,18 @@ export function NotePropertyValueField({
 	onSetTagInputRef,
 	tagInputRef,
 }: NotePropertyValueFieldProps) {
+	const textValue = property.value_text ?? "";
+	const [textDraft, setTextDraft] = useState(textValue);
+
+	useEffect(() => {
+		setTextDraft(textValue);
+	}, [textValue]);
+
+	const commitTextDraft = () => {
+		if (textDraft === textValue) return;
+		onUpdate(index, { value_text: textDraft });
+	};
+
 	if (readOnly) {
 		if (property.kind === "status") {
 			return (
@@ -200,6 +213,7 @@ export function NotePropertyValueField({
 							className="notePropertyToken"
 							onClick={() => onRemoveTag(index, value)}
 							title={`Remove ${formatTagLabel(value)}`}
+							aria-label={`Remove ${formatTagLabel(value)}`}
 						>
 							<span>{formatTagLabel(value)}</span>
 							<X size={10} />
@@ -211,6 +225,7 @@ export function NotePropertyValueField({
 						className="notePropertyTagInput"
 						value={tagDraft}
 						placeholder={property.value_list.length > 0 ? "" : "Add a tag"}
+						aria-label={`${property.key || "Tags"} value`}
 						onChange={(event) => onSetTagDraft(rowId, event.target.value)}
 						onBlur={() => onAddTag(rowId, index, tagDraft)}
 						onKeyDown={(event) => {
@@ -266,9 +281,17 @@ export function NotePropertyValueField({
 						? "url"
 						: "text"
 			}
-			value={property.value_text ?? ""}
+			value={textDraft}
 			placeholder="Value"
-			onChange={(event) => onUpdate(index, { value_text: event.target.value })}
+			aria-label={`${property.key || "Property"} value`}
+			onChange={(event) => setTextDraft(event.target.value)}
+			onBlur={commitTextDraft}
+			onKeyDown={(event) => {
+				if (event.key !== "Enter") return;
+				event.preventDefault();
+				commitTextDraft();
+				event.currentTarget.blur();
+			}}
 		/>
 	);
 }

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -289,7 +289,6 @@ export function NotePropertyValueField({
 			onKeyDown={(event) => {
 				if (event.key !== "Enter") return;
 				event.preventDefault();
-				commitTextDraft();
 				event.currentTarget.blur();
 			}}
 		/>

--- a/src/components/editor/noteProperties/RawFrontmatterEditor.tsx
+++ b/src/components/editor/noteProperties/RawFrontmatterEditor.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 interface RawFrontmatterEditorProps {
 	value: string;
 	readOnly: boolean;
@@ -14,16 +16,33 @@ export function RawFrontmatterEditor({
 	readOnly,
 	onChange,
 }: RawFrontmatterEditorProps) {
+	const [draft, setDraft] = useState(value);
+
+	useEffect(() => {
+		setDraft(value);
+	}, [value]);
+
+	const commitDraft = () => {
+		if (readOnly || draft === value) return;
+		onChange(draft.trim().length ? draft : null, draft);
+	};
+
 	return (
 		<textarea
 			className="frontmatterEditor"
-			value={value}
-			rows={Math.max(6, value.split("\n").length + 1)}
+			value={draft}
+			rows={Math.max(6, draft.split("\n").length + 1)}
 			onChange={(event) => {
-				const next = event.target.value;
-				onChange(next.trim().length ? next : null, next);
+				setDraft(event.target.value);
+			}}
+			onBlur={commitDraft}
+			onKeyDown={(event) => {
+				if (event.key !== "Enter" || !(event.metaKey || event.ctrlKey)) return;
+				event.preventDefault();
+				commitDraft();
 			}}
 			placeholder="---\ntitle: Untitled\n---"
+			aria-label="Raw frontmatter"
 			spellCheck={false}
 			readOnly={readOnly}
 		/>

--- a/src/components/editor/slashCommands.ts
+++ b/src/components/editor/slashCommands.ts
@@ -356,7 +356,7 @@ export const SlashCommand = Extension.create({
 							selectedIndex,
 							props.items.length,
 						);
-						menu.innerHTML = "";
+						menu.replaceChildren();
 						if (!props.items.length) return;
 						for (const [index, item] of props.items.entries()) {
 							const button = document.createElement("button");

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -101,7 +101,6 @@ describe("FileTreePane", () => {
 		loadSettingsMock.mockResolvedValue({
 			ui: {
 				showFileTreeFolderCounts: false,
-				showTaskProgressIndicator: true,
 			},
 		});
 		useFileTreeContextMock.mockReturnValue({

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -472,7 +472,7 @@ export const FileTreePane = memo(function FileTreePane({
 	const { itemAppearance, setItemAppearance } = useFileTreeContext();
 	const { spacePath, setError } = useSpace();
 	const [showFolderFileCounts, setShowFolderFileCounts] = useState(false);
-	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(true);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
 	const [folderFileCounts, setFolderFileCounts] = useState<
 		Record<string, number>
 	>({});

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -131,7 +131,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				: -1,
 		[activeTabPath, visibleNotes],
 	);
-	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(null);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
 	const taskSummaryPaths = useMemo(
 		() =>
 			visibleNotes

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -196,7 +196,7 @@ export function MarkdownEditorPane({
 	const [syncPulse, setSyncPulse] = useState<SyncPulse>(null);
 	const [linkedMentions, setLinkedMentions] = useState<BacklinkItem[]>([]);
 	const [relationships, setRelationships] = useState<NoteRelationship[]>([]);
-	const showTaskProgressIndicator = useTaskProgressIndicatorSetting(null);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
 	const savedTextRef = useRef(savedText);
 	const textRef = useRef(text);
 	const mtimeRef = useRef<number | null>(lastSavedMtimeMs);
@@ -303,40 +303,20 @@ export function MarkdownEditorPane({
 		}, 1400);
 	}, []);
 
-	const saveSignal = useMemo(() => {
+	const saveLabel = useMemo(() => {
 		if (saving || autosaveBusy) {
-			return {
-				state: "saving",
-				label: "Saving",
-				description: "Writing changes to disk",
-			} as const;
+			return "Saving";
 		}
 		if (isDirty) {
-			return {
-				state: "dirty",
-				label: "Edited",
-				description: "Unsaved changes",
-			} as const;
+			return "Edited";
 		}
 		if (syncPulse === "reloaded") {
-			return {
-				state: "reloaded",
-				label: "Fresh",
-				description: "Content reloaded",
-			} as const;
+			return "Fresh";
 		}
 		if (syncPulse === "saved") {
-			return {
-				state: "saved-fresh",
-				label: "Saved",
-				description: "Changes saved",
-			} as const;
+			return "Saved";
 		}
-		return {
-			state: lastSavedMtimeMs ? "saved" : "ready",
-			label: lastSavedMtimeMs ? "Saved" : "Ready",
-			description: lastSavedMtimeMs ? "All changes saved" : "Editor ready",
-		} as const;
+		return lastSavedMtimeMs ? "Saved" : "Ready";
 	}, [autosaveBusy, isDirty, lastSavedMtimeMs, saving, syncPulse]);
 
 	useEffect(() => {
@@ -1113,7 +1093,11 @@ export function MarkdownEditorPane({
 				</div>
 			) : null}
 			{showToc && !infoPanelOpen && !error && mode !== "plain" ? (
-				<FloatingTOC editor={tocEditor} />
+				<FloatingTOC
+					headings={tocHeadings}
+					activeId={tocActiveId}
+					onSelectHeading={scrollToHeading}
+				/>
 			) : null}
 
 			<NotesInfoSidebar
@@ -1136,7 +1120,7 @@ export function MarkdownEditorPane({
 				lastSavedMtimeMs={lastSavedMtimeMs}
 				lineCount={lineCount}
 				utf8SizeBytes={utf8SizeBytes}
-				saveLabel={saveSignal.label}
+				saveLabel={saveLabel}
 				onClose={() => setInfoPanelOpen(false)}
 			/>
 			<LinkedNotePreviewSheet />

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -16,6 +16,8 @@ import { Button } from "../ui/shadcn/button";
 import { ChangelogSection } from "./ChangelogSection";
 import { SettingsRow, SettingsSection } from "./SettingsScaffold";
 
+const LATEST_CHANGELOG_VERSIONS = CHANGELOG_DATA.versions.slice(0, 1);
+
 export function AboutSettingsPane() {
 	const { status: licenseStatus, loading: licenseLoading } =
 		useLicenseStatus(false);
@@ -223,7 +225,7 @@ export function AboutSettingsPane() {
 				</SettingsSection>
 
 				<SettingsSection title="Changelog">
-					<ChangelogSection versions={CHANGELOG_DATA.versions} />
+					<ChangelogSection versions={LATEST_CHANGELOG_VERSIONS} />
 				</SettingsSection>
 
 				<SettingsSection

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -10,7 +10,6 @@ const {
 	loadSettingsMock,
 	setAiAssistantModeMock,
 	setDatabaseShowColumnColorMock,
-	setDatabaseShowNoteCountMock,
 	setDelightfulGlyphMock,
 	setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTagsMock,
@@ -20,13 +19,11 @@ const {
 	setEditorVimKeybindingsMock,
 	setFolioModeMock,
 	setShowFileTreeFolderCountsMock,
-	setShowTaskProgressIndicatorMock,
 	setShowTocMock,
 } = vi.hoisted(() => ({
 	loadSettingsMock: vi.fn(),
 	setAiAssistantModeMock: vi.fn(() => Promise.resolve()),
 	setDatabaseShowColumnColorMock: vi.fn(() => Promise.resolve()),
-	setDatabaseShowNoteCountMock: vi.fn(() => Promise.resolve()),
 	setDelightfulGlyphMock: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
@@ -36,7 +33,6 @@ const {
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
 	setFolioModeMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
-	setShowTaskProgressIndicatorMock: vi.fn(() => Promise.resolve()),
 	setShowTocMock: vi.fn(() => Promise.resolve()),
 }));
 
@@ -51,7 +47,6 @@ vi.mock("../../lib/settings", () => ({
 	loadSettings: loadSettingsMock,
 	setAiAssistantMode: setAiAssistantModeMock,
 	setDatabaseShowColumnColor: setDatabaseShowColumnColorMock,
-	setDatabaseShowNoteCount: setDatabaseShowNoteCountMock,
 	setDelightfulGlyph: setDelightfulGlyphMock,
 	setEditorColorfulHeadings: setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTags: setEditorEnablePeopleMentionsAsTagsMock,
@@ -61,7 +56,6 @@ vi.mock("../../lib/settings", () => ({
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
 	setFolioMode: setFolioModeMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
-	setShowTaskProgressIndicator: setShowTaskProgressIndicatorMock,
 	setShowToc: setShowTocMock,
 }));
 
@@ -169,12 +163,10 @@ function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
 			delightfulGlyph: false,
 			folioMode: false,
 			showFileTreeFolderCounts: false,
-			showTaskProgressIndicator: true,
 			showToc: true,
 		},
 		database: {
 			showColumnColor: true,
-			showNoteCount: false,
 		},
 	};
 }
@@ -320,23 +312,6 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setEditorVimKeybindingsMock).toHaveBeenCalledWith(true);
-	});
-
-	it("saves task progress indicator visibility changes", async () => {
-		await act(async () => {
-			root.render(<AdvancedSettingsPane />);
-		});
-
-		const toggle = container.querySelector(
-			'input[aria-label="Show task progress indicators"]',
-		) as HTMLInputElement | null;
-		expect(toggle).toBeTruthy();
-
-		await act(async () => {
-			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-		});
-
-		expect(setShowTaskProgressIndicatorMock).toHaveBeenCalledWith(false);
 	});
 
 	it("saves Folio Mode changes", async () => {

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -9,7 +9,6 @@ import {
 	loadSettings,
 	setAiAssistantMode,
 	setDatabaseShowColumnColor,
-	setDatabaseShowNoteCount,
 	setDelightfulGlyph,
 	setEditorColorfulHeadings,
 	setEditorEnablePeopleMentionsAsTags,
@@ -19,7 +18,6 @@ import {
 	setEditorWidthMode,
 	setFolioMode,
 	setShowFileTreeFolderCounts,
-	setShowTaskProgressIndicator,
 	setShowToc,
 } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
@@ -122,10 +120,7 @@ export function AdvancedSettingsPane() {
 	const [folioMode, setFolioModeState] = useState(false);
 	const [showFileTreeFolderCounts, setShowFileTreeFolderCountsState] =
 		useState(false);
-	const [showTaskProgressIndicator, setShowTaskProgressIndicatorState] =
-		useState(true);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
-	const [showDatabaseNoteCount, setShowDatabaseNoteCount] = useState(false);
 	const [error, setError] = useState("");
 	const [isSavingShowToc, setIsSavingShowToc] = useState(false);
 	const [isSavingShowCollapsibleHeadings, setIsSavingShowCollapsibleHeadings] =
@@ -147,13 +142,7 @@ export function AdvancedSettingsPane() {
 		isSavingShowFileTreeFolderCounts,
 		setIsSavingShowFileTreeFolderCounts,
 	] = useState(false);
-	const [
-		isSavingShowTaskProgressIndicator,
-		setIsSavingShowTaskProgressIndicator,
-	] = useState(false);
 	const [isSavingDatabaseColumnColor, setIsSavingDatabaseColumnColor] =
-		useState(false);
-	const [isSavingDatabaseNoteCount, setIsSavingDatabaseNoteCount] =
 		useState(false);
 	const { spacePath, startIndexRebuild } = useSpace();
 
@@ -172,9 +161,7 @@ export function AdvancedSettingsPane() {
 			setDelightfulGlyphState(settings.ui.delightfulGlyph);
 			setFolioModeState(settings.ui.folioMode);
 			setShowFileTreeFolderCountsState(settings.ui.showFileTreeFolderCounts);
-			setShowTaskProgressIndicatorState(settings.ui.showTaskProgressIndicator);
 			setShowDatabaseColumnColor(settings.database.showColumnColor);
-			setShowDatabaseNoteCount(settings.database.showNoteCount);
 		} catch (cause) {
 			setError(extractErrorMessage(cause));
 		}
@@ -225,14 +212,8 @@ export function AdvancedSettingsPane() {
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFileTreeFolderCountsState(payload.ui.showFileTreeFolderCounts);
 		}
-		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
-			setShowTaskProgressIndicatorState(payload.ui.showTaskProgressIndicator);
-		}
 		if (typeof payload.database?.showColumnColor === "boolean") {
 			setShowDatabaseColumnColor(payload.database.showColumnColor);
-		}
-		if (typeof payload.database?.showNoteCount === "boolean") {
-			setShowDatabaseNoteCount(payload.database.showNoteCount);
 		}
 	});
 
@@ -522,30 +503,6 @@ export function AdvancedSettingsPane() {
 						/>
 					</SettingsRow>
 					<SettingsRow
-						label="Show task progress indicators"
-						description="Show task completion rings across the app, including the editor ribbon, sidebar file tree, and database cards."
-					>
-						<SettingsToggle
-							checked={showTaskProgressIndicator}
-							disabled={isSavingShowTaskProgressIndicator}
-							ariaLabel="Show task progress indicators"
-							onCheckedChange={(checked) => {
-								const previous = showTaskProgressIndicator;
-								setError("");
-								setShowTaskProgressIndicatorState(checked);
-								setIsSavingShowTaskProgressIndicator(true);
-								void setShowTaskProgressIndicator(checked)
-									.catch((cause) => {
-										setShowTaskProgressIndicatorState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowTaskProgressIndicator(false);
-									});
-							}}
-						/>
-					</SettingsRow>
-					<SettingsRow
 						label="Show folder file counts"
 						description="Show a recursive file total at the end of each folder row in the file tree."
 					>
@@ -594,30 +551,6 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingDatabaseColumnColor(false);
-									});
-							}}
-						/>
-					</SettingsRow>
-					<SettingsRow
-						label="Show note count"
-						description="Show the total number of notes in the database header."
-					>
-						<SettingsToggle
-							checked={showDatabaseNoteCount}
-							disabled={isSavingDatabaseNoteCount}
-							ariaLabel="Show note count"
-							onCheckedChange={(checked) => {
-								const previous = showDatabaseNoteCount;
-								setError("");
-								setShowDatabaseNoteCount(checked);
-								setIsSavingDatabaseNoteCount(true);
-								void setDatabaseShowNoteCount(checked)
-									.catch((cause) => {
-										setShowDatabaseNoteCount(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingDatabaseNoteCount(false);
 									});
 							}}
 						/>

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -97,41 +97,7 @@ describe("GeneralSettingsPane", () => {
 		container.remove();
 	});
 
-	it("hides the updates section for community builds", async () => {
-		useLicenseStatusMock.mockReturnValue({
-			status: { mode: "community_build", can_auto_update: false },
-			loading: false,
-			error: "",
-			reload: vi.fn(),
-		} as never);
-
-		await act(async () => {
-			root.render(<GeneralSettingsPane />);
-		});
-
-		expect(container.textContent).not.toContain("Automatic update checks");
-		expect(container.textContent).toContain("License Card Stub");
-	});
-
-	it("shows the updates section for official builds", async () => {
-		useLicenseStatusMock.mockReturnValue({
-			status: { mode: "licensed", can_auto_update: true },
-			loading: false,
-			error: "",
-			reload: vi.fn(),
-		} as never);
-
-		await act(async () => {
-			root.render(<GeneralSettingsPane />);
-		});
-
-		expect(container.textContent).toContain("Automatic update checks");
-		expect(container.textContent).toContain(
-			"Glyph checks for updates when the app opens and again every 3 hours while it stays open.",
-		);
-	});
-
-	it("keeps the updates section visible while license status is loading", async () => {
+	it("shows license settings without automatic update check copy", async () => {
 		useLicenseStatusMock.mockReturnValue({
 			status: undefined,
 			loading: true,
@@ -143,6 +109,10 @@ describe("GeneralSettingsPane", () => {
 			root.render(<GeneralSettingsPane />);
 		});
 
-		expect(container.textContent).toContain("Automatic update checks");
+		expect(container.textContent).not.toContain("Automatic update checks");
+		expect(container.textContent).not.toContain(
+			"Automatic updates are always on.",
+		);
+		expect(container.textContent).toContain("License Card Stub");
 	});
 });

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -1,26 +1,9 @@
-import { useLicenseStatus } from "../../lib/license";
 import { LicenseSettingsCard } from "../licensing/LicenseSettingsCard";
-import { SettingsRow, SettingsSection } from "./SettingsScaffold";
 
 export function GeneralSettingsPane() {
-	const { status: licenseStatus, loading: licenseLoading } =
-		useLicenseStatus(false);
-
 	return (
 		<div className="settingsPane">
 			<div className="settingsGrid">
-				{licenseLoading || licenseStatus?.can_auto_update ? (
-					<SettingsSection title="Updates">
-						<SettingsRow
-							label="Automatic update checks"
-							description="Glyph checks for updates when the app opens and again every 3 hours while it stays open. When an update is ready, the update button appears and installs it only when you click."
-							stacked
-							interactive={false}
-						>
-							<p className="settingsHint">Automatic updates are always on.</p>
-						</SettingsRow>
-					</SettingsSection>
-				) : null}
 				<LicenseSettingsCard />
 			</div>
 		</div>

--- a/src/hooks/useTaskProgressIndicatorSetting.ts
+++ b/src/hooks/useTaskProgressIndicatorSetting.ts
@@ -1,5 +1,3 @@
-export function useTaskProgressIndicatorSetting(
-	_defaultValue: boolean | null,
-): true {
+export function useTaskProgressIndicatorSetting(): true {
 	return true;
 }

--- a/src/hooks/useTaskProgressIndicatorSetting.ts
+++ b/src/hooks/useTaskProgressIndicatorSetting.ts
@@ -1,37 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { loadSettings } from "../lib/settings";
-import { useTauriEvent } from "../lib/tauriEvents";
-
-export function useTaskProgressIndicatorSetting(defaultValue: boolean): boolean;
 export function useTaskProgressIndicatorSetting(
-	defaultValue: boolean | null,
-): boolean | null;
-export function useTaskProgressIndicatorSetting(defaultValue: boolean | null) {
-	const [showTaskProgressIndicator, setShowTaskProgressIndicator] =
-		useState(defaultValue);
-	const settingsVersionRef = useRef(0);
-
-	useEffect(() => {
-		let cancelled = false;
-		const requestedAtVersion = settingsVersionRef.current;
-		void loadSettings()
-			.then((settings) => {
-				if (cancelled) return;
-				if (settingsVersionRef.current !== requestedAtVersion) return;
-				setShowTaskProgressIndicator(settings.ui.showTaskProgressIndicator);
-			})
-			.catch(() => undefined);
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	useTauriEvent("settings:updated", (payload) => {
-		if (typeof payload.ui?.showTaskProgressIndicator === "boolean") {
-			settingsVersionRef.current += 1;
-			setShowTaskProgressIndicator(payload.ui.showTaskProgressIndicator);
-		}
-	});
-
-	return showTaskProgressIndicator;
+	_defaultValue: boolean | null,
+): true {
+	return true;
 }

--- a/src/lib/markdownUtils.ts
+++ b/src/lib/markdownUtils.ts
@@ -8,7 +8,7 @@ export function normalizeInlineMarkdown(text: string): string {
 		"$1",
 	);
 	const withoutWikiLinks = withoutLinks.replace(
-		/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g,
+		/!?\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g,
 		(_, target: string, label?: string) => (label ?? target).trim(),
 	);
 	const withoutInlineCode = withoutWikiLinks.replace(/`([^`]+)`/g, "$1");

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -113,43 +113,6 @@ describe("settings Vim keybindings", () => {
 	});
 });
 
-describe("settings task progress indicator", () => {
-	beforeEach(() => {
-		vi.resetModules();
-		emitMock.mockClear();
-		storeState.clear();
-	});
-
-	it("defaults task progress indicator visibility to on", async () => {
-		const { loadSettings } = await import("./settings");
-		const settings = await loadSettings();
-		expect(settings.ui.showTaskProgressIndicator).toBe(true);
-	});
-
-	it("loads task progress indicator visibility from the store", async () => {
-		storeState.set("ui.showTaskProgressIndicator", false);
-		const { loadSettings } = await import("./settings");
-		const settings = await loadSettings();
-		expect(settings.ui.showTaskProgressIndicator).toBe(false);
-	});
-
-	it("loads task progress indicator visibility from the legacy store key", async () => {
-		storeState.set("ui.taskProgressIndicator.enabled", false);
-		const { loadSettings } = await import("./settings");
-		const settings = await loadSettings();
-		expect(settings.ui.showTaskProgressIndicator).toBe(false);
-	});
-
-	it("persists and emits task progress indicator visibility changes", async () => {
-		const { setShowTaskProgressIndicator } = await import("./settings");
-		await setShowTaskProgressIndicator(false);
-		expect(storeState.get("ui.showTaskProgressIndicator")).toBe(false);
-		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
-			ui: { showTaskProgressIndicator: false },
-		});
-	});
-});
-
 describe("settings Folio Mode", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -76,7 +76,6 @@ const DEFAULT_UI_ACCENT: UiAccent = "cerulean";
 const DEFAULT_UI_FONT_FAMILY = "Geist";
 const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
 const DEFAULT_AUTO_UPDATE_CHECK_INTERVAL: AutoUpdateCheckInterval = "3h";
-const DEFAULT_SHOW_TASK_PROGRESS_INDICATOR = true;
 export const MIN_UI_FONT_SIZE = 7;
 export const MAX_UI_FONT_SIZE = 40;
 const DEFAULT_UI_FONT_SIZE = 14;
@@ -119,7 +118,6 @@ export interface TaskSourceSetting {
 
 export interface DatabaseSettings {
 	showColumnColor: boolean;
-	showNoteCount: boolean;
 }
 
 export interface QuickNotesSettings {
@@ -159,7 +157,6 @@ const DEFAULT_SHORTCUT_SETTINGS: ShortcutSettings = {
 
 const DEFAULT_DATABASE_SETTINGS: DatabaseSettings = {
 	showColumnColor: true,
-	showNoteCount: false,
 };
 
 const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
@@ -271,7 +268,6 @@ async function emitSettingsUpdated(payload: {
 		delightfulGlyph?: boolean;
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
-		showTaskProgressIndicator?: boolean;
 		folioMode?: boolean;
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
@@ -294,7 +290,6 @@ async function emitSettingsUpdated(payload: {
 	};
 	database?: {
 		showColumnColor?: boolean;
-		showNoteCount?: boolean;
 	};
 	editor?: {
 		showCollapsibleHeadings?: boolean;
@@ -344,7 +339,6 @@ interface AppSettings {
 		delightfulGlyph: boolean;
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
-		showTaskProgressIndicator: boolean;
 		folioMode: boolean;
 		aiAssistantMode: AiAssistantMode;
 	};
@@ -386,7 +380,6 @@ const KEYS = {
 	delightfulGlyph: "ui.delightfulGlyph",
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
-	showTaskProgressIndicator: "ui.showTaskProgressIndicator",
 	folioMode: "ui.folioMode",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
@@ -407,17 +400,12 @@ const KEYS = {
 	shortcutsVersion: "shortcuts.version",
 	shortcutsBindings: "shortcuts.bindings",
 	databaseShowColumnColor: "database.showColumnColor",
-	databaseShowNoteCount: "database.showNoteCount",
 	onboardingLauncherSeen: "onboarding.launcherSeen",
 	onboardingStarterDismissed: "onboarding.starterDismissed",
 	onboardingCreatedFirstNote: "onboarding.createdFirstNote",
 	onboardingUsedCommandPalette: "onboarding.usedCommandPalette",
 	onboardingOpenedDailyNote: "onboarding.openedDailyNote",
 } as const;
-
-// Legacy key from older builds; kept as a read-only fallback during migration.
-const LEGACY_SHOW_TASK_PROGRESS_INDICATOR_KEY =
-	"ui.taskProgressIndicator.enabled";
 
 const ONBOARDING_KEYS = {
 	launcherSeen: KEYS.onboardingLauncherSeen,
@@ -622,8 +610,6 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawDelightfulGlyph,
 		rawShowToc,
 		rawShowFileTreeFolderCounts,
-		rawShowTaskProgressIndicator,
-		rawShowTaskProgressIndicatorLegacy,
 		rawFolioMode,
 		dailyNotesFolderRaw,
 		rawWebClippingsFolder,
@@ -640,7 +626,6 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawEditorEnablePeopleMentionsAsTags,
 		rawEditorVimKeybindings,
 		rawDatabaseShowColumnColor,
-		rawDatabaseShowNoteCount,
 		rawShortcutSettingsVersion,
 		rawShortcutBindings,
 	] = await Promise.all([
@@ -667,8 +652,6 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.delightfulGlyph),
 		store.get<boolean | null>(KEYS.showToc),
 		store.get<boolean | null>(KEYS.showFileTreeFolderCounts),
-		store.get<boolean | null>(KEYS.showTaskProgressIndicator),
-		store.get<boolean | null>(LEGACY_SHOW_TASK_PROGRESS_INDICATOR_KEY),
 		store.get<boolean | null>(KEYS.folioMode),
 		store.get<string | null>(KEYS.dailyNotesFolder),
 		store.get<string | null>(KEYS.webClippingsFolder),
@@ -685,7 +668,6 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.editorEnablePeopleMentionsAsTags),
 		store.get<boolean | null>(KEYS.editorVimKeybindings),
 		store.get<boolean | null>(KEYS.databaseShowColumnColor),
-		store.get<boolean | null>(KEYS.databaseShowNoteCount),
 		store.get<number | null>(KEYS.shortcutsVersion),
 		store.get<unknown>(KEYS.shortcutsBindings),
 	]);
@@ -732,12 +714,6 @@ export async function loadSettings(): Promise<AppSettings> {
 		typeof rawShowFileTreeFolderCounts === "boolean"
 			? rawShowFileTreeFolderCounts
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
-	const showTaskProgressIndicator =
-		typeof rawShowTaskProgressIndicator === "boolean"
-			? rawShowTaskProgressIndicator
-			: typeof rawShowTaskProgressIndicatorLegacy === "boolean"
-				? rawShowTaskProgressIndicatorLegacy
-				: DEFAULT_SHOW_TASK_PROGRESS_INDICATOR;
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
 	const dailyNotesFolder =
 		typeof dailyNotesFolderRaw === "string"
@@ -800,10 +776,6 @@ export async function loadSettings(): Promise<AppSettings> {
 			typeof rawDatabaseShowColumnColor === "boolean"
 				? rawDatabaseShowColumnColor
 				: DEFAULT_DATABASE_SETTINGS.showColumnColor,
-		showNoteCount:
-			typeof rawDatabaseShowNoteCount === "boolean"
-				? rawDatabaseShowNoteCount
-				: DEFAULT_DATABASE_SETTINGS.showNoteCount,
 	};
 	return {
 		currentSpacePath,
@@ -825,7 +797,6 @@ export async function loadSettings(): Promise<AppSettings> {
 			delightfulGlyph,
 			showToc,
 			showFileTreeFolderCounts,
-			showTaskProgressIndicator,
 			folioMode,
 			aiAssistantMode,
 		},
@@ -1100,15 +1071,6 @@ export async function setShowFileTreeFolderCounts(
 	void emitSettingsUpdated({ ui: { showFileTreeFolderCounts: enabled } });
 }
 
-export async function setShowTaskProgressIndicator(
-	enabled: boolean,
-): Promise<void> {
-	const store = await getStore();
-	await store.set(KEYS.showTaskProgressIndicator, enabled);
-	await store.save();
-	void emitSettingsUpdated({ ui: { showTaskProgressIndicator: enabled } });
-}
-
 export async function setFolioMode(enabled: boolean): Promise<void> {
 	const store = await getStore();
 	await store.set(KEYS.folioMode, enabled);
@@ -1316,15 +1278,6 @@ export async function setDatabaseShowColumnColor(
 	await store.set(KEYS.databaseShowColumnColor, enabled);
 	await store.save();
 	void emitSettingsUpdated({ database: { showColumnColor: enabled } });
-}
-
-export async function setDatabaseShowNoteCount(
-	enabled: boolean,
-): Promise<void> {
-	const store = await getStore();
-	await store.set(KEYS.databaseShowNoteCount, enabled);
-	await store.save();
-	void emitSettingsUpdated({ database: { showNoteCount: enabled } });
 }
 
 export async function setAutoUpdateLastCheckedAt(

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -78,7 +78,6 @@ type TauriEventMap = {
 			delightfulGlyph?: boolean;
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
-			showTaskProgressIndicator?: boolean;
 			folioMode?: boolean;
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
@@ -98,7 +97,6 @@ type TauriEventMap = {
 		};
 		database?: {
 			showColumnColor?: boolean;
-			showNoteCount?: boolean;
 		};
 		editor?: {
 			showCollapsibleHeadings?: boolean;

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -147,22 +147,6 @@
 	line-height: 1;
 }
 
-.databaseBoardLaneCount {
-	display: inline-flex;
-	align-items: center;
-	min-width: 0;
-	height: auto;
-	padding: 0;
-	border-radius: 0;
-	background: transparent;
-	border: none;
-	font-size: 0.7rem;
-	font-weight: var(--font-semibold);
-	font-variant-numeric: tabular-nums;
-	line-height: 1;
-	color: color-mix(in srgb, var(--database-tone) 76%, var(--text-primary));
-}
-
 .databaseBoardLaneTitleButton {
 	display: inline-flex;
 	align-items: center;

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -151,6 +151,10 @@
 	border-top: 1px solid color-mix(in srgb, var(--border-light) 60%, transparent);
 }
 
+.databaseBodyCell:has(.databaseTagSuggestions) {
+	z-index: 4;
+}
+
 .databaseTable [data-slot="table-cell"].databaseBodyCell {
 	padding-top: 0;
 	padding-bottom: 0;
@@ -415,6 +419,10 @@
 	transition: background-color 120ms ease;
 }
 
+.databaseRow:has(.databaseTagSuggestions) {
+	z-index: 4;
+}
+
 .databaseRow:hover {
 	background: var(--bg-hover);
 }
@@ -464,16 +472,6 @@
 	letter-spacing: 0.06em;
 	line-height: 1.15;
 	text-transform: uppercase;
-}
-
-.databaseGroupCount {
-	flex: 0 0 auto;
-	color: var(--text-secondary);
-	font-size: 0.65rem;
-	font-weight: var(--font-semibold);
-	font-variant-numeric: tabular-nums;
-	letter-spacing: 0.02em;
-	line-height: 1.15;
 }
 
 .databaseLoadingState,


### PR DESCRIPTION
## Summary

This PR consolidates the 0.3 startup bugfix/settings cleanup work into a single commit. It removes several count-heavy UI surfaces and obsolete preferences so the database, settings, and update surfaces stay quieter and more consistent.

## What changed

- Removed database note totals from the database header, table group rows, board lane headers, tag suggestions, and tag picker rows.
- Removed the Advanced setting for database note counts and deleted the persisted `database.showNoteCount` setting path.
- Removed the Advanced setting for task progress indicator visibility and made `useTaskProgressIndicatorSetting` always return enabled, so old stored false values no longer disable progress rings.
- Removed automatic update explanatory copy from General settings, leaving license settings as the visible General settings content.
- Limited the About settings changelog section to the latest changelog entry.
- Raised the stacking context for active database tag suggestions so dropdowns render above database table rows.
- Updated existing tests and settings mocks to match the removed settings surface.

## Why

These controls and counts were adding visual noise without giving users meaningful control. The task progress preference in particular could leave old stored settings in a bad state where progress indicators disappeared even though the intended behavior is to keep them visible. The tag suggestion layering fix handles a small interaction bug where the suggestion popover could be clipped or hidden behind database rows.

## User impact

Users should see a cleaner database experience with fewer count labels, a simpler settings surface, task progress indicators consistently visible, and tag suggestion dropdowns that layer correctly while editing database cells.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

`pnpm build` still reports the existing Vite warnings about mixed static/dynamic import of `src/lib/settings.ts` and large chunks; the build completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Responsive tag/relation cells with width-aware truncation and “+N” overflow
  * Dropdown layering fixes so tag suggestions appear above table content
  * Better code-block UI: language header and copy button with copy feedback
  * Added ARIA labels to many editor buttons for improved accessibility

* **Removed Features**
  * Task progress indicator setting and visible note-count badges across DB views
  * “Updates” section from General Settings

* **Changes**
  * Changelog now shows only the latest version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->