### PR TITLE
[codex] Clean up app surfaces

### DIFF
--- a/src/components/app/ActiveFileTitle.tsx
+++ b/src/components/app/ActiveFileTitle.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { basename, splitEditableFileName } from "../../utils/path";
+
+interface ActiveFileTitleProps {
+	path: string | null;
+	onRenameFile: (path: string, nextName: string) => Promise<string | null>;
+}
+
+export function ActiveFileTitle({ path, onRenameFile }: ActiveFileTitleProps) {
+	const fileName = path ? basename(path) : "";
+	const editableName = splitEditableFileName(fileName);
+	const activeTitleKey = path ?? "";
+	const [isRenaming, setIsRenaming] = useState(false);
+	const [draftName, setDraftName] = useState(editableName.stem);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const submittedRef = useRef(false);
+
+	useEffect(() => {
+		setIsRenaming(false);
+		setDraftName(activeTitleKey ? editableName.stem : "");
+		submittedRef.current = false;
+	}, [activeTitleKey, editableName.stem]);
+
+	useEffect(() => {
+		if (!isRenaming) return;
+		inputRef.current?.focus();
+		inputRef.current?.select();
+	}, [isRenaming]);
+
+	const commitRename = useCallback(async () => {
+		if (!path || submittedRef.current) return;
+		submittedRef.current = true;
+		const fallbackName = editableName.stem || "Untitled";
+		const nextStem = draftName.trim() || fallbackName;
+		const nextName = `${nextStem}${editableName.ext || ".md"}`;
+		if (nextName === fileName) {
+			setIsRenaming(false);
+			return;
+		}
+		try {
+			await onRenameFile(path, nextName);
+		} finally {
+			setIsRenaming(false);
+		}
+	}, [
+		draftName,
+		editableName.ext,
+		editableName.stem,
+		fileName,
+		onRenameFile,
+		path,
+	]);
+
+	const cancelRename = useCallback(() => {
+		submittedRef.current = true;
+		setDraftName(editableName.stem);
+		setIsRenaming(false);
+	}, [editableName.stem]);
+
+	if (!path) return null;
+
+	if (isRenaming) {
+		return (
+			<input
+				ref={inputRef}
+				className="plainTextInput mainTabActiveTitleInput"
+				value={draftName}
+				placeholder="Untitled"
+				aria-label="Rename current file"
+				onChange={(event) => {
+					submittedRef.current = false;
+					setDraftName(event.target.value);
+				}}
+				onBlur={() => void commitRename()}
+				onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+					if (event.key === "Enter") {
+						event.preventDefault();
+						void commitRename();
+						return;
+					}
+					if (event.key === "Escape") {
+						event.preventDefault();
+						cancelRename();
+					}
+				}}
+			/>
+		);
+	}
+
+	return (
+		<button
+			type="button"
+			className="mainTabActiveTitle"
+			title={`Rename ${fileName}`}
+			aria-label={`Rename ${fileName}`}
+			onClick={() => {
+				submittedRef.current = false;
+				setDraftName(editableName.stem);
+				setIsRenaming(true);
+			}}
+		>
+			<span className="mainTabActiveTitleText">{editableName.stem}</span>
+		</button>
+	);
+}

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -237,9 +237,6 @@ export const AllDocsPane = memo(function AllDocsPane({
 					<section key={section.id} className="allDocsSection">
 						<div className="allDocsSectionHeader">
 							<h2 className="allDocsSectionTitle">{section.label}</h2>
-							<span className="allDocsSectionCount">
-								{section.notes.length}
-							</span>
 						</div>
 						<div className="allDocsGrid">
 							{section.notes.map((note, index) => {

--- a/src/components/app/CommandList.tsx
+++ b/src/components/app/CommandList.tsx
@@ -47,12 +47,6 @@ export function CommandList({
 		return <div className="commandPaletteEmpty">No commands</div>;
 	}
 
-	const categoryToDataValue = (category: string) =>
-		category
-			.toLowerCase()
-			.replace(/[^a-z0-9]+/g, "-")
-			.replace(/^-+|-+$/g, "");
-
 	const showSectionLabels =
 		sections.length > 1 ||
 		(sections.length === 1 && sections[0]?.category !== "General");
@@ -70,8 +64,6 @@ export function CommandList({
 							type="button"
 							className="commandPaletteItem"
 							data-command-index={index}
-							data-command-id={command.id}
-							data-command-category={categoryToDataValue(section.category)}
 							data-selected={index === selectedIndex}
 							onMouseEnter={() => onSetSelectedIndex(index)}
 							onMouseDown={(e) => {

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -1,7 +1,5 @@
-import { AnimatePresence, m } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Search } from "../Icons";
-import { directionVariants } from "../ui/animations";
 import { Dialog, DialogContent, DialogTitle } from "../ui/shadcn/dialog";
 import { CommandList } from "./CommandList";
 import { CommandPaletteFooter } from "./CommandPaletteFooter";
@@ -51,9 +49,6 @@ export function CommandPalette({
 			selectedId: null,
 		};
 	});
-	const [transitionDirection, setTransitionDirection] = useState<
-		"left" | "right"
-	>("left");
 	const { activeTab, query, selectedIndex } = state;
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const listRef = useRef<HTMLDivElement | null>(null);
@@ -89,11 +84,9 @@ export function CommandPalette({
 			query.trim()
 				? [...titleMatches, ...contentMatches].map((result) => ({
 						id: result.id,
-						title: result.title,
 					}))
 				: recentFiles.map((file) => ({
 						id: file.path,
-						title: null,
 					})),
 		[contentMatches, query, recentFiles, titleMatches],
 	);
@@ -101,7 +94,6 @@ export function CommandPalette({
 	const switchTab = useCallback(
 		(tab: Tab) => {
 			if (tab === "search" && !canSearch) return;
-			setTransitionDirection(tab === "search" ? "right" : "left");
 			setState({
 				activeTab: tab,
 				query: tab === "search" ? initialQuery : "",
@@ -243,20 +235,11 @@ export function CommandPalette({
 
 				<div className="commandPaletteHeader">
 					<div className="commandPaletteInputWrapper">
-						<AnimatePresence mode="wait">
-							{activeTab === "search" && (
-								<m.span
-									key="search-icon"
-									className="commandPaletteSearchIcon"
-									initial={{ opacity: 0, scale: 0.8 }}
-									animate={{ opacity: 1, scale: 1 }}
-									exit={{ opacity: 0, scale: 0.8 }}
-									transition={{ duration: 0.12 }}
-								>
-									<Search size={15} />
-								</m.span>
-							)}
-						</AnimatePresence>
+						{activeTab === "search" && (
+							<span className="commandPaletteSearchIcon">
+								<Search size={15} />
+							</span>
+						)}
 						<input
 							ref={inputRef}
 							className="commandPaletteInput"
@@ -293,71 +276,53 @@ export function CommandPalette({
 					) : null}
 				</div>
 
-				<AnimatePresence mode="wait">
-					<m.div
-						key={activeTab}
-						className="commandPaletteBody commandPaletteScene"
-						initial={{
-							...directionVariants[transitionDirection].initial,
-							opacity: 0,
-						}}
-						animate={{
-							...directionVariants[transitionDirection].animate,
-							opacity: 1,
-						}}
-						exit={{
-							...directionVariants[transitionDirection].exit,
-							opacity: 0,
-						}}
-						transition={{ duration: 0.2 }}
-					>
-						<div className="commandPaletteList" ref={listRef}>
-							{activeTab === "commands" ? (
-								<CommandList
-									filtered={filtered}
+				<div className="commandPaletteBody">
+					<div className="commandPaletteList" ref={listRef}>
+						{activeTab === "commands" ? (
+							<CommandList
+								filtered={filtered}
+								selectedIndex={resolvedSelectedIndex}
+								onSetSelectedIndex={(index) =>
+									setState((curr) => ({
+										...curr,
+										selectedIndex: index,
+										selectedId: null,
+									}))
+								}
+								onRunCommand={runCommand}
+							/>
+						) : (
+							<>
+								{query.trim() ? (
+									<div
+										className="commandPaletteResultCountPill"
+										aria-live="polite"
+									>
+										{isSearching
+											? "Searching..."
+											: `${(titleMatches.length + contentMatches.length).toLocaleString()} results`}
+									</div>
+								) : null}
+								<SearchResultsList
+									query={query}
+									isSearching={isSearching}
+									titleMatches={titleMatches}
+									contentMatches={contentMatches}
+									recentFiles={recentFiles}
 									selectedIndex={resolvedSelectedIndex}
 									onSetSelectedIndex={(index) =>
 										setState((curr) => ({
 											...curr,
 											selectedIndex: index,
-											selectedId: null,
+											selectedId: searchEntries[index]?.id ?? null,
 										}))
 									}
-									onRunCommand={runCommand}
+									onSelectResult={selectSearchResult}
 								/>
-							) : (
-								<>
-									{query.trim() ? (
-										<div
-											className="commandPaletteResultCountPill"
-											aria-live="polite"
-										>
-											{isSearching
-												? "Searching..."
-												: `${(titleMatches.length + contentMatches.length).toLocaleString()} results`}
-										</div>
-									) : null}
-									<SearchResultsList
-										query={query}
-										isSearching={isSearching}
-										titleMatches={titleMatches}
-										contentMatches={contentMatches}
-										recentFiles={recentFiles}
-										selectedIndex={resolvedSelectedIndex}
-										onSetSelectedIndex={(index) =>
-											setState((curr) => ({
-												...curr,
-												selectedIndex: index,
-												selectedId: searchEntries[index]?.id ?? null,
-											}))
-										}
-										onSelectResult={selectSearchResult}
-									/>
-								</>
-							)}
-						</div>
-					</m.div>
-				</AnimatePresence>
+							</>
+						)}
+					</div>
+				</div>
 				<CommandPaletteFooter activeTab={activeTab} canSearch={canSearch} />
 			</DialogContent>
 		</Dialog>

--- a/src/components/app/CommandSearchFilters.tsx
+++ b/src/components/app/CommandSearchFilters.tsx
@@ -24,7 +24,6 @@ export function CommandSearchFilters({
 			<button
 				type="button"
 				className="commandSearchFilterBtn"
-				data-kind="title-only"
 				data-active={request.title_only ? "true" : "false"}
 				aria-pressed={request.title_only}
 				onClick={() =>
@@ -39,7 +38,6 @@ export function CommandSearchFilters({
 			<button
 				type="button"
 				className="commandSearchFilterBtn"
-				data-kind="tag-only"
 				data-active={request.tag_only ? "true" : "false"}
 				aria-pressed={request.tag_only}
 				onClick={() =>

--- a/src/components/app/CommandSearchResults.tsx
+++ b/src/components/app/CommandSearchResults.tsx
@@ -34,9 +34,9 @@ interface SearchResultItemProps {
 	onSelect: () => void;
 }
 
-function resultDisplayFolder(relPath: string, fallbackId?: string): string {
+function resultDisplayFolder(relPath: string): string {
 	const parts = relPath.split("/").filter(Boolean);
-	if (parts.length <= 1) return fallbackId ?? "";
+	if (parts.length <= 1) return relPath;
 	return `${parts.slice(0, -1).join("/")}/`;
 }
 
@@ -47,7 +47,7 @@ function SearchResultItem({
 	onMouseEnter,
 	onSelect,
 }: SearchResultItemProps) {
-	const resultFolder = resultDisplayFolder(result.id, result.id);
+	const resultFolder = resultDisplayFolder(result.id);
 
 	return (
 		<button

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -835,6 +835,9 @@ export const MainContent = memo(function MainContent({
 						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
 						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
 						onOpenBreadcrumbFile={onOpenFile}
+						onRenameFile={(path, nextName) =>
+							fileTree.onRenameDir(path, nextName, "file")
+						}
 						onSelectTab={setActiveTabId}
 						onCloseTab={closeTab}
 						onStartRenamePath={onStartRenamePath}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -13,8 +13,7 @@ import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
-import { type FsEntry, invoke } from "../../lib/tauri";
-import { useTauriEvent } from "../../lib/tauriEvents";
+import type { FsEntry } from "../../lib/tauri";
 import { ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
@@ -147,14 +146,11 @@ export const SidebarContent = memo(function SidebarContent({
 	const [pendingNewNotePath, setPendingNewNotePath] = useState<string | null>(
 		null,
 	);
-	const [allNotesCount, setAllNotesCount] = useState<number | null>(null);
 	const [spaceMenuOpen, setSpaceMenuOpen] = useState(false);
 	const [notesExpanded, setNotesExpanded] = useState(true);
 	const spaceMenuRef = useRef<HTMLDivElement | null>(null);
-	const allNotesCountRequestRef = useRef(0);
 	const newNoteShortcut = getBinding("new-note");
 	const quickOpenShortcut = getBinding("quick-open");
-	const showAllNotesCount = allNotesCount !== null;
 	const activeFolioFolder =
 		folioScope.kind === "folder" ? folioScope.folderPrefix : null;
 	const spaceLabel = spacePath ? formatSpaceLabel(spacePath) : "Glyph";
@@ -284,32 +280,6 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 		[onOpenFile, onRenameDir, pendingNewNotePath],
 	);
-
-	const refreshAllNotesCount = useCallback(() => {
-		const requestId = allNotesCountRequestRef.current + 1;
-		allNotesCountRequestRef.current = requestId;
-		if (!spacePath) {
-			setAllNotesCount(null);
-			return;
-		}
-		void invoke("all_docs_count", {})
-			.then((count) => {
-				if (allNotesCountRequestRef.current !== requestId) return;
-				setAllNotesCount(count);
-			})
-			.catch(() => {
-				if (allNotesCountRequestRef.current !== requestId) return;
-				setAllNotesCount(null);
-			});
-	}, [spacePath]);
-
-	useEffect(() => {
-		refreshAllNotesCount();
-	}, [refreshAllNotesCount]);
-
-	useTauriEvent("notes:external_changed", () => {
-		refreshAllNotesCount();
-	});
 
 	useEffect(() => {
 		if (!spaceMenuOpen) return;
@@ -544,9 +514,7 @@ export const SidebarContent = memo(function SidebarContent({
 							className="sidebarQuickActionBtn sidebarNavBtn"
 							data-kind="all-notes"
 							data-active={activeTopSection === "all-notes" ? "true" : "false"}
-							aria-label={
-								showAllNotesCount ? `All Notes (${allNotesCount})` : "All Notes"
-							}
+							aria-label="All Notes"
 							aria-pressed={activeTopSection === "all-notes"}
 							aria-current={
 								activeTopSection === "all-notes" ? "page" : undefined
@@ -562,9 +530,6 @@ export const SidebarContent = memo(function SidebarContent({
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">All Notes</span>
-							{showAllNotesCount ? (
-								<span className="sidebarQuickActionCount">{allNotesCount}</span>
-							) : null}
 						</button>
 						<button
 							type="button"

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -15,6 +15,7 @@ import { DATABASES_TAB_ID } from "../../lib/databases";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
+import { isMarkdownPath } from "../../utils/path";
 import { ChevronRight, File, FileText, FolderOpen } from "../Icons";
 import {
 	DropdownMenu,
@@ -24,6 +25,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "../ui/shadcn/dropdown-menu";
+import { ActiveFileTitle } from "./ActiveFileTitle";
 import type { WorkspaceTab } from "./useTabManager";
 
 interface TabBarProps {
@@ -42,6 +44,7 @@ interface TabBarProps {
 	onNavigateBreadcrumbPath: (dirPath: string) => void;
 	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
 	onOpenBreadcrumbFile: (relPath: string) => Promise<void>;
+	onRenameFile: (path: string, nextName: string) => Promise<string | null>;
 	onSelectTab: (tabId: string) => void;
 	onCloseTab: (tabId: string) => void;
 	onStartRenamePath: (path: string) => void;
@@ -104,6 +107,7 @@ export function TabBar({
 	onNavigateBreadcrumbPath,
 	onLoadBreadcrumbDir,
 	onOpenBreadcrumbFile,
+	onRenameFile,
 	onSelectTab,
 	onCloseTab,
 	onStartRenamePath,
@@ -160,6 +164,12 @@ export function TabBar({
 						}),
 				]
 			: [];
+	const activeMarkdownPath =
+		activeTabPath &&
+		!isPathSpecial(activeTabPath) &&
+		isMarkdownPath(activeTabPath)
+			? activeTabPath
+			: null;
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {
 			suppressClickRef.current = true;
@@ -208,6 +218,10 @@ export function TabBar({
 						→
 					</button>
 				</div>
+				<ActiveFileTitle
+					path={activeMarkdownPath}
+					onRenameFile={onRenameFile}
+				/>
 				{showTabs ? (
 					<>
 						<DragDropProvider onDragEnd={handleDragEnd}>

--- a/src/components/app/useCommandSearch.ts
+++ b/src/components/app/useCommandSearch.ts
@@ -137,7 +137,6 @@ export function useCommandSearch(
 	}, []);
 
 	return {
-		searchResults,
 		recentFiles: recentMarkdownFiles,
 		isSearching,
 		titleMatches,

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -1,13 +1,7 @@
 import { Tag01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-	type CSSProperties,
-	useCallback,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import type { CSSProperties } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
 import {
 	databaseCellValueFromRow,
@@ -65,7 +59,6 @@ interface DatabaseDisplayPill {
 	key: string;
 	label: string;
 	kind?: "tag";
-	style?: CSSProperties;
 	title?: string;
 }
 
@@ -76,12 +69,7 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 	const [visibleCount, setVisibleCount] = useState(() => items.length);
 
 	const renderPill = (item: DatabaseDisplayPill) => (
-		<span
-			key={item.key}
-			className="databaseCellPill"
-			style={item.style}
-			title={item.title}
-		>
+		<span key={item.key} className="databaseCellPill" title={item.title}>
 			{item.kind === "tag" ? (
 				<HugeiconsIcon
 					icon={Tag01Icon}
@@ -189,7 +177,6 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 							itemMeasureRefs.current[index] = element;
 						}}
 						className="databaseCellPill"
-						style={item.style}
 					>
 						{item.kind === "tag" ? (
 							<HugeiconsIcon
@@ -936,10 +923,9 @@ export function DatabaseCell({
 		return cellValue.value_list.map((value) => ({
 			key: `${column.id}:${value}`,
 			label: value,
-			style: databaseValueToneStyleForColor(value, laneColors[value] ?? null),
 			title: value,
 		}));
-	}, [cellValue.kind, cellValue.value_list, column.id, laneColors]);
+	}, [cellValue.kind, cellValue.value_list, column.id]);
 	const editorKey = `${row.note_path}:${column.id}:${cellValue.kind}:${cellValue.value_text ?? ""}:${cellValue.value_bool ?? ""}:${cellValue.value_list.join("\u0001")}`;
 
 	const handleSelectRow = () => {

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -822,7 +822,7 @@ function DatabasesPaneContent({
 						<>
 							<Input
 								value={nameDraft}
-								className="databasesInlineNameInput"
+								className="plainTextInput databasesInlineNameInput"
 								aria-label="Collection name"
 								style={{
 									width: `${Math.min(Math.max(nameDraft.trim().length + 2, 10), 24)}ch`,
@@ -895,7 +895,7 @@ function DatabasesPaneContent({
 											<input
 												ref={viewNameInputRef}
 												type="text"
-												className="databasesViewTabRenameInput"
+												className="plainTextInput databasesViewTabRenameInput"
 												value={viewNameDraft}
 												aria-label="View name"
 												onChange={(event) =>

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -90,7 +90,7 @@ export function NotePropertyRow({
 						/>
 						<Input
 							value={keyDraft}
-							className="notePropertyKeyInput"
+							className="plainTextInput notePropertyKeyInput"
 							placeholder="Property"
 							aria-label="Property name"
 							onChange={(event) => setKeyDraft(event.target.value)}

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -222,7 +222,7 @@ export function NotePropertyValueField({
 					<input
 						ref={(node) => onSetTagInputRef(rowId, node)}
 						type="text"
-						className="notePropertyTagInput"
+						className="plainTextInput notePropertyTagInput"
 						value={tagDraft}
 						placeholder={property.value_list.length > 0 ? "" : "Add a tag"}
 						aria-label={`${property.key || "Tags"} value`}
@@ -272,7 +272,7 @@ export function NotePropertyValueField({
 
 	return (
 		<Input
-			className="notePropertyFieldInput"
+			className="plainTextInput notePropertyFieldInput"
 			style={{ color: "var(--text-primary)" }}
 			type={
 				property.kind === "date"

--- a/src/components/editor/noteProperties/RawFrontmatterEditor.tsx
+++ b/src/components/editor/noteProperties/RawFrontmatterEditor.tsx
@@ -29,7 +29,7 @@ export function RawFrontmatterEditor({
 
 	return (
 		<textarea
-			className="frontmatterEditor"
+			className="plainTextInput frontmatterEditor"
 			value={draft}
 			rows={Math.max(6, draft.split("\n").length + 1)}
 			onChange={(event) => {

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -63,7 +63,7 @@ function DirectoryRenameInput({
 	return (
 		<input
 			ref={inputRef}
-			className="fileTreeRenameInput"
+			className="plainTextInput fileTreeRenameInput"
 			value={draftName}
 			placeholder="New Folder"
 			onChange={(event) => setDraftName(event.target.value)}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -17,7 +17,7 @@ import type {
 	FsEntry,
 	NoteTaskSummary,
 } from "../../lib/tauri";
-import { basename } from "../../utils/path";
+import { basename, splitEditableFileName } from "../../utils/path";
 import { FolderPlus, Trash2 } from "../Icons";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { isEditorTextColor } from "../editor/textColors";
@@ -38,7 +38,6 @@ import {
 import {
 	buildRowStyle,
 	rowVariants,
-	splitEditableFileName,
 	springTransition,
 } from "./fileTreeItemHelpers";
 import { getFileTypeInfo } from "./fileTypeUtils";
@@ -82,7 +81,7 @@ function FileRenameInput({
 	return (
 		<input
 			ref={inputRef}
-			className="fileTreeRenameInput"
+			className="plainTextInput fileTreeRenameInput"
 			value={draftName}
 			placeholder="Untitled"
 			onChange={(event) => setDraftName(event.target.value)}

--- a/src/components/filetree/fileTreeItemHelpers.ts
+++ b/src/components/filetree/fileTreeItemHelpers.ts
@@ -17,21 +17,6 @@ export const rowVariants = {
 	tap: { scale: 0.98 },
 };
 
-export function splitEditableFileName(name: string): {
-	stem: string;
-	ext: string;
-} {
-	const trimmed = name.trim();
-	const dotIndex = trimmed.lastIndexOf(".");
-	if (dotIndex <= 0 || dotIndex === trimmed.length - 1) {
-		return { stem: trimmed, ext: "" };
-	}
-	return {
-		stem: trimmed.slice(0, dotIndex),
-		ext: trimmed.slice(dotIndex),
-	};
-}
-
 export function buildRowStyle(
 	depth: number,
 	toneSeed?: string,

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -9,7 +9,7 @@ import {
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import type { FileTreeAppearance, NoteTaskSummary } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
-import { basename, parentDir } from "../../utils/path";
+import { basename, parentDir, splitEditableFileName } from "../../utils/path";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
 import {
@@ -17,7 +17,6 @@ import {
 	isEditorTextColor,
 } from "../editor/textColors";
 import { FileTreeAppearanceMenu } from "../filetree/FileTreeAppearanceMenu";
-import { splitEditableFileName } from "../filetree/fileTreeItemHelpers";
 import { getFileTypeInfo } from "../filetree/fileTypeUtils";
 import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import {
@@ -293,7 +292,7 @@ function FolioRenameInput({
 	return (
 		<input
 			ref={inputRef}
-			className="folioNoteRenameInput"
+			className="plainTextInput folioNoteRenameInput"
 			value={draftName}
 			placeholder="Untitled"
 			onChange={(event) => setDraftName(event.target.value)}

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -107,7 +107,6 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		filesTruncated,
 		isLoading,
 		error,
-		title,
 		nonMarkdownFileLimit,
 		missingFolder,
 	} = useFolioNotes(folioScope);
@@ -328,8 +327,6 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			}}
 		>
 			<FolioScopeHeader
-				title={title}
-				count={visibleNotes.length}
 				searchQuery={searchQuery}
 				sortMode={sortMode}
 				onSearchQueryChange={setSearchQuery}

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -9,8 +9,6 @@ import { memo } from "react";
 import type { FolioNotesSortMode } from "./folioScopes";
 
 interface FolioScopeHeaderProps {
-	title: string;
-	count: number;
 	searchQuery: string;
 	sortMode: FolioNotesSortMode;
 	onSearchQueryChange: (query: string) => void;
@@ -18,8 +16,6 @@ interface FolioScopeHeaderProps {
 }
 
 export const FolioScopeHeader = memo(function FolioScopeHeader({
-	title,
-	count,
 	searchQuery,
 	sortMode,
 	onSearchQueryChange,
@@ -34,12 +30,6 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 
 	return (
 		<header className="folioNotesHeader">
-			<div className="folioNotesTitleRow">
-				<h2 className="folioNotesTitle">{title}</h2>
-				<span className="folioNotesCount">
-					{count} {count === 1 ? "note" : "notes"}
-				</span>
-			</div>
 			<div className="folioNotesControls">
 				<label className="folioNotesSearch">
 					<HugeiconsIcon icon={SearchIcon} size={14} strokeWidth={0.9} />

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -1,22 +1,24 @@
 import {
-	BubbleChatQuestionIcon,
-	CodesandboxIcon,
 	DiscordIcon,
-	NewTwitterIcon,
+	File01Icon,
+	GlobeIcon,
+	ListViewIcon,
+	Shield01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
 import { CHANGELOG_DATA } from "../../data/releaseNotes";
 import { useLicenseStatus } from "../../lib/license";
+import { PUBLIC_CHANGELOG_URL } from "../../lib/releaseNotes";
 import type { AppInfo } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { Button } from "../ui/shadcn/button";
 import { ChangelogSection } from "./ChangelogSection";
 import { SettingsRow, SettingsSection } from "./SettingsScaffold";
 
-const LATEST_CHANGELOG_VERSIONS = CHANGELOG_DATA.versions.slice(0, 1);
+const LATEST_CHANGELOG_VERSION = CHANGELOG_DATA.versions[0] ?? null;
 
 export function AboutSettingsPane() {
 	const { status: licenseStatus, loading: licenseLoading } =
@@ -24,10 +26,6 @@ export function AboutSettingsPane() {
 	const autoUpdater = useUpdaterContext();
 	const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
 	const [error, setError] = useState("");
-	const [copyLabel, setCopyLabel] = useState("Copy Diagnostics");
-	const copyResetTimerRef = useRef<
-		ReturnType<typeof window.setTimeout> | undefined
-	>(undefined);
 	const [updateStatus, setUpdateStatus] = useState("");
 	useEffect(() => {
 		let cancelled = false;
@@ -51,28 +49,6 @@ export function AboutSettingsPane() {
 		if (!appInfo?.version) return "";
 		return `v${appInfo.version}`;
 	}, [appInfo?.version]);
-
-	const scheduleCopyLabelReset = () => {
-		if (copyResetTimerRef.current !== undefined) {
-			window.clearTimeout(copyResetTimerRef.current);
-		}
-		copyResetTimerRef.current = window.setTimeout(() => {
-			setCopyLabel("Copy Diagnostics");
-			copyResetTimerRef.current = undefined;
-		}, 1800);
-	};
-
-	const handleCopyDebugInfo = async () => {
-		const info = `Name: ${appInfo?.name ?? "Glyph"}\nVersion: ${appInfo?.version ?? "-"}\nIdentifier: ${appInfo?.identifier ?? "-"}`;
-		try {
-			await navigator.clipboard.writeText(info);
-			setCopyLabel("Copied to Clipboard");
-			scheduleCopyLabelReset();
-		} catch {
-			setCopyLabel("Copy Failed");
-			scheduleCopyLabelReset();
-		}
-	};
 
 	const handleCheckForUpdates = async () => {
 		if (!licenseStatus?.can_auto_update) return;
@@ -98,41 +74,26 @@ export function AboutSettingsPane() {
 			{error ? <div className="settingsError">{error}</div> : null}
 
 			<div className="settingsGrid">
-				<section className="settingsCard aboutHeroCard">
-					<div className="aboutIdentity">
-						<div className="aboutLogoWrap">
-							<img
-								src={`/glyph-app-icon.png?v=${appInfo?.version ?? "dev"}`}
-								alt=""
-								className="aboutLogo"
-								aria-hidden="true"
-							/>
-						</div>
-						<div className="aboutIdentityCopy">
-							<div className="aboutTitleRow">
-								<span className="aboutAppName">{appInfo?.name ?? "Glyph"}</span>
-								<span className="aboutVersion">{versionLabel}</span>
-							</div>
-							<div className="aboutStatusRow">
-								<span className="settingsPill aboutEarlyAccessBadge earlyAccessBadge">
-									Early Access
-								</span>
-								<span
-									className="aboutOpenSourceMark"
-									title="Open Source project"
-								>
-									<HugeiconsIcon
-										icon={CodesandboxIcon}
-										size={12}
-										strokeWidth={0.9}
-									/>
-									<span>Open Source</span>
-								</span>
-							</div>
-						</div>
-					</div>
+				<section className="aboutHero" aria-labelledby="about-title">
+					<img
+						src={`/glyph-app-icon.png?v=${appInfo?.version ?? "dev"}`}
+						alt=""
+						className="aboutLogo"
+						aria-hidden="true"
+					/>
+					<h2 id="about-title" className="aboutAppName">
+						{appInfo?.name ?? "Glyph"}
+						{versionLabel ? (
+							<span className="aboutVersion">{versionLabel}</span>
+						) : null}
+					</h2>
+					<p className="aboutTagline">
+						Your thoughts deserve a home,
+						<br />
+						not a server.
+					</p>
 					<p className="aboutAttribution">
-						Glyph is an independent app made by{" "}
+						Made by{" "}
 						<button
 							type="button"
 							className="settingsInlineLink"
@@ -140,9 +101,59 @@ export function AboutSettingsPane() {
 						>
 							Karat Sidhu
 						</button>
-						. Feel free to get in touch with questions, issues, or any feedback
-						you might have.
 					</p>
+					<div className="aboutQuickLinks" aria-label="About links">
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							className="aboutLinkButton"
+							onClick={() => void openUrl("https://glyphformac.com")}
+						>
+							<HugeiconsIcon icon={GlobeIcon} size={16} strokeWidth={1.6} />
+							Website
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							className="aboutLinkButton"
+							onClick={() => void openUrl(PUBLIC_CHANGELOG_URL)}
+						>
+							<HugeiconsIcon icon={ListViewIcon} size={16} strokeWidth={1.6} />
+							Release Notes
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							className="aboutLinkButton"
+							onClick={() => void openUrl("https://discord.gg/fasY8gAQR")}
+						>
+							<HugeiconsIcon icon={DiscordIcon} size={16} strokeWidth={1.6} />
+							Discord
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							className="aboutLinkButton"
+							onClick={() => void openUrl("https://glyphformac.com/terms")}
+						>
+							<HugeiconsIcon icon={File01Icon} size={16} strokeWidth={1.6} />
+							Terms
+						</Button>
+						<Button
+							type="button"
+							size="sm"
+							variant="outline"
+							className="aboutLinkButton"
+							onClick={() => void openUrl("https://glyphformac.com/privacy")}
+						>
+							<HugeiconsIcon icon={Shield01Icon} size={16} strokeWidth={1.6} />
+							Privacy
+						</Button>
+					</div>
 				</section>
 
 				<SettingsSection
@@ -225,76 +236,7 @@ export function AboutSettingsPane() {
 				</SettingsSection>
 
 				<SettingsSection title="Changelog">
-					<ChangelogSection versions={LATEST_CHANGELOG_VERSIONS} />
-				</SettingsSection>
-
-				<SettingsSection
-					title="Support"
-					description="Project links and diagnostics that help with support requests."
-				>
-					<SettingsRow
-						label="Links"
-						description="Open the author and project pages in your browser."
-					>
-						<div className="settingsActions aboutActions">
-							<Button
-								type="button"
-								size="icon-sm"
-								variant="outline"
-								onClick={() => void openUrl("https://x.com/karat_sidhu")}
-								aria-label="X (Twitter)"
-								title="X (Twitter)"
-							>
-								<HugeiconsIcon
-									icon={NewTwitterIcon}
-									size={16}
-									strokeWidth={0.9}
-								/>
-							</Button>
-							<Button
-								type="button"
-								size="icon-sm"
-								variant="outline"
-								onClick={() => void openUrl("https://discord.gg/fasY8gAQR")}
-								aria-label="Discord"
-								title="Discord"
-							>
-								<HugeiconsIcon icon={DiscordIcon} size={16} strokeWidth={0.9} />
-							</Button>
-							<Button
-								type="button"
-								size="icon-sm"
-								variant="outline"
-								onClick={() =>
-									void openUrl(
-										"https://glyph.userjot.com/?cursor=1&order=top&limit=10",
-									)
-								}
-								aria-label="Feedback"
-								title="Feedback"
-							>
-								<HugeiconsIcon
-									icon={BubbleChatQuestionIcon}
-									size={16}
-									strokeWidth={0.9}
-								/>
-							</Button>
-						</div>
-					</SettingsRow>
-					<SettingsRow
-						label="Diagnostics"
-						description="Copy app metadata so you can paste it into bug reports or support threads."
-					>
-						<Button
-							type="button"
-							size="sm"
-							variant="outline"
-							className="min-w-36 rounded-md border-border bg-background justify-center shadow-none"
-							onClick={() => void handleCopyDebugInfo()}
-						>
-							{copyLabel}
-						</Button>
-					</SettingsRow>
+					<ChangelogSection version={LATEST_CHANGELOG_VERSION} />
 				</SettingsSection>
 			</div>
 		</div>

--- a/src/components/settings/ChangelogSection.tsx
+++ b/src/components/settings/ChangelogSection.tsx
@@ -1,10 +1,9 @@
-import { ArrowRight01Icon, NewReleasesIcon } from "@hugeicons/core-free-icons";
+import { NewReleasesIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useState } from "react";
 import type { VersionReleaseNotes } from "../../data/releaseNotes";
 
 interface ChangelogSectionProps {
-	versions: VersionReleaseNotes[];
+	version: VersionReleaseNotes | null;
 }
 
 function countVersionItems(version: VersionReleaseNotes): number {
@@ -14,91 +13,47 @@ function countVersionItems(version: VersionReleaseNotes): number {
 	}, 0);
 }
 
-function VersionAccordion({
+function ReleaseNotesVersion({
 	version,
-	isOpen,
-	onToggle,
-	isLatest,
 }: {
 	version: VersionReleaseNotes;
-	isOpen: boolean;
-	onToggle: () => void;
-	isLatest: boolean;
 }) {
-	const hasContent = version.sections.some(
-		(s) => Array.isArray(s.items) && s.items.length > 0,
+	const sections = version.sections.filter(
+		(section) => Array.isArray(section.items) && section.items.length > 0,
 	);
 
 	return (
 		<div className="settingsChangelogVersion">
-			<button
-				type="button"
-				className="settingsChangelogVersionHeader"
-				onClick={onToggle}
-				aria-expanded={isOpen}
-			>
-				<div className="settingsChangelogVersionMeta">
-					<span className="settingsChangelogVersionNumber">
-						v{version.version}
-					</span>
-					{isLatest && (
-						<span className="settingsChangelogVersionBadge">Latest</span>
-					)}
-				</div>
-				<span className="settingsChangelogToggle">
-					<HugeiconsIcon
-						icon={ArrowRight01Icon}
-						size={14}
-						strokeWidth={0.9}
-						className="settingsChangelogToggleIcon"
-					/>
-				</span>
-			</button>
-
-			{isOpen && hasContent && (
+			{sections.length > 0 ? (
 				<div className="settingsChangelogVersionContent">
-					{version.sections
-						.filter(
-							(section) =>
-								Array.isArray(section.items) && section.items.length > 0,
-						)
-						.map((section) => (
-							<div key={section.category} className="settingsChangelogCategory">
-								<div
-									className="settingsChangelogCategoryLabel"
-									data-category={section.category}
-								>
-									{section.category}
-								</div>
-								<ul className="settingsChangelogItemList">
-									{section.items.map((item, index) => (
-										<li
-											key={`${section.category}-${index}`}
-											className="settingsChangelogItem"
-										>
-											{item}
-										</li>
-									))}
-								</ul>
+					{sections.map((section) => (
+						<div key={section.category} className="settingsChangelogCategory">
+							<div
+								className="settingsChangelogCategoryLabel"
+								data-category={section.category}
+							>
+								{section.category}
 							</div>
-						))}
+							<ul className="settingsChangelogItemList">
+								{section.items.map((item, index) => (
+									<li
+										key={`${section.category}-${index}`}
+										className="settingsChangelogItem"
+									>
+										{item}
+									</li>
+								))}
+							</ul>
+						</div>
+					))}
 				</div>
-			)}
+			) : null}
 		</div>
 	);
 }
 
-export function ChangelogSection({ versions }: ChangelogSectionProps) {
-	const [openVersion, setOpenVersion] = useState<string | null>(
-		() => versions[0]?.version ?? null,
-	);
-	const latestVersion = versions[0] ?? null;
-
-	const toggleVersion = (version: string) => {
-		setOpenVersion((prev) => (prev === version ? null : version));
-	};
-
-	if (versions.length === 0) {
+export function ChangelogSection({ version }: ChangelogSectionProps) {
+	if (!version) {
 		return (
 			<div className="settingsChangelogEmpty">
 				<p>No release notes available.</p>
@@ -108,34 +63,22 @@ export function ChangelogSection({ versions }: ChangelogSectionProps) {
 
 	return (
 		<div className="settingsChangelog">
-			{latestVersion ? (
-				<div className="settingsChangelogSummary">
-					<div className="settingsChangelogSummaryIcon" aria-hidden="true">
-						<HugeiconsIcon icon={NewReleasesIcon} size={18} strokeWidth={0.9} />
-					</div>
-					<div className="settingsChangelogSummaryCopy">
-						<div className="settingsChangelogSummaryEyebrow">
-							Latest release
-						</div>
-						<div className="settingsChangelogSummaryTitle">
-							v{latestVersion.version}
-						</div>
-					</div>
-					<div className="settingsChangelogSummaryMeta">
-						<span>{countVersionItems(latestVersion)} changes</span>
+			<div className="settingsChangelogSummary">
+				<div className="settingsChangelogSummaryIcon" aria-hidden="true">
+					<HugeiconsIcon icon={NewReleasesIcon} size={18} strokeWidth={0.9} />
+				</div>
+				<div className="settingsChangelogSummaryCopy">
+					<div className="settingsChangelogSummaryEyebrow">Latest release</div>
+					<div className="settingsChangelogSummaryTitle">
+						v{version.version}
 					</div>
 				</div>
-			) : null}
+				<div className="settingsChangelogSummaryMeta">
+					<span>{countVersionItems(version)} changes</span>
+				</div>
+			</div>
 			<div className="settingsChangelogList">
-				{versions.map((version, index) => (
-					<VersionAccordion
-						key={version.version}
-						version={version}
-						isOpen={openVersion === version.version}
-						onToggle={() => toggleVersion(version.version)}
-						isLatest={index === 0}
-					/>
-				))}
+				<ReleaseNotesVersion version={version} />
 			</div>
 		</div>
 	);

--- a/src/styles/app/00-header-base.css
+++ b/src/styles/app/00-header-base.css
@@ -31,43 +31,30 @@ body {
 	overflow: hidden;
 }
 
-/* Scrollbars - hidden until hover/focus for a cleaner surface */
+/* Scrollbars - rounded and subtle */
 * {
 	scrollbar-width: thin;
-	scrollbar-color: color-mix(in srgb, var(--scrollbar-thumb) 32%, transparent)
-		transparent;
-}
-
-*:hover,
-*:focus-within {
 	scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
-*::-webkit-scrollbar {
+::-webkit-scrollbar {
 	width: 10px;
 	height: 10px;
 }
 
-*::-webkit-scrollbar-track {
+::-webkit-scrollbar-track {
 	background: transparent;
 	border-radius: var(--radius-full);
 }
 
-*::-webkit-scrollbar-thumb {
-	background: color-mix(in srgb, var(--scrollbar-thumb) 32%, transparent);
+::-webkit-scrollbar-thumb {
+	background: var(--scrollbar-thumb);
 	border-radius: var(--radius-full);
 	border: 2px solid transparent;
 	background-clip: padding-box;
-	transition: background-color var(--transition-fast);
 }
 
-*:hover::-webkit-scrollbar-thumb,
-*:focus-within::-webkit-scrollbar-thumb {
-	background: var(--scrollbar-thumb);
-}
-
-*:hover::-webkit-scrollbar-thumb:hover,
-*:focus-within::-webkit-scrollbar-thumb:hover {
+::-webkit-scrollbar-thumb:hover {
 	background: var(--scrollbar-thumb-hover);
 	border: 2px solid transparent;
 	background-clip: padding-box;

--- a/src/styles/app/02-surfaces.css
+++ b/src/styles/app/02-surfaces.css
@@ -38,3 +38,29 @@ textarea {
 	resize: vertical;
 	line-height: var(--leading-normal);
 }
+
+.plainTextInput {
+	all: unset;
+	box-sizing: border-box;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	color: var(--text-primary);
+	font-family: inherit;
+	cursor: text;
+}
+
+.plainTextInput:hover,
+.plainTextInput:focus {
+	border: 0;
+	border-color: transparent;
+	background: transparent;
+	outline: none;
+	box-shadow: none;
+}
+
+.plainTextInput.plainTextInput:focus-visible {
+	outline: none;
+	box-shadow: 0 1px 0
+		color-mix(in srgb, var(--interactive-accent) 58%, transparent);
+}

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -6,6 +6,10 @@
 	--app-frame-block: 0px;
 	--app-radius: 0px;
 	--window-control-toggle-offset: 90px;
+	--collapsed-sidebar-top-reserve: calc(
+		var(--window-control-toggle-offset) +
+		38px
+	);
 
 	isolation: isolate;
 	display: flex;

--- a/src/styles/app/11-settings-misc.css
+++ b/src/styles/app/11-settings-misc.css
@@ -48,107 +48,73 @@
 	padding: 0;
 }
 
-.aboutHeroCard {
-	display: flex;
-	justify-content: flex-start;
-	position: relative;
-	padding: 20px 24px;
-	min-height: 152px;
-}
-
-.aboutIdentity {
-	display: flex;
-	align-items: center;
-	gap: 18px;
-	padding: 2px 0 6px;
-	min-width: 0;
-	max-width: 760px;
-}
-
-.aboutIdentityCopy {
+.aboutHero {
 	display: flex;
 	flex-direction: column;
-	justify-content: center;
-	gap: 10px;
-	min-width: 0;
-	text-align: left;
-}
-
-.aboutLogoWrap {
-	width: 56px;
-	height: 56px;
-	flex-shrink: 0;
-	display: flex;
 	align-items: center;
-	justify-content: center;
+	gap: 18px;
+	padding: 8px 0 26px;
 }
 
 .aboutLogo {
-	width: 100%;
-	height: 100%;
+	width: 64px;
+	height: 64px;
+	margin-bottom: 20px;
 	object-fit: contain;
 }
 
-.aboutTitleRow {
-	display: inline-flex;
-	align-items: baseline;
-	gap: 10px;
-	flex-wrap: wrap;
-}
-
 .aboutAppName {
-	font-size: 28px;
-	font-weight: 750;
-	letter-spacing: -0.03em;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	margin: 0;
 	color: var(--text-primary);
-	line-height: 1;
+	font-size: 30px;
+	font-weight: 760;
+	letter-spacing: 0;
+	line-height: 1.05;
 }
 
 .aboutVersion {
+	color: var(--text-secondary);
+	font-size: 14px;
+	font-weight: var(--font-medium);
+}
+
+.aboutTagline {
+	margin: -2px 0 0;
+	color: var(--text-secondary);
 	font-size: 16px;
 	font-weight: var(--font-medium);
-	color: color-mix(in srgb, var(--text-secondary) 86%, var(--text-primary));
-}
-
-.aboutEarlyAccessBadge {
-	margin-top: 0;
-}
-
-.aboutStatusRow {
-	display: inline-flex;
-	align-items: center;
-	flex-wrap: wrap;
-	gap: 8px;
-}
-
-.aboutOpenSourceMark {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	padding: 3px 8px;
-	border-radius: var(--radius-md);
-	border: 1px solid var(--border-light);
-	background: var(--settings-surface);
-	font-size: 10px;
-	font-weight: var(--font-medium);
-	color: var(--text-secondary);
-}
-
-.aboutActions {
-	justify-content: flex-end;
+	line-height: 1.35;
+	text-align: center;
 }
 
 .aboutAttribution {
-	position: absolute;
-	top: 50%;
-	right: 24px;
-	width: min(620px, 46%);
 	margin: 0;
 	color: var(--text-secondary);
-	font-size: 12px;
-	line-height: 1.5;
-	text-align: right;
-	transform: translateY(-50%);
+	font-size: 13px;
+	font-weight: var(--font-semibold);
+	line-height: 1.4;
+	text-align: center;
+}
+
+.aboutQuickLinks {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 10px;
+	margin-top: 28px;
+}
+
+.aboutLinkButton {
+	height: 32px;
+	border-color: var(--border-light);
+	background: var(--bg-primary);
+	box-shadow: none;
+	color: var(--text-secondary);
+	font-size: 13px;
+	font-weight: var(--font-semibold);
 }
 
 .settingsInlineLink {
@@ -335,25 +301,22 @@
 }
 
 @media (max-width: 760px) {
-	.aboutHeroCard {
-		align-items: flex-start;
-		min-height: 0;
+	.aboutHero {
+		padding-top: 4px;
 	}
 
-	.aboutIdentity {
-		align-items: flex-start;
-		flex-direction: column;
+	.aboutQuickLinks {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		width: 100%;
 	}
 
-	.aboutAttribution {
-		position: static;
-		width: auto;
-		text-align: left;
-		transform: none;
+	.aboutLinkButton {
+		width: 100%;
 	}
 
-	.aboutTitleRow {
-		flex-wrap: wrap;
+	.aboutLinkButton:nth-child(2) {
+		grid-column: span 2;
 	}
 }
 

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -50,20 +50,6 @@
 	color: var(--text-primary);
 }
 
-.allDocsSectionCount {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 24px;
-	height: 24px;
-	padding: 0 8px;
-	border-radius: var(--radius-full);
-	background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
-	color: var(--text-secondary);
-	font-size: 11px;
-	font-weight: var(--font-semibold);
-}
-
 .allDocsCard {
 	appearance: none;
 	display: flex;

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -5,6 +5,7 @@
 
 .mainTabsBar {
 	--main-tabs-right-reserve: 78px;
+	--main-tabs-left-reserve: var(--space-3);
 
 	height: 40px;
 	display: flex;
@@ -12,9 +13,16 @@
 	justify-content: flex-start;
 	gap: 8px;
 	padding: 0 calc(var(--space-3) + var(--main-tabs-right-reserve)) 0
-		var(--space-3);
+		var(--main-tabs-left-reserve);
 	border-bottom: 0;
 	background: var(--bg-primary);
+}
+
+.appShell.appShellSidebarCollapsed .mainTabsBar {
+	--main-tabs-left-reserve: max(
+		var(--space-3),
+		var(--collapsed-sidebar-top-reserve)
+	);
 }
 
 .mainTabsBar[data-empty-state="true"] {
@@ -26,6 +34,55 @@
 	align-items: center;
 	gap: 2px;
 	flex-shrink: 0;
+}
+
+.mainTabActiveTitle,
+.mainTabActiveTitleInput {
+	height: 28px;
+	min-width: 0;
+	max-width: min(30vw, 280px);
+	flex: 0 1 auto;
+	border-radius: var(--radius-md);
+	font-size: 12px;
+	font-weight: var(--font-medium);
+	line-height: 1.2;
+}
+
+.mainTabActiveTitle {
+	display: inline-flex;
+	align-items: center;
+	padding: 0 8px;
+	border: 1px solid transparent;
+	background: transparent;
+	color: var(--text-secondary);
+	cursor: text;
+	transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.mainTabActiveTitle:hover {
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+	color: var(--text-primary);
+}
+
+.mainTabActiveTitleText {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.mainTabActiveTitleInput {
+	box-sizing: border-box;
+	display: block;
+	height: 28px;
+	width: min(30vw, 280px);
+	min-width: 0;
+	max-width: min(30vw, 280px);
+	flex: 0 1 auto;
+	padding: 0 8px;
+	font-size: 12px;
+	font-weight: var(--font-medium);
+	line-height: 1.2;
 }
 
 .mainTabNavBtn {
@@ -434,6 +491,7 @@
 .mainTab:focus-visible,
 .mainTabClose:focus-visible,
 .mainTabAdd:focus-visible,
+.mainTabActiveTitle:focus-visible,
 .mainTabNavBtn:focus-visible {
 	outline: 2px solid
 		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
@@ -445,6 +503,7 @@
 	.mainTab::before,
 	.mainTabClose,
 	.mainTabAdd,
+	.mainTabActiveTitle,
 	.mainTabsBreadcrumbSep,
 	.mainTabsBreadcrumbSepButton,
 	.mainTabsBreadcrumbButton {

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -446,19 +446,15 @@
 }
 
 .fileTreeRenameInput {
+	box-sizing: border-box;
 	flex: 1;
 	min-width: 0;
-	border: 1px solid var(--border-default);
-	border-radius: var(--radius-sm);
-	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
-	color: var(--text-primary);
-	padding: 2px 6px;
+	padding: 2px 0;
 	font: inherit;
 	line-height: 1.2;
 }
 
-.fileTreeRow:focus-visible,
-.fileTreeRenameInput:focus-visible {
+.fileTreeRow:focus-visible {
 	outline: 2px solid
 		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
 	outline-offset: 2px;

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -1,12 +1,12 @@
 .frontmatterEditor {
 	width: 100%;
 	border: none;
-	background: color-mix(in srgb, var(--bg-secondary) 42%, transparent);
+	background: transparent;
 	color: var(--text-primary);
 	font-size: 11.5px;
 	line-height: 1.42;
-	padding: 7px 9px;
-	border-radius: 8px;
+	padding: 3px 0;
+	border-radius: 0;
 	resize: none;
 	overflow: visible;
 	font-family: var(--font-mono);
@@ -17,7 +17,7 @@
 .frontmatterEditor:focus {
 	outline: none;
 	box-shadow: none;
-	background: color-mix(in srgb, var(--interactive-accent) 5%, transparent);
+	background: transparent;
 }
 
 .frontmatterEditor::placeholder {
@@ -199,18 +199,16 @@ input.notePropertyValue {
 .notePropertyKeyInput:hover,
 .notePropertyFieldInput:hover,
 .notePropertyValue input:hover {
-	background: color-mix(in srgb, var(--bg-secondary) 30%, transparent);
+	background: transparent;
 }
 
 .notePropertyKeyInput:focus-visible,
 .notePropertyFieldInput:focus-visible,
 .notePropertyValue input:focus-visible {
-	background: color-mix(in srgb, var(--interactive-accent) 5%, transparent);
+	background: transparent;
 	border-color: transparent;
 	box-shadow: none;
-	outline: 2px solid
-		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
-	outline-offset: 1px;
+	outline: none;
 }
 
 .notePropertyKeyStatic {
@@ -552,9 +550,7 @@ input.notePropertyValue {
 
 .notePropertyTagField:focus-within {
 	border-color: transparent;
-	outline: 2px solid
-		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
-	outline-offset: 1px;
+	outline: none;
 }
 
 .notePropertyTagInput {
@@ -562,15 +558,10 @@ input.notePropertyValue {
 	min-width: 72px;
 	height: 20px;
 	padding: 0;
-	border: 0;
-	background: transparent;
-	color: var(--text-primary);
 	font-family: var(--font-sans);
 	font-size: 12px;
 	font-weight: var(--font-normal);
 	line-height: 1.35;
-	outline: none;
-	box-shadow: none;
 }
 
 .notePropertyTagInput::placeholder {

--- a/src/styles/app/32-command-palette.css
+++ b/src/styles/app/32-command-palette.css
@@ -45,6 +45,8 @@
 .commandPaletteBody {
 	flex: 1;
 	min-height: 0;
+	display: flex;
+	flex-direction: column;
 	overflow: hidden;
 }
 
@@ -241,14 +243,6 @@
 .commandPaletteList::-webkit-scrollbar-thumb:hover {
 	background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
 	background-clip: padding-box;
-}
-
-.commandPaletteScene {
-	flex: 1;
-	min-height: 0;
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
 }
 
 .commandPaletteResultCountPill {

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -41,27 +41,6 @@
 	color: var(--text-primary);
 }
 
-.sidebarQuickActionCount {
-	margin-left: auto;
-	margin-right: -8px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	min-width: 22px;
-	height: 20px;
-	padding: 0 6px;
-	border-radius: 6px;
-	background: var(--interactive-accent);
-	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
-	flex-shrink: 0;
-	font-size: 11px;
-	font-weight: var(--font-semibold);
-	line-height: 1;
-	color: var(--text-inverse);
-	text-align: right;
-	white-space: nowrap;
-}
-
 .sidebarTopRow {
 	position: relative;
 	display: flex;

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -208,28 +208,12 @@
 }
 
 .databasesInlineNameInput {
+	box-sizing: border-box;
 	max-width: 280px;
 	height: 28px;
 	font-size: 0.9rem;
 	font-weight: var(--font-semibold);
-	background: transparent;
-	border: 1px solid transparent;
-	border-radius: var(--database-radius-md);
-	padding: 0 6px;
-	box-shadow: none;
-	transition: border-color 120ms ease, background-color 120ms ease;
-}
-
-.databasesInlineNameInput:hover {
-	border-color: var(--border-light);
-}
-
-.databasesInlineNameInput:focus,
-.databasesInlineNameInput:focus-visible {
-	border-color: var(--border-default);
-	background: var(--bg-secondary);
-	box-shadow: none;
-	outline: none;
+	padding: 0;
 }
 
 .databasesHeaderSource {
@@ -256,18 +240,13 @@
 }
 
 .databasesViewTabRenameInput {
+	box-sizing: border-box;
 	width: 100px;
 	min-height: 30px;
 	margin: 0;
-	padding: 0 10px;
+	padding: 0;
 	font-size: 11px;
 	font-weight: var(--font-medium);
-	border: 0;
-	border-radius: 0;
-	background: var(--settings-surface);
-	color: var(--text-primary);
-	outline: none;
-	box-shadow: none;
 }
 
 .databasesViewTabMenuContent {

--- a/src/styles/app/44-settings-changelog.css
+++ b/src/styles/app/44-settings-changelog.css
@@ -56,6 +56,7 @@
 	display: flex;
 	flex-direction: column;
 	border: 1px solid var(--border-light);
+	border-top: 0;
 	overflow: hidden;
 	background: transparent;
 }
@@ -69,80 +70,8 @@
 	border-top: 1px solid var(--border-light);
 }
 
-.settingsChangelogVersionHeader {
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto;
-	align-items: center;
-	gap: 12px;
-	min-height: 42px;
-	width: 100%;
-	padding: 10px 12px;
-	background: transparent;
-	border: none;
-	color: var(--text-primary);
-	font: inherit;
-	text-align: inherit;
-	cursor: pointer;
-}
-
-.settingsChangelogVersionHeader:hover {
-	background: transparent;
-}
-
-.settingsChangelogVersionHeader:focus-visible {
-	outline: 2px solid
-		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
-	outline-offset: -2px;
-}
-
-.settingsChangelogVersionMeta {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	min-width: 0;
-}
-
-.settingsChangelogVersionNumber {
-	font-size: 12px;
-	font-weight: var(--font-semibold);
-	color: var(--text-primary);
-}
-
-.settingsChangelogVersionBadge {
-	padding: 3px 6px;
-	background: var(--settings-surface-muted);
-	font-size: 10px;
-	font-weight: var(--font-semibold);
-	color: var(--text-secondary);
-	line-height: 1;
-}
-
-.settingsChangelogToggle {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 18px;
-	height: 18px;
-	color: var(--text-tertiary);
-}
-
-.settingsChangelogToggleIcon {
-	transition: transform var(--transition-fast), color var(--transition-fast);
-}
-
-.settingsChangelogVersionHeader[aria-expanded="true"]
-	.settingsChangelogToggleIcon {
-	color: var(--text-secondary);
-	transform: rotate(90deg);
-}
-
-.settingsChangelogVersionHeader[aria-expanded="false"]
-	.settingsChangelogToggleIcon {
-	transform: rotate(0deg);
-}
-
 .settingsChangelogVersionContent {
-	padding: 2px 12px 14px;
+	padding: 14px 12px;
 	background: transparent;
 }
 
@@ -355,13 +284,8 @@
 		grid-column: 2 / 3;
 	}
 
-	.settingsChangelogVersionHeader {
-		padding: 10px 12px;
-		gap: 8px;
-	}
-
 	.settingsChangelogVersionContent {
-		padding: 0 12px 10px;
+		padding: 14px 12px;
 	}
 
 	.settingsChangelogCategory {
@@ -390,11 +314,5 @@
 
 	.whatsNewFooter {
 		padding-top: 2px;
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.settingsChangelogToggleIcon {
-		transition: none;
 	}
 }

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -319,7 +319,7 @@
 	border: 0;
 	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-secondary));
 	font-size: 0.76rem;
-	font-weight: var(--font-semibold);
+	font-weight: var(--font-medium);
 	color: color-mix(in srgb, var(--database-tone) 68%, var(--text-primary));
 	box-shadow: var(--pill-shadow);
 	white-space: nowrap;

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -26,30 +26,8 @@
 		color-mix(in srgb, var(--border-light) 58%, transparent);
 }
 
-.folioNotesTitleRow {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 10px;
-	margin-bottom: 8px;
-}
-
-.folioNotesTitle {
-	min-width: 0;
-	margin: 0;
-	color: var(--text-primary);
-	font-size: var(--text-sm);
-	font-weight: var(--font-semibold);
-	line-height: 1.2;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.folioNotesCount {
-	flex: 0 0 auto;
-	color: var(--text-tertiary);
-	font-size: 11px;
+.appShell.appShellSidebarCollapsed .folioNotesHeader {
+	padding-left: max(12px, var(--collapsed-sidebar-top-reserve));
 }
 
 .folioNotesControls {
@@ -224,21 +202,12 @@
 }
 
 .folioNoteRenameInput {
+	box-sizing: border-box;
 	flex: 1;
 	min-width: 0;
-	border: 1px solid var(--border-default);
-	border-radius: var(--radius-sm);
-	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
-	color: var(--text-primary);
-	padding: 2px 6px;
+	padding: 2px 0;
 	font: inherit;
 	line-height: 1.25;
-}
-
-.folioNoteRenameInput:focus-visible {
-	outline: 2px solid
-		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
-	outline-offset: 2px;
 }
 
 .folioNoteTaskProgress {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -8,6 +8,21 @@ export function basename(relPath: string): string {
 	return parts[parts.length - 1] ?? relPath;
 }
 
+export function splitEditableFileName(name: string): {
+	stem: string;
+	ext: string;
+} {
+	const trimmed = name.trim();
+	const dotIndex = trimmed.lastIndexOf(".");
+	if (dotIndex <= 0 || dotIndex === trimmed.length - 1) {
+		return { stem: trimmed, ext: "" };
+	}
+	return {
+		stem: trimmed.slice(0, dotIndex),
+		ext: trimmed.slice(dotIndex),
+	};
+}
+
 export function isMarkdownPath(relPath: string): boolean {
 	return relPath.toLowerCase().endsWith(".md");
 }


### PR DESCRIPTION
## Summary

This PR consolidates a set of UI cleanup commits into one focused change. It simplifies several Glyph app surfaces so they feel more like direct editing areas and less like nested settings panels or boxed controls.

## What changed

- Added an inline active-file title control in the editor, allowing file renames directly from the title area while keeping path handling centralized through `basenameFromPath`.
- Removed several leftover count and folder-name decorations from All Notes, Folio headers, and related navigation surfaces.
- Simplified command palette/search transitions by removing animation wrappers and trimming unused command search metadata.
- Reworked file, folder, folio note, database view, and database inline rename inputs so they present as direct text edits rather than bordered form controls.
- Normalized database relation and multi-select pills to use simpler accent-based styling instead of per-value/lane colors.
- Cleaned up About/settings and changelog presentation, including removing duplicated support/diagnostics structure and reducing custom CSS.
- Restored and tightened scrollbar/header/tab/sidebar CSS so collapsed-sidebar layouts reserve the right amount of space without overlapping controls.
- Kept the cleanup frontend-only, with no storage, IPC, or Rust behavior changes.

## Why

The affected surfaces had accumulated small inconsistencies: duplicated settings sections, ornamental note counts, boxed editing fields inside otherwise document-like UI, and header controls that could compete with the floating collapsed-sidebar button. This pass makes those areas quieter and more direct while reducing CSS and component clutter.

## Impact

Users should see a cleaner app chrome across the editor, All Notes, Folio mode, database cells, command palette, and About/settings screens. Rename flows remain available, but now feel more integrated with the surrounding text. The editor tab/header area also has better spacing when the sidebar is collapsed.

## Validation

- `pnpm check`
- `pnpm build`
- `cargo check` from `src-tauri`

`pnpm build` completed successfully. Vite still reports the existing large chunk warning after build output, but it does not fail the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file renaming functionality for active files in the tab bar.

* **Style**
  * Redesigned About section with quick links and updated layout.
  * Simplified input styling for cleaner appearance across note properties, file tree, and database editors.
  * Removed note count badges from sidebar and section headers.
  * Improved scrollbar visibility.
  * Removed animation effects from command palette.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->