### PR TITLE
Add Claude Code and Gemini CLI providers

### DIFF
--- a/src-tauri/src/ai_claude_code/mod.rs
+++ b/src-tauri/src/ai_claude_code/mod.rs
@@ -1,0 +1,351 @@
+use std::{path::Path, time::Duration};
+
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, Command},
+    sync::mpsc,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::ai_rig::{
+    events::AiStatusEvent,
+    helpers::{emit_tool, find_cli_binary},
+    providers::build_transcript,
+    types::{AiAssistantMode, AiChunkEvent, AiMessage, AiModel, AiProfile, AiStoredToolEvent},
+};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+
+fn find_claude_binary() -> Result<std::path::PathBuf, String> {
+    find_cli_binary("Claude Code", "CLAUDE_CLI_PATH", "claude")
+}
+
+fn prompt_text(system: &str, messages: &[AiMessage]) -> String {
+    let transcript = build_transcript(system, messages);
+    if transcript.trim().is_empty() {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.clone())
+            .unwrap_or_default()
+    } else {
+        transcript
+    }
+}
+
+fn permission_mode(mode: &AiAssistantMode) -> &'static str {
+    match mode {
+        AiAssistantMode::Chat => "plan",
+        AiAssistantMode::Create => "acceptEdits",
+    }
+}
+
+fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>(64);
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(line).await;
+            }
+        });
+    }
+    rx
+}
+
+async fn stop_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+fn auth_error_message(message: &str) -> Option<String> {
+    let lower = message.to_lowercase();
+    (lower.contains("auth")
+        || lower.contains("login")
+        || lower.contains("not logged in")
+        || lower.contains("unauthorized"))
+    .then(|| "Claude Code is not authenticated. Run `claude auth login` in your terminal, then retry in Glyph.".to_string())
+}
+
+fn emit_text(app: &AppHandle, job_id: &str, full: &mut String, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    full.push_str(text);
+    let _ = app.emit(
+        "ai:chunk",
+        AiChunkEvent {
+            job_id: job_id.to_string(),
+            delta: text.to_string(),
+        },
+    );
+}
+
+fn handle_content_part(
+    app: &AppHandle,
+    job_id: &str,
+    part: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+    emitted_stream_delta: bool,
+) {
+    match part.get("type").and_then(|v| v.as_str()) {
+        Some("text") if !emitted_stream_delta => {
+            if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                emit_text(app, job_id, full, text);
+            }
+        }
+        Some("tool_use") => {
+            let tool = part.get("name").and_then(|v| v.as_str()).unwrap_or("tool");
+            let call_id = part
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            emit_tool(
+                app,
+                job_id,
+                tool_events,
+                tool,
+                "call",
+                call_id,
+                Some(part.clone()),
+                None,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn handle_claude_event(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+    emitted_stream_delta: &mut bool,
+) -> Result<Option<bool>, String> {
+    match value.get("type").and_then(|v| v.as_str()) {
+        Some("stream_event") => {
+            let event = value.get("event").unwrap_or(&Value::Null);
+            if event.get("type").and_then(|v| v.as_str()) == Some("content_block_delta") {
+                if let Some(text) = event.pointer("/delta/text").and_then(|v| v.as_str()) {
+                    *emitted_stream_delta = true;
+                    emit_text(app, job_id, full, text);
+                }
+            }
+            Ok(None)
+        }
+        Some("assistant") => {
+            if let Some(content) = value.pointer("/message/content").and_then(|v| v.as_array()) {
+                for part in content {
+                    handle_content_part(
+                        app,
+                        job_id,
+                        part,
+                        full,
+                        tool_events,
+                        *emitted_stream_delta,
+                    );
+                }
+            }
+            Ok(None)
+        }
+        Some("user") => {
+            if let Some(content) = value.pointer("/message/content").and_then(|v| v.as_array()) {
+                for part in content {
+                    if part.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+                        continue;
+                    }
+                    let call_id = part
+                        .get("tool_use_id")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let is_error = part
+                        .get("is_error")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let error = is_error
+                        .then(|| part.get("content").and_then(|v| v.as_str()).unwrap_or(""))
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    emit_tool(
+                        app,
+                        job_id,
+                        tool_events,
+                        "tool",
+                        if is_error { "error" } else { "result" },
+                        call_id,
+                        Some(part.clone()),
+                        error,
+                    );
+                }
+            }
+            Ok(None)
+        }
+        Some("result") => {
+            if value
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                let raw = value
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Claude Code request failed");
+                return Err(auth_error_message(raw).unwrap_or_else(|| raw.to_string()));
+            }
+            if full.trim().is_empty() {
+                if let Some(result) = value.get("result").and_then(|v| v.as_str()) {
+                    emit_text(app, job_id, full, result);
+                }
+            }
+            Ok(Some(false))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub fn list_models(_profile: &AiProfile) -> Result<Vec<AiModel>, String> {
+    let _ = find_claude_binary()?;
+    Ok([
+        (
+            "default",
+            "Claude Code default",
+            "Use the Claude Code CLI default model.",
+        ),
+        ("sonnet", "Claude Sonnet", "Use Claude Code's Sonnet alias."),
+        ("opus", "Claude Opus", "Use Claude Code's Opus alias."),
+        ("haiku", "Claude Haiku", "Use Claude Code's Haiku alias."),
+    ]
+    .into_iter()
+    .map(|(id, name, description)| AiModel {
+        id: id.to_string(),
+        name: name.to_string(),
+        context_length: None,
+        description: Some(description.to_string()),
+        input_modalities: None,
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: None,
+        completion_pricing: None,
+        supported_parameters: Some(vec!["tools".to_string()]),
+        max_completion_tokens: None,
+        reasoning_effort: None,
+        default_reasoning_effort: None,
+    })
+    .collect())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_claude_code(
+    cancel: &CancellationToken,
+    app: &AppHandle,
+    job_id: &str,
+    profile: &AiProfile,
+    system: &str,
+    messages: &[AiMessage],
+    mode: &AiAssistantMode,
+    space_root: Option<&Path>,
+) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let root = space_root.ok_or_else(|| "No space is open".to_string())?;
+    let prompt = prompt_text(system, messages);
+    let binary = find_claude_binary()?;
+
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: "thinking".to_string(),
+            detail: Some("Starting Claude Code".to_string()),
+        },
+    );
+
+    let mut command = Command::new(binary);
+    command
+        .arg("--print")
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--verbose")
+        .arg("--include-partial-messages")
+        .arg("--permission-mode")
+        .arg(permission_mode(mode));
+    if !profile.model.trim().is_empty() && profile.model.trim() != "default" {
+        command.arg("--model").arg(profile.model.trim());
+    }
+    command
+        .arg(prompt)
+        .current_dir(root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start Claude Code: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Claude Code stdout".to_string())?;
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = pipe_stderr(&mut child);
+    let deadline = tokio::time::sleep(RUN_TIMEOUT);
+    tokio::pin!(deadline);
+
+    let mut full = String::new();
+    let mut tool_events = Vec::new();
+    let mut last_stderr = String::new();
+    let mut emitted_stream_delta = false;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                stop_child(&mut child).await;
+                return Ok((full, true, tool_events));
+            }
+            _ = &mut deadline => {
+                stop_child(&mut child).await;
+                return Err("Claude Code request timed out".to_string());
+            }
+            maybe_err = stderr_lines.recv() => {
+                if let Some(line) = maybe_err {
+                    if !line.trim().is_empty() {
+                        last_stderr = line;
+                    }
+                }
+            }
+            line = stdout_lines.next_line() => {
+                let line = line.map_err(|e| format!("failed reading Claude Code output: {e}"))?;
+                let Some(line) = line else {
+                    let status = child.wait().await.map_err(|e| e.to_string())?;
+                    if status.success() {
+                        return Ok((full, false, tool_events));
+                    }
+                    let detail = if last_stderr.trim().is_empty() {
+                        format!("Claude Code exited with {status}")
+                    } else {
+                        format!("Claude Code exited with {status}: {last_stderr}")
+                    };
+                    return Err(auth_error_message(&detail).unwrap_or(detail));
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let value = serde_json::from_str::<Value>(&line)
+                    .map_err(|e| format!("failed to parse Claude Code JSON output: {e}"))?;
+                if let Some(cancelled) = handle_claude_event(
+                    app,
+                    job_id,
+                    &value,
+                    &mut full,
+                    &mut tool_events,
+                    &mut emitted_stream_delta,
+                )? {
+                    let _ = child.wait().await;
+                    return Ok((full, cancelled, tool_events));
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/ai_gemini_cli/mod.rs
+++ b/src-tauri/src/ai_gemini_cli/mod.rs
@@ -1,0 +1,313 @@
+use std::{env, path::Path, time::Duration};
+
+use serde::Deserialize;
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::{io::AsyncReadExt, process::Command};
+use tokio_util::sync::CancellationToken;
+
+use crate::ai_rig::{
+    events::AiStatusEvent,
+    helpers::{find_cli_binary, http_client},
+    providers::build_transcript,
+    types::{AiAssistantMode, AiChunkEvent, AiMessage, AiModel, AiProfile, AiStoredToolEvent},
+};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+
+fn find_gemini_binary() -> Result<std::path::PathBuf, String> {
+    find_cli_binary("Gemini CLI", "GEMINI_CLI_PATH", "gemini")
+}
+
+fn prompt_text(system: &str, messages: &[AiMessage]) -> String {
+    let transcript = build_transcript(system, messages);
+    if transcript.trim().is_empty() {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.clone())
+            .unwrap_or_default()
+    } else {
+        transcript
+    }
+}
+
+fn approval_mode(mode: &AiAssistantMode) -> &'static str {
+    match mode {
+        AiAssistantMode::Chat => "plan",
+        AiAssistantMode::Create => "auto_edit",
+    }
+}
+
+async fn read_pipe<R>(mut reader: R) -> String
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut text = String::new();
+    let _ = reader.read_to_string(&mut text).await;
+    text
+}
+
+fn auth_error_message(message: &str) -> Option<String> {
+    let lower = message.to_lowercase();
+    (lower.contains("auth")
+        || lower.contains("login")
+        || lower.contains("api key")
+        || lower.contains("unauthorized")
+        || lower.contains("permission denied"))
+    .then(|| "Gemini CLI is not authenticated. Run Gemini CLI auth in your terminal or configure its official authentication environment, then retry in Glyph.".to_string())
+}
+
+fn string_at_path(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToString::to_string)
+}
+
+fn extract_response_text(value: &Value) -> Option<String> {
+    if let Some(text) = value
+        .as_str()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+    {
+        return Some(text.to_string());
+    }
+    [
+        &["response"][..],
+        &["text"][..],
+        &["result"][..],
+        &["content"][..],
+        &["message", "content"][..],
+        &["output", "text"][..],
+    ]
+    .into_iter()
+    .find_map(|path| string_at_path(value, path))
+}
+
+fn emit_response(app: &AppHandle, job_id: &str, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+    let _ = app.emit(
+        "ai:chunk",
+        AiChunkEvent {
+            job_id: job_id.to_string(),
+            delta: text.to_string(),
+        },
+    );
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiModelListResponse {
+    models: Option<Vec<GeminiModelListItem>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GeminiModelListItem {
+    name: String,
+    display_name: Option<String>,
+    description: Option<String>,
+    input_token_limit: Option<u32>,
+    output_token_limit: Option<u32>,
+    supported_generation_methods: Option<Vec<String>>,
+}
+
+fn env_api_key() -> Option<String> {
+    ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+        .into_iter()
+        .find_map(|name| {
+            env::var(name)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn cli_default_model() -> AiModel {
+    AiModel {
+        id: "default".to_string(),
+        name: "Gemini CLI default".to_string(),
+        context_length: None,
+        description: Some("Use the model configured in Gemini CLI.".to_string()),
+        input_modalities: None,
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: None,
+        completion_pricing: None,
+        supported_parameters: Some(vec!["tools".to_string()]),
+        max_completion_tokens: None,
+        reasoning_effort: None,
+        default_reasoning_effort: None,
+    }
+}
+
+fn google_model_to_ai_model(model: GeminiModelListItem) -> Option<AiModel> {
+    if let Some(methods) = &model.supported_generation_methods {
+        let can_generate = methods
+            .iter()
+            .any(|method| matches!(method.as_str(), "generateContent" | "streamGenerateContent"));
+        if !can_generate {
+            return None;
+        }
+    }
+    let id = model
+        .name
+        .strip_prefix("models/")
+        .unwrap_or(&model.name)
+        .to_string();
+    if id.trim().is_empty() {
+        return None;
+    }
+    Some(AiModel {
+        name: model.display_name.unwrap_or_else(|| id.clone()),
+        id,
+        context_length: model.input_token_limit,
+        description: model.description,
+        input_modalities: None,
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: None,
+        completion_pricing: None,
+        supported_parameters: Some(vec!["tools".to_string()]),
+        max_completion_tokens: model.output_token_limit,
+        reasoning_effort: None,
+        default_reasoning_effort: None,
+    })
+}
+
+pub async fn list_models(_profile: &AiProfile) -> Result<Vec<AiModel>, String> {
+    let _ = find_gemini_binary()?;
+    let Some(api_key) = env_api_key() else {
+        return Ok(vec![cli_default_model()]);
+    };
+
+    let client = http_client()?;
+    let mut url = reqwest::Url::parse("https://generativelanguage.googleapis.com/v1beta/models")
+        .map_err(|e| e.to_string())?;
+    url.query_pairs_mut().append_pair("key", &api_key);
+
+    let resp = client.get(url).send().await.map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("Gemini model list failed ({status}): {text}"));
+    }
+
+    let parsed: GeminiModelListResponse = resp.json().await.map_err(|e| e.to_string())?;
+    let mut models: Vec<AiModel> = parsed
+        .models
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(google_model_to_ai_model)
+        .collect();
+    models.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+    if !models.iter().any(|model| model.id == "default") {
+        models.insert(0, cli_default_model());
+    }
+    Ok(models)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_gemini_cli(
+    cancel: &CancellationToken,
+    app: &AppHandle,
+    job_id: &str,
+    profile: &AiProfile,
+    system: &str,
+    messages: &[AiMessage],
+    mode: &AiAssistantMode,
+    space_root: Option<&Path>,
+) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let root = space_root.ok_or_else(|| "No space is open".to_string())?;
+    let prompt = prompt_text(system, messages);
+    let binary = find_gemini_binary()?;
+
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: "thinking".to_string(),
+            detail: Some("Starting Gemini CLI".to_string()),
+        },
+    );
+
+    let mut command = Command::new(binary);
+    command
+        .arg("--prompt")
+        .arg(prompt)
+        .arg("--output-format")
+        .arg("json")
+        .arg("--approval-mode")
+        .arg(approval_mode(mode))
+        .arg("--skip-trust");
+    if !profile.model.trim().is_empty() && profile.model.trim() != "default" {
+        command.arg("--model").arg(profile.model.trim());
+    }
+    command
+        .current_dir(root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start Gemini CLI: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Gemini CLI stdout".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture Gemini CLI stderr".to_string())?;
+    let stdout_task = tokio::spawn(read_pipe(stdout));
+    let stderr_task = tokio::spawn(read_pipe(stderr));
+    let deadline = tokio::time::sleep(RUN_TIMEOUT);
+    tokio::pin!(deadline);
+
+    let status = loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Ok((String::new(), true, Vec::new()));
+            }
+            _ = &mut deadline => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                return Err("Gemini CLI request timed out".to_string());
+            }
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                if let Some(status) = child.try_wait().map_err(|e| e.to_string())? {
+                    break status;
+                }
+            }
+        }
+    };
+
+    let stdout = stdout_task.await.unwrap_or_default();
+    let stderr = stderr_task.await.unwrap_or_default();
+    if !status.success() {
+        let detail = if stderr.trim().is_empty() {
+            format!("Gemini CLI exited with {status}")
+        } else {
+            format!("Gemini CLI exited with {status}: {}", stderr.trim())
+        };
+        return Err(auth_error_message(&detail).unwrap_or(detail));
+    }
+
+    let full = match serde_json::from_str::<Value>(&stdout) {
+        Ok(value) => extract_response_text(&value).unwrap_or_else(|| stdout.trim().to_string()),
+        Err(_) => stdout.trim().to_string(),
+    };
+    emit_response(app, job_id, &full);
+    Ok((full, false, Vec::new()))
+}

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -197,6 +197,8 @@ pub async fn ai_profile_delete(
                 | super::types::AiProviderKind::LlamaCpp
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::Opencode
+                | super::types::AiProviderKind::ClaudeCode
+                | super::types::AiProviderKind::GeminiCli
         );
     }
     ensure_default_profiles(&mut store);
@@ -317,6 +319,8 @@ pub async fn ai_chat_start(
             super::types::AiProviderKind::CodexChatgpt
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::Opencode
+                | super::types::AiProviderKind::ClaudeCode
+                | super::types::AiProviderKind::GeminiCli
         )
     {
         return Err("Model not set for this profile".to_string());
@@ -491,6 +495,18 @@ pub async fn run_request(
     }
     if matches!(profile.provider, super::types::AiProviderKind::Amp) {
         return crate::ai_amp::run_with_amp(
+            cancel, app, job_id, profile, system, messages, mode, space_root,
+        )
+        .await;
+    }
+    if matches!(profile.provider, super::types::AiProviderKind::ClaudeCode) {
+        return crate::ai_claude_code::run_with_claude_code(
+            cancel, app, job_id, profile, system, messages, mode, space_root,
+        )
+        .await;
+    }
+    if matches!(profile.provider, super::types::AiProviderKind::GeminiCli) {
+        return crate::ai_gemini_cli::run_with_gemini_cli(
             cancel, app, job_id, profile, system, messages, mode, space_root,
         )
         .await;

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -27,6 +27,8 @@ pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
         AiProviderKind::CodexChatgpt => "https://developers.openai.com/codex/app-server/",
         AiProviderKind::Amp => "https://ampcode.com/",
         AiProviderKind::Opencode => "http://127.0.0.1:4096",
+        AiProviderKind::ClaudeCode => "https://claude.ai/",
+        AiProviderKind::GeminiCli => "https://gemini.google.com/",
     }
 }
 

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -617,6 +617,8 @@ pub async fn ai_models_list(
         AiProviderKind::Gemini => list_gemini(&client, &profile, &api_key).await,
         AiProviderKind::CodexChatgpt => list_codex_models(codex_state.inner()),
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
+        AiProviderKind::ClaudeCode => crate::ai_claude_code::list_models(&profile),
+        AiProviderKind::GeminiCli => crate::ai_gemini_cli::list_models(&profile).await,
         AiProviderKind::Opencode => {
             let root = space_root
                 .as_deref()

--- a/src-tauri/src/ai_rig/providers.rs
+++ b/src-tauri/src/ai_rig/providers.rs
@@ -17,7 +17,9 @@ pub fn capabilities(provider: &AiProviderKind) -> ProviderCapabilities {
         | AiProviderKind::LlamaCpp
         | AiProviderKind::CodexChatgpt
         | AiProviderKind::Amp
-        | AiProviderKind::Opencode => ProviderCapabilities {
+        | AiProviderKind::Opencode
+        | AiProviderKind::ClaudeCode
+        | AiProviderKind::GeminiCli => ProviderCapabilities {
             requires_max_tokens: false,
         },
     }

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -360,7 +360,11 @@ pub async fn run_with_rig(
                 Err(e) => return Err(e),
             }
         }
-        AiProviderKind::CodexChatgpt | AiProviderKind::Amp | AiProviderKind::Opencode => {
+        AiProviderKind::CodexChatgpt
+        | AiProviderKind::Amp
+        | AiProviderKind::Opencode
+        | AiProviderKind::ClaudeCode
+        | AiProviderKind::GeminiCli => {
             return Err(
                 "This provider uses a dedicated native runtime; not available in Rig runtime"
                     .to_string(),
@@ -630,6 +634,12 @@ pub async fn generate_chat_title_with_rig(
         }
         AiProviderKind::Opencode => {
             return Ok("OpenCode Chat".to_string());
+        }
+        AiProviderKind::ClaudeCode => {
+            return Ok("Claude Code Chat".to_string());
+        }
+        AiProviderKind::GeminiCli => {
+            return Ok("Gemini CLI Chat".to_string());
         }
     };
 

--- a/src-tauri/src/ai_rig/store.rs
+++ b/src-tauri/src/ai_rig/store.rs
@@ -61,6 +61,8 @@ pub fn ensure_default_profiles(store: &mut AiStore) {
         (AiProviderKind::CodexChatgpt, "codex", None, false),
         (AiProviderKind::Amp, "smart", None, false),
         (AiProviderKind::Opencode, "", None, true),
+        (AiProviderKind::ClaudeCode, "default", None, false),
+        (AiProviderKind::GeminiCli, "default", None, false),
     ];
 
     store.profiles = defaults

--- a/src-tauri/src/ai_rig/types.rs
+++ b/src-tauri/src/ai_rig/types.rs
@@ -13,6 +13,8 @@ pub enum AiProviderKind {
     CodexChatgpt,
     Amp,
     Opencode,
+    ClaudeCode,
+    GeminiCli,
 }
 
 impl AiProviderKind {
@@ -28,6 +30,8 @@ impl AiProviderKind {
             Self::CodexChatgpt => "codex_chatgpt",
             Self::Amp => "amp",
             Self::Opencode => "opencode",
+            Self::ClaudeCode => "claude_code",
+            Self::GeminiCli => "gemini_cli",
         }
     }
 
@@ -43,6 +47,8 @@ impl AiProviderKind {
             Self::CodexChatgpt => "Codex (ChatGPT)",
             Self::Amp => "Amp",
             Self::Opencode => "OpenCode",
+            Self::ClaudeCode => "Claude Code",
+            Self::GeminiCli => "Gemini CLI",
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,7 @@
 mod ai_amp;
+mod ai_claude_code;
 mod ai_codex;
+mod ai_gemini_cli;
 mod ai_opencode;
 mod ai_rig;
 mod databases;

--- a/src/components/ai/modelSelectorConstants.tsx
+++ b/src/components/ai/modelSelectorConstants.tsx
@@ -47,6 +47,8 @@ export const providerSupportKeyMap: Record<AiProviderKind, string> = {
 	codex_chatgpt: "openai",
 	amp: "amp",
 	opencode: "opencode",
+	claude_code: "anthropic",
+	gemini_cli: "gemini",
 };
 
 const endpointLabelMap: Record<string, string> = {

--- a/src/components/ai/providerLogos.ts
+++ b/src/components/ai/providerLogos.ts
@@ -42,6 +42,8 @@ export const providerLogoMeta: Record<
 		darkSrc: opencodeDarkThemeLogoUrl,
 		label: "OpenCode",
 	},
+	claude_code: { src: anthropicLogoUrl, label: "Claude Code" },
+	gemini_cli: { src: geminiLogoUrl, label: "Gemini CLI" },
 };
 
 export function getProviderLogoSrc(

--- a/src/components/settings/ai/AiModelCombobox.tsx
+++ b/src/components/settings/ai/AiModelCombobox.tsx
@@ -16,7 +16,9 @@ const providerNeedsApiKey = (provider: AiProviderKind): boolean =>
 	provider !== "llama_cpp" &&
 	provider !== "codex_chatgpt" &&
 	provider !== "amp" &&
-	provider !== "opencode";
+	provider !== "opencode" &&
+	provider !== "claude_code" &&
+	provider !== "gemini_cli";
 
 export function AiModelCombobox({
 	profileId,

--- a/src/components/settings/ai/AiProfileSections.tsx
+++ b/src/components/settings/ai/AiProfileSections.tsx
@@ -69,7 +69,9 @@ function AiProfileSectionsBody({
 		() =>
 			profileDraft?.provider !== "codex_chatgpt" &&
 			profileDraft?.provider !== "amp" &&
-			profileDraft?.provider !== "opencode",
+			profileDraft?.provider !== "opencode" &&
+			profileDraft?.provider !== "claude_code" &&
+			profileDraft?.provider !== "gemini_cli",
 		[profileDraft?.provider],
 	);
 

--- a/src/components/settings/ai/AiProviderSection.tsx
+++ b/src/components/settings/ai/AiProviderSection.tsx
@@ -1,6 +1,13 @@
+import { InformationCircleIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import type { AiModel, AiProfile, AiProviderKind } from "../../../lib/tauri";
 import { ProviderLogo } from "../../ai/modelSelectorConstants";
 import { Input } from "../../ui/shadcn/input";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "../../ui/shadcn/popover";
 import {
 	SettingsRow,
 	SettingsSection,
@@ -25,6 +32,8 @@ const aiProviderGroups: AiProviderOptionGroup[] = [
 			{ value: "codex_chatgpt", label: "Codex" },
 			{ value: "opencode", label: "OpenCode" },
 			{ value: "amp", label: "Amp" },
+			{ value: "claude_code", label: "Claude Code" },
+			{ value: "gemini_cli", label: "Gemini CLI" },
 		],
 	},
 	{
@@ -32,7 +41,7 @@ const aiProviderGroups: AiProviderOptionGroup[] = [
 		options: [
 			{ value: "openai", label: "OpenAI" },
 			{ value: "anthropic", label: "Anthropic" },
-			{ value: "gemini", label: "Google" },
+			{ value: "gemini", label: "Google Gemini API" },
 			{ value: "openrouter", label: "OpenRouter" },
 			{ value: "openai_compat", label: "OpenAI compatible" },
 		],
@@ -52,6 +61,16 @@ function findProviderOption(provider: AiProviderKind): AiProviderOption {
 		if (option) return option;
 	}
 	return { value: provider, label: provider };
+}
+
+function cliProviderWarning(provider: AiProviderKind): string | null {
+	if (provider === "claude_code") {
+		return "Use at your own risk. Anthropic’s docs say third-party products should use API key or supported cloud-provider auth and must not route Free, Pro, or Max plan credentials on behalf of users.";
+	}
+	if (provider === "gemini_cli") {
+		return "Use at your own risk. Gemini CLI docs say third-party tools must not piggyback on Gemini CLI OAuth; for third-party coding agents, Google recommends Vertex AI or Google AI Studio API keys.";
+	}
+	return null;
 }
 
 interface AiProviderSectionProps {
@@ -82,6 +101,7 @@ export function AiProviderSection({
 			? "http://localhost:8080/v1"
 			: "https://api.example.com/v1";
 	const selectedProvider = findProviderOption(profileDraft.provider);
+	const providerWarning = cliProviderWarning(profileDraft.provider);
 
 	return (
 		<SettingsSection
@@ -122,6 +142,33 @@ export function AiProviderSection({
 							</optgroup>
 						))}
 					</select>
+					{providerWarning ? (
+						<Popover>
+							<PopoverTrigger asChild>
+								<button
+									type="button"
+									className="settingsProviderWarningButton"
+									aria-label={`${selectedProvider.label} warning`}
+								>
+									<HugeiconsIcon
+										icon={InformationCircleIcon}
+										size={16}
+										strokeWidth={1.8}
+									/>
+								</button>
+							</PopoverTrigger>
+							<PopoverContent
+								align="end"
+								side="bottom"
+								sideOffset={8}
+								className="settingsProviderWarningPopover"
+							>
+								<div className="settingsProviderWarningText">
+									{providerWarning}
+								</div>
+							</PopoverContent>
+						</Popover>
+					) : null}
 				</div>
 			</SettingsRow>
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -616,7 +616,9 @@ export type AiProviderKind =
 	| "llama_cpp"
 	| "codex_chatgpt"
 	| "amp"
-	| "opencode";
+	| "opencode"
+	| "claude_code"
+	| "gemini_cli";
 
 export type AiAssistantMode = "chat" | "create";
 

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -298,6 +298,8 @@
 	.settingsProviderNativeLogoImage,
 .settingsProviderNativeLogo[data-provider="gemini"]
 	.settingsProviderNativeLogoImage,
+.settingsProviderNativeLogo[data-provider="gemini_cli"]
+	.settingsProviderNativeLogoImage,
 .settingsProviderNativeLogo[data-provider="openrouter"]
 	.settingsProviderNativeLogoImage {
 	width: 19px;
@@ -324,6 +326,55 @@
 
 .settingsFieldControl .settingsInline > select.settingsProviderNativeSelect {
 	flex-basis: 178px;
+}
+
+.settingsProviderWarningButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	flex: 0 0 auto;
+	border: 1px solid
+		color-mix(in srgb, var(--status-danger-border) 86%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--status-danger-bg) 88%, transparent);
+	color: var(--status-danger-fg);
+	line-height: 0;
+	cursor: pointer;
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--status-danger-fg) 9%, transparent);
+	transition: all var(--transition-base);
+}
+
+.settingsProviderWarningButton:hover {
+	border-color: color-mix(in srgb, var(--status-danger-fg) 48%, transparent);
+	background: color-mix(in srgb, var(--status-danger-bg) 96%, var(--bg-primary));
+	color: color-mix(in srgb, var(--status-danger-fg) 86%, var(--text-primary));
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--status-danger-fg) 18%, transparent), 0 0 0 3px
+		color-mix(in srgb, var(--status-danger-fg) 10%, transparent);
+}
+
+.settingsProviderWarningButton svg {
+	display: block;
+	width: 16px;
+	height: 16px;
+	color: currentcolor;
+	flex-shrink: 0;
+}
+
+.settingsProviderWarningPopover {
+	width: min(340px, calc(100vw - 32px));
+	padding: 12px;
+	border-color: var(--status-danger-border);
+	border-radius: var(--radius-md);
+}
+
+.settingsProviderWarningText {
+	font-size: 12px;
+	line-height: 1.45;
+	color: var(--text-secondary);
 }
 
 .settingsActions {


### PR DESCRIPTION
## Summary

- Adds native Rust runtime adapters for Claude Code and Gemini CLI, including binary discovery, prompt transcript construction, cancellation/timeout handling, authentication-oriented error messages, and chunk emission back into the existing AI event stream.
- Registers `claude_code` and `gemini_cli` as first-class AI provider kinds across the backend provider registry, default profile setup, model listing, chat dispatch, title generation, and TypeScript IPC types.
- Exposes both providers in the AI settings provider picker with provider logos and account-use warning popovers, while keeping them out of API-key-required settings flows.

## Why

Glyph already supports several hosted and local AI providers, plus dedicated native runtimes for providers that do not run through Rig. Claude Code and Gemini CLI follow that dedicated-runtime shape: they rely on local CLI authentication/configuration, can operate against the current workspace root, and need their stdout/stderr output adapted into Glyph chat events.

This change lets users choose those tools from the same AI profile UI while making the integration boundaries explicit. The warnings in settings call out that these CLI-backed options depend on user-managed local CLI auth and should not be treated like third-party API-key delegation flows.

## Implementation Notes

- Claude Code runs through `claude --print --output-format stream-json --verbose --include-partial-messages`, maps chat/create modes to Claude permission modes, streams text deltas, and records tool call/result events from Claude JSON messages.
- Gemini CLI runs through `gemini --prompt ... --output-format json`, maps chat/create modes to Gemini approval modes, parses common JSON response shapes, and falls back to the CLI default model when Google API model listing credentials are unavailable.
- Both runtimes require an open Glyph space so the CLI executes from the space root, matching workspace-aware agent expectations.
- Model discovery now routes Claude Code and Gemini CLI through their dedicated modules instead of the Rig runtime.
- The settings UI groups Claude Code and Gemini CLI under the native providers list and adds a compact warning popover for the account-auth caveats.

## User Impact

- Users can create AI profiles for Claude Code and Gemini CLI from Settings.
- CLI-backed profiles do not ask for API keys inside Glyph.
- Missing CLI binaries or auth failures surface as actionable errors that point users back to their terminal setup.
- Chat titles use provider-specific labels for these native runtime conversations.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

## Notes

- `pnpm build` completed successfully and emitted the existing Vite large-chunk warning.
- This PR is opened as a draft for review of the CLI invocation contracts and auth-policy wording before it is considered ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Claude Code as a new AI provider with streaming responses and model selection
  * Added Gemini CLI as a new AI provider with streaming responses and model selection
  * Both providers now available in AI settings and chat profiles with default configurations

* **Style**
  * Added styling for provider warning indicators and logos

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->