### PR TITLE
[codex] Add Finder reveal and file tree actions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1462,6 +1462,7 @@ pub fn run() {
             space_fs::read_write::paths::space_rename_path,
             space_fs::read_write::paths::space_delete_path,
             space_fs::read_write::paths::space_resolve_abs_path,
+            space_fs::read_write::paths::space_reveal_path,
             space_fs::read_write::paths::space_relativize_path,
             notes::properties::note_frontmatter_parse_properties,
             notes::properties::note_frontmatter_render_properties,

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -275,6 +275,44 @@ pub async fn space_resolve_abs_path(
     .map_err(|e| e.to_string())?
 }
 
+#[cfg(target_os = "macos")]
+fn reveal_file_manager_path(abs: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("open")
+        .arg("-R")
+        .arg(abs)
+        .status()
+        .map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err("failed to reveal path in Finder".to_string())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reveal_file_manager_path(_abs: &Path) -> Result<(), String> {
+    Err("revealing paths in Finder is only available on macOS".to_string())
+}
+
+#[tauri::command]
+pub async fn space_reveal_path(state: State<'_, SpaceState>, path: String) -> Result<(), String> {
+    let root = state.current_root()?;
+    tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
+        let rel = PathBuf::from(&path);
+        deny_hidden_rel_path(&rel)?;
+        let abs = paths::join_under(&root, &rel)?;
+        if !abs.exists() {
+            return Err("path does not exist".to_string());
+        }
+        if !abs.is_file() {
+            return Err("path is not a file".to_string());
+        }
+        reveal_file_manager_path(&abs)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_rename_path(
     state: State<'_, SpaceState>,

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -208,6 +208,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 								data-dragging={isDragging ? "true" : undefined}
 								data-drop-target={isDropTarget ? "true" : undefined}
 								data-has-custom-color={customColor ? "true" : "false"}
+								data-file-tree-kind="dir"
+								data-file-tree-path={entry.rel_path}
 							>
 								{appearance?.icon ? (
 									<DatabaseColumnIcon

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -3,6 +3,7 @@ import {
 	Copy01Icon,
 	DocumentCodeIcon,
 	FileViewIcon,
+	FolderOpenIcon,
 	PencilEdit02Icon,
 	PinIcon,
 	PinOffIcon,
@@ -12,6 +13,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import type { KeyboardEvent, MutableRefObject } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "../../lib/tauri";
 import type {
 	FileTreeAppearance,
 	FsEntry,
@@ -218,6 +220,13 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			event.currentTarget,
 		);
 	};
+	const handleRevealInFinder = useCallback(async () => {
+		try {
+			await invoke("space_reveal_path", { path: entry.rel_path });
+		} catch (error) {
+			console.error("Failed to show file in Finder", error);
+		}
+	}, [entry.rel_path]);
 
 	return (
 		<li className={isActive ? "fileTreeItem active" : "fileTreeItem"}>
@@ -266,6 +275,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 								data-dragging={isDragging ? "true" : undefined}
 								data-has-custom-color={customColor ? "true" : "false"}
 								data-file-tree-file="true"
+								data-file-tree-kind="file"
 								data-file-tree-path={entry.rel_path}
 							>
 								{appearance?.icon ? (
@@ -313,6 +323,17 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 									strokeWidth={0.9}
 								/>
 								Open
+							</ContextMenuItem>
+							<ContextMenuItem
+								className="fileTreeCreateMenuItem"
+								onSelect={() => void handleRevealInFinder()}
+							>
+								<HugeiconsIcon
+									icon={FolderOpenIcon}
+									size={14}
+									strokeWidth={0.9}
+								/>
+								Show in Finder
 							</ContextMenuItem>
 							<ContextMenuSeparator className="fileTreeCreateMenuSeparator" />
 							<ContextMenuItem

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -7,6 +7,7 @@ import { PinIcon, PinOffIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import {
+	type KeyboardEvent,
 	type MutableRefObject,
 	type ReactNode,
 	memo,
@@ -160,6 +161,24 @@ function FileTreeRootDrop({
 		>
 			{children}
 		</div>
+	);
+}
+
+function isDeleteKey(event: KeyboardEvent<HTMLElement>): boolean {
+	return (
+		(event.key === "Delete" || event.key === "Backspace") &&
+		!event.altKey &&
+		!event.ctrlKey &&
+		!event.metaKey
+	);
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+	return (
+		target instanceof HTMLInputElement ||
+		target instanceof HTMLTextAreaElement ||
+		target instanceof HTMLSelectElement ||
+		(target instanceof HTMLElement && target.isContentEditable)
 	);
 }
 
@@ -332,7 +351,7 @@ function TreeEntries({
 							entry={e}
 							depth={depth}
 							isExpanded={isExpanded}
-							isActive={e.rel_path === activeDirPath}
+							isActive={!activeFilePath && e.rel_path === activeDirPath}
 							isRenaming={renamingPath === e.rel_path}
 							onToggleDir={onToggleDir}
 							onEnterDir={onEnterDir}
@@ -669,6 +688,24 @@ export const FileTreePane = memo(function FileTreePane({
 		[onDeletePath],
 	);
 
+	const handleTreeKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLElement>) => {
+			if (!isDeleteKey(event) || isEditableTarget(event.target)) return;
+			if (!(event.target instanceof HTMLElement)) return;
+			const row = event.target.closest<HTMLElement>(
+				"[data-file-tree-path][data-file-tree-kind]",
+			);
+			if (!row || !event.currentTarget.contains(row)) return;
+			const path = row.dataset.fileTreePath;
+			const kind = row.dataset.fileTreeKind;
+			if (!path || (kind !== "dir" && kind !== "file")) return;
+			event.preventDefault();
+			event.stopPropagation();
+			void handleDeletePath(path, kind);
+		},
+		[handleDeletePath],
+	);
+
 	const handleDuplicateFile = useCallback(
 		async (path: string) => {
 			const duplicatedPath = await onDuplicateFile(path);
@@ -866,6 +903,7 @@ export const FileTreePane = memo(function FileTreePane({
 				initial={{ y: 10 }}
 				animate={{ y: 0 }}
 				transition={springTransition}
+				onKeyDown={handleTreeKeyDown}
 			>
 				{focusedDirPath ? (
 					<FileTreeRootDrop targetDirPath={focusedDirPath}>
@@ -994,6 +1032,7 @@ export const FileTreePane = memo(function FileTreePane({
 															}}
 															title={file.path}
 															data-file-tree-file="true"
+															data-file-tree-kind="file"
 															data-file-tree-path={file.path}
 														>
 															<span className="fileTreeName">

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -32,6 +32,7 @@ import type {
 } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { isDeleteKey } from "../../utils/keyboard";
 import {
 	isMarkdownPath,
 	normalizeRelPath,
@@ -161,15 +162,6 @@ function FileTreeRootDrop({
 		>
 			{children}
 		</div>
-	);
-}
-
-function isDeleteKey(event: KeyboardEvent<HTMLElement>): boolean {
-	return (
-		(event.key === "Delete" || event.key === "Backspace") &&
-		!event.altKey &&
-		!event.ctrlKey &&
-		!event.metaKey
 	);
 }
 

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -1,6 +1,7 @@
 import {
 	type CSSProperties,
 	memo,
+	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -361,6 +362,13 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 				className="folioNoteTaskProgress"
 			/>
 		) : null;
+	const handleRevealInFinder = useCallback(async () => {
+		try {
+			await invoke("space_reveal_path", { path: note.note_path });
+		} catch (error) {
+			console.error("Failed to show file in Finder", error);
+		}
+	}, [note.note_path]);
 	const leadingIcon = appearance?.icon ? (
 		<DatabaseColumnIcon
 			iconName={appearance.icon}
@@ -502,6 +510,12 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							onSelect={() => onOpenInNewTab(note.note_path)}
 						>
 							Open in New Tab
+						</ContextMenuItem>
+						<ContextMenuItem
+							className="fileTreeCreateMenuItem"
+							onSelect={() => void handleRevealInFinder()}
+						>
+							Show in Finder
 						</ContextMenuItem>
 						<ContextMenuSeparator className="fileTreeCreateMenuSeparator" />
 						{onRename ? (

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,12 +1,4 @@
-import {
-	type KeyboardEvent,
-	memo,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -14,6 +6,7 @@ import { extractErrorMessage } from "../../lib/errorUtils";
 import { prefetchNote } from "../../lib/navigationPrefetch";
 import type { FileTreeAppearance } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { isDeleteKey } from "../../utils/keyboard";
 import { basename } from "../../utils/path";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
@@ -98,15 +91,6 @@ function isFolioHeaderControl(target: EventTarget | null): boolean {
 		target instanceof HTMLSelectElement ||
 		target instanceof HTMLTextAreaElement ||
 		(target instanceof HTMLElement && target.isContentEditable)
-	);
-}
-
-function isDeleteKey(event: KeyboardEvent<HTMLElement>): boolean {
-	return (
-		(event.key === "Delete" || event.key === "Backspace") &&
-		!event.altKey &&
-		!event.ctrlKey &&
-		!event.metaKey
 	);
 }
 

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type KeyboardEvent,
+	memo,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -90,6 +98,15 @@ function isFolioHeaderControl(target: EventTarget | null): boolean {
 		target instanceof HTMLSelectElement ||
 		target instanceof HTMLTextAreaElement ||
 		(target instanceof HTMLElement && target.isContentEditable)
+	);
+}
+
+function isDeleteKey(event: KeyboardEvent<HTMLElement>): boolean {
+	return (
+		(event.key === "Delete" || event.key === "Backspace") &&
+		!event.altKey &&
+		!event.ctrlKey &&
+		!event.metaKey
 	);
 }
 
@@ -323,6 +340,22 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 					event.preventDefault();
 					const note = selectedIndex >= 0 ? visibleNotes[selectedIndex] : null;
 					if (note) openNote(note.note_path);
+					return;
+				}
+				if (isDeleteKey(event)) {
+					const row =
+						event.target instanceof HTMLElement
+							? event.target.closest<HTMLElement>("[data-folio-note-path]")
+							: null;
+					const pathFromFocusedRow = event.currentTarget.contains(row)
+						? row?.dataset.folioNotePath
+						: null;
+					const selectedNote =
+						selectedIndex >= 0 ? visibleNotes[selectedIndex] : null;
+					const path = pathFromFocusedRow ?? selectedNote?.note_path;
+					if (!path) return;
+					event.preventDefault();
+					void deleteNote(path);
 				}
 			}}
 		>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -820,6 +820,7 @@ interface TauriCommands {
 		void
 	>;
 	space_resolve_abs_path: CommandDef<{ path: string }, string>;
+	space_reveal_path: CommandDef<{ path: string }, void>;
 	space_relativize_path: CommandDef<{ abs_path: string }, string>;
 	space_resolve_wikilink: CommandDef<{ target: string }, string | null>;
 	space_resolve_image_wikilink: CommandDef<{ target: string }, string | null>;

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,0 +1,13 @@
+type DeleteKeyEvent = Pick<
+	KeyboardEvent,
+	"altKey" | "ctrlKey" | "key" | "metaKey"
+>;
+
+export function isDeleteKey(event: DeleteKeyEvent): boolean {
+	return (
+		(event.key === "Delete" || event.key === "Backspace") &&
+		!event.altKey &&
+		!event.ctrlKey &&
+		!event.metaKey
+	);
+}


### PR DESCRIPTION
## What changed

This PR consolidates the file-tree and Folio note-list polish into a single commit.

- Adds a new `space_reveal_path` Tauri command that safely resolves a note path inside the active space and reveals it in Finder on macOS.
- Registers the command in the backend and TypeScript IPC command map.
- Adds `Show in Finder` to note/file context menus in the file tree and Folio note list.
- Tags file-tree rows with path/kind metadata so keyboard actions can target the focused row cleanly.
- Adds Delete/Backspace handling for file-tree rows and Folio notes while avoiding editable controls.
- Prevents folders from showing the active highlight when a file is currently open, so the selected file is the only active item.

## Why

The note browser had useful right-click actions, but it lacked a direct way to reveal an open note in Finder from the common file surfaces. The file tree also treated the parent folder as active while a file was selected, which made the navigation state look ambiguous.

## Impact

Users can now reveal a note directly in Finder from both the file tree and Folio list. Keyboard deletion also works more consistently from focused note rows, and the active state in the file tree more accurately reflects the currently open file.

## Root cause

The frontend did not have a typed IPC command for reveal-in-Finder behavior, and file-tree row metadata was only partial. Folder active styling was based on the active directory alone, even when an active file path existed.

## Validation

- `pnpm check`
- `pnpm build`
- `cargo check` from `src-tauri`

`pnpm build` still reports the existing Vite large chunk warning after a successful production build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Show in Finder" context menu option for files and notes (macOS only) to quickly reveal and access them in your system file manager
  * Added keyboard shortcut support using Delete or Backspace keys for easily deleting files, folders, and notes directly from the file tree and notes list

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->