### PR TITLE
[codex] add PI coding agent provider

### DIFF
--- a/src-tauri/src/ai_pi/mod.rs
+++ b/src-tauri/src/ai_pi/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use serde_json::{json, Value};
@@ -11,6 +11,7 @@ use tokio::{
     sync::mpsc,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
 
 use crate::ai_rig::{
     events::AiStatusEvent,
@@ -71,18 +72,28 @@ async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
 }
 
 async fn stop_child(child: &mut Child) {
-    let _ = child.kill().await;
-    let _ = child.wait().await;
+    let pid = child.id();
+    debug!(?pid, "stopping PI subprocess");
+    if let Err(e) = child.kill().await {
+        debug!(?pid, error = %e, "PI subprocess kill returned an error");
+    }
+    match child.wait().await {
+        Ok(status) => debug!(?pid, %status, "PI subprocess exited"),
+        Err(e) => warn!(?pid, error = %e, "failed waiting for PI subprocess"),
+    }
 }
 
 async fn abort_and_stop(child: &mut Child, stdin: &mut Option<ChildStdin>) {
+    let pid = child.id();
     if let Some(mut child_stdin) = stdin.take() {
+        debug!(?pid, "sending PI abort request");
         let _ = write_rpc(&mut child_stdin, json!({ "type": "abort" })).await;
     }
     if tokio::time::timeout(STOP_TIMEOUT, child.wait())
         .await
         .is_err()
     {
+        warn!(?pid, "PI did not stop after abort request");
         stop_child(child).await;
     }
 }
@@ -197,6 +208,14 @@ async fn spawn_rpc(
     profile: Option<&AiProfile>,
 ) -> Result<Child, String> {
     let binary = find_pi_binary()?;
+    let model = profile.map(|profile| profile.model.trim()).unwrap_or("");
+    debug!(
+        binary = %binary.display(),
+        root = %root.display(),
+        offline,
+        model,
+        "spawning PI RPC subprocess"
+    );
     let mut command = Command::new(binary);
     command
         .arg("--mode")
@@ -211,23 +230,34 @@ async fn spawn_rpc(
         command.arg("--offline");
     }
     if let Some(profile) = profile {
-        let model = profile.model.trim();
         if !model.is_empty() {
             command.arg("--model").arg(model);
         }
         if let Some(effort) = profile.reasoning_effort.as_deref().map(str::trim) {
             if !effort.is_empty() {
+                let effort = effort.to_ascii_lowercase();
+                if !matches!(
+                    effort.as_str(),
+                    "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
+                ) {
+                    return Err(format!("Unsupported PI reasoning effort: {effort}"));
+                }
                 command.arg("--thinking").arg(effort);
             }
         }
     }
 
-    command
-        .spawn()
-        .map_err(|e| format!("failed to start PI: {e}"))
+    command.kill_on_drop(true);
+    let child = command.spawn().map_err(|e| {
+        error!(error = %e, "failed to start PI subprocess");
+        format!("failed to start PI: {e}")
+    })?;
+    info!(pid = ?child.id(), offline, model, "started PI RPC subprocess");
+    Ok(child)
 }
 
 pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
+    let started = Instant::now();
     let mut child = spawn_rpc(root, true, None).await?;
     let mut stdin = child
         .stdin
@@ -252,6 +282,10 @@ pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
     loop {
         tokio::select! {
             _ = &mut deadline => {
+                warn!(
+                    duration_ms = started.elapsed().as_millis(),
+                    "timed out waiting for PI models"
+                );
                 stop_child(&mut child).await;
                 return Err(if last_stderr.trim().is_empty() {
                     "Timed out waiting for PI models".to_string()
@@ -267,7 +301,14 @@ pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
                 }
             }
             line = stdout_lines.next_line() => {
-                let line = line.map_err(|e| format!("failed reading PI output: {e}"))?;
+                let line = match line {
+                    Ok(line) => line,
+                    Err(e) => {
+                        error!(error = %e, "failed reading PI model output");
+                        stop_child(&mut child).await;
+                        return Err(format!("failed reading PI output: {e}"));
+                    }
+                };
                 let Some(line) = line else {
                     let status = child.wait().await.map_err(|e| e.to_string())?;
                     return Err(if last_stderr.trim().is_empty() {
@@ -279,14 +320,21 @@ pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
                 if line.trim().is_empty() {
                     continue;
                 }
-                let value = serde_json::from_str::<Value>(&line)
-                    .map_err(|e| format!("failed to parse PI JSON output: {e}"))?;
+                let value = match serde_json::from_str::<Value>(&line) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        error!(error = %e, "failed to parse PI model JSON output");
+                        stop_child(&mut child).await;
+                        return Err(format!("failed to parse PI JSON output: {e}"));
+                    }
+                };
                 if value.get("type").and_then(|v| v.as_str()) != Some("response")
                     || value.get("id").and_then(|v| v.as_str()) != Some("glyph-models")
                 {
                     continue;
                 }
                 if value.get("success").and_then(|v| v.as_bool()) != Some(true) {
+                    error!("PI model list failed");
                     stop_child(&mut child).await;
                     return Err(value.get("error").and_then(|v| v.as_str()).unwrap_or("PI model list failed").to_string());
                 }
@@ -299,6 +347,11 @@ pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
                     .filter_map(parse_pi_model)
                     .collect::<Vec<_>>();
                 models.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+                info!(
+                    model_count = models.len(),
+                    duration_ms = started.elapsed().as_millis(),
+                    "loaded PI models"
+                );
                 stop_child(&mut child).await;
                 if models.is_empty() {
                     return Err("PI returned no available models".to_string());
@@ -379,6 +432,9 @@ fn push_thinking_block(out: &mut String, thinking: &str) {
 fn thinking_delta(delta: &str, line_start: &mut bool) -> String {
     let mut out = String::new();
     for segment in delta.split_inclusive('\n') {
+        if out.is_empty() && *line_start && segment.chars().all(|c| matches!(c, '\n' | '\r')) {
+            continue;
+        }
         if *line_start {
             out.push_str("> ");
             *line_start = false;
@@ -398,6 +454,7 @@ fn handle_message_update(
     full: &mut String,
     in_thinking: &mut bool,
     thinking_line_start: &mut bool,
+    thinking_has_content: &mut bool,
 ) {
     let event = value.get("assistantMessageEvent").unwrap_or(&Value::Null);
     match event.get("type").and_then(|v| v.as_str()) {
@@ -407,36 +464,40 @@ fn handle_message_update(
             }
         }
         Some("thinking_start") => {
-            if !full.ends_with("\n\n") && !full.is_empty() {
-                emit_chunk(app, job_id, full, "\n\n".to_string());
-            }
-            emit_chunk(app, job_id, full, "> Thinking\n> ".to_string());
             *in_thinking = true;
-            *thinking_line_start = false;
+            *thinking_line_start = true;
+            *thinking_has_content = false;
         }
         Some("thinking_delta") => {
             if !*in_thinking {
-                if !full.ends_with("\n\n") && !full.is_empty() {
-                    emit_chunk(app, job_id, full, "\n\n".to_string());
-                }
-                emit_chunk(app, job_id, full, "> Thinking\n> ".to_string());
                 *in_thinking = true;
-                *thinking_line_start = false;
+                *thinking_line_start = true;
+                *thinking_has_content = false;
             }
             if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
-                emit_chunk(
-                    app,
-                    job_id,
-                    full,
-                    thinking_delta(delta, thinking_line_start),
-                );
+                let delta = thinking_delta(delta, thinking_line_start);
+                if delta.trim().is_empty() {
+                    *thinking_line_start = true;
+                } else {
+                    if !*thinking_has_content {
+                        if !full.ends_with("\n\n") && !full.is_empty() {
+                            emit_chunk(app, job_id, full, "\n\n".to_string());
+                        }
+                        emit_chunk(app, job_id, full, "> Thinking\n".to_string());
+                    }
+                    emit_chunk(app, job_id, full, delta);
+                    *thinking_has_content = true;
+                }
             }
         }
         Some("thinking_end") => {
             if *in_thinking {
-                emit_chunk(app, job_id, full, "\n\n".to_string());
+                if *thinking_has_content {
+                    emit_chunk(app, job_id, full, "\n\n".to_string());
+                }
                 *in_thinking = false;
                 *thinking_line_start = false;
+                *thinking_has_content = false;
             }
         }
         _ => {}
@@ -465,6 +526,7 @@ fn handle_tool_event(
         .get("toolName")
         .and_then(|v| v.as_str())
         .unwrap_or("tool");
+    debug!(job_id, tool, phase, "PI tool event");
     let call_id = value
         .get("toolCallId")
         .and_then(|v| v.as_str())
@@ -501,8 +563,15 @@ pub async fn run_with_pi(
     _mode: &AiAssistantMode,
     space_root: Option<&Path>,
 ) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let started = Instant::now();
     let root = space_root.ok_or_else(|| "No space is open".to_string())?;
     let prompt = prompt_text(system, messages);
+    debug!(
+        job_id,
+        model = profile.model.as_str(),
+        prompt_len = prompt.len(),
+        "starting PI prompt"
+    );
 
     let _ = app.emit(
         "ai:status",
@@ -529,7 +598,11 @@ pub async fn run_with_pi(
             child_stdin,
             json!({ "id": "glyph-prompt", "type": "prompt", "message": prompt }),
         )
-        .await?;
+        .await
+        .map_err(|e| {
+            error!(job_id, error = %e, "failed writing PI prompt");
+            e
+        })?;
     } else {
         return Err("failed to capture PI stdin".to_string());
     }
@@ -548,14 +621,25 @@ pub async fn run_with_pi(
     let mut last_stderr = String::new();
     let mut in_thinking = false;
     let mut thinking_line_start = false;
+    let mut thinking_has_content = false;
 
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
+                info!(
+                    job_id,
+                    duration_ms = started.elapsed().as_millis(),
+                    "PI request cancelled"
+                );
                 abort_and_stop(&mut child, &mut stdin).await;
                 return Ok((full, true, tool_events));
             }
             _ = &mut deadline => {
+                warn!(
+                    job_id,
+                    duration_ms = started.elapsed().as_millis(),
+                    "PI request timed out"
+                );
                 abort_and_stop(&mut child, &mut stdin).await;
                 return Err("PI request timed out".to_string());
             }
@@ -567,10 +651,23 @@ pub async fn run_with_pi(
                 }
             }
             line = stdout_lines.next_line() => {
-                let line = line.map_err(|e| format!("failed reading PI output: {e}"))?;
+                let line = match line {
+                    Ok(line) => line,
+                    Err(e) => {
+                        error!(job_id, error = %e, "failed reading PI output");
+                        abort_and_stop(&mut child, &mut stdin).await;
+                        return Err(format!("failed reading PI output: {e}"));
+                    }
+                };
                 let Some(line) = line else {
                     let status = child.wait().await.map_err(|e| e.to_string())?;
-                    if status.success() && !full.trim().is_empty() {
+                    if status.success() && (!full.trim().is_empty() || !tool_events.is_empty()) {
+                        info!(
+                            job_id,
+                            duration_ms = started.elapsed().as_millis(),
+                            tool_events = tool_events.len(),
+                            "PI request completed"
+                        );
                         return Ok((full, false, tool_events));
                     }
                     return Err(if last_stderr.trim().is_empty() {
@@ -582,8 +679,14 @@ pub async fn run_with_pi(
                 if line.trim().is_empty() {
                     continue;
                 }
-                let value = serde_json::from_str::<Value>(&line)
-                    .map_err(|e| format!("failed to parse PI JSON output: {e}"))?;
+                let value = match serde_json::from_str::<Value>(&line) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        error!(job_id, error = %e, "failed to parse PI JSON output");
+                        abort_and_stop(&mut child, &mut stdin).await;
+                        return Err(format!("failed to parse PI JSON output: {e}"));
+                    }
+                };
                 match value.get("type").and_then(|v| v.as_str()) {
                     Some("response") if value.get("id").and_then(|v| v.as_str()) == Some("glyph-prompt") => {
                         if value.get("success").and_then(|v| v.as_bool()) != Some(true) {
@@ -599,6 +702,7 @@ pub async fn run_with_pi(
                             &mut full,
                             &mut in_thinking,
                             &mut thinking_line_start,
+                            &mut thinking_has_content,
                         );
                     }
                     Some("tool_execution_start") | Some("tool_execution_update") | Some("tool_execution_end") => {
@@ -621,6 +725,12 @@ pub async fn run_with_pi(
                         if full.trim().is_empty() && tool_events.is_empty() {
                             return Err("PI returned an empty response".to_string());
                         }
+                        info!(
+                            job_id,
+                            duration_ms = started.elapsed().as_millis(),
+                            tool_events = tool_events.len(),
+                            "PI agent ended"
+                        );
                         return Ok((full, false, tool_events));
                     }
                     _ => {}

--- a/src-tauri/src/ai_pi/mod.rs
+++ b/src-tauri/src/ai_pi/mod.rs
@@ -1,0 +1,631 @@
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Emitter};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, Command},
+    sync::mpsc,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::ai_rig::{
+    events::AiStatusEvent,
+    helpers::{emit_tool, find_cli_binary},
+    providers::build_transcript,
+    types::{
+        AiAssistantMode, AiChunkEvent, AiMessage, AiModel, AiProfile, AiReasoningEffortOption,
+        AiStoredToolEvent,
+    },
+};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+const CONTROL_TIMEOUT: Duration = Duration::from_secs(30);
+const STOP_TIMEOUT: Duration = Duration::from_secs(3);
+
+fn find_pi_binary() -> Result<PathBuf, String> {
+    find_cli_binary("PI", "PI_CLI_PATH", "pi")
+}
+
+fn prompt_text(system: &str, messages: &[AiMessage]) -> String {
+    let transcript = build_transcript(system, messages);
+    if transcript.trim().is_empty() {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.clone())
+            .unwrap_or_default()
+    } else {
+        transcript
+    }
+}
+
+async fn write_rpc(stdin: &mut ChildStdin, value: Value) -> Result<(), String> {
+    let mut line = serde_json::to_vec(&value).map_err(|e| e.to_string())?;
+    line.push(b'\n');
+    stdin
+        .write_all(&line)
+        .await
+        .map_err(|e| format!("failed writing to PI RPC: {e}"))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|e| format!("failed flushing PI RPC: {e}"))
+}
+
+async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>(64);
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(line).await;
+            }
+        });
+    }
+    rx
+}
+
+async fn stop_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+async fn abort_and_stop(child: &mut Child, stdin: &mut Option<ChildStdin>) {
+    if let Some(mut child_stdin) = stdin.take() {
+        let _ = write_rpc(&mut child_stdin, json!({ "type": "abort" })).await;
+    }
+    if tokio::time::timeout(STOP_TIMEOUT, child.wait())
+        .await
+        .is_err()
+    {
+        stop_child(child).await;
+    }
+}
+
+fn value_as_u32(value: Option<&Value>) -> Option<u32> {
+    value
+        .and_then(|v| v.as_u64())
+        .and_then(|v| u32::try_from(v).ok())
+}
+
+fn price_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(|v| v.as_f64())
+        .map(|v| {
+            if v.fract() == 0.0 {
+                format!("{v:.0}")
+            } else {
+                v.to_string()
+            }
+        })
+        .filter(|v| v != "0")
+}
+
+fn string_list(value: Option<&Value>) -> Option<Vec<String>> {
+    let items = value?
+        .as_array()?
+        .iter()
+        .filter_map(|item| item.as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    (!items.is_empty()).then_some(items)
+}
+
+fn reasoning_options(model: &Value) -> Option<Vec<AiReasoningEffortOption>> {
+    if model.get("reasoning").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+
+    let mut levels = vec!["off", "minimal", "low", "medium", "high"];
+    let map = model.get("thinkingLevelMap").and_then(|v| v.as_object());
+    if map
+        .and_then(|entries| entries.get("xhigh"))
+        .map(|value| !value.is_null())
+        .unwrap_or(false)
+    {
+        levels.push("xhigh");
+    }
+
+    let options = levels
+        .into_iter()
+        .filter(|level| {
+            map.and_then(|entries| entries.get(*level))
+                .map(|value| !value.is_null())
+                .unwrap_or(true)
+        })
+        .map(|level| AiReasoningEffortOption {
+            effort: level.to_string(),
+            description: None,
+        })
+        .collect::<Vec<_>>();
+
+    (!options.is_empty()).then_some(options)
+}
+
+fn parse_pi_model(value: &Value) -> Option<AiModel> {
+    let id = value.get("id")?.as_str()?.to_string();
+    let raw_name = value.get("name").and_then(|v| v.as_str()).unwrap_or(&id);
+    let provider = value.get("provider").and_then(|v| v.as_str());
+    let name = match provider {
+        Some(provider)
+            if !provider.trim().is_empty()
+                && !raw_name
+                    .to_lowercase()
+                    .contains(&provider.trim().to_lowercase()) =>
+        {
+            format!("{}: {}", provider.trim(), raw_name)
+        }
+        _ => raw_name.to_string(),
+    };
+    let cost = value.get("cost").unwrap_or(&Value::Null);
+    let reasoning_effort = reasoning_options(value);
+
+    Some(AiModel {
+        id,
+        name,
+        context_length: value_as_u32(value.get("contextWindow")),
+        description: provider.map(|provider| format!("PI provider: {provider}")),
+        input_modalities: string_list(value.get("input")),
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: price_string(cost.get("input")),
+        completion_pricing: price_string(cost.get("output")),
+        supported_parameters: Some(
+            ["tools"]
+                .into_iter()
+                .chain(reasoning_effort.is_some().then_some("reasoning"))
+                .map(str::to_string)
+                .collect(),
+        ),
+        max_completion_tokens: value_as_u32(value.get("maxTokens")),
+        reasoning_effort,
+        default_reasoning_effort: value
+            .get("reasoning")
+            .and_then(|v| v.as_bool())
+            .filter(|v| *v)
+            .map(|_| "medium".to_string()),
+    })
+}
+
+async fn spawn_rpc(
+    root: &Path,
+    offline: bool,
+    profile: Option<&AiProfile>,
+) -> Result<Child, String> {
+    let binary = find_pi_binary()?;
+    let mut command = Command::new(binary);
+    command
+        .arg("--mode")
+        .arg("rpc")
+        .arg("--no-session")
+        .current_dir(root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    if offline {
+        command.arg("--offline");
+    }
+    if let Some(profile) = profile {
+        let model = profile.model.trim();
+        if !model.is_empty() {
+            command.arg("--model").arg(model);
+        }
+        if let Some(effort) = profile.reasoning_effort.as_deref().map(str::trim) {
+            if !effort.is_empty() {
+                command.arg("--thinking").arg(effort);
+            }
+        }
+    }
+
+    command
+        .spawn()
+        .map_err(|e| format!("failed to start PI: {e}"))
+}
+
+pub async fn list_models(root: &Path) -> Result<Vec<AiModel>, String> {
+    let mut child = spawn_rpc(root, true, None).await?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "failed to capture PI stdin".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture PI stdout".to_string())?;
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = pipe_stderr(&mut child).await;
+    let deadline = tokio::time::sleep(CONTROL_TIMEOUT);
+    tokio::pin!(deadline);
+
+    write_rpc(
+        &mut stdin,
+        json!({ "id": "glyph-models", "type": "get_available_models" }),
+    )
+    .await?;
+
+    let mut last_stderr = String::new();
+    loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                stop_child(&mut child).await;
+                return Err(if last_stderr.trim().is_empty() {
+                    "Timed out waiting for PI models".to_string()
+                } else {
+                    format!("Timed out waiting for PI models: {last_stderr}")
+                });
+            }
+            maybe_err = stderr_lines.recv() => {
+                if let Some(line) = maybe_err {
+                    if !line.trim().is_empty() {
+                        last_stderr = line;
+                    }
+                }
+            }
+            line = stdout_lines.next_line() => {
+                let line = line.map_err(|e| format!("failed reading PI output: {e}"))?;
+                let Some(line) = line else {
+                    let status = child.wait().await.map_err(|e| e.to_string())?;
+                    return Err(if last_stderr.trim().is_empty() {
+                        format!("PI exited before returning models: {status}")
+                    } else {
+                        format!("PI exited before returning models: {status}: {last_stderr}")
+                    });
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let value = serde_json::from_str::<Value>(&line)
+                    .map_err(|e| format!("failed to parse PI JSON output: {e}"))?;
+                if value.get("type").and_then(|v| v.as_str()) != Some("response")
+                    || value.get("id").and_then(|v| v.as_str()) != Some("glyph-models")
+                {
+                    continue;
+                }
+                if value.get("success").and_then(|v| v.as_bool()) != Some(true) {
+                    stop_child(&mut child).await;
+                    return Err(value.get("error").and_then(|v| v.as_str()).unwrap_or("PI model list failed").to_string());
+                }
+                let mut models = value
+                    .pointer("/data/models")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(parse_pi_model)
+                    .collect::<Vec<_>>();
+                models.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.id.cmp(&b.id)));
+                stop_child(&mut child).await;
+                if models.is_empty() {
+                    return Err("PI returned no available models".to_string());
+                }
+                return Ok(models);
+            }
+        }
+    }
+}
+
+fn extract_text_from_message(message: &Value) -> String {
+    message
+        .get("content")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            let mut out = String::new();
+            for item in items {
+                match item.get("type").and_then(|v| v.as_str()) {
+                    Some("text") => {
+                        if let Some(text) = item.get("text").and_then(|v| v.as_str()) {
+                            out.push_str(text);
+                        }
+                    }
+                    Some("thinking") => {
+                        if let Some(thinking) = item.get("thinking").and_then(|v| v.as_str()) {
+                            push_thinking_block(&mut out, thinking);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            out
+        })
+        .unwrap_or_default()
+}
+
+fn agent_end_text(value: &Value) -> String {
+    value
+        .get("messages")
+        .and_then(|v| v.as_array())
+        .and_then(|messages| {
+            messages.iter().rev().find_map(|message| {
+                (message.get("role").and_then(|v| v.as_str()) == Some("assistant"))
+                    .then(|| extract_text_from_message(message))
+                    .filter(|text| !text.trim().is_empty())
+            })
+        })
+        .unwrap_or_default()
+}
+
+fn emit_chunk(app: &AppHandle, job_id: &str, full: &mut String, delta: String) {
+    if delta.is_empty() {
+        return;
+    }
+    full.push_str(&delta);
+    let _ = app.emit(
+        "ai:chunk",
+        AiChunkEvent {
+            job_id: job_id.to_string(),
+            delta,
+        },
+    );
+}
+
+fn push_thinking_block(out: &mut String, thinking: &str) {
+    if !out.ends_with("\n\n") && !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str("> Thinking\n");
+    for line in thinking.lines() {
+        out.push_str("> ");
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push('\n');
+}
+
+fn thinking_delta(delta: &str, line_start: &mut bool) -> String {
+    let mut out = String::new();
+    for segment in delta.split_inclusive('\n') {
+        if *line_start {
+            out.push_str("> ");
+            *line_start = false;
+        }
+        out.push_str(segment);
+        if segment.ends_with('\n') {
+            *line_start = true;
+        }
+    }
+    out
+}
+
+fn handle_message_update(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    in_thinking: &mut bool,
+    thinking_line_start: &mut bool,
+) {
+    let event = value.get("assistantMessageEvent").unwrap_or(&Value::Null);
+    match event.get("type").and_then(|v| v.as_str()) {
+        Some("text_delta") => {
+            if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
+                emit_chunk(app, job_id, full, delta.to_string());
+            }
+        }
+        Some("thinking_start") => {
+            if !full.ends_with("\n\n") && !full.is_empty() {
+                emit_chunk(app, job_id, full, "\n\n".to_string());
+            }
+            emit_chunk(app, job_id, full, "> Thinking\n> ".to_string());
+            *in_thinking = true;
+            *thinking_line_start = false;
+        }
+        Some("thinking_delta") => {
+            if !*in_thinking {
+                if !full.ends_with("\n\n") && !full.is_empty() {
+                    emit_chunk(app, job_id, full, "\n\n".to_string());
+                }
+                emit_chunk(app, job_id, full, "> Thinking\n> ".to_string());
+                *in_thinking = true;
+                *thinking_line_start = false;
+            }
+            if let Some(delta) = event.get("delta").and_then(|v| v.as_str()) {
+                emit_chunk(
+                    app,
+                    job_id,
+                    full,
+                    thinking_delta(delta, thinking_line_start),
+                );
+            }
+        }
+        Some("thinking_end") => {
+            if *in_thinking {
+                emit_chunk(app, job_id, full, "\n\n".to_string());
+                *in_thinking = false;
+                *thinking_line_start = false;
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_tool_event(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) {
+    let event_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let phase = match event_type {
+        "tool_execution_start" | "tool_execution_update" => "call",
+        "tool_execution_end" => {
+            if value.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+                "error"
+            } else {
+                "result"
+            }
+        }
+        _ => return,
+    };
+    let tool = value
+        .get("toolName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("tool");
+    let call_id = value
+        .get("toolCallId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let error = (phase == "error").then(|| {
+        value
+            .pointer("/result/error")
+            .or_else(|| value.pointer("/result/message"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("PI tool failed")
+            .to_string()
+    });
+
+    emit_tool(
+        app,
+        job_id,
+        tool_events,
+        tool,
+        phase,
+        call_id,
+        Some(value.clone()),
+        error,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_pi(
+    cancel: &CancellationToken,
+    app: &AppHandle,
+    job_id: &str,
+    profile: &AiProfile,
+    system: &str,
+    messages: &[AiMessage],
+    _mode: &AiAssistantMode,
+    space_root: Option<&Path>,
+) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let root = space_root.ok_or_else(|| "No space is open".to_string())?;
+    let prompt = prompt_text(system, messages);
+
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: "thinking".to_string(),
+            detail: Some("Starting PI".to_string()),
+        },
+    );
+
+    let mut child = spawn_rpc(root, false, Some(profile)).await?;
+    let mut stdin = child.stdin.take();
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture PI stdout".to_string())?;
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = pipe_stderr(&mut child).await;
+    let deadline = tokio::time::sleep(RUN_TIMEOUT);
+    tokio::pin!(deadline);
+
+    if let Some(child_stdin) = &mut stdin {
+        write_rpc(
+            child_stdin,
+            json!({ "id": "glyph-prompt", "type": "prompt", "message": prompt }),
+        )
+        .await?;
+    } else {
+        return Err("failed to capture PI stdin".to_string());
+    }
+
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: "thinking".to_string(),
+            detail: Some("PI is running".to_string()),
+        },
+    );
+
+    let mut full = String::new();
+    let mut tool_events = Vec::new();
+    let mut last_stderr = String::new();
+    let mut in_thinking = false;
+    let mut thinking_line_start = false;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                abort_and_stop(&mut child, &mut stdin).await;
+                return Ok((full, true, tool_events));
+            }
+            _ = &mut deadline => {
+                abort_and_stop(&mut child, &mut stdin).await;
+                return Err("PI request timed out".to_string());
+            }
+            maybe_err = stderr_lines.recv() => {
+                if let Some(line) = maybe_err {
+                    if !line.trim().is_empty() {
+                        last_stderr = line;
+                    }
+                }
+            }
+            line = stdout_lines.next_line() => {
+                let line = line.map_err(|e| format!("failed reading PI output: {e}"))?;
+                let Some(line) = line else {
+                    let status = child.wait().await.map_err(|e| e.to_string())?;
+                    if status.success() && !full.trim().is_empty() {
+                        return Ok((full, false, tool_events));
+                    }
+                    return Err(if last_stderr.trim().is_empty() {
+                        format!("PI exited before completion: {status}")
+                    } else {
+                        format!("PI exited before completion: {status}: {last_stderr}")
+                    });
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let value = serde_json::from_str::<Value>(&line)
+                    .map_err(|e| format!("failed to parse PI JSON output: {e}"))?;
+                match value.get("type").and_then(|v| v.as_str()) {
+                    Some("response") if value.get("id").and_then(|v| v.as_str()) == Some("glyph-prompt") => {
+                        if value.get("success").and_then(|v| v.as_bool()) != Some(true) {
+                            abort_and_stop(&mut child, &mut stdin).await;
+                            return Err(value.get("error").and_then(|v| v.as_str()).unwrap_or("PI prompt failed").to_string());
+                        }
+                    }
+                    Some("message_update") => {
+                        handle_message_update(
+                            app,
+                            job_id,
+                            &value,
+                            &mut full,
+                            &mut in_thinking,
+                            &mut thinking_line_start,
+                        );
+                    }
+                    Some("tool_execution_start") | Some("tool_execution_update") | Some("tool_execution_end") => {
+                        handle_tool_event(app, job_id, &value, &mut tool_events);
+                    }
+                    Some("agent_end") => {
+                        if full.trim().is_empty() {
+                            full = agent_end_text(&value);
+                            if !full.is_empty() {
+                                let _ = app.emit(
+                                    "ai:chunk",
+                                    AiChunkEvent {
+                                        job_id: job_id.to_string(),
+                                        delta: full.clone(),
+                                    },
+                                );
+                            }
+                        }
+                        stop_child(&mut child).await;
+                        if full.trim().is_empty() && tool_events.is_empty() {
+                            return Err("PI returned an empty response".to_string());
+                        }
+                        return Ok((full, false, tool_events));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -197,6 +197,7 @@ pub async fn ai_profile_delete(
                 | super::types::AiProviderKind::LlamaCpp
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::Opencode
+                | super::types::AiProviderKind::Pi
         );
     }
     ensure_default_profiles(&mut store);
@@ -317,6 +318,7 @@ pub async fn ai_chat_start(
             super::types::AiProviderKind::CodexChatgpt
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::Opencode
+                | super::types::AiProviderKind::Pi
         )
     {
         return Err("Model not set for this profile".to_string());
@@ -491,6 +493,12 @@ pub async fn run_request(
     }
     if matches!(profile.provider, super::types::AiProviderKind::Amp) {
         return crate::ai_amp::run_with_amp(
+            cancel, app, job_id, profile, system, messages, mode, space_root,
+        )
+        .await;
+    }
+    if matches!(profile.provider, super::types::AiProviderKind::Pi) {
+        return crate::ai_pi::run_with_pi(
             cancel, app, job_id, profile, system, messages, mode, space_root,
         )
         .await;

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -27,6 +27,7 @@ pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
         AiProviderKind::CodexChatgpt => "https://developers.openai.com/codex/app-server/",
         AiProviderKind::Amp => "https://ampcode.com/",
         AiProviderKind::Opencode => "http://127.0.0.1:4096",
+        AiProviderKind::Pi => "https://pi.dev/",
     }
 }
 

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -623,5 +623,11 @@ pub async fn ai_models_list(
                 .ok_or_else(|| "Open a space to load OpenCode models".to_string())?;
             crate::ai_opencode::list_models(root).await
         }
+        AiProviderKind::Pi => {
+            let root = space_root
+                .as_deref()
+                .ok_or_else(|| "Open a space to load PI models".to_string())?;
+            crate::ai_pi::list_models(root).await
+        }
     }
 }

--- a/src-tauri/src/ai_rig/providers.rs
+++ b/src-tauri/src/ai_rig/providers.rs
@@ -17,7 +17,8 @@ pub fn capabilities(provider: &AiProviderKind) -> ProviderCapabilities {
         | AiProviderKind::LlamaCpp
         | AiProviderKind::CodexChatgpt
         | AiProviderKind::Amp
-        | AiProviderKind::Opencode => ProviderCapabilities {
+        | AiProviderKind::Opencode
+        | AiProviderKind::Pi => ProviderCapabilities {
             requires_max_tokens: false,
         },
     }

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -360,7 +360,10 @@ pub async fn run_with_rig(
                 Err(e) => return Err(e),
             }
         }
-        AiProviderKind::CodexChatgpt | AiProviderKind::Amp | AiProviderKind::Opencode => {
+        AiProviderKind::CodexChatgpt
+        | AiProviderKind::Amp
+        | AiProviderKind::Opencode
+        | AiProviderKind::Pi => {
             return Err(
                 "This provider uses a dedicated native runtime; not available in Rig runtime"
                     .to_string(),
@@ -630,6 +633,9 @@ pub async fn generate_chat_title_with_rig(
         }
         AiProviderKind::Opencode => {
             return Ok("OpenCode Chat".to_string());
+        }
+        AiProviderKind::Pi => {
+            return Ok("PI Chat".to_string());
         }
     };
 

--- a/src-tauri/src/ai_rig/store.rs
+++ b/src-tauri/src/ai_rig/store.rs
@@ -61,6 +61,7 @@ pub fn ensure_default_profiles(store: &mut AiStore) {
         (AiProviderKind::CodexChatgpt, "codex", None, false),
         (AiProviderKind::Amp, "smart", None, false),
         (AiProviderKind::Opencode, "", None, true),
+        (AiProviderKind::Pi, "", None, true),
     ];
 
     store.profiles = defaults

--- a/src-tauri/src/ai_rig/types.rs
+++ b/src-tauri/src/ai_rig/types.rs
@@ -13,6 +13,7 @@ pub enum AiProviderKind {
     CodexChatgpt,
     Amp,
     Opencode,
+    Pi,
 }
 
 impl AiProviderKind {
@@ -28,6 +29,7 @@ impl AiProviderKind {
             Self::CodexChatgpt => "codex_chatgpt",
             Self::Amp => "amp",
             Self::Opencode => "opencode",
+            Self::Pi => "pi",
         }
     }
 
@@ -43,6 +45,7 @@ impl AiProviderKind {
             Self::CodexChatgpt => "Codex (ChatGPT)",
             Self::Amp => "Amp",
             Self::Opencode => "OpenCode",
+            Self::Pi => "PI",
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod ai_amp;
 mod ai_codex;
 mod ai_opencode;
+mod ai_pi;
 mod ai_rig;
 mod databases;
 mod file_tree_appearance;

--- a/src/assets/provider-logos/pi-dark.svg
+++ b/src/assets/provider-logos/pi-dark.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/src/assets/provider-logos/pi-light.svg
+++ b/src/assets/provider-logos/pi-light.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <path fill="#111" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#111" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/src/components/ai/modelSelectorConstants.tsx
+++ b/src/components/ai/modelSelectorConstants.tsx
@@ -47,6 +47,7 @@ export const providerSupportKeyMap: Record<AiProviderKind, string> = {
 	codex_chatgpt: "openai",
 	amp: "amp",
 	opencode: "opencode",
+	pi: "pi",
 };
 
 const endpointLabelMap: Record<string, string> = {

--- a/src/components/ai/providerLogos.ts
+++ b/src/components/ai/providerLogos.ts
@@ -10,6 +10,8 @@ import openrouterLogoUrl from "../../assets/provider-logos/open-router.svg?url";
 import openaiDarkThemeLogoUrl from "../../assets/provider-logos/openai-light.svg?url";
 import opencodeDarkThemeLogoUrl from "../../assets/provider-logos/opencode-dark.svg?url";
 import opencodeLightThemeLogoUrl from "../../assets/provider-logos/opencode-light.svg?url";
+import piDarkThemeLogoUrl from "../../assets/provider-logos/pi-dark.svg?url";
+import piLightThemeLogoUrl from "../../assets/provider-logos/pi-light.svg?url";
 import type { AiProviderKind } from "../../lib/tauri";
 
 export const providerLogoMeta: Record<
@@ -41,6 +43,11 @@ export const providerLogoMeta: Record<
 		src: opencodeLightThemeLogoUrl,
 		darkSrc: opencodeDarkThemeLogoUrl,
 		label: "OpenCode",
+	},
+	pi: {
+		src: piLightThemeLogoUrl,
+		darkSrc: piDarkThemeLogoUrl,
+		label: "PI",
 	},
 };
 

--- a/src/components/settings/ai/AiModelCombobox.tsx
+++ b/src/components/settings/ai/AiModelCombobox.tsx
@@ -11,13 +11,17 @@ interface AiModelComboboxProps {
 	onModelsChange?: (models: AiModel[] | null) => void;
 }
 
+const PROVIDERS_NO_API_KEY = new Set<AiProviderKind>([
+	"ollama",
+	"llama_cpp",
+	"codex_chatgpt",
+	"amp",
+	"opencode",
+	"pi",
+]);
+
 const providerNeedsApiKey = (provider: AiProviderKind): boolean =>
-	provider !== "ollama" &&
-	provider !== "llama_cpp" &&
-	provider !== "codex_chatgpt" &&
-	provider !== "amp" &&
-	provider !== "opencode" &&
-	provider !== "pi";
+	!PROVIDERS_NO_API_KEY.has(provider);
 
 export function AiModelCombobox({
 	profileId,

--- a/src/components/settings/ai/AiModelCombobox.tsx
+++ b/src/components/settings/ai/AiModelCombobox.tsx
@@ -16,7 +16,8 @@ const providerNeedsApiKey = (provider: AiProviderKind): boolean =>
 	provider !== "llama_cpp" &&
 	provider !== "codex_chatgpt" &&
 	provider !== "amp" &&
-	provider !== "opencode";
+	provider !== "opencode" &&
+	provider !== "pi";
 
 export function AiModelCombobox({
 	profileId,

--- a/src/components/settings/ai/AiProfileSections.tsx
+++ b/src/components/settings/ai/AiProfileSections.tsx
@@ -69,7 +69,8 @@ function AiProfileSectionsBody({
 		() =>
 			profileDraft?.provider !== "codex_chatgpt" &&
 			profileDraft?.provider !== "amp" &&
-			profileDraft?.provider !== "opencode",
+			profileDraft?.provider !== "opencode" &&
+			profileDraft?.provider !== "pi",
 		[profileDraft?.provider],
 	);
 

--- a/src/components/settings/ai/AiProfileSections.tsx
+++ b/src/components/settings/ai/AiProfileSections.tsx
@@ -14,6 +14,13 @@ interface AiProfileSectionsProps {
 	onSaveProfile: (draft: AiProfile) => Promise<void>;
 }
 
+const PROVIDERS_NO_API_KEY = new Set<AiProviderKind>([
+	"codex_chatgpt",
+	"amp",
+	"opencode",
+	"pi",
+]);
+
 export function AiProfileSections({
 	profiles,
 	activeProfileId,
@@ -67,10 +74,8 @@ function AiProfileSectionsBody({
 
 	const providerUsesApiKey = useMemo(
 		() =>
-			profileDraft?.provider !== "codex_chatgpt" &&
-			profileDraft?.provider !== "amp" &&
-			profileDraft?.provider !== "opencode" &&
-			profileDraft?.provider !== "pi",
+			!profileDraft?.provider ||
+			!PROVIDERS_NO_API_KEY.has(profileDraft.provider),
 		[profileDraft?.provider],
 	);
 

--- a/src/components/settings/ai/AiProviderSection.tsx
+++ b/src/components/settings/ai/AiProviderSection.tsx
@@ -25,6 +25,7 @@ const aiProviderGroups: AiProviderOptionGroup[] = [
 			{ value: "codex_chatgpt", label: "Codex" },
 			{ value: "opencode", label: "OpenCode" },
 			{ value: "amp", label: "Amp" },
+			{ value: "pi", label: "PI" },
 		],
 	},
 	{
@@ -76,7 +77,8 @@ export function AiProviderSection({
 	const selectedModel =
 		availableModels?.find((model) => model.id === profileDraft.model) ?? null;
 	const reasoningOptions = selectedModel?.reasoning_effort ?? null;
-	const shouldShowReasoningSelect = profileDraft.provider === "codex_chatgpt";
+	const shouldShowReasoningSelect =
+		profileDraft.provider === "codex_chatgpt" || profileDraft.provider === "pi";
 	const baseUrlPlaceholder =
 		profileDraft.provider === "llama_cpp"
 			? "http://localhost:8080/v1"
@@ -148,7 +150,8 @@ export function AiProviderSection({
 							...profileDraft,
 							model: nextModelId,
 							reasoning_effort:
-								profileDraft.provider === "codex_chatgpt"
+								profileDraft.provider === "codex_chatgpt" ||
+								profileDraft.provider === "pi"
 									? stillValid
 										? currentEffort
 										: (nextModel?.default_reasoning_effort ?? currentEffort)
@@ -163,7 +166,7 @@ export function AiProviderSection({
 				<SettingsRow
 					label="Reasoning level"
 					htmlFor="aiReasoningEffort"
-					description="Available for Codex when the current model exposes effort levels."
+					description="Available when the current model exposes effort levels."
 				>
 					{(reasoningOptions?.length ?? 0) > 0 ? (
 						<select

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -616,7 +616,8 @@ export type AiProviderKind =
 	| "llama_cpp"
 	| "codex_chatgpt"
 	| "amp"
-	| "opencode";
+	| "opencode"
+	| "pi";
 
 export type AiAssistantMode = "chat" | "create";
 

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -310,6 +310,12 @@
 	height: 21px;
 }
 
+.settingsProviderNativeLogo[data-provider="pi"]
+	.settingsProviderNativeLogoImage {
+	width: 20px;
+	height: 20px;
+}
+
 .settingsProviderNativeLogo[data-provider="ollama"]
 	.settingsProviderNativeLogoImage {
 	width: 15px;


### PR DESCRIPTION
## Summary

- Adds PI as a first-class local coding-agent provider alongside Codex, OpenCode, and Amp.
- Introduces a dedicated Rust PI RPC runtime that uses `pi --mode rpc` for model discovery, prompting, cancellation, streamed text, tool events, and thinking blocks.
- Wires PI into the AI provider settings UI, typed provider maps, model picker support, no-Glyph-API-key handling, reasoning-level controls, and provider logo assets.

## Why

Glyph already supports local coding agents through dedicated native runtimes. PI exposes a headless JSONL RPC mode, so Glyph can integrate with the user’s existing local PI installation and PI-managed providers/models without adding SDK/runtime coupling to the frontend or Rust backend.

## Implementation Notes

- `src-tauri/src/ai_pi/mod.rs` owns PI process management and JSONL RPC handling.
- Model discovery spawns `pi --mode rpc --no-session --offline`, sends `get_available_models`, and maps PI models into Glyph `AiModel` values including provider-prefixed labels, context size, max tokens, pricing, input modalities, and reasoning options.
- Chat execution spawns PI in RPC mode for the current space, sends one Glyph-built prompt, emits existing `ai:chunk` events for streamed answer text, and emits existing `ai:tool` events for PI tool execution lifecycle events.
- PI thinking events are formatted as a Markdown blockquote section headed `Thinking`; if no thinking events are emitted, normal response text still renders normally with no placeholder.
- Cancellation sends PI `abort` and falls back to killing the child process if it does not exit promptly.
- PI remains responsible for its own credentials, provider config, models, skills, extensions, tools, and settings files.

## User Impact

- Users with PI installed locally can select PI from Settings > AI provider agents.
- PI model lists are fetched automatically from the local PI installation.
- PI responses, thinking output, and tool activity appear in the existing AI workspace experience.
- Users do not need to save a Glyph API key for PI.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo fmt --check`
- `cd src-tauri && cargo check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PI as a new AI provider with full integration: model fetching, chat support, and configurable reasoning levels.
  * PI provider is now available in settings with branded logos and requires no API key.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/134)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->