### PR TITLE
[codex] Add Claude Code AI provider integration

### DIFF
--- a/src-tauri/src/ai_claude_code/mod.rs
+++ b/src-tauri/src/ai_claude_code/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
+    process::Command as StdCommand,
     time::Duration,
 };
 
@@ -113,6 +114,57 @@ fn collect_model_from_value(models: &mut Vec<String>, seen: &mut HashSet<String>
     }
 }
 
+fn is_runtime_model_id(id: &str) -> bool {
+    let id = id.strip_suffix("[1m]").unwrap_or(id);
+    let Some(rest) = id.strip_prefix("claude-") else {
+        return false;
+    };
+    if let Some(version) = rest
+        .strip_prefix("opus-")
+        .or_else(|| rest.strip_prefix("sonnet-"))
+        .or_else(|| rest.strip_prefix("haiku-"))
+    {
+        let mut parts = version.split('-');
+        return parts.next().is_some_and(|part| {
+            !part.is_empty() && part.len() <= 2 && part.chars().all(|c| c.is_ascii_digit())
+        }) && parts.all(|part| {
+            !part.is_empty() && part.len() <= 2 && part.chars().all(|c| c.is_ascii_digit())
+        });
+    }
+    matches!(
+        rest,
+        "3-opus" | "3-sonnet" | "3-haiku" | "3-5-sonnet" | "3-5-haiku" | "3-7-sonnet"
+    )
+}
+
+fn collect_models_from_runtime_text(
+    text: &str,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    for token in
+        text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '[' || c == ']'))
+    {
+        if is_runtime_model_id(token) {
+            push_model_id(models, seen, token);
+        }
+    }
+}
+
+fn collect_models_from_runtime(
+    binary: &Path,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    if let Ok(output) = StdCommand::new(binary).arg("--help").output() {
+        collect_models_from_runtime_text(&String::from_utf8_lossy(&output.stdout), models, seen);
+        collect_models_from_runtime_text(&String::from_utf8_lossy(&output.stderr), models, seen);
+    }
+    if let Ok(bytes) = std::fs::read(binary) {
+        collect_models_from_runtime_text(&String::from_utf8_lossy(&bytes), models, seen);
+    }
+}
+
 fn claude_settings_paths(root: &Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
@@ -162,13 +214,14 @@ fn model_entry_for_id(id: &str) -> AiModel {
 }
 
 pub fn list_models(root: &Path, profile: &AiProfile) -> Result<Vec<AiModel>, String> {
-    find_claude_binary()?;
+    let binary = find_claude_binary()?;
     let mut seen = HashSet::new();
     let mut ids = Vec::new();
 
     for (id, _, _) in CLAUDE_CODE_ALIAS_MODELS {
         push_model_id(&mut ids, &mut seen, id);
     }
+    collect_models_from_runtime(&binary, &mut ids, &mut seen);
     for path in claude_settings_paths(root) {
         if let Some(value) = read_json_file(&path) {
             collect_models_from_settings(&value, &mut ids, &mut seen);
@@ -211,6 +264,36 @@ async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
 async fn stop_child(child: &mut Child) {
     let _ = child.kill().await;
     let _ = child.wait().await;
+}
+
+struct KillChildOnDrop {
+    child: Child,
+}
+
+impl KillChildOnDrop {
+    fn new(child: Child) -> Self {
+        Self { child }
+    }
+}
+
+impl Drop for KillChildOnDrop {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+impl std::ops::Deref for KillChildOnDrop {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl std::ops::DerefMut for KillChildOnDrop {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
+    }
 }
 
 async fn close_stdin(mut stdin: ChildStdin, prompt: String) -> Result<(), String> {
@@ -593,9 +676,11 @@ pub async fn run_with_claude_code(
         command.arg("--model").arg(model);
     }
 
-    let mut child = command
-        .spawn()
-        .map_err(|e| format!("failed to start Claude Code: {e}"))?;
+    let mut child = KillChildOnDrop::new(
+        command
+            .spawn()
+            .map_err(|e| format!("failed to start Claude Code: {e}"))?,
+    );
     let stdin = child
         .stdin
         .take()

--- a/src-tauri/src/ai_claude_code/mod.rs
+++ b/src-tauri/src/ai_claude_code/mod.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use regex::Regex;
 use serde_json::Value;
 use tauri::{AppHandle, Emitter};
 use tokio::{
@@ -22,7 +21,6 @@ use crate::ai_rig::{
 };
 
 const RUN_TIMEOUT: Duration = Duration::from_secs(600);
-const STARTUP_LISTENER_GRACE: Duration = Duration::from_millis(250);
 const EXIT_AFTER_RESULT_GRACE: Duration = Duration::from_secs(2);
 const STARTUP_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_MODEL_ID: &str = "default";
@@ -125,32 +123,6 @@ fn claude_settings_paths(root: &Path) -> Vec<PathBuf> {
     paths
 }
 
-fn discover_models_from_binary(
-    binary: &Path,
-    models: &mut Vec<String>,
-    seen: &mut HashSet<String>,
-) {
-    let Ok(bytes) = std::fs::read(binary) else {
-        return;
-    };
-    let haystack = String::from_utf8_lossy(&bytes);
-    let Ok(model_re) = Regex::new(
-        r"claude-(?:(?:opus|sonnet|haiku)-\d{1,2}(?:-\d{1,2}){0,2}|\d{1,2}(?:-\d{1,2}){0,2}-(?:opus|sonnet|haiku))",
-    ) else {
-        return;
-    };
-    for matched in model_re.find_iter(&haystack) {
-        if haystack
-            .get(matched.end()..)
-            .and_then(|tail| tail.chars().next())
-            .is_some_and(|next| next.is_ascii_alphanumeric())
-        {
-            continue;
-        }
-        push_model_id(models, seen, matched.as_str());
-    }
-}
-
 fn claude_model_name(id: &str) -> String {
     let Some(rest) = id.strip_prefix("claude-") else {
         return id.to_string();
@@ -190,14 +162,13 @@ fn model_entry_for_id(id: &str) -> AiModel {
 }
 
 pub fn list_models(root: &Path, profile: &AiProfile) -> Result<Vec<AiModel>, String> {
-    let binary = find_claude_binary()?;
+    find_claude_binary()?;
     let mut seen = HashSet::new();
     let mut ids = Vec::new();
 
     for (id, _, _) in CLAUDE_CODE_ALIAS_MODELS {
         push_model_id(&mut ids, &mut seen, id);
     }
-    discover_models_from_binary(&binary, &mut ids, &mut seen);
     for path in claude_settings_paths(root) {
         if let Some(value) = read_json_file(&path) {
             collect_models_from_settings(&value, &mut ids, &mut seen);
@@ -573,8 +544,6 @@ pub async fn run_with_claude_code(
     let binary = find_claude_binary()?;
     let prompt = prompt_text(messages);
 
-    tokio::time::sleep(STARTUP_LISTENER_GRACE).await;
-
     emit_status(
         app,
         job_id,
@@ -694,7 +663,7 @@ pub async fn run_with_claude_code(
                 let value = serde_json::from_str::<Value>(&line)
                     .map_err(|e| format!("failed to parse Claude Code JSON output: {e}"))?;
                 if let Some(done) = handle_event(app, job_id, &value, &mut full, &mut tool_events)? {
-                    wait_after_result(&mut child, &last_stderr).await?;
+                    let _ = wait_after_result(&mut child, &last_stderr).await;
                     return Ok((full, done, tool_events));
                 }
             }

--- a/src-tauri/src/ai_claude_code/mod.rs
+++ b/src-tauri/src/ai_claude_code/mod.rs
@@ -1,0 +1,703 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use regex::Regex;
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, Command},
+    sync::mpsc,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::ai_rig::{
+    events::AiStatusEvent,
+    helpers::{emit_tool, find_cli_binary},
+    providers::build_transcript,
+    types::{AiAssistantMode, AiChunkEvent, AiMessage, AiModel, AiProfile, AiStoredToolEvent},
+};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+const STARTUP_LISTENER_GRACE: Duration = Duration::from_millis(250);
+const EXIT_AFTER_RESULT_GRACE: Duration = Duration::from_secs(2);
+const STARTUP_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_MODEL_ID: &str = "default";
+const CLAUDE_CODE_ALIAS_MODELS: &[(&str, &str, &str)] = &[
+    (
+        DEFAULT_MODEL_ID,
+        "Default",
+        "Claude Code runtime default for the signed-in account.",
+    ),
+    ("sonnet", "Sonnet", "Claude Code latest Sonnet alias."),
+    (
+        "sonnet[1m]",
+        "Sonnet (1M context)",
+        "Claude Code latest Sonnet alias with a 1 million token context window.",
+    ),
+    ("opus", "Opus", "Claude Code latest Opus alias."),
+    (
+        "opusplan",
+        "Opus Plan",
+        "Claude Code uses Opus for planning and Sonnet for execution.",
+    ),
+    ("haiku", "Haiku", "Claude Code latest Haiku alias."),
+];
+
+fn find_claude_binary() -> Result<PathBuf, String> {
+    find_cli_binary("Claude Code", "CLAUDE_CODE_CLI_PATH", "claude")
+}
+
+fn model_entry(id: &str, name: &str, description: &str) -> AiModel {
+    AiModel {
+        id: id.to_string(),
+        name: name.to_string(),
+        context_length: None,
+        description: Some(description.to_string()),
+        input_modalities: None,
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: None,
+        completion_pricing: None,
+        supported_parameters: Some(vec!["tools".to_string()]),
+        max_completion_tokens: None,
+        reasoning_effort: None,
+        default_reasoning_effort: None,
+    }
+}
+
+fn read_json_file(path: &Path) -> Option<Value> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn push_model_id(models: &mut Vec<String>, seen: &mut HashSet<String>, id: &str) {
+    let trimmed = id.trim();
+    if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+        return;
+    }
+    models.push(trimmed.to_string());
+}
+
+fn collect_models_from_settings(
+    value: &Value,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+        push_model_id(models, seen, model);
+    }
+    if let Some(items) = value.get("availableModels").and_then(|v| v.as_array()) {
+        for item in items {
+            collect_model_from_value(models, seen, item);
+        }
+    }
+    if let Some(items) = value.get("allowModels").and_then(|v| v.as_array()) {
+        for item in items {
+            collect_model_from_value(models, seen, item);
+        }
+    }
+}
+
+fn collect_model_from_value(models: &mut Vec<String>, seen: &mut HashSet<String>, value: &Value) {
+    if let Some(model) = value.as_str() {
+        push_model_id(models, seen, model);
+        return;
+    }
+    for key in ["id", "model", "name"] {
+        if let Some(model) = value.get(key).and_then(|v| v.as_str()) {
+            push_model_id(models, seen, model);
+            return;
+        }
+    }
+}
+
+fn claude_settings_paths(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        paths.push(home.join(".claude/settings.json"));
+    }
+    paths.push(root.join(".claude/settings.json"));
+    paths.push(root.join(".claude/settings.local.json"));
+    paths
+}
+
+fn discover_models_from_binary(
+    binary: &Path,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    let Ok(bytes) = std::fs::read(binary) else {
+        return;
+    };
+    let haystack = String::from_utf8_lossy(&bytes);
+    let Ok(model_re) = Regex::new(
+        r"claude-(?:(?:opus|sonnet|haiku)-\d{1,2}(?:-\d{1,2}){0,2}|\d{1,2}(?:-\d{1,2}){0,2}-(?:opus|sonnet|haiku))",
+    ) else {
+        return;
+    };
+    for matched in model_re.find_iter(&haystack) {
+        if haystack
+            .get(matched.end()..)
+            .and_then(|tail| tail.chars().next())
+            .is_some_and(|next| next.is_ascii_alphanumeric())
+        {
+            continue;
+        }
+        push_model_id(models, seen, matched.as_str());
+    }
+}
+
+fn claude_model_name(id: &str) -> String {
+    let Some(rest) = id.strip_prefix("claude-") else {
+        return id.to_string();
+    };
+    let parts = rest.split('-').collect::<Vec<_>>();
+    if parts.len() < 2 {
+        return id.to_string();
+    }
+    if parts[0].chars().all(|c| c.is_ascii_digit()) {
+        let family = parts.last().copied().unwrap_or_default();
+        let version = parts[..parts.len().saturating_sub(1)].join(".");
+        return format!("Claude {version} {}", title_word(family));
+    }
+    format!("Claude {} {}", title_word(parts[0]), parts[1..].join("."))
+}
+
+fn title_word(value: &str) -> String {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+        None => String::new(),
+    }
+}
+
+fn model_entry_for_id(id: &str) -> AiModel {
+    if let Some((_, name, description)) = CLAUDE_CODE_ALIAS_MODELS
+        .iter()
+        .find(|(alias, _, _)| *alias == id)
+    {
+        return model_entry(id, name, description);
+    }
+    model_entry(
+        id,
+        &claude_model_name(id),
+        "Claude Code model discovered from the installed Claude Code runtime.",
+    )
+}
+
+pub fn list_models(root: &Path, profile: &AiProfile) -> Result<Vec<AiModel>, String> {
+    let binary = find_claude_binary()?;
+    let mut seen = HashSet::new();
+    let mut ids = Vec::new();
+
+    for (id, _, _) in CLAUDE_CODE_ALIAS_MODELS {
+        push_model_id(&mut ids, &mut seen, id);
+    }
+    discover_models_from_binary(&binary, &mut ids, &mut seen);
+    for path in claude_settings_paths(root) {
+        if let Some(value) = read_json_file(&path) {
+            collect_models_from_settings(&value, &mut ids, &mut seen);
+        }
+    }
+    push_model_id(&mut ids, &mut seen, &profile.model);
+
+    let models = ids.into_iter().map(|id| model_entry_for_id(&id)).collect();
+
+    Ok(models)
+}
+
+fn prompt_text(messages: &[AiMessage]) -> String {
+    let transcript = build_transcript("", messages);
+    if transcript.trim().is_empty() {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.clone())
+            .unwrap_or_default()
+    } else {
+        transcript
+    }
+}
+
+async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>(64);
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(line).await;
+            }
+        });
+    }
+    rx
+}
+
+async fn stop_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+async fn close_stdin(mut stdin: ChildStdin, prompt: String) -> Result<(), String> {
+    let mut prompt_bytes = prompt.into_bytes();
+    if !prompt_bytes.ends_with(b"\n") {
+        prompt_bytes.push(b'\n');
+    }
+    stdin
+        .write_all(&prompt_bytes)
+        .await
+        .map_err(|e| format!("failed writing Claude Code prompt: {e}"))?;
+    stdin
+        .shutdown()
+        .await
+        .map_err(|e| format!("failed closing Claude Code stdin: {e}"))?;
+    drop(stdin);
+    Ok(())
+}
+
+async fn wait_after_result(child: &mut Child, last_stderr: &str) -> Result<(), String> {
+    match tokio::time::timeout(EXIT_AFTER_RESULT_GRACE, child.wait()).await {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(status)) => Err(if last_stderr.trim().is_empty() {
+            format!("Claude Code exited with {status}")
+        } else {
+            format!("Claude Code exited with {status}: {last_stderr}")
+        }),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => {
+            stop_child(child).await;
+            Ok(())
+        }
+    }
+}
+
+fn emit_chunk(app: &AppHandle, job_id: &str, full: &mut String, delta: &str) {
+    if delta.is_empty() {
+        return;
+    }
+    full.push_str(delta);
+    let _ = app.emit(
+        "ai:chunk",
+        AiChunkEvent {
+            job_id: job_id.to_string(),
+            delta: delta.to_string(),
+        },
+    );
+}
+
+fn emit_status(app: &AppHandle, job_id: &str, status: &str, detail: Option<String>) {
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: status.to_string(),
+            detail,
+        },
+    );
+}
+
+fn tool_name(value: &Value) -> &str {
+    value
+        .get("name")
+        .or_else(|| value.get("tool"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("tool")
+}
+
+fn tool_id(value: &Value) -> Option<String> {
+    value
+        .get("id")
+        .or_else(|| value.get("tool_use_id"))
+        .or_else(|| value.get("call_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+fn emit_tool_once(
+    app: &AppHandle,
+    job_id: &str,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+    tool: &str,
+    phase: &str,
+    call_id: Option<String>,
+    payload: Option<Value>,
+    error: Option<String>,
+) {
+    if call_id.as_deref().is_some_and(|id| {
+        tool_events.iter().any(|event| {
+            event.call_id.as_deref() == Some(id) && event.tool == tool && event.phase == phase
+        })
+    }) {
+        return;
+    }
+    emit_tool(
+        app,
+        job_id,
+        tool_events,
+        tool,
+        phase,
+        call_id,
+        payload,
+        error,
+    );
+}
+
+fn handle_stream_event(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) {
+    let event = value.get("event").unwrap_or(&Value::Null);
+    match event.get("type").and_then(|v| v.as_str()) {
+        Some("content_block_delta") => {
+            let delta = event.get("delta").unwrap_or(&Value::Null);
+            if delta.get("type").and_then(|v| v.as_str()) == Some("text_delta") {
+                if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
+                    emit_chunk(app, job_id, full, text);
+                }
+            }
+        }
+        Some("content_block_start") => {
+            let block = event.get("content_block").unwrap_or(&Value::Null);
+            if block.get("type").and_then(|v| v.as_str()) == Some("tool_use") {
+                emit_tool_once(
+                    app,
+                    job_id,
+                    tool_events,
+                    tool_name(block),
+                    "call",
+                    tool_id(block),
+                    Some(block.clone()),
+                    None,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_assistant_message(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) {
+    let Some(content) = value.pointer("/message/content").and_then(|v| v.as_array()) else {
+        return;
+    };
+    for part in content {
+        match part.get("type").and_then(|v| v.as_str()) {
+            Some("text") if full.trim().is_empty() => {
+                if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                    emit_chunk(app, job_id, full, text);
+                }
+            }
+            Some("tool_use") => {
+                emit_tool_once(
+                    app,
+                    job_id,
+                    tool_events,
+                    tool_name(part),
+                    "call",
+                    tool_id(part),
+                    Some(part.clone()),
+                    None,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn handle_user_message(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) {
+    let Some(content) = value.pointer("/message/content").and_then(|v| v.as_array()) else {
+        return;
+    };
+    for part in content {
+        if part.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+            continue;
+        }
+        let is_error = part
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let error = is_error
+            .then(|| part.get("content").and_then(|v| v.as_str()).unwrap_or(""))
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        emit_tool_once(
+            app,
+            job_id,
+            tool_events,
+            "tool",
+            if is_error { "error" } else { "result" },
+            tool_id(part),
+            Some(part.clone()),
+            error,
+        );
+    }
+}
+
+fn handle_system_event(app: &AppHandle, job_id: &str, value: &Value) {
+    match value.get("subtype").and_then(|v| v.as_str()) {
+        Some("api_retry") => {
+            let attempt = value
+                .get("attempt")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "?".to_string());
+            let max = value
+                .get("max_retries")
+                .and_then(|v| v.as_u64())
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "?".to_string());
+            emit_status(
+                app,
+                job_id,
+                "thinking",
+                Some(format!(
+                    "Claude Code retrying API request ({attempt}/{max})"
+                )),
+            );
+        }
+        Some("plugin_install") => {
+            let status = value
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("running");
+            let name = value
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("plugins");
+            emit_status(
+                app,
+                job_id,
+                "thinking",
+                Some(format!("Claude Code plugin install {status}: {name}")),
+            );
+        }
+        Some("init") => {
+            emit_status(
+                app,
+                job_id,
+                "thinking",
+                Some("Claude Code is running".to_string()),
+            );
+        }
+        Some("status") => {
+            if value.get("status").and_then(|v| v.as_str()) == Some("requesting") {
+                emit_status(
+                    app,
+                    job_id,
+                    "thinking",
+                    Some("Claude Code is thinking".to_string()),
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn handle_event(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) -> Result<Option<bool>, String> {
+    match value.get("type").and_then(|v| v.as_str()) {
+        Some("stream_event") => {
+            handle_stream_event(app, job_id, value, full, tool_events);
+            Ok(None)
+        }
+        Some("assistant") => {
+            handle_assistant_message(app, job_id, value, full, tool_events);
+            Ok(None)
+        }
+        Some("user") => {
+            handle_user_message(app, job_id, value, tool_events);
+            Ok(None)
+        }
+        Some("system") => {
+            handle_system_event(app, job_id, value);
+            Ok(None)
+        }
+        Some("result") => {
+            if value
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                return Err(value
+                    .get("error")
+                    .or_else(|| value.get("result"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Claude Code request failed")
+                    .to_string());
+            }
+            if full.trim().is_empty() {
+                if let Some(result) = value.get("result").and_then(|v| v.as_str()) {
+                    emit_chunk(app, job_id, full, result);
+                }
+            }
+            Ok(Some(false))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_claude_code(
+    cancel: &CancellationToken,
+    app: &AppHandle,
+    job_id: &str,
+    profile: &AiProfile,
+    system: &str,
+    messages: &[AiMessage],
+    mode: &AiAssistantMode,
+    space_root: Option<&Path>,
+) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let root = space_root.ok_or_else(|| "No space is open".to_string())?;
+    let binary = find_claude_binary()?;
+    let prompt = prompt_text(messages);
+
+    tokio::time::sleep(STARTUP_LISTENER_GRACE).await;
+
+    emit_status(
+        app,
+        job_id,
+        "thinking",
+        Some("Starting Claude Code".to_string()),
+    );
+
+    let mut command = Command::new(binary);
+    command
+        .arg("-p")
+        .arg("--input-format")
+        .arg("text")
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--verbose")
+        .arg("--include-partial-messages")
+        .arg("--no-session-persistence")
+        .current_dir(root)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    match mode {
+        AiAssistantMode::Chat => {
+            command
+                .arg("--permission-mode")
+                .arg("dontAsk")
+                .arg("--tools")
+                .arg("");
+        }
+        AiAssistantMode::Create => {
+            command
+                .arg("--permission-mode")
+                .arg("acceptEdits")
+                .arg("--tools")
+                .arg("Read,Edit,Write,Glob,Grep")
+                .arg("--allowedTools")
+                .arg("Read,Edit,Write,Glob,Grep");
+        }
+    }
+
+    if !system.trim().is_empty() {
+        command.arg("--append-system-prompt").arg(system.trim());
+    }
+    let model = profile.model.trim();
+    if !model.is_empty() && model != DEFAULT_MODEL_ID {
+        command.arg("--model").arg(model);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start Claude Code: {e}"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| "failed to capture Claude Code stdin".to_string())?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Claude Code stdout".to_string())?;
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = pipe_stderr(&mut child).await;
+
+    close_stdin(stdin, prompt).await?;
+
+    let timeout = tokio::time::sleep(RUN_TIMEOUT);
+    tokio::pin!(timeout);
+    let startup_timeout = tokio::time::sleep(STARTUP_OUTPUT_TIMEOUT);
+    tokio::pin!(startup_timeout);
+    let mut full = String::new();
+    let mut tool_events = Vec::new();
+    let mut last_stderr = String::new();
+    let mut saw_stdout = false;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                stop_child(&mut child).await;
+                return Ok((String::new(), true, tool_events));
+            }
+            _ = &mut timeout => {
+                stop_child(&mut child).await;
+                return Err("Claude Code request timed out".to_string());
+            }
+            _ = &mut startup_timeout, if !saw_stdout => {
+                stop_child(&mut child).await;
+                return Err(if last_stderr.trim().is_empty() {
+                    "Claude Code produced no output after starting".to_string()
+                } else {
+                    format!("Claude Code produced no output after starting: {last_stderr}")
+                });
+            }
+            maybe_err = stderr_lines.recv() => {
+                if let Some(line) = maybe_err {
+                    if !line.trim().is_empty() {
+                        last_stderr = line;
+                    }
+                }
+            }
+            line = stdout_lines.next_line() => {
+                let line = line.map_err(|e| format!("failed reading Claude Code output: {e}"))?;
+                let Some(line) = line else {
+                    let status = child.wait().await.map_err(|e| e.to_string())?;
+                    if status.success() && !full.trim().is_empty() {
+                        return Ok((full, false, tool_events));
+                    }
+                    return Err(if last_stderr.trim().is_empty() {
+                        format!("Claude Code exited with {status}")
+                    } else {
+                        format!("Claude Code exited with {status}: {last_stderr}")
+                    });
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                saw_stdout = true;
+                let value = serde_json::from_str::<Value>(&line)
+                    .map_err(|e| format!("failed to parse Claude Code JSON output: {e}"))?;
+                if let Some(done) = handle_event(app, job_id, &value, &mut full, &mut tool_events)? {
+                    wait_after_result(&mut child, &last_stderr).await?;
+                    return Ok((full, done, tool_events));
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -196,6 +196,7 @@ pub async fn ai_profile_delete(
             super::types::AiProviderKind::Ollama
                 | super::types::AiProviderKind::LlamaCpp
                 | super::types::AiProviderKind::Amp
+                | super::types::AiProviderKind::ClaudeCode
                 | super::types::AiProviderKind::Opencode
                 | super::types::AiProviderKind::Pi
         );
@@ -317,6 +318,7 @@ pub async fn ai_chat_start(
             profile.provider,
             super::types::AiProviderKind::CodexChatgpt
                 | super::types::AiProviderKind::Amp
+                | super::types::AiProviderKind::ClaudeCode
                 | super::types::AiProviderKind::Opencode
                 | super::types::AiProviderKind::Pi
         )
@@ -493,6 +495,12 @@ pub async fn run_request(
     }
     if matches!(profile.provider, super::types::AiProviderKind::Amp) {
         return crate::ai_amp::run_with_amp(
+            cancel, app, job_id, profile, system, messages, mode, space_root,
+        )
+        .await;
+    }
+    if matches!(profile.provider, super::types::AiProviderKind::ClaudeCode) {
+        return crate::ai_claude_code::run_with_claude_code(
             cancel, app, job_id, profile, system, messages, mode, space_root,
         )
         .await;

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -26,6 +26,7 @@ pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
         AiProviderKind::LlamaCpp => "http://localhost:8080/v1",
         AiProviderKind::CodexChatgpt => "https://developers.openai.com/codex/app-server/",
         AiProviderKind::Amp => "https://ampcode.com/",
+        AiProviderKind::ClaudeCode => "https://code.claude.com/",
         AiProviderKind::Opencode => "http://127.0.0.1:4096",
         AiProviderKind::Pi => "https://pi.dev/",
     }

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -617,6 +617,12 @@ pub async fn ai_models_list(
         AiProviderKind::Gemini => list_gemini(&client, &profile, &api_key).await,
         AiProviderKind::CodexChatgpt => list_codex_models(codex_state.inner()),
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
+        AiProviderKind::ClaudeCode => {
+            let root = space_root
+                .as_deref()
+                .ok_or_else(|| "Open a space to load Claude Code models".to_string())?;
+            crate::ai_claude_code::list_models(root, &profile)
+        }
         AiProviderKind::Opencode => {
             let root = space_root
                 .as_deref()

--- a/src-tauri/src/ai_rig/providers.rs
+++ b/src-tauri/src/ai_rig/providers.rs
@@ -17,6 +17,7 @@ pub fn capabilities(provider: &AiProviderKind) -> ProviderCapabilities {
         | AiProviderKind::LlamaCpp
         | AiProviderKind::CodexChatgpt
         | AiProviderKind::Amp
+        | AiProviderKind::ClaudeCode
         | AiProviderKind::Opencode
         | AiProviderKind::Pi => ProviderCapabilities {
             requires_max_tokens: false,

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -362,6 +362,7 @@ pub async fn run_with_rig(
         }
         AiProviderKind::CodexChatgpt
         | AiProviderKind::Amp
+        | AiProviderKind::ClaudeCode
         | AiProviderKind::Opencode
         | AiProviderKind::Pi => {
             return Err(
@@ -630,6 +631,9 @@ pub async fn generate_chat_title_with_rig(
         }
         AiProviderKind::Amp => {
             return Ok("Amp Chat".to_string());
+        }
+        AiProviderKind::ClaudeCode => {
+            return Ok("Claude Code Chat".to_string());
         }
         AiProviderKind::Opencode => {
             return Ok("OpenCode Chat".to_string());

--- a/src-tauri/src/ai_rig/store.rs
+++ b/src-tauri/src/ai_rig/store.rs
@@ -60,6 +60,7 @@ pub fn ensure_default_profiles(store: &mut AiStore) {
         ),
         (AiProviderKind::CodexChatgpt, "codex", None, false),
         (AiProviderKind::Amp, "smart", None, false),
+        (AiProviderKind::ClaudeCode, "default", None, false),
         (AiProviderKind::Opencode, "", None, true),
         (AiProviderKind::Pi, "", None, true),
     ];

--- a/src-tauri/src/ai_rig/types.rs
+++ b/src-tauri/src/ai_rig/types.rs
@@ -12,6 +12,7 @@ pub enum AiProviderKind {
     LlamaCpp,
     CodexChatgpt,
     Amp,
+    ClaudeCode,
     Opencode,
     Pi,
 }
@@ -28,6 +29,7 @@ impl AiProviderKind {
             Self::LlamaCpp => "llama_cpp",
             Self::CodexChatgpt => "codex_chatgpt",
             Self::Amp => "amp",
+            Self::ClaudeCode => "claude_code",
             Self::Opencode => "opencode",
             Self::Pi => "pi",
         }
@@ -44,6 +46,7 @@ impl AiProviderKind {
             Self::LlamaCpp => "llama.cpp",
             Self::CodexChatgpt => "Codex (ChatGPT)",
             Self::Amp => "Amp",
+            Self::ClaudeCode => "Claude Code",
             Self::Opencode => "OpenCode",
             Self::Pi => "PI",
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod ai_amp;
+mod ai_claude_code;
 mod ai_codex;
 mod ai_opencode;
 mod ai_pi;

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -16,6 +16,9 @@ export interface UIMessage {
 }
 
 type SendMessageArgs = { text: string };
+type ChunkPayload = { job_id: string; delta: string };
+type DonePayload = { job_id: string; cancelled: boolean };
+type ErrorPayload = { job_id: string; message: string };
 
 type SendMessageOptions = {
 	body?: {
@@ -59,6 +62,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	const messagesRef = useRef<UIMessage[]>([]);
 	const activeJobIdRef = useRef<string | null>(null);
 	const activeThreadIdRef = useRef<string | null>(null);
+	const awaitingStartRef = useRef(false);
 	const stopListenersRef = useRef<Array<() => void>>([]);
 	const doneTimerRef = useRef<number | null>(null);
 	const onComplete = options.onComplete;
@@ -90,6 +94,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	const completeActiveJob = useCallback(() => {
 		clearDoneTimer();
 		activeJobIdRef.current = null;
+		awaitingStartRef.current = false;
 		cleanupListeners();
 		setStatus("ready");
 		onComplete?.();
@@ -107,6 +112,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 		}
 		clearDoneTimer();
 		activeJobIdRef.current = null;
+		awaitingStartRef.current = false;
 		cleanupListeners();
 		setStatus("ready");
 	}, [cleanupListeners, clearDoneTimer]);
@@ -125,6 +131,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 			setError(null);
 			stop();
 
+			const previousMessages = messagesRef.current;
 			const userId = crypto.randomUUID();
 			const assistantId = crypto.randomUUID();
 			const userMessage: UIMessage = {
@@ -137,13 +144,10 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				role: "assistant",
 				parts: [{ type: "text", text: "" }],
 			};
-			const nextMessages = [
-				...messagesRef.current,
-				userMessage,
-				assistantMessage,
-			];
+			const nextMessages = [...previousMessages, userMessage, assistantMessage];
 			updateMessages(nextMessages);
 			setStatus("submitted");
+			awaitingStartRef.current = true;
 
 			try {
 				clearDoneTimer();
@@ -153,7 +157,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				activeThreadIdRef.current = threadId;
 				const systemPrompt = options?.body?.system_prompt?.trim() ?? "";
 				const requestMessages = asAiMessages([
-					...messagesRef.current,
+					...previousMessages,
 					userMessage,
 				]);
 				if (systemPrompt) {
@@ -162,22 +166,14 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 						content: systemPrompt,
 					});
 				}
-				const { job_id: jobId } = await invoke("ai_chat_start", {
-					request: {
-						profile_id: profileId,
-						messages: requestMessages,
-						thread_id: threadId,
-						mode: options?.body?.mode ?? "create",
-						context: options?.body?.context || undefined,
-						context_manifest: options?.body?.context_manifest,
-						audit: options?.body?.audit ?? true,
-					},
-				});
-
-				activeJobIdRef.current = jobId;
-
-				const onChunk = await listenTauriEvent("ai:chunk", (payload) => {
-					if (payload.job_id !== activeJobIdRef.current) return;
+				const pendingChunks: ChunkPayload[] = [];
+				let pendingDone: DonePayload | null = null;
+				let pendingError: ErrorPayload | null = null;
+				const shouldBufferEvent = (jobId: string) =>
+					awaitingStartRef.current && !activeJobIdRef.current && !!jobId;
+				const isActiveJob = (jobId: string) => jobId === activeJobIdRef.current;
+				const handleChunk = (payload: ChunkPayload) => {
+					if (!isActiveJob(payload.job_id)) return;
 					clearDoneTimer();
 					setStatus("streaming");
 					updateMessages((prev) =>
@@ -195,30 +191,78 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 							};
 						}),
 					);
-				});
-
-				const onDone = await listenTauriEvent("ai:done", (payload) => {
-					if (payload.job_id !== activeJobIdRef.current) return;
+				};
+				const handleDone = (payload: DonePayload) => {
+					if (!isActiveJob(payload.job_id)) return;
+					awaitingStartRef.current = false;
 					clearDoneTimer();
 					doneTimerRef.current = window.setTimeout(() => {
 						if (payload.job_id !== activeJobIdRef.current) return;
 						completeActiveJob();
 					}, DONE_SETTLE_MS);
-				});
-
-				const onError = await listenTauriEvent("ai:error", (payload) => {
-					if (payload.job_id !== activeJobIdRef.current) return;
+				};
+				const handleError = (payload: ErrorPayload) => {
+					if (!isActiveJob(payload.job_id)) return;
 					clearDoneTimer();
 					activeJobIdRef.current = null;
+					awaitingStartRef.current = false;
 					cleanupListeners();
 					setError(new Error(payload.message));
 					setStatus("error");
+				};
+
+				const onChunk = await listenTauriEvent("ai:chunk", (payload) => {
+					if (shouldBufferEvent(payload.job_id)) {
+						pendingChunks.push(payload);
+						return;
+					}
+					handleChunk(payload);
+				});
+
+				const onDone = await listenTauriEvent("ai:done", (payload) => {
+					if (shouldBufferEvent(payload.job_id)) {
+						pendingDone = payload;
+						return;
+					}
+					handleDone(payload);
+				});
+
+				const onError = await listenTauriEvent("ai:error", (payload) => {
+					if (shouldBufferEvent(payload.job_id)) {
+						pendingError = payload;
+						return;
+					}
+					handleError(payload);
 				});
 
 				stopListenersRef.current = [onChunk, onDone, onError];
+
+				const { job_id: jobId } = await invoke("ai_chat_start", {
+					request: {
+						profile_id: profileId,
+						messages: requestMessages,
+						thread_id: threadId,
+						mode: options?.body?.mode ?? "create",
+						context: options?.body?.context || undefined,
+						context_manifest: options?.body?.context_manifest,
+						audit: options?.body?.audit ?? true,
+					},
+				});
+
+				activeJobIdRef.current = jobId;
+				awaitingStartRef.current = false;
+				for (const payload of pendingChunks) {
+					handleChunk(payload);
+				}
+				if (pendingError) {
+					handleError(pendingError);
+				} else if (pendingDone) {
+					handleDone(pendingDone);
+				}
 			} catch (err) {
 				clearDoneTimer();
 				activeJobIdRef.current = null;
+				awaitingStartRef.current = false;
 				cleanupListeners();
 				setError(err instanceof Error ? err : new Error(String(err)));
 				setStatus("error");

--- a/src/components/ai/modelSelectorConstants.tsx
+++ b/src/components/ai/modelSelectorConstants.tsx
@@ -46,6 +46,7 @@ export const providerSupportKeyMap: Record<AiProviderKind, string> = {
 	llama_cpp: "llama_cpp",
 	codex_chatgpt: "openai",
 	amp: "amp",
+	claude_code: "anthropic",
 	opencode: "opencode",
 	pi: "pi",
 };

--- a/src/components/ai/providerLogos.ts
+++ b/src/components/ai/providerLogos.ts
@@ -1,7 +1,6 @@
 import openaiLightThemeLogoUrl from "../../assets/provider-logos/OpenAI_light.svg?url";
 import ampLogoUrl from "../../assets/provider-logos/amp.svg?url";
 import anthropicLogoUrl from "../../assets/provider-logos/claude-ai.svg?url";
-import claudeCodeLogoUrl from "../../assets/provider-logos/claude-ai.svg?url";
 import codexDarkThemeLogoUrl from "../../assets/provider-logos/codex-dark.svg?url";
 import codexLightThemeLogoUrl from "../../assets/provider-logos/codex-light.svg?url";
 import geminiLogoUrl from "../../assets/provider-logos/google-gemini.svg?url";
@@ -40,7 +39,7 @@ export const providerLogoMeta: Record<
 		label: "Codex (ChatGPT)",
 	},
 	amp: { src: ampLogoUrl, label: "Amp" },
-	claude_code: { src: claudeCodeLogoUrl, label: "Claude Code" },
+	claude_code: { src: anthropicLogoUrl, label: "Claude Code" },
 	opencode: {
 		src: opencodeLightThemeLogoUrl,
 		darkSrc: opencodeDarkThemeLogoUrl,

--- a/src/components/ai/providerLogos.ts
+++ b/src/components/ai/providerLogos.ts
@@ -1,6 +1,7 @@
 import openaiLightThemeLogoUrl from "../../assets/provider-logos/OpenAI_light.svg?url";
 import ampLogoUrl from "../../assets/provider-logos/amp.svg?url";
 import anthropicLogoUrl from "../../assets/provider-logos/claude-ai.svg?url";
+import claudeCodeLogoUrl from "../../assets/provider-logos/claude-ai.svg?url";
 import codexDarkThemeLogoUrl from "../../assets/provider-logos/codex-dark.svg?url";
 import codexLightThemeLogoUrl from "../../assets/provider-logos/codex-light.svg?url";
 import geminiLogoUrl from "../../assets/provider-logos/google-gemini.svg?url";
@@ -39,6 +40,7 @@ export const providerLogoMeta: Record<
 		label: "Codex (ChatGPT)",
 	},
 	amp: { src: ampLogoUrl, label: "Amp" },
+	claude_code: { src: claudeCodeLogoUrl, label: "Claude Code" },
 	opencode: {
 		src: opencodeLightThemeLogoUrl,
 		darkSrc: opencodeDarkThemeLogoUrl,

--- a/src/components/settings/ai/AiModelCombobox.tsx
+++ b/src/components/settings/ai/AiModelCombobox.tsx
@@ -16,6 +16,7 @@ const PROVIDERS_NO_API_KEY = new Set<AiProviderKind>([
 	"llama_cpp",
 	"codex_chatgpt",
 	"amp",
+	"claude_code",
 	"opencode",
 	"pi",
 ]);

--- a/src/components/settings/ai/AiProfileSections.tsx
+++ b/src/components/settings/ai/AiProfileSections.tsx
@@ -17,6 +17,7 @@ interface AiProfileSectionsProps {
 const PROVIDERS_NO_API_KEY = new Set<AiProviderKind>([
 	"codex_chatgpt",
 	"amp",
+	"claude_code",
 	"opencode",
 	"pi",
 ]);

--- a/src/components/settings/ai/AiProviderSection.tsx
+++ b/src/components/settings/ai/AiProviderSection.tsx
@@ -25,6 +25,7 @@ const aiProviderGroups: AiProviderOptionGroup[] = [
 			{ value: "codex_chatgpt", label: "Codex" },
 			{ value: "opencode", label: "OpenCode" },
 			{ value: "amp", label: "Amp" },
+			{ value: "claude_code", label: "Claude Code" },
 			{ value: "pi", label: "PI" },
 		],
 	},

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -616,6 +616,7 @@ export type AiProviderKind =
 	| "llama_cpp"
 	| "codex_chatgpt"
 	| "amp"
+	| "claude_code"
 	| "opencode"
 	| "pi";
 


### PR DESCRIPTION
## Summary

This PR adds Claude Code as a first-class AI provider in Glyph's existing AI profile and chat system.

The integration introduces a new Tauri backend module that runs the local `claude` CLI in stream-json mode, translates Claude Code output into Glyph's existing AI events, and exposes Claude Code models through the same model listing surface used by the rest of the AI provider stack. It also registers the provider in the frontend so users can select Claude Code, see the proper provider branding, and use it without configuring an API key.

## What Changed

- Added `src-tauri/src/ai_claude_code/mod.rs` to execute Claude Code through the installed CLI.
- Streams Claude Code text deltas into Glyph's `ai:chunk` event pipeline.
- Maps Claude Code tool calls, tool results, errors, retries, init, and status events into Glyph's tool/status timeline events.
- Supports create mode with Claude Code file-editing tools and chat mode with tools disabled.
- Discovers Claude Code models from built-in aliases, Claude settings, the selected profile model, and model ids embedded in the installed CLI.
- Registers the `claude_code` provider across Rust provider types, defaults, capabilities, model listing, request dispatch, and chat-title generation.
- Adds `claude_code` to the TypeScript `AiProviderKind` union and settings/model selector provider maps.
- Reuses the existing Anthropic/Claude logo asset for Claude Code provider branding.
- Updates `useRigChat` to register event listeners before starting a job and buffer early events until the returned job id is known.

## Why

Glyph already had account/CLI-backed AI providers such as Codex, Amp, OpenCode, and PI. Claude Code fits the same offline-desktop workflow, but it was not represented in the provider enum, settings UI, model loading, or backend request dispatch.

The chat hook change handles a startup race that becomes more visible with fast local CLI providers: a backend can emit chunks, status, or completion before the frontend has stored the job id returned from `ai_chat_start`. Buffering those early events keeps the first response from being dropped.

## User Impact

Users can now add or use the default Claude Code profile without entering an API key, pick Claude Code from the AI provider list, select supported Claude Code model aliases, and run Claude Code-backed chat/create requests from Glyph.

Create mode allows Claude Code to use read/edit/write/search tools in the open space, while chat mode keeps the request conversational by disabling tools.

## Implementation Notes

Claude Code is invoked with:

- `--input-format text`
- `--output-format stream-json`
- `--verbose`
- `--include-partial-messages`
- `--no-session-persistence`

The backend writes the prompt to stdin, reads line-delimited JSON from stdout, tracks stderr for useful failure messages, handles cancellation and timeouts, and returns the accumulated assistant response plus stored tool events to the shared AI runtime.

## Validation

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

All checks passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Code as a new AI provider option in settings and provider lists
  * Added model discovery and human-friendly model naming for Claude Code
  * Enabled Claude Code conversations with streaming events, tool call/result handling, and lifecycle updates
  * Claude Code provider can be used/configured without requiring an API key

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/135)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->