### PR TITLE
Add drag regions to editor header

### DIFF
--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -55,6 +55,7 @@ import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { cn } from "../../lib/utils";
+import { onWindowDragMouseDown } from "../../utils/window";
 import { Calendar, FileText, Settings } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
 import type {
@@ -844,7 +845,14 @@ export const MainContent = memo(function MainContent({
 						onReorder={reorderTabs}
 					/>
 				</div>
-			) : null}
+			) : (
+				<div
+					aria-hidden="true"
+					className="mainTabsEmptyDragRegion"
+					data-tauri-drag-region
+					onMouseDown={onWindowDragMouseDown}
+				/>
+			)}
 			{content ?? (
 				<div className="mainEmptyState">
 					{showStarterPane ? (

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -16,6 +16,7 @@ import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { isMarkdownPath } from "../../utils/path";
+import { onWindowDragMouseDown } from "../../utils/window";
 import { ChevronRight, File, FileText, FolderOpen } from "../Icons";
 import {
 	DropdownMenu,
@@ -191,7 +192,11 @@ export function TabBar({
 	);
 
 	return (
-		<div className="mainTabsBarWrap">
+		<div
+			className="mainTabsBarWrap"
+			data-tauri-drag-region
+			onMouseDown={onWindowDragMouseDown}
+		>
 			<div
 				className="mainTabsBar"
 				data-empty-state={useWindowBackground ? "true" : "false"}

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -3,6 +3,12 @@
 	background: var(--bg-primary);
 }
 
+.mainTabsEmptyDragRegion {
+	height: 40px;
+	flex-shrink: 0;
+	background: var(--bg-primary);
+}
+
 .mainTabsBar {
 	--main-tabs-right-reserve: 78px;
 	--main-tabs-left-reserve: var(--space-3);


### PR DESCRIPTION
## Summary
- lets the populated tab bar act as a Tauri drag region
- adds an empty tab-row drag region when no tabs are open
- preserves the existing main tab background styling for the draggable header area

## Why
The editor header had less draggable surface than expected, especially when the tab row was empty. This makes the top editor area consistently usable for dragging the desktop window without changing the tab layout.

## Testing
- pnpm check
- pnpm build

## Notes
- Vite still reports the existing large chunk warning during build.
- There is an uncommitted local change in src/data/release-notes.json that is not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window dragging to work consistently across the interface, including when the tab bar is not displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->