### PR TITLE
Improve quick note and sidebar navigation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ use tauri::{
 };
 
 static RECENT_SPACES_MENU_REVISION: AtomicU64 = AtomicU64::new(0);
+static QUICK_NOTE_WINDOW_LOCK: Mutex<()> = Mutex::new(());
 const QUICK_NOTE_WINDOW_LABEL: &str = "quick-note";
 
 fn init_tracing() {
@@ -954,6 +955,10 @@ fn system_monospace_fonts_list() -> Result<Vec<String>, String> {
 }
 
 fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
+    let _guard = QUICK_NOTE_WINDOW_LOCK
+        .lock()
+        .map_err(|_| "failed to lock quick note window state".to_string())?;
+
     if let Some(window) = app.get_webview_window(QUICK_NOTE_WINDOW_LABEL) {
         return Ok(window);
     }

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -92,6 +92,7 @@ const LazyCommandPalette = lazy(loadCommandPalette);
 
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 600;
+const SIDEBAR_AUTO_COLLAPSE_WIDTH = 760;
 export function AppShell() {
 	const space = useSpace();
 	const {
@@ -126,8 +127,8 @@ export function AppShell() {
 		setActiveFilePath,
 	} = fileTreeCtx;
 	const {
-		sidebarCollapsed,
-		setSidebarCollapsed,
+		sidebarCollapsed: sidebarCollapsedState,
+		setSidebarCollapsed: setSidebarCollapsedState,
 		folioMode,
 		paletteOpen,
 		setPaletteOpen,
@@ -167,6 +168,19 @@ export function AppShell() {
 	const [whatsNewVersion, setWhatsNewVersion] =
 		useState<VersionReleaseNotes | null>(null);
 	const autoUpdater = useUpdaterContext();
+	const [sidebarAutoCollapsed, setSidebarAutoCollapsed] = useState(() =>
+		typeof window === "undefined"
+			? false
+			: window.innerWidth <= SIDEBAR_AUTO_COLLAPSE_WIDTH,
+	);
+	const sidebarCollapsed = sidebarCollapsedState || sidebarAutoCollapsed;
+	const setSidebarCollapsed = useCallback(
+		(collapsed: boolean) => {
+			if (!collapsed && sidebarAutoCollapsed) return;
+			setSidebarCollapsedState(collapsed);
+		},
+		[setSidebarCollapsedState, sidebarAutoCollapsed],
+	);
 	const gitSync = useGitSync({
 		spacePath,
 		saveCurrentEditor,
@@ -186,6 +200,25 @@ export function AppShell() {
 		onResize: setSidebarWidth,
 		currentWidth: sidebarWidth,
 	});
+
+	useEffect(() => {
+		const query = window.matchMedia(
+			`(max-width: ${SIDEBAR_AUTO_COLLAPSE_WIDTH}px)`,
+		);
+		const syncSidebarBreakpoint = () => {
+			setSidebarAutoCollapsed(query.matches);
+			if (query.matches) {
+				setSidebarCollapsedState(true);
+			}
+		};
+
+		syncSidebarBreakpoint();
+		query.addEventListener("change", syncSidebarBreakpoint);
+		return () => {
+			query.removeEventListener("change", syncSidebarBreakpoint);
+		};
+	}, [setSidebarCollapsedState]);
+
 	useEffect(() => {
 		let cancelled = false;
 		const idle = window.setTimeout(() => {
@@ -1097,13 +1130,15 @@ export function AppShell() {
 					activateTabByIndex(index);
 				},
 			})),
-			...commands.map((command) => ({
-				id: command.id,
-				shortcut: command.shortcut,
-				enabled: command.enabled,
-				allowInEditable: command.allowInEditable,
-				action: command.action,
-			})),
+			...commands
+				.filter((command) => command.id !== "open-quick-note")
+				.map((command) => ({
+					id: command.id,
+					shortcut: command.shortcut,
+					enabled: command.enabled,
+					allowInEditable: command.allowInEditable,
+					action: command.action,
+				})),
 		],
 		[
 			activateTabByIndex,
@@ -1160,14 +1195,23 @@ export function AppShell() {
 			{sidebarCollapsed && (
 				<div className="sidebarCollapsedToggle">
 					<WindowChromeIconButton
-						ariaLabel="Expand sidebar"
+						ariaLabel={
+							sidebarAutoCollapsed
+								? "Sidebar hidden while window is narrow"
+								: "Expand sidebar"
+						}
 						ariaPressed={false}
+						disabled={sidebarAutoCollapsed}
 						onClick={() => setSidebarCollapsed(false)}
-						title={`Expand sidebar${
-							toggleSidebarShortcut
-								? ` (${getShortcutTooltip(toggleSidebarShortcut)})`
-								: ""
-						}`}
+						title={
+							sidebarAutoCollapsed
+								? "Widen the window to show the sidebar"
+								: `Expand sidebar${
+										toggleSidebarShortcut
+											? ` (${getShortcutTooltip(toggleSidebarShortcut)})`
+											: ""
+									}`
+						}
 					>
 						<LayoutAlignLeft size={14} />
 					</WindowChromeIconButton>
@@ -1194,6 +1238,8 @@ export function AppShell() {
 				}
 				onToggleDir={fileTree.toggleDir}
 				onLoadDir={fileTree.loadDir}
+				onExpandAllDirs={fileTree.expandAllDirs}
+				onCollapseAllDirs={fileTree.collapseAllDirs}
 				onSelectTag={(t) => openTagSearchPalette(t)}
 				sidebarCollapsed={sidebarCollapsed}
 				onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -9,6 +9,8 @@ import { SidebarSettingsContent } from "./SidebarSettingsContent";
 interface SidebarProps {
 	onToggleDir: (dirPath: string) => void;
 	onLoadDir: (dirPath: string, force?: boolean) => Promise<void>;
+	onExpandAllDirs: () => Promise<void>;
+	onCollapseAllDirs: () => void;
 	onSelectDir: (dirPath: string) => void;
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
@@ -50,6 +52,8 @@ interface SidebarProps {
 export const Sidebar = memo(function Sidebar({
 	onToggleDir,
 	onLoadDir,
+	onExpandAllDirs,
+	onCollapseAllDirs,
 	onSelectDir,
 	onOpenFile,
 	onNewNote,
@@ -130,6 +134,8 @@ export const Sidebar = memo(function Sidebar({
 								<SidebarContent
 									onToggleDir={onToggleDir}
 									onLoadDir={onLoadDir}
+									onExpandAllDirs={onExpandAllDirs}
+									onCollapseAllDirs={onCollapseAllDirs}
 									onSelectDir={onSelectDir}
 									onOpenFile={onOpenFile}
 									onNewNote={onNewNote}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -1,5 +1,7 @@
 import {
+	ArrowShrinkIcon,
 	CollectionsBookmarkIcon,
+	ExpandParagraphIcon,
 	Home01Icon,
 	LibraryIcon,
 	NoteIcon,
@@ -21,6 +23,8 @@ import { FileTreePane } from "../filetree";
 interface SidebarContentProps {
 	onToggleDir: (dirPath: string) => void;
 	onLoadDir: (dirPath: string, force?: boolean) => Promise<void>;
+	onExpandAllDirs: () => Promise<void>;
+	onCollapseAllDirs: () => void;
 	onSelectDir: (dirPath: string) => void;
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
@@ -101,6 +105,8 @@ function folioTreeRootEntries(
 export const SidebarContent = memo(function SidebarContent({
 	onToggleDir,
 	onLoadDir,
+	onExpandAllDirs,
+	onCollapseAllDirs,
 	onSelectDir,
 	onOpenFile,
 	onNewNote,
@@ -557,26 +563,58 @@ export const SidebarContent = memo(function SidebarContent({
 							className="sidebarStackItem sidebarStackItemGrow"
 							data-section="files"
 						>
-							<button
-								type="button"
-								className="sidebarStackHeader sidebarStackHeaderToggle"
-								onClick={handleNotesHeaderClick}
-								aria-expanded={notesExpanded}
-								aria-label={notesExpanded ? "Collapse Notes" : "Expand Notes"}
-							>
-								<span>Notes</span>
-								{notesExpanded ? (
-									<ChevronDown
-										size={10}
-										className="sidebarStackHeaderChevron"
-									/>
-								) : (
-									<ChevronRight
-										size={10}
-										className="sidebarStackHeaderChevron"
-									/>
-								)}
-							</button>
+							<div className="sidebarStackHeader">
+								<button
+									type="button"
+									className="sidebarStackHeaderToggle"
+									onClick={handleNotesHeaderClick}
+									aria-expanded={notesExpanded}
+									aria-label={notesExpanded ? "Collapse Notes" : "Expand Notes"}
+								>
+									<span>Notes</span>
+									{notesExpanded ? (
+										<ChevronDown
+											size={10}
+											className="sidebarStackHeaderChevron"
+										/>
+									) : (
+										<ChevronRight
+											size={10}
+											className="sidebarStackHeaderChevron"
+										/>
+									)}
+								</button>
+								<div className="sidebarStackHeaderActions">
+									<button
+										type="button"
+										className="sidebarStackHeaderAction"
+										title="Expand all folders"
+										aria-label="Expand all folders"
+										onClick={() => {
+											void onExpandAllDirs();
+										}}
+									>
+										<HugeiconsIcon
+											icon={ExpandParagraphIcon}
+											size={13}
+											strokeWidth={0.9}
+										/>
+									</button>
+									<button
+										type="button"
+										className="sidebarStackHeaderAction"
+										title="Collapse all folders"
+										aria-label="Collapse all folders"
+										onClick={onCollapseAllDirs}
+									>
+										<HugeiconsIcon
+											icon={ArrowShrinkIcon}
+											size={13}
+											strokeWidth={0.9}
+										/>
+									</button>
+								</div>
+							</div>
 							{notesExpanded ? (
 								<FileTreePane
 									rootEntries={folioMode ? folioRootEntries : rootEntries}

--- a/src/components/app/WindowChromeIconButton.tsx
+++ b/src/components/app/WindowChromeIconButton.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 interface WindowChromeIconButtonProps {
 	ariaLabel: string;
 	ariaPressed?: boolean;
+	disabled?: boolean;
 	onClick: () => void;
 	title: string;
 	children: ReactNode;
@@ -11,6 +12,7 @@ interface WindowChromeIconButtonProps {
 export function WindowChromeIconButton({
 	ariaLabel,
 	ariaPressed,
+	disabled = false,
 	onClick,
 	title,
 	children,
@@ -22,6 +24,7 @@ export function WindowChromeIconButton({
 			className="windowChromeSidebarToggle"
 			aria-label={ariaLabel}
 			aria-pressed={ariaPressed}
+			disabled={disabled}
 			data-window-drag-ignore
 			onClick={onClick}
 			title={title}

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -3,15 +3,32 @@ import {
 	type KeyboardEvent,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
 import { isMissingFileError } from "../../lib/fsErrors";
 import { loadSettings, reloadFromDisk } from "../../lib/settings";
-import { invoke } from "../../lib/tauri";
+import { type FsEntry, invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
-import { basename } from "../../utils/path";
-import { Save } from "../Icons";
+import { basename, parentDir } from "../../utils/path";
+import { ChevronDown, FileText, Save } from "../Icons";
+
+const QUICK_NOTE_TARGET_VALUE = "__quick-note-today__";
+const MARKDOWN_TARGET_LIMIT = 2000;
+
+interface QuickNoteTarget {
+	value: string;
+	path: string;
+	label: string;
+	detail: string;
+}
+
+interface QuickNoteTargetGroup {
+	folder: string;
+	label: string;
+	targets: QuickNoteTarget[];
+}
 
 function pad(value: number): string {
 	return value.toString().padStart(2, "0");
@@ -38,6 +55,13 @@ function appendMarkdown(existing: string, entry: string): string {
 
 async function appendQuickNote(folder: string, text: string): Promise<string> {
 	const path = quickNotePath(folder);
+	return appendQuickNoteToPath(path, text);
+}
+
+async function appendQuickNoteToPath(
+	path: string,
+	text: string,
+): Promise<string> {
 	try {
 		const doc = await invoke("space_read_text", { path });
 		await invoke("space_write_text", {
@@ -62,38 +86,157 @@ function savedLabel(path: string) {
 	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
 }
 
+function targetDetail(path: string) {
+	return parentDir(path) || "Space root";
+}
+
+function quickNoteTarget(folder: string): QuickNoteTarget {
+	const path = quickNotePath(folder);
+	return {
+		value: QUICK_NOTE_TARGET_VALUE,
+		path,
+		label: "Today's quick note",
+		detail: targetDetail(path),
+	};
+}
+
+function fileTarget(entry: FsEntry): QuickNoteTarget {
+	return {
+		value: entry.rel_path,
+		path: entry.rel_path,
+		label: savedLabel(entry.rel_path),
+		detail: targetDetail(entry.rel_path),
+	};
+}
+
+function sortMarkdownFiles(files: FsEntry[]): FsEntry[] {
+	return [...files].sort((a, b) => {
+		const folderCompare = parentDir(a.rel_path).localeCompare(
+			parentDir(b.rel_path),
+		);
+		if (folderCompare !== 0) return folderCompare;
+		return savedLabel(a.rel_path).localeCompare(savedLabel(b.rel_path));
+	});
+}
+
+function groupTargets(targets: QuickNoteTarget[]): QuickNoteTargetGroup[] {
+	const groups = new Map<string, QuickNoteTarget[]>();
+	for (const target of targets) {
+		const folder = parentDir(target.path);
+		groups.set(folder, [...(groups.get(folder) ?? []), target]);
+	}
+	return [...groups.entries()].map(([folder, groupTargets]) => ({
+		folder,
+		label: folder || "Space root",
+		targets: groupTargets,
+	}));
+}
+
 export function QuickNoteWindow() {
 	const [folder, setFolder] = useState("Quick Notes");
 	const [draft, setDraft] = useState("");
 	const [status, setStatus] = useState("");
 	const [saving, setSaving] = useState(false);
+	const [targetValue, setTargetValue] = useState(QUICK_NOTE_TARGET_VALUE);
+	const [targetsOpen, setTargetsOpen] = useState(false);
+	const [fileTargets, setFileTargets] = useState<QuickNoteTarget[]>([]);
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const targetSelectorRef = useRef<HTMLDivElement | null>(null);
+	const targetTriggerRef = useRef<HTMLButtonElement | null>(null);
 
 	const hasText = draft.trim().length > 0;
+	const defaultTarget = useMemo(() => quickNoteTarget(folder), [folder]);
+	const groupedFileTargets = useMemo(
+		() => groupTargets(fileTargets),
+		[fileTargets],
+	);
+	const selectedTarget =
+		targetValue === QUICK_NOTE_TARGET_VALUE
+			? defaultTarget
+			: (fileTargets.find((target) => target.value === targetValue) ??
+				defaultTarget);
 	const isMac =
 		navigator.platform.toLowerCase().includes("mac") ||
 		navigator.userAgent.includes("Mac");
 	const shortcutLabel = isMac ? "⌘+Enter" : "Ctrl+Enter";
 	const shortcutModifierLabel = isMac ? "⌘" : "Ctrl";
 
+	const chooseTarget = useCallback((value: string) => {
+		setTargetValue(value);
+		setTargetsOpen(false);
+		window.setTimeout(() => textareaRef.current?.focus(), 20);
+	}, []);
+
+	const focusTargetOption = useCallback((position: "first" | "last") => {
+		window.requestAnimationFrame(() => {
+			const options =
+				targetSelectorRef.current?.querySelectorAll<HTMLButtonElement>(
+					".quickNoteTargetMenu .quickNoteTargetOption",
+				);
+			const nextOption =
+				position === "first" ? options?.[0] : options?.[options.length - 1];
+			nextOption?.focus();
+		});
+	}, []);
+
 	const refreshSettings = useCallback(async (withReload = false) => {
 		if (withReload) await reloadFromDisk();
 		const settings = await loadSettings();
-		setFolder(settings.quickNotes.folder);
+		const nextFolder = settings.quickNotes.folder;
+		setFolder(nextFolder);
+		return nextFolder;
+	}, []);
+
+	const refreshTargets = useCallback(async (nextFolder: string) => {
+		try {
+			const files = await invoke("space_list_markdown_files", {
+				recursive: true,
+				limit: MARKDOWN_TARGET_LIMIT,
+			});
+			const defaultPath = quickNotePath(nextFolder);
+			setFileTargets(
+				sortMarkdownFiles(files)
+					.filter((entry) => entry.rel_path !== defaultPath)
+					.map(fileTarget),
+			);
+		} catch (cause) {
+			setStatus(cause instanceof Error ? cause.message : String(cause));
+		}
 	}, []);
 
 	useEffect(() => {
-		void refreshSettings().catch(() => {});
+		void refreshSettings()
+			.then((nextFolder) => refreshTargets(nextFolder))
+			.catch(() => {});
 		const focusTimer = window.setTimeout(
 			() => textareaRef.current?.focus(),
 			80,
 		);
 		return () => window.clearTimeout(focusTimer);
-	}, [refreshSettings]);
+	}, [refreshSettings, refreshTargets]);
+
+	useEffect(() => {
+		if (!targetsOpen) return;
+		const handlePointerDown = (event: PointerEvent) => {
+			if (
+				event.target instanceof Node &&
+				targetSelectorRef.current?.contains(event.target)
+			) {
+				return;
+			}
+			setTargetsOpen(false);
+		};
+		document.addEventListener("pointerdown", handlePointerDown);
+		return () => {
+			document.removeEventListener("pointerdown", handlePointerDown);
+		};
+	}, [targetsOpen]);
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.quickNotes?.folder === "string") {
-			setFolder(payload.quickNotes.folder);
+			const nextFolder = payload.quickNotes.folder;
+			setFolder(nextFolder);
+			void refreshTargets(nextFolder);
 		}
 	});
 
@@ -103,10 +246,14 @@ export function QuickNoteWindow() {
 		setSaving(true);
 		setStatus("");
 		try {
-			const path = await appendQuickNote(folder, text);
+			const path =
+				selectedTarget.value === QUICK_NOTE_TARGET_VALUE
+					? await appendQuickNote(folder, text)
+					: await appendQuickNoteToPath(selectedTarget.path, text);
 			setDraft("");
 			setStatus(`Saved ${savedLabel(path)}`);
 			void emit("quick-note:open_note", { path }).catch(() => {});
+			void refreshTargets(folder);
 			window.setTimeout(() => setStatus(""), 1600);
 			window.setTimeout(() => textareaRef.current?.focus(), 20);
 		} catch (cause) {
@@ -114,12 +261,16 @@ export function QuickNoteWindow() {
 		} finally {
 			setSaving(false);
 		}
-	}, [draft, folder, saving]);
+	}, [draft, folder, refreshTargets, saving, selectedTarget]);
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
 		const primary = event.metaKey || event.ctrlKey;
 		if (event.key === "Escape") {
 			event.preventDefault();
+			if (targetsOpen) {
+				setTargetsOpen(false);
+				return;
+			}
 			void invoke("hide_quick_note_window");
 			return;
 		}
@@ -127,6 +278,40 @@ export function QuickNoteWindow() {
 			event.preventDefault();
 			void save();
 		}
+	};
+
+	const handleTargetTriggerKeyDown = (
+		event: KeyboardEvent<HTMLButtonElement>,
+	) => {
+		if (event.key === "Escape") {
+			event.preventDefault();
+			setTargetsOpen(false);
+			return;
+		}
+		if (
+			event.key === "Enter" ||
+			event.key === " " ||
+			event.key === "ArrowDown" ||
+			event.key === "ArrowUp"
+		) {
+			event.preventDefault();
+			setTargetsOpen(true);
+			void refreshTargets(folder);
+			if (event.key === "ArrowDown") {
+				focusTargetOption("first");
+			} else if (event.key === "ArrowUp") {
+				focusTargetOption("last");
+			}
+		}
+	};
+
+	const handleTargetOptionKeyDown = (
+		event: KeyboardEvent<HTMLButtonElement>,
+	) => {
+		if (event.key !== "Escape") return;
+		event.preventDefault();
+		setTargetsOpen(false);
+		window.setTimeout(() => targetTriggerRef.current?.focus(), 20);
 	};
 
 	return (
@@ -142,32 +327,116 @@ export function QuickNoteWindow() {
 				spellCheck
 			/>
 			<div className="quickNoteEditorChrome">
-				<div className="quickNoteStatus" aria-live="polite">
-					{status}
-				</div>
-				<button
-					type="button"
-					className="quickNoteSaveButton"
-					aria-label={saving ? "Saving quick note" : "Save quick note"}
-					title={
-						saving ? "Saving quick note" : `Save quick note (${shortcutLabel})`
-					}
-					disabled={saving || !hasText}
-					onClick={() => void save()}
-				>
-					<Save size={16} />
-					<span className="quickNoteSaveLabel">Save</span>
-					<span className="commandPaletteShortcut" aria-hidden="true">
-						<kbd>
-							<span className="commandPaletteShortcutCombo">
-								<span className="commandPaletteShortcutPart">
-									{shortcutModifierLabel}
-								</span>
-								<span className="commandPaletteShortcutPart">↵</span>
+				<div className="quickNoteTargetGroup">
+					<FileText size={14} aria-hidden="true" />
+					<div className="quickNoteTargetSelectWrap" ref={targetSelectorRef}>
+						<button
+							ref={targetTriggerRef}
+							type="button"
+							className="quickNoteTargetTrigger"
+							aria-label="Quick note destination"
+							aria-expanded={targetsOpen}
+							aria-haspopup="listbox"
+							title={selectedTarget.path}
+							onClick={() => {
+								setTargetsOpen((open) => !open);
+								void refreshTargets(folder);
+							}}
+							onKeyDown={handleTargetTriggerKeyDown}
+						>
+							<span className="quickNoteTargetTriggerText">
+								{selectedTarget.label}
 							</span>
-						</kbd>
-					</span>
-				</button>
+							<span className="quickNoteTargetTriggerDetail">
+								{selectedTarget.detail}
+							</span>
+							<ChevronDown size={12} aria-hidden="true" />
+						</button>
+						{targetsOpen ? (
+							<div
+								className="quickNoteTargetMenu"
+								aria-label="Quick note destination"
+							>
+								<button
+									type="button"
+									className={
+										selectedTarget.value === defaultTarget.value
+											? "quickNoteTargetOption is-selected"
+											: "quickNoteTargetOption"
+									}
+									aria-selected={selectedTarget.value === defaultTarget.value}
+									onClick={() => chooseTarget(defaultTarget.value)}
+									onKeyDown={handleTargetOptionKeyDown}
+								>
+									<span className="quickNoteTargetOptionLabel">
+										{defaultTarget.label}
+									</span>
+									<span className="quickNoteTargetOptionDetail">
+										{defaultTarget.detail}
+									</span>
+								</button>
+								{groupedFileTargets.map((group) => (
+									<div
+										key={group.folder || "__root__"}
+										className="quickNoteTargetMenuGroup"
+									>
+										<div className="quickNoteTargetMenuGroupLabel">
+											{group.label}
+										</div>
+										{group.targets.map((target) => (
+											<button
+												key={target.value}
+												type="button"
+												className={
+													selectedTarget.value === target.value
+														? "quickNoteTargetOption is-selected"
+														: "quickNoteTargetOption"
+												}
+												aria-selected={selectedTarget.value === target.value}
+												onClick={() => chooseTarget(target.value)}
+												onKeyDown={handleTargetOptionKeyDown}
+											>
+												<span className="quickNoteTargetOptionLabel">
+													{target.label}
+												</span>
+											</button>
+										))}
+									</div>
+								))}
+							</div>
+						) : null}
+					</div>
+				</div>
+				<div className="quickNoteActionGroup">
+					<div className="quickNoteStatus" aria-live="polite">
+						{status}
+					</div>
+					<button
+						type="button"
+						className="quickNoteSaveButton"
+						aria-label={saving ? "Saving quick note" : "Save quick note"}
+						title={
+							saving
+								? "Saving quick note"
+								: `Save quick note (${shortcutLabel})`
+						}
+						disabled={saving || !hasText}
+						onClick={() => void save()}
+					>
+						<Save size={16} />
+						<span className="quickNoteSaveLabel">Save</span>
+						<span className="commandPaletteShortcut" aria-hidden="true">
+							<kbd>
+								<span className="commandPaletteShortcutCombo">
+									<span className="commandPaletteShortcutPart">
+										{shortcutModifierLabel}
+									</span>
+									<span className="commandPaletteShortcutPart">↵</span>
+								</span>
+							</kbd>
+						</span>
+					</button>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -9,14 +9,18 @@
 						"Pi joins as a first-class agent provider",
 						"Claude joins as a first-class agent provider, running through `claude -p` per Anthropic's terms of service",
 						"Right-click a note in the file tree or Folio to get Show in Finder, which opens Finder with the file selected",
-						"The Mermaid editor embeds a fixed-height canvas in the note, with pan, fit, and Cmd-wheel zoom"
+						"The Mermaid editor embeds a fixed-height canvas in the note, with pan, fit, and Cmd-wheel zoom",
+						"Quick Note can now append to any note in the current space with an in-window folder-grouped picker"
 					]
 				},
 				{
 					"category": "Improved",
 					"items": [
 						"Active TOC dashes shift to the accent color, and the collapsed container drops its extra styling so only the dashes show",
-						"Mermaid renders through beautiful-mermaid with sanitized SVG, and clicking into the source switches between editable text and the rendered diagram"
+						"The file tree Notes header now has expand-all and collapse-all controls for quickly opening or closing every folder",
+						"Mermaid renders through beautiful-mermaid with sanitized SVG, and clicking into the source switches between editable text and the rendered diagram",
+						"The sidebar collapses once the window drops to 760px and stays closed until you make it wider, with the main area expanding to fill the gap",
+						"The expand sidebar button greys out while the window is too narrow to reopen the sidebar"
 					]
 				},
 				{

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -1,6 +1,7 @@
 import { join } from "@tauri-apps/api/path";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useRef } from "react";
+import { extractErrorMessage } from "../lib/errorUtils";
 import type { FsEntry } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
 import { isMarkdownPath, parentDir } from "../utils/path";
@@ -11,6 +12,8 @@ import type { CreateMarkdownFileOptions } from "./useFileTreeCRUD";
 export interface UseFileTreeResult {
 	loadDir: (dirPath: string, force?: boolean) => Promise<void>;
 	toggleDir: (dirPath: string) => void;
+	expandAllDirs: () => Promise<void>;
+	collapseAllDirs: () => void;
 	openFile: (relPath: string) => Promise<void>;
 	openMarkdownFile: (relPath: string) => Promise<void>;
 	openNonMarkdownExternally: (relPath: string) => Promise<void>;
@@ -193,6 +196,59 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 		[evictCollapsedDirState, loadDir, updateExpandedDirsAndRef],
 	);
 
+	const expandAllDirs = useCallback(async () => {
+		if (!spacePath) return;
+		try {
+			setError("");
+			const nextChildrenByDir: Record<string, FsEntry[] | undefined> = {};
+			const nextExpandedDirs = new Set<string>();
+			const loadedDirs = new Set<string>();
+			const pendingDirs = [""];
+
+			for (let index = 0; index < pendingDirs.length; index += 1) {
+				const dirPath = pendingDirs[index];
+				if (dirPath === undefined || loadedDirs.has(dirPath)) continue;
+				const entries = normalizeEntries(
+					await invoke("space_list_dir", dirPath ? { dir: dirPath } : {}),
+				);
+				loadedDirs.add(dirPath);
+				if (dirPath) {
+					nextChildrenByDir[dirPath] = entries;
+				} else {
+					updateRootEntries((prev) =>
+						areEntriesEqual(prev, entries) ? prev : entries,
+					);
+				}
+
+				for (const entry of entries) {
+					if (entry.kind !== "dir") continue;
+					nextExpandedDirs.add(entry.rel_path);
+					pendingDirs.push(entry.rel_path);
+				}
+			}
+
+			updateChildrenByDir(nextChildrenByDir);
+			updateExpandedDirsAndRef(nextExpandedDirs);
+			loadedDirsRef.current = loadedDirs;
+			loadRequestVersionRef.current.clear();
+		} catch (error) {
+			setError(extractErrorMessage(error));
+		}
+	}, [
+		spacePath,
+		setError,
+		updateChildrenByDir,
+		updateExpandedDirsAndRef,
+		updateRootEntries,
+	]);
+
+	const collapseAllDirs = useCallback(() => {
+		updateExpandedDirsAndRef(new Set());
+		updateChildrenByDir({});
+		loadedDirsRef.current = new Set(loadedDirsRef.current.has("") ? [""] : []);
+		loadRequestVersionRef.current.clear();
+	}, [updateChildrenByDir, updateExpandedDirsAndRef]);
+
 	const openMarkdownFile = useCallback(
 		async (relPath: string) => {
 			setError("");
@@ -255,6 +311,8 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 	return {
 		loadDir,
 		toggleDir,
+		expandAllDirs,
+		collapseAllDirs,
 		openFile,
 		openMarkdownFile,
 		openNonMarkdownExternally,

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -87,3 +87,27 @@
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 }
+
+@media (max-width: 760px) {
+	.appShell .sidebar {
+		width: 0 !important;
+		min-width: 0;
+		border: 0;
+		overflow: hidden;
+	}
+
+	.appShell .sidebarContentRoot {
+		display: none;
+	}
+
+	.appShell .sidebarResizeHandle {
+		width: 0;
+		margin-left: 0;
+		margin-right: 0;
+		pointer-events: none;
+	}
+
+	.appShell .mainArea {
+		border-left-width: 0;
+	}
+}

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -104,6 +104,16 @@
 	color: var(--text-primary);
 }
 
+.windowChromeSidebarToggle:disabled {
+	opacity: 0.45;
+	cursor: default;
+}
+
+.windowChromeSidebarToggle:disabled:hover {
+	background: transparent;
+	color: var(--text-secondary);
+}
+
 .windowChromeSidebarToggle svg {
 	width: 16px;
 	height: 16px;
@@ -205,6 +215,7 @@
 	gap: 6px;
 	min-height: 22px;
 	padding: 6px 16px 1px;
+	justify-content: space-between;
 	color: var(--text-primary);
 	font-size: var(--text-sm);
 	font-weight: var(--font-normal);
@@ -217,12 +228,14 @@
 	flex-shrink: 0;
 }
 
-button.sidebarStackHeader {
+.sidebarStackHeaderToggle {
 	appearance: none;
 	background: transparent;
 	border: 0;
 	margin: 0;
-	width: 100%;
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 0;
 	cursor: pointer;
 	text-align: left;
 	font: inherit;
@@ -230,7 +243,49 @@ button.sidebarStackHeader {
 	font-weight: var(--font-normal);
 	font-size: var(--text-sm);
 	display: flex;
+	align-items: center;
+	gap: 6px;
 	justify-content: flex-start;
+}
+
+.sidebarStackHeaderToggle:hover,
+.sidebarStackHeaderToggle:focus-visible,
+.sidebarStackHeaderToggle:active {
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-primary);
+	outline: none;
+}
+
+.sidebarStackHeaderActions {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	flex-shrink: 0;
+}
+
+.sidebarStackHeaderAction {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-tertiary);
+	cursor: pointer;
+	transition: color var(--transition-fast);
+}
+
+.sidebarStackHeaderAction:hover,
+.sidebarStackHeaderAction:focus-visible,
+.sidebarStackHeaderAction:active {
+	background: transparent;
+	box-shadow: none;
+	color: var(--text-primary);
+	outline: none;
 }
 
 .sidebarStackHeaderChevron {

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -51,6 +51,166 @@
 	pointer-events: none;
 }
 
+.quickNoteTargetGroup,
+.quickNoteActionGroup {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+	gap: 8px;
+}
+
+.quickNoteTargetGroup {
+	flex: 1 1 auto;
+	max-width: min(560px, calc(100% - 142px));
+	color: var(--text-tertiary);
+	pointer-events: auto;
+}
+
+.quickNoteTargetGroup > svg {
+	flex: 0 0 auto;
+	color: currentcolor;
+}
+
+.quickNoteTargetSelectWrap {
+	position: relative;
+	min-width: 0;
+	max-width: 100%;
+}
+
+.quickNoteTargetTrigger {
+	width: 100%;
+	min-width: 190px;
+	max-width: 100%;
+	height: 30px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 0 8px;
+	border: 1px solid transparent;
+	border-radius: 7px;
+	outline: none;
+	background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: var(--text-sm);
+	line-height: 30px;
+	letter-spacing: 0;
+	cursor: pointer;
+}
+
+.quickNoteTargetTrigger:hover {
+	background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
+	color: var(--text-primary);
+}
+
+.quickNoteTargetTrigger:focus-visible {
+	border-color: color-mix(in srgb, var(--interactive-accent) 44%, transparent);
+	box-shadow: 0 0 0 2px
+		color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+}
+
+.quickNoteTargetTriggerText,
+.quickNoteTargetTriggerDetail,
+.quickNoteTargetOptionLabel,
+.quickNoteTargetOptionDetail {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.quickNoteTargetTriggerText {
+	flex: 0 1 auto;
+	color: currentcolor;
+}
+
+.quickNoteTargetTriggerDetail {
+	flex: 1 1 auto;
+	color: var(--text-tertiary);
+	font-size: 12px;
+}
+
+.quickNoteTargetTrigger > svg {
+	flex: 0 0 auto;
+	color: currentcolor;
+}
+
+.quickNoteTargetMenu {
+	position: absolute;
+	left: 0;
+	bottom: 38px;
+	z-index: 6;
+	width: min(360px, calc(100vw - 72px));
+	max-height: 230px;
+	padding: 6px;
+	overflow-y: auto;
+	border: 1px solid color-mix(in srgb, var(--border-default) 74%, transparent);
+	border-radius: 10px;
+	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+	box-shadow: 0 18px 48px color-mix(in srgb, black 22%, transparent);
+	pointer-events: auto;
+}
+
+.quickNoteTargetOption {
+	width: 100%;
+	min-width: 0;
+	min-height: 30px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 5px 8px;
+	border: 0;
+	border-radius: 7px;
+	background: transparent;
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: var(--text-sm);
+	line-height: 1.2;
+	letter-spacing: 0;
+	text-align: left;
+	cursor: pointer;
+}
+
+.quickNoteTargetOption:hover,
+.quickNoteTargetOption:focus-visible {
+	outline: none;
+	background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+	color: var(--text-primary);
+}
+
+.quickNoteTargetOption.is-selected {
+	background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+	color: var(--text-primary);
+}
+
+.quickNoteTargetOptionLabel {
+	flex: 1 1 auto;
+}
+
+.quickNoteTargetOptionDetail {
+	flex: 0 1 auto;
+	color: var(--text-tertiary);
+	font-size: 12px;
+}
+
+.quickNoteTargetMenuGroup {
+	margin-top: 4px;
+}
+
+.quickNoteTargetMenuGroupLabel {
+	padding: 7px 8px 4px;
+	color: var(--text-tertiary);
+	font-size: 11px;
+	font-weight: var(--font-medium);
+	line-height: 1.2;
+	letter-spacing: 0;
+}
+
+.quickNoteActionGroup {
+	flex: 0 0 auto;
+	justify-content: flex-end;
+}
+
 .quickNoteSaveButton {
 	display: inline-flex;
 	align-items: center;


### PR DESCRIPTION
## Summary

  - Adds a folder-grouped note picker to Quick Note so users can append to any note in the current
  space.
  - Adds responsive sidebar collapse behavior when the app width becomes constrained.
  - Adds expand-all and collapse-all controls to the Notes file tree header.
  - Updates release notes for the new Quick Note and navigation improvements.

  ## Verification

  - pnpm check
  - pnpm build
  - cd src-tauri && cargo check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick note destination selector: choose which folder or file to save your quick notes.
  * Expand all and collapse all controls for managing file tree folders.

* **Improvements**
  * Sidebar automatically collapses on narrow screens (760px or less) for better space usage.
  * Sidebar toggle button is disabled when sidebar is automatically collapsed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->