### PR TITLE
feat(ui): refine folio workspace

### DIFF
--- a/src/components/Icons/FileIcons.tsx
+++ b/src/components/Icons/FileIcons.tsx
@@ -15,6 +15,7 @@ import {
 	HtmlFile01Icon,
 	KanbanIcon,
 	Music as MusicIcon,
+	NoteIcon,
 	Palette as PaletteIcon,
 	Pdf01Icon,
 	Ppt01Icon,
@@ -27,7 +28,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import type { IconProps } from "./NavigationIcons";
 
 export const FileText = (props: IconProps) => (
-	<HugeiconsIcon icon={Document} strokeWidth={0.9} {...props} />
+	<HugeiconsIcon icon={NoteIcon} strokeWidth={0.9} {...props} />
 );
 export const File = (props: IconProps) => (
 	<HugeiconsIcon icon={FileIcon} strokeWidth={0.9} {...props} />

--- a/src/components/ai/ModelSelector.module.css
+++ b/src/components/ai/ModelSelector.module.css
@@ -361,10 +361,10 @@
 .detailTag {
 	display: inline-block;
 	padding: 1px 6px;
-	border-radius: var(--radius-full);
+	border-radius: 4px;
 	font-size: 10px;
 	background: color-mix(in srgb, var(--bg-secondary) 80%, transparent);
-	border: 1px solid color-mix(in srgb, var(--border-light) 40%, transparent);
+	border: 0;
 	color: var(--text-secondary);
 }
 

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { join } from "@tauri-apps/api/path";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { AnimatePresence } from "motion/react";
 import {
@@ -1015,14 +1016,22 @@ export function AppShell() {
 		[setError],
 	);
 
+	const handleCloseTabOrWindow = useCallback(async () => {
+		if (tabs.length > 0) {
+			closeActiveTab();
+			return;
+		}
+		await getCurrentWindow()
+			.close()
+			.catch(() => {});
+	}, [closeActiveTab, tabs.length]);
+
 	useMenuListeners({
 		onNewNote: handleNewNoteFromMenu,
 		onCreateFromTemplate: handleCreateFromTemplateFromMenu,
 		onOpenDailyNote: handleOpenDailyNoteFromMenu,
 		onSaveNote: handleSaveNoteFromMenu,
-		onCloseTab: () => {
-			window.dispatchEvent(new Event("glyph:close-active-tab"));
-		},
+		onCloseTab: () => void handleCloseTabOrWindow(),
 		onOpenSpace,
 		onOpenRecentSpaceAtPath: onOpenSpaceAtPath,
 		onCreateSpace,
@@ -1130,6 +1139,12 @@ export function AppShell() {
 				action: openSearchPalette,
 				allowInEditable: true,
 			},
+			{
+				id: "close-window-when-no-tabs",
+				shortcut: getBinding("close-active-tab"),
+				enabled: tabs.length === 0,
+				action: handleCloseTabOrWindow,
+			},
 			...Array.from({ length: 9 }, (_, index) => ({
 				id: `activate-tab-${index + 1}`,
 				shortcut: getBinding(`activate-tab-${index + 1}`),
@@ -1153,6 +1168,7 @@ export function AppShell() {
 			closeSettings,
 			commands,
 			getBinding,
+			handleCloseTabOrWindow,
 			openCommandPalette,
 			openSearchPalette,
 			settingsMode,
@@ -1295,7 +1311,6 @@ export function AppShell() {
 				setActiveTabId={setActiveTabId}
 				setDirtyByPath={setDirtyByPath}
 				closeTab={closeTab}
-				closeActiveTab={closeActiveTab}
 				closeTabsForPathRemoval={closeTabsForPathRemoval}
 				renameTabsForPath={renameTabsForPath}
 				reorderTabs={reorderTabs}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -281,7 +281,6 @@ interface MainContentProps {
 	setActiveTabId: (tabId: string | null) => void;
 	setDirtyByPath: Dispatch<SetStateAction<Record<string, boolean>>>;
 	closeTab: (tabId: string) => void;
-	closeActiveTab: () => void;
 	closeTabsForPathRemoval: (path: string, recursive?: boolean) => void;
 	renameTabsForPath: (
 		fromPath: string,
@@ -389,7 +388,6 @@ export const MainContent = memo(function MainContent({
 	setActiveTabId,
 	setDirtyByPath,
 	closeTab,
-	closeActiveTab,
 	closeTabsForPathRemoval,
 	renameTabsForPath,
 	reorderTabs,
@@ -452,9 +450,6 @@ export const MainContent = memo(function MainContent({
 	}, [replaceActiveTabWithBlank, showGettingStartedRequest, spacePath]);
 
 	useEffect(() => {
-		const handleCloseActiveTab = () => {
-			closeActiveTab();
-		};
 		const handlePathRemoved = (event: Event) => {
 			const detail = (event as CustomEvent<PathRemovedDetail>).detail;
 			if (!detail?.path) return;
@@ -465,18 +460,13 @@ export const MainContent = memo(function MainContent({
 			if (!detail?.fromPath || !detail?.toPath) return;
 			renameTabsForPath(detail.fromPath, detail.toPath, detail.recursive);
 		};
-		window.addEventListener("glyph:close-active-tab", handleCloseActiveTab);
 		window.addEventListener(PATH_REMOVED_EVENT, handlePathRemoved);
 		window.addEventListener(PATH_RENAMED_EVENT, handlePathRenamed);
 		return () => {
-			window.removeEventListener(
-				"glyph:close-active-tab",
-				handleCloseActiveTab,
-			);
 			window.removeEventListener(PATH_REMOVED_EVENT, handlePathRemoved);
 			window.removeEventListener(PATH_RENAMED_EVENT, handlePathRenamed);
 		};
-	}, [closeActiveTab, closeTabsForPathRemoval, renameTabsForPath]);
+	}, [closeTabsForPathRemoval, renameTabsForPath]);
 
 	const viewerPath = activeTabPath;
 	const openCommandPaletteShortcut = getBinding("open-command-palette");
@@ -906,16 +896,6 @@ export const MainContent = memo(function MainContent({
 							<h2 className="settingsPanelTitle">
 								{activeSettingsTabMeta.label}
 							</h2>
-							{activeSettingsTabMeta.badgeText ? (
-								<span
-									className={`settingsPanelBadge earlyAccessBadge ${activeSettingsTabMeta.id === "git" ? "settingsBetaBadge" : ""}`}
-								>
-									{activeSettingsTabMeta.badgeIcon
-										? activeSettingsTabMeta.badgeIcon()
-										: null}
-									<span>{activeSettingsTabMeta.badgeText}</span>
-								</span>
-							) : null}
 						</div>
 					</header>
 					{settingsTabContentByTab[settingsTab]}

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -49,14 +49,6 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							<span className="sidebarQuickActionLabel settingsTabLabel">
 								{tab.label}
 							</span>
-							{tab.badgeText ? (
-								<span
-									className={`settingsTabBadge earlyAccessBadge ${tab.id === "git" ? "settingsBetaBadge" : ""}`}
-								>
-									{tab.badgeIcon ? tab.badgeIcon() : null}
-									<span>{tab.badgeText}</span>
-								</span>
-							) : null}
 						</button>
 					))}
 				</div>

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -30,8 +30,10 @@ interface FolioNoteListItemProps {
 	onOpen: (path: string) => void;
 	onOpenInNewTab: (path: string) => void;
 	onPrefetch: (path: string) => void;
+	isPinned?: boolean;
 	onRename?: (path: string) => void;
 	onDelete: (path: string) => void;
+	onTogglePinned?: (path: string) => Promise<void> | void;
 	onFocus: () => void;
 	taskSummary?: NoteTaskSummary | null;
 	isRenaming?: boolean;
@@ -315,8 +317,10 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	onOpen,
 	onOpenInNewTab,
 	onPrefetch,
+	isPinned = false,
 	onRename,
 	onDelete,
+	onTogglePinned,
 	onFocus,
 	taskSummary = null,
 	isRenaming = false,
@@ -388,6 +392,14 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							},
 						]
 					: []),
+				...(onTogglePinned
+					? [
+							{
+								label: isPinned ? "Unpin file" : "Pin file",
+								action: () => void onTogglePinned(note.note_path),
+							},
+						]
+					: []),
 				fileTreeAppearanceNativeMenu("file", appearance, (nextAppearance) =>
 					onChangeAppearance(note.note_path, nextAppearance),
 				),
@@ -403,15 +415,17 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 		[
 			appearance,
 			handleRevealInFinder,
+			isPinned,
 			note.note_path,
 			onChangeAppearance,
 			onDelete,
 			onOpen,
 			onOpenInNewTab,
 			onRename,
+			onTogglePinned,
 		],
 	);
-	const leadingIcon = appearance?.icon ? (
+	const fileIcon = appearance?.icon ? (
 		<DatabaseColumnIcon
 			iconName={appearance.icon}
 			size={15}
@@ -424,6 +438,11 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 			style={{ color: iconColor }}
 			aria-hidden="true"
 		/>
+	);
+	const noteTitleIcon = (
+		<span className="folioNoteTitleIcon" aria-hidden="true">
+			{fileIcon}
+		</span>
 	);
 	const rowDetails = (
 		<div className="folioNoteBody">
@@ -462,7 +481,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	);
 	const fileDetails = (
 		<span className="folioFileLine">
-			{leadingIcon}
+			{fileIcon}
 			<span className="folioFileName">{fileStem || title}</span>
 			{extBadge ? <span className="fileTreeExtBadge">{extBadge}</span> : null}
 		</span>
@@ -475,6 +494,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 					className="folioNoteRow"
 					data-state={selected ? "selected" : "idle"}
 					data-kind={isMarkdown ? "markdown" : "file"}
+					data-pinned={isPinned ? "true" : undefined}
 					data-folio-note-path={note.note_path}
 					title={note.note_path}
 					style={rowStyle}
@@ -499,6 +519,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 					className="folioNoteRow"
 					data-state={selected ? "selected" : "idle"}
 					data-kind={isMarkdown ? "markdown" : "file"}
+					data-pinned={isPinned ? "true" : undefined}
 					data-folio-note-path={note.note_path}
 					aria-current={selected ? "page" : undefined}
 					onClick={(event) => {
@@ -528,6 +549,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							<span className="folioNoteRowTop">
 								<span className="folioNoteTitle">{title}</span>
 								{taskProgress}
+								{noteTitleIcon}
 							</span>
 							{rowDetails}
 						</>

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -12,6 +12,8 @@ const {
 	prefetchNoteMock,
 	invokeMock,
 	scopeRef,
+	pinnedFilesRef,
+	togglePinnedFileMock,
 	taskSummariesRef,
 	showTaskProgressIndicatorRef,
 } = vi.hoisted(() => ({
@@ -19,6 +21,8 @@ const {
 	prefetchNoteMock: vi.fn(),
 	invokeMock: vi.fn(),
 	scopeRef: { current: { kind: "all" } as FolioScope },
+	pinnedFilesRef: { current: [] as string[] },
+	togglePinnedFileMock: vi.fn(),
 	taskSummariesRef: {
 		current: {} as Record<
 			string,
@@ -35,6 +39,8 @@ vi.mock("../../contexts", () => ({
 	useFileTreeContext: () => ({
 		itemAppearance: {},
 		setItemAppearance: vi.fn(),
+		pinnedFiles: pinnedFilesRef.current,
+		togglePinnedFile: togglePinnedFileMock,
 	}),
 }));
 
@@ -125,6 +131,7 @@ describe("FolioNotesListPane", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		scopeRef.current = { kind: "all" };
+		pinnedFilesRef.current = [];
 		taskSummariesRef.current = {};
 		showTaskProgressIndicatorRef.current = true;
 		loadAllDocsMock.mockResolvedValue(notes);
@@ -174,10 +181,10 @@ describe("FolioNotesListPane", () => {
 		await act(async () => renderPane("Projects/Roadmap.md"));
 		await waitFor(() => container.textContent?.includes("Roadmap") ?? false);
 
-		expect(container.textContent).toContain("All Notes");
 		expect(container.textContent).toContain("Roadmap");
 		expect(container.textContent).toContain("Launch planning and milestones");
 		expect(container.textContent).toContain("Sketch");
+		expect(container.querySelector(".folioNotesTitle")).toBeNull();
 		expect(loadAllDocsMock).toHaveBeenCalledWith(null);
 		expect(renderedNotePaths(container)).toEqual([
 			"Projects/Roadmap.md",
@@ -211,6 +218,24 @@ describe("FolioNotesListPane", () => {
 
 		expect(container.textContent).toContain("Roadmap");
 		expect(container.textContent).not.toContain("Sketch");
+	});
+
+	it("keeps pinned notes at the top of the folio list", async () => {
+		pinnedFilesRef.current = ["Ideas/Sketch.md"];
+
+		await act(async () => renderPane());
+		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
+
+		expect(renderedNotePaths(container)).toEqual([
+			"Ideas/Sketch.md",
+			"Projects/Roadmap.md",
+		]);
+		expect(container.textContent).toContain("Pinned");
+		expect(
+			container
+				.querySelector('[data-folio-note-path="Ideas/Sketch.md"]')
+				?.getAttribute("data-pinned"),
+		).toBe("true");
 	});
 
 	it("renders task progress rings on note cards", async () => {
@@ -317,7 +342,6 @@ describe("FolioNotesListPane", () => {
 		await act(async () => renderPane());
 		await waitFor(() => container.textContent?.includes("Sketch") ?? false);
 
-		expect(container.textContent).toContain("@mira");
 		expect(renderedNotePaths(container)).toEqual(["Ideas/Sketch.md"]);
 		expect(container.textContent).not.toContain("Roadmap");
 	});

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,13 +1,20 @@
+import { PinIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
-import { prefetchNote } from "../../lib/navigationPrefetch";
-import type { FileTreeAppearance } from "../../lib/tauri";
+import {
+	loadAllDocs,
+	navigationQueryKeys,
+	prefetchNote,
+} from "../../lib/navigationPrefetch";
+import type { AllDocsItem, FileTreeAppearance } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { isDeleteKey } from "../../utils/keyboard";
-import { basename } from "../../utils/path";
+import { basename, isMarkdownPath } from "../../utils/path";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
 import type { FolioNotesSortMode } from "./folioScopes";
@@ -21,12 +28,72 @@ interface FolioNotesListPaneProps {
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
 
+const FOLIO_SORT_MODE_STORAGE_KEY = "glyph.folio.sortMode";
+
+function isFolioNotesSortMode(value: unknown): value is FolioNotesSortMode {
+	return value === "alphabetical" || value === "edited" || value === "created";
+}
+
+function readStoredFolioSortMode(): FolioNotesSortMode {
+	if (typeof window === "undefined") return "alphabetical";
+	try {
+		const value = window.localStorage.getItem(FOLIO_SORT_MODE_STORAGE_KEY);
+		return isFolioNotesSortMode(value) ? value : "alphabetical";
+	} catch {
+		return "alphabetical";
+	}
+}
+
+function writeStoredFolioSortMode(sortMode: FolioNotesSortMode) {
+	if (typeof window === "undefined") return;
+	try {
+		window.localStorage.setItem(FOLIO_SORT_MODE_STORAGE_KEY, sortMode);
+	} catch {
+		// Best-effort UI persistence.
+	}
+}
+
 function noteTitle(note: FolioItem): string {
 	const fallback = basename(note.note_path);
 	return (
 		note.title.trim() ||
 		(note.is_markdown ? fallback.replace(/\.md$/i, "") : fallback)
 	);
+}
+
+function normalizePinnedPath(path: string): string {
+	return path
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+}
+
+function titleFromPinnedPath(path: string): string {
+	const name = basename(path);
+	return isMarkdownPath(path) ? name.replace(/\.md$/i, "") : name;
+}
+
+function allDocsItemToFolioItem(item: AllDocsItem): FolioItem {
+	return {
+		...item,
+		note_path: normalizePinnedPath(item.note_path),
+		created: item.created || null,
+		updated: item.updated || null,
+		is_markdown: true,
+	};
+}
+
+function fallbackPinnedItem(path: string): FolioItem {
+	return {
+		note_path: path,
+		title: titleFromPinnedPath(path),
+		preview: "",
+		created: null,
+		updated: null,
+		tags: [],
+		people: [],
+		is_markdown: isMarkdownPath(path),
+	};
 }
 
 function noteMatchesFilter(note: FolioItem, query: string): boolean {
@@ -102,7 +169,9 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	onDeleteFile,
 }: FolioNotesListPaneProps) {
 	const { folioScope } = useUILayoutContext();
-	const { itemAppearance, setItemAppearance } = useFileTreeContext();
+	const { itemAppearance, setItemAppearance, pinnedFiles, togglePinnedFile } =
+		useFileTreeContext();
+	const queryClient = useQueryClient();
 	const {
 		notes,
 		filesTruncated,
@@ -111,18 +180,81 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		nonMarkdownFileLimit,
 		missingFolder,
 	} = useFolioNotes(folioScope);
+	const normalizedPinnedFiles = useMemo(
+		() =>
+			pinnedFiles
+				.map(normalizePinnedPath)
+				.filter((path, index, paths) => path && paths.indexOf(path) === index),
+		[pinnedFiles],
+	);
+	const hasPinnedMarkdownFiles = useMemo(
+		() => normalizedPinnedFiles.some(isMarkdownPath),
+		[normalizedPinnedFiles],
+	);
+	const pinnedMarkdownQuery = useQuery({
+		queryKey: navigationQueryKeys.allDocsList(null),
+		queryFn: () => loadAllDocs(null),
+		enabled: hasPinnedMarkdownFiles,
+	});
 	const [searchQuery, setSearchQuery] = useState("");
-	const [sortMode, setSortMode] = useState<FolioNotesSortMode>("alphabetical");
+	const [sortMode, setSortMode] = useState<FolioNotesSortMode>(
+		readStoredFolioSortMode,
+	);
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const paneRef = useRef<HTMLElement | null>(null);
-	const visibleNotes = useMemo(
+	const pinnedPathSet = useMemo(
+		() => new Set(normalizedPinnedFiles),
+		[normalizedPinnedFiles],
+	);
+	const notesByPath = useMemo(
+		() =>
+			new Map(
+				notes.map(
+					(note) => [normalizePinnedPath(note.note_path), note] as const,
+				),
+			),
+		[notes],
+	);
+	const allDocsByPath = useMemo(
+		() =>
+			new Map(
+				(pinnedMarkdownQuery.data ?? []).map(
+					(note) =>
+						[
+							normalizePinnedPath(note.note_path),
+							allDocsItemToFolioItem(note),
+						] as const,
+				),
+			),
+		[pinnedMarkdownQuery.data],
+	);
+	const visiblePinnedNotes = useMemo(
+		() =>
+			normalizedPinnedFiles
+				.map(
+					(path) =>
+						notesByPath.get(path) ??
+						allDocsByPath.get(path) ??
+						fallbackPinnedItem(path),
+				)
+				.filter((note) => noteMatchesFilter(note, searchQuery)),
+		[allDocsByPath, normalizedPinnedFiles, notesByPath, searchQuery],
+	);
+	const visibleRegularNotes = useMemo(
 		() =>
 			notes
+				.filter(
+					(note) => !pinnedPathSet.has(normalizePinnedPath(note.note_path)),
+				)
 				.filter((note) => noteMatchesFilter(note, searchQuery))
 				.slice()
 				.sort((left, right) => compareNotes(left, right, sortMode)),
-		[notes, searchQuery, sortMode],
+		[notes, pinnedPathSet, searchQuery, sortMode],
+	);
+	const visibleNotes = useMemo(
+		() => [...visiblePinnedNotes, ...visibleRegularNotes],
+		[visiblePinnedNotes, visibleRegularNotes],
 	);
 	const selectedIndex = useMemo(
 		() =>
@@ -146,14 +278,29 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	);
 
 	useTauriEvent("notes:external_changed", (payload) => {
+		if (hasPinnedMarkdownFiles) {
+			void queryClient.invalidateQueries({
+				queryKey: navigationQueryKeys.allDocsList(null),
+			});
+		}
 		if (!payload.rel_path || !taskSummaryPaths.includes(payload.rel_path))
 			return;
 		setTaskSummaryRefreshKey((key) => key + 1);
+	});
+	useTauriEvent("space:fs_changed", () => {
+		if (!hasPinnedMarkdownFiles) return;
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocsList(null),
+		});
 	});
 	const focusPane = useCallback(() => {
 		requestAnimationFrame(() =>
 			paneRef.current?.focus({ preventScroll: true }),
 		);
+	}, []);
+	const changeSortMode = useCallback((nextSortMode: FolioNotesSortMode) => {
+		setSortMode(nextSortMode);
+		writeStoredFolioSortMode(nextSortMode);
 	}, []);
 	const scrollNoteIntoView = useCallback((path: string) => {
 		requestAnimationFrame(() => {
@@ -211,6 +358,16 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			await onDeleteFile(path);
 		},
 		[onDeleteFile],
+	);
+	const togglePinnedNote = useCallback(
+		async (path: string) => {
+			try {
+				await togglePinnedFile(path);
+			} catch (error) {
+				console.error("Failed to toggle pinned folio file", error);
+			}
+		},
+		[togglePinnedFile],
 	);
 	const changeAppearance = useCallback(
 		async (path: string, appearance: FileTreeAppearance) => {
@@ -277,16 +434,54 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 					</div>
 				) : null}
 				<ul className="folioNotesList">
-					{visibleNotes.map((note) => (
+					{visiblePinnedNotes.length > 0 ? (
+						<li className="folioNotesPinnedHeading">
+							<HugeiconsIcon icon={PinIcon} size={12} strokeWidth={1} />
+							<span>Pinned</span>
+						</li>
+					) : null}
+					{visiblePinnedNotes.map((note) => (
 						<FolioNoteListItem
 							key={note.note_path}
 							note={note}
 							selected={activeTabPath === note.note_path}
+							isPinned
 							onOpen={openNote}
 							onOpenInNewTab={openNoteInNewTab}
 							onPrefetch={prefetchNote}
 							onRename={onRenameFile ? renameNote : undefined}
 							onDelete={deleteNote}
+							onTogglePinned={togglePinnedNote}
+							onFocus={focusPane}
+							isRenaming={
+								Boolean(onRenameFile) && renamingPath === note.note_path
+							}
+							onCommitRename={commitRename}
+							onCancelRename={cancelRename}
+							appearance={itemAppearance[note.note_path] ?? null}
+							onChangeAppearance={changeAppearance}
+							taskSummary={
+								showTaskProgressIndicator && note.is_markdown
+									? (taskSummariesByPath[note.note_path] ?? null)
+									: null
+							}
+						/>
+					))}
+					{visiblePinnedNotes.length > 0 && visibleRegularNotes.length > 0 ? (
+						<li className="folioNotesPinnedDivider" aria-hidden="true" />
+					) : null}
+					{visibleRegularNotes.map((note) => (
+						<FolioNoteListItem
+							key={note.note_path}
+							note={note}
+							selected={activeTabPath === note.note_path}
+							isPinned={false}
+							onOpen={openNote}
+							onOpenInNewTab={openNoteInNewTab}
+							onPrefetch={prefetchNote}
+							onRename={onRenameFile ? renameNote : undefined}
+							onDelete={deleteNote}
+							onTogglePinned={togglePinnedNote}
 							onFocus={focusPane}
 							isRenaming={
 								Boolean(onRenameFile) && renamingPath === note.note_path
@@ -347,7 +542,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				searchQuery={searchQuery}
 				sortMode={sortMode}
 				onSearchQueryChange={setSearchQuery}
-				onSortModeChange={setSortMode}
+				onSortModeChange={changeSortMode}
 			/>
 			{body}
 		</aside>

--- a/src/components/preview/MarkdownEditorPane.test.tsx
+++ b/src/components/preview/MarkdownEditorPane.test.tsx
@@ -1,17 +1,22 @@
 // @vitest-environment jsdom
 
-import { type ButtonHTMLAttributes, act } from "react";
+import { act } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FORCE_NOTE_EDIT_MODE_EVENT } from "../../lib/appEvents";
 import { MarkdownEditorPane } from "./MarkdownEditorPane";
 
-const { noteInlineEditorMock, localNoteGraphDialogMock, invokeMock } =
-	vi.hoisted(() => ({
-		noteInlineEditorMock: vi.fn(),
-		localNoteGraphDialogMock: vi.fn(),
-		invokeMock: vi.fn(),
-	}));
+const {
+	noteInlineEditorMock,
+	localNoteGraphDialogMock,
+	invokeMock,
+	showNativePopupMenuMock,
+} = vi.hoisted(() => ({
+	noteInlineEditorMock: vi.fn(),
+	localNoteGraphDialogMock: vi.fn(),
+	invokeMock: vi.fn(),
+	showNativePopupMenuMock: vi.fn(),
+}));
 
 // React 19 expects tests to opt into act-aware scheduling.
 (
@@ -37,27 +42,12 @@ vi.mock("../../lib/tauri", () => ({
 	invoke: invokeMock,
 }));
 
-vi.mock("../../lib/tauriEvents", () => ({
-	useTauriEvent: () => {},
+vi.mock("../../lib/nativeContextMenu", () => ({
+	showNativePopupMenu: showNativePopupMenuMock,
 }));
 
-vi.mock("motion/react", () => ({
-	AnimatePresence: ({ children }: { children: unknown }) => children,
-	m: {
-		div: ({
-			initial: _initial,
-			animate: _animate,
-			exit: _exit,
-			transition: _transition,
-			...props
-		}: React.HTMLAttributes<HTMLDivElement> & {
-			initial?: unknown;
-			animate?: unknown;
-			exit?: unknown;
-			transition?: unknown;
-		}) => <div {...props} />,
-	},
-	useReducedMotion: () => true,
+vi.mock("../../lib/tauriEvents", () => ({
+	useTauriEvent: () => {},
 }));
 
 vi.mock("../editor/NoteInlineEditor", () => ({
@@ -120,25 +110,35 @@ vi.mock("./NotesInfoSidebar", () => ({
 		) : null,
 }));
 
-vi.mock("../ui/shadcn/button", () => ({
-	Button: ({
-		children,
-		type,
-		...props
-	}: ButtonHTMLAttributes<HTMLButtonElement> & {
-		variant?: string;
-		size?: string;
-		asChild?: boolean;
-	}) => (
-		<button type={type ?? "button"} {...props}>
-			{children}
-		</button>
-	),
-}));
-
 vi.mock("@hugeicons/react", () => ({
 	HugeiconsIcon: () => null,
 }));
+
+type TestNativeMenuItem =
+	| {
+			label: string;
+			action: () => void;
+			checked?: boolean;
+			enabled?: boolean;
+	  }
+	| { type: "separator" };
+
+function getLastNativeMenuItems(): TestNativeMenuItem[] {
+	const lastCall =
+		showNativePopupMenuMock.mock.calls[
+			showNativePopupMenuMock.mock.calls.length - 1
+		];
+	return lastCall?.[1] ?? [];
+}
+
+function runNativeMenuAction(label: string) {
+	const item = getLastNativeMenuItems().find(
+		(item): item is Extract<TestNativeMenuItem, { label: string }> =>
+			"label" in item && item.label === label,
+	);
+	expect(item).toBeDefined();
+	item?.action();
+}
 
 describe("MarkdownEditorPane", () => {
 	let container: HTMLDivElement;
@@ -225,6 +225,8 @@ describe("MarkdownEditorPane", () => {
 		invokeMock.mockImplementation(mockInvoke);
 		noteInlineEditorMock.mockReset();
 		localNoteGraphDialogMock.mockReset();
+		showNativePopupMenuMock.mockReset();
+		showNativePopupMenuMock.mockResolvedValue(false);
 
 		container = document.createElement("div");
 		document.body.appendChild(container);
@@ -353,13 +355,10 @@ describe("MarkdownEditorPane", () => {
 		await act(async () => {
 			actionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
+		expect(showNativePopupMenuMock).toHaveBeenCalled();
 
-		const infoButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.textContent?.trim() === "Info",
-		);
-		expect(infoButton).not.toBeNull();
 		await act(async () => {
-			infoButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			runNativeMenuAction("Info");
 		});
 
 		expect(container.textContent).toContain("Save status");
@@ -408,14 +407,10 @@ describe("MarkdownEditorPane", () => {
 		await act(async () => {
 			actionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
-
-		const rawModeButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.textContent?.includes("Raw"),
-		);
-		expect(rawModeButton).not.toBeNull();
+		expect(showNativePopupMenuMock).toHaveBeenCalled();
 
 		await act(async () => {
-			rawModeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			runNativeMenuAction("Raw");
 		});
 
 		const editorButton = Array.from(container.querySelectorAll("button")).find(
@@ -452,14 +447,10 @@ describe("MarkdownEditorPane", () => {
 		await act(async () => {
 			actionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
-
-		const graphButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.textContent?.includes("Local graph"),
-		);
-		expect(graphButton).not.toBeNull();
+		expect(showNativePopupMenuMock).toHaveBeenCalled();
 
 		await act(async () => {
-			graphButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			runNativeMenuAction("Local graph");
 		});
 
 		expect(

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1,14 +1,17 @@
 import {
-	FlowConnectionIcon,
-	InformationCircleIcon,
 	SlidersHorizontalIcon,
-	SourceCodeIcon,
 	SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/react";
-import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type MouseEvent as ReactMouseEvent,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import {
 	useAISidebarContext,
 	useEditorRegistration,
@@ -26,6 +29,7 @@ import {
 	type ToggleNoteInfoSidebarDetail,
 } from "../../lib/appEvents";
 import { extractErrorMessage } from "../../lib/errorUtils";
+import { showNativePopupMenu } from "../../lib/nativeContextMenu";
 import { setPrefetchedNote } from "../../lib/navigationPrefetch";
 import {
 	joinYamlFrontmatter,
@@ -42,7 +46,6 @@ import {
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { countWords, formatReadingTime } from "../../lib/textStats";
 import { normalizeRelPath } from "../../utils/path";
-import { Edit, Eye } from "../Icons";
 import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
@@ -52,7 +55,6 @@ import type {
 	NoteInlineEditorMode,
 } from "../editor/types";
 import { LocalNoteGraphDialog } from "../graph/LocalNoteGraphDialog";
-import { Button } from "../ui/shadcn/button";
 import { LinkedNotePreviewSheet } from "./LinkedNotePreviewSheet";
 import { NotesInfoSidebar } from "./NotesInfoSidebar";
 import {
@@ -178,7 +180,6 @@ export function MarkdownEditorPane({
 	const [saving, setSaving] = useState(false);
 	const [autosaveBusy, setAutosaveBusy] = useState(false);
 	const [error, setError] = useState(() => initialError || "");
-	const [actionsOpen, setActionsOpen] = useState(false);
 	const [infoPanelOpen, setInfoPanelOpen] = useState(false);
 	const [localGraphOpen, setLocalGraphOpen] = useState(false);
 	const [lastSavedMtimeMs, setLastSavedMtimeMs] = useState<number | null>(
@@ -215,7 +216,6 @@ export function MarkdownEditorPane({
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const { openSettings, showToc } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
-	const shouldReduceMotion = useReducedMotion();
 
 	const isDirty = text !== savedText;
 	const { frontmatter: currentFrontmatter, body: currentBody } = useMemo(
@@ -341,7 +341,6 @@ export function MarkdownEditorPane({
 		setSyncPulse(null);
 		hasUserEditsRef.current = false;
 		setError(initialError);
-		setActionsOpen(false);
 		if (activeRelPathRef.current !== relPath) {
 			setInfoPanelOpen(false);
 		}
@@ -755,6 +754,49 @@ export function MarkdownEditorPane({
 		[currentBody, runAutosave],
 	);
 
+	const toggleInfoPanel = useCallback(() => {
+		setInfoPanelOpen((open) => {
+			const nextOpen = !open;
+			if (nextOpen) setAiPanelOpen(false);
+			return nextOpen;
+		});
+	}, [setAiPanelOpen]);
+
+	const handleEditorActionsMenu = useCallback(
+		(event: ReactMouseEvent<HTMLButtonElement>) => {
+			void showNativePopupMenu(event, [
+				{
+					label: "Info",
+					checked: infoPanelOpen,
+					action: toggleInfoPanel,
+				},
+				{
+					label: "Local graph",
+					action: () => setLocalGraphOpen(true),
+				},
+				{ type: "separator" },
+				{
+					label: "Edit",
+					checked: mode === "rich",
+					action: () => setMode("rich"),
+				},
+				{
+					label: "Preview",
+					checked: mode === "preview",
+					action: () => setMode("preview"),
+				},
+				{
+					label: "Raw",
+					checked: mode === "plain",
+					action: () => setMode("plain"),
+				},
+			]).catch((error: unknown) => {
+				console.error("Failed to show editor actions menu", error);
+			});
+		},
+		[infoPanelOpen, mode, toggleInfoPanel],
+	);
+
 	return (
 		<section className="filePreviewPane markdownEditorPane" ref={paneRef}>
 			<div className="markdownEditorFloatActions">
@@ -791,136 +833,20 @@ export function MarkdownEditorPane({
 					>
 						<HugeiconsIcon icon={SparklesIcon} size={15} strokeWidth={0.9} />
 					</button>
-					<div className="markdownEditorActionsMenu">
-						<button
-							type="button"
-							className="markdownEditorMenuTrigger"
-							data-open={actionsOpen ? "true" : "false"}
-							onClick={() => setActionsOpen((prev) => !prev)}
-							aria-label={
-								actionsOpen ? "Close editor actions" : "Open editor actions"
-							}
-							title={
-								actionsOpen ? "Close editor actions" : "Open editor actions"
-							}
-							aria-expanded={actionsOpen}
-						>
-							<HugeiconsIcon
-								icon={SlidersHorizontalIcon}
-								size={15}
-								strokeWidth={0.9}
-							/>
-						</button>
-						<AnimatePresence initial={false}>
-							{actionsOpen ? (
-								<m.div
-									className="markdownEditorActionsPanel"
-									initial={
-										shouldReduceMotion
-											? false
-											: { opacity: 0, y: -6, scale: 0.98 }
-									}
-									animate={{ opacity: 1, y: 0, scale: 1 }}
-									exit={
-										shouldReduceMotion
-											? { opacity: 0 }
-											: { opacity: 0, y: -4, scale: 0.985 }
-									}
-									transition={
-										shouldReduceMotion
-											? { duration: 0 }
-											: { duration: 0.1, ease: "easeOut" }
-									}
-								>
-									<Button
-										type="button"
-										variant="ghost"
-										size="xs"
-										className="markdownEditorActionItem"
-										data-active={infoPanelOpen}
-										onClick={() => {
-											setInfoPanelOpen((open) => {
-												const nextOpen = !open;
-												if (nextOpen) setAiPanelOpen(false);
-												return nextOpen;
-											});
-											setActionsOpen(false);
-										}}
-									>
-										<HugeiconsIcon
-											icon={InformationCircleIcon}
-											size={12}
-											strokeWidth={0.9}
-										/>
-										Info
-									</Button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="xs"
-										className="markdownEditorActionItem"
-										onClick={() => {
-											setLocalGraphOpen(true);
-											setActionsOpen(false);
-										}}
-									>
-										<HugeiconsIcon
-											icon={FlowConnectionIcon}
-											size={12}
-											strokeWidth={0.9}
-										/>
-										Local graph
-									</Button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="xs"
-										className="markdownEditorActionItem"
-										data-active={mode === "rich"}
-										onClick={() => {
-											setMode("rich");
-											setActionsOpen(false);
-										}}
-									>
-										<Edit size={12} />
-										Edit
-									</Button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="xs"
-										className="markdownEditorActionItem"
-										data-active={mode === "preview"}
-										onClick={() => {
-											setMode("preview");
-											setActionsOpen(false);
-										}}
-									>
-										<Eye size={12} />
-										Preview
-									</Button>
-									<Button
-										type="button"
-										variant="ghost"
-										size="xs"
-										className="markdownEditorActionItem"
-										data-active={mode === "plain"}
-										onClick={() => {
-											setMode("plain");
-											setActionsOpen(false);
-										}}
-									>
-										<HugeiconsIcon
-											icon={SourceCodeIcon}
-											size={12}
-											strokeWidth={0.9}
-										/>
-										Raw
-									</Button>
-								</m.div>
-							) : null}
-						</AnimatePresence>
-					</div>
+					<button
+						type="button"
+						className="markdownEditorMenuTrigger"
+						onClick={handleEditorActionsMenu}
+						aria-label="Open editor actions"
+						title="Open editor actions"
+						aria-haspopup="menu"
+					>
+						<HugeiconsIcon
+							icon={SlidersHorizontalIcon}
+							size={15}
+							strokeWidth={0.9}
+						/>
+					</button>
 				</div>
 			</div>
 			{error ? (

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -446,12 +446,7 @@ export function AdvancedSettingsPane() {
 					description="Global app-level controls for the sidebar and workspace UI."
 				>
 					<SettingsRow
-						label={
-							<span className="settingsLabelWithHelp">
-								Folio Mode
-								<span className="settingsPill settingsTinyBetaBadge">Beta</span>
-							</span>
-						}
+						label="Folio Mode"
 						description="Show navigation, notes, and editor in a three-column workspace."
 					>
 						<SettingsToggle

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -1,6 +1,5 @@
 import {
 	CheckmarkCircle02Icon,
-	ConstructionIcon,
 	GitBranchIcon,
 	InformationCircleIcon,
 	Link01Icon,
@@ -165,25 +164,6 @@ export function GitSettingsPane() {
 		<div className="settingsPane">
 			{error ? <div className="settingsError">{error}</div> : null}
 			<div className="settingsGrid">
-				<section className="settingsCard gitBetaNotice">
-					<div className="gitBetaNoticeIcon" aria-hidden="true">
-						<HugeiconsIcon
-							icon={ConstructionIcon}
-							size={16}
-							strokeWidth={0.9}
-						/>
-					</div>
-					<div className="gitBetaNoticeBody">
-						<div className="gitBetaNoticeTitleRow">
-							<div className="gitBetaNoticeTitle">Git Sync is in beta</div>
-							<span className="earlyAccessBadge gitBetaBadge">In Beta</span>
-						</div>
-						<div className="gitBetaNoticeText">
-							Things might break, especially around sync edge cases and unusual
-							repository states. Use it carefully and keep backups you trust.
-						</div>
-					</div>
-				</section>
 				<SettingsSection
 					title="Connection"
 					description="Glyph uses Git automatically when the opened space is already a repository."

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -1,7 +1,6 @@
 import {
 	Archive02Icon,
 	CommandIcon,
-	ConstructionIcon,
 	GitBranchIcon,
 	Settings01Icon,
 	SparklesIcon,
@@ -26,8 +25,6 @@ export interface SettingsTabMeta {
 	id: SettingsTab;
 	label: string;
 	renderIcon: () => ReactElement;
-	badgeText?: string;
-	badgeIcon?: () => ReactElement;
 }
 
 interface SettingsTabGroup {
@@ -75,10 +72,6 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		label: "Git",
 		renderIcon: () => (
 			<HugeiconsIcon icon={GitBranchIcon} size={14} strokeWidth={0.9} />
-		),
-		badgeText: "Beta",
-		badgeIcon: () => (
-			<HugeiconsIcon icon={ConstructionIcon} size={11} strokeWidth={0.9} />
 		),
 	},
 	{

--- a/src/styles/app/09-settings-shell.css
+++ b/src/styles/app/09-settings-shell.css
@@ -166,25 +166,11 @@
 	text-align: left;
 }
 
-.settingsTabBadge {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	flex: 0 0 auto;
-	margin-left: auto;
-}
-
 .settingsPanelTitleRow {
 	display: flex;
 	align-items: center;
 	gap: 10px;
 	flex-wrap: wrap;
-}
-
-.settingsPanelBadge {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
 }
 
 .settingsTabButton:hover {

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -33,34 +33,6 @@
 	background: color-mix(in srgb, var(--color-blue-500) 10%, transparent);
 }
 
-.settingsTinyBetaBadge {
-	padding: 2px 5px;
-	font-size: 9px;
-	letter-spacing: 0;
-	text-transform: uppercase;
-	color: color-mix(in srgb, var(--color-yellow-600) 78%, var(--text-primary));
-	border-color: color-mix(in srgb, var(--color-yellow-500) 28%, transparent);
-	background: color-mix(in srgb, var(--color-yellow-500) 8%, transparent);
-}
-
-.earlyAccessBadge {
-	--early-access-color: var(--interactive-accent);
-
-	padding: 4px 8px;
-	border-radius: var(--pill-radius);
-	border: 0;
-	font-size: 10px;
-	font-weight: var(--font-semibold);
-	line-height: 1;
-	color: color-mix(in srgb, var(--early-access-color) 66%, var(--text-primary));
-	background: color-mix(
-		in srgb,
-		var(--early-access-color) 11%,
-		var(--bg-primary)
-	);
-	box-shadow: var(--pill-shadow);
-}
-
 .settingsSection {
 	display: flex;
 	flex-direction: column;

--- a/src/styles/app/11-settings-misc.css
+++ b/src/styles/app/11-settings-misc.css
@@ -201,61 +201,6 @@
 	opacity: 0.56;
 }
 
-.gitBetaNotice {
-	display: flex;
-	align-items: flex-start;
-	gap: 12px;
-	padding: 14px 16px;
-	border-color: color-mix(in srgb, #eab308 34%, var(--border-default));
-	background: color-mix(in srgb, #eab308 10%, var(--settings-surface-muted));
-}
-
-.gitBetaNoticeIcon {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 32px;
-	height: 32px;
-	border-radius: var(--radius-md);
-	background: color-mix(in srgb, #eab308 16%, transparent);
-	color: color-mix(in srgb, #ca8a04 88%, var(--text-primary));
-	flex: 0 0 auto;
-}
-
-.gitBetaNoticeBody {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
-	min-width: 0;
-}
-
-.gitBetaNoticeTitleRow {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	flex-wrap: wrap;
-}
-
-.gitBetaNoticeTitle {
-	font-size: 14px;
-	font-weight: var(--font-semibold);
-	color: var(--text-primary);
-}
-
-.gitBetaNoticeText {
-	font-size: 12px;
-	line-height: 1.5;
-	color: var(--text-secondary);
-}
-
-.gitBetaBadge {
-	--early-access-color: #d97706;
-}
-
-.settingsBetaBadge {
-	--early-access-color: #d97706;
-}
-
 .settingsValueCard {
 	width: 100%;
 	display: flex;

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -352,7 +352,7 @@ input.notePropertyValue {
 	max-width: 100%;
 	padding: 0 7px;
 	border: 0;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 	background: color-mix(
 		in srgb,
 		var(--interactive-accent) 8%,
@@ -366,7 +366,7 @@ input.notePropertyValue {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 }
 
 .statusPropertyPill {
@@ -378,14 +378,14 @@ input.notePropertyValue {
 	height: 22px;
 	padding: 0 7px;
 	border: 0;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 	background: color-mix(in srgb, var(--database-tone) 11%, var(--bg-secondary));
 	color: color-mix(in srgb, var(--database-tone) 72%, var(--text-primary));
 	font-family: var(--font-sans);
 	font-size: var(--text-xs);
 	font-weight: var(--font-semibold);
 	line-height: 1;
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 }
 
 .statusPropertyPillIcon {
@@ -425,7 +425,7 @@ input.notePropertyValue {
 	outline: 2px solid
 		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	outline-offset: 2px;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 }
 
 .notePropertyStatusMenu {
@@ -448,7 +448,7 @@ input.notePropertyValue {
 	width: 100%;
 	gap: 6px;
 	padding: 3px 24px 3px 5px;
-	border-radius: var(--database-control-radius, var(--radius-md));
+	border-radius: 4px;
 	text-align: left;
 	color: var(--text-secondary);
 }
@@ -456,7 +456,6 @@ input.notePropertyValue {
 .notePropertyStatusOption .statusPropertyPill {
 	height: 24px;
 	padding-inline: 7px;
-	box-shadow: none;
 }
 
 .notePropertyStatusOption[data-highlighted],
@@ -503,7 +502,7 @@ input.notePropertyValue {
 	height: 22px;
 	padding: 0 7px;
 	border: 0;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 	background: color-mix(in srgb, var(--pill-tone) 10%, var(--bg-secondary));
 	color: color-mix(in srgb, var(--pill-tone) 68%, var(--text-primary));
 	font-family: var(--font-sans);
@@ -511,7 +510,7 @@ input.notePropertyValue {
 	font-weight: var(--font-semibold);
 	line-height: 1;
 	cursor: pointer;
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 	transition: background 120ms ease, color 120ms ease;
 }
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -107,11 +107,11 @@
 		var(--bg-secondary)
 	);
 	border: 0;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 	padding: 1px 7px;
 	font-weight: var(--font-semibold);
 	line-height: 1.35;
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 	cursor: pointer;
 	transition: background 120ms ease, color 120ms ease;
 }

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -245,10 +245,6 @@
 	display: none;
 }
 
-.markdownEditorActionsMenu {
-	position: relative;
-}
-
 .markdownEditorMenuTrigger {
 	position: relative;
 	display: inline-flex;
@@ -268,8 +264,7 @@
 	transition: none;
 }
 
-.markdownEditorMenuTrigger:hover,
-.markdownEditorMenuTrigger[data-open="true"] {
+.markdownEditorMenuTrigger:hover {
 	border: none;
 	background: transparent;
 	box-shadow: none;
@@ -285,48 +280,6 @@
 
 .markdownEditorAiTrigger svg {
 	transform: translateY(-1px);
-}
-
-.markdownEditorActionsPanel {
-	position: absolute;
-	top: calc(100% + 6px);
-	right: 0;
-	min-width: 138px;
-	display: flex;
-	flex-direction: column;
-	gap: 2px;
-	padding: 5px;
-	border-radius: calc(var(--radius-md) + 2px);
-	border: 1px solid color-mix(in srgb, var(--border-light) 86%, transparent);
-	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
-	backdrop-filter: blur(16px);
-	-webkit-backdrop-filter: blur(16px);
-	box-shadow: 0 16px 36px
-		color-mix(in srgb, var(--shadow-color, #000) 8%, transparent);
-}
-
-.markdownEditorActionItem {
-	width: 100%;
-	justify-content: flex-start;
-	font-size: 11px;
-	color: var(--text-secondary);
-	border-radius: var(--radius-md);
-	transition: transform var(--transition-base), background-color
-		var(--transition-base), color var(--transition-base);
-}
-
-.markdownEditorActionItem:hover:not(:disabled) {
-	transform: translateY(-1px);
-	color: var(--text-primary);
-}
-
-.markdownEditorActionItem[data-active="true"] {
-	background: color-mix(
-		in srgb,
-		var(--interactive-accent) 8%,
-		var(--bg-secondary)
-	);
-	color: var(--text-primary);
 }
 
 .markdownEditorCenter {

--- a/src/styles/app/36-tasks.css
+++ b/src/styles/app/36-tasks.css
@@ -121,8 +121,8 @@
 	align-items: center;
 	height: 22px;
 	padding: 0 8px;
-	border-radius: var(--pill-radius);
 	border: 0;
+	border-radius: 4px;
 	background: color-mix(
 		in srgb,
 		var(--interactive-accent) 7%,
@@ -135,7 +135,7 @@
 		var(--interactive-accent) 58%,
 		var(--text-secondary)
 	);
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 }
 
 .tasksMetaTagInline {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -286,7 +286,7 @@
 	flex: 0 0 auto;
 	padding: 2px 6px;
 	border: 0;
-	border-radius: var(--pill-radius);
+	border-radius: 4px;
 	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-secondary));
 	font-size: 0.66rem;
 	font-weight: var(--font-medium);

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -248,12 +248,6 @@
 	background: color-mix(in srgb, var(--bg-primary) 78%, var(--bg-secondary));
 }
 
-.databaseTagField .notePropertyToken {
-	--pill-tone: var(--interactive-accent);
-
-	border-color: transparent;
-}
-
 .databaseTagField .notePropertyToken:hover,
 .databaseTagField .notePropertyToken:focus-visible {
 	background: color-mix(in srgb, var(--pill-tone) 16%, var(--bg-secondary));
@@ -315,13 +309,13 @@
 	align-items: center;
 	gap: 5px;
 	padding: 2px 8px;
-	border-radius: var(--pill-radius);
 	border: 0;
+	border-radius: 4px;
 	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-secondary));
 	font-size: 0.76rem;
 	font-weight: var(--font-medium);
 	color: color-mix(in srgb, var(--database-tone) 68%, var(--text-primary));
-	box-shadow: var(--pill-shadow);
+	box-shadow: none;
 	white-space: nowrap;
 	flex: 0 0 auto;
 }

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -21,19 +21,31 @@
 
 .folioNotesHeader {
 	flex: 0 0 auto;
-	padding: 12px 12px 9px;
+	padding: 10px 14px;
 	border-bottom: 1px solid
-		color-mix(in srgb, var(--border-light) 58%, transparent);
+		color-mix(in srgb, var(--border-light) 52%, transparent);
 }
 
 .appShell.appShellSidebarCollapsed .folioNotesHeader {
-	padding-left: max(12px, var(--collapsed-sidebar-top-reserve));
+	padding-left: max(14px, var(--collapsed-sidebar-top-reserve));
 }
 
 .folioNotesControls {
 	display: flex;
 	align-items: center;
 	gap: 6px;
+}
+
+.folioNotesTitle {
+	min-width: 0;
+	margin: 0 0 9px;
+	overflow: hidden;
+	color: color-mix(in srgb, var(--text-secondary) 86%, var(--text-primary));
+	font-size: 11px;
+	font-weight: var(--font-semibold);
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .folioNotesSearch {
@@ -136,7 +148,7 @@
 	overflow: auto;
 	list-style: none;
 	margin: 0;
-	padding: 0;
+	padding: 3px 0 8px;
 }
 
 .folioNoteListItem {
@@ -144,33 +156,82 @@
 	padding: 0;
 }
 
+.folioNotesPinnedHeading {
+	height: 25px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 14px 4px;
+	color: color-mix(in srgb, var(--text-tertiary) 88%, transparent);
+	font-size: 10px;
+	font-weight: var(--font-medium);
+	line-height: 1;
+}
+
+.folioNotesPinnedHeading svg {
+	flex: 0 0 auto;
+}
+
+.folioNotesPinnedDivider {
+	height: 8px;
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 44%, transparent);
+	background: color-mix(in srgb, var(--bg-secondary) 42%, transparent);
+}
+
 .folioNoteRow {
+	position: relative;
 	width: 100%;
-	min-height: 116px;
+	min-height: 104px;
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
 	justify-content: flex-start;
-	gap: 6px;
-	padding: 10px 16px 9px;
+	gap: 7px;
+	padding: 11px 14px 10px;
 	border: 0;
 	border-bottom: 1px solid
-		color-mix(in srgb, var(--border-light) 58%, transparent);
+		color-mix(in srgb, var(--border-light) 44%, transparent);
 	border-radius: 0;
 	background: transparent;
 	color: var(--text-primary);
 	text-align: left;
 	cursor: default;
+	transition: background-color 120ms ease;
+}
+
+.folioNoteRow[data-pinned="true"] {
+	background: color-mix(in srgb, var(--interactive-accent) 3%, transparent);
 }
 
 .folioNoteRow:hover,
 .folioNoteRow:focus-visible {
-	background: var(--bg-hover);
+	background: color-mix(in srgb, var(--bg-hover) 76%, transparent);
 	outline: none;
 }
 
 .folioNoteRow[data-state="selected"] {
-	background: color-mix(in srgb, var(--interactive-accent) 8%, var(--bg-hover));
+	background: color-mix(in srgb, var(--interactive-accent) 5%, transparent);
+}
+
+.folioNoteRow[data-state="selected"]::before {
+	content: "";
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	width: 2px;
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 68%,
+		var(--text-secondary)
+	);
+	opacity: 0.82;
+}
+
+.folioNoteRow[data-state="selected"]:hover,
+.folioNoteRow[data-state="selected"]:focus-visible {
+	background: color-mix(in srgb, var(--interactive-accent) 6%, var(--bg-hover));
 }
 
 .folioNoteRow[data-kind="file"] {
@@ -180,12 +241,16 @@
 	padding-bottom: 9px;
 }
 
+.folioNoteRow:has(.folioNoteThumbnail) {
+	min-height: 126px;
+}
+
 .folioNoteRowTop {
 	flex: 0 0 auto;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 8px;
+	gap: 7px;
 	min-width: 0;
 }
 
@@ -195,10 +260,21 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--text-primary);
+	color: var(--folio-file-color, var(--text-primary));
 	font-size: 13px;
-	font-weight: var(--font-medium);
-	line-height: 1.25;
+	font-weight: var(--font-semibold);
+	line-height: 1.32;
+}
+
+.folioNoteTitleIcon {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	color: var(--folio-file-color, var(--text-tertiary));
+	opacity: 0.72;
 }
 
 .folioNoteRenameInput {
@@ -236,12 +312,12 @@
 
 .folioNoteBody {
 	min-width: 0;
-	flex: 1;
+	flex: 0 0 auto;
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
-	grid-template-rows: 1fr auto;
+	grid-template-rows: auto auto;
 	column-gap: 10px;
-	row-gap: 6px;
+	row-gap: 7px;
 	align-items: start;
 }
 
@@ -254,12 +330,12 @@
 	min-width: 0;
 	flex: 0 0 auto;
 	display: -webkit-box;
-	-webkit-line-clamp: 3;
+	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	overflow: hidden;
-	color: color-mix(in srgb, var(--text-secondary) 90%, transparent);
+	color: color-mix(in srgb, var(--text-secondary) 82%, transparent);
 	font-size: 12px;
-	line-height: 1.38;
+	line-height: 1.42;
 	white-space: normal;
 	overflow-wrap: anywhere;
 }
@@ -267,11 +343,11 @@
 .folioNoteThumbnail {
 	grid-column: 2;
 	grid-row: 1;
-	width: 58px;
-	height: 58px;
+	width: 52px;
+	height: 52px;
 	overflow: hidden;
 	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
-	border-radius: 6px;
+	border-radius: 5px;
 	background: var(--bg-secondary);
 }
 
@@ -289,9 +365,10 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 8px;
+	gap: 10px;
 	min-width: 0;
-	margin-top: auto;
+	margin-top: 1px;
+	overflow: hidden;
 }
 
 .folioNoteTags {
@@ -299,14 +376,16 @@
 	flex: 1;
 	display: flex;
 	align-items: center;
-	gap: 6px;
+	gap: 4px;
 	overflow: hidden;
 }
 
 .folioNoteTag {
-	max-width: 104px;
-	min-height: 18px;
-	padding: 1px 7px;
+	max-width: 98px;
+	min-height: 16px;
+	padding: 1px 6px;
+	background: color-mix(in srgb, var(--bg-hover) 68%, transparent);
+	color: color-mix(in srgb, var(--text-secondary) 76%, var(--text-tertiary));
 	font-size: 10px;
 	line-height: 1.2;
 	overflow: hidden;
@@ -317,7 +396,7 @@
 .folioNoteFolder {
 	min-width: 0;
 	overflow: hidden;
-	color: var(--text-tertiary);
+	color: color-mix(in srgb, var(--text-tertiary) 86%, transparent);
 	font-size: 10px;
 	line-height: 16px;
 	text-overflow: ellipsis;
@@ -329,8 +408,9 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	color: var(--text-tertiary);
+	color: color-mix(in srgb, var(--text-tertiary) 82%, transparent);
 	font-size: 10px;
+	line-height: 16px;
 	white-space: nowrap;
 }
 
@@ -354,6 +434,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	color: var(--folio-file-color, var(--text-primary));
 	font-size: 13px;
 	font-weight: var(--font-medium);
 	line-height: 1.25;


### PR DESCRIPTION
## Summary

This PR makes Folio mode feel more finished and predictable for daily navigation. The notes list can now preserve pinned files at the top, retain the user-selected sort mode, and better respect custom note appearance so the Folio workspace matches the rest of Glyph’s file surfaces.

It also tightens a few adjacent UI behaviors that were creating visual or interaction friction: shared tag/status pills are flatter, the editor actions control now uses the native popup menu, settings no longer advertises Folio/Git as beta, and the close-tab command closes the window when there are no tabs left.

### What changed

- Added pinned-file handling in `src/components/folio/FolioNotesListPane.tsx`, including a `Pinned` section, pin/unpin context-menu actions, filtering support, and fallback rows for pinned files that are outside the active Folio scope.
- Persisted the Folio sort mode in `localStorage` and kept pinned notes above the regular sorted list.
- Updated Folio note rows to show custom/default icons in the title area and apply custom appearance colors to note titles and file names.
- Replaced the floating editor actions panel with a native popup menu for Info, Local graph, Edit, Preview, and Raw mode actions.
- Updated close-tab handling so the same command closes the active tab when one exists, or closes the Tauri window when no tabs are open.
- Removed beta badges/notices from Folio Mode and Git settings, plus the now-unused badge metadata and CSS.
- Flattened shared tag/status pill styling across note properties, tasks, database views, editor inline tags, model details, and Folio note tags.
- Added/updated coverage for pinned Folio rows, the headerless Folio controls, and the editor actions popup behavior.

## Related Issues

N/A

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] `pnpm test -- src/components/folio/FolioNotesListPane.test.tsx` (Vitest completed 47 files / 242 tests)
- [ ] Relevant manual testing completed on macOS (not run; no interactive Tauri session opened)

## Screenshots or Recordings

Not added; no manual UI capture was generated for this branch.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed (N/A: no docs/templates needed)
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin/unpin notes in folio mode with dedicated pinned section
  * Sort preference persistence in folio mode

* **Style**
  * Removed beta status indicators from settings and features
  * Editor actions menu now uses native popup style
  * Refined folio notes list appearance and styling
  * Standardized pill element styling with updated border radius and shadows

* **Improvements**
  * Application closes when final tab is closed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->