### PR TITLE
feat(database): improve project workflows

### DIFF
--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -19,10 +19,12 @@ use crate::space::SpaceState;
 use crate::space_fs::helpers::deny_hidden_rel_path;
 
 use super::query::{load_database_document, query_database_rows, read_note_markdown, row_by_path};
-use super::store::{bootstrap_defaults, default_view, list_summaries, load_store, save_store};
+use super::store::{
+    bootstrap_defaults, default_field_value, default_view, list_summaries, load_store, save_store,
+};
 use super::types::{
     DatabaseCellValue, DatabaseColumn, DatabaseCreateRowResult, DatabaseDefinition,
-    DatabaseDocument, DatabasePreviewContext, DatabaseRow, DatabaseSummary,
+    DatabaseDocument, DatabasePreviewContext, DatabaseRow, DatabaseSchemaField, DatabaseSummary,
 };
 
 fn key(name: &str) -> Value {
@@ -248,9 +250,119 @@ fn validate_editable_column(row: &DatabaseRow, column: &DatabaseColumn) -> Resul
     }
 }
 
-fn create_new_row_markdown(note_path: &str, title: &str) -> Result<String, String> {
+struct NewRowFieldDefault {
+    key: String,
+    kind: String,
+    value: DatabaseCellValue,
+}
+
+fn normalize_field_key(key: &str) -> String {
+    key.trim().to_lowercase()
+}
+
+fn is_reserved_frontmatter_key(key: &str) -> bool {
+    matches!(
+        normalize_field_key(key).as_str(),
+        "created"
+            | "folder"
+            | "glyph"
+            | "id"
+            | "linked_notes"
+            | "path"
+            | "tags"
+            | "title"
+            | "updated"
+    )
+}
+
+fn schema_field_default(field: &DatabaseSchemaField) -> Option<NewRowFieldDefault> {
+    let key = field.property_key.as_deref()?.trim();
+    if key.is_empty() || is_reserved_frontmatter_key(key) {
+        return None;
+    }
+    Some(NewRowFieldDefault {
+        key: key.to_string(),
+        kind: field.kind.clone(),
+        value: field
+            .default_value
+            .clone()
+            .or_else(|| default_field_value(&field.label, &field.kind, Some(key)))?,
+    })
+}
+
+fn column_field_default(column: &DatabaseColumn) -> Option<NewRowFieldDefault> {
+    if column.column_type != "property" {
+        return None;
+    }
+    let key = column.property_key.as_deref()?.trim();
+    if key.is_empty() || is_reserved_frontmatter_key(key) {
+        return None;
+    }
+    let kind = column
+        .property_kind
+        .clone()
+        .unwrap_or_else(|| "text".to_string());
+    Some(NewRowFieldDefault {
+        key: key.to_string(),
+        value: default_field_value(&column.label, &kind, Some(key))?,
+        kind,
+    })
+}
+
+fn database_new_row_field_defaults(database: &DatabaseDefinition) -> Vec<NewRowFieldDefault> {
+    let mut defaults = Vec::new();
+    let mut seen = BTreeMap::<String, ()>::new();
+    for field in &database.schema {
+        let Some(default) = schema_field_default(field) else {
+            continue;
+        };
+        if seen.insert(normalize_field_key(&default.key), ()).is_none() {
+            defaults.push(default);
+        }
+    }
+    for column in database.views.iter().flat_map(|view| view.columns.iter()) {
+        let Some(default) = column_field_default(column) else {
+            continue;
+        };
+        if seen.insert(normalize_field_key(&default.key), ()).is_none() {
+            defaults.push(default);
+        }
+    }
+    defaults
+}
+
+fn yaml_value_from_field_default(default: &NewRowFieldDefault) -> Value {
+    match default.kind.as_str() {
+        "checkbox" => Value::Bool(default.value.value_bool.unwrap_or(false)),
+        "tags" | "relation" | "multi_select" => Value::Sequence(
+            if default.value.value_list.is_empty() {
+                default.value.value_text.iter().cloned().collect::<Vec<_>>()
+            } else {
+                default.value.value_list.clone()
+            }
+            .into_iter()
+            .map(Value::String)
+            .collect(),
+        ),
+        _ => default
+            .value
+            .value_text
+            .clone()
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+    }
+}
+
+fn create_new_row_markdown(
+    database: &DatabaseDefinition,
+    note_path: &str,
+    title: &str,
+) -> Result<String, String> {
     let mut mapping = Mapping::new();
     mapping.insert(key("title"), Value::String(title.to_string()));
+    for default in database_new_row_field_defaults(database) {
+        mapping.insert(key(&default.key), yaml_value_from_field_default(&default));
+    }
     mapping.insert(key("tags"), Value::Sequence(Vec::new()));
     render_note_markdown(note_path, "", mapping)
 }
@@ -528,7 +640,7 @@ pub async fn databases_create_row(
         };
         let mut index = 2;
         loop {
-            let next = create_new_row_markdown(&candidate, &title)?;
+            let next = create_new_row_markdown(&database, &candidate, &title)?;
             if write_new_markdown_note(&root, &recent_local_changes, &candidate, &next)? {
                 break;
             }

--- a/src-tauri/src/databases/query.rs
+++ b/src-tauri/src/databases/query.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
+use chrono::Datelike;
 use rusqlite::{params, Connection};
 
 use crate::index::commands::parse_raw_search_query;
@@ -225,14 +226,23 @@ fn cell_text_values(cell: &DatabaseCellValue) -> Vec<String> {
 }
 
 fn date_matches_shortcut(value: &str, shortcut: &str) -> bool {
-    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(value) else {
-        return false;
+    let date = match chrono::DateTime::parse_from_rfc3339(value) {
+        Ok(parsed) => parsed.with_timezone(&chrono::Local).date_naive(),
+        Err(_) => match chrono::NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d") {
+            Ok(parsed) => parsed,
+            Err(_) => return false,
+        },
     };
-    let date = parsed.with_timezone(&chrono::Local).date_naive();
     let today = chrono::Local::now().date_naive();
     match normalize_text(shortcut).as_str() {
         "today" => date == today,
         "yesterday" => date == today - chrono::Days::new(1),
+        "overdue" => date < today,
+        "this week" => {
+            let days_until_sunday = 6 - today.weekday().num_days_from_monday();
+            let week_end = today + chrono::Days::new(days_until_sunday as u64);
+            date >= today && date <= week_end
+        }
         "last 7 days" => date >= today - chrono::Days::new(6) && date <= today,
         "last 30 days" => date >= today - chrono::Days::new(29) && date <= today,
         _ => false,

--- a/src-tauri/src/databases/store.rs
+++ b/src-tauri/src/databases/store.rs
@@ -7,8 +7,8 @@ use crate::glyph_paths::ensure_glyph_dir;
 use crate::io_atomic;
 
 use super::types::{
-    DatabaseColumn, DatabaseDefinition, DatabaseFilter, DatabaseNewNoteConfig, DatabaseSchemaField,
-    DatabaseSource, DatabaseStore, DatabaseSummary, DatabaseViewDefinition,
+    DatabaseCellValue, DatabaseColumn, DatabaseDefinition, DatabaseFilter, DatabaseNewNoteConfig,
+    DatabaseSchemaField, DatabaseSource, DatabaseStore, DatabaseSummary, DatabaseViewDefinition,
 };
 
 const DATABASES_STORE_FILE: &str = "databases.json";
@@ -72,6 +72,7 @@ pub(crate) fn default_view(name: &str) -> DatabaseViewDefinition {
         grouping: None,
         board_lane_colors: Default::default(),
         board_lane_order: Default::default(),
+        board_card_order: Default::default(),
         created_at: now.clone(),
         updated_at: now,
     }
@@ -118,6 +119,7 @@ fn system_database(id: &str, name: &str, recent: bool) -> DatabaseDefinition {
                 label: "Title".to_string(),
                 kind: "title".to_string(),
                 property_key: None,
+                default_value: None,
                 relation_database_id: None,
             },
             DatabaseSchemaField {
@@ -125,6 +127,7 @@ fn system_database(id: &str, name: &str, recent: bool) -> DatabaseDefinition {
                 label: "Tags".to_string(),
                 kind: "tags".to_string(),
                 property_key: None,
+                default_value: None,
                 relation_database_id: None,
             },
             DatabaseSchemaField {
@@ -132,6 +135,7 @@ fn system_database(id: &str, name: &str, recent: bool) -> DatabaseDefinition {
                 label: "Updated".to_string(),
                 kind: "datetime".to_string(),
                 property_key: None,
+                default_value: None,
                 relation_database_id: None,
             },
         ],
@@ -149,6 +153,78 @@ fn normalize_frontmatter_property_kind(kind: &mut String) {
         return;
     }
     *kind = "text".to_string();
+}
+
+fn normalized_field_name(value: &str) -> String {
+    value
+        .trim()
+        .to_lowercase()
+        .replace(['_', '-'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn matches_field_name(label: &str, property_key: Option<&str>, names: &[&str]) -> bool {
+    let normalized_names = names
+        .iter()
+        .map(|name| normalized_field_name(name))
+        .collect::<Vec<_>>();
+    [Some(label), property_key]
+        .into_iter()
+        .flatten()
+        .map(normalized_field_name)
+        .any(|value| normalized_names.iter().any(|name| name == &value))
+}
+
+pub(crate) fn default_field_value(
+    label: &str,
+    kind: &str,
+    property_key: Option<&str>,
+) -> Option<DatabaseCellValue> {
+    let normalized_key = property_key.map(normalized_field_name).unwrap_or_default();
+    let normalized_label = normalized_field_name(label);
+    let is_status = kind == "status"
+        || normalized_key == "status"
+        || normalized_key.ends_with(" status")
+        || normalized_label == "status"
+        || normalized_label.ends_with(" status");
+    let default_text = if is_status {
+        Some("Not Started".to_string())
+    } else if matches_field_name(label, property_key, &["priority", "prio"]) {
+        Some("Medium".to_string())
+    } else {
+        None
+    };
+    if default_text.is_none() && kind != "checkbox" {
+        return None;
+    }
+    let is_list = matches!(kind, "tags" | "relation" | "multi_select");
+
+    Some(DatabaseCellValue {
+        kind: kind.to_string(),
+        value_text: if is_list { None } else { default_text.clone() },
+        value_bool: (kind == "checkbox").then_some(false),
+        value_list: if is_list {
+            default_text.into_iter().collect()
+        } else {
+            Vec::new()
+        },
+    })
+}
+
+fn normalize_schema_field_defaults(store: &mut DatabaseStore) {
+    for database in &mut store.databases {
+        for field in &mut database.schema {
+            if field.property_key.is_none() {
+                continue;
+            }
+            if field.default_value.is_none() {
+                field.default_value =
+                    default_field_value(&field.label, &field.kind, field.property_key.as_deref());
+            }
+        }
+    }
 }
 
 fn normalize_store_property_kinds(store: &mut DatabaseStore) {
@@ -221,6 +297,7 @@ pub fn load_store(space_root: &Path) -> Result<DatabaseStore, String> {
             normalize_store_property_kinds(&mut store);
             prune_unsupported_view_layouts(&mut store);
             normalize_status_colors(&mut store);
+            normalize_schema_field_defaults(&mut store);
             Ok(bootstrap_defaults(store))
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(default_store()),
@@ -245,6 +322,7 @@ pub fn bootstrap_defaults(mut store: DatabaseStore) -> DatabaseStore {
     store.version = DATABASES_STORE_VERSION;
     prune_unsupported_view_layouts(&mut store);
     normalize_status_colors(&mut store);
+    normalize_schema_field_defaults(&mut store);
     store
 }
 

--- a/src-tauri/src/databases/types.rs
+++ b/src-tauri/src/databases/types.rs
@@ -99,6 +99,8 @@ pub struct DatabaseViewDefinition {
     pub board_lane_colors: BTreeMap<String, String>,
     #[serde(default)]
     pub board_lane_order: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    pub board_card_order: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -111,6 +113,8 @@ pub struct DatabaseSchemaField {
     pub kind: String,
     #[serde(default)]
     pub property_key: Option<String>,
+    #[serde(default)]
+    pub default_value: Option<DatabaseCellValue>,
     #[serde(default)]
     pub relation_database_id: Option<String>,
 }

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -335,11 +335,11 @@ export const AllDocsPane = memo(function AllDocsPane({
 													{visibleTags.map((tag) => (
 														<span
 															key={`${note.note_path}:${tag}`}
-															className="databaseBoardTag"
+															className="allDocsCardTag"
 														>
 															<HugeiconsIcon
 																icon={Tag01Icon}
-																className="databaseTagPillIcon"
+																className="allDocsCardTagIcon"
 																size={11}
 																strokeWidth={1.2}
 															/>
@@ -347,7 +347,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 														</span>
 													))}
 													{extraTagCount > 0 ? (
-														<span className="databaseBoardTag is-muted">
+														<span className="allDocsCardTag is-muted">
 															+{extraTagCount}
 														</span>
 													) : null}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1326,7 +1326,7 @@ export function AppShell() {
 				showGettingStartedRequest={showGettingStartedRequest}
 				openDatabasesId={openDatabasesId}
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}
-				onOpenDailyNotesSettings={() => openSettings("general")}
+				onOpenDailyNotesSettings={() => openSettings("space")}
 				onRightSidebarOpenChange={setRightSidebarOpen}
 			/>
 			<AnimatePresence>

--- a/src/components/calendar/CalendarPane.tsx
+++ b/src/components/calendar/CalendarPane.tsx
@@ -9,7 +9,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useSpace, useUILayoutContext } from "../../contexts";
 import { useDailyNote } from "../../hooks/useDailyNote";
 import {
@@ -121,6 +121,10 @@ function getTaskGroupMeta(label: string): {
 	return { displayLabel: label };
 }
 
+function countLabel(count: number, singular: string, plural = `${singular}s`) {
+	return `${count} ${count === 1 ? singular : plural}`;
+}
+
 export function CalendarPane({
 	initialData = null,
 	onOpenFile,
@@ -135,6 +139,7 @@ export function CalendarPane({
 	const [anchorDate, setAnchorDate] = useState(
 		() => readStorage(ANCHOR_STORAGE_KEY) ?? initialSelectedDate,
 	);
+	const taskInputRef = useRef<HTMLInputElement>(null);
 	const normalizedAnchorDate = isDateInsideWeek(selectedDate, anchorDate)
 		? anchorDate
 		: selectedDate;
@@ -401,6 +406,20 @@ export function CalendarPane({
 		await openDailyNoteForDate(selectedDate);
 	}, [openDailyNoteForDate, selectedDate]);
 
+	const openTodayDailyNote = useCallback(async () => {
+		goToToday();
+		await openDailyNoteForDate(today);
+	}, [goToToday, openDailyNoteForDate, today]);
+
+	const focusTodayTaskComposer = useCallback(() => {
+		if (!dailyNotesFolder) {
+			onOpenDailyNotesSettings();
+			return;
+		}
+		goToToday();
+		window.requestAnimationFrame(() => taskInputRef.current?.focus());
+	}, [dailyNotesFolder, goToToday, onOpenDailyNotesSettings]);
+
 	const openNativeMenu = useCallback(
 		async (event: React.MouseEvent<HTMLButtonElement>) => {
 			await showNativePopupMenu(event, [
@@ -426,6 +445,22 @@ export function CalendarPane({
 	const overdueTasks = data?.tasks.overdue ?? [];
 	const ongoingTasks = data?.tasks.ongoing ?? [];
 	const noteActivity = data?.detail.note_activity ?? [];
+	const weekTaskCount = useMemo(
+		() => (data?.days ?? []).reduce((total, day) => total + day.task_count, 0),
+		[data?.days],
+	);
+	const weekNoteCount = useMemo(
+		() =>
+			(data?.days ?? []).reduce(
+				(total, day) => total + day.note_activity_count,
+				0,
+			),
+		[data?.days],
+	);
+	const weekDailyNoteCount = useMemo(
+		() => (data?.days ?? []).filter((day) => day.has_daily_note).length,
+		[data?.days],
+	);
 	const selectedDateObj = useMemo(
 		() => parseCalendarDate(selectedDate),
 		[selectedDate],
@@ -469,14 +504,13 @@ export function CalendarPane({
 	return (
 		<div className="calendarPaneOuter">
 			<section className="calendarPane">
-				<div className="calendarNativePanel">
-					<header className="calendarNativeTitlebar">
-						<div className="calendarNativeTitleBlock">
-							<h2 className="calendarNativeTitle">
-								{weekTitle(weekRange.dates)}
-							</h2>
+				<div className="calendarDashboard">
+					<header className="calendarDashboardHeader">
+						<div className="calendarDashboardTitleBlock">
+							<h2>{selectedHeading}</h2>
+							<p>{weekTitle(weekRange.dates)}</p>
 						</div>
-						<div className="calendarNativeActions">
+						<div className="calendarDashboardActions">
 							<Button
 								type="button"
 								variant="ghost"
@@ -495,7 +529,7 @@ export function CalendarPane({
 								type="button"
 								variant="ghost"
 								size="icon-xs"
-								className="sidebarTopIconButton"
+								className="sidebarTopIconButton calendarAccentIconButton"
 								onClick={goToToday}
 								aria-label="Today"
 							>
@@ -536,10 +570,70 @@ export function CalendarPane({
 						</div>
 					</header>
 
-					<div className="calendarWeekHeader">
-						<div className="calendarWeekMonth">
-							<span>{selectedMonth.month}</span>
-							<small>{selectedMonth.year}</small>
+					{error || calendarQuery.error ? (
+						<div className="calendarError">
+							{error ||
+								(calendarQuery.error instanceof Error
+									? calendarQuery.error.message
+									: String(calendarQuery.error))}
+						</div>
+					) : null}
+
+					<section
+						className="calendarCommandBar"
+						aria-label="Home quick actions"
+					>
+						<div className="calendarCommandTitle">
+							<h3>Home / Today</h3>
+						</div>
+						<div className="calendarCommandActions">
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="calendarAccentButton"
+								onClick={() => void openTodayDailyNote()}
+							>
+								<HugeiconsIcon icon={NoteIcon} size={14} strokeWidth={0.9} />
+								Open daily note
+							</Button>
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="calendarAccentButton"
+								onClick={focusTodayTaskComposer}
+							>
+								<HugeiconsIcon
+									icon={TaskAdd02Icon}
+									size={14}
+									strokeWidth={0.9}
+								/>
+								New task
+							</Button>
+						</div>
+					</section>
+
+					<section className="calendarWeekPanel">
+						<div className="calendarWeekHeader">
+							<div className="calendarWeekMonth">
+								<span>{selectedMonth.month}</span>
+								<small>{selectedMonth.year}</small>
+							</div>
+							<div className="calendarWeekStats" aria-label="Week summary">
+								<span>
+									<strong>{weekNoteCount}</strong>
+									notes
+								</span>
+								<span>
+									<strong>{weekTaskCount}</strong>
+									tasks
+								</span>
+								<span>
+									<strong>{weekDailyNoteCount}</strong>
+									daily notes
+								</span>
+							</div>
 						</div>
 						<div
 							className="calendarWeekStrip"
@@ -562,27 +656,22 @@ export function CalendarPane({
 								);
 							})}
 						</div>
-					</div>
+					</section>
 
-					{error || calendarQuery.error ? (
-						<div className="calendarError">
-							{error ||
-								(calendarQuery.error instanceof Error
-									? calendarQuery.error.message
-									: String(calendarQuery.error))}
-						</div>
-					) : null}
-
-					<section className="calendarPanelSection">
-						<div className="calendarPanelSectionHeader">
-							<h3>Notes</h3>
-							<div className="calendarPanelHeaderActions">
-								<span>{selectedHeading}</span>
+					<div className="calendarDashboardContent">
+						<section className="calendarPanelSection calendarNotesSection">
+							<div className="calendarPanelSectionHeader">
+								<div>
+									<h3>Notes</h3>
+									<span>
+										{countLabel(noteActivity.length, "note")} for this day
+									</span>
+								</div>
 								<Button
 									type="button"
 									variant="ghost"
 									size="icon-xs"
-									className="sidebarTopIconButton"
+									className="sidebarTopIconButton calendarAccentIconButton"
 									onClick={() => void openSelectedDailyNote()}
 									aria-label={`Open or create note for ${format(selectedDateObj, "MMM d")}`}
 									title={`Open or create note for ${format(selectedDateObj, "MMM d")}`}
@@ -590,97 +679,141 @@ export function CalendarPane({
 									<HugeiconsIcon icon={NoteIcon} size={13} strokeWidth={0.9} />
 								</Button>
 							</div>
-						</div>
-						<ul className="calendarNotesList">
-							{noteActivity.length === 0 ? (
-								<li className="calendarEmptyRow">No notes for this day</li>
-							) : null}
-							{noteActivity.map((note) => (
-								<li key={note.note_id}>
-									<button
-										type="button"
-										className="calendarNoteRow"
-										onClick={() => void onOpenFile(note.note_path)}
-										onMouseEnter={() => prefetchNote(note.note_path)}
-										onFocus={() => prefetchNote(note.note_path)}
-									>
-										<span>
-											<HugeiconsIcon
-												icon={NoteIcon}
-												size={14}
-												strokeWidth={0.9}
-											/>
-										</span>
-										<span className="calendarNoteTitle">{noteTitle(note)}</span>
-										<span className="calendarNoteTime">
-											{noteTimeLabel(note)}
-										</span>
-									</button>
-								</li>
-							))}
-						</ul>
-					</section>
+							<ul className="calendarNotesList">
+								{noteActivity.length === 0 ? (
+									<li className="calendarEmptyRow">No notes for this day</li>
+								) : null}
+								{noteActivity.map((note) => {
+									const visibleTags = note.tags.slice(0, 2);
+									const hiddenTagCount = Math.max(
+										0,
+										note.tags.length - visibleTags.length,
+									);
+									return (
+										<li key={note.note_id}>
+											<button
+												type="button"
+												className="calendarNoteRow"
+												onClick={() => void onOpenFile(note.note_path)}
+												onMouseEnter={() => prefetchNote(note.note_path)}
+												onFocus={() => prefetchNote(note.note_path)}
+											>
+												<span className="calendarNoteIcon">
+													<HugeiconsIcon
+														icon={NoteIcon}
+														size={14}
+														strokeWidth={0.9}
+													/>
+												</span>
+												<span className="calendarNoteBody">
+													<span className="calendarNoteTitleRow">
+														<span className="calendarNoteTitle">
+															{noteTitle(note)}
+														</span>
+														{visibleTags.length > 0 ? (
+															<span className="calendarNoteTags">
+																{visibleTags.map((tag) => (
+																	<span key={tag} className="calendarNoteTag">
+																		#{tag}
+																	</span>
+																))}
+																{hiddenTagCount > 0 ? (
+																	<span className="calendarNoteTag is-muted">
+																		+{hiddenTagCount}
+																	</span>
+																) : null}
+															</span>
+														) : null}
+													</span>
+													{note.preview ? (
+														<span className="calendarNotePreview">
+															{note.preview}
+														</span>
+													) : null}
+												</span>
+												<span className="calendarNoteTime">
+													{noteTimeLabel(note)}
+												</span>
+											</button>
+										</li>
+									);
+								})}
+							</ul>
+						</section>
 
-					<section className="calendarPanelSection calendarTasksSection">
-						<div className="calendarPanelSectionHeader">
-							<h3>Tasks</h3>
-						</div>
-						<div className="calendarTasksScrollArea">
-							{renderTaskGroup("For this day", agendaTasks)}
-							{renderTaskGroup("Overdue", overdueTasks)}
-							{renderTaskGroup("Ongoing", ongoingTasks)}
-							{agendaTasks.length === 0 &&
-							overdueTasks.length === 0 &&
-							ongoingTasks.length === 0 ? (
-								<div className="calendarEmptyRow">No tasks for this day</div>
-							) : null}
-						</div>
+						<section className="calendarPanelSection calendarTasksSection">
+							<div className="calendarPanelSectionHeader">
+								<div>
+									<h3>Tasks</h3>
+									<span>
+										{countLabel(
+											agendaTasks.length +
+												overdueTasks.length +
+												ongoingTasks.length,
+											"task",
+										)}{" "}
+										in view
+									</span>
+								</div>
+							</div>
+							<div className="calendarTasksScrollArea">
+								{renderTaskGroup("For this day", agendaTasks)}
+								{renderTaskGroup("Overdue", overdueTasks)}
+								{renderTaskGroup("Ongoing", ongoingTasks)}
+								{agendaTasks.length === 0 &&
+								overdueTasks.length === 0 &&
+								ongoingTasks.length === 0 ? (
+									<div className="calendarEmptyRow">No tasks for this day</div>
+								) : null}
+							</div>
 
-						{dailyNotesFolder ? (
-							<div className="calendarTaskComposer">
-								<span>+</span>
-								<Input
-									value={taskDraft}
-									onChange={(event) => setTaskDraft(event.target.value)}
-									placeholder="New task..."
-									onKeyDown={(event) => {
-										if (event.key === "Enter" && !event.shiftKey) {
-											event.preventDefault();
-											void submitTask();
-										}
-									}}
-								/>
-								<Button
-									type="button"
-									size="icon-xs"
-									variant="ghost"
-									className="sidebarTopIconButton"
-									onClick={() => void submitTask()}
-									disabled={submitTaskMutation.isPending || !taskDraft.trim()}
-									aria-label="Add task"
-								>
-									<HugeiconsIcon
-										icon={TaskAdd02Icon}
-										size={14}
-										strokeWidth={0.9}
+							{dailyNotesFolder ? (
+								<div className="calendarTaskComposer">
+									<span>+</span>
+									<Input
+										ref={taskInputRef}
+										value={taskDraft}
+										onChange={(event) => setTaskDraft(event.target.value)}
+										placeholder="New task..."
+										onKeyDown={(event) => {
+											if (event.key === "Enter" && !event.shiftKey) {
+												event.preventDefault();
+												void submitTask();
+											}
+										}}
 									/>
-								</Button>
-							</div>
-						) : (
-							<div className="calendarInlineSetup">
-								<span>Set a daily notes folder to add tasks here.</span>
-								<Button
-									type="button"
-									variant="ghost"
-									size="xs"
-									onClick={onOpenDailyNotesSettings}
-								>
-									<Settings size={13} />
-									Settings
-								</Button>
-							</div>
-						)}
-					</section>
+									<Button
+										type="button"
+										size="icon-xs"
+										variant="ghost"
+										className="sidebarTopIconButton calendarAccentIconButton"
+										onClick={() => void submitTask()}
+										disabled={submitTaskMutation.isPending || !taskDraft.trim()}
+										aria-label="Add task"
+									>
+										<HugeiconsIcon
+											icon={TaskAdd02Icon}
+											size={14}
+											strokeWidth={0.9}
+										/>
+									</Button>
+								</div>
+							) : (
+								<div className="calendarInlineSetup">
+									<span>Set a daily notes folder to add tasks here.</span>
+									<Button
+										type="button"
+										variant="ghost"
+										size="xs"
+										onClick={onOpenDailyNotesSettings}
+									>
+										<Settings size={13} />
+										Settings
+									</Button>
+								</div>
+							)}
+						</section>
+					</div>
 
 					{loading ? (
 						<div className="calendarLoading">Refreshing...</div>

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -369,12 +369,17 @@ function DatabaseBoardLaneView({
 						type="button"
 						className="databaseBoardLaneHandle"
 						disabled={lane.id === DATABASE_BOARD_EMPTY_LANE_ID}
-						aria-label={`Reorder ${lane.label} column`}
+						aria-label={
+							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
+								? "No value stays last"
+								: `Open ${lane.label} lane options`
+						}
 						title={
 							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
 								? "No value stays last"
 								: `Open ${lane.label} lane options`
 						}
+						aria-haspopup="menu"
 						onClick={handleLaneMenuClick}
 						onContextMenu={handleLaneContextMenu}
 					>
@@ -615,18 +620,18 @@ export function DatabaseBoard({
 			if (!row) return;
 			if (targetLaneId === sourceLaneId) {
 				if (targetNotePath && targetNotePath !== notePath) {
-					moveCardToLane(notePath, targetLaneId, targetNotePath);
+					moveCardToLane(notePath, targetLaneId, targetNotePath, sourceLaneId);
 				} else if (!targetNotePath) {
 					const targetLane = lanes.find((lane) => lane.id === targetLaneId);
 					const lastRow = targetLane?.rows[targetLane.rows.length - 1];
 					if (lastRow?.note_path !== notePath) {
-						moveCardToLane(notePath, targetLaneId, null);
+						moveCardToLane(notePath, targetLaneId, null, sourceLaneId);
 					}
 				}
 				return;
 			}
 			if (boardRowHasLane(row, groupColumn, targetLaneId)) {
-				moveCardToLane(notePath, targetLaneId, targetNotePath);
+				moveCardToLane(notePath, targetLaneId, targetNotePath, sourceLaneId);
 				return;
 			}
 			try {
@@ -636,7 +641,7 @@ export function DatabaseBoard({
 					groupColumn,
 					boardDropValue(row, groupColumn, targetLaneId, sourceLaneId),
 				);
-				moveCardToLane(notePath, targetLaneId, targetNotePath);
+				moveCardToLane(notePath, targetLaneId, targetNotePath, sourceLaneId);
 			} catch (error) {
 				setMoveError(extractErrorMessage(error));
 			}

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -30,16 +30,27 @@ import {
 	DATABASE_BOARD_EMPTY_LANE_ID,
 	type DatabaseBoardLane,
 	boardDropValue,
+	boardLaneIdFromLabel,
+	boardLaneValue,
 	boardRowHasLane,
+	canManageBoardLanes,
 } from "../../lib/database/board";
-import { formatDatabaseDateTime } from "../../lib/database/config";
+import {
+	databaseCellValueFromRow,
+	formatDatabaseDateTime,
+} from "../../lib/database/config";
 import { databaseValueToneStyleForColor } from "../../lib/database/palette";
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
 import { extractErrorMessage } from "../../lib/errorUtils";
-import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import {
+	type NativeContextMenuItem,
+	showNativeContextMenu,
+	showNativePopupMenu,
+} from "../../lib/nativeContextMenu";
 import { statusToneStyle } from "../../lib/statusProperties";
 import type { NoteTaskSummary } from "../../lib/tauri";
 import { parentDir } from "../../utils/path";
+import { Plus } from "../Icons";
 import {
 	EDITOR_TEXT_COLORS,
 	type EditorTextColor,
@@ -50,10 +61,19 @@ import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
 import { Button } from "../ui/shadcn/button";
 import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../ui/shadcn/dialog";
+import {
 	DropdownMenu,
 	DropdownMenuContent,
 	DropdownMenuTrigger,
 } from "../ui/shadcn/dropdown-menu";
+import { Input } from "../ui/shadcn/input";
 import { formatDatabaseTagLabel } from "./databaseTagLabel";
 
 interface DatabaseBoardProps {
@@ -67,9 +87,14 @@ interface DatabaseBoardProps {
 	onOpenColumns: () => void;
 	onGroupColumnIdChange: (groupColumnId: string | null) => void;
 	laneOrderByGroup?: Record<string, string[]>;
+	cardOrderByGroup?: Record<string, Record<string, string[]>>;
 	onLaneOrderChange?: (
 		groupColumnId: string,
 		laneOrder: string[],
+	) => void | Promise<void>;
+	onCardOrderChange?: (
+		groupColumnId: string,
+		cardOrder: Record<string, string[]>,
 	) => void | Promise<void>;
 	laneColors?: Record<string, string>;
 	statusColors?: Record<string, EditorTextColor>;
@@ -87,6 +112,12 @@ interface DatabaseBoardProps {
 			value_list: string[];
 		},
 	) => Promise<void>;
+}
+
+interface LaneEditState {
+	mode: "add" | "rename";
+	lane: DatabaseBoardLane | null;
+	value: string;
 }
 
 const EMPTY_LANE_COLORS: Record<string, string> = {};
@@ -162,6 +193,8 @@ interface DatabaseBoardLaneViewProps {
 	onLaneColorChange?:
 		| ((laneId: string, color: EditorTextColor | null) => void)
 		| null;
+	onAddLane?: () => void;
+	onRenameLane?: (lane: DatabaseBoardLane) => void;
 	reorderableLanes: DatabaseBoardLane[];
 	moveLaneToIndex: (sourceLaneId: string, targetIndex: number) => void;
 	children: ReactNode;
@@ -176,6 +209,8 @@ function DatabaseBoardLaneView({
 	isStatusGroup,
 	shouldReduceMotion,
 	onLaneColorChange,
+	onAddLane,
+	onRenameLane,
 	reorderableLanes,
 	moveLaneToIndex,
 	children,
@@ -185,22 +220,54 @@ function DatabaseBoardLaneView({
 		data: { laneId: lane.id },
 		accept: "database-board-card",
 	});
+	const laneMenuItems = useMemo<NativeContextMenuItem[]>(
+		() => [
+			...(onRenameLane
+				? [
+						{
+							label: `Rename ${lane.label}`,
+							action: () => onRenameLane(lane),
+						},
+					]
+				: []),
+			...(onAddLane
+				? [
+						{
+							label: "Add lane",
+							action: onAddLane,
+						},
+					]
+				: []),
+			...(onRenameLane || onAddLane ? [{ type: "separator" as const }] : []),
+			...reorderableLanes.map((targetLane, index) => ({
+				label: `Position ${index + 1}: ${targetLane.label}`,
+				enabled: targetLane.id !== lane.id,
+				action: () => moveLaneToIndex(lane.id, index),
+			})),
+		],
+		[lane, moveLaneToIndex, onAddLane, onRenameLane, reorderableLanes],
+	);
 	const handleLaneContextMenu = useCallback(
 		(event: MouseEvent<HTMLButtonElement>) => {
 			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
 
-			void showNativeContextMenu(
-				event,
-				reorderableLanes.map((targetLane, index) => ({
-					label: `Position ${index + 1}: ${targetLane.label}`,
-					enabled: targetLane.id !== lane.id,
-					action: () => moveLaneToIndex(lane.id, index),
-				})),
-			).catch((error: unknown) => {
+			void showNativeContextMenu(event, laneMenuItems).catch(
+				(error: unknown) => {
+					console.error("Failed to show board lane context menu", error);
+				},
+			);
+		},
+		[lane.id, laneMenuItems],
+	);
+	const handleLaneMenuClick = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
+
+			void showNativePopupMenu(event, laneMenuItems).catch((error: unknown) => {
 				console.error("Failed to show board lane context menu", error);
 			});
 		},
-		[lane.id, moveLaneToIndex, reorderableLanes],
+		[lane.id, laneMenuItems],
 	);
 
 	return (
@@ -208,6 +275,7 @@ function DatabaseBoardLaneView({
 			ref={ref}
 			className="databaseBoardLane"
 			data-show-column-color={showColumnColor ? "true" : "false"}
+			data-workflow-state={lane.workflowState}
 			style={
 				isStatusGroup
 					? statusToneStyle(lane.label, statusColors)
@@ -305,8 +373,9 @@ function DatabaseBoardLaneView({
 						title={
 							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
 								? "No value stays last"
-								: `Right-click to move ${lane.label}`
+								: `Open ${lane.label} lane options`
 						}
+						onClick={handleLaneMenuClick}
 						onContextMenu={handleLaneContextMenu}
 					>
 						<span className="databaseBoardLaneHandleDots" />
@@ -340,6 +409,14 @@ function DatabaseBoardCardView({
 	children,
 }: DatabaseBoardCardViewProps) {
 	const dragId = boardCardDragId(row.note_path, laneId);
+	const { ref: droppableRef, isDropTarget } = useDroppable({
+		id: `card:${dragId}`,
+		data: {
+			laneId,
+			notePath: row.note_path,
+		},
+		accept: "database-board-card",
+	});
 	const { ref, handleRef, isDragging } = useDraggable({
 		id: dragId,
 		type: "database-board-card",
@@ -351,10 +428,11 @@ function DatabaseBoardCardView({
 	});
 	const setCardRef = useCallback(
 		(element: HTMLButtonElement | null) => {
+			droppableRef(element);
 			ref(element);
 			handleRef(element);
 		},
-		[handleRef, ref],
+		[droppableRef, handleRef, ref],
 	);
 
 	return (
@@ -364,6 +442,7 @@ function DatabaseBoardCardView({
 			className="databaseBoardCard"
 			data-state={selected ? "selected" : undefined}
 			data-dragging={isDragging ? "true" : undefined}
+			data-drop-target={isDropTarget ? "true" : undefined}
 			onClick={() => {
 				if (suppressClickRef.current) return;
 				onSelectRow(row.note_path);
@@ -397,7 +476,9 @@ export function DatabaseBoard({
 	onOpenColumns,
 	onGroupColumnIdChange,
 	laneOrderByGroup = {},
+	cardOrderByGroup = {},
 	onLaneOrderChange,
+	onCardOrderChange,
 	laneColors = EMPTY_LANE_COLORS,
 	statusColors = {},
 	onLaneColorChange,
@@ -405,16 +486,26 @@ export function DatabaseBoard({
 	onSaveCell,
 }: DatabaseBoardProps) {
 	const shouldReduceMotion = useReducedMotion();
-	const { groupColumn, groupColumns, lanes, moveLaneToIndex } =
-		useDatabaseBoard({
-			rows,
-			columns,
-			initialGroupColumnId: persistedGroupColumnId,
-			initialLaneOrderByGroup: laneOrderByGroup,
-			onGroupColumnIdChange,
-			onLaneOrderChange,
-		});
+	const {
+		groupColumn,
+		groupColumns,
+		lanes,
+		addLane,
+		moveLaneToIndex,
+		renameLane,
+		moveCardToLane,
+	} = useDatabaseBoard({
+		rows,
+		columns,
+		initialGroupColumnId: persistedGroupColumnId,
+		initialLaneOrderByGroup: laneOrderByGroup,
+		initialCardOrderByGroup: cardOrderByGroup,
+		onGroupColumnIdChange,
+		onLaneOrderChange,
+		onCardOrderChange,
+	});
 	const [moveError, setMoveError] = useState("");
+	const [laneEdit, setLaneEdit] = useState<LaneEditState | null>(null);
 	const suppressClickRef = useRef(false);
 	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
 	const taskSummaryPaths = useMemo(
@@ -430,6 +521,7 @@ export function DatabaseBoard({
 		[lanes],
 	);
 	const isStatusGroup = groupColumn?.property_kind === "status";
+	const canManageLanes = canManageBoardLanes(groupColumn);
 	const handleLaneColorChange = useCallback(
 		(laneId: string, color: EditorTextColor | null) => {
 			if (isStatusGroup) {
@@ -441,19 +533,100 @@ export function DatabaseBoard({
 		[isStatusGroup, onLaneColorChange, onStatusColorChange],
 	);
 
+	const handleAddLane = useCallback(() => {
+		if (!groupColumn || !canManageLanes) return;
+		setMoveError("");
+		setLaneEdit({ mode: "add", lane: null, value: "" });
+	}, [canManageLanes, groupColumn]);
+
+	const handleRenameLane = useCallback(
+		(lane: DatabaseBoardLane) => {
+			if (!groupColumn || !canManageLanes) return;
+			setMoveError("");
+			setLaneEdit({ mode: "rename", lane, value: lane.label });
+		},
+		[canManageLanes, groupColumn],
+	);
+
+	const commitLaneEdit = useCallback(async () => {
+		if (!laneEdit || !groupColumn || !canManageLanes) return;
+		const laneId = boardLaneIdFromLabel(groupColumn, laneEdit.value);
+		if (!laneId) return;
+		if (
+			lanes.some((lane) => lane.id === laneId && lane.id !== laneEdit.lane?.id)
+		) {
+			setMoveError(`"${laneId}" already exists.`);
+			return;
+		}
+		setMoveError("");
+		if (laneEdit.mode === "add") {
+			addLane(laneId);
+			setLaneEdit(null);
+			return;
+		}
+		const lane = laneEdit.lane;
+		if (!lane || laneId === lane.id) {
+			setLaneEdit(null);
+			return;
+		}
+		try {
+			await Promise.all(
+				lane.rows.map((row) => {
+					const cell = databaseCellValueFromRow(row, groupColumn);
+					const value =
+						groupColumn.property_kind === "multi_select"
+							? {
+									kind: cell.kind,
+									value_list: Array.from(
+										new Set([
+											...cell.value_list.filter((value) => value !== lane.id),
+											laneId,
+										]),
+									),
+								}
+							: boardLaneValue(groupColumn, laneId);
+					return onSaveCell(row.note_path, groupColumn, value);
+				}),
+			);
+			renameLane(lane.id, laneId);
+			setLaneEdit(null);
+		} catch (error) {
+			setMoveError(extractErrorMessage(error));
+		}
+	}, [
+		addLane,
+		canManageLanes,
+		groupColumn,
+		laneEdit,
+		lanes,
+		onSaveCell,
+		renameLane,
+	]);
+
 	const handleLaneDrop = useCallback(
 		async (
 			notePath: string | null,
 			targetLaneId: string,
 			sourceLaneId?: string | null,
+			targetNotePath?: string | null,
 		) => {
 			if (!notePath || !groupColumn) return;
 			const row = rows.find((entry) => entry.note_path === notePath);
 			if (!row) return;
 			if (targetLaneId === sourceLaneId) {
+				if (targetNotePath && targetNotePath !== notePath) {
+					moveCardToLane(notePath, targetLaneId, targetNotePath);
+				} else if (!targetNotePath) {
+					const targetLane = lanes.find((lane) => lane.id === targetLaneId);
+					const lastRow = targetLane?.rows[targetLane.rows.length - 1];
+					if (lastRow?.note_path !== notePath) {
+						moveCardToLane(notePath, targetLaneId, null);
+					}
+				}
 				return;
 			}
 			if (boardRowHasLane(row, groupColumn, targetLaneId)) {
+				moveCardToLane(notePath, targetLaneId, targetNotePath);
 				return;
 			}
 			try {
@@ -463,11 +636,12 @@ export function DatabaseBoard({
 					groupColumn,
 					boardDropValue(row, groupColumn, targetLaneId, sourceLaneId),
 				);
+				moveCardToLane(notePath, targetLaneId, targetNotePath);
 			} catch (error) {
 				setMoveError(extractErrorMessage(error));
 			}
 		},
-		[groupColumn, onSaveCell, rows],
+		[groupColumn, lanes, moveCardToLane, onSaveCell, rows],
 	);
 
 	const handleDragEnd = useCallback(
@@ -481,20 +655,76 @@ export function DatabaseBoard({
 			const { source, target } = event.operation;
 			const notePath =
 				typeof source?.data.notePath === "string" ? source.data.notePath : null;
-			const targetLaneId = typeof target?.id === "string" ? target.id : null;
+			const targetLaneId =
+				typeof target?.data.laneId === "string"
+					? target.data.laneId
+					: typeof target?.id === "string"
+						? target.id
+						: null;
+			const targetNotePath =
+				typeof target?.data.notePath === "string" ? target.data.notePath : null;
 			const sourceLaneId =
 				typeof source?.data.sourceLaneId === "string"
 					? source.data.sourceLaneId
 					: null;
 			if (!targetLaneId) return;
 
-			void handleLaneDrop(notePath, targetLaneId, sourceLaneId);
+			void handleLaneDrop(notePath, targetLaneId, sourceLaneId, targetNotePath);
 		},
 		[handleLaneDrop],
 	);
 
 	return (
 		<div className="databaseBoardShell">
+			<Dialog
+				open={laneEdit != null}
+				onOpenChange={(open) => {
+					if (!open) setLaneEdit(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>
+							{laneEdit?.mode === "rename" ? "Rename lane" : "Add lane"}
+						</DialogTitle>
+						<DialogDescription>
+							{groupColumn
+								? `Set the ${groupColumn.label} value for this board lane.`
+								: "Set the board lane value."}
+						</DialogDescription>
+					</DialogHeader>
+					<form
+						className="grid gap-4"
+						onSubmit={(event) => {
+							event.preventDefault();
+							void commitLaneEdit();
+						}}
+					>
+						<Input
+							autoFocus
+							value={laneEdit?.value ?? ""}
+							aria-label="Lane name"
+							onChange={(event) =>
+								setLaneEdit((current) =>
+									current ? { ...current, value: event.target.value } : current,
+								)
+							}
+						/>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => setLaneEdit(null)}
+							>
+								Cancel
+							</Button>
+							<Button type="submit">
+								{laneEdit?.mode === "rename" ? "Rename" : "Add"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
 			{moveError ? (
 				<m.div
 					className="databaseBoardError"
@@ -549,6 +779,8 @@ export function DatabaseBoard({
 									isStatusGroup={isStatusGroup}
 									shouldReduceMotion={shouldReduceMotion}
 									onLaneColorChange={handleLaneColorChange}
+									onAddLane={canManageLanes ? handleAddLane : undefined}
+									onRenameLane={canManageLanes ? handleRenameLane : undefined}
 									reorderableLanes={reorderableLanes}
 									moveLaneToIndex={moveLaneToIndex}
 								>
@@ -685,11 +917,26 @@ export function DatabaseBoard({
 										})
 									) : (
 										<div className="databaseBoardLaneEmptyCard">
-											Drop notes here
+											{lane.workflowState === "archived"
+												? "Archive notes here"
+												: lane.workflowState === "done"
+													? "Completed notes land here"
+													: "Drop notes here"}
 										</div>
 									)}
 								</DatabaseBoardLaneView>
 							))}
+							{canManageLanes ? (
+								<button
+									type="button"
+									className="databaseBoardAddLaneButton"
+									onClick={handleAddLane}
+									title="Add lane"
+									aria-label="Add board lane"
+								>
+									<Plus size={14} aria-hidden="true" />
+								</button>
+							) : null}
 						</div>
 					</div>
 				</DragDropProvider>

--- a/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
@@ -190,7 +190,20 @@ function isFilterPresetApplied(
 			filter.column_id === preset.filter?.column_id &&
 			filter.operator === preset.filter.operator &&
 			(filter.value_text ?? "") === (preset.filter.value_text ?? "") &&
-			(filter.value_bool ?? null) === (preset.filter.value_bool ?? null),
+			(filter.value_bool ?? null) === (preset.filter.value_bool ?? null) &&
+			filterValueListsEqual(filter.value_list, preset.filter.value_list),
+	);
+}
+
+function filterValueListsEqual(
+	currentValueList: string[] | null | undefined,
+	presetValueList: string[] | null | undefined,
+): boolean {
+	const currentValues = currentValueList ?? [];
+	const presetValues = presetValueList ?? [];
+	return (
+		currentValues.length === presetValues.length &&
+		currentValues.every((value, index) => value === presetValues[index])
 	);
 }
 

--- a/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
@@ -3,23 +3,38 @@ import type {
 	DatabaseColumn,
 	DatabaseConfig,
 	DatabaseFilter,
+	DatabasePropertyOption,
 } from "../../lib/database/types";
 import { ChevronDown, Plus, Trash2 } from "../Icons";
 import { Input } from "../ui/shadcn/input";
 import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import { DatabaseTagPicker } from "./DatabaseTagPicker";
+import {
+	type DatabaseFilterPreset,
+	databaseFilterPresets,
+} from "./databaseViewPresets";
 
 interface FiltersPanelProps {
 	config: DatabaseConfig;
+	availableProperties: DatabasePropertyOption[];
 	filterError: string;
 	filterUiKeys: string[];
 	filterKeyCounterRef: MutableRefObject<number>;
 	defaultFilterColumn: DatabaseColumn | null;
+	onApplyFilterPreset: (preset: DatabaseFilterPreset) => void;
 	updateFilters: (
 		updater: (filters: DatabaseFilter[]) => DatabaseFilter[],
 		keyUpdater?: (keys: string[]) => string[],
 	) => Promise<void>;
 }
+
+const DATE_SHORTCUT_OPTIONS = [
+	"Overdue",
+	"Today",
+	"This Week",
+	"Last 7 Days",
+	"Last 30 Days",
+];
 
 function isTagFilterColumn(column?: DatabaseColumn | null): boolean {
 	return column?.type === "tags" || column?.property_kind === "tags";
@@ -102,7 +117,7 @@ function operatorLabel(operator: DatabaseFilter["operator"]): string {
 		case "none_of":
 			return "is none of";
 		case "within_last_7_days":
-			return "within last 7 days";
+			return "is";
 	}
 }
 
@@ -165,14 +180,31 @@ function FilterJoiner({ index }: { index: number }) {
 	);
 }
 
+function isFilterPresetApplied(
+	filters: DatabaseFilter[],
+	preset: DatabaseFilterPreset,
+): boolean {
+	if (!preset.filter) return false;
+	return filters.some(
+		(filter) =>
+			filter.column_id === preset.filter?.column_id &&
+			filter.operator === preset.filter.operator &&
+			(filter.value_text ?? "") === (preset.filter.value_text ?? "") &&
+			(filter.value_bool ?? null) === (preset.filter.value_bool ?? null),
+	);
+}
+
 export function FiltersPanel({
 	config,
+	availableProperties,
 	filterError,
 	filterUiKeys,
 	filterKeyCounterRef,
 	defaultFilterColumn,
+	onApplyFilterPreset,
 	updateFilters,
 }: FiltersPanelProps) {
+	const presets = databaseFilterPresets(config, availableProperties);
 	return (
 		<section
 			className="databaseViewOptionsPanel is-wide"
@@ -199,6 +231,27 @@ export function FiltersPanel({
 				Filters use database columns, tags, and note properties. To find words
 				in note text, use Search or this view's search box.
 			</p>
+			<div className="databaseViewPresetGroup" aria-label="Filter presets">
+				<span className="databaseViewPresetLabel">Presets</span>
+				<div className="databaseViewPresetChips">
+					{presets.map((preset) => {
+						const applied = isFilterPresetApplied(config.filters, preset);
+						return (
+							<button
+								key={preset.id}
+								type="button"
+								className="databaseViewPresetChip"
+								disabled={!preset.filter || applied}
+								data-active={applied ? "true" : "false"}
+								title={preset.disabledReason ?? preset.label}
+								onClick={() => onApplyFilterPreset(preset)}
+							>
+								{preset.label}
+							</button>
+						);
+					})}
+				</div>
+			</div>
 			{filterError ? (
 				<div className="databaseViewPanelError">{filterError}</div>
 			) : null}
@@ -294,7 +347,32 @@ export function FiltersPanel({
 										</option>
 									))}
 								</select>
-								{showsValue ? (
+								{filter.operator === "within_last_7_days" ? (
+									<select
+										className="databaseViewInlineSelect"
+										value={filter.value_text ?? "Last 7 Days"}
+										aria-label={`Filter ${index + 1} date range`}
+										onChange={(event) =>
+											void updateFilters((filters) =>
+												filters.map((entry, i) =>
+													i === index
+														? {
+																...entry,
+																value_text: event.target.value,
+																value_list: [],
+															}
+														: entry,
+												),
+											)
+										}
+									>
+										{DATE_SHORTCUT_OPTIONS.map((option) => (
+											<option key={option} value={option}>
+												{option}
+											</option>
+										))}
+									</select>
+								) : showsValue ? (
 									usesTagPicker ? (
 										<DatabaseTagPicker
 											value={filter.value_text ?? ""}

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -34,6 +34,11 @@ import {
 import { FiltersPanel } from "./DatabaseViewOptionsFiltersPanel";
 import { SortPanel } from "./DatabaseViewOptionsSortPanel";
 import { SourcePanel } from "./DatabaseViewOptionsSourcePanel";
+import {
+	type DatabaseFilterPreset,
+	type DatabaseSortPreset,
+	ensurePresetColumn,
+} from "./databaseViewPresets";
 
 type OptionsPanel = "source" | "columns" | "filters" | "sort";
 
@@ -391,6 +396,19 @@ export function DatabaseViewOptionsPopover({
 		}
 	};
 
+	const applyFilterPreset = async (preset: DatabaseFilterPreset) => {
+		if (!preset.filter || !preset.column) return;
+		const nextColumns = ensurePresetColumn(config.columns, preset.column);
+		const nextFilters = [...config.filters, preset.filter];
+		const saved = await updateConfig({
+			...config,
+			columns: nextColumns,
+			filters: nextFilters,
+		});
+		if (!saved) return;
+		setFilterUiKeys(deriveFilterUiKeys(nextFilters));
+	};
+
 	const defaultFilterColumn =
 		config.columns.find((column) => column.visible) ??
 		config.columns[0] ??
@@ -417,6 +435,15 @@ export function DatabaseViewOptionsPopover({
 					direction: patch.direction ?? activeSort?.direction ?? "asc",
 				},
 			],
+		});
+	};
+
+	const applySortPreset = (preset: DatabaseSortPreset) => {
+		if (!preset.sort || !preset.column) return;
+		void updateConfig({
+			...config,
+			columns: ensurePresetColumn(config.columns, preset.column),
+			sorts: [preset.sort],
 		});
 	};
 
@@ -485,20 +512,24 @@ export function DatabaseViewOptionsPopover({
 				{activePanel === "filters" ? (
 					<FiltersPanel
 						config={config}
+						availableProperties={availableProperties}
 						filterError={filterError}
 						filterUiKeys={filterUiKeys}
 						filterKeyCounterRef={filterKeyCounterRef}
 						defaultFilterColumn={defaultFilterColumn}
+						onApplyFilterPreset={applyFilterPreset}
 						updateFilters={updateFilters}
 					/>
 				) : null}
 				{activePanel === "sort" ? (
 					<SortPanel
 						config={config}
+						availableProperties={availableProperties}
 						activeSort={activeSort}
 						sortColumn={sortColumn}
 						sortDirection={sortDirection}
 						setSort={setSort}
+						onApplySortPreset={applySortPreset}
 						updateConfig={updateConfig}
 					/>
 				) : null}

--- a/src/components/database/DatabaseViewOptionsSortPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsSortPanel.tsx
@@ -1,17 +1,24 @@
 import type {
 	DatabaseColumn,
 	DatabaseConfig,
+	DatabasePropertyOption,
 	DatabaseSort,
 } from "../../lib/database/types";
 import { Plus } from "../Icons";
 import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
+import {
+	type DatabaseSortPreset,
+	databaseSortPresets,
+} from "./databaseViewPresets";
 
 interface SortPanelProps {
 	config: DatabaseConfig;
+	availableProperties: DatabasePropertyOption[];
 	activeSort: DatabaseSort | null;
 	sortColumn: DatabaseColumn | null;
 	sortDirection: "asc" | "desc";
 	setSort: (patch: Partial<DatabaseSort>) => void;
+	onApplySortPreset: (preset: DatabaseSortPreset) => void;
 	updateConfig: (config: DatabaseConfig) => Promise<boolean>;
 }
 
@@ -50,12 +57,15 @@ function directionLabel(
 
 export function SortPanel({
 	config,
+	availableProperties,
 	activeSort,
 	sortColumn,
 	sortDirection,
 	setSort,
+	onApplySortPreset,
 	updateConfig,
 }: SortPanelProps) {
+	const presets = databaseSortPresets(config, availableProperties);
 	return (
 		<section className="databaseViewOptionsPanel is-sort" aria-label="Sort by">
 			<div className="databaseViewPanelHeader">
@@ -69,6 +79,37 @@ export function SortPanel({
 						Reset
 					</button>
 				) : null}
+			</div>
+			<div className="databaseViewPresetGroup" aria-label="Sort presets">
+				<span className="databaseViewPresetLabel">Presets</span>
+				<div className="databaseViewPresetChips">
+					{presets.map((preset) => {
+						const presetSort = preset.sort;
+						const applied =
+							activeSort != null &&
+							presetSort != null &&
+							activeSort.column_id === presetSort.column_id &&
+							activeSort.direction === presetSort.direction;
+						return (
+							<button
+								key={preset.id}
+								type="button"
+								className="databaseViewPresetChip"
+								disabled={!presetSort || applied}
+								data-active={applied ? "true" : "false"}
+								title={
+									preset.disabledReason ??
+									(activeSort
+										? `Replace current sort with ${preset.label}`
+										: preset.label)
+								}
+								onClick={() => onApplySortPreset(preset)}
+							>
+								{preset.label}
+							</button>
+						);
+					})}
+				</div>
 			</div>
 			{activeSort ? (
 				<div className="databaseViewSortRow">

--- a/src/components/database/databaseViewPresets.ts
+++ b/src/components/database/databaseViewPresets.ts
@@ -1,0 +1,349 @@
+import { createPropertyColumn } from "../../lib/database/config";
+import type {
+	DatabaseColumn,
+	DatabaseConfig,
+	DatabaseFilter,
+	DatabasePropertyOption,
+	DatabaseSort,
+} from "../../lib/database/types";
+
+interface PresetColumnContext {
+	columns: DatabaseColumn[];
+	availableProperties: DatabasePropertyOption[];
+}
+
+export interface DatabaseFilterPreset {
+	id: string;
+	label: string;
+	filter: DatabaseFilter | null;
+	column: DatabaseColumn | null;
+	disabledReason: string | null;
+}
+
+export interface DatabaseSortPreset {
+	id: string;
+	label: string;
+	sort: DatabaseSort | null;
+	column: DatabaseColumn | null;
+	disabledReason: string | null;
+}
+
+const STATUS_PROPERTY_NAMES = ["status", "state", "stage"];
+const DUE_DATE_PROPERTY_NAMES = ["due date", "due", "deadline"];
+const PRIORITY_PROPERTY_NAMES = ["priority", "prio"];
+const OWNER_PROPERTY_NAMES = ["owner", "owners", "assignee", "assignees"];
+const BLOCKED_PROPERTY_NAMES = ["blocked tasks", "blocked", "blockers"];
+const PROJECT_STATUS_PROPERTY_NAMES = [
+	"project status",
+	...STATUS_PROPERTY_NAMES,
+];
+
+function normalizePresetKey(value: string | null | undefined): string {
+	return (value ?? "")
+		.trim()
+		.toLowerCase()
+		.replace(/[_-]+/g, " ")
+		.replace(/\s+/g, " ");
+}
+
+function hiddenPropertyColumn(
+	property: DatabasePropertyOption,
+): DatabaseColumn {
+	return {
+		...createPropertyColumn({ ...property, key: property.key.trim() }),
+		visible: false,
+	};
+}
+
+function columnMatchesName(column: DatabaseColumn, names: string[]): boolean {
+	const normalizedNames = new Set(names.map(normalizePresetKey));
+	return [column.property_key, column.label, column.id]
+		.map(normalizePresetKey)
+		.some((value) => normalizedNames.has(value));
+}
+
+function propertyMatchesName(
+	property: DatabasePropertyOption,
+	names: string[],
+): boolean {
+	const normalizedNames = new Set(names.map(normalizePresetKey));
+	return normalizedNames.has(normalizePresetKey(property.key));
+}
+
+function findPropertyColumn(
+	context: PresetColumnContext,
+	names: string[],
+	kinds?: string[],
+): DatabaseColumn | null {
+	const matchesKind = (kind: string | null | undefined) =>
+		!kinds || kinds.includes(kind ?? "");
+	const existing =
+		context.columns.find(
+			(column) =>
+				column.type === "property" &&
+				columnMatchesName(column, names) &&
+				matchesKind(column.property_kind),
+		) ??
+		context.columns.find(
+			(column) =>
+				column.type === "property" &&
+				columnMatchesName(column, names) &&
+				column.property_kind === "status",
+		);
+	if (existing) return existing;
+
+	const property =
+		context.availableProperties.find(
+			(option) =>
+				propertyMatchesName(option, names) && matchesKind(option.kind),
+		) ??
+		context.availableProperties.find(
+			(option) =>
+				propertyMatchesName(option, names) && option.kind === "status",
+		);
+	return property ? hiddenPropertyColumn(property) : null;
+}
+
+function statusColumn(context: PresetColumnContext): DatabaseColumn | null {
+	return (
+		context.columns.find(
+			(column) =>
+				column.type === "property" && column.property_kind === "status",
+		) ??
+		findPropertyColumn(context, STATUS_PROPERTY_NAMES, ["status", "text"]) ??
+		null
+	);
+}
+
+function dueDateColumn(context: PresetColumnContext): DatabaseColumn | null {
+	return findPropertyColumn(context, DUE_DATE_PROPERTY_NAMES, [
+		"date",
+		"datetime",
+		"text",
+	]);
+}
+
+function priorityColumn(context: PresetColumnContext): DatabaseColumn | null {
+	return findPropertyColumn(context, PRIORITY_PROPERTY_NAMES);
+}
+
+function ownerColumn(context: PresetColumnContext): DatabaseColumn | null {
+	return findPropertyColumn(context, OWNER_PROPERTY_NAMES);
+}
+
+function blockedTasksColumn(
+	context: PresetColumnContext,
+): DatabaseColumn | null {
+	return findPropertyColumn(context, BLOCKED_PROPERTY_NAMES);
+}
+
+function projectStatusColumn(
+	context: PresetColumnContext,
+): DatabaseColumn | null {
+	return (
+		findPropertyColumn(context, PROJECT_STATUS_PROPERTY_NAMES, [
+			"status",
+			"text",
+		]) ?? statusColumn(context)
+	);
+}
+
+function textFilter(
+	column: DatabaseColumn,
+	operator: DatabaseFilter["operator"],
+	value: string,
+): DatabaseFilter {
+	return {
+		column_id: column.id,
+		operator,
+		value_text: value,
+		value_list: [value],
+	};
+}
+
+function dateShortcutFilter(
+	column: DatabaseColumn,
+	value: string,
+): DatabaseFilter {
+	return {
+		column_id: column.id,
+		operator: "within_last_7_days",
+		value_text: value,
+		value_list: [],
+	};
+}
+
+function highPriorityValue(column: DatabaseColumn): string {
+	return column.property_kind === "number" ? "1" : "High";
+}
+
+function ownerOperator(column: DatabaseColumn): DatabaseFilter["operator"] {
+	if (column.property_kind === "tags") return "tags_contains";
+	if (column.property_kind === "multi_select") return "any_of";
+	return "equals";
+}
+
+function blockedTasksFilter(column: DatabaseColumn): DatabaseFilter {
+	if (column.property_kind === "checkbox") {
+		return {
+			column_id: column.id,
+			operator: "is_true",
+			value_list: [],
+		};
+	}
+	if (column.property_kind === "number") {
+		return textFilter(column, "greater_than", "0");
+	}
+	return textFilter(column, "contains", "Blocked");
+}
+
+function filterPreset(
+	id: string,
+	label: string,
+	column: DatabaseColumn | null,
+	buildFilter: (column: DatabaseColumn) => DatabaseFilter,
+	disabledReason: string,
+): DatabaseFilterPreset {
+	return {
+		id,
+		label,
+		column,
+		filter: column ? buildFilter(column) : null,
+		disabledReason: column ? null : disabledReason,
+	};
+}
+
+export function databaseFilterPresets(
+	config: DatabaseConfig,
+	availableProperties: DatabasePropertyOption[],
+): DatabaseFilterPreset[] {
+	const context = { columns: config.columns, availableProperties };
+	return [
+		filterPreset(
+			"status-not-done",
+			"Status is not Done",
+			statusColumn(context),
+			(column) => textFilter(column, "not_equals", "Done"),
+			"Add a Status property to use this preset.",
+		),
+		filterPreset(
+			"due-overdue",
+			"Due date is overdue",
+			dueDateColumn(context),
+			(column) => dateShortcutFilter(column, "Overdue"),
+			"Add a Due date property to use this preset.",
+		),
+		filterPreset(
+			"due-this-week",
+			"Due date is this week",
+			dueDateColumn(context),
+			(column) => dateShortcutFilter(column, "This Week"),
+			"Add a Due date property to use this preset.",
+		),
+		filterPreset(
+			"priority-high",
+			"Priority is High",
+			priorityColumn(context),
+			(column) => textFilter(column, "equals", highPriorityValue(column)),
+			"Add a Priority property to use this preset.",
+		),
+		filterPreset(
+			"owner-me",
+			'Owner is "me"',
+			ownerColumn(context),
+			(column) => textFilter(column, ownerOperator(column), "me"),
+			"Add an Owner property to use this preset.",
+		),
+		filterPreset(
+			"has-blocked-tasks",
+			"Has blocked tasks",
+			blockedTasksColumn(context),
+			blockedTasksFilter,
+			"Add a Blocked tasks property to use this preset.",
+		),
+		filterPreset(
+			"project-active",
+			"Project is active",
+			projectStatusColumn(context),
+			(column) => textFilter(column, "equals", "Active"),
+			"Add a Status property to use this preset.",
+		),
+	];
+}
+
+function sortPreset(
+	id: string,
+	label: string,
+	column: DatabaseColumn | null,
+	direction: DatabaseSort["direction"],
+	disabledReason: string,
+): DatabaseSortPreset {
+	return {
+		id,
+		label,
+		column,
+		sort: column ? { column_id: column.id, direction } : null,
+		disabledReason: column ? null : disabledReason,
+	};
+}
+
+export function databaseSortPresets(
+	config: DatabaseConfig,
+	availableProperties: DatabasePropertyOption[],
+): DatabaseSortPreset[] {
+	const context = { columns: config.columns, availableProperties };
+	const updatedColumn =
+		config.columns.find((column) => column.id === "updated") ?? null;
+	return [
+		sortPreset(
+			"updated-newest",
+			"Recently updated",
+			updatedColumn,
+			"desc",
+			"Updated column is unavailable.",
+		),
+		sortPreset(
+			"due-soon",
+			"Due date soon",
+			dueDateColumn(context),
+			"asc",
+			"Add a Due date property to use this sort.",
+		),
+		sortPreset(
+			"priority-high",
+			"Priority high first",
+			priorityColumn(context),
+			"asc",
+			"Add a Priority property to use this sort.",
+		),
+		sortPreset(
+			"status",
+			"Status",
+			statusColumn(context),
+			"asc",
+			"Add a Status property to use this sort.",
+		),
+		sortPreset(
+			"owner",
+			"Owner",
+			ownerColumn(context),
+			"asc",
+			"Add an Owner property to use this sort.",
+		),
+		sortPreset(
+			"project",
+			"Project",
+			findPropertyColumn(context, ["project", "projects"]),
+			"asc",
+			"Add a Project property to use this sort.",
+		),
+	];
+}
+
+export function ensurePresetColumn(
+	columns: DatabaseColumn[],
+	column: DatabaseColumn,
+): DatabaseColumn[] {
+	if (columns.some((entry) => entry.id === column.id)) return columns;
+	return [...columns, column];
+}

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -81,6 +81,7 @@ interface DatabasesPaneProps {
 
 const EMPTY_BOARD_LANE_COLORS: Record<string, string> = {};
 const EMPTY_BOARD_LANE_ORDER: Record<string, string[]> = {};
+const EMPTY_BOARD_CARD_ORDER: Record<string, Record<string, string[]>> = {};
 const MIN_DATABASE_COLUMN_WIDTH = 120;
 const MAX_DATABASE_COLUMN_WIDTH = 900;
 
@@ -112,6 +113,7 @@ function currentConfig(
 			board_group_by: view.grouping?.column_id ?? null,
 			board_lane_colors: view.board_lane_colors ?? EMPTY_BOARD_LANE_COLORS,
 			board_lane_order: view.board_lane_order ?? EMPTY_BOARD_LANE_ORDER,
+			board_card_order: view.board_card_order ?? EMPTY_BOARD_CARD_ORDER,
 		},
 		columns: view.columns,
 		sorts: view.sorts,
@@ -144,6 +146,8 @@ function replaceCurrentView(
 							config.view.board_lane_colors ?? EMPTY_BOARD_LANE_COLORS,
 						board_lane_order:
 							config.view.board_lane_order ?? EMPTY_BOARD_LANE_ORDER,
+						board_card_order:
+							config.view.board_card_order ?? EMPTY_BOARD_CARD_ORDER,
 						columns: config.columns,
 						sorts: config.sorts,
 						filters: config.filters,
@@ -691,6 +695,7 @@ function DatabasesPaneContent({
 					grouping: null,
 					board_lane_colors: {},
 					board_lane_order: {},
+					board_card_order: {},
 					created_at: now,
 					updated_at: now,
 				},
@@ -1173,6 +1178,9 @@ function DatabasesPaneContent({
 							laneOrderByGroup={
 								activeConfig.view.board_lane_order ?? EMPTY_BOARD_LANE_ORDER
 							}
+							cardOrderByGroup={
+								activeConfig.view.board_card_order ?? EMPTY_BOARD_CARD_ORDER
+							}
 							laneColors={activeConfig.view.board_lane_colors ?? {}}
 							statusColors={statusColors}
 							showColumnColor={showDatabaseColumnColor}
@@ -1197,6 +1205,18 @@ function DatabasesPaneContent({
 										board_lane_order: {
 											...(activeConfig.view.board_lane_order ?? {}),
 											[groupColumnId]: laneOrder,
+										},
+									},
+								})
+							}
+							onCardOrderChange={(groupColumnId, cardOrder) =>
+								void handleSaveConfig({
+									...activeConfig,
+									view: {
+										...activeConfig.view,
+										board_card_order: {
+											...(activeConfig.view.board_card_order ?? {}),
+											[groupColumnId]: cardOrder,
 										},
 									},
 								})

--- a/src/hooks/database/useDatabaseBoard.ts
+++ b/src/hooks/database/useDatabaseBoard.ts
@@ -430,6 +430,7 @@ export function useDatabaseBoard({
 			notePath: string,
 			targetLaneId: string,
 			targetNotePath?: string | null,
+			sourceLaneId?: string | null,
 		) => {
 			if (!groupColumn) return;
 			const displayedCardOrder = laneRowsById(lanes);
@@ -443,6 +444,7 @@ export function useDatabaseBoard({
 				notePath,
 				targetLaneId,
 				targetNotePath,
+				sourceLaneId,
 			);
 			if (cardOrdersEqual(currentCardOrder, nextCardOrder)) return;
 			displayedCardIdsRef.current = {

--- a/src/hooks/database/useDatabaseBoard.ts
+++ b/src/hooks/database/useDatabaseBoard.ts
@@ -12,7 +12,9 @@ import {
 	createBoardLanes,
 	defaultBoardGroupColumnId,
 	getBoardGroupColumns,
+	moveBoardCardToLane,
 	moveBoardLaneToIndex,
+	orderBoardLaneRows,
 	orderBoardLanes,
 } from "../../lib/database/board";
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
@@ -22,10 +24,15 @@ interface UseDatabaseBoardParams {
 	columns: DatabaseColumn[];
 	initialGroupColumnId?: string | null;
 	initialLaneOrderByGroup?: Record<string, string[]>;
+	initialCardOrderByGroup?: Record<string, Record<string, string[]>>;
 	onGroupColumnIdChange?: (groupColumnId: string | null) => void;
 	onLaneOrderChange?: (
 		groupColumnId: string,
 		laneOrder: string[],
+	) => void | Promise<void>;
+	onCardOrderChange?: (
+		groupColumnId: string,
+		cardOrder: Record<string, string[]>,
 	) => void | Promise<void>;
 }
 
@@ -49,6 +56,29 @@ function laneOrderRecordsEqual(
 		(key) =>
 			rightKeySet.has(key) &&
 			laneOrdersEqual(left[key] ?? [], right[key] ?? []),
+	);
+}
+
+function cardOrdersEqual(
+	left: Record<string, string[]>,
+	right: Record<string, string[]>,
+): boolean {
+	return laneOrderRecordsEqual(left, right);
+}
+
+function cardOrderRecordsEqual(
+	left: Record<string, Record<string, string[]>>,
+	right: Record<string, Record<string, string[]>>,
+): boolean {
+	const leftKeys = Object.keys(left);
+	const rightKeys = Object.keys(right);
+	if (leftKeys.length !== rightKeys.length) return false;
+
+	const rightKeySet = new Set(rightKeys);
+	return leftKeys.every(
+		(key) =>
+			rightKeySet.has(key) &&
+			cardOrdersEqual(left[key] ?? {}, right[key] ?? {}),
 	);
 }
 
@@ -85,13 +115,52 @@ function pruneLaneOrderRecord(
 	);
 }
 
+function pruneCardOrderRecord(
+	cardOrderByGroup: Record<string, Record<string, string[]>>,
+	activeGroupIds: Set<string>,
+): Record<string, Record<string, string[]>> {
+	return Object.fromEntries(
+		Object.entries(cardOrderByGroup).filter(([groupColumnId]) =>
+			activeGroupIds.has(groupColumnId),
+		),
+	);
+}
+
+function laneRowsById(lanes: DatabaseBoardLane[]): Record<string, string[]> {
+	return Object.fromEntries(
+		lanes.map((lane) => [lane.id, lane.rows.map((row) => row.note_path)]),
+	);
+}
+
+function mergeCardOrder(
+	currentCardOrder: Record<string, string[]>,
+	displayedCardOrder: Record<string, string[]>,
+): Record<string, string[]> {
+	const nextEntries = Object.entries(displayedCardOrder)
+		.map(([laneId, displayedOrder]) => {
+			const displayedSet = new Set(displayedOrder);
+			const currentOrder = currentCardOrder[laneId] ?? [];
+			const nextOrder = [
+				...currentOrder.filter((notePath) => displayedSet.has(notePath)),
+				...displayedOrder.filter(
+					(notePath) => !currentOrder.includes(notePath),
+				),
+			];
+			return [laneId, nextOrder] as const;
+		})
+		.filter(([, order]) => order.length > 0);
+	return Object.fromEntries(nextEntries);
+}
+
 export function useDatabaseBoard({
 	rows,
 	columns,
 	initialGroupColumnId = null,
 	initialLaneOrderByGroup = {},
+	initialCardOrderByGroup = {},
 	onGroupColumnIdChange,
 	onLaneOrderChange,
+	onCardOrderChange,
 }: UseDatabaseBoardParams) {
 	const groupColumns = useMemo(() => getBoardGroupColumns(columns), [columns]);
 	const [rawGroupColumnId, setRawGroupColumnId] = useState<string | null>(
@@ -100,14 +169,25 @@ export function useDatabaseBoard({
 	const [laneOrderByGroup, setLaneOrderByGroup] = useState<
 		Record<string, string[]>
 	>(() => initialLaneOrderByGroup);
+	const [cardOrderByGroup, setCardOrderByGroup] = useState<
+		Record<string, Record<string, string[]>>
+	>(() => initialCardOrderByGroup);
 	const displayedLaneIdsRef = useRef<Record<string, string[]>>(
 		initialLaneOrderByGroup,
 	);
+	const displayedCardIdsRef = useRef<Record<string, Record<string, string[]>>>(
+		initialCardOrderByGroup,
+	);
 	const onLaneOrderChangeRef = useRef(onLaneOrderChange);
+	const onCardOrderChangeRef = useRef(onCardOrderChange);
 
 	useEffect(() => {
 		onLaneOrderChangeRef.current = onLaneOrderChange;
 	}, [onLaneOrderChange]);
+
+	useEffect(() => {
+		onCardOrderChangeRef.current = onCardOrderChange;
+	}, [onCardOrderChange]);
 
 	useEffect(() => {
 		if (
@@ -124,6 +204,22 @@ export function useDatabaseBoard({
 				: initialLaneOrderByGroup,
 		);
 	}, [initialLaneOrderByGroup]);
+
+	useEffect(() => {
+		if (
+			cardOrderRecordsEqual(
+				displayedCardIdsRef.current,
+				initialCardOrderByGroup,
+			)
+		)
+			return;
+		displayedCardIdsRef.current = initialCardOrderByGroup;
+		setCardOrderByGroup((current) =>
+			cardOrderRecordsEqual(current, initialCardOrderByGroup)
+				? current
+				: initialCardOrderByGroup,
+		);
+	}, [initialCardOrderByGroup]);
 
 	const effectiveGroupColumnId = useMemo(() => {
 		const candidate = rawGroupColumnId ?? initialGroupColumnId;
@@ -142,14 +238,21 @@ export function useDatabaseBoard({
 	);
 
 	const lanes = useMemo(() => {
-		const rawLanes = createBoardLanes(rows, groupColumn);
-		if (!groupColumn) return rawLanes;
 		const previousLaneIds =
-			laneOrderByGroup[groupColumn.id] ??
-			displayedLaneIdsRef.current[groupColumn.id] ??
-			[];
-		return orderBoardLanes(rawLanes, previousLaneIds);
-	}, [groupColumn, laneOrderByGroup, rows]);
+			groupColumn != null
+				? (laneOrderByGroup[groupColumn.id] ??
+					displayedLaneIdsRef.current[groupColumn.id] ??
+					[])
+				: [];
+		const rawLanes = createBoardLanes(rows, groupColumn, previousLaneIds);
+		if (!groupColumn) return rawLanes;
+		const orderedLanes = orderBoardLanes(rawLanes, previousLaneIds);
+		const previousCardOrder =
+			cardOrderByGroup[groupColumn.id] ??
+			displayedCardIdsRef.current[groupColumn.id] ??
+			{};
+		return orderBoardLaneRows(orderedLanes, previousCardOrder);
+	}, [cardOrderByGroup, groupColumn, laneOrderByGroup, rows]);
 
 	useEffect(() => {
 		if (!groupColumn) return;
@@ -186,6 +289,39 @@ export function useDatabaseBoard({
 		void onLaneOrderChangeRef.current?.(groupColumn.id, nextLaneOrder);
 	}, [groupColumn, groupColumns, laneOrderByGroup, lanes]);
 
+	useEffect(() => {
+		if (!groupColumn) return;
+		const displayedCardOrder = laneRowsById(lanes);
+		const currentCardOrder =
+			cardOrderByGroup[groupColumn.id] ??
+			displayedCardIdsRef.current[groupColumn.id] ??
+			{};
+		const nextCardOrder = mergeCardOrder(currentCardOrder, displayedCardOrder);
+		if (cardOrdersEqual(currentCardOrder, nextCardOrder)) return;
+
+		const activeGroupIds = new Set(groupColumns.map((column) => column.id));
+		displayedCardIdsRef.current = pruneCardOrderRecord(
+			{
+				...displayedCardIdsRef.current,
+				[groupColumn.id]: nextCardOrder,
+			},
+			activeGroupIds,
+		);
+		setCardOrderByGroup((current) => {
+			const nextCardOrderByGroup = pruneCardOrderRecord(
+				{
+					...current,
+					[groupColumn.id]: nextCardOrder,
+				},
+				activeGroupIds,
+			);
+			return cardOrderRecordsEqual(current, nextCardOrderByGroup)
+				? current
+				: nextCardOrderByGroup;
+		});
+		void onCardOrderChangeRef.current?.(groupColumn.id, nextCardOrder);
+	}, [cardOrderByGroup, groupColumn, groupColumns, lanes]);
+
 	const moveLaneToIndex = useCallback(
 		(sourceLaneId: string, targetIndex: number) => {
 			if (!groupColumn) return;
@@ -216,12 +352,121 @@ export function useDatabaseBoard({
 		[groupColumn, groupColumns, laneOrderByGroup, lanes],
 	);
 
+	const addLane = useCallback(
+		(laneId: string) => {
+			if (!groupColumn || laneId === DATABASE_BOARD_EMPTY_LANE_ID) return;
+			const currentLaneOrder =
+				laneOrderByGroup[groupColumn.id] ??
+				displayedLaneIdsRef.current[groupColumn.id] ??
+				displayLaneOrder(lanes);
+			if (currentLaneOrder.includes(laneId)) return;
+			const nextLaneOrder = [...currentLaneOrder, laneId];
+			displayedLaneIdsRef.current = {
+				...displayedLaneIdsRef.current,
+				[groupColumn.id]: nextLaneOrder,
+			};
+			setLaneOrderByGroup((current) => ({
+				...current,
+				[groupColumn.id]: nextLaneOrder,
+			}));
+			void onLaneOrderChangeRef.current?.(groupColumn.id, nextLaneOrder);
+		},
+		[groupColumn, laneOrderByGroup, lanes],
+	);
+
+	const renameLane = useCallback(
+		(sourceLaneId: string, nextLaneId: string) => {
+			if (
+				!groupColumn ||
+				sourceLaneId === DATABASE_BOARD_EMPTY_LANE_ID ||
+				nextLaneId === DATABASE_BOARD_EMPTY_LANE_ID ||
+				sourceLaneId === nextLaneId
+			) {
+				return;
+			}
+
+			const currentLaneOrder =
+				laneOrderByGroup[groupColumn.id] ??
+				displayedLaneIdsRef.current[groupColumn.id] ??
+				displayLaneOrder(lanes);
+			const nextLaneOrder = currentLaneOrder.map((laneId) =>
+				laneId === sourceLaneId ? nextLaneId : laneId,
+			);
+			const currentCardOrder =
+				cardOrderByGroup[groupColumn.id] ??
+				displayedCardIdsRef.current[groupColumn.id] ??
+				{};
+			const nextCardOrder = Object.fromEntries(
+				Object.entries(currentCardOrder).map(([laneId, order]) => [
+					laneId === sourceLaneId ? nextLaneId : laneId,
+					order,
+				]),
+			);
+
+			displayedLaneIdsRef.current = {
+				...displayedLaneIdsRef.current,
+				[groupColumn.id]: nextLaneOrder,
+			};
+			displayedCardIdsRef.current = {
+				...displayedCardIdsRef.current,
+				[groupColumn.id]: nextCardOrder,
+			};
+			setLaneOrderByGroup((current) => ({
+				...current,
+				[groupColumn.id]: nextLaneOrder,
+			}));
+			setCardOrderByGroup((current) => ({
+				...current,
+				[groupColumn.id]: nextCardOrder,
+			}));
+			void onLaneOrderChangeRef.current?.(groupColumn.id, nextLaneOrder);
+			void onCardOrderChangeRef.current?.(groupColumn.id, nextCardOrder);
+		},
+		[cardOrderByGroup, groupColumn, laneOrderByGroup, lanes],
+	);
+
+	const moveCardToLane = useCallback(
+		(
+			notePath: string,
+			targetLaneId: string,
+			targetNotePath?: string | null,
+		) => {
+			if (!groupColumn) return;
+			const displayedCardOrder = laneRowsById(lanes);
+			const currentCardOrder =
+				cardOrderByGroup[groupColumn.id] ??
+				displayedCardIdsRef.current[groupColumn.id] ??
+				{};
+			const nextCardOrder = moveBoardCardToLane(
+				currentCardOrder,
+				displayedCardOrder,
+				notePath,
+				targetLaneId,
+				targetNotePath,
+			);
+			if (cardOrdersEqual(currentCardOrder, nextCardOrder)) return;
+			displayedCardIdsRef.current = {
+				...displayedCardIdsRef.current,
+				[groupColumn.id]: nextCardOrder,
+			};
+			setCardOrderByGroup((current) => ({
+				...current,
+				[groupColumn.id]: nextCardOrder,
+			}));
+			void onCardOrderChangeRef.current?.(groupColumn.id, nextCardOrder);
+		},
+		[cardOrderByGroup, groupColumn, lanes],
+	);
+
 	return {
 		groupColumns,
 		groupColumn,
 		groupColumnId: effectiveGroupColumnId,
 		lanes,
+		addLane,
 		moveLaneToIndex,
+		renameLane,
+		moveCardToLane,
 		setGroupColumnId: (nextColumnId: string | null) => {
 			startTransition(() => setRawGroupColumnId(nextColumnId));
 			onGroupColumnIdChange?.(nextColumnId);

--- a/src/lib/database/board.test.ts
+++ b/src/lib/database/board.test.ts
@@ -10,6 +10,7 @@ import {
 	createDatabaseRowGroups,
 	defaultBoardGroupColumnId,
 	getBoardGroupColumns,
+	moveBoardCardToLane,
 	moveBoardLaneToIndex,
 	orderBoardLanes,
 } from "./board";
@@ -243,6 +244,31 @@ describe("database board helpers", () => {
 				2,
 			),
 		).toEqual(["doing", "review", "backlog"]);
+	});
+
+	it("moves multi-membership cards without removing unrelated lanes", () => {
+		expect(
+			moveBoardCardToLane(
+				{
+					swift: ["Projects/One.md", "Projects/Two.md"],
+					ios: ["Projects/Two.md", "Projects/Three.md"],
+					project: ["Projects/Three.md", "Projects/Two.md"],
+				},
+				{
+					swift: ["Projects/One.md", "Projects/Two.md"],
+					ios: ["Projects/Two.md", "Projects/Three.md"],
+					project: ["Projects/Three.md", "Projects/Two.md"],
+				},
+				"Projects/Two.md",
+				"project",
+				"Projects/Three.md",
+				"swift",
+			),
+		).toEqual({
+			swift: ["Projects/One.md"],
+			ios: ["Projects/Two.md", "Projects/Three.md"],
+			project: ["Projects/Two.md", "Projects/Three.md"],
+		});
 	});
 
 	it("creates update payloads for the target lane", () => {

--- a/src/lib/database/board.test.ts
+++ b/src/lib/database/board.test.ts
@@ -192,15 +192,34 @@ describe("database board helpers", () => {
 
 	it("preserves existing lane order when rows refresh", () => {
 		const unordered = [
-			{ id: "done", label: "Done", cardCount: 1, rows: [firstRow] },
-			{ id: "backlog", label: "Backlog", cardCount: 2, rows: [secondRow] },
+			{
+				id: "done",
+				label: "Done",
+				cardCount: 1,
+				rows: [firstRow],
+				workflowState: "done" as const,
+			},
+			{
+				id: "backlog",
+				label: "Backlog",
+				cardCount: 2,
+				rows: [secondRow],
+				workflowState: "open" as const,
+			},
 			{
 				id: DATABASE_BOARD_EMPTY_LANE_ID,
 				label: "No value",
 				cardCount: 0,
 				rows: [],
+				workflowState: "open" as const,
 			},
-			{ id: "review", label: "Review", cardCount: 1, rows: [thirdRow] },
+			{
+				id: "review",
+				label: "Review",
+				cardCount: 1,
+				rows: [thirdRow],
+				workflowState: "open" as const,
+			},
 		];
 
 		expect(

--- a/src/lib/database/board.ts
+++ b/src/lib/database/board.ts
@@ -394,6 +394,7 @@ export function moveBoardCardToLane(
 	notePath: string,
 	targetLaneId: string,
 	targetNotePath?: string | null,
+	sourceLaneId?: string | string[] | null,
 ): Record<string, string[]> {
 	const nextOrder: Record<string, string[]> = {};
 	const laneIds = new Set([
@@ -401,22 +402,36 @@ export function moveBoardCardToLane(
 		...Object.keys(cardOrderByLane),
 		targetLaneId,
 	]);
+	const sourceLaneIds = new Set(
+		Array.isArray(sourceLaneId)
+			? sourceLaneId
+			: sourceLaneId
+				? [sourceLaneId]
+				: Object.entries(laneRowsById)
+						.filter(([, rows]) => rows.includes(notePath))
+						.map(([laneId]) => laneId),
+	);
 
 	for (const laneId of laneIds) {
 		const knownRows = laneRowsById[laneId] ?? [];
 		const knownRowSet = new Set(knownRows);
+		const shouldRemoveFromLane = sourceLaneIds.has(laneId);
 		nextOrder[laneId] = [
 			...(cardOrderByLane[laneId] ?? []).filter(
-				(path) => path !== notePath && knownRowSet.has(path),
+				(path) =>
+					(!shouldRemoveFromLane || path !== notePath) && knownRowSet.has(path),
 			),
 			...knownRows.filter(
 				(path) =>
-					path !== notePath && !(cardOrderByLane[laneId] ?? []).includes(path),
+					(!shouldRemoveFromLane || path !== notePath) &&
+					!(cardOrderByLane[laneId] ?? []).includes(path),
 			),
 		];
 	}
 
-	const targetRows = nextOrder[targetLaneId] ?? [];
+	const targetRows = (nextOrder[targetLaneId] ?? []).filter(
+		(path) => path !== notePath,
+	);
 	const targetIndex =
 		targetNotePath && targetNotePath !== notePath
 			? targetRows.indexOf(targetNotePath)

--- a/src/lib/database/board.ts
+++ b/src/lib/database/board.ts
@@ -1,14 +1,21 @@
-import { statusLabel, statusOptionFromValue } from "../statusProperties";
+import {
+	statusColorKey,
+	statusLabel,
+	statusOptionFromValue,
+} from "../statusProperties";
 import { databaseCellValueFromRow } from "./config";
 import type { DatabaseCellValue, DatabaseColumn, DatabaseRow } from "./types";
 
 export const DATABASE_BOARD_EMPTY_LANE_ID = "__empty__";
+
+export type DatabaseBoardWorkflowState = "open" | "done" | "archived";
 
 export interface DatabaseBoardLane {
 	id: string;
 	label: string;
 	cardCount: number;
 	rows: DatabaseRow[];
+	workflowState: DatabaseBoardWorkflowState;
 }
 
 export interface DatabaseRowGroup {
@@ -19,11 +26,21 @@ export interface DatabaseRowGroup {
 }
 
 function isMultiValueBoardColumn(column: DatabaseColumn): boolean {
-	return column.type === "tags" || column.property_kind === "tags";
+	return (
+		column.type === "tags" ||
+		column.property_kind === "tags" ||
+		column.property_kind === "multi_select"
+	);
 }
 
 function isBoardGroupColumn(column: DatabaseColumn): boolean {
-	return column.type === "tags" || column.type === "property";
+	return (
+		column.type === "tags" ||
+		(column.type === "property" &&
+			column.property_kind !== "relation" &&
+			column.property_kind !== "url" &&
+			column.property_kind !== "date")
+	);
 }
 
 export function getBoardGroupColumns(
@@ -41,6 +58,45 @@ export function defaultBoardGroupColumnId(
 function checkboxLaneLabel(value: boolean | null): string {
 	if (value == null) return "No value";
 	return value ? "Checked" : "Unchecked";
+}
+
+function laneWorkflowState(
+	column: DatabaseColumn,
+	laneId: string,
+	label: string,
+): DatabaseBoardWorkflowState {
+	if (laneId === DATABASE_BOARD_EMPTY_LANE_ID) return "open";
+	if (column.property_kind === "checkbox" && laneId === "true") return "done";
+	if (column.property_kind !== "status") return "open";
+	const key = statusColorKey(label);
+	if (key === "archived") return "archived";
+	if (key === "done" || key === "completed" || key === "success") {
+		return "done";
+	}
+	return "open";
+}
+
+function boardLaneLabel(column: DatabaseColumn, laneId: string): string {
+	if (laneId === DATABASE_BOARD_EMPTY_LANE_ID) return "No value";
+	if (column.property_kind === "checkbox") {
+		return checkboxLaneLabel(laneId === "true");
+	}
+	if (column.property_kind === "status") return statusLabel(laneId);
+	return laneId;
+}
+
+function createEmptyLane(
+	column: DatabaseColumn,
+	laneId: string,
+): DatabaseBoardLane {
+	const label = boardLaneLabel(column, laneId);
+	return {
+		id: laneId,
+		label,
+		cardCount: 0,
+		rows: [],
+		workflowState: laneWorkflowState(column, laneId, label),
+	};
 }
 
 function compareBoardRows(left: DatabaseRow, right: DatabaseRow): number {
@@ -75,6 +131,24 @@ function normalizeBoardTagValue(value: string): string | null {
 		.replace(/\s+/g, "-")
 		.replace(/[^a-z0-9_/-]/g, "");
 	return normalized || null;
+}
+
+export function canManageBoardLanes(column: DatabaseColumn | null): boolean {
+	return (
+		column?.type === "property" &&
+		(column.property_kind === "status" ||
+			column.property_kind === "multi_select")
+	);
+}
+
+export function boardLaneIdFromLabel(
+	column: DatabaseColumn,
+	label: string,
+): string | null {
+	const trimmed = label.trim();
+	if (!trimmed) return null;
+	if (column.property_kind === "status") return statusLabel(trimmed);
+	return trimmed;
 }
 
 function rawLaneValues(row: DatabaseRow, column: DatabaseColumn): string[] {
@@ -127,6 +201,7 @@ export function boardLaneIdForRow(
 export function createBoardLanes(
 	rows: DatabaseRow[],
 	column: DatabaseColumn | null,
+	configuredLaneIds: string[] = [],
 ): DatabaseBoardLane[] {
 	if (!column) return [];
 
@@ -146,27 +221,48 @@ export function createBoardLanes(
 				label: checkboxLaneLabel(false),
 				cardCount: buckets.get("false")?.length ?? 0,
 				rows: sortLaneRows(buckets.get("false") ?? []),
+				workflowState: laneWorkflowState(
+					column,
+					"false",
+					checkboxLaneLabel(false),
+				),
 			},
 			{
 				id: "true",
 				label: checkboxLaneLabel(true),
 				cardCount: buckets.get("true")?.length ?? 0,
 				rows: sortLaneRows(buckets.get("true") ?? []),
+				workflowState: laneWorkflowState(
+					column,
+					"true",
+					checkboxLaneLabel(true),
+				),
 			},
 			{
 				id: DATABASE_BOARD_EMPTY_LANE_ID,
 				label: checkboxLaneLabel(null),
 				cardCount: buckets.get(DATABASE_BOARD_EMPTY_LANE_ID)?.length ?? 0,
 				rows: sortLaneRows(buckets.get(DATABASE_BOARD_EMPTY_LANE_ID) ?? []),
+				workflowState: laneWorkflowState(
+					column,
+					DATABASE_BOARD_EMPTY_LANE_ID,
+					checkboxLaneLabel(null),
+				),
 			},
 		];
 	}
 
 	const lanes = new Map<string, DatabaseBoardLane>();
+	if (canManageBoardLanes(column)) {
+		for (const laneId of configuredLaneIds) {
+			if (laneId === DATABASE_BOARD_EMPTY_LANE_ID || lanes.has(laneId))
+				continue;
+			lanes.set(laneId, createEmptyLane(column, laneId));
+		}
+	}
 	for (const row of rows) {
 		for (const laneId of boardLaneIdsForRow(row, column)) {
-			const label =
-				laneId === DATABASE_BOARD_EMPTY_LANE_ID ? "No value" : laneId;
+			const label = boardLaneLabel(column, laneId);
 			const existing = lanes.get(laneId);
 			if (existing) {
 				existing.rows.push(row);
@@ -178,6 +274,7 @@ export function createBoardLanes(
 				label,
 				cardCount: 1,
 				rows: [row],
+				workflowState: laneWorkflowState(column, laneId, label),
 			});
 		}
 	}
@@ -188,6 +285,7 @@ export function createBoardLanes(
 			label: "No value",
 			cardCount: 0,
 			rows: [],
+			workflowState: "open",
 		});
 	}
 
@@ -202,11 +300,7 @@ export function createBoardLanes(
 }
 
 function groupLabel(column: DatabaseColumn, laneId: string): string {
-	if (laneId === DATABASE_BOARD_EMPTY_LANE_ID) return "No value";
-	if (column.property_kind === "checkbox") {
-		return checkboxLaneLabel(laneId === "true");
-	}
-	return laneId;
+	return boardLaneLabel(column, laneId);
 }
 
 export function createDatabaseRowGroups(
@@ -274,6 +368,68 @@ export function orderBoardLanes(
 		.filter((lane): lane is DatabaseBoardLane => lane != null);
 }
 
+export function orderBoardLaneRows(
+	lanes: DatabaseBoardLane[],
+	cardOrderByLane: Record<string, string[]>,
+): DatabaseBoardLane[] {
+	return lanes.map((lane) => {
+		const rowByPath = new Map(lane.rows.map((row) => [row.note_path, row]));
+		const orderedRows = (cardOrderByLane[lane.id] ?? [])
+			.map((notePath) => rowByPath.get(notePath))
+			.filter((row): row is DatabaseRow => row != null);
+		const orderedPathSet = new Set(orderedRows.map((row) => row.note_path));
+		return {
+			...lane,
+			rows: [
+				...orderedRows,
+				...lane.rows.filter((row) => !orderedPathSet.has(row.note_path)),
+			],
+		};
+	});
+}
+
+export function moveBoardCardToLane(
+	cardOrderByLane: Record<string, string[]>,
+	laneRowsById: Record<string, string[]>,
+	notePath: string,
+	targetLaneId: string,
+	targetNotePath?: string | null,
+): Record<string, string[]> {
+	const nextOrder: Record<string, string[]> = {};
+	const laneIds = new Set([
+		...Object.keys(laneRowsById),
+		...Object.keys(cardOrderByLane),
+		targetLaneId,
+	]);
+
+	for (const laneId of laneIds) {
+		const knownRows = laneRowsById[laneId] ?? [];
+		const knownRowSet = new Set(knownRows);
+		nextOrder[laneId] = [
+			...(cardOrderByLane[laneId] ?? []).filter(
+				(path) => path !== notePath && knownRowSet.has(path),
+			),
+			...knownRows.filter(
+				(path) =>
+					path !== notePath && !(cardOrderByLane[laneId] ?? []).includes(path),
+			),
+		];
+	}
+
+	const targetRows = nextOrder[targetLaneId] ?? [];
+	const targetIndex =
+		targetNotePath && targetNotePath !== notePath
+			? targetRows.indexOf(targetNotePath)
+			: -1;
+	const boundedTargetIndex = targetIndex >= 0 ? targetIndex : targetRows.length;
+	targetRows.splice(boundedTargetIndex, 0, notePath);
+	nextOrder[targetLaneId] = targetRows;
+
+	return Object.fromEntries(
+		Object.entries(nextOrder).filter(([, order]) => order.length > 0),
+	);
+}
+
 export function moveBoardLaneToIndex(
 	laneIds: string[],
 	sourceLaneId: string,
@@ -334,6 +490,15 @@ export function boardDropValue(
 			return {
 				kind: cell.kind,
 				value_list: [],
+			};
+		}
+		if (column.property_kind === "multi_select") {
+			return {
+				kind: cell.kind,
+				value_list: uniqueLaneValues([
+					...cell.value_list.filter((value) => value !== _sourceLaneId),
+					laneId,
+				]),
 			};
 		}
 		if (column.type === "tags" || column.property_kind === "tags") {

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -141,6 +141,16 @@ function normalizeTagText(value: string | null | undefined): string {
 	return normalizeText(value).replace(/^#+/, "");
 }
 
+function isTagColumn(column: DatabaseColumn): boolean {
+	return column.type === "tags" || column.property_kind === "tags";
+}
+
+function tagMatchesHierarchy(filterValue: string, cellValue: string): boolean {
+	const filterTag = normalizeTagText(filterValue);
+	const cellTag = normalizeTagText(cellValue);
+	return cellTag === filterTag || cellTag.startsWith(`${filterTag}/`);
+}
+
 function parseFilterNumber(value: string): number | null {
 	const normalized = value.trim().replace(/[$,%]/g, "");
 	if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/.test(normalized)) {
@@ -148,6 +158,70 @@ function parseFilterNumber(value: string): number | null {
 	}
 	const parsed = Number(normalized);
 	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseFilterDate(value: string | null | undefined): Date | null {
+	if (!value) return null;
+	const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+	if (dateOnly) {
+		const [, year, month, day] = dateOnly;
+		return new Date(Number(year), Number(month) - 1, Number(day));
+	}
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function startOfToday(): Date {
+	const today = new Date();
+	return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+}
+
+function weekEndFromToday(today: Date): Date {
+	const day = today.getDay();
+	const daysUntilSunday = (7 - day) % 7;
+	const end = new Date(today);
+	end.setDate(today.getDate() + daysUntilSunday);
+	return end;
+}
+
+function dateMatchesShortcut(
+	value: string | null | undefined,
+	shortcut: string,
+): boolean {
+	const parsed = parseFilterDate(value);
+	if (!parsed) return false;
+	const date = new Date(
+		parsed.getFullYear(),
+		parsed.getMonth(),
+		parsed.getDate(),
+	);
+	const today = startOfToday();
+	const normalized = normalizeText(shortcut);
+	switch (normalized) {
+		case "today":
+			return date.getTime() === today.getTime();
+		case "yesterday": {
+			const yesterday = new Date(today);
+			yesterday.setDate(today.getDate() - 1);
+			return date.getTime() === yesterday.getTime();
+		}
+		case "overdue":
+			return date < today;
+		case "this week":
+			return date >= today && date <= weekEndFromToday(today);
+		case "last 7 days": {
+			const start = new Date(today);
+			start.setDate(today.getDate() - 6);
+			return date >= start && date <= today;
+		}
+		case "last 30 days": {
+			const start = new Date(today);
+			start.setDate(today.getDate() - 29);
+			return date >= start && date <= today;
+		}
+		default:
+			return false;
+	}
 }
 
 function cellTextValues(cell: DatabaseCellValue): string[] {
@@ -173,17 +247,26 @@ export function rowMatchesFilters(
 		);
 		const listValues = cell.value_list.map(normalizeText).filter(Boolean);
 		const textValues = cellTextValues(cell);
+		const values = [...textValues, ...listValues];
 		switch (filter.operator) {
 			case "contains":
 				if (!filterText) return true;
-				return [...textValues, ...listValues].some((value) =>
-					value.includes(filterText),
-				);
+				return values.some((value) => value.includes(filterText));
 			case "equals":
 				if (!filterText) return true;
-				return [...textValues, ...listValues].some(
-					(value) => value === filterText,
-				);
+				return values.some((value) => value === filterText);
+			case "not_equals":
+				if (!filterText) return true;
+				return values.every((value) => value !== filterText);
+			case "not_contains":
+				if (!filterText) return true;
+				return values.every((value) => !value.includes(filterText));
+			case "starts_with":
+				if (!filterText) return true;
+				return values.some((value) => value.startsWith(filterText));
+			case "ends_with":
+				if (!filterText) return true;
+				return values.some((value) => value.endsWith(filterText));
 			case "is_empty":
 				return (
 					textValues.length === 0 &&
@@ -202,14 +285,52 @@ export function rowMatchesFilters(
 				return cell.value_bool === false;
 			case "tags_contains":
 				if (!filterText) return true;
-				return cell.value_list.some(
-					(value) => normalizeTagText(value) === normalizeTagText(filterText),
+				return cell.value_list.some((value) =>
+					tagMatchesHierarchy(filterText, value),
+				);
+			case "any_of": {
+				const filterValues =
+					filter.value_list.length > 0
+						? filter.value_list
+						: filter.value_text
+							? [filter.value_text]
+							: [];
+				if (filterValues.length === 0) return true;
+				const normalizedFilters = filterValues.map(normalizeText);
+				return values.some((value) =>
+					normalizedFilters.some((filterValue) =>
+						isTagColumn(column)
+							? tagMatchesHierarchy(filterValue, value)
+							: value === filterValue,
+					),
+				);
+			}
+			case "none_of": {
+				const filterValues =
+					filter.value_list.length > 0
+						? filter.value_list
+						: filter.value_text
+							? [filter.value_text]
+							: [];
+				const normalizedFilters = filterValues.map(normalizeText);
+				return values.every((value) =>
+					normalizedFilters.every((filterValue) =>
+						isTagColumn(column)
+							? !tagMatchesHierarchy(filterValue, value)
+							: value !== filterValue,
+					),
+				);
+			}
+			case "within_last_7_days":
+				return dateMatchesShortcut(
+					cell.value_text,
+					filter.value_text ?? "Last 7 Days",
 				);
 			case "greater_than":
 			case "less_than": {
 				const filterNumber = parseFilterNumber(filterText);
 				if (filterNumber == null) return true;
-				return [...textValues, ...listValues].some((value) => {
+				return values.some((value) => {
 					const cellNumber = parseFilterNumber(value);
 					if (cellNumber == null) return false;
 					return filter.operator === "greater_than"

--- a/src/lib/nativeContextMenu.ts
+++ b/src/lib/nativeContextMenu.ts
@@ -36,8 +36,10 @@ interface NativeContextMenuEvent {
 	stopPropagation: () => void;
 }
 
-interface NativePopupMenuEvent extends NativeContextMenuEvent {
+interface NativePopupMenuEvent {
 	currentTarget: Element;
+	preventDefault: () => void;
+	stopPropagation: () => void;
 }
 
 interface NativeMenuResult {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -113,6 +113,7 @@ interface DatabaseViewState {
 	board_group_by?: string | null;
 	board_lane_colors?: Record<string, string>;
 	board_lane_order?: Record<string, string[]>;
+	board_card_order?: Record<string, Record<string, string[]>>;
 }
 
 export interface DatabaseColumn {
@@ -209,6 +210,7 @@ interface WorkspaceDatabaseView {
 	grouping?: WorkspaceDatabaseGrouping | null;
 	board_lane_colors?: Record<string, string>;
 	board_lane_order?: Record<string, string[]>;
+	board_card_order?: Record<string, Record<string, string[]>>;
 	created_at: string;
 	updated_at: string;
 }
@@ -218,6 +220,7 @@ interface WorkspaceDatabaseSchemaField {
 	label: string;
 	kind: string;
 	property_key?: string | null;
+	default_value?: DatabaseCellValue | null;
 	relation_database_id?: string | null;
 }
 

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -261,6 +261,37 @@
 	overflow: hidden;
 }
 
+.allDocsCardTag {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	max-width: 100%;
+	flex: 0 0 auto;
+	padding: 2px 7px;
+	border: 0;
+	border-radius: 4px;
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 9%,
+		var(--bg-primary)
+	);
+	color: color-mix(in srgb, var(--interactive-accent) 62%, var(--text-primary));
+	font-size: 0.68rem;
+	font-weight: var(--font-medium);
+	line-height: 1.2;
+	white-space: nowrap;
+}
+
+.allDocsCardTag.is-muted {
+	background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
+	color: var(--text-tertiary);
+}
+
+.allDocsCardTagIcon {
+	flex: 0 0 auto;
+	color: currentcolor;
+}
+
 @media (max-width: 900px) {
 	.allDocsGrid {
 		grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -610,6 +610,61 @@
 	line-height: 1.35;
 }
 
+.databaseViewPresetGroup {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin: -2px 4px 10px;
+	padding: 8px;
+	border-radius: var(--database-control-radius);
+	background: color-mix(in srgb, var(--bg-secondary) 52%, transparent);
+}
+
+.databaseViewPresetLabel {
+	color: var(--text-tertiary);
+	font-size: 0.72rem;
+	font-weight: var(--font-medium);
+}
+
+.databaseViewPresetChips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.databaseViewPresetChip {
+	min-height: 28px;
+	max-width: 100%;
+	padding: 0 9px;
+	border: 1px solid var(--database-control-border);
+	border-radius: var(--database-control-radius);
+	background: color-mix(in srgb, var(--bg-primary) 76%, var(--bg-secondary));
+	color: var(--text-secondary);
+	font-size: 0.78rem;
+	font-weight: var(--font-medium);
+	cursor: pointer;
+}
+
+.databaseViewPresetChip:hover:not(:disabled),
+.databaseViewPresetChip[data-active="true"] {
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 42%,
+		var(--database-control-border)
+	);
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 10%,
+		var(--bg-primary)
+	);
+	color: var(--interactive-accent);
+}
+
+.databaseViewPresetChip:disabled {
+	cursor: default;
+	opacity: 0.55;
+}
+
 .databaseViewPanelError {
 	margin: 0 8px 8px;
 	color: var(--text-error);

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -76,6 +76,15 @@
 	background: transparent;
 }
 
+.databaseBoardLane[data-workflow-state="done"] {
+	background: color-mix(in srgb, var(--database-tone) 5%, var(--bg-secondary));
+}
+
+.databaseBoardLane[data-workflow-state="archived"] {
+	opacity: 0.82;
+	background: color-mix(in srgb, var(--text-tertiary) 7%, var(--bg-secondary));
+}
+
 .databaseBoardLane[data-active="true"] {
 	background: color-mix(in srgb, var(--database-tone) 9%, var(--bg-secondary));
 	outline: 1px solid color-mix(in srgb, var(--database-tone) 24%, transparent);
@@ -206,6 +215,12 @@
 .databaseBoardCard[data-dragging="true"] {
 	opacity: 0.7;
 	outline-color: color-mix(in srgb, var(--interactive-accent) 38%, transparent);
+}
+
+.databaseBoardCard[data-drop-target="true"] {
+	outline-color: color-mix(in srgb, var(--interactive-accent) 50%, transparent);
+	box-shadow: inset 0 2px 0
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
 }
 
 .databaseBoardCard[data-state="selected"] {
@@ -376,6 +391,26 @@
 	font-size: 0.94rem;
 	font-weight: var(--font-semibold);
 	color: var(--text-primary);
+}
+
+.databaseBoardAddLaneButton {
+	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 34px;
+	height: 34px;
+	margin-top: 10px;
+	border: 1px dashed color-mix(in srgb, var(--border-default) 78%, transparent);
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
+	color: var(--text-tertiary);
+	cursor: pointer;
+}
+
+.databaseBoardAddLaneButton:hover {
+	color: var(--text-primary);
+	background: var(--bg-hover);
 }
 
 .databaseTable {

--- a/src/styles/app/42-calendar.css
+++ b/src/styles/app/42-calendar.css
@@ -11,42 +11,29 @@
 	container-type: inline-size;
 	display: flex;
 	min-height: 100%;
-	padding: clamp(16px, 3vw, 32px);
+	padding: clamp(18px, 2.8vw, 34px);
 }
 
-.calendarNativePanel {
+.calendarDashboard {
 	display: flex;
 	flex-direction: column;
-	width: min(100%, 660px);
-	height: min(720px, calc(100vh - 72px));
-	margin: auto;
-	overflow: hidden;
-	border: 1px solid color-mix(in srgb, var(--border-light) 76%, transparent);
-	border-radius: var(--radius-8);
-	background: var(--bg-secondary);
+	gap: 14px;
+	width: min(100%, 1120px);
+	min-height: min(760px, calc(100vh - 68px));
+	margin: 0 auto;
 }
 
-.calendarNativeTitlebar,
-.calendarWeekHeader,
-.calendarPanelSection,
-.calendarLoading {
-	padding-inline: 18px;
-}
-
-.calendarNativeTitlebar {
+.calendarDashboardHeader {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 12px;
-	min-height: 44px;
-	border-bottom: 1px solid
-		color-mix(in srgb, var(--border-light) 72%, transparent);
+	gap: 18px;
+	min-height: 52px;
 	-webkit-app-region: drag;
 }
 
-.calendarNativeTitleBlock,
-.calendarNativeActions,
-.calendarPanelHeaderActions,
+.calendarDashboardTitleBlock,
+.calendarDashboardActions,
 .calendarPanelSectionHeader,
 .calendarSectionHeader {
 	display: flex;
@@ -55,37 +42,25 @@
 	min-width: 0;
 }
 
-.calendarNativeTitleBlock {
-	align-items: baseline;
+.calendarDashboardTitleBlock {
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
 }
 
-.calendarNativeActions,
+.calendarDashboardActions,
 .calendarPanelSectionHeader,
 .calendarSectionHeader {
 	justify-content: space-between;
 }
 
-.calendarNativeActions {
+.calendarDashboardActions {
 	flex: 0 0 auto;
 	gap: 2px;
 	-webkit-app-region: no-drag;
 }
 
-.calendarPanelHeaderActions {
-	flex: 0 0 auto;
-}
-
-.calendarNativeTitle,
-.calendarPanelSectionHeader h3,
-.calendarSectionTitle {
-	margin: 0;
-	color: var(--text-primary);
-	font-size: var(--text-sm);
-	font-weight: var(--font-semibold);
-	letter-spacing: 0;
-}
-
-.calendarNativeTitleBlock span,
+.calendarDashboardTitleBlock p,
 .calendarPanelSectionHeader span,
 .calendarWeekMonth small,
 .calendarNoteTime,
@@ -96,12 +71,99 @@
 	font-size: var(--text-xs);
 }
 
+.calendarDashboardTitleBlock h2,
+.calendarPanelSectionHeader h3,
+.calendarSectionTitle {
+	margin: 0;
+	color: var(--text-primary);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0;
+}
+
+.calendarDashboardTitleBlock h2 {
+	font-size: 1.45rem;
+	line-height: 1.1;
+}
+
+.calendarDashboardTitleBlock p {
+	margin: 0;
+}
+
+.calendarDashboardContent {
+	display: grid;
+	grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.25fr);
+	align-items: stretch;
+	gap: 14px;
+	flex: 1;
+	min-height: 0;
+}
+
+.calendarCommandBar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 12px 10px 16px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 76%, transparent);
+	border-radius: var(--radius-8);
+	background: var(--bg-secondary);
+}
+
+.calendarCommandTitle {
+	display: flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.calendarCommandTitle h3 {
+	margin: 0;
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0;
+}
+
+.calendarCommandActions {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: 4px;
+}
+
+.calendarAccentButton,
+.calendarAccentIconButton {
+	border: 0;
+	background: var(--interactive-accent);
+	color: var(--text-inverse);
+	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
+}
+
+.calendarAccentButton:hover,
+.calendarAccentButton:focus-visible,
+.calendarAccentIconButton:hover,
+.calendarAccentIconButton:focus-visible {
+	background: var(--interactive-accent-hover);
+	color: var(--text-inverse);
+}
+
+.calendarAccentButton svg,
+.calendarAccentIconButton svg {
+	color: currentcolor;
+}
+
+.calendarWeekPanel,
+.calendarPanelSection {
+	border: 1px solid color-mix(in srgb, var(--border-light) 76%, transparent);
+	border-radius: var(--radius-8);
+	background: var(--bg-secondary);
+}
+
 .calendarWeekHeader {
 	display: grid;
-	grid-template-columns: 112px minmax(0, 1fr);
+	grid-template-columns: minmax(120px, 0.32fr) minmax(0, 1fr);
 	align-items: center;
-	gap: 0;
-	padding-block: 28px 22px;
+	gap: 18px;
+	padding: 16px 18px 12px;
 	border-bottom: 1px solid
 		color-mix(in srgb, var(--border-light) 72%, transparent);
 }
@@ -117,14 +179,41 @@
 }
 
 .calendarWeekMonth small {
-	font-size: 1rem;
 	font-weight: var(--font-medium);
+}
+
+.calendarWeekStats {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 8px;
+	min-width: 0;
+}
+
+.calendarWeekStats span {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 8px;
+	min-width: 0;
+	padding: 8px 10px;
+	border-radius: var(--radius-md);
+	background: var(--bg-primary);
+	color: var(--text-tertiary);
+	font-size: var(--text-xs);
+}
+
+.calendarWeekStats strong {
+	color: var(--text-primary);
+	font-size: var(--text-md);
+	font-weight: var(--font-semibold);
+	line-height: 1;
 }
 
 .calendarWeekStrip {
 	display: grid;
 	grid-template-columns: repeat(7, minmax(0, 1fr));
-	gap: 0;
+	gap: 8px;
+	padding: 12px 18px 16px;
 }
 
 .calendarWeekDay {
@@ -132,12 +221,12 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 12px;
-	height: 92px;
+	gap: 8px;
+	height: 108px;
 	min-width: 0;
 	padding: 0;
 	border: 1px solid transparent;
-	border-radius: var(--radius-lg);
+	border-radius: var(--radius-md);
 	background: transparent;
 	color: color-mix(in srgb, var(--text-secondary) 58%, var(--text-tertiary));
 	cursor: pointer;
@@ -155,7 +244,7 @@
 
 .calendarWeekDay strong {
 	color: inherit;
-	font-size: 1.9rem;
+	font-size: 1.75rem;
 	font-weight: var(--font-medium);
 	letter-spacing: 0;
 	line-height: 1;
@@ -170,7 +259,7 @@
 }
 
 .calendarError {
-	margin: 10px 18px 0;
+	margin: 0;
 	padding: 8px 10px;
 	border-radius: var(--radius-md);
 	background: var(--status-danger-bg);
@@ -186,15 +275,23 @@
 .calendarPanelSection {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
-	flex: 0 0 176px;
+	gap: 12px;
+	height: clamp(320px, calc(100vh - 382px), 520px);
 	min-height: 0;
-	padding-block: 16px 0;
+	padding: 16px;
+	overflow: hidden;
 }
 
+.calendarNotesSection,
 .calendarTasksSection {
-	flex: 1;
-	padding-bottom: 18px;
+	min-width: 0;
+}
+
+.calendarPanelSectionHeader > div {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	min-width: 0;
 }
 
 .calendarNotesList,
@@ -209,31 +306,106 @@
 }
 
 .calendarNotesList {
+	flex: 1;
+	gap: 8px;
 	overflow-y: auto;
 }
 
 .calendarNoteRow {
 	display: grid;
-	grid-template-columns: 22px minmax(0, 1fr) auto;
-	align-items: center;
-	gap: 8px;
+	grid-template-columns: 24px minmax(0, 1fr) auto;
+	align-items: start;
+	gap: 10px;
 	width: 100%;
-	min-height: 32px;
-	padding: 4px 6px;
+	min-height: 52px;
+	padding: 10px 10px 12px;
 	border: 0;
 	border-radius: var(--radius-md);
 	background: transparent;
 	color: var(--text-primary);
+	line-height: 1.2;
 	text-align: left;
 }
 
+.calendarNoteIcon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 24px;
+	color: var(--text-tertiary);
+}
+
+.calendarNoteBody {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.calendarNoteTitleRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
 .calendarNoteTitle {
+	flex: 1 1 auto;
 	min-width: 0;
 	overflow: hidden;
 	font-size: var(--text-sm);
 	font-weight: var(--font-medium);
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.calendarNotePreview {
+	display: -webkit-box;
+	overflow: hidden;
+	color: var(--text-tertiary);
+	font-size: var(--text-xs);
+	line-height: 1.35;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.calendarNoteTags {
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
+	justify-content: flex-end;
+	flex: 0 1 48%;
+	gap: 5px;
+	min-width: 0;
+	min-height: 20px;
+	margin-left: auto;
+	overflow: hidden;
+}
+
+.calendarNoteTag {
+	display: flex;
+	align-items: center;
+	max-width: 120px;
+	min-height: 20px;
+	overflow: hidden;
+	padding: 2px 7px;
+	border-radius: 4px;
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 9%,
+		var(--bg-primary)
+	);
+	color: color-mix(in srgb, var(--interactive-accent) 62%, var(--text-primary));
+	font-size: 0.68rem;
+	font-weight: var(--font-medium);
+	line-height: 1.2;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.calendarNoteTag.is-muted {
+	background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
+	color: var(--text-tertiary);
 }
 
 .calendarTasksScrollArea {
@@ -264,5 +436,65 @@
 }
 
 .calendarLoading {
-	padding-block: 0 12px;
+	padding-inline: 2px;
+	padding-block: 0;
+}
+
+@container (max-width: 780px) {
+	.calendarDashboard {
+		min-height: 0;
+	}
+
+	.calendarWeekHeader,
+	.calendarDashboardContent {
+		grid-template-columns: 1fr;
+	}
+
+	.calendarDashboardHeader {
+		align-items: flex-start;
+	}
+
+	.calendarCommandBar {
+		align-items: stretch;
+		flex-direction: column;
+	}
+
+	.calendarCommandActions {
+		flex-wrap: wrap;
+	}
+
+	.calendarWeekStats {
+		grid-template-columns: 1fr;
+	}
+
+	.calendarWeekStrip {
+		grid-template-columns: repeat(7, minmax(68px, 1fr));
+		overflow-x: auto;
+	}
+
+	.calendarDashboardContent {
+		display: grid;
+	}
+
+	.calendarPanelSection {
+		height: clamp(300px, 46vh, 460px);
+	}
+}
+
+@container (max-width: 520px) {
+	.calendarPane {
+		padding: 12px;
+	}
+
+	.calendarWeekDay {
+		height: 88px;
+	}
+
+	.calendarDashboardTitleBlock h2 {
+		font-size: 1.2rem;
+	}
+
+	.calendarPanelSection {
+		height: clamp(280px, 50vh, 420px);
+	}
 }


### PR DESCRIPTION
## Summary

This improves project/database workflows so a database can behave more like a lightweight project tracker without requiring users to hand-configure every view from scratch.

The database layer now provides smarter defaults for new rows, richer filter/sort presets, and more stable board behavior. Home also moves from a narrow weekly panel into a wider dashboard that surfaces the selected day, week activity, notes, tasks, and quick actions in one place.

What changed:

- Added database filter and sort presets that detect common properties such as status, due date, priority, owner, blocked tasks, and project status.
- Extended client-side database filtering with additional operators, list matching, numeric comparisons, and date shortcut handling for preset-driven views.
- Persisted board card order per group and improved board grouping for status, checkbox, tags, and multi-select properties.
- Added board lane helpers for managed lanes, empty configured lanes, workflow state, lane labels, card movement, and row ordering.
- Added database schema default values and backend row creation defaults so new notes can start with useful frontmatter for status, priority, checkbox, and list-like fields.
- Redesigned the Home/Calendar pane into a dashboard with week stats, note/task sections, quick daily-note access, and a task composer shortcut.
- Polished All Docs and database/calendar styling so tags, board cards, and dashboard panels fit the updated surfaces.

## Related Issues

N/A

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] `pnpm test -- src/lib/database/board.test.ts` (Vitest completed with 47 files / 242 tests passing)
- [ ] Relevant manual testing completed on macOS — Not run in this PR prep pass.

## Screenshots or Recordings

Not captured in this PR prep pass.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-group board card ordering with intra-lane reordering and lane add/rename actions.
  * Filter and sort presets for quick database views.
  * Schema-level default values for new database rows.
  * Expanded date-filter shortcuts (today, yesterday, this week, overdue).

* **UI Improvements**
  * Calendar redesigned into a “Home / Today” dashboard with weekly stats and quick daily-note/task actions.
  * Improved board lane management and workflow-state visuals.
  * Restyled tag pills and preset UI; daily-notes settings shortcut now targets the space settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->