### PR TITLE
feat(flow): add visual flow documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"@tiptap/react": "^3.19.0",
 		"@tiptap/starter-kit": "^3.19.0",
 		"@tiptap/suggestion": "^3.19.0",
+		"@xyflow/react": "^12.10.2",
 		"beautiful-mermaid": "^1.1.3",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@tiptap/suggestion':
         specifier: ^3.19.0
         version: 3.19.0(@tiptap/core@3.19.0(@tiptap/pm@3.19.0))(@tiptap/pm@3.19.0)
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       beautiful-mermaid:
         specifier: ^1.1.3
         version: 1.1.3
@@ -1862,6 +1865,24 @@ packages:
   '@types/cytoscape-fcose@2.2.5':
     resolution: {integrity: sha512-FaM6MM5zC4Yh72E60vkpbM4tstJS90wj3u1Vq/SMiK/MShhLaMd17QkmR39S14aUWdfNSlUEfx/g/XkDdFmXDA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1932,6 +1953,15 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1968,6 +1998,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1996,6 +2029,44 @@ packages:
   cytoscape@3.33.3:
     resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
     engines: {node: '>=0.10'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2692,6 +2763,21 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -4286,6 +4372,27 @@ snapshots:
     dependencies:
       cytoscape: 3.33.3
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -4369,6 +4476,29 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xyflow/react@12.10.2(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.10)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -4404,6 +4534,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   clsx@2.1.1: {}
 
   convert-source-map@2.0.0: {}
@@ -4427,6 +4559,42 @@ snapshots:
       cytoscape: 3.33.3
 
   cytoscape@3.33.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@7.0.0:
     dependencies:
@@ -5123,3 +5291,10 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  zustand@4.5.7(@types/react@19.2.10)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      react: 19.2.4

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -1164,13 +1164,23 @@ pub async fn backlinks(
                     SELECT r.from_id
                     FROM note_relationships r
                     WHERE r.to_id = ? OR r.to_title = ? OR r.target_title = ?
+                    UNION
+                    SELECT e.flow_id
+                    FROM flow_edges e
+                    WHERE e.from_id = ? OR e.to_id = ?
+                    UNION
+                    SELECT e.from_id
+                    FROM flow_edges e
+                    WHERE e.to_id = ?
                  ) refs ON refs.from_id = n.id
                  ORDER BY n.updated DESC
                  LIMIT 100",
             )
             .map_err(|e| e.to_string())?;
         let mut rows = stmt
-            .query(rusqlite::params![note_id, stem, note_id, stem, stem])
+            .query(rusqlite::params![
+                note_id, stem, note_id, stem, stem, note_id, note_id, note_id
+            ])
             .map_err(|e| e.to_string())?;
         let mut out = Vec::new();
         while let Some(row) = rows.next().map_err(|e| e.to_string())? {
@@ -1245,13 +1255,25 @@ fn local_note_graph_for_conn(
                 SELECT r.from_id AS note_id
                 FROM note_relationships r
                 WHERE r.to_id = ?
+                UNION
+                SELECT e.to_id AS note_id
+                FROM flow_edges e
+                WHERE e.from_id = ?
+                UNION
+                SELECT e.from_id AS note_id
+                FROM flow_edges e
+                WHERE e.to_id = ?
+                UNION
+                SELECT e.flow_id AS note_id
+                FROM flow_edges e
+                WHERE e.from_id = ? OR e.to_id = ?
              ) related ON related.note_id = n.id
              WHERE n.id <> ?",
         )
         .map_err(|e| e.to_string())?;
     let mut neighbor_rows = neighbor_stmt
         .query(rusqlite::params![
-            note_id, note_id, note_id, note_id, note_id
+            note_id, note_id, note_id, note_id, note_id, note_id, note_id, note_id, note_id
         ])
         .map_err(|e| e.to_string())?;
     while let Some(row) = neighbor_rows.next().map_err(|e| e.to_string())? {
@@ -1293,6 +1315,15 @@ fn local_note_graph_for_conn(
             SELECT from_id, to_id
             FROM note_relationships
             WHERE to_id IS NOT NULL
+            UNION
+            SELECT from_id, to_id
+            FROM flow_edges
+            UNION
+            SELECT flow_id AS from_id, from_id AS to_id
+            FROM flow_edges
+            UNION
+            SELECT flow_id AS from_id, to_id
+            FROM flow_edges
          )
          WHERE from_id IN ({placeholders})
            AND to_id IN ({placeholders})

--- a/src-tauri/src/index/db.rs
+++ b/src-tauri/src/index/db.rs
@@ -6,7 +6,7 @@ use std::sync::{Mutex, OnceLock};
 
 use super::schema::ensure_schema;
 
-const INDEX_DB_VERSION: i32 = 6;
+const INDEX_DB_VERSION: i32 = 7;
 const WAL_SIZE_LIMIT_BYTES: i64 = 1_048_576;
 
 fn schema_cache() -> &'static Mutex<HashSet<PathBuf>> {

--- a/src-tauri/src/index/flow.rs
+++ b/src-tauri/src/index/flow.rs
@@ -1,0 +1,224 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use serde::Deserialize;
+
+use super::links::normalize_rel_path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlowFileEdge {
+    pub from_id: String,
+    pub to_id: String,
+    pub label: Option<String>,
+    pub ordinal: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FlowIndexData {
+    pub body: String,
+    pub preview: String,
+    pub file_links: HashSet<String>,
+    pub url_links: HashSet<String>,
+    pub file_edges: Vec<FlowFileEdge>,
+}
+
+#[derive(Deserialize)]
+struct FlowDocument {
+    #[serde(default)]
+    nodes: Vec<FlowNode>,
+    #[serde(default)]
+    edges: Vec<FlowEdge>,
+}
+
+#[derive(Deserialize)]
+struct FlowNode {
+    id: Option<String>,
+    #[serde(rename = "type")]
+    node_type: Option<String>,
+    text: Option<String>,
+    file: Option<String>,
+    url: Option<String>,
+    label: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FlowEdge {
+    from_node: Option<String>,
+    to_node: Option<String>,
+    label: Option<String>,
+}
+
+pub fn is_flow_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("flow"))
+        .unwrap_or(false)
+}
+
+pub fn parse_flow_index_data(flow_json: &str) -> Result<FlowIndexData, String> {
+    let doc: FlowDocument = serde_json::from_str(flow_json).map_err(|e| e.to_string())?;
+    let mut text_parts = Vec::new();
+    let mut file_links = HashSet::new();
+    let mut url_links = HashSet::new();
+    let mut file_by_node_id = HashMap::<String, String>::new();
+
+    for node in &doc.nodes {
+        if let Some(label) = node
+            .label
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            text_parts.push(label.to_string());
+        }
+
+        match node.node_type.as_deref() {
+            Some("text") => {
+                if let Some(text) = node
+                    .text
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                {
+                    text_parts.push(text.to_string());
+                }
+            }
+            Some("file") => {
+                if let (Some(node_id), Some(file)) = (
+                    node.id.as_deref(),
+                    node.file.as_deref().and_then(normalize_flow_file_ref),
+                ) {
+                    text_parts.push(file.clone());
+                    file_links.insert(file.clone());
+                    file_by_node_id.insert(node_id.to_string(), file);
+                }
+            }
+            Some("link") => {
+                if let Some(url) = node.url.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+                    text_parts.push(url.to_string());
+                    url_links.insert(url.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut file_edges = Vec::new();
+    for (ordinal, edge) in doc.edges.iter().enumerate() {
+        if let Some(label) = edge
+            .label
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            text_parts.push(label.to_string());
+        }
+
+        let Some(from_node) = edge.from_node.as_deref() else {
+            continue;
+        };
+        let Some(to_node) = edge.to_node.as_deref() else {
+            continue;
+        };
+        let Some(from_id) = file_by_node_id.get(from_node) else {
+            continue;
+        };
+        let Some(to_id) = file_by_node_id.get(to_node) else {
+            continue;
+        };
+        if from_id == to_id {
+            continue;
+        }
+        file_edges.push(FlowFileEdge {
+            from_id: from_id.clone(),
+            to_id: to_id.clone(),
+            label: edge.label.as_ref().map(|label| label.trim().to_string()),
+            ordinal: ordinal as i64,
+        });
+    }
+
+    let body = compact_text(&text_parts.join("\n"));
+    let preview = preview_from_body(&body);
+    Ok(FlowIndexData {
+        body,
+        preview,
+        file_links,
+        url_links,
+        file_edges,
+    })
+}
+
+fn normalize_flow_file_ref(raw: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_matches('/');
+    if trimmed.is_empty() || has_uri_scheme(trimmed) {
+        return None;
+    }
+    let without_fragment = trimmed.split('#').next().unwrap_or(trimmed);
+    let without_query = without_fragment
+        .split('?')
+        .next()
+        .unwrap_or(without_fragment);
+    normalize_rel_path(without_query)
+}
+
+fn has_uri_scheme(target: &str) -> bool {
+    let Some((scheme, _rest)) = target.split_once(':') else {
+        return false;
+    };
+    !scheme.is_empty()
+        && scheme
+            .chars()
+            .next()
+            .is_some_and(|value| value.is_ascii_alphabetic())
+        && scheme
+            .chars()
+            .all(|value| value.is_ascii_alphanumeric() || matches!(value, '+' | '.' | '-'))
+}
+
+fn compact_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn preview_from_body(body: &str) -> String {
+    const MAX_PREVIEW_CHARS: usize = 240;
+    let mut preview = body.chars().take(MAX_PREVIEW_CHARS).collect::<String>();
+    if body.chars().count() > MAX_PREVIEW_CHARS {
+        preview.push_str("...");
+    }
+    preview
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_flow_index_data;
+
+    #[test]
+    fn parses_flow_text_files_links_and_file_edges() {
+        let data = parse_flow_index_data(
+            r#"{
+              "nodes": [
+                {"id":"text-1","type":"text","text":"Launch notes"},
+                {"id":"file-1","type":"file","file":"Projects/A.md"},
+                {"id":"file-2","type":"file","file":"Projects/B.md#Heading"},
+                {"id":"link-1","type":"link","url":"https://example.com"}
+              ],
+              "edges": [
+                {"id":"edge-1","fromNode":"file-1","toNode":"file-2","label":"depends"}
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(data.body.contains("Launch notes"));
+        assert!(data.body.contains("https://example.com"));
+        assert!(data.file_links.contains("Projects/A.md"));
+        assert!(data.file_links.contains("Projects/B.md"));
+        assert_eq!(data.url_links.len(), 1);
+        assert_eq!(data.file_edges.len(), 1);
+        assert_eq!(data.file_edges[0].from_id, "Projects/A.md");
+        assert_eq!(data.file_edges[0].to_id, "Projects/B.md");
+    }
+}

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -7,6 +7,7 @@ use std::{
 use crate::utils::{self, file_timestamp_strings_if_exists};
 
 use super::db::{open_db, resolve_title_to_id};
+use super::flow::{is_flow_path, parse_flow_index_data, FlowIndexData};
 use super::frontmatter::{
     parse_frontmatter_title_created_updated, preview_from_markdown, split_frontmatter,
 };
@@ -44,7 +45,11 @@ fn fts_body_with_frontmatter(markdown: &str) -> String {
     }
 }
 
-fn collect_markdown_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, String> {
+fn is_indexable_document_path(path: &Path) -> bool {
+    utils::is_markdown_path(path) || is_flow_path(path)
+}
+
+fn collect_indexable_document_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, String> {
     let mut out: Vec<(String, PathBuf)> = Vec::new();
     let mut stack: Vec<PathBuf> = vec![space_root.to_path_buf()];
 
@@ -74,7 +79,7 @@ fn collect_markdown_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, S
             if !meta.is_file() {
                 continue;
             }
-            if !utils::is_markdown_path(&path) {
+            if !is_indexable_document_path(&path) {
                 continue;
             }
             let rel = match path.strip_prefix(space_root) {
@@ -104,7 +109,21 @@ fn link_kind_for_id(to_id: &str) -> &'static str {
 pub fn index_note(space_root: &Path, note_id: &str, markdown: &str) -> Result<(), String> {
     let conn = open_db(space_root)?;
     let file_path = space_root.join(note_id);
-    index_note_with_conn(&conn, note_id, markdown, &file_path)
+    if is_flow_path(Path::new(note_id)) || is_flow_path(&file_path) {
+        index_flow_with_conn(&conn, note_id, markdown, &file_path)
+    } else {
+        index_note_with_conn(&conn, note_id, markdown, &file_path)
+    }
+}
+
+fn title_from_rel_path(path: &str) -> String {
+    Path::new(path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Untitled")
+        .to_string()
 }
 
 fn index_note_with_conn(
@@ -132,14 +151,7 @@ fn index_note_with_conn(
     let (mut title, created, updated) =
         parse_frontmatter_title_created_updated(markdown, file_path);
     if title == "Untitled" {
-        if let Some(stem) = Path::new(note_id)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-        {
-            title = stem.to_string();
-        }
+        title = title_from_rel_path(note_id);
     }
     let title_for_fts = title.clone();
     let preview = preview_from_markdown(note_id, markdown);
@@ -220,6 +232,104 @@ fn index_note_with_conn(
     Ok(())
 }
 
+fn index_flow_with_conn(
+    conn: &rusqlite::Connection,
+    flow_id: &str,
+    flow_json: &str,
+    file_path: &Path,
+) -> Result<(), String> {
+    let etag = sha256_hex(flow_json.as_bytes());
+    let existing_etag: Option<String> = conn
+        .query_row(
+            "SELECT etag FROM notes WHERE id = ? LIMIT 1",
+            [flow_id],
+            |row| row.get(0),
+        )
+        .ok();
+    if existing_etag.as_deref() == Some(etag.as_str()) {
+        refresh_indexed_timestamps_if_needed(conn, flow_id, file_path)?;
+        return Ok(());
+    }
+
+    let data = parse_flow_index_data(flow_json).unwrap_or_else(|error| {
+        tracing::warn!(
+            flow_id = flow_id,
+            error = %error,
+            "Indexing flow text fallback after JSON parse error"
+        );
+        let preview = flow_json
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .chars()
+            .take(240)
+            .collect::<String>();
+        FlowIndexData {
+            body: flow_json.to_string(),
+            preview,
+            file_links: HashSet::new(),
+            url_links: HashSet::new(),
+            file_edges: Vec::new(),
+        }
+    });
+
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    let (created, updated) = utils::file_timestamp_strings(file_path);
+    let title = title_from_rel_path(flow_id);
+
+    tx.execute(
+        "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag, preview) VALUES(?, ?, ?, ?, ?, ?, ?)",
+        rusqlite::params![flow_id, title, created, updated, flow_id, etag, data.preview],
+    )
+    .map_err(|e| e.to_string())?;
+
+    tx.execute("DELETE FROM notes_fts WHERE id = ?", [flow_id])
+        .map_err(|e| e.to_string())?;
+    tx.execute(
+        "INSERT INTO notes_fts(id, title, body) VALUES(?, ?, ?)",
+        rusqlite::params![flow_id, title, data.body],
+    )
+    .map_err(|e| e.to_string())?;
+
+    tx.execute("DELETE FROM links WHERE from_id = ?", [flow_id])
+        .map_err(|e| e.to_string())?;
+    tx.execute("DELETE FROM tags WHERE note_id = ?", [flow_id])
+        .map_err(|e| e.to_string())?;
+    delete_note_properties(&tx, flow_id)?;
+    delete_note_relationships(&tx, flow_id)?;
+    delete_note_tasks(&tx, flow_id)?;
+    tx.execute("DELETE FROM flow_edges WHERE flow_id = ?", [flow_id])
+        .map_err(|e| e.to_string())?;
+
+    for to_id in data.file_links {
+        tx.execute(
+            "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, NULL, 'flow_file')",
+            rusqlite::params![flow_id, to_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    for url in data.url_links {
+        tx.execute(
+            "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind) VALUES(?, NULL, ?, 'flow_url')",
+            rusqlite::params![flow_id, url],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    for edge in data.file_edges {
+        tx.execute(
+            "INSERT OR REPLACE INTO flow_edges(flow_id, from_id, to_id, label, ordinal)
+             VALUES(?, ?, ?, ?, ?)",
+            rusqlite::params![flow_id, edge.from_id, edge.to_id, edge.label, edge.ordinal],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 fn refresh_indexed_timestamps_if_needed(
     conn: &rusqlite::Connection,
     note_id: &str,
@@ -283,6 +393,11 @@ pub fn remove_note(space_root: &Path, note_id: &str) -> Result<(), String> {
         [note_id],
     )
     .map_err(|e| e.to_string())?;
+    tx.execute(
+        "DELETE FROM flow_edges WHERE flow_id = ? OR from_id = ? OR to_id = ?",
+        rusqlite::params![note_id, note_id, note_id],
+    )
+    .map_err(|e| e.to_string())?;
     delete_note_tasks(&tx, note_id)?;
     tx.commit().map_err(|e| e.to_string())?;
     Ok(())
@@ -305,34 +420,94 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
         .map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM note_relationships", [])
         .map_err(|e| e.to_string())?;
+    tx.execute("DELETE FROM flow_edges", [])
+        .map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM tasks", [])
         .map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM tasks_fts", [])
         .map_err(|e| e.to_string())?;
 
-    let note_paths = collect_markdown_files(space_root)?;
+    let note_paths = collect_indexable_document_files(space_root)?;
     let mut link_data: Vec<(String, HashSet<String>, HashSet<String>)> =
         Vec::with_capacity(note_paths.len());
     let mut relationship_data = Vec::with_capacity(note_paths.len());
     let count = note_paths.len();
 
     for (rel, path) in &note_paths {
-        let markdown = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let text = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
 
-        let (mut title, created, updated) =
-            parse_frontmatter_title_created_updated(&markdown, path);
-        if title == "Untitled" {
-            if let Some(stem) = Path::new(rel)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-            {
-                title = stem.to_string();
+        if is_flow_path(path) {
+            let data = parse_flow_index_data(&text).unwrap_or_else(|error| {
+                tracing::warn!(
+                    flow_id = rel,
+                    error = %error,
+                    "Indexing flow text fallback during rebuild after JSON parse error"
+                );
+                let preview = text
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .chars()
+                    .take(240)
+                    .collect::<String>();
+                FlowIndexData {
+                    body: text.clone(),
+                    preview,
+                    file_links: HashSet::new(),
+                    url_links: HashSet::new(),
+                    file_edges: Vec::new(),
+                }
+            });
+            let (created, updated) = utils::file_timestamp_strings(path);
+            let title = title_from_rel_path(rel);
+            let etag = sha256_hex(text.as_bytes());
+
+            tx.execute(
+                "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag, preview) VALUES(?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![rel, title, created, updated, rel, etag, data.preview],
+            )
+            .map_err(|e| e.to_string())?;
+
+            tx.execute("DELETE FROM notes_fts WHERE id = ?", [rel])
+                .map_err(|e| e.to_string())?;
+            tx.execute(
+                "INSERT INTO notes_fts(id, title, body) VALUES(?, ?, ?)",
+                rusqlite::params![rel, title, data.body],
+            )
+            .map_err(|e| e.to_string())?;
+
+            for to_id in data.file_links {
+                tx.execute(
+                    "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, NULL, 'flow_file')",
+                    rusqlite::params![rel, to_id],
+                )
+                .map_err(|e| e.to_string())?;
             }
+            for url in data.url_links {
+                tx.execute(
+                    "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind) VALUES(?, NULL, ?, 'flow_url')",
+                    rusqlite::params![rel, url],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+            for edge in data.file_edges {
+                tx.execute(
+                    "INSERT OR REPLACE INTO flow_edges(flow_id, from_id, to_id, label, ordinal)
+                     VALUES(?, ?, ?, ?, ?)",
+                    rusqlite::params![rel, edge.from_id, edge.to_id, edge.label, edge.ordinal],
+                )
+                .map_err(|e| e.to_string())?;
+            }
+
+            continue;
         }
-        let etag = sha256_hex(markdown.as_bytes());
-        let preview = preview_from_markdown(rel, &markdown);
+
+        let (mut title, created, updated) = parse_frontmatter_title_created_updated(&text, path);
+        if title == "Untitled" {
+            title = title_from_rel_path(rel);
+        }
+        let etag = sha256_hex(text.as_bytes());
+        let preview = preview_from_markdown(rel, &text);
 
         tx.execute(
             "INSERT OR REPLACE INTO notes(id, title, created, updated, path, etag, preview) VALUES(?, ?, ?, ?, ?, ?, ?)",
@@ -342,7 +517,7 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
 
         tx.execute("DELETE FROM notes_fts WHERE id = ?", [rel])
             .map_err(|e| e.to_string())?;
-        let body = fts_body_with_frontmatter(&markdown);
+        let body = fts_body_with_frontmatter(&text);
         tx.execute(
             "INSERT INTO notes_fts(id, title, body) VALUES(?, ?, ?)",
             rusqlite::params![rel, title, body],
@@ -350,11 +525,11 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
         .map_err(|e| e.to_string())?;
 
         let people_tags = if people_tags_enabled {
-            expand_indexed_people(&parse_inline_people(&markdown))
+            expand_indexed_people(&parse_inline_people(&text))
         } else {
             Vec::new()
         };
-        for tag in expand_indexed_tags(&parse_all_tags(&markdown))
+        for tag in expand_indexed_tags(&parse_all_tags(&text))
             .into_iter()
             .chain(people_tags.into_iter())
         {
@@ -364,7 +539,7 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
             )
             .map_err(|e| e.to_string())?;
         }
-        if let Err(error) = reindex_note_properties(&tx, rel, &markdown) {
+        if let Err(error) = reindex_note_properties(&tx, rel, &text) {
             tracing::warn!(
                 note_id = rel,
                 rel_path = rel,
@@ -372,11 +547,11 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
                 "Skipping note property indexing during rebuild after frontmatter parse error"
             );
         }
-        reindex_note_tasks(&tx, rel, rel, &updated, &etag, &markdown)?;
+        reindex_note_tasks(&tx, rel, rel, &updated, &etag, &text)?;
 
-        let (to_ids, to_titles) = parse_outgoing_links(rel, &markdown);
+        let (to_ids, to_titles) = parse_outgoing_links(rel, &text);
         link_data.push((rel.clone(), to_ids, to_titles));
-        relationship_data.push((rel.clone(), parse_frontmatter_relationships(&markdown)));
+        relationship_data.push((rel.clone(), parse_frontmatter_relationships(&text)));
     }
 
     for (rel, to_ids, to_titles) in &link_data {

--- a/src-tauri/src/index/links.rs
+++ b/src-tauri/src/index/links.rs
@@ -150,6 +150,7 @@ fn is_linkable_file_target(target: &str) -> bool {
             | "avif"
             | "tif"
             | "tiff"
+            | "flow"
     )
 }
 

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub(crate) mod db;
+mod flow;
 mod frontmatter;
 mod helpers;
 mod indexer;

--- a/src-tauri/src/index/schema.rs
+++ b/src-tauri/src/index/schema.rs
@@ -40,6 +40,19 @@ CREATE INDEX IF NOT EXISTS note_relationships_from_idx ON note_relationships(fro
 CREATE INDEX IF NOT EXISTS note_relationships_to_id_idx ON note_relationships(to_id);
 CREATE INDEX IF NOT EXISTS note_relationships_to_title_idx ON note_relationships(to_title);
 
+CREATE TABLE IF NOT EXISTS flow_edges (
+  flow_id TEXT NOT NULL,
+  from_id TEXT NOT NULL,
+  to_id TEXT NOT NULL,
+  label TEXT,
+  ordinal INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (flow_id, from_id, to_id, ordinal)
+);
+
+CREATE INDEX IF NOT EXISTS flow_edges_flow_idx ON flow_edges(flow_id);
+CREATE INDEX IF NOT EXISTS flow_edges_from_idx ON flow_edges(from_id);
+CREATE INDEX IF NOT EXISTS flow_edges_to_idx ON flow_edges(to_id);
+
 CREATE TABLE IF NOT EXISTS tags (
   note_id TEXT NOT NULL,
   tag TEXT NOT NULL,

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -17,6 +17,15 @@ struct ExternalChangeEvent {
 
 const DEBOUNCE_MS: u64 = 100;
 
+fn is_indexable_document_path(path: &std::path::Path) -> bool {
+    utils::is_markdown_path(path)
+        || path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("flow"))
+            .unwrap_or(false)
+}
+
 pub fn set_notes_watcher(
     state: &SpaceState,
     app: tauri::AppHandle,
@@ -99,7 +108,7 @@ pub fn set_notes_watcher(
                 continue;
             }
 
-            if utils::is_markdown_path(&path)
+            if is_indexable_document_path(&path)
                 && !has_recent_local_change(&recent_local_changes, &rel_s)
             {
                 let _ = idx_tx.send((rel_s.clone(), is_remove));

--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use serde::Serialize;
+use serde_json::Value;
 
 use crate::{index, paths, utils};
 
@@ -37,7 +38,11 @@ pub fn rewrite_links_after_rename(
     for rel_path in markdown_files {
         let abs = paths::join_under(space_root, Path::new(&rel_path))?;
         let original = std::fs::read_to_string(&abs).map_err(|e| e.to_string())?;
-        let rewrite = rewrite_markdown_links_for_path(&original, plan, &rel_path);
+        let rewrite = if is_flow_rel_path(&rel_path) {
+            rewrite_flow_links_for_path(&original, plan)
+        } else {
+            rewrite_markdown_links_for_path(&original, plan, &rel_path)
+        };
 
         if rewrite.markdown != original {
             rewrites.push((rel_path, abs, rewrite.markdown, rewrite.changed_links));
@@ -111,6 +116,51 @@ pub fn rewrite_markdown_links_for_path(
 
     RewriteMarkdownResult {
         markdown: out,
+        changed_links,
+    }
+}
+
+pub fn rewrite_flow_links_for_path(
+    flow_json: &str,
+    plan: &LinkRewritePlan,
+) -> RewriteMarkdownResult {
+    let Ok(mut value) = serde_json::from_str::<Value>(flow_json) else {
+        return RewriteMarkdownResult {
+            markdown: flow_json.to_string(),
+            changed_links: 0,
+        };
+    };
+    let Some(nodes) = value.get_mut("nodes").and_then(Value::as_array_mut) else {
+        return RewriteMarkdownResult {
+            markdown: flow_json.to_string(),
+            changed_links: 0,
+        };
+    };
+
+    let mut changed_links = 0;
+    for node in nodes {
+        let Some(file_value) = node.get_mut("file") else {
+            continue;
+        };
+        let Some(file) = file_value.as_str() else {
+            continue;
+        };
+        if let Some(replacement) = rewrite_flow_file_target(file, plan) {
+            *file_value = Value::String(replacement);
+            changed_links += 1;
+        }
+    }
+
+    if changed_links == 0 {
+        return RewriteMarkdownResult {
+            markdown: flow_json.to_string(),
+            changed_links,
+        };
+    }
+
+    let markdown = serde_json::to_string_pretty(&value).unwrap_or_else(|_| flow_json.to_string());
+    RewriteMarkdownResult {
+        markdown,
         changed_links,
     }
 }
@@ -291,6 +341,41 @@ fn rewrite_markdown_target_path(
     }
 
     None
+}
+
+fn rewrite_flow_file_target(target: &str, plan: &LinkRewritePlan) -> Option<String> {
+    let trimmed = target.trim();
+    if is_external_target(trimmed) {
+        return None;
+    }
+
+    let (without_fragment, fragment) = split_once_preserve(trimmed, '#');
+    let (without_query, query) = split_once_preserve(without_fragment, '?');
+    let replacement = rewrite_target(without_query.trim().trim_matches('/'), plan, true)
+        .or_else(|| rewrite_unique_attachment_basename(without_query.trim(), plan))?;
+    Some(format!("{replacement}{query}{fragment}"))
+}
+
+fn rewrite_unique_attachment_basename(target: &str, plan: &LinkRewritePlan) -> Option<String> {
+    if plan.is_dir || is_markdown_rel_path(&plan.from_rel_path) || !plan.from_basename_is_unique {
+        return None;
+    }
+    let normalized = normalize_rel_path(target);
+    if normalized.eq_ignore_ascii_case(&basename(&plan.from_rel_path)) {
+        return Some(plan.to_rel_path.clone());
+    }
+    None
+}
+
+fn is_flow_rel_path(path: &str) -> bool {
+    matches!(
+        Path::new(path)
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref(),
+        Some("flow")
+    )
 }
 
 fn join_rel_path(base: &str, target: &str) -> String {
@@ -520,7 +605,7 @@ fn collect_markdown_files_and_basename_counts(
             }
             let name = entry_name.to_string_lossy().to_ascii_lowercase();
             *basename_counts.entry(name).or_insert(0) += 1;
-            if utils::is_markdown_path(&path) {
+            if utils::is_markdown_path(&path) || is_flow_rel_path(&to_slash(&path)) {
                 let rel = path
                     .strip_prefix(space_root)
                     .map_err(|error| error.to_string())?;
@@ -571,7 +656,7 @@ fn to_slash(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{rewrite_markdown_links_for_path, LinkRewritePlan};
+    use super::{rewrite_flow_links_for_path, rewrite_markdown_links_for_path, LinkRewritePlan};
 
     fn plan() -> LinkRewritePlan {
         LinkRewritePlan {
@@ -616,6 +701,18 @@ mod tests {
 
         assert_eq!(output.markdown, "[[new-dir/a]] [a](new-dir/a.md)");
         assert_eq!(output.changed_links, 2);
+    }
+
+    #[test]
+    fn rewrites_flow_file_node_paths() {
+        let input = r#"{"nodes":[{"id":"a","type":"file","file":"folder/old-title.md"},{"id":"b","type":"file","file":"untouched.md"}],"edges":[]}"#;
+        let output = rewrite_flow_links_for_path(input, &plan());
+
+        assert!(output
+            .markdown
+            .contains("\"file\": \"folder/new-title.md\""));
+        assert!(output.markdown.contains("\"file\": \"untouched.md\""));
+        assert_eq!(output.changed_links, 1);
     }
 
     #[test]

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -19,6 +19,15 @@ struct NoteChangeEvent {
     removed: bool,
 }
 
+fn is_indexable_document_path(path: &Path) -> bool {
+    utils::is_markdown_path(path)
+        || path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("flow"))
+            .unwrap_or(false)
+}
+
 fn split_duplicate_name(file_name: &str) -> (&str, &str) {
     match file_name.rfind('.') {
         Some(index) if index > 0 => (&file_name[..index], &file_name[index..]),
@@ -151,18 +160,19 @@ fn duplicate_file_under_root(
         }
 
         let is_markdown = utils::is_markdown_path(&duplicate_rel);
+        let should_index = is_indexable_document_path(&duplicate_rel);
         crate::io_atomic::copy_atomic(&source_abs, &duplicate_abs).map_err(|e| e.to_string())?;
 
         let duplicate_rel_string = utils::to_slash(&duplicate_rel);
-        if is_markdown {
+        if should_index {
             mark_recent_local_change(recent_local_changes, &duplicate_rel_string);
             match std::fs::read_to_string(&duplicate_abs) {
-                Ok(markdown) => {
-                    if let Err(error) = index::index_note(root, &duplicate_rel_string, &markdown) {
+                Ok(text) => {
+                    if let Err(error) = index::index_note(root, &duplicate_rel_string, &text) {
                         tracing::warn!(
                             note_id = %duplicate_rel_string,
                             error = %error,
-                            "failed to index duplicated markdown note"
+                            "failed to index duplicated document"
                         );
                     }
                 }
@@ -170,7 +180,7 @@ fn duplicate_file_under_root(
                     tracing::warn!(
                         note_id = %duplicate_rel_string,
                         error = %error,
-                        "failed to read duplicated markdown note for indexing"
+                        "failed to read duplicated document for indexing"
                     );
                 }
             }
@@ -180,7 +190,7 @@ fn duplicate_file_under_root(
     }
 }
 
-fn remove_markdown_notes_from_index(
+fn remove_indexed_documents_from_index(
     root: &Path,
     rel_path: &str,
     abs_path: &Path,
@@ -209,7 +219,7 @@ fn remove_markdown_notes_from_index(
         return;
     }
 
-    if utils::is_markdown_path(abs_path) {
+    if is_indexable_document_path(abs_path) {
         mark_recent_local_change(recent_local_changes, rel_path);
         let _ = index::remove_note(root, rel_path);
     }
@@ -241,7 +251,7 @@ pub async fn space_duplicate_path(
     })
     .await
     .map_err(|e| e.to_string())??;
-    if entry.is_markdown {
+    if is_indexable_document_path(Path::new(&entry.rel_path)) {
         let _ = app.emit(
             "notes:external_changed",
             NoteChangeEvent {
@@ -339,7 +349,7 @@ pub async fn space_rename_path(
         }
         let is_dir = from_abs.is_dir();
         let rewrite_plan = if is_dir
-            || utils::is_markdown_path(&from_abs)
+            || is_indexable_document_path(&from_abs)
             || link_rewrite::is_supported_attachment_path(&from_abs)
         {
             Some(link_rewrite::plan_for_rename(
@@ -363,8 +373,8 @@ pub async fn space_rename_path(
                     for changed in &result.changed_files {
                         mark_recent_local_change(&recent_local_changes, changed);
                         match std::fs::read_to_string(root.join(changed)) {
-                            Ok(markdown) => {
-                                if let Err(error) = index::index_note(&root, changed, &markdown) {
+                            Ok(text) => {
+                                if let Err(error) = index::index_note(&root, changed, &text) {
                                     tracing::warn!(
                                         note_id = %changed,
                                         error = %error,
@@ -432,19 +442,19 @@ fn reindex_after_rename(
                         mark_recent_local_change(recent_local_changes, &new_id);
                         let _ = index::remove_note(root, &old_id);
                         let abs = root.join(&new_id);
-                        if let Ok(markdown) = std::fs::read_to_string(&abs) {
-                            let _ = index::index_note(root, &new_id, &markdown);
+                        if let Ok(text) = std::fs::read_to_string(&abs) {
+                            let _ = index::index_note(root, &new_id, &text);
                         }
                     }
                 }
             }
         }
-    } else if utils::is_markdown_path(to_abs) {
+    } else if is_indexable_document_path(to_abs) {
         mark_recent_local_change(recent_local_changes, from_path);
         mark_recent_local_change(recent_local_changes, to_path);
         let _ = index::remove_note(root, from_path);
-        if let Ok(markdown) = std::fs::read_to_string(to_abs) {
-            let _ = index::index_note(root, to_path, &markdown);
+        if let Ok(text) = std::fs::read_to_string(to_abs) {
+            let _ = index::index_note(root, to_path, &text);
         }
     }
 }
@@ -465,7 +475,13 @@ pub async fn space_delete_path(
         deny_hidden_rel_path(&rel)?;
         let abs = paths::join_under(&root, &rel)?;
         let meta = std::fs::metadata(&abs).map_err(|e| e.to_string())?;
-        remove_markdown_notes_from_index(&root, &path, &abs, &recent_local_changes, meta.is_dir());
+        remove_indexed_documents_from_index(
+            &root,
+            &path,
+            &abs,
+            &recent_local_changes,
+            meta.is_dir(),
+        );
         if meta.is_dir() {
             if recursive.unwrap_or(false) {
                 move_path_to_trash(&abs)

--- a/src-tauri/src/space_fs/read_write/text.rs
+++ b/src-tauri/src/space_fs/read_write/text.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::{ffi::OsStr, io::Write, path::PathBuf};
+use std::{io::Write, path::PathBuf};
 use tauri::{Emitter, State};
 
 use crate::space::state::mark_recent_local_change;
@@ -14,6 +14,17 @@ use super::super::types::{
 struct NoteChangeEvent {
     rel_path: String,
     removed: bool,
+}
+
+fn is_indexable_document_path(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            ext.eq_ignore_ascii_case("md")
+                || ext.eq_ignore_ascii_case("markdown")
+                || ext.eq_ignore_ascii_case("flow")
+        })
+        .unwrap_or(false)
 }
 
 #[tauri::command]
@@ -92,7 +103,7 @@ pub async fn space_write_text(
     let root = state.current_root()?;
     let recent_local_changes = state.recent_local_changes();
     let event_rel_path = PathBuf::from(&path).to_string_lossy().to_string();
-    let should_emit_note_change = PathBuf::from(&path).extension() == Some(OsStr::new("md"));
+    let should_emit_note_change = is_indexable_document_path(&PathBuf::from(&path));
     let result =
         tauri::async_runtime::spawn_blocking(move || -> Result<TextFileWriteResult, String> {
             let rel = PathBuf::from(&path);
@@ -109,7 +120,7 @@ pub async fn space_write_text(
             }
 
             let rel_path = rel.to_string_lossy().to_string();
-            let should_index = rel.extension() == Some(OsStr::new("md"));
+            let should_index = is_indexable_document_path(&rel);
             let bytes = text.into_bytes();
             if should_index {
                 mark_recent_local_change(&recent_local_changes, &rel_path);

--- a/src/App.css
+++ b/src/App.css
@@ -47,6 +47,8 @@
 @import "./styles/app/44-settings-changelog.css";
 @import "./styles/app/45-local-graph.css";
 @import "./styles/app/46-quick-note.css";
+@import "./styles/app/48-flow.css";
+@import "./styles/app/50-flow.css";
 
 /* Shadow reset: Intentionally disables Tailwind's default shadows.
    The app uses custom shadow variables (--shadow-sm, --shadow-md, etc.)

--- a/src/components/Icons/FileIcons.tsx
+++ b/src/components/Icons/FileIcons.tsx
@@ -16,6 +16,7 @@ import {
 	KanbanIcon,
 	Music as MusicIcon,
 	NoteIcon,
+	PaintBoardIcon,
 	Palette as PaletteIcon,
 	Pdf01Icon,
 	Ppt01Icon,
@@ -86,6 +87,9 @@ export const Table = (props: IconProps) => (
 );
 export const Kanban = (props: IconProps) => (
 	<HugeiconsIcon icon={KanbanIcon} strokeWidth={0.9} {...props} />
+);
+export const Flow = (props: IconProps) => (
+	<HugeiconsIcon icon={PaintBoardIcon} strokeWidth={0.9} {...props} />
 );
 export const Cpu = (props: IconProps) => (
 	<HugeiconsIcon icon={CpuIcon} strokeWidth={0.9} {...props} />

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -62,7 +62,12 @@ import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { listTemplates, renderTemplate } from "../../lib/templates";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
-import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
+import {
+	canOpenInWorkspace,
+	isMarkdownPath,
+	normalizeRelPath,
+	parentDir,
+} from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { LayoutAlignLeft } from "../Icons";
 import { dispatchAiContextAttach } from "../ai/aiContextEvents";
@@ -365,7 +370,7 @@ export function AppShell() {
 	const openWorkspaceFile = useCallback(
 		async (path: string) => {
 			if (!path) return;
-			if (isMarkdownPath(path)) {
+			if (canOpenInWorkspace(path)) {
 				setActiveDirPath(parentDir(path));
 				openFileTab(path);
 				return;
@@ -405,7 +410,7 @@ export function AppShell() {
 	const openFolioWorkspaceFile = useCallback(
 		async (path: string) => {
 			if (!path) return;
-			if (!isMarkdownPath(path)) {
+			if (!canOpenInWorkspace(path)) {
 				await fileTree.openFile(path);
 				return;
 			}
@@ -418,7 +423,7 @@ export function AppShell() {
 	const openWorkspaceFileInNewTab = useCallback(
 		async (path: string) => {
 			if (!path) return;
-			if (!isMarkdownPath(path)) {
+			if (!canOpenInWorkspace(path)) {
 				await openWorkspaceFile(path);
 				return;
 			}
@@ -435,7 +440,7 @@ export function AppShell() {
 	const openFolioWorkspaceFileInNewTab = useCallback(
 		async (path: string) => {
 			if (!path) return;
-			if (!isMarkdownPath(path)) {
+			if (!canOpenInWorkspace(path)) {
 				await openFolioWorkspaceFile(path);
 				return;
 			}
@@ -702,6 +707,13 @@ export function AppShell() {
 				: (activeDirPath ?? "");
 		return fileTree.onNewFileInDir(nextDir);
 	}, [activeDirPath, dailyNotesFolder, fileTree, spacePath]);
+
+	const createFlowInSelectedFolder = useCallback(async () => {
+		if (!spacePath) return null;
+		const nextDir =
+			activeDirPath ?? (activeFilePath ? parentDir(activeFilePath) : "");
+		return fileTree.onNewFlowInDir(nextDir);
+	}, [activeDirPath, activeFilePath, fileTree, spacePath]);
 
 	const handleNewNoteFromMenu = useCallback(() => {
 		if (!spacePath) return;
@@ -1065,6 +1077,7 @@ export function AppShell() {
 		closeActiveTab,
 		closeAllTabs,
 		closeSpace,
+		createFlowInSelectedFolder,
 		createDatabaseAndOpen,
 		createNoteInSelectedFolder,
 		fileTree,
@@ -1253,6 +1266,7 @@ export function AppShell() {
 				onOpenFile={(p) => void openWorkspaceFile(p)}
 				onNewNote={() => void createNoteInSelectedFolder()}
 				onNewFileInDir={(p) => void fileTree.onNewFileInDir(p)}
+				onNewFlowInDir={(p) => void fileTree.onNewFlowInDir(p)}
 				onCreateFromTemplateInDir={(p) => void openTemplatePicker(p)}
 				onNewFolderInDir={(p) => fileTree.onNewFolderInDir(p)}
 				onDuplicateFile={(p) => duplicateFileWithActiveEditorFlush(p)}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -80,12 +80,14 @@ import {
 	loadAllDocsPane,
 	loadCalendarPane,
 	loadDatabasesPane,
+	loadFlowPane,
 } from "./prefetchablePanes";
 import type { WorkspaceTab } from "./useTabManager";
 
 const DatabasesPane = lazy(loadDatabasesPane);
 const CalendarPane = lazy(loadCalendarPane);
 const AllDocsPane = lazy(loadAllDocsPane);
+const FlowPane = lazy(loadFlowPane);
 const ShortcutsSettingsPane = lazy(() =>
 	import("../settings/ShortcutsSettingsPane").then((module) => ({
 		default: module.ShortcutsSettingsPane,
@@ -711,6 +713,25 @@ export const MainContent = memo(function MainContent({
 				/>
 			);
 		}
+		if (viewerPath.toLowerCase().endsWith(".flow")) {
+			return (
+				<Suspense
+					fallback={<div className="databaseLoadingState">Loading flow…</div>}
+				>
+					<FlowPane
+						relPath={viewerPath}
+						openFile={onOpenFile}
+						onDirtyChange={(dirty) =>
+							setDirtyByPath((prev) =>
+								prev[viewerPath] === dirty
+									? prev
+									: { ...prev, [viewerPath]: dirty },
+							)
+						}
+					/>
+				</Suspense>
+			);
+		}
 		return null;
 	}, [
 		fileTree,
@@ -729,6 +750,10 @@ export const MainContent = memo(function MainContent({
 			if (!target) return;
 			if (target.toLowerCase().endsWith(".md")) {
 				prefetchNote(target);
+				return;
+			}
+			if (target.toLowerCase().endsWith(".flow")) {
+				void loadFlowPane();
 				return;
 			}
 			if (target === ALL_DOCS_TAB_ID) {
@@ -784,8 +809,8 @@ export const MainContent = memo(function MainContent({
 			SETTINGS_TABS.find((tab) => tab.id === settingsTab) ?? SETTINGS_TABS[0],
 		[settingsTab],
 	);
-	const editorCanvas = (
-		<div className="canvasPaneHost">
+	const editorFlow = (
+		<div className="flowPaneHost">
 			<DailyNotesSetupToast
 				visible={dailyNoteSetupToastVisible}
 				onDismiss={() => setDailyNoteSetupToastVisible(false)}
@@ -929,7 +954,7 @@ export const MainContent = memo(function MainContent({
 				className="mainArea"
 				data-right-sidebar-open={rightSidebarOpen ? "true" : undefined}
 			>
-				<div className="canvasWrapper">
+				<div className="flowWrapper">
 					{folioMode ? (
 						<FolioWorkspace
 							activeTabPath={activeTabPath}
@@ -940,10 +965,10 @@ export const MainContent = memo(function MainContent({
 							}
 							onDeleteFile={(path) => fileTree.onDeletePath(path, "file")}
 						>
-							{editorCanvas}
+							{editorFlow}
 						</FolioWorkspace>
 					) : (
-						editorCanvas
+						editorFlow
 					)}
 				</div>
 			</main>

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -15,6 +15,7 @@ interface SidebarProps {
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
 	onNewFileInDir: (dirPath: string) => void;
+	onNewFlowInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
@@ -54,6 +55,7 @@ export const Sidebar = memo(function Sidebar({
 	onOpenFile,
 	onNewNote,
 	onNewFileInDir,
+	onNewFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
@@ -132,6 +134,7 @@ export const Sidebar = memo(function Sidebar({
 									onOpenFile={onOpenFile}
 									onNewNote={onNewNote}
 									onNewFileInDir={onNewFileInDir}
+									onNewFlowInDir={onNewFlowInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 									onNewFolderInDir={onNewFolderInDir}
 									onDuplicateFile={onDuplicateFile}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -34,6 +34,7 @@ interface SidebarContentProps {
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
 	onNewFileInDir: (dirPath: string) => void;
+	onNewFlowInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
@@ -112,6 +113,7 @@ export const SidebarContent = memo(function SidebarContent({
 	onOpenFile,
 	onNewNote,
 	onNewFileInDir,
+	onNewFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
@@ -146,7 +148,7 @@ export const SidebarContent = memo(function SidebarContent({
 	} = useFileTreeContext();
 	const { folioMode, folioScope, setFolioScope } = useUILayoutContext();
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
-	const [pendingNewNotePath, setPendingNewNotePath] = useState<string | null>(
+	const [pendingNewFilePath, setPendingNewFilePath] = useState<string | null>(
 		null,
 	);
 	const [notesExpanded, setNotesExpanded] = useState(true);
@@ -183,7 +185,7 @@ export const SidebarContent = memo(function SidebarContent({
 		const nextPath = path.trim();
 		if (!nextPath) return;
 		setRenamingPath(nextPath);
-		setPendingNewNotePath(nextPath);
+		setPendingNewFilePath(nextPath);
 	}, []);
 
 	useEffect(() => {
@@ -250,7 +252,7 @@ export const SidebarContent = memo(function SidebarContent({
 
 	const handleCancelRename = useCallback(() => {
 		setRenamingPath(null);
-		setPendingNewNotePath(null);
+		setPendingNewFilePath(null);
 	}, []);
 
 	const handleCommitDirRename = useCallback(
@@ -268,12 +270,12 @@ export const SidebarContent = memo(function SidebarContent({
 			const renamed = await onRenameDir(path, nextName, "file");
 			if (!renamed) return;
 			setRenamingPath(null);
-			if (pendingNewNotePath === path) {
+			if (pendingNewFilePath === path) {
 				onOpenFile(renamed);
-				setPendingNewNotePath(null);
+				setPendingNewFilePath(null);
 			}
 		},
-		[onOpenFile, onRenameDir, pendingNewNotePath],
+		[onOpenFile, onRenameDir, pendingNewFilePath],
 	);
 
 	const handleShowSpaceMenu = useCallback(
@@ -527,6 +529,7 @@ export const SidebarContent = memo(function SidebarContent({
 									onOpenFile={onOpenFile}
 									onPrefetchFile={onPrefetchFile}
 									onNewFileInDir={onNewFileInDir}
+									onNewFlowInDir={onNewFlowInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 									onNewFolderInDir={onNewFolderInDir}
 									onDuplicateFile={onDuplicateFile}

--- a/src/components/app/prefetchablePanes.ts
+++ b/src/components/app/prefetchablePanes.ts
@@ -12,3 +12,8 @@ export const loadAllDocsPane = () =>
 	import("./AllDocsPane").then((module) => ({
 		default: module.AllDocsPane,
 	}));
+
+export const loadFlowPane = () =>
+	import("../flow/FlowPane").then((module) => ({
+		default: module.FlowPane,
+	}));

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -16,6 +16,7 @@ import {
 	Link01Icon,
 	MoveIcon,
 	NoteIcon,
+	PaintBoardIcon,
 	PencilEdit02Icon,
 	PinIcon,
 	PinOffIcon,
@@ -69,6 +70,7 @@ interface UseAppCommandsDeps {
 	closeActiveTab: () => void;
 	closeAllTabs: () => void;
 	closeSpace: () => void;
+	createFlowInSelectedFolder: () => Promise<string | null>;
 	createDatabaseAndOpen: () => Promise<string | null>;
 	createNoteInSelectedFolder: () => Promise<string | null>;
 	fileTree: UseFileTreeResult;
@@ -257,6 +259,7 @@ export function useAppCommands({
 	closeActiveTab,
 	closeAllTabs,
 	closeSpace,
+	createFlowInSelectedFolder,
 	createDatabaseAndOpen,
 	createNoteInSelectedFolder,
 	fileTree,
@@ -332,6 +335,16 @@ export function useAppCommands({
 				shortcut: { meta: true, key: "n" },
 				enabled: Boolean(spacePath),
 				action: () => void createNoteInSelectedFolder(),
+			},
+			{
+				id: "new-flow",
+				label: "New flow",
+				icon: (
+					<HugeiconsIcon icon={PaintBoardIcon} size={16} strokeWidth={0.9} />
+				),
+				category: "File Operations",
+				enabled: Boolean(spacePath),
+				action: () => void createFlowInSelectedFolder(),
 			},
 			{
 				id: "open-quick-note",
@@ -809,6 +822,7 @@ export function useAppCommands({
 		onCreateSpace,
 		onOpenSpace,
 		openMarkdownTabsLength,
+		createFlowInSelectedFolder,
 		createDatabaseAndOpen,
 		createNoteInSelectedFolder,
 		requestOpenDailyNote,

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useRecentFiles } from "../../hooks/useRecentFiles";
-import { isMarkdownPath } from "../../utils/path";
+import { canOpenInWorkspace, isMarkdownPath } from "../../utils/path";
 
 export interface WorkspaceTab {
 	id: string;
@@ -302,7 +302,7 @@ export function useTabManager(spacePath: string | null) {
 		(activeHistory?.index ?? -1) < (activeHistory?.entries.length ?? 0) - 1;
 
 	const canOpenInMainPane = useCallback(
-		(path: string) => isMarkdownPath(path),
+		(path: string) => canOpenInWorkspace(path),
 		[],
 	);
 

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -25,6 +25,8 @@ import {
 } from "./fileTreeItemHelpers";
 import { fileTreeAppearanceNativeMenu } from "./fileTreeNativeContextMenu";
 
+const noopCreateFlowInDir = () => undefined;
+
 function DirectoryRenameInput({
 	initialName,
 	relPath,
@@ -96,6 +98,7 @@ interface FileTreeDirItemProps {
 	onCommitRename: (dirPath: string, nextName: string) => Promise<void> | void;
 	onCancelRename: () => void;
 	onNewFileInDir: (dirPath: string) => unknown;
+	onNewFlowInDir?: (dirPath: string) => unknown;
 	onCreateFromTemplateInDir: (dirPath: string) => unknown;
 	onNewFolderInDir: (dirPath: string) => unknown;
 	onDeletePath: (path: string, kind: "dir" | "file") => void;
@@ -119,6 +122,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	onCommitRename,
 	onCancelRename,
 	onNewFileInDir,
+	onNewFlowInDir = noopCreateFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDeletePath,
@@ -168,6 +172,10 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					action: () => void onNewFileInDir(entry.rel_path),
 				},
 				{
+					label: "Create flow",
+					action: () => void onNewFlowInDir(entry.rel_path),
+				},
+				{
 					label: "Create from template",
 					action: () => void onCreateFromTemplateInDir(entry.rel_path),
 				},
@@ -196,6 +204,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			onChangeAppearance,
 			onCreateFromTemplateInDir,
 			onDeletePath,
+			onNewFlowInDir,
 			onNewFileInDir,
 			onNewFolderInDir,
 			onStartRename,

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -29,6 +29,7 @@ import { getFileTypeInfo } from "./fileTypeUtils";
 const DEFAULT_MOVE_CLICK_SUPPRESS_REF: MutableRefObject<boolean> = {
 	current: false,
 };
+const noopCreateFlowInDir = () => undefined;
 
 function FileRenameInput({
 	initialName,
@@ -102,6 +103,7 @@ interface FileTreeFileItemProps {
 	onOpenFile: (filePath: string) => void;
 	onPrefetchFile?: (filePath: string) => void;
 	onNewFileInDir: (dirPath: string) => unknown;
+	onNewFlowInDir?: (dirPath: string) => unknown;
 	onCreateFromTemplateInDir: (dirPath: string) => unknown;
 	onNewFolderInDir: (dirPath: string) => unknown;
 	onDuplicateFile: (path: string) => unknown;
@@ -132,6 +134,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	onOpenFile,
 	onPrefetchFile,
 	onNewFileInDir,
+	onNewFlowInDir = noopCreateFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
@@ -238,6 +241,10 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					action: () => void onNewFileInDir(parentDirPath),
 				},
 				{
+					label: "Create flow",
+					action: () => void onNewFlowInDir(parentDirPath),
+				},
+				{
 					label: "Create from template",
 					action: () => void onCreateFromTemplateInDir(parentDirPath),
 				},
@@ -263,6 +270,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			onCreateFromTemplateInDir,
 			onDeletePath,
 			onDuplicateFile,
+			onNewFlowInDir,
 			onNewFileInDir,
 			onNewFolderInDir,
 			onOpenFile,
@@ -347,7 +355,14 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 								className="fileTreeTaskProgress"
 							/>
 						) : null}
-						{extBadge && <span className="fileTreeExtBadge">{extBadge}</span>}
+						{extBadge ? (
+							<span
+								className="fileTreeExtBadge"
+								data-ext={extBadge.toLowerCase()}
+							>
+								{extBadge}
+							</span>
+						) : null}
 					</m.button>
 				)}
 			</div>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -59,6 +59,7 @@ interface FileTreePaneProps {
 	onOpenFile: (filePath: string) => void;
 	onPrefetchFile?: (filePath: string) => void;
 	onNewFileInDir: (dirPath: string) => void;
+	onNewFlowInDir?: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
@@ -81,6 +82,7 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const MARKDOWN_PREVIEW_MAX_BYTES = 4096;
 const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
+const noopCreateFlowInDir = () => undefined;
 
 function spaceLabelFromPath(path: string | null): string {
 	if (!path) return "Glyph";
@@ -256,6 +258,7 @@ interface TreeEntriesProps {
 	onOpenFile: (filePath: string) => void;
 	onPrefetchFile?: (filePath: string) => void;
 	onNewFileInDir: (dirPath: string) => void;
+	onNewFlowInDir?: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
@@ -299,6 +302,7 @@ function TreeEntries({
 	onOpenFile,
 	onPrefetchFile,
 	onNewFileInDir,
+	onNewFlowInDir = noopCreateFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
@@ -346,6 +350,7 @@ function TreeEntries({
 							onEnterDir={onEnterDir}
 							onSelectDir={onSelectDir}
 							onNewFileInDir={onNewFileInDir}
+							onNewFlowInDir={onNewFlowInDir}
 							onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 							onNewFolderInDir={onNewFolderInDir}
 							onDeletePath={onDeletePath}
@@ -378,6 +383,7 @@ function TreeEntries({
 									onOpenFile={onOpenFile}
 									onPrefetchFile={onPrefetchFile}
 									onNewFileInDir={onNewFileInDir}
+									onNewFlowInDir={onNewFlowInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 									onNewFolderInDir={onNewFolderInDir}
 									onDuplicateFile={onDuplicateFile}
@@ -413,6 +419,7 @@ function TreeEntries({
 						onOpenFile={onOpenFile}
 						onPrefetchFile={onPrefetchFile}
 						onNewFileInDir={onNewFileInDir}
+						onNewFlowInDir={onNewFlowInDir}
 						onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 						onNewFolderInDir={onNewFolderInDir}
 						onDuplicateFile={onDuplicateFile}
@@ -459,6 +466,7 @@ export const FileTreePane = memo(function FileTreePane({
 	onOpenFile,
 	onPrefetchFile,
 	onNewFileInDir,
+	onNewFlowInDir,
 	onCreateFromTemplateInDir,
 	onNewFolderInDir,
 	onDuplicateFile,
@@ -921,6 +929,7 @@ export const FileTreePane = memo(function FileTreePane({
 								onOpenFile={onOpenFile}
 								onPrefetchFile={onPrefetchFile}
 								onNewFileInDir={onNewFileInDir}
+								onNewFlowInDir={onNewFlowInDir}
 								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 								onNewFolderInDir={handleCreateFolder}
 								onDuplicateFile={handleDuplicateFile}
@@ -1059,6 +1068,7 @@ export const FileTreePane = memo(function FileTreePane({
 								onOpenFile={onOpenFile}
 								onPrefetchFile={onPrefetchFile}
 								onNewFileInDir={onNewFileInDir}
+								onNewFlowInDir={onNewFlowInDir}
 								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 								onNewFolderInDir={handleCreateFolder}
 								onDuplicateFile={handleDuplicateFile}

--- a/src/components/filetree/fileTypeUtils.ts
+++ b/src/components/filetree/fileTypeUtils.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import { isFlowPath } from "../../utils/path";
 import type { IconProps } from "../Icons";
 import {
 	Archive,
@@ -19,6 +20,7 @@ import {
 	FileTxt,
 	FileXml,
 	Film,
+	Flow,
 	Hash,
 	Music,
 	Palette,
@@ -38,6 +40,9 @@ export function getFileTypeInfo(
 
 	if (isMarkdown) {
 		return { Icon: FileText, color: "var(--text-accent)", label: "markdown" };
+	}
+	if (isFlowPath(relPath)) {
+		return { Icon: Flow, color: "var(--text-accent)", label: "flow" };
 	}
 	if (
 		[

--- a/src/components/flow/FlowNodes.tsx
+++ b/src/components/flow/FlowNodes.tsx
@@ -1,0 +1,300 @@
+import { RotateClockwiseIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	Handle,
+	type NodeProps,
+	NodeResizer,
+	Position,
+	useReactFlow,
+} from "@xyflow/react";
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import type { FlowEdge, FlowNode } from "../../lib/flow";
+import { parseNotePreview } from "../../lib/notePreview";
+import { invoke } from "../../lib/tauri";
+import { basename, isMarkdownPath } from "../../utils/path";
+
+interface TextFilePreviewDoc {
+	rel_path: string;
+	text: string;
+	mtime_ms: number;
+	truncated: boolean;
+	bytes_read: number;
+	total_bytes: number;
+}
+
+function FlowHandles() {
+	return (
+		<>
+			<Handle id="top" type="source" position={Position.Top} />
+			<Handle id="right" type="source" position={Position.Right} />
+			<Handle id="bottom" type="source" position={Position.Bottom} />
+			<Handle id="left" type="source" position={Position.Left} />
+			<Handle id="top" type="target" position={Position.Top} />
+			<Handle id="right" type="target" position={Position.Right} />
+			<Handle id="bottom" type="target" position={Position.Bottom} />
+			<Handle id="left" type="target" position={Position.Left} />
+		</>
+	);
+}
+
+function nodeStyle(color?: string, rotation?: number) {
+	const style = {
+		"--flow-node-rotation": `${rotation ?? 0}deg`,
+	} as CSSProperties;
+	if (color) {
+		return { ...style, "--flow-node-accent": color } as CSSProperties;
+	}
+	return style;
+}
+
+function FlowNodeResizer({
+	selected,
+	minWidth,
+	minHeight,
+}: {
+	selected: boolean;
+	minWidth: number;
+	minHeight: number;
+}) {
+	return (
+		<NodeResizer
+			isVisible={selected}
+			minWidth={minWidth}
+			minHeight={minHeight}
+			color="var(--interactive-accent)"
+			handleClassName="flowNodeResizeHandle"
+			lineClassName="flowNodeResizeLine"
+		/>
+	);
+}
+
+function FlowRotateHandle({
+	id,
+	selected,
+	rotation,
+}: {
+	id: string;
+	selected: boolean;
+	rotation?: number;
+}) {
+	const { setNodes } = useReactFlow<FlowNode, FlowEdge>();
+
+	const updateRotation = useCallback(
+		(nextRotation: number) => {
+			setNodes((nodes) =>
+				nodes.map((node) =>
+					node.id === id
+						? {
+								...node,
+								data: {
+									...node.data,
+									rotation: normalizeRotation(nextRotation),
+								},
+							}
+						: node,
+				),
+			);
+		},
+		[id, setNodes],
+	);
+
+	const onPointerDown = useCallback(
+		(event: ReactPointerEvent<HTMLButtonElement>) => {
+			const nodeElement = event.currentTarget.closest(".flowRotatableNode");
+			if (!(nodeElement instanceof HTMLElement)) return;
+			event.preventDefault();
+			event.stopPropagation();
+
+			const updateFromPointer = (clientX: number, clientY: number) => {
+				const rect = nodeElement.getBoundingClientRect();
+				const centerX = rect.left + rect.width / 2;
+				const centerY = rect.top + rect.height / 2;
+				const angle =
+					(Math.atan2(clientY - centerY, clientX - centerX) * 180) / Math.PI +
+					90;
+				updateRotation(angle);
+			};
+
+			updateFromPointer(event.clientX, event.clientY);
+
+			const onPointerMove = (moveEvent: PointerEvent) => {
+				updateFromPointer(moveEvent.clientX, moveEvent.clientY);
+			};
+			const onPointerUp = () => {
+				window.removeEventListener("pointermove", onPointerMove);
+				window.removeEventListener("pointerup", onPointerUp);
+			};
+
+			window.addEventListener("pointermove", onPointerMove);
+			window.addEventListener("pointerup", onPointerUp);
+		},
+		[updateRotation],
+	);
+
+	if (!selected) return null;
+
+	return (
+		<button
+			type="button"
+			className="flowRotateHandle nodrag nopan"
+			title="Rotate"
+			aria-label="Rotate node"
+			onPointerDown={onPointerDown}
+		>
+			<HugeiconsIcon icon={RotateClockwiseIcon} size={13} strokeWidth={1.7} />
+			<span className="sr-only">{Math.round(rotation ?? 0)} degrees</span>
+		</button>
+	);
+}
+
+export const FlowTextNode = memo(function FlowTextNode({
+	id,
+	data,
+	selected,
+}: NodeProps<FlowNode>) {
+	const { setNodes } = useReactFlow<FlowNode, FlowEdge>();
+	const text = data.flowType === "text" ? data.text : "";
+	const glyphKind = data.flowType === "text" ? data.glyphKind : "text";
+
+	return (
+		<section
+			className="flowNode flowTextNode flowRotatableNode"
+			data-kind={glyphKind}
+			style={nodeStyle(data.color, data.rotation)}
+		>
+			<FlowNodeResizer selected={selected} minWidth={180} minHeight={120} />
+			<FlowRotateHandle id={id} selected={selected} rotation={data.rotation} />
+			<FlowHandles />
+			<div className="flowTextDragHandle" aria-hidden="true" />
+			<textarea
+				className="flowTextInput nodrag nopan nowheel"
+				value={text}
+				placeholder="Write a thought..."
+				onChange={(event) => {
+					const nextText = event.target.value;
+					setNodes((nodes) =>
+						nodes.map((node) =>
+							node.id === id && node.data.flowType === "text"
+								? {
+										...node,
+										data: { ...node.data, text: nextText },
+									}
+								: node,
+						),
+					);
+				}}
+			/>
+		</section>
+	);
+});
+
+export const FlowFileNode = memo(function FlowFileNode({
+	id,
+	data,
+	selected,
+}: NodeProps<FlowNode>) {
+	const file = data.flowType === "file" ? data.file : "";
+	const [preview, setPreview] = useState<TextFilePreviewDoc | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const fileName = useMemo(() => basename(file), [file]);
+	const title = useMemo(() => fileName.replace(/\.md$/i, ""), [fileName]);
+
+	useEffect(() => {
+		if (!file || !isMarkdownPath(file)) {
+			setPreview(null);
+			setError(null);
+			return;
+		}
+		let cancelled = false;
+		void invoke("space_read_text_preview", { path: file, max_bytes: 6000 })
+			.then((doc) => {
+				if (!cancelled) {
+					setPreview(doc);
+					setError(null);
+				}
+			})
+			.catch((cause) => {
+				if (!cancelled) {
+					setPreview(null);
+					setError(cause instanceof Error ? cause.message : String(cause));
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [file]);
+
+	const parsed = preview ? parseNotePreview(file, preview.text) : null;
+
+	return (
+		<section
+			className="flowNode flowFileNode flowRotatableNode"
+			style={nodeStyle(data.color, data.rotation)}
+		>
+			<FlowNodeResizer selected={selected} minWidth={220} minHeight={130} />
+			<FlowRotateHandle id={id} selected={selected} rotation={data.rotation} />
+			<FlowHandles />
+			<header className="flowNodeHeader">
+				<strong>{parsed?.title || title || "Untitled"}</strong>
+			</header>
+			<div className="flowNodeBody nowheel">
+				{error ? (
+					<p className="flowNodeMuted">{error}</p>
+				) : parsed?.content ? (
+					<pre className="flowMarkdownPreview">{parsed.content}</pre>
+				) : (
+					<p className="flowNodeMuted">{file}</p>
+				)}
+			</div>
+			<div className="flowFileName" title={file}>
+				{fileName || file}
+			</div>
+		</section>
+	);
+});
+
+export const FlowLinkNode = memo(function FlowLinkNode({
+	id,
+	data,
+	selected,
+}: NodeProps<FlowNode>) {
+	const url = data.flowType === "link" ? data.url : "";
+	return (
+		<section
+			className="flowNode flowLinkNode flowRotatableNode"
+			style={nodeStyle(data.color, data.rotation)}
+		>
+			<FlowNodeResizer selected={selected} minWidth={220} minHeight={110} />
+			<FlowRotateHandle id={id} selected={selected} rotation={data.rotation} />
+			<FlowHandles />
+			<header className="flowNodeHeader">
+				<strong>{url.replace(/^https?:\/\//, "") || "Untitled link"}</strong>
+			</header>
+			<p className="flowNodeMuted">{url}</p>
+		</section>
+	);
+});
+
+export const FlowGroupNode = memo(function FlowGroupNode({
+	id,
+	data,
+	selected,
+}: NodeProps<FlowNode>) {
+	const label = data.flowType === "group" ? data.label : "";
+	return (
+		<section
+			className="flowGroupNode flowRotatableNode"
+			style={nodeStyle(data.color, data.rotation)}
+			aria-label={label || "Flow group"}
+		>
+			<FlowNodeResizer selected={selected} minWidth={260} minHeight={180} />
+			<FlowRotateHandle id={id} selected={selected} rotation={data.rotation} />
+			<div className="flowGroupLabel">{label || "Group"}</div>
+		</section>
+	);
+});
+
+function normalizeRotation(rotation: number): number {
+	return Math.round(((rotation % 360) + 360) % 360);
+}

--- a/src/components/flow/FlowPane.tsx
+++ b/src/components/flow/FlowPane.tsx
@@ -1,0 +1,1001 @@
+import {
+	Delete02Icon,
+	File01Icon,
+	FitToScreenIcon,
+	GroupLayersIcon,
+	MinusSignIcon,
+	PlusSignIcon,
+	TextIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	Background,
+	type Connection,
+	type EdgeChange,
+	type NodeChange,
+	type NodeMouseHandler,
+	Panel,
+	ReactFlow,
+	ReactFlowProvider,
+	type Viewport,
+	useEdgesState,
+	useNodesState,
+	useReactFlow,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { extractErrorMessage } from "../../lib/errorUtils";
+import {
+	type FlowDocument,
+	type FlowEdge,
+	type FlowNode,
+	createEmptyFlowDocument,
+	flowDocumentToReactFlow,
+	nextFlowNodeId,
+	parseFlowDocument,
+	reactFlowToFlowDocument,
+	serializeFlowDocument,
+} from "../../lib/flow";
+import { invoke } from "../../lib/tauri";
+import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
+import { Button } from "../ui/shadcn/button";
+import { Input } from "../ui/shadcn/input";
+import {
+	FlowFileNode,
+	FlowGroupNode,
+	FlowLinkNode,
+	FlowTextNode,
+} from "./FlowNodes";
+
+const AUTOSAVE_DELAY_MS = 650;
+const DEFAULT_NODE_WIDTH = 280;
+const DEFAULT_NODE_HEIGHT = 180;
+const GROUP_PADDING = 48;
+
+interface FlowPaneProps {
+	relPath: string;
+	openFile?: (relPath: string) => Promise<void> | void;
+	onDirtyChange?: (dirty: boolean) => void;
+}
+
+const nodeTypes = {
+	flowText: FlowTextNode,
+	flowFile: FlowFileNode,
+	flowLink: FlowLinkNode,
+	flowGroup: FlowGroupNode,
+};
+
+export function FlowPane(props: FlowPaneProps) {
+	return (
+		<ReactFlowProvider>
+			<FlowPaneInner {...props} />
+		</ReactFlowProvider>
+	);
+}
+
+function FlowPaneInner({ relPath, openFile, onDirtyChange }: FlowPaneProps) {
+	const { fitView, screenToFlowPosition, zoomIn, zoomOut } = useReactFlow<
+		FlowNode,
+		FlowEdge
+	>();
+	const [nodes, setNodes, onNodesChangeBase] = useNodesState<FlowNode>([]);
+	const [edges, setEdges, onEdgesChangeBase] = useEdgesState<FlowEdge>([]);
+	const [viewport, setViewport] = useState<Viewport>({ x: 0, y: 0, zoom: 1 });
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+	const baseMtimeRef = useRef<number | null>(null);
+	const savedTextRef = useRef("");
+	const loadTokenRef = useRef(0);
+
+	const selectedNode = useMemo(
+		() => nodes.find((node) => node.selected) ?? null,
+		[nodes],
+	);
+	const selectedEdge = useMemo(
+		() => edges.find((edge) => edge.selected) ?? null,
+		[edges],
+	);
+	const selectedGroupableNodeCount = useMemo(
+		() =>
+			nodes.filter((node) => node.selected && node.data.flowType !== "group")
+				.length,
+		[nodes],
+	);
+
+	const currentText = useMemo(() => {
+		const document = reactFlowToFlowDocument({ nodes, edges, viewport });
+		return serializeFlowDocument(document);
+	}, [edges, nodes, viewport]);
+	const dirty = !loading && currentText !== savedTextRef.current;
+
+	const persistFlow = useCallback(
+		async (nextText = currentText) => {
+			setError("");
+			try {
+				const result = await invoke("space_write_text", {
+					path: relPath,
+					text: nextText,
+					base_mtime_ms: baseMtimeRef.current,
+				});
+				baseMtimeRef.current = result.mtime_ms;
+				savedTextRef.current = nextText;
+			} catch (cause) {
+				const message = extractErrorMessage(cause);
+				if (
+					!message.includes(
+						"conflict: on-disk file changed since it was opened",
+					)
+				) {
+					setError(message);
+					return;
+				}
+				try {
+					const latest = await invoke("space_read_text", { path: relPath });
+					const retry = await invoke("space_write_text", {
+						path: relPath,
+						text: nextText,
+						base_mtime_ms: latest.mtime_ms,
+					});
+					baseMtimeRef.current = retry.mtime_ms;
+					savedTextRef.current = nextText;
+				} catch (retryCause) {
+					setError(extractErrorMessage(retryCause));
+				}
+			}
+		},
+		[currentText, relPath],
+	);
+
+	useEffect(() => {
+		onDirtyChange?.(dirty);
+	}, [dirty, onDirtyChange]);
+
+	useEffect(() => {
+		const token = loadTokenRef.current + 1;
+		loadTokenRef.current = token;
+		setLoading(true);
+		setError("");
+		baseMtimeRef.current = null;
+		savedTextRef.current = "";
+		setNodes([]);
+		setEdges([]);
+
+		const applyDocument = (
+			document: FlowDocument,
+			rawText: string,
+			mtimeMs: number | null,
+		) => {
+			const flow = flowDocumentToReactFlow(document);
+			baseMtimeRef.current = mtimeMs;
+			savedTextRef.current = rawText || serializeFlowDocument(document);
+			setNodes(flow.nodes);
+			setEdges(flow.edges);
+			setViewport(flow.viewport);
+			setLoading(false);
+		};
+
+		const loadFlow = async () => {
+			try {
+				const doc = await invoke("space_read_text", { path: relPath });
+				if (loadTokenRef.current !== token) return;
+				applyDocument(parseFlowDocument(doc.text), doc.text, doc.mtime_ms);
+			} catch (cause) {
+				if (loadTokenRef.current !== token) return;
+				const message = extractErrorMessage(cause);
+				if (!isMissingFileMessage(message)) {
+					setError(message);
+					setLoading(false);
+					return;
+				}
+				applyDocument(createEmptyFlowDocument(), "", null);
+			}
+		};
+
+		void loadFlow();
+	}, [relPath, setEdges, setNodes]);
+
+	useEffect(() => {
+		if (loading || !dirty) return;
+		const timer = window.setTimeout(() => {
+			void persistFlow(currentText);
+		}, AUTOSAVE_DELAY_MS);
+		return () => window.clearTimeout(timer);
+	}, [currentText, dirty, loading, persistFlow]);
+
+	const onNodesChange = useCallback(
+		(changes: NodeChange<FlowNode>[]) => {
+			onNodesChangeBase(changes);
+		},
+		[onNodesChangeBase],
+	);
+
+	const onEdgesChange = useCallback(
+		(changes: EdgeChange<FlowEdge>[]) => {
+			onEdgesChangeBase(changes);
+		},
+		[onEdgesChangeBase],
+	);
+
+	const addNodeAtCenter = useCallback(
+		(kind: "text" | "group") => {
+			const position = screenToFlowPosition({
+				x: window.innerWidth / 2,
+				y: window.innerHeight / 2,
+			});
+			const node = createFlowNode(kind, position);
+			setNodes((current) => [...current, node]);
+		},
+		[screenToFlowPosition, setNodes],
+	);
+
+	const groupSelectedNodes = useCallback(() => {
+		setNodes((current) => groupSelectedFlowNodes(current));
+	}, [setNodes]);
+
+	const addPickedFileNode = useCallback(async () => {
+		setError("");
+		try {
+			const { open } = await import("@tauri-apps/plugin-dialog");
+			const selection = await open({
+				title: "Add note or file to flow",
+				multiple: false,
+				directory: false,
+				defaultPath: await flowPickerDefaultPath(relPath),
+			});
+			const absPath = Array.isArray(selection)
+				? (selection[0] ?? null)
+				: selection;
+			if (!absPath) return;
+			const filePath = normalizeRelPath(
+				await invoke("space_relativize_path", { abs_path: absPath }),
+			);
+			const kind = isMarkdownPath(filePath) ? "note" : "file";
+			const position = screenToFlowPosition({
+				x: window.innerWidth / 2,
+				y: window.innerHeight / 2,
+			});
+			setNodes((current) => [
+				...current,
+				createFlowFileNode(kind, filePath, position),
+			]);
+		} catch (cause) {
+			setError(extractErrorMessage(cause));
+		}
+	}, [relPath, screenToFlowPosition, setNodes]);
+
+	const onConnect = useCallback(
+		(connection: Connection) => {
+			if (!connection.source || !connection.target) return;
+			const edge = {
+				id: nextFlowNodeId("edge"),
+				source: connection.source,
+				target: connection.target,
+				sourceHandle: connection.sourceHandle,
+				targetHandle: connection.targetHandle,
+				markerEnd: { type: "arrowclosed" as const },
+			} satisfies FlowEdge;
+			setEdges((current) => [...current, edge]);
+		},
+		[setEdges],
+	);
+
+	const onMoveEnd = useCallback(
+		(_event: MouseEvent | TouchEvent | null, nextViewport: Viewport) =>
+			setViewport(nextViewport),
+		[],
+	);
+
+	const onNodeDragStop = useCallback<NodeMouseHandler<FlowNode>>(
+		(_event, draggedNode) => {
+			if (draggedNode.data.flowType === "group") return;
+			setNodes((current) =>
+				parentNodeToContainingGroup(current, draggedNode.id),
+			);
+		},
+		[setNodes],
+	);
+
+	const updateSelectedNode = useCallback(
+		(updater: (node: FlowNode) => FlowNode) => {
+			if (!selectedNode) return;
+			setNodes((current) =>
+				current.map((node) =>
+					node.id === selectedNode.id ? updater(node) : node,
+				),
+			);
+		},
+		[selectedNode, setNodes],
+	);
+
+	const updateSelectedEdge = useCallback(
+		(updater: (edge: FlowEdge) => FlowEdge) => {
+			if (!selectedEdge) return;
+			setEdges((current) =>
+				current.map((edge) =>
+					edge.id === selectedEdge.id ? updater(edge) : edge,
+				),
+			);
+		},
+		[selectedEdge, setEdges],
+	);
+
+	const deleteSelection = useCallback(() => {
+		const selectedNodeIds = new Set(
+			nodes.filter((node) => node.selected).map((node) => node.id),
+		);
+		const selectedEdgeIds = new Set(
+			edges.filter((edge) => edge.selected).map((edge) => edge.id),
+		);
+		setNodes((current) => removeSelectedFlowNodes(current, selectedNodeIds));
+		setEdges((current) =>
+			current.filter(
+				(edge) =>
+					!selectedEdgeIds.has(edge.id) &&
+					!selectedNodeIds.has(edge.source) &&
+					!selectedNodeIds.has(edge.target),
+			),
+		);
+	}, [edges, nodes, setEdges, setNodes]);
+
+	const detachSelectedNode = useCallback(() => {
+		if (!selectedNode?.parentId) return;
+		setNodes((current) => detachFlowNodeFromParent(current, selectedNode.id));
+	}, [selectedNode, setNodes]);
+
+	if (loading) {
+		return <div className="glyphFlowState">Loading flow...</div>;
+	}
+
+	return (
+		<div className="glyphFlowPane">
+			<ReactFlow
+				nodes={nodes}
+				edges={edges}
+				nodeTypes={nodeTypes}
+				defaultViewport={viewport}
+				fitView={nodes.length > 0}
+				minZoom={0.15}
+				maxZoom={2.5}
+				onNodesChange={onNodesChange}
+				onEdgesChange={onEdgesChange}
+				onConnect={onConnect}
+				onMoveEnd={onMoveEnd}
+				onNodeDragStop={onNodeDragStop}
+				onNodeDoubleClick={(_event, node) => {
+					if (node.data.flowType === "file") void openFile?.(node.data.file);
+				}}
+				proOptions={{ hideAttribution: true }}
+			>
+				<Background color="var(--glyph-flow-grid)" gap={24} size={1} />
+				<Panel position="bottom-center" className="glyphFlowToolbar">
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title="Add note or file"
+						onClick={() => void addPickedFileNode()}
+					>
+						<HugeiconsIcon icon={File01Icon} size={15} strokeWidth={1} />
+					</Button>
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title="Add text"
+						onClick={() => addNodeAtCenter("text")}
+					>
+						<HugeiconsIcon icon={TextIcon} size={15} strokeWidth={1} />
+					</Button>
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title={
+							selectedGroupableNodeCount > 0 ? "Group selection" : "Add group"
+						}
+						onClick={() =>
+							selectedGroupableNodeCount > 0
+								? groupSelectedNodes()
+								: addNodeAtCenter("group")
+						}
+					>
+						<HugeiconsIcon icon={GroupLayersIcon} size={15} strokeWidth={1} />
+					</Button>
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title="Zoom out"
+						onClick={() => void zoomOut({ duration: 160 })}
+					>
+						<HugeiconsIcon icon={MinusSignIcon} size={15} strokeWidth={1} />
+					</Button>
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title="Zoom in"
+						onClick={() => void zoomIn({ duration: 160 })}
+					>
+						<HugeiconsIcon icon={PlusSignIcon} size={15} strokeWidth={1} />
+					</Button>
+					<Button
+						type="button"
+						size="icon-sm"
+						variant="secondary"
+						title="Fit view"
+						onClick={() => void fitView({ duration: 180, padding: 0.2 })}
+					>
+						<HugeiconsIcon icon={FitToScreenIcon} size={15} strokeWidth={1} />
+					</Button>
+					{selectedNode || selectedEdge ? (
+						<Button
+							type="button"
+							size="icon-sm"
+							variant="secondary"
+							title="Delete selection"
+							onClick={deleteSelection}
+						>
+							<HugeiconsIcon icon={Delete02Icon} size={15} strokeWidth={1} />
+						</Button>
+					) : null}
+				</Panel>
+				{error ? (
+					<Panel position="top-right" className="glyphFlowError">
+						{error}
+					</Panel>
+				) : null}
+				{selectedNode ? (
+					<FlowNodeInspector
+						node={selectedNode}
+						onUpdate={updateSelectedNode}
+						onDetach={selectedNode.parentId ? detachSelectedNode : undefined}
+					/>
+				) : selectedEdge ? (
+					<FlowDocumentEdgeInspector
+						edge={selectedEdge}
+						onUpdate={updateSelectedEdge}
+					/>
+				) : null}
+			</ReactFlow>
+		</div>
+	);
+}
+
+interface FlowNodeInspectorProps {
+	node: FlowNode;
+	onUpdate: (updater: (node: FlowNode) => FlowNode) => void;
+	onDetach?: () => void;
+}
+
+function FlowNodeInspector({
+	node,
+	onUpdate,
+	onDetach,
+}: FlowNodeInspectorProps) {
+	return (
+		<Panel position="bottom-right" className="glyphFlowInspector">
+			{onDetach ? (
+				<div className="glyphFlowInspectorActions">
+					<Button
+						type="button"
+						size="xs"
+						variant="secondary"
+						onClick={onDetach}
+					>
+						Ungroup
+					</Button>
+				</div>
+			) : null}
+			{node.data.flowType === "link" ? (
+				<FlowField label="URL">
+					<Input
+						value={node.data.url}
+						onChange={(event) =>
+							onUpdate((current) =>
+								current.data.flowType === "link"
+									? {
+											...current,
+											data: { ...current.data, url: event.target.value },
+										}
+									: current,
+							)
+						}
+					/>
+				</FlowField>
+			) : null}
+			{node.data.flowType === "group" ? (
+				<FlowField label="Label">
+					<Input
+						value={node.data.label ?? ""}
+						onChange={(event) =>
+							onUpdate((current) =>
+								current.data.flowType === "group"
+									? {
+											...current,
+											data: { ...current.data, label: event.target.value },
+										}
+									: current,
+							)
+						}
+					/>
+				</FlowField>
+			) : null}
+			<FlowColorField
+				label="Color"
+				value={node.data.color}
+				fallback={defaultNodeColor(node)}
+				onChange={(color) =>
+					onUpdate((current) => ({
+						...current,
+						data: {
+							...current.data,
+							color,
+						},
+					}))
+				}
+			/>
+		</Panel>
+	);
+}
+
+interface FlowDocumentEdgeInspectorProps {
+	edge: FlowEdge;
+	onUpdate: (updater: (edge: FlowEdge) => FlowEdge) => void;
+}
+
+function FlowDocumentEdgeInspector({
+	edge,
+	onUpdate,
+}: FlowDocumentEdgeInspectorProps) {
+	const label = typeof edge.label === "string" ? edge.label : "";
+	const color = typeof edge.style?.stroke === "string" ? edge.style.stroke : "";
+
+	return (
+		<Panel position="bottom-right" className="glyphFlowInspector">
+			<FlowField label="Label">
+				<Input
+					value={label}
+					onChange={(event) =>
+						onUpdate((current) => ({
+							...current,
+							label: event.target.value || undefined,
+						}))
+					}
+				/>
+			</FlowField>
+			<FlowColorField
+				label="Color"
+				value={color}
+				fallback="#667085"
+				onChange={(nextColor) =>
+					onUpdate((current) => ({
+						...current,
+						style: {
+							...current.style,
+							stroke: nextColor,
+						},
+					}))
+				}
+			/>
+		</Panel>
+	);
+}
+
+function FlowField({
+	label,
+	children,
+}: {
+	label: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="glyphFlowField">
+			<span>{label}</span>
+			{children}
+		</div>
+	);
+}
+
+function FlowColorField({
+	label,
+	value,
+	fallback,
+	onChange,
+}: {
+	label: string;
+	value?: string;
+	fallback: string;
+	onChange: (color: string | undefined) => void;
+}) {
+	const pickerValue = colorPickerValue(value, fallback);
+
+	return (
+		<div className="glyphFlowField">
+			<span>{label}</span>
+			<div className="glyphFlowColorControl">
+				<input
+					type="color"
+					value={pickerValue}
+					aria-label={label}
+					onChange={(event) => onChange(event.target.value)}
+				/>
+				<Button
+					type="button"
+					size="xs"
+					variant="ghost"
+					disabled={!value}
+					onClick={() => onChange(undefined)}
+				>
+					Default
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function groupSelectedFlowNodes(nodes: FlowNode[]): FlowNode[] {
+	const selectedNodes = nodes.filter(
+		(node) => node.selected && node.data.flowType !== "group",
+	);
+	if (selectedNodes.length === 0) return nodes;
+
+	const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+	const selectedRects = selectedNodes.map((node) =>
+		getFlowNodeRect(node, nodeMap),
+	);
+	const bounds = getFlowRectBounds(selectedRects);
+	const groupId = nextFlowNodeId("group");
+	const groupPosition = {
+		x: Math.round(bounds.x - GROUP_PADDING),
+		y: Math.round(bounds.y - GROUP_PADDING),
+	};
+	const groupWidth = Math.round(bounds.width + GROUP_PADDING * 2);
+	const groupHeight = Math.round(bounds.height + GROUP_PADDING * 2);
+	const selectedIds = new Set(selectedNodes.map((node) => node.id));
+	const groupNode: FlowNode = {
+		...createFlowNode("group", groupPosition),
+		id: groupId,
+		width: groupWidth,
+		height: groupHeight,
+		style: { width: groupWidth, height: groupHeight },
+		selected: true,
+	};
+
+	const nextNodes = nodes.map((node) => {
+		if (!selectedIds.has(node.id)) {
+			return { ...node, selected: false };
+		}
+		const absolute = getFlowNodeAbsolutePosition(node, nodeMap);
+		return {
+			...node,
+			parentId: groupId,
+			extent: "parent" as const,
+			position: {
+				x: Math.round(absolute.x - groupPosition.x),
+				y: Math.round(absolute.y - groupPosition.y),
+			},
+			selected: false,
+		};
+	});
+
+	return orderFlowNodes([...nextNodes, groupNode]);
+}
+
+function parentNodeToContainingGroup(
+	nodes: FlowNode[],
+	nodeId: string,
+): FlowNode[] {
+	const node = nodes.find((current) => current.id === nodeId);
+	if (!node || node.data.flowType === "group") return nodes;
+
+	const nodeMap = new Map(nodes.map((current) => [current.id, current]));
+	const targetGroup = findContainingGroup(node, nodes, nodeMap);
+	if (!targetGroup || node.parentId === targetGroup.id) return nodes;
+
+	const nodeAbsolute = getFlowNodeAbsolutePosition(node, nodeMap);
+	const groupAbsolute = getFlowNodeAbsolutePosition(targetGroup, nodeMap);
+	const nextNodes = nodes.map((current) =>
+		current.id === node.id
+			? {
+					...current,
+					parentId: targetGroup.id,
+					extent: "parent" as const,
+					position: {
+						x: Math.round(nodeAbsolute.x - groupAbsolute.x),
+						y: Math.round(nodeAbsolute.y - groupAbsolute.y),
+					},
+				}
+			: current,
+	);
+
+	return orderFlowNodes(nextNodes);
+}
+
+function detachFlowNodeFromParent(
+	nodes: FlowNode[],
+	nodeId: string,
+): FlowNode[] {
+	const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+	return nodes.map((node) => {
+		if (node.id !== nodeId || !node.parentId) return node;
+		const absolute = getFlowNodeAbsolutePosition(node, nodeMap);
+		return {
+			...node,
+			parentId: undefined,
+			extent: undefined,
+			position: {
+				x: Math.round(absolute.x),
+				y: Math.round(absolute.y),
+			},
+		};
+	});
+}
+
+function removeSelectedFlowNodes(
+	nodes: FlowNode[],
+	selectedNodeIds: Set<string>,
+): FlowNode[] {
+	if (selectedNodeIds.size === 0) return nodes;
+	const selectedGroupIds = new Set(
+		nodes
+			.filter(
+				(node) =>
+					selectedNodeIds.has(node.id) && node.data.flowType === "group",
+			)
+			.map((node) => node.id),
+	);
+	const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+
+	return nodes
+		.flatMap((node) => {
+			if (selectedNodeIds.has(node.id)) return [];
+			if (!node.parentId || !selectedGroupIds.has(node.parentId)) return [node];
+			const absolute = getFlowNodeAbsolutePosition(node, nodeMap);
+			return [
+				{
+					...node,
+					parentId: undefined,
+					extent: undefined,
+					position: {
+						x: Math.round(absolute.x),
+						y: Math.round(absolute.y),
+					},
+				},
+			];
+		})
+		.map((node) =>
+			node.parentId && selectedNodeIds.has(node.parentId)
+				? { ...node, parentId: undefined, extent: undefined }
+				: node,
+		);
+}
+
+function findContainingGroup(
+	node: FlowNode,
+	nodes: FlowNode[],
+	nodeMap: Map<string, FlowNode>,
+): FlowNode | null {
+	const nodeRect = getFlowNodeRect(node, nodeMap);
+	const nodeCenter = {
+		x: nodeRect.x + nodeRect.width / 2,
+		y: nodeRect.y + nodeRect.height / 2,
+	};
+
+	const containingGroups = nodes
+		.filter((candidate) => candidate.data.flowType === "group")
+		.map((candidate) => ({
+			node: candidate,
+			rect: getFlowNodeRect(candidate, nodeMap),
+		}))
+		.filter(({ node: candidate, rect }) => {
+			if (candidate.id === node.id) return false;
+			return (
+				nodeCenter.x >= rect.x &&
+				nodeCenter.x <= rect.x + rect.width &&
+				nodeCenter.y >= rect.y &&
+				nodeCenter.y <= rect.y + rect.height
+			);
+		})
+		.sort(
+			(a, b) => a.rect.width * a.rect.height - b.rect.width * b.rect.height,
+		);
+
+	return containingGroups[0]?.node ?? null;
+}
+
+function getFlowRectBounds(
+	rects: Array<{ x: number; y: number; width: number; height: number }>,
+): { x: number; y: number; width: number; height: number } {
+	const minX = Math.min(...rects.map((rect) => rect.x));
+	const minY = Math.min(...rects.map((rect) => rect.y));
+	const maxX = Math.max(...rects.map((rect) => rect.x + rect.width));
+	const maxY = Math.max(...rects.map((rect) => rect.y + rect.height));
+	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+function getFlowNodeRect(
+	node: FlowNode,
+	nodeMap: Map<string, FlowNode>,
+): { x: number; y: number; width: number; height: number } {
+	const position = getFlowNodeAbsolutePosition(node, nodeMap);
+	const size = getFlowNodeSize(node);
+	return { ...position, ...size };
+}
+
+function getFlowNodeAbsolutePosition(
+	node: FlowNode,
+	nodeMap: Map<string, FlowNode>,
+): { x: number; y: number } {
+	let x = node.position.x;
+	let y = node.position.y;
+	let parentId = node.parentId;
+	const visited = new Set<string>();
+
+	while (parentId && !visited.has(parentId)) {
+		visited.add(parentId);
+		const parent = nodeMap.get(parentId);
+		if (!parent) break;
+		x += parent.position.x;
+		y += parent.position.y;
+		parentId = parent.parentId;
+	}
+
+	return { x, y };
+}
+
+function getFlowNodeSize(node: FlowNode): {
+	width: number;
+	height: number;
+} {
+	return {
+		width:
+			typeof node.measured?.width === "number"
+				? node.measured.width
+				: Number(node.style?.width) || node.width || DEFAULT_NODE_WIDTH,
+		height:
+			typeof node.measured?.height === "number"
+				? node.measured.height
+				: Number(node.style?.height) || node.height || DEFAULT_NODE_HEIGHT,
+	};
+}
+
+function orderFlowNodes(nodes: FlowNode[]): FlowNode[] {
+	const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+	const ordered: FlowNode[] = [];
+	const visited = new Set<string>();
+
+	const visit = (node: FlowNode) => {
+		if (visited.has(node.id)) return;
+		if (node.parentId) {
+			const parent = nodeMap.get(node.parentId);
+			if (parent) visit(parent);
+		}
+		visited.add(node.id);
+		ordered.push(node);
+	};
+
+	for (const node of nodes) {
+		if (!node.parentId) visit(node);
+	}
+	for (const node of nodes) {
+		visit(node);
+	}
+
+	return ordered;
+}
+
+function createFlowNode(
+	kind: "text" | "group",
+	position: { x: number; y: number },
+): FlowNode {
+	if (kind === "group") {
+		return {
+			id: nextFlowNodeId("group"),
+			type: "flowGroup",
+			position,
+			width: 420,
+			height: 280,
+			style: { width: 420, height: 280 },
+			zIndex: -1,
+			data: {
+				flowType: "group",
+				label: "Group",
+				color: "#d7e7ff",
+				glyphKind: "group",
+			},
+		};
+	}
+
+	return {
+		id: nextFlowNodeId(kind),
+		type: "flowText",
+		position,
+		width: DEFAULT_NODE_WIDTH,
+		height: DEFAULT_NODE_HEIGHT,
+		style: { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT },
+		data: {
+			flowType: "text",
+			text: "Text",
+			color: "#f7f7f8",
+			glyphKind: "text",
+		},
+	};
+}
+
+function createFlowFileNode(
+	kind: "note" | "file",
+	file: string,
+	position: { x: number; y: number },
+): FlowNode {
+	return {
+		id: nextFlowNodeId(kind),
+		type: "flowFile",
+		position,
+		width: DEFAULT_NODE_WIDTH,
+		height: 150,
+		style: { width: DEFAULT_NODE_WIDTH, height: 150 },
+		data: {
+			flowType: "file",
+			file,
+			color: kind === "note" ? "#d9f4e8" : "#e6e7eb",
+			glyphKind: kind,
+		},
+	};
+}
+
+function defaultNodeColor(node: FlowNode): string {
+	if (node.data.flowType === "text") {
+		return node.data.glyphKind === "sticky" ? "#fff4b8" : "#f7f7f8";
+	}
+	if (node.data.flowType === "file") {
+		return node.data.glyphKind === "note" ? "#d9f4e8" : "#e6e7eb";
+	}
+	if (node.data.flowType === "group") return "#d7e7ff";
+	return "#e6e7eb";
+}
+
+function colorPickerValue(value: string | undefined, fallback: string): string {
+	const normalized = normalizeHexColor(value);
+	return normalized ?? normalizeHexColor(fallback) ?? "#667085";
+}
+
+function normalizeHexColor(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	if (!trimmed) return null;
+	const short = trimmed.match(/^#([0-9a-f]{3})$/i);
+	if (short) {
+		return `#${short[1]
+			.split("")
+			.map((part) => `${part}${part}`)
+			.join("")
+			.toLowerCase()}`;
+	}
+	if (/^#[0-9a-f]{6}$/i.test(trimmed)) return trimmed.toLowerCase();
+	return null;
+}
+
+async function flowPickerDefaultPath(flowPath: string): Promise<string> {
+	const currentSpace = await invoke("space_get_current");
+	if (!currentSpace) return "";
+	const flowDir = parentDir(flowPath);
+	if (!flowDir) return currentSpace;
+	const { join } = await import("@tauri-apps/api/path");
+	return join(currentSpace, flowDir);
+}
+
+function isMissingFileMessage(message: string): boolean {
+	const normalized = message.toLowerCase();
+	return (
+		normalized.includes("no such file") ||
+		normalized.includes("not found") ||
+		normalized.includes("os error 2")
+	);
+}

--- a/src/components/flow/index.ts
+++ b/src/components/flow/index.ts
@@ -1,0 +1,1 @@
+export { FlowPane } from "./FlowPane";

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -483,7 +483,11 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 		<span className="folioFileLine">
 			{fileIcon}
 			<span className="folioFileName">{fileStem || title}</span>
-			{extBadge ? <span className="fileTreeExtBadge">{extBadge}</span> : null}
+			{extBadge ? (
+				<span className="fileTreeExtBadge" data-ext={extBadge.toLowerCase()}>
+					{extBadge}
+				</span>
+			) : null}
 		</span>
 	);
 

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -4,7 +4,7 @@ import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
 import type { AllDocsItem, FsEntry, FsEntryList } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
-import { basename } from "../../utils/path";
+import { basename, isMarkdownPath } from "../../utils/path";
 import {
 	type FolioScope,
 	folioScopeTitle,
@@ -134,7 +134,11 @@ function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {
 	for (const note of notes) {
 		const path = normalizeRelPath(note.note_path);
 		if (!path) continue;
-		out.set(path, { ...note, note_path: path, is_markdown: true });
+		out.set(path, {
+			...note,
+			note_path: path,
+			is_markdown: isMarkdownPath(path),
+		});
 	}
 	for (const file of files) {
 		if (!file.note_path || out.has(file.note_path)) continue;

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -4,10 +4,13 @@ import { useCallback, useRef } from "react";
 import { extractErrorMessage } from "../lib/errorUtils";
 import type { FsEntry } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
-import { isMarkdownPath, parentDir } from "../utils/path";
+import { canOpenInWorkspace, parentDir } from "../utils/path";
 import { areEntriesEqual, normalizeEntries } from "./fileTreeHelpers";
 import { useFileTreeCRUD } from "./useFileTreeCRUD";
-import type { CreateMarkdownFileOptions } from "./useFileTreeCRUD";
+import type {
+	CreateFlowFileOptions,
+	CreateMarkdownFileOptions,
+} from "./useFileTreeCRUD";
 
 export interface UseFileTreeResult {
 	loadDir: (dirPath: string, force?: boolean) => Promise<void>;
@@ -20,8 +23,12 @@ export interface UseFileTreeResult {
 	createMarkdownFileAtPath: (
 		options: CreateMarkdownFileOptions,
 	) => Promise<string | null>;
+	createFlowFileAtPath: (
+		options: CreateFlowFileOptions,
+	) => Promise<string | null>;
 	onNewFile: () => Promise<string | null>;
 	onNewFileInDir: (dirPath: string) => Promise<string | null>;
+	onNewFlowInDir: (dirPath: string) => Promise<string | null>;
 	onNewFolderInDir: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onRenameDir: (
@@ -249,13 +256,20 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 		loadRequestVersionRef.current.clear();
 	}, [updateChildrenByDir, updateExpandedDirsAndRef]);
 
-	const openMarkdownFile = useCallback(
+	const selectWorkspaceFile = useCallback(
 		async (relPath: string) => {
 			setError("");
 			setActiveFilePath(relPath);
 			setActiveDirPath(parentDir(relPath));
 		},
 		[setActiveDirPath, setActiveFilePath, setError],
+	);
+
+	const openMarkdownFile = useCallback(
+		async (relPath: string) => {
+			await selectWorkspaceFile(relPath);
+		},
+		[selectWorkspaceFile],
 	);
 
 	const openNonMarkdownExternally = useCallback(
@@ -276,8 +290,8 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 	const openFile = useCallback(
 		async (relPath: string) => {
 			if (!relPath) return;
-			if (isMarkdownPath(relPath)) {
-				await openMarkdownFile(relPath);
+			if (canOpenInWorkspace(relPath)) {
+				await selectWorkspaceFile(relPath);
 				return;
 			}
 			setActiveFilePath(relPath);
@@ -285,7 +299,7 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 			await openNonMarkdownExternally(relPath);
 		},
 		[
-			openMarkdownFile,
+			selectWorkspaceFile,
 			openNonMarkdownExternally,
 			setActiveFilePath,
 			setActiveDirPath,

--- a/src/hooks/useFileTreeCRUD.ts
+++ b/src/hooks/useFileTreeCRUD.ts
@@ -6,6 +6,7 @@ import {
 	dispatchPathRenamed,
 } from "../lib/appEvents";
 import { extractErrorMessage } from "../lib/errorUtils";
+import { createEmptyFlowDocument, serializeFlowDocument } from "../lib/flow";
 import { isMissingFileError } from "../lib/fsErrors";
 import {
 	invalidateAllDocsPrefetch,
@@ -16,7 +17,7 @@ import {
 import { updateOnboardingSettings } from "../lib/settings";
 import type { FsEntry, LinkRewriteResult } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
-import { isMarkdownPath, parentDir } from "../utils/path";
+import { isFlowPath, isMarkdownPath, parentDir } from "../utils/path";
 import {
 	compareEntries,
 	normalizeEntry,
@@ -57,6 +58,11 @@ export interface CreateMarkdownFileOptions {
 	openParentDir?: string | null;
 }
 
+export interface CreateFlowFileOptions {
+	path: string;
+	openParentDir?: string | null;
+}
+
 function showLinkRewriteToast(result: LinkRewriteResult) {
 	if (result.changed_files.length === 0) return;
 	const linkLabel = result.changed_links === 1 ? "link" : "links";
@@ -67,6 +73,19 @@ function showLinkRewriteToast(result: LinkRewriteResult) {
 			description: `Repaired references in ${result.changed_files.length.toLocaleString()} ${fileLabel}.`,
 		},
 	);
+}
+
+function uniqueUntitledFlowFileName(siblings: FsEntry[]): string {
+	const siblingNames = new Set(
+		siblings.map((entry) => entry.name.toLowerCase()),
+	);
+	const fileName = "Untitled.flow";
+	if (!siblingNames.has(fileName.toLowerCase())) return fileName;
+	let suffix = 2;
+	while (siblingNames.has(`untitled ${suffix}.flow`)) {
+		suffix += 1;
+	}
+	return `Untitled ${suffix}.flow`;
 }
 
 export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
@@ -202,6 +221,53 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 		[insertEntryOptimistic, refreshAfterCreate, setError, updateExpandedDirs],
 	);
 
+	const createFlowFileAtPath = useCallback(
+		async ({ path, openParentDir }: CreateFlowFileOptions) => {
+			setError("");
+			try {
+				const flowRel = isFlowPath(path) ? path : `${path}.flow`;
+				const fileName = flowRel.split("/").pop()?.trim() || "Untitled.flow";
+				try {
+					await invoke("space_read_text", { path: flowRel });
+					throw new Error(`File already exists: ${flowRel}`);
+				} catch (error) {
+					if (!isMissingFileError(error)) {
+						throw error;
+					}
+				}
+				await invoke("space_write_text", {
+					path: flowRel,
+					text: serializeFlowDocument(createEmptyFlowDocument()),
+					base_mtime_ms: null,
+				});
+				insertEntryOptimistic(parentDir(flowRel), {
+					name: fileName,
+					rel_path: flowRel,
+					kind: "file",
+					is_markdown: false,
+				});
+				const nextOpenParentDir =
+					typeof openParentDir === "string"
+						? openParentDir
+						: parentDir(flowRel);
+				if (nextOpenParentDir) {
+					updateExpandedDirs((prev) => {
+						if (prev.has(nextOpenParentDir)) return prev;
+						const next = new Set(prev);
+						next.add(nextOpenParentDir);
+						return next;
+					});
+				}
+				await refreshAfterCreate(parentDir(flowRel));
+				return flowRel;
+			} catch (e) {
+				setError(extractErrorMessage(e));
+				return null;
+			}
+		},
+		[insertEntryOptimistic, refreshAfterCreate, setError, updateExpandedDirs],
+	);
+
 	const onNewFileInDir = useCallback(
 		async (dirPath: string) => {
 			if (!spacePath) return null;
@@ -238,6 +304,33 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 			}
 		},
 		[createMarkdownFileAtPath, setError, spacePath],
+	);
+
+	const onNewFlowInDir = useCallback(
+		async (dirPath: string) => {
+			if (!spacePath) return null;
+			setError("");
+			try {
+				const siblings = await invoke(
+					"space_list_dir",
+					dirPath ? { dir: dirPath } : {},
+				);
+				const fileName = uniqueUntitledFlowFileName(siblings);
+				const flowRel = dirPath ? `${dirPath}/${fileName}` : fileName;
+				const createdPath = await createFlowFileAtPath({
+					path: flowRel,
+					openParentDir: dirPath,
+				});
+				if (createdPath) {
+					dispatchFileTreeStartRename({ path: createdPath });
+				}
+				return createdPath;
+			} catch (e) {
+				setError(extractErrorMessage(e));
+				return null;
+			}
+		},
+		[createFlowFileAtPath, setError, spacePath],
 	);
 
 	const onNewFile = useCallback(async () => {
@@ -651,8 +744,10 @@ export function useFileTreeCRUD(deps: UseFileTreeCRUDDeps) {
 
 	return {
 		createMarkdownFileAtPath,
+		createFlowFileAtPath,
 		onNewFile,
 		onNewFileInDir,
+		onNewFlowInDir,
 		onNewFolderInDir,
 		onDuplicateFile,
 		onRenameDir,

--- a/src/lib/flow.ts
+++ b/src/lib/flow.ts
@@ -1,0 +1,492 @@
+import type { Edge, Node, Viewport } from "@xyflow/react";
+
+export const FLOW_SCHEMA_VERSION = 1;
+
+export interface GlyphFlowExtension {
+	schemaVersion: 1;
+	nodeGroups?: Record<string, string>;
+	nodeModes?: Record<string, "preview" | "compact" | "full">;
+}
+
+export interface FlowViewport {
+	x: number;
+	y: number;
+	zoom: number;
+}
+
+export type FlowColor = string;
+export type FlowNodeType = "text" | "file" | "link" | "group";
+export type FlowGlyphNodeKind =
+	| "text"
+	| "sticky"
+	| "note"
+	| "file"
+	| "link"
+	| "group";
+
+export interface FlowDocumentNodeBase {
+	id: string;
+	type: FlowNodeType;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	color?: FlowColor;
+	glyph?: {
+		groupId?: string;
+		mode?: "preview" | "compact" | "full";
+		kind?: FlowGlyphNodeKind;
+		rotation?: number;
+	};
+}
+
+export interface FlowTextNode extends FlowDocumentNodeBase {
+	type: "text";
+	text: string;
+}
+
+export interface FlowFileNode extends FlowDocumentNodeBase {
+	type: "file";
+	file: string;
+	subpath?: string;
+}
+
+export interface FlowLinkNode extends FlowDocumentNodeBase {
+	type: "link";
+	url: string;
+}
+
+export interface FlowGroupNode extends FlowDocumentNodeBase {
+	type: "group";
+	label?: string;
+	background?: string;
+	backgroundStyle?: "cover" | "ratio" | "repeat";
+}
+
+export type FlowDocumentNode =
+	| FlowTextNode
+	| FlowFileNode
+	| FlowLinkNode
+	| FlowGroupNode;
+
+export interface FlowDocumentEdge {
+	id: string;
+	fromNode: string;
+	fromSide?: "top" | "right" | "bottom" | "left";
+	fromEnd?: "none" | "arrow";
+	toNode: string;
+	toSide?: "top" | "right" | "bottom" | "left";
+	toEnd?: "none" | "arrow";
+	color?: FlowColor;
+	label?: string;
+}
+
+export interface FlowDocument {
+	version: 1;
+	nodes: FlowDocumentNode[];
+	edges: FlowDocumentEdge[];
+	viewport?: FlowViewport;
+	glyph?: GlyphFlowExtension;
+}
+
+export type FlowNodeData =
+	| {
+			flowType: "text";
+			text: string;
+			color?: string;
+			glyphKind?: "text" | "sticky";
+			rotation?: number;
+	  }
+	| {
+			flowType: "file";
+			file: string;
+			subpath?: string;
+			color?: string;
+			glyphKind?: "note" | "file";
+			rotation?: number;
+	  }
+	| {
+			flowType: "link";
+			url: string;
+			color?: string;
+			glyphKind?: "link";
+			rotation?: number;
+	  }
+	| {
+			flowType: "group";
+			label?: string;
+			color?: string;
+			glyphKind?: "group";
+			rotation?: number;
+	  };
+
+export type FlowNode = Node<FlowNodeData>;
+export type FlowEdge = Edge<Record<string, never>>;
+
+const DEFAULT_VIEWPORT: FlowViewport = { x: 0, y: 0, zoom: 1 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
+}
+
+function normalizeNodeGlyph(
+	value: unknown,
+): FlowDocumentNodeBase["glyph"] | undefined {
+	if (!isRecord(value)) return undefined;
+	const mode =
+		value.mode === "compact" ||
+		value.mode === "full" ||
+		value.mode === "preview"
+			? value.mode
+			: undefined;
+	return {
+		groupId: asString(value.groupId),
+		mode,
+		kind: normalizeNodeKind(value.kind),
+		rotation: normalizeRotation(value.rotation),
+	};
+}
+
+function normalizeRotation(value: unknown): number | undefined {
+	const rotation = asNumber(value);
+	if (rotation === undefined) return undefined;
+	return ((rotation % 360) + 360) % 360;
+}
+
+function normalizeNodeKind(value: unknown): FlowGlyphNodeKind | undefined {
+	if (
+		value === "text" ||
+		value === "sticky" ||
+		value === "note" ||
+		value === "file" ||
+		value === "link" ||
+		value === "group"
+	) {
+		return value;
+	}
+	return undefined;
+}
+
+function normalizeNode(raw: unknown): FlowDocumentNode | null {
+	if (!isRecord(raw)) return null;
+	const id = asString(raw.id);
+	const type = asString(raw.type);
+	const x = asNumber(raw.x);
+	const y = asNumber(raw.y);
+	const width = asNumber(raw.width);
+	const height = asNumber(raw.height);
+	if (!id || !type || x === undefined || y === undefined) return null;
+
+	const base = {
+		id,
+		x,
+		y,
+		width: width ?? 280,
+		height: height ?? 180,
+		color: asString(raw.color),
+		glyph: normalizeNodeGlyph(raw.glyph),
+	};
+
+	if (type === "text") {
+		return { ...base, type, text: asString(raw.text) ?? "" };
+	}
+	if (type === "file") {
+		const file = asString(raw.file);
+		if (!file) return null;
+		return { ...base, type, file, subpath: asString(raw.subpath) };
+	}
+	if (type === "link") {
+		const url = asString(raw.url);
+		if (!url) return null;
+		return { ...base, type, url };
+	}
+	if (type === "group") {
+		return {
+			...base,
+			type,
+			label: asString(raw.label),
+			background: asString(raw.background),
+			backgroundStyle:
+				raw.backgroundStyle === "cover" ||
+				raw.backgroundStyle === "ratio" ||
+				raw.backgroundStyle === "repeat"
+					? raw.backgroundStyle
+					: undefined,
+		};
+	}
+	return null;
+}
+
+function normalizeEdge(raw: unknown): FlowDocumentEdge | null {
+	if (!isRecord(raw)) return null;
+	const id = asString(raw.id);
+	const fromNode = asString(raw.fromNode);
+	const toNode = asString(raw.toNode);
+	if (!id || !fromNode || !toNode) return null;
+	return {
+		id,
+		fromNode,
+		toNode,
+		fromSide: sideFromHandle(asString(raw.fromSide)),
+		toSide: sideFromHandle(asString(raw.toSide)),
+		fromEnd: raw.fromEnd === "arrow" ? "arrow" : "none",
+		toEnd: raw.toEnd === "none" ? "none" : "arrow",
+		color: asString(raw.color),
+		label: asString(raw.label),
+	};
+}
+
+export function createEmptyFlowDocument(): FlowDocument {
+	return {
+		version: FLOW_SCHEMA_VERSION,
+		nodes: [],
+		edges: [],
+		viewport: DEFAULT_VIEWPORT,
+		glyph: { schemaVersion: FLOW_SCHEMA_VERSION },
+	};
+}
+
+export function serializeFlowDocument(document: FlowDocument): string {
+	return `${JSON.stringify(document, null, "\t")}\n`;
+}
+
+export function parseFlowDocument(text: string): FlowDocument {
+	const fallback = createEmptyFlowDocument();
+	if (!text.trim()) return fallback;
+	const raw = JSON.parse(text) as unknown;
+	if (!isRecord(raw)) return fallback;
+	const nodes = Array.isArray(raw.nodes)
+		? raw.nodes
+				.map(normalizeNode)
+				.filter((node): node is FlowDocumentNode => Boolean(node))
+		: [];
+	const edges = Array.isArray(raw.edges)
+		? raw.edges
+				.map(normalizeEdge)
+				.filter((edge): edge is FlowDocumentEdge => Boolean(edge))
+		: [];
+	const viewport = isRecord(raw.viewport)
+		? {
+				x: asNumber(raw.viewport.x) ?? DEFAULT_VIEWPORT.x,
+				y: asNumber(raw.viewport.y) ?? DEFAULT_VIEWPORT.y,
+				zoom: asNumber(raw.viewport.zoom) ?? DEFAULT_VIEWPORT.zoom,
+			}
+		: DEFAULT_VIEWPORT;
+	return {
+		version: FLOW_SCHEMA_VERSION,
+		nodes,
+		edges,
+		viewport,
+		glyph: { schemaVersion: FLOW_SCHEMA_VERSION },
+	};
+}
+
+export function flowDocumentToReactFlow(document: FlowDocument): {
+	nodes: FlowNode[];
+	edges: FlowEdge[];
+	viewport: Viewport;
+} {
+	const nodes = document.nodes.map((node) => {
+		const parentId = node.glyph?.groupId;
+		const base = {
+			id: node.id,
+			position: { x: node.x, y: node.y },
+			width: node.width,
+			height: node.height,
+			style: { width: node.width, height: node.height },
+			parentId,
+			extent: parentId ? ("parent" as const) : undefined,
+		};
+		if (node.type === "text") {
+			return {
+				...base,
+				type: "flowText",
+				data: {
+					flowType: "text",
+					text: node.text,
+					color: node.color,
+					glyphKind:
+						node.glyph?.kind === "sticky" || node.glyph?.kind === "text"
+							? node.glyph.kind
+							: "text",
+					rotation: node.glyph?.rotation,
+				},
+			} satisfies FlowNode;
+		}
+		if (node.type === "file") {
+			return {
+				...base,
+				type: "flowFile",
+				data: {
+					flowType: "file",
+					file: node.file,
+					subpath: node.subpath,
+					color: node.color,
+					glyphKind:
+						node.glyph?.kind === "file" || node.glyph?.kind === "note"
+							? node.glyph.kind
+							: node.file.toLowerCase().endsWith(".md")
+								? "note"
+								: "file",
+					rotation: node.glyph?.rotation,
+				},
+			} satisfies FlowNode;
+		}
+		if (node.type === "link") {
+			return {
+				...base,
+				type: "flowLink",
+				data: {
+					flowType: "link",
+					url: node.url,
+					color: node.color,
+					glyphKind: "link",
+					rotation: node.glyph?.rotation,
+				},
+			} satisfies FlowNode;
+		}
+		return {
+			...base,
+			type: "flowGroup",
+			data: {
+				flowType: "group",
+				label: node.label,
+				color: node.color,
+				glyphKind: "group",
+				rotation: node.glyph?.rotation,
+			},
+			zIndex: -1,
+		} satisfies FlowNode;
+	});
+
+	const edges = document.edges.map((edge) => ({
+		id: edge.id,
+		source: edge.fromNode,
+		target: edge.toNode,
+		sourceHandle: edge.fromSide,
+		targetHandle: edge.toSide,
+		label: edge.label,
+		animated: false,
+		style: edge.color ? { stroke: edge.color } : undefined,
+		markerEnd:
+			edge.toEnd === "none" ? undefined : { type: "arrowclosed" as const },
+	})) satisfies FlowEdge[];
+
+	return {
+		nodes,
+		edges,
+		viewport: document.viewport ?? DEFAULT_VIEWPORT,
+	};
+}
+
+export function reactFlowToFlowDocument(args: {
+	nodes: FlowNode[];
+	edges: FlowEdge[];
+	viewport: Viewport;
+}): FlowDocument {
+	const nodes = args.nodes.map((node) => {
+		const base = {
+			id: node.id,
+			x: Math.round(node.position.x),
+			y: Math.round(node.position.y),
+			width: Math.round(
+				typeof node.measured?.width === "number"
+					? node.measured.width
+					: Number(node.style?.width) || node.width || 280,
+			),
+			height: Math.round(
+				typeof node.measured?.height === "number"
+					? node.measured.height
+					: Number(node.style?.height) || node.height || 180,
+			),
+			color: node.data.color,
+			glyph:
+				node.parentId || node.data.glyphKind || node.data.rotation
+					? {
+							groupId: node.parentId,
+							kind: node.data.glyphKind,
+							rotation: node.data.rotation,
+						}
+					: undefined,
+		};
+		if (node.data.flowType === "text") {
+			return {
+				...base,
+				type: "text",
+				text: node.data.text,
+			} satisfies FlowTextNode;
+		}
+		if (node.data.flowType === "file") {
+			return {
+				...base,
+				type: "file",
+				file: node.data.file,
+				subpath: node.data.subpath,
+			} satisfies FlowFileNode;
+		}
+		if (node.data.flowType === "link") {
+			return {
+				...base,
+				type: "link",
+				url: node.data.url,
+			} satisfies FlowLinkNode;
+		}
+		return {
+			...base,
+			type: "group",
+			label: node.data.label,
+		} satisfies FlowGroupNode;
+	});
+
+	const edges = args.edges.map((edge) => ({
+		id: edge.id,
+		fromNode: edge.source,
+		toNode: edge.target,
+		fromSide: sideFromHandle(edge.sourceHandle ?? undefined),
+		toSide: sideFromHandle(edge.targetHandle ?? undefined),
+		toEnd: edge.markerEnd ? "arrow" : "none",
+		label: typeof edge.label === "string" ? edge.label : undefined,
+		color:
+			typeof edge.style?.stroke === "string" ? edge.style.stroke : undefined,
+	})) satisfies FlowDocumentEdge[];
+
+	return {
+		version: FLOW_SCHEMA_VERSION,
+		nodes,
+		edges,
+		viewport: {
+			x: args.viewport.x,
+			y: args.viewport.y,
+			zoom: args.viewport.zoom,
+		},
+		glyph: { schemaVersion: FLOW_SCHEMA_VERSION },
+	};
+}
+
+export function sideFromHandle(
+	handle: string | null | undefined,
+): "top" | "right" | "bottom" | "left" | undefined {
+	if (
+		handle === "top" ||
+		handle === "right" ||
+		handle === "bottom" ||
+		handle === "left"
+	) {
+		return handle;
+	}
+	return undefined;
+}
+
+export function nextFlowNodeId(prefix: string): string {
+	return `${prefix}-${crypto.randomUUID()}`;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -64,7 +64,7 @@ interface TextFileDocBatch {
 	error: string | null;
 }
 
-interface TextFilePreviewDoc {
+export interface TextFilePreviewDoc {
 	rel_path: string;
 	text: string;
 	mtime_ms: number;

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -689,6 +689,16 @@
 			"allowInEditable": false,
 			"commandPalette": true
 		},
+		"new-flow": {
+			"id": "new-flow",
+			"label": "New Flow",
+			"description": "Create a new flow in the current folder.",
+			"category": "file",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": true
+		},
 		"new-note": {
 			"id": "new-note",
 			"label": "New Note",

--- a/src/styles/app/05-main-area.css
+++ b/src/styles/app/05-main-area.css
@@ -1,5 +1,5 @@
 /* ─────────────────────────────────────────────────────────────────────────────
-   MAIN CANVAS AREA - Floating center panel
+   MAIN FLOW AREA - Floating center panel
    ───────────────────────────────────────────────────────────────────────────── */
 .mainArea {
 	flex: 1;
@@ -19,7 +19,7 @@
 	transition: border-color 220ms ease;
 }
 
-.mainArea:has(.canvasWrapper) {
+.mainArea:has(.flowWrapper) {
 	background: transparent;
 }
 

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -4,7 +4,7 @@
 	--right-sidebar-island-radius: 0px;
 }
 
-.canvasWrapper {
+.flowWrapper {
 	flex: 1;
 	position: relative;
 	min-height: 0;
@@ -13,7 +13,7 @@
 	display: flex;
 }
 
-.canvasPaneHost {
+.flowPaneHost {
 	flex: 1;
 	min-width: 0;
 	min-height: 0;
@@ -27,7 +27,7 @@
 	transition: border-radius 180ms ease;
 }
 
-.mainArea[data-right-sidebar-open="true"] .canvasPaneHost {
+.mainArea[data-right-sidebar-open="true"] .flowPaneHost {
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 }

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -383,6 +383,13 @@
 	box-shadow: var(--pill-shadow);
 }
 
+.fileTreeExtBadge[data-ext="flow"] {
+	padding: 1px 6px;
+	background: color-mix(in srgb, var(--bg-hover) 68%, transparent);
+	color: color-mix(in srgb, var(--text-secondary) 76%, var(--text-tertiary));
+	box-shadow: none;
+}
+
 .fileTreeTaskProgress {
 	flex-shrink: 0;
 	width: 12px;
@@ -403,6 +410,11 @@
 .fileTreeRow[data-has-custom-color="true"] .fileTreeExtBadge {
 	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-hover));
 	color: color-mix(in srgb, var(--database-tone) 66%, var(--text-primary));
+}
+
+.fileTreeRow[data-has-custom-color="true"] .fileTreeExtBadge[data-ext="flow"] {
+	background: color-mix(in srgb, var(--database-tone) 8%, transparent);
+	color: color-mix(in srgb, var(--database-tone) 58%, var(--text-secondary));
 }
 
 .fileTreeRenameInput {

--- a/src/styles/app/48-flow.css
+++ b/src/styles/app/48-flow.css
@@ -1,0 +1,409 @@
+.glyphFlowPane {
+	--glyph-flow-grid: color-mix(in srgb, var(--text-secondary) 22%, transparent);
+	--glyph-flow-edge: color-mix(
+		in srgb,
+		var(--text-secondary) 72%,
+		var(--interactive-accent)
+	);
+
+	position: relative;
+	width: 100%;
+	height: 100%;
+	min-height: 360px;
+	background: color-mix(in srgb, var(--bg-canvas) 76%, var(--bg-primary));
+	color: var(--text-primary);
+}
+
+.glyphFlowPane .react-flow__renderer {
+	background: linear-gradient(
+			180deg,
+			color-mix(in srgb, var(--bg-primary) 52%, transparent),
+			transparent 34%
+		), var(--bg-canvas);
+}
+
+.glyphFlowState {
+	display: grid;
+	place-items: center;
+	width: 100%;
+	height: 100%;
+	min-height: 360px;
+	color: var(--text-secondary);
+	font-size: var(--text-sm);
+	background: var(--bg-canvas);
+}
+
+.glyphFlowToolbar,
+.glyphFlowError,
+.glyphFlowInspector {
+	border: 1px solid color-mix(in srgb, var(--border-default) 68%, transparent);
+	background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+	backdrop-filter: blur(16px);
+	-webkit-backdrop-filter: blur(16px);
+	box-shadow: 0 14px 34px
+		color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+}
+
+.glyphFlowToolbar {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	margin-bottom: 12px;
+	padding: 6px;
+	border-radius: var(--radius-md);
+}
+
+.glyphFlowToolbar button span {
+	font-size: 11px;
+	line-height: 1;
+}
+
+.glyphFlowError {
+	max-width: min(360px, calc(100vw - 2rem));
+	padding: 7px 10px;
+	border-radius: var(--radius-md);
+	color: var(--status-danger-fg);
+	font-size: 11px;
+	line-height: 1.2;
+}
+
+.glyphFlowInspector {
+	display: grid;
+	gap: 10px;
+	width: min(280px, calc(100vw - 2rem));
+	padding: 12px;
+	border-radius: var(--radius-lg);
+}
+
+.glyphFlowInspectorHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	text-transform: capitalize;
+}
+
+.glyphFlowInspectorActions {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.glyphFlowInspectorGrid {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 8px;
+}
+
+.glyphFlowField {
+	display: grid;
+	gap: 5px;
+	color: var(--text-secondary);
+	font-size: 11px;
+}
+
+.glyphFlowField input,
+.glyphFlowSelect,
+.glyphFlowTextarea {
+	border-color: color-mix(in srgb, var(--border-default) 82%, transparent);
+	background: color-mix(in srgb, var(--bg-secondary) 74%, transparent);
+	color: var(--text-primary);
+}
+
+.glyphFlowColorControl {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.glyphFlowColorControl input[type="color"] {
+	width: 34px;
+	height: 28px;
+	flex: 0 0 auto;
+	padding: 2px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 82%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-secondary) 74%, transparent);
+	cursor: pointer;
+}
+
+.glyphFlowColorControl input[type="color"]::-webkit-color-swatch-wrapper {
+	padding: 0;
+}
+
+.glyphFlowColorControl input[type="color"]::-webkit-color-swatch {
+	border: 0;
+	border-radius: calc(var(--radius-md) - 3px);
+}
+
+.glyphFlowTextarea,
+.glyphFlowSelect {
+	width: 100%;
+	min-width: 0;
+	border: 1px solid color-mix(in srgb, var(--border-default) 82%, transparent);
+	border-radius: var(--radius-md);
+	outline: none;
+}
+
+.glyphFlowTextarea {
+	min-height: 92px;
+	resize: vertical;
+	padding: 8px 9px;
+	font: inherit;
+	line-height: 1.4;
+}
+
+.glyphFlowSelect {
+	height: 32px;
+	padding: 0 9px;
+	font: inherit;
+}
+
+.glyphFlowTextarea:focus-visible,
+.glyphFlowSelect:focus-visible {
+	border-color: var(--interactive-accent);
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+}
+
+.flowNode,
+.flowGroupNode {
+	--flow-node-accent: color-mix(
+		in srgb,
+		var(--interactive-accent) 34%,
+		var(--bg-primary)
+	);
+
+	position: relative;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	border: 1px solid
+		color-mix(in srgb, var(--flow-node-accent) 56%, var(--border-default));
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--flow-node-accent) 28%, var(--bg-primary));
+	box-shadow: 0 12px 28px
+		color-mix(in srgb, var(--shadow-color, #000) 8%, transparent);
+	color: var(--text-primary);
+}
+
+.flowNode {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	padding: 12px;
+}
+
+.flowTextNode {
+	padding: 0;
+	background: color-mix(in srgb, var(--flow-node-accent) 54%, var(--bg-primary));
+}
+
+.flowGroupNode {
+	border-style: dashed;
+	background: color-mix(in srgb, var(--flow-node-accent) 18%, transparent);
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--bg-primary) 54%, transparent);
+}
+
+.react-flow__node.selected .flowNode,
+.react-flow__node.selected .flowGroupNode {
+	border-color: var(--interactive-accent);
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--interactive-accent) 18%, transparent), 0 16px 36px
+		color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+}
+
+.flowNodeHeader {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.flowNodeHeader strong {
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--text-sm);
+	font-weight: 600;
+	line-height: 1.2;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flowNodeKind,
+.flowGroupLabel {
+	color: var(--text-secondary);
+	font-size: 9px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.flowNodeKind {
+	flex: 0 0 auto;
+	padding: 2px 5px;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--bg-primary) 62%, transparent);
+}
+
+.flowGroupLabel {
+	padding: 10px 12px;
+	font-weight: 600;
+}
+
+.flowNodeBody {
+	min-height: 0;
+	overflow: auto;
+	color: color-mix(in srgb, var(--text-primary) 84%, var(--text-secondary));
+	font-size: 11px;
+	line-height: 1.35;
+}
+
+.flowNodeMuted {
+	margin: 0;
+	color: var(--text-secondary);
+	font-size: 11px;
+	line-height: 1.35;
+	overflow-wrap: anywhere;
+}
+
+.flowMarkdownPreview {
+	margin: 0;
+	overflow: hidden;
+	color: inherit;
+	font: inherit;
+	white-space: pre-wrap;
+}
+
+.flowTextInput {
+	width: 100%;
+	height: 100%;
+	min-height: 100%;
+	resize: none;
+	border: 0;
+	background: transparent;
+	color: var(--text-primary);
+	padding: 12px;
+	font: inherit;
+	line-height: 1.45;
+	outline: none;
+}
+
+.flowTextInput::placeholder {
+	color: var(--text-tertiary);
+}
+
+.glyphFlowPane .react-flow__handle {
+	width: 8px;
+	height: 8px;
+	border: 1px solid var(--bg-primary);
+	background: var(--interactive-accent);
+	opacity: 0.8;
+}
+
+.glyphFlowNode {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: 100%;
+	height: 100%;
+	padding: 12px;
+	overflow: hidden;
+	border: 1px solid
+		color-mix(in srgb, var(--glyph-node-color) 54%, var(--border-default));
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--glyph-node-color) 28%, var(--bg-primary));
+	box-shadow: 0 12px 28px
+		color-mix(in srgb, var(--shadow-color, #000) 8%, transparent);
+	color: var(--text-primary);
+}
+
+.glyphFlowNode[data-kind="group"] {
+	background: color-mix(in srgb, var(--glyph-node-color) 20%, transparent);
+	border-style: dashed;
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--bg-primary) 54%, transparent);
+}
+
+.glyphFlowNode[data-kind="sticky"] {
+	background: color-mix(in srgb, var(--glyph-node-color) 70%, var(--bg-primary));
+}
+
+.glyphFlowNode[data-selected="true"] {
+	border-color: var(--interactive-accent);
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--interactive-accent) 18%, transparent), 0 16px 36px
+		color-mix(in srgb, var(--shadow-color, #000) 12%, transparent);
+}
+
+.glyphFlowNodeTop {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.glyphFlowNodeTop strong {
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--text-sm);
+	font-weight: 600;
+	line-height: 1.2;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.glyphFlowNodeKind {
+	flex: 0 0 auto;
+	padding: 2px 5px;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--bg-primary) 62%, transparent);
+	color: var(--text-secondary);
+	font-size: 9px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.glyphFlowNodeSubtitle,
+.glyphFlowNodeBody {
+	display: -webkit-box;
+	overflow: hidden;
+	color: var(--text-secondary);
+	font-size: 11px;
+	line-height: 1.35;
+	-webkit-box-orient: vertical;
+}
+
+.glyphFlowNodeSubtitle {
+	-webkit-line-clamp: 2;
+}
+
+.glyphFlowNodeBody {
+	color: color-mix(in srgb, var(--text-primary) 84%, var(--text-secondary));
+	white-space: pre-wrap;
+	-webkit-line-clamp: 5;
+}
+
+.glyphFlowHandle {
+	width: 8px;
+	height: 8px;
+	border: 1px solid var(--bg-primary);
+	background: var(--interactive-accent);
+	opacity: 0.8;
+}
+
+.glyphFlowEdgeLabel {
+	position: absolute;
+	padding: 3px 7px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 70%, transparent);
+	border-radius: 999px;
+	background: var(--bg-primary);
+	color: var(--text-secondary);
+	font-size: 10.5px;
+	line-height: 1.2;
+	pointer-events: all;
+	box-shadow: 0 8px 22px
+		color-mix(in srgb, var(--shadow-color, #000) 10%, transparent);
+}

--- a/src/styles/app/50-flow.css
+++ b/src/styles/app/50-flow.css
@@ -1,0 +1,303 @@
+.flowEditorPane {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+	height: 100%;
+	flex-direction: column;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+}
+
+.flowToolbar {
+	display: flex;
+	min-height: 42px;
+	align-items: center;
+	gap: 10px;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 6px 10px;
+	background: var(--bg-primary);
+}
+
+.flowToolbarGroup {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.flowToolbarStatus {
+	margin-left: auto;
+	max-width: 320px;
+	overflow: hidden;
+	color: var(--text-tertiary);
+	font-size: 12px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flowEdgeInspector {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 6px 10px;
+	background: var(--bg-secondary);
+}
+
+.flowEdgeLabelInput {
+	width: min(360px, 100%);
+	height: 28px;
+}
+
+.flowHost {
+	position: relative;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.flowHost .react-flow {
+	background: var(--bg-primary);
+}
+
+.flowHost .react-flow__background {
+	opacity: 0.45;
+}
+
+.flowHost .react-flow__controls,
+.flowHost .react-flow__minimap {
+	border: 1px solid var(--border-subtle);
+	background: var(--bg-primary);
+	box-shadow: var(--shadow-md);
+}
+
+.flowHintPanel {
+	border: 1px solid var(--border-subtle);
+	border-radius: var(--radius-md);
+	padding: 5px 8px;
+	background: var(--bg-primary);
+	color: var(--text-tertiary);
+	font-size: 12px;
+	box-shadow: var(--shadow-sm);
+}
+
+.flowNode {
+	position: relative;
+	display: flex;
+	width: 100%;
+	height: 100%;
+	min-width: 0;
+	min-height: 0;
+	flex-direction: column;
+	overflow: visible;
+	border: 1px solid
+		color-mix(
+			in srgb,
+			var(--flow-node-accent, var(--border-default)) 42%,
+			var(--border-default)
+		);
+	border-radius: var(--radius-md);
+	background: color-mix(
+		in srgb,
+		var(--flow-node-accent, var(--bg-primary)) 20%,
+		var(--bg-primary)
+	);
+	box-shadow: var(--shadow-sm);
+	transform: rotate(var(--flow-node-rotation, 0deg));
+	transform-origin: center;
+}
+
+.flowNodeHeader {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 9px 10px 7px;
+	background: transparent;
+}
+
+.flowNodeResizeHandle.react-flow__resize-control.handle {
+	width: 10px;
+	height: 10px;
+	border: 1px solid var(--bg-primary);
+	border-radius: 999px;
+	background: var(--interactive-accent);
+	box-shadow: 0 2px 8px
+		color-mix(in srgb, var(--shadow-color, #000) 20%, transparent);
+}
+
+.flowNodeResizeLine.react-flow__resize-control.line {
+	border-color: color-mix(in srgb, var(--interactive-accent) 78%, transparent);
+}
+
+.flowRotateHandle {
+	position: absolute;
+	top: -34px;
+	left: 50%;
+	z-index: 5;
+	width: 22px;
+	height: 22px;
+	border: 1px solid
+		color-mix(in srgb, var(--interactive-accent) 80%, var(--bg-primary));
+	border-radius: 999px;
+	background: var(--bg-primary);
+	box-shadow: 0 4px 12px
+		color-mix(in srgb, var(--shadow-color, #000) 18%, transparent);
+	color: var(--interactive-accent);
+	cursor: grab;
+	display: grid;
+	place-items: center;
+	transform: translateX(-50%);
+}
+
+.flowRotateHandle::before {
+	position: absolute;
+	top: 21px;
+	left: 50%;
+	width: 1px;
+	height: 12px;
+	background: color-mix(in srgb, var(--interactive-accent) 72%, transparent);
+	content: "";
+	transform: translateX(-50%);
+}
+
+.flowRotateHandle:active {
+	cursor: grabbing;
+}
+
+.flowNodeHeader strong {
+	overflow: hidden;
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flowNodeBody {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow: auto;
+	padding: 9px 10px;
+}
+
+.flowMarkdownPreview {
+	margin: 0;
+	white-space: pre-wrap;
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: 12px;
+	line-height: 1.45;
+}
+
+.flowNodeMuted {
+	margin: 0;
+	color: var(--text-tertiary);
+	font-size: 12px;
+	line-height: 1.4;
+	word-break: break-word;
+}
+
+.flowFileName {
+	flex: 0 0 auto;
+	border-top: 1px solid
+		color-mix(in srgb, var(--border-subtle) 78%, transparent);
+	padding: 6px 10px;
+	overflow: hidden;
+	color: color-mix(in srgb, var(--text-secondary) 84%, var(--text-tertiary));
+	font-size: 11px;
+	line-height: 1.2;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flowTextNode {
+	background: color-mix(
+		in srgb,
+		var(--flow-node-accent, var(--color-yellow-500)) 24%,
+		var(--bg-primary)
+	);
+}
+
+.flowTextDragHandle {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 26px;
+	border-bottom: 1px solid var(--border-subtle);
+	padding: 5px 9px;
+	background: color-mix(in srgb, var(--bg-primary) 22%, transparent);
+	color: var(--text-tertiary);
+	cursor: grab;
+	font-size: 10px;
+	font-weight: 600;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.flowTextDragHandle:active {
+	cursor: grabbing;
+}
+
+.flowTextInput {
+	width: 100%;
+	height: 100%;
+	min-height: 0;
+	resize: none;
+	border: 0;
+	padding: 12px;
+	background: transparent;
+	color: var(--text-primary);
+	font: inherit;
+	font-size: 13px;
+	line-height: 1.45;
+	outline: none;
+}
+
+.flowGroupNode {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	border: 1px solid
+		color-mix(
+			in srgb,
+			var(--flow-node-accent, var(--border-default)) 50%,
+			var(--border-default)
+		);
+	border-radius: var(--radius-md);
+	background: color-mix(
+		in srgb,
+		var(--flow-node-accent, var(--bg-secondary)) 8%,
+		transparent
+	);
+	overflow: visible;
+	transform: rotate(var(--flow-node-rotation, 0deg));
+	transform-origin: center;
+}
+
+.flowGroupLabel {
+	position: absolute;
+	top: 8px;
+	left: 10px;
+	max-width: calc(100% - 20px);
+	overflow: hidden;
+	border-radius: var(--radius-sm);
+	padding: 2px 6px;
+	background: var(--bg-primary);
+	color: var(--text-secondary);
+	font-size: 12px;
+	font-weight: 600;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.flowHost .react-flow__handle {
+	width: 9px;
+	height: 9px;
+	border: 1px solid var(--bg-primary);
+	background: var(--text-accent);
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.flowHost .react-flow__node:hover .react-flow__handle,
+.flowHost .react-flow__node.selected .react-flow__handle {
+	opacity: 1;
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -27,6 +27,23 @@ export function isMarkdownPath(relPath: string): boolean {
 	return relPath.toLowerCase().endsWith(".md");
 }
 
+export function isFlowPath(relPath: string): boolean {
+	return relPath.toLowerCase().endsWith(".flow");
+}
+
+export type WorkspaceFileKind = "markdown" | "flow" | "other";
+
+export function workspaceFileKind(relPath: string): WorkspaceFileKind {
+	if (isMarkdownPath(relPath)) return "markdown";
+	if (isFlowPath(relPath)) return "flow";
+	return "other";
+}
+
+export function canOpenInWorkspace(relPath: string): boolean {
+	const kind = workspaceFileKind(relPath);
+	return kind === "markdown" || kind === "flow";
+}
+
 export function normalizeRelPath(path: string): string {
 	return path
 		.trim()


### PR DESCRIPTION
## Summary

Adds first-class `.flow` documents so Glyph spaces can hold visual canvases alongside Markdown notes. The motivation is to let users map ideas, notes, files, links, and relationships spatially without leaving the offline-first workspace, while keeping those documents searchable and connected to existing note graph features.

This PR introduces a React Flow-based editor with text, file/note, link, and group nodes; resizing, rotation, color controls, edge labels, grouping, fit/zoom controls, dirty tracking, and autosave through the existing Tauri text-file write path. Flow files are surfaced in the file tree, command palette, tab system, folio note list, icons, and app pane loader so they behave like normal workspace documents.

On the backend, `.flow` files are indexed as durable JSON documents. Flow text, file nodes, URL nodes, and file-to-file edges now feed search, links, backlinks, local graph queries, watcher indexing, and rename link rewrites. This adds a `flow_edges` index table and keeps flow file references updated when linked files move.

## Related Issues

N/A

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

Not captured in this flow.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Flow document support (`.flow` files) as a new document type with a dedicated visual editor.
  * Flow documents can be created, edited, and managed alongside Markdown files.
  * Flow documents are indexed and searchable alongside regular notes.
  * Added "New Flow" command to create Flow files in any directory.
  * Flow files display with a custom icon in the file tree.
  * File operations (rename, duplicate) now properly handle Flow documents and update internal references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->