### PR TITLE
feat(tags): add beautiful tag icons

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod pinned_files;
 mod space;
 mod space_fs;
 mod system_fonts;
+mod tag_appearance;
 pub(crate) mod utils;
 
 use serde::Serialize;
@@ -1447,6 +1448,8 @@ pub fn run() {
             file_tree_appearance::commands::file_tree_appearance_set,
             file_tree_appearance::commands::file_tree_appearance_rename_path,
             file_tree_appearance::commands::file_tree_appearance_delete_path,
+            tag_appearance::commands::tag_appearance_list,
+            tag_appearance::commands::tag_appearance_set,
             pinned_files::commands::pinned_files_list,
             pinned_files::commands::pinned_files_toggle,
             pinned_files::commands::pinned_files_rename_path,

--- a/src-tauri/src/tag_appearance/commands.rs
+++ b/src-tauri/src/tag_appearance/commands.rs
@@ -1,0 +1,58 @@
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+use tauri::State;
+
+use crate::space::SpaceState;
+
+use super::store::{load_store, normalize_appearance, normalize_tag_key, save_store};
+use super::types::TagAppearance;
+
+fn tag_appearance_mutex() -> &'static Mutex<()> {
+    static TAG_APPEARANCE_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    TAG_APPEARANCE_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+#[tauri::command]
+pub async fn tag_appearance_list(
+    state: State<'_, SpaceState>,
+) -> Result<BTreeMap<String, TagAppearance>, String> {
+    let root = state.current_root()?;
+    tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
+        let _guard = tag_appearance_mutex()
+            .lock()
+            .map_err(|_| "tag appearance mutex poisoned".to_string())?;
+        Ok(load_store(&root)?.entries)
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+pub async fn tag_appearance_set(
+    state: State<'_, SpaceState>,
+    tag: String,
+    icon: Option<String>,
+) -> Result<Option<TagAppearance>, String> {
+    let root = state.current_root()?;
+    tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
+        let tag = normalize_tag_key(&tag)?;
+        let _guard = tag_appearance_mutex()
+            .lock()
+            .map_err(|_| "tag appearance mutex poisoned".to_string())?;
+        let mut store = load_store(&root)?;
+        let next = normalize_appearance(icon);
+        match next.clone() {
+            Some(appearance) => {
+                store.entries.insert(tag, appearance);
+            }
+            None => {
+                store.entries.remove(&tag);
+            }
+        }
+        save_store(&root, &store)?;
+        Ok(next)
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}

--- a/src-tauri/src/tag_appearance/mod.rs
+++ b/src-tauri/src/tag_appearance/mod.rs
@@ -1,0 +1,3 @@
+pub mod commands;
+pub mod store;
+pub mod types;

--- a/src-tauri/src/tag_appearance/store.rs
+++ b/src-tauri/src/tag_appearance/store.rs
@@ -1,0 +1,70 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::glyph_paths::ensure_glyph_dir;
+use crate::index::tags::normalize_tag;
+use crate::io_atomic;
+
+use super::types::{TagAppearance, TagAppearanceStore};
+
+const TAG_APPEARANCE_STORE_FILE: &str = "tag_appearance.json";
+const TAG_APPEARANCE_STORE_VERSION: u32 = 1;
+
+fn store_path(space_root: &Path) -> Result<PathBuf, String> {
+    Ok(ensure_glyph_dir(space_root)?.join(TAG_APPEARANCE_STORE_FILE))
+}
+
+fn default_store() -> TagAppearanceStore {
+    TagAppearanceStore {
+        version: TAG_APPEARANCE_STORE_VERSION,
+        entries: BTreeMap::new(),
+    }
+}
+
+pub fn normalize_store(mut store: TagAppearanceStore) -> TagAppearanceStore {
+    store.version = TAG_APPEARANCE_STORE_VERSION;
+    store.entries = store
+        .entries
+        .into_iter()
+        .filter_map(|(tag, appearance)| {
+            let tag = normalize_tag(&tag)?;
+            let appearance = appearance.normalized()?;
+            Some((tag, appearance))
+        })
+        .collect();
+    store
+}
+
+pub fn load_store(space_root: &Path) -> Result<TagAppearanceStore, String> {
+    let path = store_path(space_root)?;
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let store: TagAppearanceStore =
+                serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+            if store.version > TAG_APPEARANCE_STORE_VERSION {
+                return Err(format!(
+                    "unsupported tag appearance store version {} (max supported {})",
+                    store.version, TAG_APPEARANCE_STORE_VERSION
+                ));
+            }
+            Ok(normalize_store(store))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(default_store()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn save_store(space_root: &Path, store: &TagAppearanceStore) -> Result<(), String> {
+    let path = store_path(space_root)?;
+    let store = normalize_store(store.clone());
+    let bytes = serde_json::to_vec_pretty(&store).map_err(|error| error.to_string())?;
+    io_atomic::write_atomic(&path, &bytes).map_err(|error| error.to_string())
+}
+
+pub fn normalize_tag_key(tag: &str) -> Result<String, String> {
+    normalize_tag(tag).ok_or_else(|| "invalid tag".to_string())
+}
+
+pub fn normalize_appearance(icon: Option<String>) -> Option<TagAppearance> {
+    TagAppearance { icon }.normalized()
+}

--- a/src-tauri/src/tag_appearance/types.rs
+++ b/src-tauri/src/tag_appearance/types.rs
@@ -1,0 +1,31 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct TagAppearance {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+impl TagAppearance {
+    pub fn normalized(self) -> Option<Self> {
+        let icon = self.icon.and_then(|value| {
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        });
+
+        icon.map(|icon| Self { icon: Some(icon) })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagAppearanceStore {
+    pub version: u32,
+    #[serde(default)]
+    pub entries: BTreeMap<String, TagAppearance>,
+}

--- a/src/components/AppearancePicker.tsx
+++ b/src/components/AppearancePicker.tsx
@@ -1,0 +1,224 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+import { useMemo, useRef, useState } from "react";
+import {
+	DATABASE_COLUMN_ICON_OPTIONS,
+	type DatabaseColumnIconOption,
+	getDatabaseColumnIconOption,
+} from "../lib/database/columnIcons";
+import { Search } from "./Icons";
+import { DatabaseColumnIcon } from "./database/DatabaseColumnIcon";
+import {
+	EDITOR_TEXT_COLORS,
+	type EditorTextColor,
+	type EditorTextColorOption,
+} from "./editor/textColors";
+import { Button } from "./ui/shadcn/button";
+import { Dialog, DialogContent, DialogTitle } from "./ui/shadcn/dialog";
+import { Input } from "./ui/shadcn/input";
+import { ScrollArea } from "./ui/shadcn/scroll-area";
+
+interface AppearancePickerProps {
+	title: string;
+	trigger?: (openPicker: () => void) => ReactNode;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	iconValue?: string | null;
+	defaultIconName?: string;
+	iconOptions?: readonly DatabaseColumnIconOption[];
+	onIconChange?: (
+		iconName: string | null,
+		option: DatabaseColumnIconOption | null,
+	) => void;
+	showDefaultIcon?: boolean;
+	colorValue?: EditorTextColor | null;
+	colorOptions?: readonly EditorTextColorOption[];
+	onColorChange?: (color: EditorTextColor | null) => void;
+	showColors?: boolean;
+}
+
+export function AppearancePicker({
+	title,
+	trigger,
+	open,
+	onOpenChange,
+	iconValue,
+	defaultIconName = "tag",
+	iconOptions = DATABASE_COLUMN_ICON_OPTIONS,
+	onIconChange,
+	showDefaultIcon = false,
+	colorValue = null,
+	colorOptions = EDITOR_TEXT_COLORS,
+	onColorChange,
+	showColors = false,
+}: AppearancePickerProps) {
+	const [internalOpen, setInternalOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const resolvedOpen = open ?? internalOpen;
+	const selectedIconName = getDatabaseColumnIconOption(iconValue)
+		? iconValue
+		: defaultIconName;
+
+	const filteredOptions = useMemo(() => {
+		const normalizedQuery = query.trim().toLowerCase();
+		if (!normalizedQuery) return iconOptions;
+		return iconOptions.filter(
+			(option) =>
+				option.id.includes(normalizedQuery) ||
+				option.label.toLowerCase().includes(normalizedQuery),
+		);
+	}, [iconOptions, query]);
+
+	function setOpen(nextOpen: boolean) {
+		if (open === undefined) setInternalOpen(nextOpen);
+		onOpenChange?.(nextOpen);
+		if (!nextOpen) {
+			setQuery("");
+			return;
+		}
+		window.requestAnimationFrame(() => inputRef.current?.focus());
+	}
+
+	return (
+		<>
+			{trigger?.(() => setOpen(true))}
+			<Dialog open={resolvedOpen} onOpenChange={setOpen}>
+				<DialogContent
+					className="commandPalette appearancePickerDialog top-[46%] gap-0 border-none bg-transparent p-0 shadow-none sm:max-w-[420px]"
+					showCloseButton={false}
+				>
+					<DialogTitle className="sr-only">{title}</DialogTitle>
+					<div className="commandPaletteHeader">
+						<div className="commandPaletteInputWrapper">
+							<Search
+								size={13}
+								className="commandPaletteSearchIcon"
+								aria-hidden="true"
+							/>
+							<Input
+								ref={inputRef}
+								value={query}
+								placeholder="Search icons"
+								className="commandPaletteInput"
+								onChange={(event) => setQuery(event.target.value)}
+							/>
+						</div>
+						{showColors ? (
+							<div className="appearancePickerColors" aria-label="Colors">
+								<button
+									type="button"
+									className="appearancePickerColor"
+									data-active={colorValue === null ? "true" : undefined}
+									onClick={() => {
+										onColorChange?.(null);
+										setOpen(false);
+									}}
+								>
+									<span className="appearancePickerDefaultColor" />
+									<span>Default</span>
+								</button>
+								{colorOptions.map((color) => (
+									<button
+										key={color.id}
+										type="button"
+										className="appearancePickerColor"
+										data-active={colorValue === color.id ? "true" : undefined}
+										onClick={() => {
+											onColorChange?.(color.id);
+											setOpen(false);
+										}}
+									>
+										<span
+											className="appearancePickerSwatch"
+											style={{ color: `var(${color.cssVar})` }}
+										/>
+										<span>{color.label}</span>
+									</button>
+								))}
+							</div>
+						) : null}
+					</div>
+					<div className="commandPaletteBody">
+						<ScrollArea className="appearancePickerScroll">
+							<div className="appearancePickerGrid">
+								{showDefaultIcon ? (
+									<Button
+										type="button"
+										variant={iconValue ? "ghost" : "secondary"}
+										size="icon-sm"
+										title="Default icon"
+										aria-label="Use default icon"
+										className="appearancePickerOption"
+										onClick={() => {
+											onIconChange?.(null, null);
+											setOpen(false);
+										}}
+									>
+										<DatabaseColumnIcon iconName={defaultIconName} size={15} />
+									</Button>
+								) : null}
+								{filteredOptions.map((option) => {
+									const active =
+										option.id === selectedIconName && Boolean(iconValue);
+									return (
+										<Button
+											key={option.id}
+											type="button"
+											variant={active ? "secondary" : "ghost"}
+											size="icon-sm"
+											title={option.label}
+											aria-label={`Use ${option.label} icon`}
+											aria-pressed={active}
+											className="appearancePickerOption"
+											onClick={() => {
+												onIconChange?.(option.id, option);
+												setOpen(false);
+											}}
+										>
+											<DatabaseColumnIcon iconName={option.id} size={15} />
+										</Button>
+									);
+								})}
+								{filteredOptions.length === 0 ? (
+									<div className="appearancePickerEmpty">No icons found.</div>
+								) : null}
+							</div>
+						</ScrollArea>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}
+
+export function AppearancePickerIconTrigger({
+	iconName,
+	className,
+	disabled,
+	label,
+	onClick,
+}: {
+	iconName: string;
+	className?: string;
+	disabled?: boolean;
+	label: string;
+	onClick: () => void;
+}) {
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="icon-xs"
+			className={cn("shrink-0", className)}
+			disabled={disabled}
+			aria-label={label}
+			onClick={(event) => {
+				event.stopPropagation();
+				onClick();
+			}}
+		>
+			<DatabaseColumnIcon iconName={iconName} size={14} />
+		</Button>
+	);
+}

--- a/src/components/TagIconPicker.tsx
+++ b/src/components/TagIconPicker.tsx
@@ -1,0 +1,68 @@
+import {
+	DEFAULT_TAG_ICON_NAME,
+	TAG_ICON_OPTIONS,
+	type TagIconOption,
+	type TagIconOverrides,
+	isTagIconName,
+	resolveTagIconName,
+} from "../lib/tagIcons";
+import {
+	AppearancePicker,
+	AppearancePickerIconTrigger,
+} from "./AppearancePicker";
+
+export interface TagIconPickerProps {
+	tag: string;
+	value?: string | null;
+	overrides?: TagIconOverrides | null;
+	beautifulTagsEnabled?: boolean;
+	options?: readonly TagIconOption[];
+	disabled?: boolean;
+	className?: string;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	onChange: (iconName: string, option: TagIconOption) => void;
+}
+
+export function TagIconPicker({
+	tag,
+	value,
+	overrides,
+	beautifulTagsEnabled = true,
+	options = TAG_ICON_OPTIONS,
+	disabled,
+	className,
+	open,
+	onOpenChange,
+	onChange,
+}: TagIconPickerProps) {
+	const selectedIconName =
+		value?.trim() || resolveTagIconName(tag, overrides, beautifulTagsEnabled);
+	const displayIconName = isTagIconName(selectedIconName)
+		? selectedIconName
+		: DEFAULT_TAG_ICON_NAME;
+
+	return (
+		<AppearancePicker
+			title="Choose tag icon"
+			open={open}
+			onOpenChange={onOpenChange}
+			iconValue={displayIconName}
+			defaultIconName={DEFAULT_TAG_ICON_NAME}
+			iconOptions={options}
+			onIconChange={(iconName, option) => {
+				if (!iconName || !option) return;
+				onChange(iconName, option);
+			}}
+			trigger={(openPicker) => (
+				<AppearancePickerIconTrigger
+					iconName={displayIconName}
+					className={className}
+					disabled={disabled}
+					label={`Choose icon for ${tag}`}
+					onClick={openPicker}
+				/>
+			)}
+		/>
+	);
+}

--- a/src/components/TagIconPicker.tsx
+++ b/src/components/TagIconPicker.tsx
@@ -4,6 +4,7 @@ import {
 	type TagIconOption,
 	type TagIconOverrides,
 	isTagIconName,
+	normalizeTagIconKey,
 	resolveTagIconName,
 } from "../lib/tagIcons";
 import {
@@ -21,7 +22,7 @@ export interface TagIconPickerProps {
 	className?: string;
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
-	onChange: (iconName: string, option: TagIconOption) => void;
+	onChange: (iconName: string | null, option: TagIconOption | null) => void;
 }
 
 export function TagIconPicker({
@@ -41,16 +42,27 @@ export function TagIconPicker({
 	const displayIconName = isTagIconName(selectedIconName)
 		? selectedIconName
 		: DEFAULT_TAG_ICON_NAME;
+	const defaultIconName = resolveTagIconName(tag, null, beautifulTagsEnabled);
+	const defaultDisplayIconName = isTagIconName(defaultIconName)
+		? defaultIconName
+		: DEFAULT_TAG_ICON_NAME;
+	const overrideIconName =
+		value === undefined ? resolveOverrideIconName(tag, overrides) : value;
 
 	return (
 		<AppearancePicker
 			title="Choose tag icon"
 			open={open}
 			onOpenChange={onOpenChange}
-			iconValue={displayIconName}
-			defaultIconName={DEFAULT_TAG_ICON_NAME}
+			iconValue={overrideIconName}
+			defaultIconName={defaultDisplayIconName}
 			iconOptions={options}
+			showDefaultIcon
 			onIconChange={(iconName, option) => {
+				if (iconName === null && option === null) {
+					onChange(null, null);
+					return;
+				}
 				if (!iconName || !option) return;
 				onChange(iconName, option);
 			}}
@@ -65,4 +77,23 @@ export function TagIconPicker({
 			)}
 		/>
 	);
+}
+
+function resolveOverrideIconName(
+	tag: string,
+	overrides: TagIconOverrides | null | undefined,
+): string | null {
+	if (!overrides) return null;
+
+	const normalizedTag = normalizeTagIconKey(tag);
+	const keys = [tag, tag.trim()];
+	if (normalizedTag) keys.push(normalizedTag, `#${normalizedTag}`);
+
+	for (const key of new Set(keys.filter(Boolean))) {
+		if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+		const iconName = overrides[key];
+		return typeof iconName === "string" ? iconName.trim() || null : null;
+	}
+
+	return null;
 }

--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -24,7 +24,7 @@ interface TagsPaneProps {
 	onSelectPerson: (handle: string) => void;
 	beautifulTags?: boolean;
 	tagAppearance?: Record<string, TagAppearance>;
-	onChangeTagIcon?: (tag: string, iconName: string) => Promise<void>;
+	onChangeTagIcon?: (tag: string, iconName: string | null) => Promise<void>;
 }
 
 const springTransition = springPresets.bouncy;
@@ -258,7 +258,7 @@ function TagRowIcon({
 	tag: string;
 	beautifulTags: boolean;
 	overrides: TagIconOverrides;
-	onChangeTagIcon?: (tag: string, iconName: string) => Promise<void>;
+	onChangeTagIcon?: (tag: string, iconName: string | null) => Promise<void>;
 }) {
 	if (beautifulTags) {
 		return (
@@ -268,7 +268,8 @@ function TagRowIcon({
 				beautifulTagsEnabled={beautifulTags}
 				className="tagsIconPicker"
 				onChange={(iconName) => {
-					void onChangeTagIcon?.(tag, iconName).catch((error: unknown) => {
+					if (!onChangeTagIcon) return;
+					void onChangeTagIcon(tag, iconName).catch((error: unknown) => {
 						console.error("Failed to change tag icon", error);
 					});
 				}}

--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -1,9 +1,20 @@
 import { Tag01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
-import { type CSSProperties, memo, useCallback, useState } from "react";
-import type { PersonCount, TagCount } from "../lib/tauri";
+import {
+	type CSSProperties,
+	memo,
+	useCallback,
+	useMemo,
+	useState,
+} from "react";
+import {
+	type TagIconOverrides,
+	tagIconOverridesFromAppearance,
+} from "../lib/tagIcons";
+import type { PersonCount, TagAppearance, TagCount } from "../lib/tauri";
 import { ChevronDown, ChevronRight } from "./Icons";
+import { TagIconPicker } from "./TagIconPicker";
 import { springPresets } from "./ui/animations";
 
 interface TagsPaneProps {
@@ -11,6 +22,9 @@ interface TagsPaneProps {
 	people: PersonCount[];
 	onSelectTag: (tag: string) => void;
 	onSelectPerson: (handle: string) => void;
+	beautifulTags?: boolean;
+	tagAppearance?: Record<string, TagAppearance>;
+	onChangeTagIcon?: (tag: string, iconName: string) => Promise<void>;
 }
 
 const springTransition = springPresets.bouncy;
@@ -67,6 +81,9 @@ export const TagsPane = memo(function TagsPane({
 	people,
 	onSelectTag,
 	onSelectPerson,
+	beautifulTags = false,
+	tagAppearance = {},
+	onChangeTagIcon,
 }: TagsPaneProps) {
 	const onClick = useCallback(
 		(tag: string) => onSelectTag(tag.startsWith("#") ? tag : `#${tag}`),
@@ -81,6 +98,10 @@ export const TagsPane = memo(function TagsPane({
 	const [sectionExpanded, setSectionExpanded] = useState(false);
 	const rows = buildTagTreeRows(tags);
 	const peopleRows = buildPeopleRows(people);
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
 
 	const TAG_LIMIT = 5;
 	const hasMoreTags = rows.length > TAG_LIMIT;
@@ -124,11 +145,9 @@ export const TagsPane = memo(function TagsPane({
 						{visibleRows.map((tag) => {
 							return (
 								<m.li key={tag.tag} className="tagsItem">
-									<m.button
-										type="button"
+									<m.div
 										className="tagsButton"
 										data-explicit={tag.isExplicit ? "true" : "false"}
-										onClick={() => onClick(tag.tag)}
 										style={
 											{
 												paddingInlineStart: `${8 + tag.depth * 16}px`,
@@ -137,22 +156,23 @@ export const TagsPane = memo(function TagsPane({
 										title={`#${tag.tag} · ${tag.totalCount} note${
 											tag.totalCount === 1 ? "" : "s"
 										}`}
-										whileHover={{
-											backgroundColor: "var(--bg-hover)",
-										}}
 										transition={springTransition}
 									>
-										<span className="tagsNameWrap">
-											<HugeiconsIcon
-												icon={Tag01Icon}
-												className="tagsIcon"
-												size={12}
-												strokeWidth={0.9}
-											/>
+										<TagRowIcon
+											tag={tag.tag}
+											beautifulTags={beautifulTags}
+											overrides={tagIconOverrides}
+											onChangeTagIcon={onChangeTagIcon}
+										/>
+										<button
+											type="button"
+											className="tagsMainButton"
+											onClick={() => onClick(tag.tag)}
+										>
 											<span className="tagsName">{tag.label}</span>
-										</span>
-										<span className="tagsCount">{tag.totalCount}</span>
-									</m.button>
+											<span className="tagsCount">{tag.totalCount}</span>
+										</button>
+									</m.div>
 								</m.li>
 							);
 						})}
@@ -228,3 +248,40 @@ export const TagsPane = memo(function TagsPane({
 		</m.section>
 	);
 });
+
+function TagRowIcon({
+	tag,
+	beautifulTags,
+	overrides,
+	onChangeTagIcon,
+}: {
+	tag: string;
+	beautifulTags: boolean;
+	overrides: TagIconOverrides;
+	onChangeTagIcon?: (tag: string, iconName: string) => Promise<void>;
+}) {
+	if (beautifulTags) {
+		return (
+			<TagIconPicker
+				tag={tag}
+				overrides={overrides}
+				beautifulTagsEnabled={beautifulTags}
+				className="tagsIconPicker"
+				onChange={(iconName) => {
+					void onChangeTagIcon?.(tag, iconName).catch((error: unknown) => {
+						console.error("Failed to change tag icon", error);
+					});
+				}}
+			/>
+		);
+	}
+
+	return (
+		<HugeiconsIcon
+			icon={Tag01Icon}
+			className="tagsIcon"
+			size={12}
+			strokeWidth={0.9}
+		/>
+	);
+}

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -1,4 +1,4 @@
-import { Folder01Icon, Tag01Icon } from "@hugeicons/core-free-icons";
+import { Folder01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -10,15 +10,22 @@ import {
 	subDays,
 } from "date-fns";
 import { m, useReducedMotion } from "motion/react";
-import { memo, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
+import { useFileTreeContext } from "../../contexts";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import {
 	loadAllDocs,
 	navigationQueryKeys,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
+import {
+	DEFAULT_TAG_ICON_NAME,
+	resolveTagIconName,
+	tagIconOverridesFromAppearance,
+} from "../../lib/tagIcons";
 import type { AllDocsItem } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
 import { springPresets } from "../ui/animations";
 
@@ -169,6 +176,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 	emptyMessage = "No notes yet. Create one to get started.",
 	initialNotes = null,
 }: AllDocsPaneProps) {
+	const { beautifulTags, tagAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
 	const queryClient = useQueryClient();
@@ -182,6 +190,17 @@ export const AllDocsPane = memo(function AllDocsPane({
 		initialData: initialNotes ?? undefined,
 	});
 	const notes = notesQuery.data ?? [];
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
+	const iconNameForTag = useCallback(
+		(tag: string) =>
+			beautifulTags
+				? resolveTagIconName(tag, tagIconOverrides, beautifulTags)
+				: DEFAULT_TAG_ICON_NAME,
+		[beautifulTags, tagIconOverrides],
+	);
 
 	useTauriEvent("notes:external_changed", () => {
 		void queryClient.invalidateQueries({
@@ -337,8 +356,8 @@ export const AllDocsPane = memo(function AllDocsPane({
 															key={`${note.note_path}:${tag}`}
 															className="allDocsCardTag"
 														>
-															<HugeiconsIcon
-																icon={Tag01Icon}
+															<DatabaseColumnIcon
+																iconName={iconNameForTag(tag)}
 																className="allDocsCardTagIcon"
 																size={11}
 																strokeWidth={1.2}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -259,7 +259,7 @@ export const SidebarContent = memo(function SidebarContent({
 	}, []);
 
 	const handleChangeTagIcon = useCallback(
-		async (tag: string, iconName: string) => {
+		async (tag: string, iconName: string | null) => {
 			try {
 				await setTagAppearance(tag, iconName);
 			} catch (error) {

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -16,9 +16,11 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import { toast } from "sonner";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
+import { extractErrorMessage } from "../../lib/errorUtils";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import { type FsEntry, invoke } from "../../lib/tauri";
 import { ChevronDown, ChevronRight } from "../Icons";
@@ -143,6 +145,9 @@ export const SidebarContent = memo(function SidebarContent({
 		togglePinnedFile,
 		tags,
 		people,
+		beautifulTags,
+		tagAppearance,
+		setTagAppearance,
 	} = useFileTreeContext();
 	const { folioMode, folioScope, setFolioScope } = useUILayoutContext();
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
@@ -252,6 +257,20 @@ export const SidebarContent = memo(function SidebarContent({
 		setRenamingPath(null);
 		setPendingNewNotePath(null);
 	}, []);
+
+	const handleChangeTagIcon = useCallback(
+		async (tag: string, iconName: string) => {
+			try {
+				await setTagAppearance(tag, iconName);
+			} catch (error) {
+				toast.error("Could not update tag icon", {
+					description: extractErrorMessage(error),
+				});
+				throw error;
+			}
+		},
+		[setTagAppearance],
+	);
 
 	const handleCommitDirRename = useCallback(
 		async (dirPath: string, nextName: string) => {
@@ -548,6 +567,9 @@ export const SidebarContent = memo(function SidebarContent({
 								people={people}
 								onSelectTag={handleSelectTag}
 								onSelectPerson={handleSelectPerson}
+								beautifulTags={beautifulTags}
+								tagAppearance={tagAppearance}
+								onChangeTagIcon={handleChangeTagIcon}
 							/>
 						</section>
 					</div>

--- a/src/components/calendar/CalendarPane.tsx
+++ b/src/components/calendar/CalendarPane.tsx
@@ -10,7 +10,11 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useSpace, useUILayoutContext } from "../../contexts";
+import {
+	useFileTreeContext,
+	useSpace,
+	useUILayoutContext,
+} from "../../contexts";
 import { useDailyNote } from "../../hooks/useDailyNote";
 import {
 	buildWeekRange,
@@ -30,6 +34,11 @@ import {
 	navigationQueryKeys,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
+import {
+	DEFAULT_TAG_ICON_NAME,
+	resolveTagIconName,
+	tagIconOverridesFromAppearance,
+} from "../../lib/tagIcons";
 import { todayIsoDateLocal } from "../../lib/tasks";
 import {
 	type CalendarNoteActivityItem,
@@ -40,6 +49,7 @@ import {
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { renderTemplate } from "../../lib/templates";
 import { Settings } from "../Icons";
+import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { TaskRow } from "../tasks/TaskRow";
 import { Button } from "../ui/shadcn/button";
 import { Input } from "../ui/shadcn/input";
@@ -130,6 +140,7 @@ export function CalendarPane({
 	onOpenFile,
 	onOpenDailyNotesSettings,
 }: CalendarPaneProps) {
+	const { beautifulTags, tagAppearance } = useFileTreeContext();
 	const today = useMemo(() => todayIsoDateLocal(), []);
 	const initialSelectedDate = useMemo(
 		() => readStorage(SELECTED_STORAGE_KEY) ?? todayIsoDateLocal(),
@@ -140,6 +151,17 @@ export function CalendarPane({
 		() => readStorage(ANCHOR_STORAGE_KEY) ?? initialSelectedDate,
 	);
 	const taskInputRef = useRef<HTMLInputElement>(null);
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
+	const iconNameForTag = useCallback(
+		(tag: string) =>
+			beautifulTags
+				? resolveTagIconName(tag, tagIconOverrides, beautifulTags)
+				: DEFAULT_TAG_ICON_NAME,
+		[beautifulTags, tagIconOverrides],
+	);
 	const normalizedAnchorDate = isDateInsideWeek(selectedDate, anchorDate)
 		? anchorDate
 		: selectedDate;
@@ -714,6 +736,14 @@ export function CalendarPane({
 															<span className="calendarNoteTags">
 																{visibleTags.map((tag) => (
 																	<span key={tag} className="calendarNoteTag">
+																		{beautifulTags ? (
+																			<DatabaseColumnIcon
+																				iconName={iconNameForTag(tag)}
+																				className="calendarNoteTagIcon"
+																				size={10}
+																				strokeWidth={1.2}
+																			/>
+																		) : null}
 																		#{tag}
 																	</span>
 																))}

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -23,6 +23,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useFileTreeContext } from "../../contexts";
 import { useDatabaseBoard } from "../../hooks/database/useDatabaseBoard";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -49,6 +50,11 @@ import {
 } from "../../lib/nativeContextMenu";
 import { priorityToneStyle } from "../../lib/priorityProperties";
 import { statusToneStyle } from "../../lib/statusProperties";
+import {
+	DEFAULT_TAG_ICON_NAME,
+	resolveTagIconName,
+	tagIconOverridesFromAppearance,
+} from "../../lib/tagIcons";
 import type { NoteTaskSummary } from "../../lib/tauri";
 import { parentDir } from "../../utils/path";
 import { Plus } from "../Icons";
@@ -82,6 +88,7 @@ import {
 	DropdownMenuTrigger,
 } from "../ui/shadcn/dropdown-menu";
 import { Input } from "../ui/shadcn/input";
+import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "./databaseTagLabel";
 
 interface DatabaseBoardProps {
@@ -531,6 +538,7 @@ export function DatabaseBoard({
 	onStatusColorChange,
 	onSaveCell,
 }: DatabaseBoardProps) {
+	const { beautifulTags, tagAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion();
 	const {
 		groupColumn,
@@ -554,6 +562,17 @@ export function DatabaseBoard({
 	const [laneEdit, setLaneEdit] = useState<LaneEditState | null>(null);
 	const suppressClickRef = useRef(false);
 	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
+	const iconNameForTag = useCallback(
+		(tag: string) =>
+			beautifulTags
+				? resolveTagIconName(tag, tagIconOverrides, beautifulTags)
+				: DEFAULT_TAG_ICON_NAME,
+		[beautifulTags, tagIconOverrides],
+	);
 	const taskSummaryPaths = useMemo(
 		() => Array.from(new Set(rows.map((row) => row.note_path).filter(Boolean))),
 		[rows],
@@ -1001,10 +1020,13 @@ export function DatabaseBoard({
 																<span
 																	key={`${row.note_path}:${tag}`}
 																	className="databaseBoardTag"
+																	data-beautiful-tags={
+																		beautifulTags ? "true" : undefined
+																	}
 																	title={formatDatabaseTagLabel(tag)}
 																>
-																	<HugeiconsIcon
-																		icon={Tag01Icon}
+																	<DatabaseColumnIcon
+																		iconName={iconNameForTag(tag)}
 																		className="databaseTagPillIcon"
 																		size={11}
 																		strokeWidth={1.2}

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -1,5 +1,3 @@
-import { Tag01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { CSSProperties } from "react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
@@ -19,6 +17,11 @@ import {
 	statusColorKey,
 	statusOptionsWithCustomValues,
 } from "../../lib/statusProperties";
+import {
+	DEFAULT_TAG_ICON_NAME,
+	resolveTagIconName,
+	tagIconOverridesFromAppearance,
+} from "../../lib/tagIcons";
 import { X } from "../Icons";
 import { Toggle } from "../base/toggle/toggle";
 import {
@@ -36,6 +39,7 @@ import {
 	DropdownMenuTrigger,
 } from "../ui/shadcn/dropdown-menu";
 import { Input } from "../ui/shadcn/input";
+import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import { buildDatabaseTagPickerOptions } from "./DatabaseTagPicker";
 import { formatDatabaseTagLabel } from "./databaseTagLabel";
 
@@ -64,6 +68,7 @@ interface DatabaseDisplayPill {
 	key: string;
 	label: string;
 	kind?: "tag";
+	iconName?: string;
 	title?: string;
 }
 
@@ -76,8 +81,8 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 	const renderPill = (item: DatabaseDisplayPill) => (
 		<span key={item.key} className="databaseCellPill" title={item.title}>
 			{item.kind === "tag" ? (
-				<HugeiconsIcon
-					icon={Tag01Icon}
+				<DatabaseColumnIcon
+					iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 					className="databaseTagPillIcon"
 					size={11}
 					strokeWidth={1.2}
@@ -184,8 +189,8 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 						className="databaseCellPill"
 					>
 						{item.kind === "tag" ? (
-							<HugeiconsIcon
-								icon={Tag01Icon}
+							<DatabaseColumnIcon
+								iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 								className="databaseTagPillIcon"
 								size={11}
 								strokeWidth={1.2}
@@ -255,7 +260,11 @@ function DatabaseCellEditor({
 	onSave,
 	onClose,
 }: DatabaseCellEditorProps) {
-	const { tags: availableTags } = useFileTreeContext();
+	const {
+		tags: availableTags,
+		beautifulTags,
+		tagAppearance,
+	} = useFileTreeContext();
 	const cellValue = useMemo(
 		() => databaseCellValueFromRow(row, column),
 		[column, row],
@@ -337,6 +346,17 @@ function DatabaseCellEditor({
 		}
 		return suggestions.slice(0, DATABASE_CELL_TAG_SUGGESTION_LIMIT);
 	}, [availableTags, cellValue.value_list, tagDraft, valueOptions]);
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
+	const iconNameForTag = useCallback(
+		(tag: string) =>
+			beautifulTags
+				? resolveTagIconName(tag, tagIconOverrides, beautifulTags)
+				: DEFAULT_TAG_ICON_NAME,
+		[beautifulTags, tagIconOverrides],
+	);
 	const valueSuggestions = useMemo(() => {
 		if (!isListLike) return [];
 		const query = valueDraft.trim().toLowerCase();
@@ -513,8 +533,8 @@ function DatabaseCellEditor({
 							}}
 							title={`Remove ${formatDatabaseTagLabel(value)}`}
 						>
-							<HugeiconsIcon
-								icon={Tag01Icon}
+							<DatabaseColumnIcon
+								iconName={iconNameForTag(value)}
 								className="databaseTagPillIcon"
 								size={11}
 								strokeWidth={1.2}
@@ -967,6 +987,7 @@ export function DatabaseCell({
 	onRenameTitle,
 	onSave,
 }: DatabaseCellProps) {
+	const { beautifulTags, tagAppearance } = useFileTreeContext();
 	const editable = isColumnEditable(column);
 	const cellValue = useMemo(
 		() => databaseCellValueFromRow(row, column),
@@ -977,15 +998,27 @@ export function DatabaseCell({
 		cellValue.kind === "datetime"
 			? formatDatabaseDateTime(cellValue.value_text)
 			: (cellValue.value_text ?? "");
+	const tagIconOverrides = useMemo(
+		() => tagIconOverridesFromAppearance(tagAppearance),
+		[tagAppearance],
+	);
+	const iconNameForTag = useCallback(
+		(tag: string) =>
+			beautifulTags
+				? resolveTagIconName(tag, tagIconOverrides, beautifulTags)
+				: DEFAULT_TAG_ICON_NAME,
+		[beautifulTags, tagIconOverrides],
+	);
 	const tagPillItems = useMemo<DatabaseDisplayPill[]>(() => {
 		if (cellValue.kind !== "tags") return [];
 		return cellValue.value_list.map((value) => ({
 			key: `${column.id}:${value}`,
 			kind: "tag",
+			iconName: iconNameForTag(value),
 			label: formatDatabaseTagLabel(value),
 			title: formatDatabaseTagLabel(value),
 		}));
-	}, [cellValue.kind, cellValue.value_list, column.id]);
+	}, [cellValue.kind, cellValue.value_list, column.id, iconNameForTag]);
 	const listPillItems = useMemo<DatabaseDisplayPill[]>(() => {
 		if (cellValue.kind !== "relation" && cellValue.kind !== "multi_select") {
 			return [];

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -101,7 +101,7 @@ interface FileTreeDirItemProps {
 	onDeletePath: (path: string, kind: "dir" | "file") => void;
 	onEnterDir?: (dirPath: string) => void;
 	appearance?: FileTreeAppearance | null;
-	onChangeAppearance: (appearance: FileTreeAppearance) => void;
+	onOpenAppearancePicker: () => void;
 	fileCount?: number | null;
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
 }
@@ -124,7 +124,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	onDeletePath,
 	onEnterDir,
 	appearance,
-	onChangeAppearance,
+	onOpenAppearancePicker,
 	fileCount,
 	onMoveClickSuppressRef,
 }: FileTreeDirItemProps) {
@@ -180,7 +180,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					label: "Rename",
 					action: onStartRename,
 				},
-				fileTreeAppearanceNativeMenu("dir", appearance, onChangeAppearance),
+				fileTreeAppearanceNativeMenu(onOpenAppearancePicker),
 				{ type: "separator" },
 				{
 					label: "Delete folder",
@@ -191,9 +191,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			});
 		},
 		[
-			appearance,
 			entry.rel_path,
-			onChangeAppearance,
+			onOpenAppearancePicker,
 			onCreateFromTemplateInDir,
 			onDeletePath,
 			onNewFileInDir,

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -111,7 +111,8 @@ interface FileTreeFileItemProps {
 	parentDirPath: string;
 	onDeletePath: (path: string, kind: "dir" | "file") => void;
 	appearance?: FileTreeAppearance | null;
-	onChangeAppearance: (appearance: FileTreeAppearance) => void;
+	onChangeAppearance?: (appearance: FileTreeAppearance) => void;
+	onOpenAppearancePicker?: () => void;
 	isPinned: boolean;
 	onTogglePinned: (path: string) => Promise<void> | void;
 	onMoveClickSuppressRef?: MutableRefObject<boolean>;
@@ -141,7 +142,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	parentDirPath,
 	onDeletePath,
 	appearance,
-	onChangeAppearance,
+	onOpenAppearancePicker,
 	isPinned,
 	onTogglePinned,
 	onMoveClickSuppressRef = DEFAULT_MOVE_CLICK_SUPPRESS_REF,
@@ -231,7 +232,9 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					label: isPinned ? "Unpin file" : "Pin file",
 					action: () => void onTogglePinned(entry.rel_path),
 				},
-				fileTreeAppearanceNativeMenu("file", appearance, onChangeAppearance),
+				fileTreeAppearanceNativeMenu(
+					onOpenAppearancePicker ?? (() => undefined),
+				),
 				{ type: "separator" },
 				{
 					label: "Add file",
@@ -255,11 +258,10 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			});
 		},
 		[
-			appearance,
 			entry.rel_path,
 			handleRevealInFinder,
 			isPinned,
-			onChangeAppearance,
+			onOpenAppearancePicker,
 			onCreateFromTemplateInDir,
 			onDeletePath,
 			onDuplicateFile,

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -744,9 +744,12 @@ export const FileTreePane = memo(function FileTreePane({
 	const updatePickerAppearance = useCallback(
 		(nextAppearance: FileTreeAppearance) => {
 			if (!appearancePickerEntry) return;
-			void handleChangeAppearance(appearancePickerEntry, nextAppearance);
+			void handleChangeAppearance(appearancePickerEntry, {
+				...(itemAppearance[appearancePickerEntry.rel_path] ?? {}),
+				...nextAppearance,
+			});
 		},
-		[appearancePickerEntry, handleChangeAppearance],
+		[appearancePickerEntry, handleChangeAppearance, itemAppearance],
 	);
 
 	const handleEnterDir = useCallback(
@@ -933,7 +936,6 @@ export const FileTreePane = memo(function FileTreePane({
 					showDefaultIcon
 					onIconChange={(icon) => {
 						updatePickerAppearance({
-							color: appearancePickerColor,
 							icon,
 						});
 					}}
@@ -943,7 +945,6 @@ export const FileTreePane = memo(function FileTreePane({
 					onColorChange={(color) => {
 						updatePickerAppearance({
 							color,
-							icon: appearancePickerIcon,
 						});
 					}}
 				/>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -39,7 +39,9 @@ import {
 	parentDir,
 	basename as relBasename,
 } from "../../utils/path";
+import { AppearancePicker } from "../AppearancePicker";
 import { ChevronRight } from "../Icons";
+import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
 import { FileTreeDirItem } from "./FileTreeDirItem";
@@ -81,6 +83,10 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const MARKDOWN_PREVIEW_MAX_BYTES = 4096;
 const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
+
+interface AppearancePickerTarget {
+	entry: FsEntry;
+}
 
 function spaceLabelFromPath(path: string | null): string {
 	if (!path) return "Glyph";
@@ -271,6 +277,7 @@ interface TreeEntriesProps {
 		entry: FsEntry,
 		appearance: FileTreeAppearance,
 	) => Promise<void> | void;
+	onOpenAppearancePicker: (entry: FsEntry) => void;
 	pinnedFiles: string[];
 	onTogglePinnedFile: (path: string) => Promise<void>;
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
@@ -311,6 +318,7 @@ function TreeEntries({
 	folderFileCounts,
 	showFolderFileCounts,
 	onChangeAppearance,
+	onOpenAppearancePicker,
 	pinnedFiles,
 	onTogglePinnedFile,
 	onMoveClickSuppressRef,
@@ -355,9 +363,7 @@ function TreeEntries({
 									? (folderFileCounts[e.rel_path] ?? null)
 									: null
 							}
-							onChangeAppearance={(appearance) =>
-								onChangeAppearance(e, appearance)
-							}
+							onOpenAppearancePicker={() => onOpenAppearancePicker(e)}
 							onStartRename={() => onStartRename(e.rel_path)}
 							onCommitRename={onCommitDirRename}
 							onCancelRename={onCancelRename}
@@ -390,6 +396,7 @@ function TreeEntries({
 									folderFileCounts={folderFileCounts}
 									showFolderFileCounts={showFolderFileCounts}
 									onChangeAppearance={onChangeAppearance}
+									onOpenAppearancePicker={onOpenAppearancePicker}
 									pinnedFiles={pinnedFiles}
 									onTogglePinnedFile={onTogglePinnedFile}
 									onMoveClickSuppressRef={onMoveClickSuppressRef}
@@ -423,9 +430,7 @@ function TreeEntries({
 						parentDirPath={parentDir(e.rel_path)}
 						onDeletePath={onDeletePath}
 						appearance={itemAppearance[e.rel_path] ?? null}
-						onChangeAppearance={(appearance) =>
-							onChangeAppearance(e, appearance)
-						}
+						onOpenAppearancePicker={() => onOpenAppearancePicker(e)}
 						isPinned={pinnedFiles.includes(e.rel_path)}
 						onTogglePinned={onTogglePinnedFile}
 						onMoveClickSuppressRef={onMoveClickSuppressRef}
@@ -486,6 +491,8 @@ export const FileTreePane = memo(function FileTreePane({
 		Record<string, string | null | undefined>
 	>({});
 	const [filePreviewRefreshKey, setFilePreviewRefreshKey] = useState(0);
+	const [appearancePickerTarget, setAppearancePickerTarget] =
+		useState<AppearancePickerTarget | null>(null);
 	const filePreviewRequestRef = useRef("");
 	const moveClickSuppressRef = useRef(false);
 	const previousSpacePathRef = useRef(spacePath);
@@ -717,6 +724,31 @@ export const FileTreePane = memo(function FileTreePane({
 		[setError, setItemAppearance],
 	);
 
+	const handleOpenAppearancePicker = useCallback((entry: FsEntry) => {
+		setAppearancePickerTarget({ entry });
+	}, []);
+
+	const appearancePickerEntry = appearancePickerTarget?.entry ?? null;
+	const appearancePickerAppearance = appearancePickerEntry
+		? (itemAppearance[appearancePickerEntry.rel_path] ?? null)
+		: null;
+	const appearancePickerColor =
+		appearancePickerAppearance?.color &&
+		isEditorTextColor(appearancePickerAppearance.color)
+			? appearancePickerAppearance.color
+			: null;
+	const appearancePickerIcon = appearancePickerAppearance?.icon ?? null;
+	const appearancePickerDefaultIcon =
+		appearancePickerEntry?.kind === "dir" ? "folder" : "document";
+
+	const updatePickerAppearance = useCallback(
+		(nextAppearance: FileTreeAppearance) => {
+			if (!appearancePickerEntry) return;
+			void handleChangeAppearance(appearancePickerEntry, nextAppearance);
+		},
+		[appearancePickerEntry, handleChangeAppearance],
+	);
+
 	const handleEnterDir = useCallback(
 		(dirPath: string) => {
 			setFocusedDirPath(dirPath);
@@ -890,6 +922,31 @@ export const FileTreePane = memo(function FileTreePane({
 				transition={springTransition}
 				onKeyDown={handleTreeKeyDown}
 			>
+				<AppearancePicker
+					title="Choose file tree appearance"
+					open={appearancePickerTarget !== null}
+					onOpenChange={(open) => {
+						if (!open) setAppearancePickerTarget(null);
+					}}
+					iconValue={appearancePickerIcon}
+					defaultIconName={appearancePickerDefaultIcon}
+					showDefaultIcon
+					onIconChange={(icon) => {
+						updatePickerAppearance({
+							color: appearancePickerColor,
+							icon,
+						});
+					}}
+					showColors
+					colorValue={appearancePickerColor}
+					colorOptions={EDITOR_TEXT_COLORS}
+					onColorChange={(color) => {
+						updatePickerAppearance({
+							color,
+							icon: appearancePickerIcon,
+						});
+					}}
+				/>
 				{focusedDirPath ? (
 					<FileTreeRootDrop targetDirPath={focusedDirPath}>
 						<FolderBreadcrumb
@@ -933,6 +990,7 @@ export const FileTreePane = memo(function FileTreePane({
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
 								onChangeAppearance={handleChangeAppearance}
+								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}
 								onTogglePinnedFile={onTogglePinnedFile}
 								onMoveClickSuppressRef={moveClickSuppressRef}
@@ -1071,6 +1129,7 @@ export const FileTreePane = memo(function FileTreePane({
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
 								onChangeAppearance={handleChangeAppearance}
+								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}
 								onTogglePinnedFile={onTogglePinnedFile}
 								onMoveClickSuppressRef={moveClickSuppressRef}

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -496,6 +496,11 @@ export const FileTreePane = memo(function FileTreePane({
 	const filePreviewRequestRef = useRef("");
 	const moveClickSuppressRef = useRef(false);
 	const previousSpacePathRef = useRef(spacePath);
+	const itemAppearanceRef = useRef(itemAppearance);
+
+	useEffect(() => {
+		itemAppearanceRef.current = itemAppearance;
+	}, [itemAppearance]);
 
 	useEffect(() => {
 		if (previousSpacePathRef.current === spacePath) return;
@@ -744,12 +749,20 @@ export const FileTreePane = memo(function FileTreePane({
 	const updatePickerAppearance = useCallback(
 		(nextAppearance: FileTreeAppearance) => {
 			if (!appearancePickerEntry) return;
-			void handleChangeAppearance(appearancePickerEntry, {
-				...(itemAppearance[appearancePickerEntry.rel_path] ?? {}),
+			const path = appearancePickerEntry.rel_path;
+			const mergedAppearance = {
+				...(itemAppearanceRef.current[path] ?? {}),
 				...nextAppearance,
+			};
+			itemAppearanceRef.current = {
+				...itemAppearanceRef.current,
+				[path]: mergedAppearance,
+			};
+			void handleChangeAppearance(appearancePickerEntry, {
+				...mergedAppearance,
 			});
 		},
-		[appearancePickerEntry, handleChangeAppearance, itemAppearance],
+		[appearancePickerEntry, handleChangeAppearance],
 	);
 
 	const handleEnterDir = useCallback(

--- a/src/components/filetree/fileTreeNativeContextMenu.ts
+++ b/src/components/filetree/fileTreeNativeContextMenu.ts
@@ -16,10 +16,25 @@ function currentColor(
 }
 
 export function fileTreeAppearanceNativeMenu(
+	onOpenAppearancePicker: () => void,
+): NativeContextMenuItem;
+export function fileTreeAppearanceNativeMenu(
 	itemKind: "dir" | "file",
 	appearance: FileTreeAppearance | null | undefined,
 	onChangeAppearance: (appearance: FileTreeAppearance) => void,
+): NativeContextMenuItem;
+export function fileTreeAppearanceNativeMenu(
+	first: (() => void) | "dir" | "file",
+	appearance?: FileTreeAppearance | null,
+	onChangeAppearance?: (appearance: FileTreeAppearance) => void,
 ): NativeContextMenuItem {
+	if (typeof first === "function") {
+		return {
+			label: "Icon & Color...",
+			action: first,
+		};
+	}
+
 	const selectedColor = currentColor(appearance);
 	const selectedIcon = appearance?.icon ?? null;
 
@@ -35,7 +50,7 @@ export function fileTreeAppearanceNativeMenu(
 						label: color.label,
 						checked: selectedColor === color.id,
 						action: () =>
-							onChangeAppearance({
+							onChangeAppearance?.({
 								color: color.id,
 								icon: selectedIcon,
 							}),
@@ -45,7 +60,7 @@ export function fileTreeAppearanceNativeMenu(
 						label: "Default Color",
 						checked: selectedColor === null,
 						action: () =>
-							onChangeAppearance({
+							onChangeAppearance?.({
 								color: null,
 								icon: selectedIcon,
 							}),
@@ -57,10 +72,10 @@ export function fileTreeAppearanceNativeMenu(
 				label: "Icon",
 				items: [
 					{
-						label: itemKind === "dir" ? "Default Folder" : "Default File",
+						label: first === "dir" ? "Default Folder" : "Default File",
 						checked: selectedIcon === null,
 						action: () =>
-							onChangeAppearance({
+							onChangeAppearance?.({
 								color: selectedColor,
 								icon: null,
 							}),
@@ -69,7 +84,7 @@ export function fileTreeAppearanceNativeMenu(
 						label: option.label,
 						checked: selectedIcon === option.id,
 						action: () =>
-							onChangeAppearance({
+							onChangeAppearance?.({
 								color: selectedColor,
 								icon: option.id,
 							}),

--- a/src/components/filetree/fileTreeNativeContextMenu.ts
+++ b/src/components/filetree/fileTreeNativeContextMenu.ts
@@ -1,96 +1,10 @@
-import { DATABASE_COLUMN_ICON_OPTIONS } from "../../lib/database/columnIcons";
 import type { NativeContextMenuItem } from "../../lib/nativeContextMenu";
-import type { FileTreeAppearance } from "../../lib/tauri";
-import {
-	EDITOR_TEXT_COLORS,
-	type EditorTextColor,
-	isEditorTextColor,
-} from "../editor/textColors";
-
-function currentColor(
-	appearance?: FileTreeAppearance | null,
-): EditorTextColor | null {
-	return appearance?.color && isEditorTextColor(appearance.color)
-		? appearance.color
-		: null;
-}
 
 export function fileTreeAppearanceNativeMenu(
 	onOpenAppearancePicker: () => void,
-): NativeContextMenuItem;
-export function fileTreeAppearanceNativeMenu(
-	itemKind: "dir" | "file",
-	appearance: FileTreeAppearance | null | undefined,
-	onChangeAppearance: (appearance: FileTreeAppearance) => void,
-): NativeContextMenuItem;
-export function fileTreeAppearanceNativeMenu(
-	first: (() => void) | "dir" | "file",
-	appearance?: FileTreeAppearance | null,
-	onChangeAppearance?: (appearance: FileTreeAppearance) => void,
 ): NativeContextMenuItem {
-	if (typeof first === "function") {
-		return {
-			label: "Icon & Color...",
-			action: first,
-		};
-	}
-
-	const selectedColor = currentColor(appearance);
-	const selectedIcon = appearance?.icon ?? null;
-
 	return {
-		type: "submenu",
-		label: "Icon & Color",
-		items: [
-			{
-				type: "submenu",
-				label: "Color",
-				items: [
-					...EDITOR_TEXT_COLORS.map((color) => ({
-						label: color.label,
-						checked: selectedColor === color.id,
-						action: () =>
-							onChangeAppearance?.({
-								color: color.id,
-								icon: selectedIcon,
-							}),
-					})),
-					{ type: "separator" },
-					{
-						label: "Default Color",
-						checked: selectedColor === null,
-						action: () =>
-							onChangeAppearance?.({
-								color: null,
-								icon: selectedIcon,
-							}),
-					},
-				],
-			},
-			{
-				type: "submenu",
-				label: "Icon",
-				items: [
-					{
-						label: first === "dir" ? "Default Folder" : "Default File",
-						checked: selectedIcon === null,
-						action: () =>
-							onChangeAppearance?.({
-								color: selectedColor,
-								icon: null,
-							}),
-					},
-					...DATABASE_COLUMN_ICON_OPTIONS.map((option) => ({
-						label: option.label,
-						checked: selectedIcon === option.id,
-						action: () =>
-							onChangeAppearance?.({
-								color: selectedColor,
-								icon: option.id,
-							}),
-					})),
-				],
-			},
-		],
+		label: "Icon & Color...",
+		action: onOpenAppearancePicker,
 	};
 }

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -43,10 +43,7 @@ interface FolioNoteListItemProps {
 	) => Promise<boolean> | boolean;
 	onCancelRename: () => void;
 	appearance?: FileTreeAppearance | null;
-	onChangeAppearance: (
-		path: string,
-		appearance: FileTreeAppearance,
-	) => Promise<void> | void;
+	onOpenAppearancePicker: (path: string) => void;
 }
 
 type FolioImageRef =
@@ -327,7 +324,7 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	onCommitRename,
 	onCancelRename,
 	appearance = null,
-	onChangeAppearance,
+	onOpenAppearancePicker,
 }: FolioNoteListItemProps) {
 	const title = note.title.trim() || titleFromPath(note.note_path);
 	const isMarkdown = note.is_markdown;
@@ -400,8 +397,8 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 							},
 						]
 					: []),
-				fileTreeAppearanceNativeMenu("file", appearance, (nextAppearance) =>
-					onChangeAppearance(note.note_path, nextAppearance),
+				fileTreeAppearanceNativeMenu(() =>
+					onOpenAppearancePicker(note.note_path),
 				),
 				{ type: "separator" },
 				{
@@ -413,13 +410,12 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 			});
 		},
 		[
-			appearance,
 			handleRevealInFinder,
 			isPinned,
 			note.note_path,
-			onChangeAppearance,
 			onDelete,
 			onOpen,
+			onOpenAppearancePicker,
 			onOpenInNewTab,
 			onRename,
 			onTogglePinned,

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -15,6 +15,8 @@ import type { AllDocsItem, FileTreeAppearance } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { isDeleteKey } from "../../utils/keyboard";
 import { basename, isMarkdownPath } from "../../utils/path";
+import { AppearancePicker } from "../AppearancePicker";
+import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { FolioNoteListItem } from "./FolioNoteListItem";
 import { FolioScopeHeader } from "./FolioScopeHeader";
 import type { FolioNotesSortMode } from "./folioScopes";
@@ -201,6 +203,9 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		readStoredFolioSortMode,
 	);
 	const [renamingPath, setRenamingPath] = useState<string | null>(null);
+	const [appearancePickerPath, setAppearancePickerPath] = useState<
+		string | null
+	>(null);
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const paneRef = useRef<HTMLElement | null>(null);
 	const pinnedPathSet = useMemo(
@@ -382,6 +387,21 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		},
 		[setItemAppearance],
 	);
+	const pickerAppearance = appearancePickerPath
+		? (itemAppearance[appearancePickerPath] ?? null)
+		: null;
+	const pickerColor =
+		pickerAppearance?.color && isEditorTextColor(pickerAppearance.color)
+			? pickerAppearance.color
+			: null;
+	const pickerIcon = pickerAppearance?.icon ?? null;
+	const updatePickerAppearance = useCallback(
+		(nextAppearance: FileTreeAppearance) => {
+			if (!appearancePickerPath) return;
+			void changeAppearance(appearancePickerPath, nextAppearance);
+		},
+		[appearancePickerPath, changeAppearance],
+	);
 	const openAdjacentNote = useCallback(
 		(direction: 1 | -1) => {
 			if (!visibleNotes.length || selectedIndex < 0) return;
@@ -459,7 +479,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 							onCommitRename={commitRename}
 							onCancelRename={cancelRename}
 							appearance={itemAppearance[note.note_path] ?? null}
-							onChangeAppearance={changeAppearance}
+							onOpenAppearancePicker={setAppearancePickerPath}
 							taskSummary={
 								showTaskProgressIndicator && note.is_markdown
 									? (taskSummariesByPath[note.note_path] ?? null)
@@ -489,7 +509,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 							onCommitRename={commitRename}
 							onCancelRename={cancelRename}
 							appearance={itemAppearance[note.note_path] ?? null}
-							onChangeAppearance={changeAppearance}
+							onOpenAppearancePicker={setAppearancePickerPath}
 							taskSummary={
 								showTaskProgressIndicator && note.is_markdown
 									? (taskSummariesByPath[note.note_path] ?? null)
@@ -538,6 +558,31 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				}
 			}}
 		>
+			<AppearancePicker
+				title="Choose file appearance"
+				open={appearancePickerPath !== null}
+				onOpenChange={(open) => {
+					if (!open) setAppearancePickerPath(null);
+				}}
+				iconValue={pickerIcon}
+				defaultIconName="document"
+				showDefaultIcon
+				onIconChange={(icon) => {
+					updatePickerAppearance({
+						color: pickerColor,
+						icon,
+					});
+				}}
+				showColors
+				colorValue={pickerColor}
+				colorOptions={EDITOR_TEXT_COLORS}
+				onColorChange={(color) => {
+					updatePickerAppearance({
+						color,
+						icon: pickerIcon,
+					});
+				}}
+			/>
 			<FolioScopeHeader
 				searchQuery={searchQuery}
 				sortMode={sortMode}

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -398,9 +398,12 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	const updatePickerAppearance = useCallback(
 		(nextAppearance: FileTreeAppearance) => {
 			if (!appearancePickerPath) return;
-			void changeAppearance(appearancePickerPath, nextAppearance);
+			void changeAppearance(appearancePickerPath, {
+				...(itemAppearance[appearancePickerPath] ?? {}),
+				...nextAppearance,
+			});
 		},
-		[appearancePickerPath, changeAppearance],
+		[appearancePickerPath, changeAppearance, itemAppearance],
 	);
 	const openAdjacentNote = useCallback(
 		(direction: 1 | -1) => {
@@ -569,7 +572,6 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				showDefaultIcon
 				onIconChange={(icon) => {
 					updatePickerAppearance({
-						color: pickerColor,
 						icon,
 					});
 				}}
@@ -579,7 +581,6 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				onColorChange={(color) => {
 					updatePickerAppearance({
 						color,
-						icon: pickerIcon,
 					});
 				}}
 			/>

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -122,10 +122,14 @@ vi.mock("./SettingsScaffold", () => ({
 	}
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
+function makeSettings(
+	colorfulHeadings: boolean,
+	vimKeybindings = false,
+	beautifulTags = false,
+) {
 	return {
 		editor: {
-			beautifulTags: false,
+			beautifulTags,
 			colorfulHeadings,
 			editorWidthMode: "compact" as const,
 			enablePeopleMentionsAsTags: false,
@@ -206,6 +210,50 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setEditorColorfulHeadingsMock).toHaveBeenCalledWith(true);
+	});
+
+	it("shows Beautiful Tags off by default", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Beautiful Tags"]',
+		) as HTMLInputElement | null;
+
+		expect(container.textContent).toContain("Beautiful Tags");
+		expect(toggle?.checked).toBe(false);
+	});
+
+	it("reflects stored Beautiful Tags state", async () => {
+		loadSettingsMock.mockResolvedValue(makeSettings(false, false, true));
+
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Beautiful Tags"]',
+		) as HTMLInputElement | null;
+
+		expect(toggle?.checked).toBe(true);
+	});
+
+	it("saves Beautiful Tags changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Beautiful Tags"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setEditorBeautifulTagsMock).toHaveBeenCalledWith(true);
 	});
 
 	it("saves show frontmatter in editor changes", async () => {

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -10,6 +10,7 @@ const {
 	loadSettingsMock,
 	setAiAssistantModeMock,
 	setDatabaseShowColumnColorMock,
+	setEditorBeautifulTagsMock,
 	setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowFrontmatterInEditorMock,
@@ -23,6 +24,7 @@ const {
 	loadSettingsMock: vi.fn(),
 	setAiAssistantModeMock: vi.fn(() => Promise.resolve()),
 	setDatabaseShowColumnColorMock: vi.fn(() => Promise.resolve()),
+	setEditorBeautifulTagsMock: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadingsMock: vi.fn(() => Promise.resolve()),
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
 	setEditorShowFrontmatterInEditorMock: vi.fn(() => Promise.resolve()),
@@ -45,6 +47,7 @@ vi.mock("../../lib/settings", () => ({
 	loadSettings: loadSettingsMock,
 	setAiAssistantMode: setAiAssistantModeMock,
 	setDatabaseShowColumnColor: setDatabaseShowColumnColorMock,
+	setEditorBeautifulTags: setEditorBeautifulTagsMock,
 	setEditorColorfulHeadings: setEditorColorfulHeadingsMock,
 	setEditorEnablePeopleMentionsAsTags: setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowFrontmatterInEditor: setEditorShowFrontmatterInEditorMock,
@@ -122,6 +125,7 @@ vi.mock("./SettingsScaffold", () => ({
 function makeSettings(colorfulHeadings: boolean, vimKeybindings = false) {
 	return {
 		editor: {
+			beautifulTags: false,
 			colorfulHeadings,
 			editorWidthMode: "compact" as const,
 			enablePeopleMentionsAsTags: false,

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -9,6 +9,7 @@ import {
 	loadSettings,
 	setAiAssistantMode,
 	setDatabaseShowColumnColor,
+	setEditorBeautifulTags,
 	setEditorColorfulHeadings,
 	setEditorEnablePeopleMentionsAsTags,
 	setEditorShowCollapsibleHeadings,
@@ -106,6 +107,7 @@ export function AdvancedSettingsPane() {
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
 	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
+	const [beautifulTags, setBeautifulTags] = useState(false);
 	const [editorWidthMode, setEditorWidthModeState] =
 		useState<EditorWidthMode>("compact");
 	const [enablePeopleMentionsAsTags, setEnablePeopleMentionsAsTags] =
@@ -126,6 +128,7 @@ export function AdvancedSettingsPane() {
 		useState(false);
 	const [isSavingColorfulHeadings, setIsSavingColorfulHeadings] =
 		useState(false);
+	const [isSavingBeautifulTags, setIsSavingBeautifulTags] = useState(false);
 	const [isSavingEditorWidthMode, setIsSavingEditorWidthMode] = useState(false);
 	const [
 		isSavingEnablePeopleMentionsAsTags,
@@ -149,6 +152,7 @@ export function AdvancedSettingsPane() {
 			setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
 			setShowFrontmatterInEditor(settings.editor.showFrontmatterInEditor);
 			setColorfulHeadings(settings.editor.colorfulHeadings);
+			setBeautifulTags(settings.editor.beautifulTags);
 			setEditorWidthModeState(settings.editor.editorWidthMode);
 			setEnablePeopleMentionsAsTags(settings.editor.enablePeopleMentionsAsTags);
 			setVimKeybindings(settings.editor.vimKeybindings === true);
@@ -175,6 +179,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.editor?.colorfulHeadings === "boolean") {
 			setColorfulHeadings(payload.editor.colorfulHeadings);
+		}
+		if (typeof payload.editor?.beautifulTags === "boolean") {
+			setBeautifulTags(payload.editor.beautifulTags);
 		}
 		if (
 			payload.editor?.editorWidthMode === "compact" ||
@@ -321,6 +328,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingColorfulHeadings(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Beautiful Tags"
+						description="Enable the experimental Beautiful Tags presentation for tags."
+					>
+						<SettingsToggle
+							checked={beautifulTags}
+							disabled={isSavingBeautifulTags}
+							ariaLabel="Beautiful Tags"
+							onCheckedChange={(checked) => {
+								const previous = beautifulTags;
+								setError("");
+								setBeautifulTags(checked);
+								setIsSavingBeautifulTags(true);
+								void setEditorBeautifulTags(checked)
+									.catch((cause) => {
+										setBeautifulTags(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingBeautifulTags(false);
 									});
 							}}
 						/>

--- a/src/contexts/FileTreeContext.test.tsx
+++ b/src/contexts/FileTreeContext.test.tsx
@@ -27,6 +27,7 @@ vi.mock("../lib/settings", () => ({
 	loadSettings: () =>
 		Promise.resolve({
 			editor: {
+				beautifulTags: false,
 				enablePeopleMentionsAsTags: false,
 			},
 		}),
@@ -76,6 +77,7 @@ describe("FileTreeProvider pinned files", () => {
 		invokeMock.mockImplementation((command: string) => {
 			if (command === "space_list_dir") return Promise.resolve([]);
 			if (command === "file_tree_appearance_list") return Promise.resolve({});
+			if (command === "tag_appearance_list") return Promise.resolve({});
 			if (command === "tags_list") return Promise.resolve([]);
 			if (command === "people_list") return Promise.resolve([]);
 			if (command === "pinned_files_toggle") {

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -167,16 +167,27 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 	const refreshTagAppearance = useCallback(async () => {
 		const requestId = tagAppearanceRequestIdRef.current + 1;
 		tagAppearanceRequestIdRef.current = requestId;
-		if (!currentSpacePathRef.current) {
+		const originSpace = currentSpacePathRef.current;
+		if (!originSpace) {
 			setTagAppearanceState({});
 			return;
 		}
 		try {
 			const nextAppearance = await invoke("tag_appearance_list");
-			if (requestId !== tagAppearanceRequestIdRef.current) return;
+			if (
+				requestId !== tagAppearanceRequestIdRef.current ||
+				originSpace !== currentSpacePathRef.current
+			) {
+				return;
+			}
 			setTagAppearanceState(nextAppearance);
 		} catch {
-			if (requestId !== tagAppearanceRequestIdRef.current) return;
+			if (
+				requestId !== tagAppearanceRequestIdRef.current ||
+				originSpace !== currentSpacePathRef.current
+			) {
+				return;
+			}
 			setTagAppearanceState({});
 		}
 	}, []);
@@ -238,6 +249,7 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		setTagsError("");
 		if (!spacePath) return;
 
+		const originSpace = spacePath;
 		let cancelled = false;
 		(async () => {
 			try {
@@ -259,8 +271,14 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 				/* ignore appearance load errors */
 			}
 			try {
+				const requestId = tagAppearanceRequestIdRef.current + 1;
+				tagAppearanceRequestIdRef.current = requestId;
 				const appearance = await invoke("tag_appearance_list");
-				if (!cancelled) {
+				if (
+					!cancelled &&
+					requestId === tagAppearanceRequestIdRef.current &&
+					originSpace === currentSpacePathRef.current
+				) {
 					setTagAppearanceState(appearance);
 				}
 			} catch {

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -10,10 +10,12 @@ import {
 } from "react";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { loadSettings } from "../lib/settings";
+import { normalizeTagIconKey } from "../lib/tagIcons";
 import type {
 	FileTreeAppearance,
 	FsEntry,
 	PersonCount,
+	TagAppearance,
 	TagCount,
 } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
@@ -57,8 +59,12 @@ export interface FileTreeContextValue {
 	deleteItemAppearance: (path: string) => Promise<void>;
 	tags: TagCount[];
 	people: PersonCount[];
+	beautifulTags: boolean;
+	tagAppearance: Record<string, TagAppearance>;
 	tagsError: string;
 	refreshTags: () => Promise<void>;
+	refreshTagAppearance: () => Promise<void>;
+	setTagAppearance: (tag: string, icon: string | null) => Promise<void>;
 }
 
 const FileTreeContext = createContext<FileTreeContextValue | null>(null);
@@ -108,9 +114,14 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 	>({});
 	const [tags, setTags] = useState<TagCount[]>([]);
 	const [people, setPeople] = useState<PersonCount[]>([]);
+	const [beautifulTags, setBeautifulTags] = useState(false);
+	const [tagAppearance, setTagAppearanceState] = useState<
+		Record<string, TagAppearance>
+	>({});
 	const [tagsError, setTagsError] = useState("");
 	const peopleMentionsEnabledRef = useRef(false);
 	const tagsRequestIdRef = useRef(0);
+	const tagAppearanceRequestIdRef = useRef(0);
 	const currentSpacePathRef = useRef<string | null>(spacePath);
 	const pinnedFilesRefreshTimerRef = useRef<number | null>(null);
 	currentSpacePathRef.current = spacePath;
@@ -153,6 +164,23 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		}
 	}, []);
 
+	const refreshTagAppearance = useCallback(async () => {
+		const requestId = tagAppearanceRequestIdRef.current + 1;
+		tagAppearanceRequestIdRef.current = requestId;
+		if (!currentSpacePathRef.current) {
+			setTagAppearanceState({});
+			return;
+		}
+		try {
+			const nextAppearance = await invoke("tag_appearance_list");
+			if (requestId !== tagAppearanceRequestIdRef.current) return;
+			setTagAppearanceState(nextAppearance);
+		} catch {
+			if (requestId !== tagAppearanceRequestIdRef.current) return;
+			setTagAppearanceState({});
+		}
+	}, []);
+
 	useEffect(() => {
 		let cancelled = false;
 		void loadSettings()
@@ -160,21 +188,25 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 				if (cancelled) return;
 				peopleMentionsEnabledRef.current =
 					settings.editor.enablePeopleMentionsAsTags;
+				setBeautifulTags(settings.editor.beautifulTags);
 				if (currentSpacePathRef.current) {
 					void refreshTags();
+					void refreshTagAppearance();
 				}
 			})
 			.catch(() => {
 				if (cancelled) return;
 				peopleMentionsEnabledRef.current = false;
+				setBeautifulTags(false);
 				if (currentSpacePathRef.current) {
 					void refreshTags();
+					void refreshTagAppearance();
 				}
 			});
 		return () => {
 			cancelled = true;
 		};
-	}, [refreshTags]);
+	}, [refreshTagAppearance, refreshTags]);
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
@@ -186,6 +218,9 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			if (currentSpacePathRef.current) {
 				void refreshTags();
 			}
+		}
+		if (typeof payload.editor?.beautifulTags === "boolean") {
+			setBeautifulTags(payload.editor.beautifulTags);
 		}
 	});
 
@@ -199,6 +234,7 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		setItemAppearanceState({});
 		setTags([]);
 		setPeople([]);
+		setTagAppearanceState({});
 		setTagsError("");
 		if (!spacePath) return;
 
@@ -221,6 +257,14 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 				}
 			} catch {
 				/* ignore appearance load errors */
+			}
+			try {
+				const appearance = await invoke("tag_appearance_list");
+				if (!cancelled) {
+					setTagAppearanceState(appearance);
+				}
+			} catch {
+				/* ignore tag appearance load errors */
 			}
 			try {
 				const files = await invoke("pinned_files_list");
@@ -386,6 +430,31 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		[spacePath],
 	);
 
+	const setTagAppearance = useCallback<
+		FileTreeContextValue["setTagAppearance"]
+	>(
+		async (tag, icon) => {
+			const currentSpacePath = spacePath;
+			const next = await invoke("tag_appearance_set", {
+				tag,
+				icon,
+			});
+			if (currentSpacePathRef.current !== currentSpacePath) return;
+			setTagAppearanceState((prev) => {
+				const normalizedTag = normalizeTagIconKey(tag) ?? tag;
+				if (!next) {
+					if (!(normalizedTag in prev) && !(tag in prev)) return prev;
+					const nextMap = { ...prev };
+					delete nextMap[normalizedTag];
+					delete nextMap[tag];
+					return nextMap;
+				}
+				return { ...prev, [normalizedTag]: next };
+			});
+		},
+		[spacePath],
+	);
+
 	const updateRootEntries = useCallback<
 		FileTreeContextValue["updateRootEntries"]
 	>((next) => {
@@ -445,8 +514,12 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			deleteItemAppearance,
 			tags,
 			people,
+			beautifulTags,
+			tagAppearance,
 			tagsError,
 			refreshTags,
+			refreshTagAppearance,
+			setTagAppearance,
 		}),
 		[
 			rootEntries,
@@ -470,8 +543,12 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			deleteItemAppearance,
 			tags,
 			people,
+			beautifulTags,
+			tagAppearance,
 			tagsError,
 			refreshTags,
+			refreshTagAppearance,
+			setTagAppearance,
 		],
 	);
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -128,6 +128,7 @@ interface EditorSettings {
 	showCollapsibleHeadings: boolean;
 	showFrontmatterInEditor: boolean;
 	colorfulHeadings: boolean;
+	beautifulTags: boolean;
 	editorWidthMode: EditorWidthMode;
 	attachmentStorageMode: AttachmentStorageMode;
 	attachmentFolder: string | null;
@@ -163,6 +164,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	showCollapsibleHeadings: false,
 	showFrontmatterInEditor: false,
 	colorfulHeadings: false,
+	beautifulTags: false,
 	editorWidthMode: "compact",
 	attachmentStorageMode: "note-folder",
 	attachmentFolder: DEFAULT_ATTACHMENT_FOLDER,
@@ -291,6 +293,7 @@ async function emitSettingsUpdated(payload: {
 		showCollapsibleHeadings?: boolean;
 		showFrontmatterInEditor?: boolean;
 		colorfulHeadings?: boolean;
+		beautifulTags?: boolean;
 		editorWidthMode?: EditorWidthMode;
 		attachmentStorageMode?: AttachmentStorageMode;
 		attachmentFolder?: string | null;
@@ -375,6 +378,7 @@ const KEYS = {
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
+	editorBeautifulTags: "editor.beautifulTags",
 	editorEditorWidthMode: "editor.editorWidthMode",
 	editorAttachmentStorageMode: "editor.attachmentStorageMode",
 	editorAttachmentFolder: "editor.attachmentFolder",
@@ -608,6 +612,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawEditorShowCollapsibleHeadings,
 		rawEditorShowFrontmatterInEditor,
 		rawEditorColorfulHeadings,
+		rawEditorBeautifulTags,
 		rawEditorWidthMode,
 		rawEditorAttachmentStorageMode,
 		rawEditorAttachmentFolder,
@@ -648,6 +653,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.editorShowCollapsibleHeadings),
 		store.get<boolean | null>(KEYS.editorShowFrontmatterInEditor),
 		store.get<boolean | null>(KEYS.editorColorfulHeadings),
+		store.get<boolean | null>(KEYS.editorBeautifulTags),
 		store.get<unknown>(KEYS.editorEditorWidthMode),
 		store.get<unknown>(KEYS.editorAttachmentStorageMode),
 		store.get<string | null>(KEYS.editorAttachmentFolder),
@@ -739,6 +745,10 @@ export async function loadSettings(): Promise<AppSettings> {
 			typeof rawEditorColorfulHeadings === "boolean"
 				? rawEditorColorfulHeadings
 				: DEFAULT_EDITOR_SETTINGS.colorfulHeadings,
+		beautifulTags:
+			typeof rawEditorBeautifulTags === "boolean"
+				? rawEditorBeautifulTags
+				: DEFAULT_EDITOR_SETTINGS.beautifulTags,
 		editorWidthMode: asEditorWidthMode(rawEditorWidthMode),
 		attachmentStorageMode,
 		attachmentFolder,
@@ -1066,6 +1076,15 @@ export async function setEditorColorfulHeadings(
 	await store.save();
 	void emitSettingsUpdated({
 		editor: { colorfulHeadings: enabled },
+	});
+}
+
+export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.editorBeautifulTags, enabled);
+	await store.save();
+	void emitSettingsUpdated({
+		editor: { beautifulTags: enabled },
 	});
 }
 

--- a/src/lib/tagIcons.ts
+++ b/src/lib/tagIcons.ts
@@ -1,0 +1,208 @@
+import {
+	DATABASE_COLUMN_ICON_OPTIONS,
+	type DatabaseColumnIconOption,
+	getDatabaseColumnIconOption,
+} from "./database/columnIcons";
+import type { TagAppearance } from "./tauri";
+
+export type TagIconOption = DatabaseColumnIconOption;
+export type TagIconName = (typeof DATABASE_COLUMN_ICON_OPTIONS)[number]["id"];
+export type TagIconOverrides = Readonly<
+	Record<string, string | null | undefined>
+>;
+
+export const DEFAULT_TAG_ICON_NAME = "tag" satisfies TagIconName;
+export const TAG_ICON_OPTIONS = DATABASE_COLUMN_ICON_OPTIONS;
+
+export const PREDEFINED_TAG_ICON_ALIASES = {
+	ai: "ai",
+	archive: "archive",
+	archived: "archive",
+	art: "brush",
+	article: "document",
+	articles: "document",
+	"artificial-intelligence": "ai",
+	audio: "music",
+	automation: "workflow",
+	blog: "globe",
+	book: "book",
+	bookmark: "bookmark",
+	bookmarks: "bookmark",
+	books: "book",
+	business: "briefcase",
+	calendar: "calendar",
+	camera: "camera",
+	chart: "chart",
+	code: "code",
+	coding: "code",
+	contact: "user",
+	contacts: "user",
+	daily: "calendar",
+	database: "database",
+	dev: "terminal",
+	development: "terminal",
+	done: "check-circle",
+	draft: "document",
+	email: "mail",
+	event: "calendar",
+	events: "calendar",
+	favorite: "star",
+	favorites: "star",
+	finance: "chart",
+	flag: "flag",
+	folder: "folder",
+	goal: "target",
+	goals: "target",
+	home: "home",
+	idea: "idea",
+	ideas: "idea",
+	image: "image",
+	images: "image",
+	inbox: "mail",
+	journal: "note",
+	link: "link",
+	links: "link",
+	location: "location",
+	map: "location",
+	media: "video",
+	meeting: "message",
+	meetings: "message",
+	music: "music",
+	note: "note",
+	notes: "note",
+	photo: "camera",
+	photos: "camera",
+	priority: "priority",
+	project: "folder",
+	projects: "folder",
+	protected: "shield",
+	read: "book-open",
+	reading: "book-open",
+	reference: "bookmark",
+	references: "bookmark",
+	reminder: "reminder",
+	reminders: "reminder",
+	research: "idea",
+	security: "shield",
+	settings: "settings",
+	source: "source",
+	sparkle: "sparkles",
+	sparkles: "sparkles",
+	star: "star",
+	status: "status",
+	study: "book-open",
+	task: "task",
+	tasks: "task",
+	todo: "task",
+	travel: "route",
+	video: "video",
+	videos: "video",
+	web: "globe",
+	work: "briefcase",
+	workflow: "workflow",
+} as const satisfies Readonly<Record<string, TagIconName>>;
+
+const PREDEFINED_TAG_ICON_ALIAS_LOOKUP: Readonly<Record<string, TagIconName>> =
+	PREDEFINED_TAG_ICON_ALIASES;
+
+export function normalizeTagIconKey(tag: string): string | null {
+	const normalized = tag
+		.trim()
+		.replace(/^#+/, "")
+		.toLowerCase()
+		.replace(/\s+/g, "-")
+		.replace(/[^a-z0-9_/-]/g, "");
+
+	if (
+		!normalized ||
+		normalized.startsWith("/") ||
+		normalized.endsWith("/") ||
+		normalized.includes("//")
+	) {
+		return null;
+	}
+
+	return normalized.split("/").every(Boolean) ? normalized : null;
+}
+
+export function getTagIconOption(
+	iconName: string | null | undefined,
+): TagIconOption | null {
+	return getDatabaseColumnIconOption(iconName);
+}
+
+export function isTagIconName(
+	iconName: string | null | undefined,
+): iconName is TagIconName {
+	return Boolean(getTagIconOption(iconName));
+}
+
+export function resolveTagIconName(
+	tag: string,
+	overrides: TagIconOverrides | null | undefined,
+	beautifulTagsEnabled: boolean,
+): string {
+	const normalizedTag = normalizeTagIconKey(tag);
+	const overrideIconName = resolveOverrideIconName(
+		tag,
+		normalizedTag,
+		overrides,
+	);
+	if (overrideIconName) return overrideIconName;
+
+	if (beautifulTagsEnabled && normalizedTag) {
+		const aliasIconName = resolveAliasIconName(normalizedTag);
+		if (aliasIconName) return aliasIconName;
+	}
+
+	return DEFAULT_TAG_ICON_NAME;
+}
+
+export function tagIconOverridesFromAppearance(
+	appearance: Readonly<Record<string, TagAppearance>>,
+): TagIconOverrides {
+	return Object.fromEntries(
+		Object.entries(appearance).map(([tag, item]) => [tag, item.icon ?? null]),
+	);
+}
+
+function resolveOverrideIconName(
+	tag: string,
+	normalizedTag: string | null,
+	overrides: TagIconOverrides | null | undefined,
+): string | null {
+	if (!overrides) return null;
+
+	for (const key of overrideKeys(tag, normalizedTag)) {
+		if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+
+		const iconName = overrides[key];
+		if (typeof iconName !== "string") return DEFAULT_TAG_ICON_NAME;
+
+		const trimmedIconName = iconName.trim();
+		return trimmedIconName || DEFAULT_TAG_ICON_NAME;
+	}
+
+	return null;
+}
+
+function overrideKeys(tag: string, normalizedTag: string | null): string[] {
+	const keys = [tag, tag.trim()];
+	if (normalizedTag) {
+		keys.push(normalizedTag, `#${normalizedTag}`);
+	}
+	return Array.from(new Set(keys.filter(Boolean)));
+}
+
+function resolveAliasIconName(normalizedTag: string): TagIconName | null {
+	const exactIconName = PREDEFINED_TAG_ICON_ALIAS_LOOKUP[normalizedTag];
+	if (exactIconName) return exactIconName;
+
+	const segments = normalizedTag.split("/");
+	const rootIconName = PREDEFINED_TAG_ICON_ALIAS_LOOKUP[segments[0] ?? ""];
+	if (rootIconName) return rootIconName;
+
+	const leafIconName =
+		PREDEFINED_TAG_ICON_ALIAS_LOOKUP[segments[segments.length - 1] ?? ""];
+	return leafIconName ?? null;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -37,6 +37,10 @@ export interface FileTreeAppearance {
 	icon?: string | null;
 }
 
+export interface TagAppearance {
+	icon?: string | null;
+}
+
 type PinnedFiles = string[];
 
 export interface TextFileDoc {
@@ -766,6 +770,11 @@ interface TauriCommands {
 		void
 	>;
 	file_tree_appearance_delete_path: CommandDef<{ path: string }, void>;
+	tag_appearance_list: CommandDef<void, Record<string, TagAppearance>>;
+	tag_appearance_set: CommandDef<
+		{ tag: string; icon?: string | null },
+		TagAppearance | null
+	>;
 	pinned_files_list: CommandDef<void, PinnedFiles>;
 	pinned_files_toggle: CommandDef<{ path: string }, PinnedFiles>;
 	pinned_files_rename_path: CommandDef<

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -99,6 +99,7 @@ type TauriEventMap = {
 			showCollapsibleHeadings?: boolean;
 			showFrontmatterInEditor?: boolean;
 			colorfulHeadings?: boolean;
+			beautifulTags?: boolean;
 			editorWidthMode?: EditorWidthMode;
 			attachmentStorageMode?: AttachmentStorageMode;
 			attachmentFolder?: string | null;

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -84,13 +84,37 @@ button.tagsHeaderTitle {
 	width: 100%;
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: flex-start;
 	gap: var(--space-3);
 	padding: 1px 8px;
 	min-height: 28px;
 	border-radius: 8px;
 	color: var(--text-primary);
 	font-size: var(--text-sm);
+}
+
+.tagsMainButton {
+	appearance: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 6px;
+	min-width: 0;
+	flex: 1 1 0%;
+	overflow: hidden;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.tagsMainButton:hover,
+.tagsMainButton:active {
+	background: transparent;
+	color: inherit;
 }
 
 .tagsButton[data-explicit="false"] {
@@ -116,6 +140,98 @@ button.tagsHeaderTitle {
 	height: 12px;
 }
 
+.tagsIconPicker {
+	width: 18px;
+	height: 18px;
+	margin-left: -3px;
+	color: currentcolor;
+}
+
+.tagsIconPicker:hover,
+.tagsIconPicker:active,
+.tagsIconPicker:focus-visible {
+	background: transparent;
+	color: currentcolor;
+	box-shadow: none;
+}
+
+.appearancePickerDialog {
+	width: min(420px, calc(100vw - 48px));
+	max-height: min(70vh, 560px);
+}
+
+.appearancePickerScroll {
+	height: min(46vh, 320px);
+	padding: 14px;
+}
+
+.appearancePickerGrid {
+	display: grid;
+	grid-template-columns: repeat(6, minmax(0, 1fr));
+	gap: 6px;
+}
+
+.appearancePickerOption {
+	width: 100%;
+	aspect-ratio: 1;
+}
+
+.appearancePickerEmpty {
+	grid-column: 1 / -1;
+	padding: 24px 8px;
+	color: var(--text-tertiary);
+	font-size: var(--text-sm);
+	text-align: center;
+}
+
+.appearancePickerColors {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	padding: 8px 0 2px;
+}
+
+.appearancePickerColor {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	min-height: 26px;
+	padding: 0 9px;
+	border: 1px solid var(--border-light);
+	border-radius: var(--radius-md);
+	background: var(--bg-primary);
+	color: var(--text-secondary);
+	font-size: var(--text-xs);
+}
+
+.appearancePickerColor[data-active="true"] {
+	border-color: var(--border-focus);
+	color: var(--text-primary);
+	background: var(--bg-hover);
+}
+
+.appearancePickerSwatch,
+.appearancePickerDefaultColor {
+	width: 10px;
+	height: 10px;
+	border-radius: 999px;
+	flex: 0 0 auto;
+}
+
+.appearancePickerSwatch {
+	background: currentcolor;
+}
+
+.appearancePickerDefaultColor {
+	border: 1px solid var(--border-default);
+	background: linear-gradient(
+		135deg,
+		transparent 0 45%,
+		var(--text-tertiary) 45% 55%,
+		transparent 55% 100%
+	);
+}
+
 .tagsName {
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -124,6 +240,7 @@ button.tagsHeaderTitle {
 }
 
 .tagsCount {
+	margin-left: auto;
 	color: var(--text-tertiary);
 	font-size: var(--text-xs);
 	flex-shrink: 0;
@@ -136,12 +253,6 @@ button.tagsHeaderTitle {
 	color: var(--text-tertiary);
 	cursor: pointer;
 	background: transparent;
-}
-
-.tagsToggle:hover,
-.tagsToggle:active {
-	background: transparent;
-	color: var(--text-tertiary);
 }
 
 .tagsEmpty {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -390,6 +390,10 @@
 	display: none;
 }
 
+.databaseBoardTag[data-beautiful-tags="true"] .databaseTagPillIcon {
+	display: block;
+}
+
 .databaseBoardCardFooter {
 	display: flex;
 	align-items: center;

--- a/src/styles/app/42-calendar.css
+++ b/src/styles/app/42-calendar.css
@@ -385,6 +385,7 @@
 .calendarNoteTag {
 	display: flex;
 	align-items: center;
+	gap: 4px;
 	max-width: 120px;
 	min-height: 20px;
 	overflow: hidden;
@@ -401,6 +402,11 @@
 	line-height: 1.2;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.calendarNoteTagIcon {
+	flex: 0 0 auto;
+	color: currentcolor;
 }
 
 .calendarNoteTag.is-muted {


### PR DESCRIPTION
## Summary

This PR adds the opt-in Beautiful Tags experience so tags can render with clearer, semantically useful icons instead of every tag using the same generic mark. The motivation is to make dense tag surfaces easier to scan without changing the default app behavior for existing users: the new setting is off by default, custom overrides are persisted per space, and the old plain tag treatment remains the fallback.

The implementation introduces a small persisted tag appearance store under `.glyph/tag_appearance.json`, exposes typed Tauri commands for reading and updating per-tag icons, and wires the data through the existing file tree context. On the frontend, tags now resolve icons from explicit overrides first, then from predefined smart aliases when Beautiful Tags is enabled, and finally from the default tag icon.

What changed in detail:

- Added the `beautifulTags` advanced editor setting, including settings persistence, settings update events, and an Advanced Settings toggle.
- Added Rust-side `tag_appearance` storage with versioned JSON, tag normalization, atomic writes, and command registration.
- Added frontend Tauri types and invoke coverage for `tag_appearance_list` and `tag_appearance_set`.
- Added shared tag icon resolution in `src/lib/tagIcons.ts`, including normalized tag keys, explicit overrides, predefined aliases, nested tag fallback behavior, and a default icon fallback.
- Added reusable appearance picking UI via `AppearancePicker` and `TagIconPicker`, sharing the existing database column icon vocabulary instead of introducing a parallel icon system.
- Updated tag displays in the sidebar, tag pane, all docs, file tree, database cells/boards, and calendar surfaces so the same tag appearance rules are applied consistently.
- Updated the file tree native context menu path so folder/file appearance customization uses the shared picker flow.
- Updated CSS for tag chips, icon picker layout, database board tags, and calendar tag rendering.
- Updated focused tests around advanced settings defaults/events and file tree context behavior.

## Related Issues

N/A

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

Manual macOS UI testing was not run as part of this yeet pass.

## Screenshots or Recordings

Not included. This PR affects visible tag and appearance-picker UI, so reviewers should validate the tag pane/sidebar/database/calendar surfaces locally when reviewing the branch.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable tag icons and colors via an Appearance Picker dialog; per-space tag appearance is persisted and editable from lists and context menus.
  * “Beautiful Tags” toggle in Advanced Settings to enable/disable rich tag icons.

* **UI Changes**
  * Custom tag icons now appear across sidebar, calendar, database, file tree, and folio lists.
  * Appearance picker integrated into file/tree and note context menus; error toasts shown on save failures.

* **Tests**
  * Added tests for Beautiful Tags setting and tag appearance initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->