### PR TITLE
feat: searchable settings, architecture docs, and AGENTS.md updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ cd src-tauri && cargo clippy   # Lint Rust
 
 **Pre-push:** `pnpm check && pnpm build && cd src-tauri && cargo check`
 
+**Never run a dev server (Vite, `pnpm dev`, `pnpm tauri dev`, or otherwise) — the user handles dev.**
+
 ## Architecture
 
 **Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: SQLite + filesystem in `.glyph/` folder.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,6 @@
 ## Commands
 
 ```bash
-pnpm dev            # Vite dev server (frontend only)
-pnpm tauri dev      # Full Tauri app in dev mode
 pnpm build          # TypeScript check + Vite build
 pnpm check          # Biome lint + format check
 pnpm format         # Auto-format with Biome
@@ -13,6 +11,13 @@ pnpm test -- src/lib/diff.test.ts          # Single test file
 pnpm test -- -t "test name"               # Single test by name
 cd src-tauri && cargo check    # Typecheck Rust backend
 cd src-tauri && cargo clippy   # Lint Rust
+```
+
+**Reference only — do not run dev servers:**
+
+```bash
+pnpm dev            # Vite dev server (frontend only)
+pnpm tauri dev      # Full Tauri app in dev mode
 ```
 
 **Pre-push:** `pnpm check && pnpm build && cd src-tauri && cargo check`

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -1,0 +1,189 @@
+# System Overview
+
+Glyph is an offline-first desktop note app. The app stores the user's notes as files in a chosen folder, keeps derived metadata in `.glyph/`, and uses Tauri commands to connect a React interface to a Rust backend.
+
+Use this document first. It gives you the map for the other architecture manuals and names the files that own the main behavior.
+
+## Architecture Shape
+
+Glyph has four main runtime boundaries:
+
+1. React frontend in `src/`
+2. Tauri command contract in `src/lib/tauri.ts`
+3. Rust backend in `src-tauri/src/`
+4. Space folder on disk, including `.md` files and `.glyph/` derived data
+
+The frontend never reads the workspace filesystem directly for core app data. It calls the typed `invoke()` helper in `src/lib/tauri.ts`. Rust receives those commands, checks the active space, validates relative paths, performs filesystem or SQLite work, and emits events back to the UI.
+
+```text
+User
+  |
+  v
+React shell, editor, AI panel, database views
+  |
+  | invoke("command", payload)
+  v
+src/lib/tauri.ts typed command map
+  |
+  v
+Tauri command handlers in src-tauri/src/lib.rs
+  |
+  +--> space files: markdown, attachments, folders
+  +--> .glyph/glyph.sqlite derived index
+  +--> .glyph/databases.json workspace database definitions
+  +--> app config: settings, AI profiles, license, update state
+```
+
+## Manual Set
+
+Read the docs in this order when you are onboarding or changing a cross-cutting feature:
+
+1. `01-system-overview.md`: the boundary map and change rules.
+2. `02-spaces-storage-filesystem.md`: spaces, `.glyph/`, path validation, file events.
+3. `03-frontend-shell-state.md`: providers, shell state, tabs, command routing, prefetch.
+4. `04-ipc-and-native-runtime.md`: typed IPC, command registration, menus, windows.
+5. `05-editor-markdown-autosave.md`: TipTap, Markdown serialization, autosave, conflicts.
+6. `06-index-search-graph-tasks.md`: SQLite index, FTS, tags, links, graph, tasks.
+7. `07-databases-frontmatter.md`: workspace databases, table/board views, frontmatter writes.
+8. `08-ai-runtime-tools-history.md`: AI providers, context building, tool access, history.
+9. `09-settings-menus-git-sync-native-windows.md`: settings, shortcuts, Git sync, native windows.
+10. `10-security-and-operational-invariants.md`: invariants that keep data and secrets safe.
+
+The set uses two patterns from external architecture documentation practice:
+
+- Keep architecture docs next to the code so engineers can update docs in the same change as code. ADR guidance recommends lightweight Markdown records in source control for this reason. See <https://docs.cloud.google.com/architecture/architecture-decision-records>.
+- Prefer useful levels of abstraction. The C4 model names context, container, component, and code views. These docs use context and container views where they help, then jump to concrete file ownership. See <https://c4model.com/diagrams>.
+- Separate explanation from procedural checklists. Diataxis names explanation and reference as distinct documentation needs; these manuals combine both but keep "Change Checklist" and "Debugging Map" sections easy to scan. See <https://diataxis.fr/>.
+
+## Repository Containers
+
+### React App
+
+The React app lives under `src/`. `src/App.tsx` wraps `<AppShell />` in `AppProviders` and `LicenseGate`. `src/contexts/index.tsx` composes the app providers in this order:
+
+1. TanStack Query client
+2. `SpaceProvider`
+3. `FileTreeProvider`
+4. `UIProvider`
+5. `EditorProvider`
+
+That order matters. File tree state depends on the active space. UI state depends on space changes. Editor state exposes save behavior to shell shortcuts and menus.
+
+### Tauri IPC Boundary
+
+`src/lib/tauri.ts` defines the TypeScript command map and exports a typed `invoke()` wrapper. The frontend should use this wrapper instead of `@tauri-apps/api/core` directly. The wrapper gives command names a typed payload and result.
+
+Rust registers the matching commands in `src-tauri/src/lib.rs` inside `tauri::generate_handler!`. Adding a command requires changes on both sides:
+
+1. Implement or expose the Rust command.
+2. Register it in `src-tauri/src/lib.rs`.
+3. Add the command signature to `TauriCommands` in `src/lib/tauri.ts`.
+4. Call it through `invoke()` from React.
+
+### Rust Backend
+
+The Rust backend owns durable operations and native integration:
+
+- `space/`: active space lifecycle and filesystem watcher
+- `space_fs/`: list, read, write, rename, delete, preview, link resolution
+- `index/`: derived SQLite index for notes, tags, links, tasks, search, calendar, graph
+- `databases/`: workspace database definitions and frontmatter-backed row edits
+- `ai_rig/`, `ai_codex/`, `ai_amp/`, `ai_claude_code/`, `ai_opencode/`, `ai_pi/`: AI runtimes
+- `git_sync/`: Git sync configuration, status, background runs
+- `license/`: trial/license bootstrap and Gumroad verification
+- `paths.rs`, `io_atomic.rs`, `net.rs`: cross-cutting safety helpers
+
+### Disk Model
+
+The selected space folder contains user-owned content. Markdown notes are first-class files. Attachments and other files can live beside notes.
+
+Glyph stores app metadata under `.glyph/` in the space:
+
+- `.glyph/glyph.sqlite`: derived SQLite index
+- `.glyph/databases.json`: workspace database definitions and status colors
+- `.glyph/cache/ai/`: per-run AI audit JSON
+- `.glyph/Glyph/ai_history/`: AI chat history records
+- `.glyph/Glyph/ai_secrets.json`: per-space AI API keys
+- `.glyph/cache/`: cache material
+
+App-level preferences that do not belong to a single space live in Tauri app config through plugins or Rust app config paths.
+
+## Primary Data Flows
+
+### Open a Space
+
+1. React calls `space_open` or `space_create` from `SpaceContext`.
+2. Rust canonicalizes the folder and creates or opens Glyph metadata.
+3. Rust stores the active root in `SpaceState`.
+4. Rust resets the index schema cache.
+5. Rust installs a recursive notes watcher.
+6. React stores the selected path in settings and clears stale caches.
+7. `FileTreeProvider` lists the root and starts `index_rebuild`.
+
+See `02-spaces-storage-filesystem.md` for the details.
+
+### Open and Save a Note
+
+1. The tab manager opens a markdown file target.
+2. `MarkdownEditorPane` reads the note through `space_read_text`.
+3. `NoteInlineEditor` owns the TipTap editor instance.
+4. User edits update Markdown text in React state.
+5. Autosave calls `space_write_text` with the last known `mtime_ms`.
+6. Rust validates the path, checks conflicts, writes atomically, indexes the note, and emits `notes:external_changed`.
+
+See `05-editor-markdown-autosave.md`.
+
+### Query Notes
+
+1. The UI calls search, all-docs, calendar, tags, graph, database, or task commands.
+2. Rust opens `.glyph/glyph.sqlite`.
+3. Rust queries derived rows generated from Markdown content.
+4. If the result needs note content, Rust reads the backing note file after validating the path.
+
+See `06-index-search-graph-tasks.md` and `07-databases-frontmatter.md`.
+
+### AI Chat
+
+1. The AI panel builds user messages and optional context.
+2. `useRigChat` starts `ai_chat_start`.
+3. Rust chooses a native provider runtime or Rig runtime based on the selected profile.
+4. Rust emits `ai:chunk`, `ai:tool`, `ai:status`, `ai:done`, and `ai:error`.
+5. React streams the assistant response and tool timeline.
+6. Rust writes per-run audit JSON under `.glyph/cache/ai/` and chat history under `.glyph/Glyph/ai_history/`.
+
+See `08-ai-runtime-tools-history.md`.
+
+## Change Rules
+
+Use these rules when changing the architecture:
+
+- Keep the active space as the root of user data. Do not add a second source of truth for notes.
+- Treat `.glyph/glyph.sqlite` as derived. Rebuild it when the parser or schema behavior changes.
+- Route durable filesystem writes through Rust. The frontend may use Tauri plugins for dialogs and opening external files, but note content should go through `space_fs`.
+- Use `paths::join_under()` and hidden-path checks for any space-relative path.
+- Use `io_atomic::write_atomic()` for durable writes unless a create-new operation needs `OpenOptions::create_new`.
+- Update both `src/lib/tauri.ts` and `src-tauri/src/lib.rs` for new commands.
+- Emit events when the UI needs to refresh derived state after backend work.
+- Keep AI tools scoped to the active space and block hidden paths.
+
+## Code Reading Checklist
+
+Start with these files when you need current behavior:
+
+- `src/App.tsx`
+- `src/contexts/index.tsx`
+- `src/components/app/AppShell.tsx`
+- `src/lib/tauri.ts`
+- `src-tauri/src/lib.rs`
+- `src-tauri/src/space/commands.rs`
+- `src-tauri/src/space/state.rs`
+- `src-tauri/src/space/watcher.rs`
+- `src-tauri/src/space_fs/read_write/text.rs`
+- `src-tauri/src/index/schema.rs`
+- `src-tauri/src/index/indexer.rs`
+- `src-tauri/src/databases/commands.rs`
+- `src-tauri/src/ai_rig/commands.rs`
+
+## When This Doc Is Wrong
+
+Treat the code as the source of truth. Update this document when you change a boundary, add a durable store, change command registration, or move ownership between React and Rust.

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -1,0 +1,277 @@
+# Spaces, Storage, and Filesystem Flow
+
+Glyph treats a user-selected folder as a space. A space contains the user's notes and attachments, plus a `.glyph/` directory for app metadata. The Rust backend owns space lifecycle, file safety, writes, indexing side effects, and filesystem change events.
+
+This doc explains how a space opens, how files move through the system, and what code you must touch when changing storage behavior.
+
+## Owned Files
+
+The active space root contains user content:
+
+```text
+My Space/
+  Notes/
+    Plan.md
+  assets/
+    pasted-image.png
+  .glyph/
+    glyph.sqlite
+    databases.json
+    cache/
+    Glyph/
+      ai_history/
+      ai_secrets.json
+```
+
+Code ownership:
+
+- `src-tauri/src/space/commands.rs`: create, open, close, onboarding note command
+- `src-tauri/src/space/helpers.rs`: create/open implementation and onboarding helpers
+- `src-tauri/src/space/state.rs`: active root, watcher handle, local-change tracking, store mutexes
+- `src-tauri/src/space/watcher.rs`: recursive filesystem watcher and index refresh
+- `src-tauri/src/glyph_paths.rs`: `.glyph/` paths
+- `src-tauri/src/space_fs/`: file tree, read/write, preview, rename, delete, link resolution
+- `src-tauri/src/paths.rs`: traversal-safe joining
+- `src-tauri/src/io_atomic.rs`: crash-safer writes and copies
+- `src/contexts/SpaceContext.tsx`: frontend space state and recent-space handling
+- `src/contexts/FileTreeContext.tsx`: frontend tree state tied to a space
+- `src/hooks/useFileTree.ts`: frontend filesystem operations and tree loading
+- `src/hooks/useFileTreeCRUD.ts`: create, rename, move, delete UI actions
+
+## Space State
+
+Rust stores active space state in `SpaceState`:
+
+```rust
+pub struct SpaceState {
+    pub(crate) current: Mutex<Option<PathBuf>>,
+    pub(crate) notes_watcher: Mutex<Option<notify::RecommendedWatcher>>,
+    recent_local_changes: RecentLocalChanges,
+    db_store_mutex: Arc<Mutex<()>>,
+    file_tree_appearance_mutex: Arc<Mutex<()>>,
+    pinned_files_mutex: Arc<Mutex<()>>,
+}
+```
+
+The state has three jobs:
+
+1. Hold the active root path.
+2. Hold the watcher so it stays alive for the current space.
+3. Share mutexes for JSON stores that live under `.glyph/`.
+
+`current_root()` returns an error when no space is open. Most commands call it first, so the backend enforces "no active space, no workspace operation."
+
+## Opening a Space
+
+Frontend flow in `SpaceContext`:
+
+1. `loadSettings()` reads the last space path.
+2. If a path exists, React calls `invoke("space_open", { path })`.
+3. User actions call `space_open` or `space_create` from `applySpaceSelection()`.
+4. On successful open, React stores the root in settings and updates recent spaces.
+5. On switching spaces, React closes the previous space, clears AI/editor prefetch caches, and clears current space path.
+
+Rust flow in `space_open` and `space_create`:
+
+1. Build a `PathBuf` from the user-selected path.
+2. Canonicalize the directory through helper code.
+3. Create or open Glyph metadata.
+4. Reset the index schema cache with `index::db::reset_schema_cache()`.
+5. Store the canonical root in `SpaceState.current`.
+6. Install the notes watcher with `set_notes_watcher()`.
+7. Enable the native Close Space menu item.
+
+`space_close` clears `current`, drops the watcher, resets the schema cache, and disables Close Space.
+
+## Path Safety
+
+All space-relative filesystem code should join paths with `paths::join_under(root, rel)`.
+
+`join_under()` rejects:
+
+- absolute paths
+- `..`
+- platform root or prefix components
+
+Space filesystem commands also call `deny_hidden_rel_path()` from `space_fs/helpers.rs`. It rejects any path component that starts with `.`. That blocks access to `.glyph/` through normal workspace file APIs.
+
+Use both checks for user-controlled space-relative paths:
+
+```rust
+let rel = PathBuf::from(&path);
+deny_hidden_rel_path(&rel)?;
+let abs = paths::join_under(&root, &rel)?;
+```
+
+Do not bypass these helpers for convenience. A command that reads or writes a user-provided path without these checks can expose `.glyph/`, app metadata, or files outside the space.
+
+## File Listing
+
+`src-tauri/src/space_fs/list.rs` owns directory listing:
+
+- `space_list_dir`: immediate children for the file tree
+- `space_list_markdown_files`: markdown list for pickers and search surfaces
+- `space_list_non_markdown_files`: attachment and non-markdown list
+
+The list code hides names that `should_hide()` marks hidden, validates the starting directory, and sorts directories before files for `space_list_dir`.
+
+Frontend loading uses `useFileTree()`:
+
+- `loadDir()` calls `space_list_dir`.
+- `loadedDirsRef` avoids duplicate loads.
+- `loadRequestVersionRef` drops stale responses.
+- `expandedDirs` controls which children stay hydrated.
+- `expandAllDirs()` walks directories breadth-first from the root.
+
+## Reading Text
+
+`space_read_text`:
+
+1. Validates the relative path.
+2. Reads bytes from disk.
+3. Requires valid UTF-8.
+4. Returns text, SHA-256 etag, and `mtime_ms`.
+
+`space_read_texts_batch` repeats the same validation per path and returns per-file errors instead of failing the whole batch. AI context and preview features use batch-style behavior when partial results matter.
+
+`space_read_text_preview` and `space_read_binary_preview` live in `space_fs/read_write/preview.rs`. They limit read size for preview panes and file pickers.
+
+## Writing Text
+
+`space_write_text` handles note and text writes:
+
+1. Validates the relative path.
+2. Checks `base_mtime_ms` when the caller supplies it.
+3. Creates parent folders.
+4. Marks markdown writes as recent local changes.
+5. Writes bytes through `io_atomic::write_atomic()`.
+6. Reindexes markdown content with `index::index_note()`.
+7. Emits `notes:external_changed` for markdown files because the watcher suppresses local writes.
+
+The `base_mtime_ms` check protects an open editor from silently overwriting a file changed outside the app. `MarkdownEditorPane` handles the conflict path by reading the latest file and retrying once with the new mtime.
+
+`space_open_or_create_text` uses `OpenOptions::create_new` because it must not overwrite an existing file.
+
+## Atomic Writes
+
+`io_atomic::write_atomic()` writes to a hidden temporary file in the destination folder, syncs the file, renames it into place, and syncs the parent directory. This pattern protects against partial files after a crash.
+
+Use `io_atomic::copy_atomic()` when duplicating a file. Use `OpenOptions::create_new` only when the operation must reserve a new path without overwriting.
+
+## Watcher and Event Flow
+
+`set_notes_watcher()` installs a recursive watcher with `notify`.
+
+The watcher emits two event types:
+
+- `space:fs_changed`: any visible create, modify, or remove event
+- `notes:external_changed`: markdown events that should refresh note-backed UI
+
+The watcher also updates the SQLite index for markdown files. It debounces index work for 100ms and collapses repeated events by relative path.
+
+Recent local changes prevent a loop:
+
+1. Local markdown writes call `mark_recent_local_change()`.
+2. The watcher sees the filesystem event.
+3. `has_recent_local_change()` returns true for about two seconds.
+4. The watcher skips the external note event and index work.
+5. The writer emits the needed `notes:external_changed` event after indexing.
+
+Frontend consumers:
+
+- `FileTreeContext` refreshes pinned files after remove events.
+- `AppShell` queues changed paths, reloads affected file tree directories after 150ms, and invalidates prefetch caches.
+- `MarkdownEditorPane` reloads the active note after `notes:external_changed` when the editor is clean.
+
+## Rename, Duplicate, Delete
+
+`space_fs/read_write/paths.rs` owns path mutations.
+
+### Duplicate
+
+`space_duplicate_path`:
+
+- rejects directories
+- reserves the duplicate with a hidden lock file
+- uses case-insensitive sibling names to choose `Copy`, `Copy 2`, and so on
+- copies with `copy_atomic()`
+- indexes the duplicate if it is markdown
+- emits `notes:external_changed`
+
+### Rename
+
+`space_rename_path`:
+
+- validates source and destination
+- rejects existing destinations
+- plans link rewrites for markdown notes, supported attachments, and directories
+- renames the path
+- reindexes moved markdown notes
+- rewrites links in affected notes
+- reindexes notes whose links changed
+
+Frontend code must also update open tabs, pinned files, and appearance maps. `useTabManager()` owns tab retargeting. `FileTreeContext` owns pinned and appearance retargeting.
+
+### Delete
+
+`space_delete_path`:
+
+- validates the path
+- removes markdown rows from the index before deleting
+- requires `recursive` for directories
+- moves the path to trash through `trash.rs`
+
+Delete events close matching tabs through `dispatchPathRemoved()` and `closeTabsForPathRemoval()`.
+
+## Link Resolution
+
+`space_fs/link_ops.rs` resolves:
+
+- wiki links
+- image wiki links
+- markdown links relative to a source path
+- link suggestions for autocomplete
+
+The editor and preview panes dispatch link click events. `AppShell` listens and either opens a workspace file, opens a search palette, or opens an external URL.
+
+## Storage Stores Under `.glyph/`
+
+`glyph_paths.rs` defines app-controlled paths:
+
+- `glyph_dir()`: `.glyph`
+- `glyph_db_path()`: `.glyph/glyph.sqlite`
+- `glyph_cache_dir()`: `.glyph/cache`
+- `glyph_app_dir()`: `.glyph/Glyph`
+- `ai_history_dir()`: `.glyph/Glyph/ai_history`
+
+JSON stores under `.glyph/` include:
+
+- `databases.json` from `databases/store.rs`
+- `ai_secrets.json` from `ai_rig/local_secrets.rs`
+- Git sync config from `git_sync/store.rs`
+- file tree appearance from `file_tree_appearance/store.rs`
+- tag appearance from `tag_appearance/store.rs`
+- pinned files from `pinned_files/store.rs`
+
+Each store uses a mutex from `SpaceState` or a module-specific guard where concurrent writes could collide. Keep that pattern when adding a new `.glyph/` JSON store.
+
+## Change Checklist
+
+When you change filesystem behavior:
+
+1. Identify whether the data belongs to user content, derived `.glyph/` state, or app config.
+2. Validate all user-provided paths with `deny_hidden_rel_path()` and `join_under()`.
+3. Use `write_atomic()` for overwrites.
+4. Mark local markdown changes before writes that the watcher will see.
+5. Reindex markdown changes before emitting UI refresh events.
+6. Update pinned files, appearance paths, and tabs for path moves.
+7. Add or adjust events when the frontend needs to refresh cached state.
+8. Keep `.glyph/` inaccessible through normal space file commands.
+
+## Failure Modes
+
+- If the UI shows stale file tree entries, inspect `space:fs_changed` handling in `AppShell`.
+- If an editor overwrites external changes, inspect `base_mtime_ms` in `space_write_text` and `persistDoc()`.
+- If the index misses a note, inspect `mark_recent_local_change()` timing and explicit `index_note()` calls.
+- If JSON metadata corrupts after a crash, inspect whether the store writes through `io_atomic::write_atomic()`.
+- If a path bug can reach `.glyph/`, treat it as a security bug.

--- a/docs/architecture/03-frontend-shell-state.md
+++ b/docs/architecture/03-frontend-shell-state.md
@@ -1,0 +1,315 @@
+# Frontend Shell and State
+
+The frontend shell coordinates spaces, file tree state, tabs, settings mode, command routing, AI panel visibility, shortcuts, and prefetch. React owns interaction state. Rust owns durable workspace operations.
+
+This document explains the provider stack and the shell files you should read before changing navigation or global UI behavior.
+
+## Entry Point
+
+`src/App.tsx` has the top-level composition:
+
+```tsx
+<LazyMotion features={domAnimation}>
+  <AppProviders>
+    <LicenseGate>
+      <AppShell />
+    </LicenseGate>
+  </AppProviders>
+</LazyMotion>
+```
+
+`LicenseGate` protects the app surface. `AppShell` still expects all providers to exist under it.
+
+## Provider Stack
+
+`src/contexts/index.tsx` composes providers in this order:
+
+```text
+QueryClientProvider
+  SpaceProvider
+    FileTreeProvider
+      UIProvider
+        EditorProvider
+          AppShell
+```
+
+The order encodes dependencies:
+
+- `SpaceProvider` has no workspace state dependency.
+- `FileTreeProvider` depends on `spacePath`.
+- `UIProvider` reacts to space changes and settings.
+- `EditorProvider` exposes save state to the shell.
+
+Do not move providers without checking their hooks. A provider that calls `useSpace()` must stay inside `SpaceProvider`.
+
+## Space Provider
+
+`src/contexts/SpaceContext.tsx` owns:
+
+- app info
+- current space path
+- last space path
+- recent spaces
+- onboarding note path
+- indexing flag
+- open/create/close actions
+
+On startup, it:
+
+1. Calls `app_info`.
+2. Loads settings.
+3. Syncs people-mentions-as-tags to the Rust index runtime.
+4. Reopens the last space when settings contain one.
+5. Syncs native recent-space menu entries.
+
+When opening a new space, it closes the previous one first and clears caches:
+
+- `clearAiPanelCaches()`
+- `clearInlineImageHydrationCache()`
+- `invalidateNavigationPrefetch()`
+
+That prevents a note preview, AI context, or editor image cache from leaking across spaces.
+
+## File Tree Provider
+
+`src/contexts/FileTreeContext.tsx` owns file browser state:
+
+- root entries
+- loaded children by directory
+- expanded directories
+- active directory and file
+- pinned files
+- file tree appearance
+- tags and people
+- tag appearance
+
+It fetches tags with paging because tag lists can exceed one command response. It fetches people only when `enablePeopleMentionsAsTags` is enabled in settings.
+
+When `spacePath` changes, it clears file tree state, lists the root with `space_list_dir`, starts `index_rebuild`, loads appearance stores, and loads pinned files.
+
+It listens for:
+
+- `settings:updated`: refresh tag behavior and tag rendering flags
+- `space:fs_changed`: refresh pinned files after removals
+
+## UI Provider
+
+`src/contexts/UIContext.tsx` owns global view state:
+
+- sidebar collapsed and width
+- command palette open state
+- open markdown tabs list
+- active markdown tab path
+- daily note and template settings
+- table of contents setting
+- folio mode and scope
+- settings mode and active settings tab
+- AI enabled/open state
+- AI assistant mode
+
+It uses a reducer because many actions touch related fields. For example, disabling AI also closes the AI panel. Opening settings forces the sidebar open.
+
+On space close, it clears open markdown tabs and active markdown tab path. On space open, it opens the sidebar.
+
+It listens for `settings:updated` so settings windows and panes can update the live shell without a reload.
+
+## Editor Provider
+
+`src/contexts/EditorContext.tsx` exposes the currently mounted editor:
+
+- `registerEditor()`
+- `saveCurrentEditor()`
+- `hasUnsavedChanges()`
+- `getCurrentMarkdown(relPath)`
+
+`MarkdownEditorPane` registers editor state. Shell-level shortcuts and menu items call `saveCurrentEditor()` without needing props from the active editor component.
+
+Only the current editor can be registered. If a feature introduces multiple editable panes, it must either preserve this current-editor model or replace it with keyed editor registration.
+
+## App Shell
+
+`src/components/app/AppShell.tsx` is the coordination layer. It pulls from all providers and wires:
+
+- sidebar rendering
+- main content rendering
+- tabs
+- command palette
+- native menu listeners
+- keyboard shortcuts
+- Git sync
+- daily notes
+- templates
+- AI context attachment
+- file tree refresh queue
+- prefetch
+- update indicator
+- quick note events
+- onboarding and release-note prompts
+
+This file is intentionally broad. When behavior starts mixing render, state, effects, and commands too heavily, extract a hook or subcomponent. Current examples:
+
+- `useTabManager()`
+- `useWorkspaceLinkEvents()`
+- `useAppCommands()`
+- `useCommandShortcuts()`
+- `useShortcutBindings()`
+- `useMenuListeners()`
+- `useGitSync()`
+- `useDailyNote()`
+
+## Tab Manager
+
+`src/components/app/useTabManager.ts` owns workspace tabs:
+
+- tab records
+- active tab id
+- dirty flags by path
+- per-tab markdown navigation history
+- recent files
+- retargeting tabs on rename
+- closing tabs on removal
+- tab reordering
+- keyboard activation
+
+Tabs have three kinds:
+
+```ts
+type WorkspaceTab = {
+  id: string;
+  kind: "blank" | "file" | "special";
+  target: string | null;
+};
+```
+
+Special tabs use stable ids such as:
+
+- all docs
+- calendar
+- databases
+- templates
+
+Markdown file tabs sync into `UIProvider` as `openMarkdownTabs` and `activeMarkdownTabPath`. AI context actions use those values.
+
+### Rename and Delete Behavior
+
+When a path gets renamed:
+
+- file tree CRUD updates the backend path
+- `AppShell` calls `renameTabsForPath()`
+- `FileTreeContext` updates pinned file paths and appearance keys
+
+When a path gets removed:
+
+- `space:fs_changed` reaches `AppShell`
+- `dispatchPathRemoved()` broadcasts the path
+- `closeTabsForPathRemoval()` removes matching file tabs
+- dirty flags and history entries for removed paths disappear
+
+## File Tree Hook
+
+`src/hooks/useFileTree.ts` bridges file tree UI actions to Tauri commands.
+
+Responsibilities:
+
+- load directories
+- track loaded directories
+- discard stale directory responses
+- expand and collapse directory state
+- open markdown files inside the app
+- open non-markdown files externally
+- delegate create, rename, move, duplicate, delete to `useFileTreeCRUD()`
+
+The hook uses refs for request versions and loaded directories because those values must not retrigger renders on every filesystem load.
+
+## Command Routing
+
+Global commands live in three layers:
+
+1. Command manifest and bindings in `src/lib/shortcuts/` and `src/shared/appCommandManifest.json`
+2. Runtime command construction in `src/components/app/useAppCommands.tsx`
+3. Palette, shortcuts, and native menu dispatch in `AppShell`
+
+Native menu events arrive through `useMenuListeners()`. Keyboard events arrive through `useCommandShortcuts()`. Both call the same command actions whenever possible.
+
+When adding a command, update:
+
+- shared manifest if it belongs in menus or shortcuts
+- shortcut registry if configurable
+- `useAppCommands()` for runtime enablement and action
+- menu listener wiring if the native menu needs it
+
+## Prefetch
+
+`src/lib/navigationPrefetch.ts` caches expensive next-view data:
+
+- markdown note docs
+- all-docs data
+- calendar data
+- database landing and rows
+
+`AppShell` prefetches when users hover or navigate. It invalidates cache on:
+
+- `notes:external_changed`
+- space changes
+- explicit note path changes
+
+This cache improves navigation but must not become a source of truth. Every prefetch entry needs an invalidation path.
+
+## Settings Mode
+
+Settings render inside the main app surface rather than as a separate route. `UIProvider` stores `settingsMode` and `settingsTab`. `AppShell` opens settings from menus, commands, and panes.
+
+Some settings change Rust behavior:
+
+- people mentions as tags call `index_set_people_mentions_as_tags_enabled`
+- shortcuts call `set_menu_shortcuts`
+- quick note shortcut calls `set_quick_note_global_shortcut`
+- translucent app calls `set_window_vibrancy_theme`
+
+Keep UI settings and native runtime settings in sync when adding a preference.
+
+## AI Panel State
+
+`UIProvider` has a separate `AISidebarContext`:
+
+- `aiEnabled`
+- `aiPanelOpen`
+- `aiAssistantMode`
+
+The shell closes the note info sidebar when the AI panel opens, and closes the AI panel when the note info sidebar opens. That keeps the right side of the editor from displaying two competing panels.
+
+AI context attachment flows through `dispatchAiContextAttach()`. Shell commands can attach the current note or all open notes to the AI composer.
+
+## Native Window Integration
+
+The shell calls Tauri APIs directly for UI-only native actions:
+
+- `getCurrentWindow()` for close/focus behavior
+- `@tauri-apps/plugin-dialog` for open/save dialogs
+- `@tauri-apps/plugin-opener` for revealing or opening external paths
+- `@tauri-apps/api/path` for path joins used in native dialog defaults
+
+Durable workspace file changes still go through backend commands.
+
+## Change Checklist
+
+When changing shell behavior:
+
+1. Decide which provider owns the state.
+2. Keep durable workspace data out of React-only state.
+3. Use `invoke()` for backend operations.
+4. Add cache invalidation for any prefetched data.
+5. Update native menu and shortcut routing together.
+6. Retarget tabs, pinned files, and appearance when paths move.
+7. Reset state on space changes if the state belongs to a space.
+8. Avoid adding broad behavior directly to `AppShell` when a focused hook can own it.
+
+## Debugging Map
+
+- Space will not open: `SpaceContext.tsx`, `space/commands.rs`
+- File tree stale: `useFileTree.ts`, `AppShell` `space:fs_changed` handler
+- Shortcut works but menu does not: `useMenuListeners.ts`, `menu_manifest.rs`, `set_menu_shortcuts`
+- Menu works but shortcut does not: `useShortcutBindings.ts`, `useCommandShortcuts.ts`
+- Tabs wrong after rename: `useTabManager.ts`, `useFileTreeCRUD.ts`
+- AI context attaches wrong notes: `openMarkdownTabs`, `activeMarkdownTabPath`, `aiContextEvents.ts`
+- Settings change not reflected live: `settings:updated` emitter and listener

--- a/docs/architecture/04-ipc-and-native-runtime.md
+++ b/docs/architecture/04-ipc-and-native-runtime.md
@@ -1,0 +1,260 @@
+# IPC and Native Runtime
+
+Glyph uses Tauri as the bridge between React and Rust. The IPC boundary has a typed frontend map and explicit Rust registration. Native menus, windows, plugins, and global shortcuts live next to that command boundary because they all belong to the app runtime rather than to a single React component.
+
+## Main Files
+
+Frontend:
+
+- `src/lib/tauri.ts`: typed `invoke()` wrapper and command result types
+- `src/lib/tauriEvents.ts`: typed event helpers
+- `src/hooks/useMenuListeners.ts`: native menu event consumers
+- `src/lib/shortcuts/`: shortcut normalization and registry
+- `src/shared/appCommandManifest.json`: app command metadata shared with native menu code
+
+Rust:
+
+- `src-tauri/src/lib.rs`: Tauri builder, command registration, menus, windows, plugins
+- `src-tauri/src/menu_manifest.rs`: native menu command lookup and accelerators
+- feature modules under `src-tauri/src/*/commands.rs`: command handlers
+
+## Command Contract
+
+The frontend command contract lives in `TauriCommands` in `src/lib/tauri.ts`.
+
+Each entry declares:
+
+```ts
+type CommandDef<Args, Result> = { args: Args; result: Result };
+```
+
+For example:
+
+```ts
+space_read_text: CommandDef<{ path: string }, TextFileDoc>;
+```
+
+Callers use the exported `invoke()` helper:
+
+```ts
+const doc = await invoke("space_read_text", { path });
+```
+
+The helper wraps `@tauri-apps/api/core` and converts thrown values into `TauriInvokeError`. This gives UI code a consistent `Error.message` path.
+
+## Rust Registration
+
+Rust registers commands in `src-tauri/src/lib.rs`:
+
+```rust
+.invoke_handler(tauri::generate_handler![
+    app_info,
+    license::commands::license_bootstrap_status,
+    space_fs::read_write::text::space_read_text,
+    ...
+])
+```
+
+Tauri command names come from Rust function names unless the handler uses command attributes such as `rename_all = "snake_case"`.
+
+Adding a command requires four changes:
+
+1. Implement the command in a Rust module.
+2. Register it in `generate_handler!`.
+3. Add its TypeScript signature in `TauriCommands`.
+4. Use `invoke()` from React.
+
+If any of those steps are missing, the failure usually appears at runtime. TypeScript only protects commands that exist in the TypeScript map.
+
+## Command Categories
+
+The command map covers these groups:
+
+- App and native shell: app info, windows, menus, vibrancy, fonts
+- License: bootstrap, activate, clear local
+- Space lifecycle: create, open, close, onboarding
+- Space filesystem: list, read, write, preview, create, rename, duplicate, delete, link resolution
+- Appearance stores: file tree, tags, pinned files
+- Index: rebuild, search, all docs, calendar, tags, people, tasks, backlinks, graph
+- Databases: list, get, create, update, delete, query rows, mutate cells, create rows, preview context
+- Git sync: status, config, run, disconnect
+- AI: profiles, secrets, models, chat, context, history, Codex account
+
+Keep command names descriptive. Most existing commands use a module prefix: `space_`, `index_`, `databases_`, `ai_`, `codex_`, `git_sync_`.
+
+## Tauri Builder
+
+`run()` in `src-tauri/src/lib.rs` creates the app:
+
+1. Initializes tracing.
+2. Builds the native menu.
+3. Handles menu events.
+4. Configures setup behavior.
+5. Handles window close behavior.
+6. Manages shared Rust state.
+7. Installs plugins.
+8. Registers commands.
+9. Runs the Tauri app.
+
+Managed state:
+
+- `ai_rig::AiState`
+- `ai_codex::state::CodexState`
+- `git_sync::GitSyncState`
+- `space::SpaceState`
+- `MenuState`
+- `QuickNoteShortcutState`
+
+Plugins:
+
+- global shortcut
+- dialog
+- notification
+- opener
+- process
+- store
+- updater
+
+## Menu Events
+
+Native menu items do not call React directly. `on_menu_event` in Rust emits app events:
+
+- Recent spaces emit `menu:open_recent_space` with a path.
+- App commands emit `menu:app_command` with a command id.
+
+React listens through `useMenuListeners()` and calls the same actions used by command palette and shortcuts.
+
+This keeps native menus, keyboard shortcuts, and command palette behavior aligned.
+
+## Menu Manifest
+
+`menu_manifest.rs` maps native menu ids to command metadata from `src/shared/appCommandManifest.json`. Rust uses it to:
+
+- find labels
+- find default bindings
+- convert shortcut strings into native accelerators
+
+`set_menu_shortcuts` lets React push updated shortcut bindings into the native menu after settings load or change.
+
+When adding a user-configurable command:
+
+1. Add it to the shared command manifest.
+2. Add it to the shortcut registry.
+3. Add native menu handling when needed.
+4. Send updated accelerators through `set_menu_shortcuts`.
+
+## Recent Spaces Menu
+
+`MenuState` stores recent spaces and shortcut overrides. Rust uses revisioned menu item ids such as `space.recent.{revision}.{index}` so stale events can still parse safely.
+
+`SpaceContext` calls `set_recent_spaces_menu` whenever recent spaces or current space changes. It excludes the current space from the menu.
+
+## Markdown Menu Visibility
+
+React calls `set_markdown_menu_visible` when `activeMarkdownTabPath` changes. Rust rebuilds or toggles markdown-specific menu items based on whether a markdown note is active.
+
+The shell should update this only from active tab state, not from arbitrary file tree selection.
+
+## Windows
+
+`src-tauri/src/lib.rs` owns native windows:
+
+- Main window
+- Settings window behavior when present
+- Quick note window
+
+Close behavior:
+
+- Settings window close requests hide the window.
+- Quick note window close requests hide the window.
+- On macOS, closing the main window hides it instead of exiting the app.
+
+Quick note window helpers:
+
+- `show_quick_note_window`
+- `hide_quick_note_window`
+- `show_main_window`
+- `set_quick_note_global_shortcut`
+
+The quick note window uses a lock to prevent duplicate creation races.
+
+## Global Shortcut
+
+React reads shortcut settings and calls `set_quick_note_global_shortcut`. Rust registers or updates the global shortcut through `tauri_plugin_global_shortcut`.
+
+The shortcut emits a native action that opens the quick note window. Keep this path separate from normal in-app command shortcuts because it must work while the app window is not focused.
+
+## App Setup
+
+During setup, Rust:
+
+- refreshes AI provider support metadata in the background
+- sizes and centers the main window to 80 percent of the current monitor
+- applies macOS vibrancy when available
+
+Frontend startup then hydrates settings and space state. Do not assume React settings are available in Rust setup unless you pass them through a command later.
+
+## Events
+
+Backend-to-frontend events include:
+
+- `menu:open_recent_space`
+- `menu:app_command`
+- `space:fs_changed`
+- `notes:external_changed`
+- `settings:updated`
+- `ai:chunk`
+- `ai:done`
+- `ai:error`
+- `ai:status`
+- `ai:tool`
+- `ai:profiles-updated`
+- `git_sync:status`
+- `quick-note:open_note`
+
+Use events for state changes that multiple frontend areas need to react to. Use command return values for direct request/response work.
+
+## Error Handling
+
+Most Rust commands return `Result<T, String>`. The frontend receives those strings through `TauriInvokeError.message`.
+
+Keep error messages actionable because they often surface directly in toast messages or settings panes. Avoid logging secrets in Rust errors or traces.
+
+## Threading Rules
+
+Rust commands that perform filesystem walks, SQLite work, Git calls, or blocking IO use `tauri::async_runtime::spawn_blocking`. This keeps Tauri's async runtime responsive.
+
+Examples:
+
+- opening spaces
+- rebuilding index
+- querying databases
+- reading and writing files
+- running Git sync background work
+
+Use async commands for operations that await network or runtime work. Use `spawn_blocking` inside async commands for blocking filesystem or SQLite sections.
+
+## Change Checklist
+
+When adding or changing IPC:
+
+1. Add the Rust command near the module that owns the behavior.
+2. Use `State<'_, SpaceState>` when the command needs a space.
+3. Validate paths before filesystem work.
+4. Wrap blocking work in `spawn_blocking`.
+5. Register the command in `src-tauri/src/lib.rs`.
+6. Add the typed command to `src/lib/tauri.ts`.
+7. Emit an event only if other UI surfaces need to react.
+8. Update menus, shortcuts, or command palette if the operation is user-invokable.
+9. Keep command payloads serializable with snake_case where Rust uses `rename_all = "snake_case"`.
+
+## Drift Checks
+
+Use these checks when IPC feels broken:
+
+- Rust command exists but frontend fails with "unknown command": check `generate_handler!`.
+- TypeScript cannot call a command: check `TauriCommands`.
+- Payload arrives empty: check casing and the command attribute.
+- Menu item does nothing: check `menu_manifest.rs` and `useMenuListeners()`.
+- Shortcut text differs from native menu: check `set_menu_shortcuts` and `toTauriAccelerator()`.
+- Event listener never fires: check event name spelling in Rust `emit()` and frontend listener.

--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -1,0 +1,347 @@
+# Editor, Markdown, and Autosave
+
+Glyph edits Markdown files through a TipTap rich editor, but the durable document remains Markdown text on disk. The editor stack has three jobs: convert Markdown into an editable ProseMirror document, keep React state in sync with editor changes, and persist the file through Rust with conflict detection.
+
+## Main Files
+
+Frontend:
+
+- `src/components/preview/MarkdownEditorPane.tsx`: document load, save, autosave, external reload, note sidebars
+- `src/components/editor/NoteInlineEditor.tsx`: editor surface, toolbar overlays, frontmatter panel, backlinks, interactions
+- `src/components/editor/hooks/useNoteEditor.ts`: TipTap instance, Markdown conversion, paste handling, image paste
+- `src/components/editor/extensions/index.ts`: extension composition
+- `src/components/editor/markdown/`: wiki link and Markdown bridge helpers
+- `src/components/editor/hooks/useHydrateInlineImages.ts`: image path hydration
+- `src/components/editor/hooks/useTaskInlineDates.ts`: inline task date editing
+- `src/components/editor/hooks/useExtractSelectionToNote.ts`: extract selection flow
+- `src/contexts/EditorContext.tsx`: current editor save registration
+
+Backend:
+
+- `src-tauri/src/space_fs/read_write/text.rs`: read/write text docs
+- `src-tauri/src/space_fs/read_write/binary.rs`: pasted image persistence
+- `src-tauri/src/index/indexer.rs`: reindex note after write
+- `src-tauri/src/notes/frontmatter.rs`: parse and render frontmatter mappings
+- `src-tauri/src/notes/properties.rs`: property conversion
+
+## Ownership Split
+
+`MarkdownEditorPane` owns the file.
+
+It knows:
+
+- current text
+- last saved text
+- last saved mtime
+- dirty state
+- autosave state
+- external change reload state
+- note info sidebar state
+- local graph dialog state
+
+`NoteInlineEditor` owns the editing UI.
+
+It knows:
+
+- rich/raw editor mode
+- TipTap editor instance
+- frontmatter draft
+- selection ribbon
+- table controls
+- find bar
+- backlinks display
+- code block controls
+- extract-to-note dialog
+
+`useNoteEditor` owns the TipTap integration.
+
+It knows:
+
+- extension list
+- Markdown preprocessing and postprocessing
+- editor click handling
+- paste behavior
+- image upload placeholders
+- settings that change editor features
+
+Keep those roles separate. File persistence should stay in `MarkdownEditorPane`. TipTap transaction logic should stay in `useNoteEditor`.
+
+## Document Load Flow
+
+When a markdown tab opens:
+
+1. `MainContent` renders `MarkdownEditorPane` for the tab target.
+2. `MarkdownEditorPane` checks prefetched/cached docs.
+3. If no initial doc exists, it calls `space_read_text`.
+4. Rust validates the path and returns `TextFileDoc`.
+5. React stores:
+   - `text`
+   - `savedText`
+   - `lastSavedMtimeMs`
+6. `NoteInlineEditor` receives `markdown={text}`.
+7. `useNoteEditor` splits frontmatter from body and loads the body into TipTap.
+
+`TextFileDoc` includes:
+
+- `rel_path`
+- `text`
+- `etag`
+- `mtime_ms`
+
+The editor uses `mtime_ms` for conflict detection. It does not use `etag` for the autosave conflict check.
+
+## Markdown Conversion
+
+The durable file includes optional YAML frontmatter and Markdown body.
+
+`useNoteEditor` calls:
+
+- `splitYamlFrontmatter()` to separate frontmatter and body
+- `preprocessMarkdownForEditor()` before loading body into TipTap
+- `postprocessMarkdownFromEditor()` after `editor.getMarkdown()`
+- `joinYamlFrontmatter()` to rebuild the full document
+
+Wiki links need bridge logic because TipTap and Markdown need different representations for editing and serialization.
+
+Use the bridge helpers rather than ad hoc string replacement when changing wiki-link Markdown behavior.
+
+## TipTap Extensions
+
+`createEditorExtensions()` composes:
+
+- StarterKit
+- Link
+- Table, TableRow, TableHeader, TableCell
+- TaskList and TaskItem
+- TipTap Markdown extension
+- Slash commands
+- Code block highlighting
+- colored text
+- highlighted text
+- collapsible headings
+- markdown images
+- markdown link autocomplete
+- mermaid preview
+- note search
+- person autocomplete
+- tag decorations
+- Vim mode
+- wiki links
+- callout decorations
+- task list shortcuts
+- markdown image shortcuts
+
+Feature settings can enable or disable parts of this list:
+
+- people mentions as tags
+- vim keybindings
+- markdown link autocomplete
+- collapsible headings
+
+The extension list should stay centralized. Adding extensions from a component creates inconsistent editor behavior across rich editor surfaces.
+
+## Editor Transaction Flow
+
+`useNoteEditor` listens to TipTap transactions:
+
+1. Ignore transactions without document changes.
+2. Ignore suppressed updates caused by programmatic content replacement.
+3. Ignore changes when not in rich edit mode.
+4. Convert editor Markdown to durable Markdown.
+5. Join the current frontmatter.
+6. Compare with `lastEmittedMarkdownRef`.
+7. Call `onChange(nextMarkdown)`.
+
+`MarkdownEditorPane` receives `onChange` and updates `text`. It also marks that the user has edited the document, which enables autosave.
+
+## Autosave
+
+Autosave behavior lives in `MarkdownEditorPane`.
+
+The core values:
+
+- `text`: current editor text
+- `savedText`: last persisted text
+- `textRef`: current text ref for async code
+- `savedTextRef`: last persisted text ref
+- `mtimeRef`: last known saved mtime
+- `autosaveInFlightRef`: one save in progress
+- `autosaveQueuedRef`: another save should run after current save
+- `hasUserEditsRef`: autosave should run only after user edits
+
+Autosave triggers:
+
+- 900ms after dirty user edits
+- component cleanup if current text differs from saved text
+- immediate save after property/frontmatter commits
+- explicit save command from menus or shortcuts
+
+`runAutosave()` serializes saves:
+
+1. If a save is in flight, set `autosaveQueuedRef`.
+2. Snapshot current text.
+3. Skip if snapshot equals saved text.
+4. Call `persistDoc()`.
+5. If a queued save exists, run again.
+6. If save succeeded but text changed during save, run again.
+
+This avoids concurrent writes to the same note from the same pane.
+
+## Save and Conflict Detection
+
+`persistDoc()` calls:
+
+```ts
+invoke("space_write_text", {
+  path,
+  text: nextText,
+  base_mtime_ms: mtimeRef.current,
+});
+```
+
+Rust checks:
+
+1. Current file mtime.
+2. If `base_mtime_ms` exists and differs, return conflict.
+3. Otherwise write atomically.
+4. Reindex markdown.
+5. Return new `mtime_ms`.
+
+On conflict, `MarkdownEditorPane`:
+
+1. Reads the latest file with `space_read_text`.
+2. If latest text already equals the text being saved, accepts the latest mtime.
+3. Otherwise updates `savedTextRef` and `mtimeRef` to the latest file.
+4. Retries `space_write_text` once using the latest mtime.
+
+This strategy favors the user's current editor text after one refresh. It does not merge concurrent edits. If you need merge behavior, design it as a new conflict flow rather than hiding it inside `persistDoc()`.
+
+## External Changes
+
+Rust emits `notes:external_changed` after external markdown changes and after local writes that the watcher suppresses.
+
+`MarkdownEditorPane` handles it:
+
+1. Normalize the event path and current path.
+2. Ignore events for other notes.
+3. Debounce for 180ms.
+4. If editor is dirty, saving, or autosaving, set `pendingExternalReloadRef`.
+5. Otherwise read the latest file and replace text/savedText.
+6. When the editor later becomes clean, apply pending external reload.
+
+This prevents the active note from reloading while the user has unsaved changes.
+
+## Image Paste
+
+`useNoteEditor` handles pasted images in rich mode:
+
+1. Detect image clipboard files.
+2. Resolve target folder from editor settings:
+   - space root
+   - specific attachment folder
+   - note folder
+3. Insert temporary object URL image nodes as placeholders.
+4. Convert each file to a data URL.
+5. Call `space_save_pasted_image`.
+6. Replace placeholders with final image attributes.
+7. Revoke object URLs.
+
+The backend writes the image into the space and returns:
+
+- `asset_rel_path`
+- `href`
+- `markdown`
+
+Do not store pasted images only in the editor document. They must become files in the space.
+
+## Frontmatter and Properties
+
+Frontmatter appears in two ways:
+
+- raw frontmatter editing
+- structured property editing
+
+`NoteInlineEditor` keeps a frontmatter draft. Property tools call frontmatter render/parse commands or local helpers depending on the path. On frontmatter commit, `MarkdownEditorPane` runs autosave immediately.
+
+Database cell edits also update note frontmatter from the backend. See `07-databases-frontmatter.md`.
+
+## Links and Navigation
+
+Editor click handling in `useNoteEditor` recognizes:
+
+- tag tokens
+- person tokens
+- wiki links
+- Markdown links
+- external HTTP/HTTPS links
+
+It dispatches app events:
+
+- `dispatchTagClick()`
+- `dispatchPersonClick()`
+- `dispatchWikiLinkClick()`
+- `dispatchMarkdownLinkClick()`
+
+`AppShell` listens through `useWorkspaceLinkEvents()` and decides whether to open a note, open search, or open an external URL.
+
+## Backlinks, Relationships, and Info Sidebar
+
+`NoteInlineEditor` loads simple backlinks for display near the editor.
+
+`MarkdownEditorPane` loads richer side panel data:
+
+- backlinks
+- linked notes extracted from Markdown
+- frontmatter relationships
+- preview context for database views
+- word, character, line, and reading-time stats
+- task progress summary
+- local graph dialog
+
+These values derive from either current editor text or index queries. Keep UI responsive by loading heavier data only when the sidebar or graph needs it.
+
+## Editor Registration
+
+`MarkdownEditorPane` registers with `EditorProvider`:
+
+```ts
+{
+  relPath,
+  isDirty,
+  save: onSave,
+  getMarkdown: () => textRef.current,
+}
+```
+
+Shell commands use that registration for:
+
+- Save Note
+- Duplicate active markdown after flushing current edits
+- Copy open note as Markdown
+- Git sync before running
+- AI context for current open note
+
+If a note pane unmounts, `useEditorRegistration()` clears the registration.
+
+## Change Checklist
+
+When changing editor behavior:
+
+1. Keep disk persistence in `MarkdownEditorPane`.
+2. Keep TipTap transaction and paste behavior in `useNoteEditor`.
+3. Use Markdown bridge helpers for wiki-link serialization.
+4. Preserve `base_mtime_ms` conflict checks.
+5. Reindex notes after backend writes.
+6. Emit or handle `notes:external_changed` when note-derived UI must refresh.
+7. Avoid programmatic content replacement loops by using suppression refs.
+8. Flush the editor before operations that duplicate, sync, or export the current note.
+9. Keep image paste storage tied to a real space file.
+
+## Debugging Map
+
+- Text jumps to old content: inspect external reload path and dirty checks.
+- Autosave loops: inspect `lastEmittedMarkdownRef`, `savedTextRef`, and transaction suppression.
+- Conflict message appears often: inspect mtime tracking and outside file writes.
+- Wiki links serialize incorrectly: inspect `wikiLinkMarkdownBridge.ts`.
+- Images show in editor but break after reload: inspect `space_save_pasted_image` and inline image hydration.
+- Save shortcut misses active note: inspect `EditorProvider` registration and pane mount order.

--- a/docs/architecture/06-index-search-graph-tasks.md
+++ b/docs/architecture/06-index-search-graph-tasks.md
@@ -1,0 +1,366 @@
+# SQLite Index, Search, Graph, and Tasks
+
+Glyph keeps Markdown files as the durable source of truth. The SQLite database under `.glyph/glyph.sqlite` is a derived index. It accelerates search, tags, backlinks, relationships, calendar activity, database rows, and tasks.
+
+If the index is wrong, rebuild it from Markdown. Do not treat SQLite rows as the authoritative note content.
+
+## Main Files
+
+Backend:
+
+- `src-tauri/src/index/schema.rs`: table and FTS schema
+- `src-tauri/src/index/db.rs`: database path, WAL setup, schema cache, migrations
+- `src-tauri/src/index/indexer.rs`: note indexing, removal, rebuild
+- `src-tauri/src/index/commands.rs`: Tauri commands for search, all docs, calendar, tags, tasks, graph
+- `src-tauri/src/index/frontmatter.rs`: frontmatter title and preview parsing
+- `src-tauri/src/index/links.rs`: outgoing link parsing
+- `src-tauri/src/index/tags.rs`: tag and people mention parsing
+- `src-tauri/src/index/properties.rs`: frontmatter property indexing
+- `src-tauri/src/index/relationships.rs`: relationship indexing and query
+- `src-tauri/src/index/search_advanced.rs`: structured search
+- `src-tauri/src/index/search_hybrid.rs`: FTS plus local semantic-ish ranking
+- `src-tauri/src/index/tasks/`: task parsing, mutation, summaries
+
+Frontend consumers:
+
+- `src/components/app/AllDocsPane.tsx`
+- `src/components/calendar/CalendarPane.tsx`
+- `src/components/TagsPane.tsx`
+- `src/components/tasks/`
+- `src/components/graph/LocalNoteGraphDialog.tsx`
+- `src/components/database/`
+- `src/components/app/CommandSearchResults.tsx`
+- `src/hooks/useMarkdownTaskSummary.ts`
+- `src/hooks/useTaskSummariesForPaths.ts`
+
+## Database Location
+
+`db_path(space_root)` returns:
+
+```text
+.glyph/glyph.sqlite
+```
+
+`open_db()` creates the parent directory, opens the database, configures WAL, ensures schema, and runs migrations. It caches schema setup by database path so repeated commands do not run schema checks on every open.
+
+Opening or closing a space calls `reset_schema_cache()` so a different space gets a fresh schema check.
+
+## WAL and Schema Version
+
+`db.rs` sets:
+
+- `INDEX_DB_VERSION = 6`
+- `journal_mode = WAL`
+- `journal_size_limit = 1_048_576`
+- `SQLITE_FCNTL_PERSIST_WAL`
+
+Migrations are hard-coded by `user_version`:
+
+- version 2: tags table gains `is_explicit`
+- version 3: normalize unknown frontmatter property kinds
+- version 5: infer status property kinds
+- version 6: infer priority property kinds
+
+Schema creation still uses `CREATE TABLE IF NOT EXISTS`. Migrations fix existing databases that already have older tables.
+
+## Tables
+
+`schema.rs` creates:
+
+### `notes`
+
+Stores one row per markdown note:
+
+- `id`: space-relative note path
+- `title`
+- `created`
+- `updated`
+- `path`
+- `etag`
+- `preview`
+
+`id` and `path` are currently the note path. The index uses paths as stable identifiers.
+
+### `links`
+
+Stores outgoing links:
+
+- `from_id`
+- `to_id`
+- `to_title`
+- `kind`
+
+`to_id` is set when the link resolves to a known note or file path. `to_title` stores unresolved wiki titles.
+
+### `note_relationships`
+
+Stores frontmatter relationship fields:
+
+- `from_id`
+- `field_key`
+- `to_id`
+- `to_title`
+- `target_title`
+- `ordinal`
+
+Relationships support richer graph and database relation columns than raw links.
+
+### `tags`
+
+Stores note tags:
+
+- `note_id`
+- `tag`
+- `is_explicit`
+
+Explicit tags come directly from the note. Derived parent tags let searches for `#work` include notes tagged `#work/today`.
+
+People mentions can be stored under the `people/` namespace when the setting is enabled.
+
+### `note_properties`
+
+Stores frontmatter properties:
+
+- `note_id`
+- `key`
+- `value_type`
+- `value_text`
+- `value_json`
+- `ordinal`
+
+`value_text` powers filtering and sorting. `value_json` preserves typed values such as booleans and lists.
+
+### `notes_fts`
+
+FTS5 virtual table for note title/body search.
+
+### `tasks`
+
+Stores parsed Markdown tasks:
+
+- `task_id`
+- `note_id`
+- `note_path`
+- line range
+- list path
+- raw and normalized text
+- checked/status/priority
+- date fields
+- tags, project, section
+- source hash
+- note etag and timestamps
+
+### `tasks_fts`
+
+FTS5 virtual table for task text.
+
+## Indexing a Note
+
+`index_note(space_root, note_id, markdown)` opens SQLite and calls `index_note_with_conn()`.
+
+The indexer:
+
+1. Computes SHA-256 etag from Markdown bytes.
+2. If the etag did not change, it ensures relationships are indexed and refreshes timestamps when the file mtime changed.
+3. Parses frontmatter title, created, and updated.
+4. Falls back to the filename stem for untitled notes.
+5. Builds a preview.
+6. Inserts or replaces the `notes` row.
+7. Replaces the `notes_fts` row.
+8. Deletes old links and tags.
+9. Parses tags and optional people mentions.
+10. Reindexes frontmatter properties.
+11. Reindexes relationships.
+12. Reindexes tasks.
+13. Parses outgoing links.
+14. Resolves wiki titles to note ids when the title is unique.
+15. Inserts link rows.
+16. Commits the transaction.
+
+The etag short path matters. If content did not change, tasks keep their original indexed timestamp while note updated time can refresh.
+
+## Removing a Note
+
+`remove_note()` deletes:
+
+- `notes`
+- `notes_fts`
+- links where the note is source or target
+- tags
+- note properties
+- note relationships from this note
+- tasks
+
+It also converts relationships from other notes that pointed at this note back to unresolved title form.
+
+Delete and rename commands call this function when markdown paths disappear or move.
+
+## Rebuilding the Index
+
+`rebuild(space_root)`:
+
+1. Deletes all derived rows.
+2. Walks visible Markdown files under the space.
+3. Indexes notes, FTS, tags, properties, tasks.
+4. Collects link and relationship data.
+5. Resolves links after all notes exist.
+6. Inserts relationships after all note titles can resolve.
+7. Returns the indexed count.
+
+`index_rebuild` runs this in `spawn_blocking` and sends a system notification when done.
+
+`FileTreeProvider` starts an index rebuild after listing the root when a space opens.
+
+## Search
+
+Glyph exposes three search commands:
+
+- `search`: simple text search through `hybrid_search()`
+- `search_advanced`: structured request with query, tags, people, title-only, tag-only, limit
+- `search_parse_and_run`: command palette query parser that turns raw text into `SearchAdvancedRequest`
+
+`hybrid_search()` combines:
+
+- FTS5 `MATCH` with BM25 ranking
+- local candidate scan over title and preview
+- trigram Jaccard score
+- phrase and title bonuses
+
+This is not embedding search. It is deterministic local ranking over indexed text.
+
+Advanced search can join multiple `tags` aliases. For tag hierarchy, normalization happens in `tags.rs` and structured filtering happens in `search_advanced.rs`.
+
+## Tags and People
+
+Tags come from Markdown body and frontmatter. The parser expands hierarchical tags so parent tag searches include children.
+
+People mentions are optional. `SpaceContext` syncs the setting to Rust with:
+
+```ts
+invoke("index_set_people_mentions_as_tags_enabled", { enabled })
+```
+
+The Rust flag is process-local. When the setting changes, the index may need a rebuild for stored people tags to reflect the new behavior.
+
+Frontend tag lists page through:
+
+- `tags_list`
+- `people_list`
+
+`FileTreeProvider` stores those lists for sidebar tag navigation.
+
+## Backlinks and Graph
+
+Backlinks query the `links` and relationship tables. The local graph command returns nodes and edges around a selected note.
+
+The graph distinguishes:
+
+- note nodes
+- tag nodes
+- note-to-note link edges
+- note-to-tag edges
+- relationship edges
+
+Frontend renders local graph data in `LocalNoteGraphDialog`.
+
+When link resolution feels wrong, inspect:
+
+- `index/links.rs` for parsing
+- `resolve_title_to_id()` in `db.rs`
+- rename link rewriting in `space_fs/link_rewrite.rs`
+- `space_fs/link_ops.rs` for click-time resolution
+
+## Calendar
+
+`calendar_query_range` returns:
+
+- day summaries
+- selected day note activity
+- daily note path info
+- task groups
+
+It uses:
+
+- note created/updated timestamps
+- task scheduled/due dates
+- daily note folder setting passed from the frontend
+
+Date comparisons convert RFC3339 timestamps to local dates where needed.
+
+## Tasks
+
+The tasks subsystem parses Markdown task list items and stores derived task rows.
+
+Commands include:
+
+- `task_set_checked`
+- `task_set_dates`
+- `task_dates_by_ordinal`
+- `task_update_by_ordinal`
+- `task_summary`
+- `task_summaries_for_paths`
+
+Task mutations write back to the Markdown file, then reindex. This preserves the rule that Markdown is the source of truth.
+
+Task row fields support:
+
+- checked state
+- status
+- priority
+- due date
+- scheduled date
+- start date
+- completed timestamp
+- recurrence
+- tags
+- project
+- section
+
+Frontend inline date controls use ordinal-based helpers when operating on the current editor text.
+
+## All Docs
+
+`all_docs_list` queries the `notes` table and joins tag and people blobs. It supports an optional folder prefix and a high limit capped at 5,000.
+
+`all_docs_count` uses the same folder prefix logic.
+
+All-docs UI should treat this as an index view. If a note is missing, run or inspect `index_rebuild`.
+
+## Index Consumers
+
+The index feeds:
+
+- command palette search
+- all notes
+- tags and people sidebars
+- backlinks
+- local graph
+- calendar
+- task panes and progress indicators
+- database source rows
+- AI tools when search can use FTS
+
+Changes to schema or indexing can affect many surfaces. Run focused manual checks across at least search, tags, backlinks, databases, and tasks after broad index changes.
+
+## Change Checklist
+
+When changing the index:
+
+1. Confirm whether the source of truth stays in Markdown.
+2. Update `schema.rs` for new tables or columns.
+3. Increment `INDEX_DB_VERSION` when existing databases need migration.
+4. Add migration code in `db.rs`.
+5. Update `index_note_with_conn()` and `rebuild()` together.
+6. Update `remove_note()` for any new per-note derived rows.
+7. Update frontend result types in `src/lib/tauri.ts` when command outputs change.
+8. Rebuild the index after parser behavior changes.
+9. Check downstream consumers, especially databases and calendar.
+
+## Debugging Map
+
+- Search misses a note: inspect `notes_fts` insertion and FTS query syntax.
+- Tag count wrong: inspect explicit vs derived tag rows.
+- Backlink wrong after rename: inspect link rewrite and `remove_note()`.
+- Database row missing: inspect `source_ids()` in `databases/query.rs` and `notes` rows.
+- Task checkbox writes wrong line: inspect task ordinal parsing and task source hashes.
+- Rebuild slow: inspect full space walk and per-note parser work.

--- a/docs/architecture/07-databases-frontmatter.md
+++ b/docs/architecture/07-databases-frontmatter.md
@@ -1,0 +1,430 @@
+# Workspace Databases and Frontmatter
+
+Glyph databases are saved views over notes. A database definition lives in `.glyph/databases.json`; each row is still a Markdown note. Editable cells write back to YAML frontmatter, then the note gets reindexed.
+
+This design keeps databases offline and file-based. It also means database behavior depends on the index staying fresh.
+
+## Main Files
+
+Backend:
+
+- `src-tauri/src/databases/types.rs`: database document, view, column, filter, row types
+- `src-tauri/src/databases/store.rs`: `.glyph/databases.json`, defaults, normalization
+- `src-tauri/src/databases/query.rs`: source selection, filtering, sorting, row hydration
+- `src-tauri/src/databases/commands.rs`: Tauri commands and frontmatter mutations
+- `src-tauri/src/index/properties.rs`: indexed frontmatter property rows
+- `src-tauri/src/notes/frontmatter.rs`: YAML mapping parse/render
+- `src-tauri/src/notes/properties.rs`: property kind/value helpers
+
+Frontend:
+
+- `src/components/databases/DatabasesPane.tsx`: databases landing
+- `src/components/database/DatabaseTable.tsx`: table view
+- `src/components/database/DatabaseBoard.tsx`: board view
+- `src/components/database/DatabaseToolbar.tsx`: view controls
+- `src/components/database/DatabaseCell.tsx`: cell rendering and editing
+- `src/components/database/DatabaseViewOptions*.tsx`: source, columns, filters, sort panels
+- `src/hooks/database/useDatabaseBoard.ts`: board state helpers
+- `src/lib/database/`: config, board, selected view storage, types
+- `src/lib/tauri.ts`: database IPC types
+
+## Durable Model
+
+The database store lives at:
+
+```text
+.glyph/databases.json
+```
+
+The store shape:
+
+```rust
+pub struct DatabaseStore {
+    pub version: u32,
+    pub databases: Vec<DatabaseDefinition>,
+    pub status_colors: BTreeMap<String, String>,
+}
+```
+
+Current store version:
+
+```rust
+const DATABASES_STORE_VERSION: u32 = 3;
+```
+
+The store contains definitions and view preferences. It does not contain row data. Row data comes from notes and the SQLite index.
+
+## Default Databases
+
+`default_store()` creates two system databases:
+
+- `all-notes`
+- `recently-edited`
+
+`bootstrap_defaults()` appends missing system databases when loading an existing store.
+
+System databases:
+
+- use `is_system = true`
+- cannot be deleted
+- cannot be renamed
+- use stable ids
+
+Default views include columns for title, tags, and updated time. The Recently Edited view adds a `within_last_7_days` filter.
+
+## Database Definition
+
+`DatabaseDefinition` contains:
+
+- `id`
+- `name`
+- `icon`
+- `color`
+- `is_system`
+- `source`
+- `new_note`
+- `schema`
+- `views`
+- timestamps
+
+`source` selects which notes can appear:
+
+- `all_notes`
+- `folder`
+- `tag`
+- `search`
+
+`new_note.folder` controls where `databases_create_row` creates a new note.
+
+`schema` describes frontmatter-backed fields and built-in fields that the database exposes.
+
+## Views
+
+`DatabaseViewDefinition` contains:
+
+- `id`
+- `name`
+- `layout`: `table` or `board`
+- `search`
+- `icon`
+- `color`
+- columns
+- sorts
+- filters
+- grouping
+- board lane colors
+- board lane order
+- board card order
+- timestamps
+
+Unsupported layouts are pruned on load and update. If all views disappear after pruning, the store adds a default table view.
+
+## Columns
+
+Built-in columns come from `query.rs`:
+
+- `title`
+- `path`
+- `folder`
+- `created`
+- `updated`
+- `tags`
+- `linked_notes`
+
+Property columns use:
+
+- `column_type = "property"`
+- `property_key`
+- `property_kind`
+
+Property kinds include:
+
+- `text`
+- `url`
+- `date`
+- `checkbox`
+- `tags`
+- `status`
+- `priority`
+- `relation`
+- `multi_select`
+
+Store normalization downgrades unsupported frontmatter property kinds to `text`.
+
+## Loading and Saving the Store
+
+`load_store()`:
+
+1. Reads `.glyph/databases.json`.
+2. Parses JSON into `DatabaseStore`.
+3. Rejects stores newer than the supported version.
+4. Upgrades version `0` to current version.
+5. Normalizes property kinds.
+6. Prunes unsupported layouts.
+7. Normalizes status colors.
+8. Adds missing default field values.
+9. Bootstraps default system databases.
+
+If the file does not exist, it returns `default_store()`.
+
+`save_store()` writes pretty JSON with `io_atomic::write_atomic()`.
+
+Commands that mutate the store lock `SpaceState.db_store_mutex()` before loading and saving.
+
+## Source Selection
+
+`source_ids()` in `query.rs` selects note paths from the index:
+
+- `all_notes`: latest notes from `notes`
+- `folder`: direct or recursive folder SQL
+- `tag`: notes with exact normalized tag
+- `search`: calls `parse_raw_search_query()` and `run_search_advanced()`
+
+The source scan limit is 2,000 notes. Row query pagination then applies view search, filters, sort, offset, and limit.
+
+Folder source behavior:
+
+- recursive folder source uses `id LIKE '{folder}/%'`
+- direct folder source excludes grandchildren
+- empty folder source means root-level notes for direct mode or all notes for recursive mode
+
+## Row Hydration
+
+`hydrate_rows_by_paths()` turns note ids into `DatabaseRow` records.
+
+It joins:
+
+- `notes` for title, created, updated, preview
+- `tags` for tag lists
+- `links` and `note_relationships` for linked notes
+- `note_properties` for frontmatter properties
+
+Large path sets are chunked with `SQLITE_BATCH_SIZE = 500` to keep SQLite parameter lists manageable.
+
+The frontend receives rows with:
+
+- note path
+- title
+- folder
+- timestamps
+- preview
+- tags
+- linked notes
+- properties keyed by property name
+
+## Filtering
+
+Filters run in Rust over hydrated rows. Supported operators include:
+
+- equals
+- not_equals
+- contains
+- not_contains
+- starts_with
+- ends_with
+- greater_than
+- less_than
+- is_empty
+- is_not_empty
+- is_true
+- is_false
+- tags_contains
+- any_of
+- none_of
+- within_last_7_days
+
+Numeric comparisons parse numbers after removing `$`, `,`, and `%`.
+
+Date shortcuts include:
+
+- Today
+- Yesterday
+- Overdue
+- This Week
+- Last 7 Days
+- Last 30 Days
+
+Tag filters normalize tags and support hierarchy matching through `tag_matches_hierarchy()`.
+
+## View Search
+
+`row_matches_search()` performs simple term matching across:
+
+- title
+- note path
+- folder
+- preview
+- tags
+- linked notes
+- property values
+
+All query terms must appear somewhere in the combined row text.
+
+This search happens after source selection. A database with `source.kind = "search"` first uses index search to choose candidates, then view search can narrow those rows.
+
+## Sorting
+
+Rows sort by configured columns. Sort comparison uses column kind:
+
+- dates parse as `YYYY-MM-DD`
+- datetimes parse as RFC3339
+- checkboxes compare booleans
+- text cells compare case-insensitive text
+- numeric-looking text sorts numerically before text fallback
+
+Sorting happens after filtering and before pagination.
+
+## Cell Editing
+
+`databases_update_cell` writes editable columns back to the note.
+
+Editable:
+
+- `title`
+- `tags`
+- `property`
+
+Read-only:
+
+- `path`
+- `folder`
+- `created`
+- `updated`
+- `linked_notes`
+
+Flow:
+
+1. Load current row with `row_by_path()`.
+2. Validate the column is editable.
+3. Validate path and read Markdown.
+4. Parse frontmatter mapping.
+5. Convert the cell value to YAML.
+6. Insert or replace the YAML key.
+7. Render frontmatter plus original body.
+8. Write Markdown with `write_markdown_note()`.
+9. Reindex the note.
+10. Return the fresh row.
+
+This makes frontmatter the durable database cell storage.
+
+## Creating Rows
+
+`databases_create_row` creates a new Markdown note.
+
+Flow:
+
+1. Load the database definition.
+2. Choose folder from `database.new_note.folder`.
+3. Normalize title, defaulting to `Untitled`.
+4. Slugify title into a filename.
+5. Build frontmatter:
+   - title
+   - schema defaults
+   - tags
+   - initial values from caller
+6. Render Markdown.
+7. Write with `OpenOptions::create_new`.
+8. On collision, try `Title 2.md`, `Title 3.md`, and so on.
+9. Stop after 1,000 collisions.
+10. Index the new note.
+11. Return the created row.
+
+Reserved frontmatter keys cannot be used for new-note defaults:
+
+- `created`
+- `folder`
+- `glyph`
+- `id`
+- `linked_notes`
+- `path`
+- `tags`
+- `title`
+- `updated`
+
+## Board View
+
+Board layout uses the same row query result as table layout. The difference lives in view state:
+
+- `grouping`
+- `board_lane_colors`
+- `board_lane_order`
+- `board_card_order`
+
+Frontend board helpers in `src/hooks/database/useDatabaseBoard.ts` group rows, apply lane order, and persist board state through `databases_update`.
+
+Because board card order lives in the database view definition, it is workspace-level metadata rather than note content.
+
+## Status Colors
+
+Status colors live in the same store:
+
+```rust
+status_colors: BTreeMap<String, String>
+```
+
+`databases_status_color_set` normalizes status ids and validates colors. Supported colors:
+
+- gray
+- brown
+- orange
+- yellow
+- green
+- blue
+- purple
+- red
+
+Invalid colors are dropped on load.
+
+## Preview Context
+
+`databases_preview_context` returns richer note context for database previews:
+
+- title
+- Markdown content
+- timestamps
+- word count
+- character count
+- line count
+- reading time
+- backlinks
+
+It reads the note file and queries backlinks from the index. This command accepts an unused `_space_path` parameter for caller compatibility, but it uses the active `SpaceState`.
+
+## Frontend Flow
+
+Typical database page flow:
+
+1. `DatabasesPane` lists summaries with `databases_list`.
+2. User opens a database.
+3. Frontend calls `databases_get` to load definition and available properties.
+4. Frontend selects a view.
+5. Table or board calls `databases_query_rows`.
+6. Cell edits call `databases_update_cell`.
+7. View edits call `databases_update`.
+8. New row action calls `databases_create_row`.
+
+Available properties come from the index, not from the database store alone. If property suggestions are stale, rebuild the index.
+
+## Change Checklist
+
+When changing databases:
+
+1. Decide whether the data belongs in note frontmatter or `.glyph/databases.json`.
+2. Update Rust types and TypeScript IPC types together.
+3. Bump `DATABASES_STORE_VERSION` only when old stores need normalization or rejection.
+4. Add normalization for unsupported or old values.
+5. Keep row content derived from Markdown and index rows.
+6. Use `db_store_mutex()` for store writes.
+7. Use atomic writes for store saves and note writes.
+8. Reindex notes after any frontmatter mutation.
+9. Update both table and board behavior when changing view fields.
+
+## Debugging Map
+
+- Database missing: inspect `databases.json` and `bootstrap_defaults()`.
+- Row missing: inspect source selection and index `notes` rows.
+- Property column empty: inspect `note_properties` indexing.
+- Cell edit does not persist: inspect `apply_cell_update_to_markdown()`.
+- New row goes to wrong folder: inspect `database.new_note.folder`.
+- Board order resets: inspect `board_card_order` and `databases_update`.
+- Status color rejected: inspect `normalize_status_id()` and allowed colors.

--- a/docs/architecture/08-ai-runtime-tools-history.md
+++ b/docs/architecture/08-ai-runtime-tools-history.md
@@ -309,7 +309,7 @@ The per-run audit JSON includes:
 
 The chat history includes:
 
-- version
+- version: 1
 - stored job id, using the resolved history id
 - generated title
 - creation timestamp
@@ -317,6 +317,9 @@ The chat history includes:
 - profile details without secrets
 - messages with the assistant response appended when present
 - tool events
+
+The durable chat history schema currently uses version 1 to prevent migration
+drift.
 
 History commands:
 

--- a/docs/architecture/08-ai-runtime-tools-history.md
+++ b/docs/architecture/08-ai-runtime-tools-history.md
@@ -1,0 +1,356 @@
+# AI Runtime, Tools, and History
+
+Glyph has one AI panel in the frontend and several backend runtimes. Rig-backed providers use local workspace tools. Dedicated providers such as Codex, Amp, Claude Code, OpenCode, and Pi use native runtime modules. Completed and cancelled chat paths stream events back to React and write history under the active space.
+
+## Main Files
+
+Frontend:
+
+- `src/components/ai/AIPanel.tsx`: panel composition
+- `src/components/ai/AIComposer.tsx`: prompt input and context attachment
+- `src/components/ai/AIChatThread.tsx`: conversation rendering
+- `src/components/ai/AIToolTimeline.tsx`: tool/status rendering
+- `src/components/ai/ModelSelector.tsx`: provider/model selection
+- `src/components/ai/hooks/useRigChat.ts`: streaming chat hook
+- `src/components/ai/useAiProfiles.ts`: profile state
+- `src/components/ai/useAiContext.ts`: context attachment and build flow
+- `src/components/settings/AiSettingsPane.tsx`: AI settings shell
+- `src/components/settings/ai/`: provider, API key, model, Codex account settings
+
+Backend:
+
+- `src-tauri/src/ai_rig/types.rs`: shared AI types
+- `src-tauri/src/ai_rig/commands.rs`: profiles, secrets, chat start/cancel, history commands
+- `src-tauri/src/ai_rig/runtime.rs`: Rig provider runtime
+- `src-tauri/src/ai_rig/tools.rs`: space-scoped tool bundle
+- `src-tauri/src/ai_rig/context.rs`: context indexing and payload building
+- `src-tauri/src/ai_rig/store.rs`: app-level AI profile store
+- `src-tauri/src/ai_rig/local_secrets.rs`: per-space API keys
+- `src-tauri/src/ai_rig/history.rs`: chat history readers
+- `src-tauri/src/ai_rig/audit.rs`: audit/history writes
+- `src-tauri/src/ai_codex/`: Codex account and chat runtime
+- `src-tauri/src/ai_amp/`, `ai_claude_code/`, `ai_opencode/`, `ai_pi/`: dedicated provider runtimes
+
+## Provider Model
+
+`AiProviderKind` supports:
+
+- OpenAI
+- OpenAI-compatible
+- OpenRouter
+- Anthropic
+- Gemini
+- Ollama
+- llama.cpp
+- Codex ChatGPT
+- Amp
+- Claude Code
+- OpenCode
+- Pi
+
+Profiles store:
+
+- provider
+- model
+- base URL
+- custom headers
+- private-host permission
+- reasoning effort
+
+Profiles live in app config at `ai.json`, not in the space. API keys live per space through `local_secrets.rs` so each space can have separate credentials.
+
+Default profiles are generated in `ensure_default_profiles()`. Provider ids are stable provider keys such as `openai`, `anthropic`, and `codex_chatgpt`.
+
+## Profile Store
+
+`ai_rig/store.rs` reads and writes `ai.json` under Tauri app config.
+
+Rules:
+
+- Every supported provider gets one normalized profile.
+- Profile id and display name are derived from provider kind.
+- Deleting a profile clears model/base URL/headers rather than removing the provider slot.
+- Local providers default to `allow_private_hosts = true`.
+- Store writes use `io_atomic::write_atomic()`.
+
+Profile update commands emit `ai:profiles-updated`.
+
+## Secrets
+
+AI API keys are managed through commands:
+
+- `ai_secret_set`
+- `ai_secret_clear`
+- `ai_secret_status`
+- `ai_secret_list`
+
+These commands require an open space. They store secrets outside note content and outside `ai.json`.
+
+Current storage path:
+
+```text
+.glyph/Glyph/ai_secrets.json
+```
+
+Normal workspace file APIs and AI tools reject hidden `.glyph/` paths, so standard in-app file access cannot read this file. The file is sensitive app metadata, not an encrypted keychain item.
+
+Never put API keys into:
+
+- `.glyph/databases.json`
+- `.glyph/glyph.sqlite`
+- AI audit logs
+- frontend settings JSON
+- app traces
+
+## Chat Start Flow
+
+Frontend flow in `useRigChat()`:
+
+1. User sends text.
+2. The hook appends a user message and empty assistant message.
+3. It subscribes to `ai:chunk`, `ai:done`, and `ai:error`.
+4. It calls `ai_chat_start`.
+5. It receives `job_id`.
+6. It streams chunks into the assistant message.
+7. Done settles after a short delay so late chunks can arrive.
+
+Backend flow in `ai_chat_start()`:
+
+1. Allocate `job_id`.
+2. Resolve `history_id` from thread id or job id.
+3. Register a cancellation token in `AiState`.
+4. Force audit on unless caller explicitly already set it.
+5. Resolve active space root.
+6. Load normalized profiles and selected profile.
+7. Validate model unless the provider runtime owns its model default.
+8. Spawn an async task.
+9. Resolve API key from local secrets.
+10. Split system messages from chat messages.
+11. Call `run_request()`.
+12. Retry once for transient provider errors.
+13. Emit done or error.
+14. Write audit/history after successful or cancelled runs when a space exists.
+15. Finish the job in `AiState`.
+
+Cancellation calls `ai_chat_cancel`, which cancels the token by job id.
+
+## Runtime Selection
+
+`run_request()` chooses the runtime:
+
+- `CodexChatgpt`: `ai_codex::chat::run_with_codex`
+- `OpenCode`: `ai_opencode::run_with_opencode`
+- `Amp`: `ai_amp::run_with_amp`
+- `ClaudeCode`: `ai_claude_code::run_with_claude_code`
+- `Pi`: `ai_pi::run_with_pi`
+- everything else: `runtime::run_with_rig`
+
+Dedicated runtimes return the same tuple as Rig:
+
+```rust
+(String, bool, Vec<AiStoredToolEvent>)
+```
+
+That keeps the command and history path shared even when provider internals differ.
+
+## Rig Runtime
+
+`run_with_rig()` supports OpenAI, OpenAI-compatible, OpenRouter, Anthropic, Gemini, Ollama, and llama.cpp.
+
+It:
+
+1. Requires an open space.
+2. Adds create-mode tool discipline to the system prompt.
+3. Builds a transcript.
+4. Creates a `ToolBundle` for the active root.
+5. Builds provider client and agent.
+6. Attaches tools in create mode.
+7. Streams text and tool events through `run_stream()`.
+8. Emits finalizing status.
+
+Create mode gets tools. Chat mode does not.
+
+Ollama can retry without tools when the selected model rejects tool calling.
+
+OpenAI-compatible and llama.cpp can try alternate base URLs when needed.
+
+## Streaming Events
+
+Backend emits:
+
+- `ai:status`: thinking, tool_call, tool_result, finalizing, or provider-specific detail
+- `ai:chunk`: assistant text delta
+- `ai:tool`: tool call/result/error record
+- `ai:done`: job completed or cancelled
+- `ai:error`: job failed
+
+Frontend uses:
+
+- `useRigChat()` for chunk/done/error
+- `useAiToolEvents()` for tool timeline/status
+
+Events carry `job_id`. Frontend handlers must ignore events that do not match the active job.
+
+## Tool Bundle
+
+Rig create mode exposes tools from `ai_rig/tools.rs`:
+
+- `list_dir`
+- `search`
+- `stat`
+- `read_file`
+- `read_files_batch`
+- `write_file`
+- `apply_patch`
+- `move`
+- `mkdir`
+- `delete`
+
+Tool safety rules:
+
+- All paths are relative to active space.
+- Paths are normalized.
+- `..` is rejected.
+- hidden path components are rejected.
+- reads block binary or oversized files.
+- read output is capped.
+- list and search output is capped.
+- recursive delete requires `CONFIRM`.
+- overwrite move requires `CONFIRM`.
+- writes use `io_atomic::write_atomic()`.
+
+Tool writes currently operate at the filesystem level. If a tool writes Markdown, the normal watcher should update the index. If you add direct note-write tools, consider explicit `index_note()` calls and note-change events.
+
+## Tool Loop Limit
+
+`run_stream()` keeps at most 10 tool events. If the model loops through too many tools, the runtime returns:
+
+```text
+tool loop detected; stopping after too many tool calls
+```
+
+This protects the user from runaway tool use and unbounded history logs.
+
+## AI Context
+
+`ai_rig/context.rs` builds prompt context from selected attachments.
+
+Commands:
+
+- `ai_context_index`: list folders and files available for attachment
+- `ai_context_build`: read selected files/folders into a bounded text payload
+- `ai_context_resolve_paths`: expand attachments into concrete paths
+
+Defaults and limits:
+
+- file list limit: 20,000
+- default context budget: 12,000 chars
+- max context budget: 250,000 chars
+- token estimate: chars divided by 4
+
+Folders add a heading and then include files until budget runs out. Duplicate files are skipped.
+
+Context response includes:
+
+- `payload`
+- `manifest`
+- `resolved_paths`
+
+The manifest gets written to audit logs so users can inspect what the model saw.
+
+## Codex Account Runtime
+
+`ai_codex/commands.rs` exposes account commands:
+
+- `codex_account_read`
+- `codex_login_start`
+- `codex_login_complete`
+- `codex_logout`
+- `codex_rate_limits_read`
+
+`ai_codex/chat.rs` runs Codex chat through a JSON-RPC transport held in `CodexState`.
+
+Codex chat:
+
+- defaults model to `gpt-5.1-codex` if profile model is empty
+- starts or resumes a thread
+- sets working directory to the active space root
+- uses `approvalPolicy = "never"`
+- converts Codex notifications into Glyph AI chunk/tool/status events
+
+Because Codex owns its own account flow, it does not use API keys from `ai_secret_*`.
+
+## History and Audit
+
+After a successful or cancelled run, `ai_chat_start()` calls `write_audit_log()`.
+
+`write_audit_log()` writes two records:
+
+- per-run audit JSON under `.glyph/cache/ai/{job_id}.json`
+- chat history under `.glyph/Glyph/ai_history/{history_id}.json`
+
+Chat history lives under:
+
+```text
+.glyph/Glyph/ai_history/
+```
+
+The per-run audit JSON includes:
+
+- job id
+- profile details without secrets
+- request messages
+- context manifest
+- truncated context
+- truncated response
+- cancellation state
+- tool events
+- `outcome`, currently initialized as `null`
+
+The chat history includes:
+
+- version
+- stored job id, using the resolved history id
+- generated title
+- creation timestamp
+- cancellation state
+- profile details without secrets
+- messages with the assistant response appended when present
+- tool events
+
+History commands:
+
+- `ai_chat_history_list`
+- `ai_chat_history_get`
+
+The title generator uses the selected provider when possible. Dedicated runtimes return fixed titles such as `Codex Chat`.
+
+## Provider Metadata
+
+On startup, Rust refreshes provider support metadata from LiteLLM's provider endpoint support JSON. It caches the document in app config and falls back to cached data when network fetch fails.
+
+This powers provider settings UI. The app should tolerate missing metadata because offline use remains a core constraint.
+
+## Change Checklist
+
+When changing AI behavior:
+
+1. Keep profile config separate from API keys.
+2. Require an open space for workspace context, tools, and local secrets.
+3. Emit job-scoped events and ignore non-active jobs in React.
+4. Keep create-mode tools space-scoped.
+5. Cap tool reads, lists, searches, and context payloads.
+6. Write audit/history without secrets.
+7. Update `AiProviderKind`, default profiles, model lists, logos, settings UI, and runtime selection together when adding a provider.
+8. Preserve cancellation token checks inside streaming loops.
+9. Keep native runtimes returning the same tuple shape as Rig.
+
+## Debugging Map
+
+- Chat starts then no chunks: inspect event subscription timing in `useRigChat()`.
+- Wrong provider runtime: inspect `run_request()`.
+- Model setting ignored: inspect provider default profile and dedicated runtime defaults.
+- Tools can read hidden files: inspect `normalize_rel_path()` and `safe_join()`.
+- Context too large: inspect `ai_context_build` budget and manifest.
+- History missing: inspect active space and `write_audit_log()`.
+- Codex login hangs: inspect `codex_login_complete` notification matching by flow id.

--- a/docs/architecture/09-settings-menus-git-sync-native-windows.md
+++ b/docs/architecture/09-settings-menus-git-sync-native-windows.md
@@ -1,0 +1,319 @@
+# Settings, Menus, Git Sync, and Native Windows
+
+Glyph keeps most preferences in a Tauri store, mirrors live changes through events, and pushes native runtime settings through Tauri commands. Git sync and native windows sit beside settings because they depend on both workspace state and desktop integration.
+
+## Main Files
+
+Settings and shortcuts:
+
+- `src/lib/settings.ts`: settings store, defaults, migrations, update helpers
+- `src/components/settings/`: settings panes
+- `src/components/settings/ai/`: AI settings sections
+- `src/lib/shortcuts/`: shortcut types, registry, platform normalization
+- `src/shared/appCommandManifest.json`: command metadata
+- `src/components/app/useAppCommands.tsx`: command list and enablement
+- `src/hooks/useShortcutBindings.ts`: configured shortcut loading
+- `src/hooks/useCommandShortcuts.ts`: keyboard dispatch
+
+Menus and windows:
+
+- `src-tauri/src/lib.rs`: menu, windows, setup, global shortcut, vibrancy
+- `src-tauri/src/menu_manifest.rs`: native menu command mapping
+- `src/hooks/useMenuListeners.ts`: menu event handling
+- `src/components/quick-note/QuickNoteWindow.tsx`: quick note UI
+- `src/lib/windowLabels.ts`: window labels
+
+Git sync:
+
+- `src/hooks/useGitSync.ts`: frontend controller
+- `src/components/settings/GitSettingsPane.tsx`: settings UI
+- `src-tauri/src/git_sync/commands.rs`: Tauri commands
+- `src-tauri/src/git_sync/service.rs`: status, config, background sync
+- `src-tauri/src/git_sync/git.rs`: git command wrappers
+- `src-tauri/src/git_sync/store.rs`: per-space sync config
+- `src-tauri/src/git_sync/types.rs`: config/status types
+
+## Settings Store
+
+`src/lib/settings.ts` uses `LazyStore("settings.json")` from `@tauri-apps/plugin-store`.
+
+Settings include:
+
+- current and recent spaces
+- theme mode, accent, font families, font sizes
+- auto-update check interval
+- AI enabled and assistant mode
+- daily notes folder
+- quick notes folder
+- template folder and daily note template
+- task source
+- database UI settings
+- editor settings
+- file tree settings
+- shortcut bindings
+- onboarding flags
+
+Defaults live in the same file. The loader normalizes older values into current shapes.
+
+## Live Settings Event
+
+Settings helpers call `emitSettingsUpdated()` after updates. The event name is:
+
+```text
+settings:updated
+```
+
+Listeners include:
+
+- `UIProvider`: AI, TOC, folio, daily notes, templates
+- `FileTreeProvider`: people mentions and beautiful tags
+- `useNoteEditor`: editor feature flags and attachment settings
+- `AppShell`: collapsible headings
+- settings panes that need cross-window refresh
+
+Use this event when a setting changes live UI behavior. Do not require a full app reload for normal preference changes.
+
+## Settings That Affect Rust
+
+Some settings must be sent to Rust:
+
+- people mentions as tags: `index_set_people_mentions_as_tags_enabled`
+- menu shortcuts: `set_menu_shortcuts`
+- quick note global shortcut: `set_quick_note_global_shortcut`
+- window vibrancy: `set_window_vibrancy_theme`
+
+Keep the Tauri runtime synchronized after settings load and after updates.
+
+## Shortcut Architecture
+
+Shortcut data has three layers:
+
+1. Command metadata in `src/shared/appCommandManifest.json`
+2. Shortcut registry and normalization in `src/lib/shortcuts/`
+3. Runtime handlers in `AppShell` through `useCommandShortcuts()`
+
+The shell builds handlers from:
+
+- fixed Escape/back settings shortcuts
+- command palette/search shortcuts
+- close-window fallback
+- tab number activation
+- commands from `useAppCommands()`
+
+`allowInEditable` controls whether a shortcut can fire while focus sits in an input/editor.
+
+Native menu shortcuts use the same configured bindings. `AppShell` converts shortcut definitions with `toTauriAccelerator()` and sends them through `set_menu_shortcuts`.
+
+## Command Palette
+
+The command palette is lazy-loaded:
+
+- `loadCommandPalette()`
+- `LazyCommandPalette`
+
+`AppShell` preloads it after 500ms idle time. Commands come from `useAppCommands()`, which receives current shell state and returns action objects with enablement.
+
+Command search uses the index for note search and the command registry for command results.
+
+When adding a command:
+
+1. Put shared metadata in the manifest when needed.
+2. Add shortcut registry entry if configurable.
+3. Add action and enablement to `useAppCommands()`.
+4. Add menu mapping if the native menu should expose it.
+5. Check command palette, keyboard, and native menu paths.
+
+## Native Menus
+
+Rust builds the main menu in `src-tauri/src/lib.rs`. Menu events follow one of two paths:
+
+- Recent-space menu item emits `menu:open_recent_space`.
+- Command menu item emits `menu:app_command`.
+
+`useMenuListeners()` maps those events to shell actions:
+
+- new note
+- create from template
+- open daily note
+- save note
+- close tab
+- open/create/close/reveal space
+- Git sync
+- AI pane and context actions
+- editor formatting actions
+
+This lets native menus call the same functions as keyboard shortcuts and command palette commands.
+
+## Window Runtime
+
+`lib.rs` owns window setup and close behavior:
+
+- The main window is centered and sized to 80 percent of the current monitor.
+- macOS vibrancy applies during setup and can change later through command.
+- Settings window close requests hide the window.
+- Quick note window close requests hide the window.
+- macOS main window close requests hide the window.
+
+Quick note commands:
+
+- `show_quick_note_window`
+- `hide_quick_note_window`
+- `show_main_window`
+- `set_quick_note_global_shortcut`
+
+Use the `QUICK_NOTE_WINDOW_LOCK` pattern if you add another command that can create a singleton window from multiple triggers.
+
+## Quick Notes
+
+The quick note flow opens a small native window and writes notes into the configured quick notes folder. When a quick note should open in the main window, backend/frontend code emits:
+
+```text
+quick-note:open_note
+```
+
+`AppShell` listens and opens the note through normal workspace navigation.
+
+Quick notes still use the active space. If no space is open, quick note commands should fail or prompt through UI rather than creating files in app config.
+
+## Git Sync Model
+
+Git sync is per space. Config lives under the space, not app config.
+
+Frontend `useGitSync()` owns:
+
+- current status
+- loading/error state
+- status refresh
+- manual sync
+- auto sync resume
+- settings navigation
+
+It saves the current editor before running sync:
+
+```ts
+await saveCurrentEditor();
+```
+
+It builds run context from settings so backend can maintain managed ignores for templates and attachments.
+
+## Git Sync Status
+
+`git_sync_status_read` returns `GitSyncStatus`, derived from:
+
+- git installed check
+- repository inspection
+- sync config
+- runtime phase
+- repo health
+- local change count
+- ahead/behind count
+- preflight issue
+- conflict risk
+
+`service.rs` can auto-adopt an existing repo when the space root is already a Git repo with a remote.
+
+Unsupported state:
+
+- the active space is inside a larger Git repo
+- detached HEAD
+- wrong branch
+- missing origin
+- no commits
+- no Git installed
+
+## Git Sync Run
+
+`git_sync_run`:
+
+1. Requires an active space.
+2. Requires Git installed.
+3. Loads config.
+4. Skips auto run when disabled or paused.
+5. Refuses to start if another sync is running.
+6. Emits initial `git_sync:status`.
+7. Spawns blocking background sync.
+
+Background run:
+
+1. Inspect repository.
+2. Reject nested repo.
+3. Check repo health and conflict risk.
+4. Record last attempted timestamp.
+5. Upsert managed `.gitignore`.
+6. Fetch remote.
+7. Stage sync inclusions.
+8. Commit local changes as `Glyph sync`.
+9. Merge remote branch if it exists.
+10. Push branch, setting upstream when needed.
+11. Record success and emit status.
+
+On auto-sync failure, consecutive failures increment. After three auto failures, Git sync pauses itself.
+
+## Git Sync Conflict Posture
+
+Git sync tries to avoid overwriting remote changes:
+
+- `overlapping_change_risk()` detects conflict risk before sync.
+- Preflight issues stop the sync before mutation.
+- Conflict policy can choose local-wins merge behavior when configured.
+- Auto-sync pauses after repeated failures.
+
+Manual Git operations remain the escape hatch for complex conflicts.
+
+## Auto Sync
+
+`useGitSync()` starts an auto run once per opened space when:
+
+- status is configured
+- enabled
+- not paused
+
+It also starts an interval using `status.interval_minutes`, clamped to at least one minute in the frontend and one to 1,440 minutes in the backend.
+
+## Native Notifications
+
+Rust sends notifications for:
+
+- index rebuild complete
+- AI response ready
+- AI request failed
+
+Git sync status uses app events instead of system notifications.
+
+## Change Checklist
+
+When changing settings:
+
+1. Add a default value.
+2. Add normalization for unknown or legacy values.
+3. Add update helper.
+4. Emit `settings:updated` with the smallest useful payload.
+5. Update live listeners.
+6. Sync Rust runtime when needed.
+
+When changing shortcuts or menus:
+
+1. Update command manifest.
+2. Update shortcut registry.
+3. Update `useAppCommands()`.
+4. Update native menu mapping.
+5. Verify palette, keyboard, and menu paths.
+
+When changing Git sync:
+
+1. Preserve editor flush before sync.
+2. Keep config per space.
+3. Emit `git_sync:status` after runtime state changes.
+4. Handle missing Git and unsupported repo shapes.
+5. Avoid running two syncs at the same time.
+6. Keep auto-sync failure pause behavior.
+
+## Debugging Map
+
+- Setting changes only after restart: inspect `settings:updated` payload and listeners.
+- Native shortcut text stale: inspect `set_menu_shortcuts`.
+- Global quick note shortcut dead: inspect `set_quick_note_global_shortcut`.
+- Command works in palette but not menu: inspect `useMenuListeners()` and `menu_manifest.rs`.
+- Git sync starts with stale note content: inspect `saveCurrentEditor()` in `useGitSync()`.
+- Auto sync keeps running after failure: inspect consecutive failure count and paused config.
+- Window closes instead of hiding on macOS: inspect `on_window_event` in `lib.rs`.

--- a/docs/architecture/10-security-and-operational-invariants.md
+++ b/docs/architecture/10-security-and-operational-invariants.md
@@ -1,0 +1,285 @@
+# Security and Operational Invariants
+
+Glyph is an offline-first desktop app that works on user-selected folders. The app must protect three things: files outside the active space, app metadata under `.glyph/`, and user secrets. Most safety comes from narrow path APIs, atomic writes, explicit network checks, and a clear source-of-truth rule.
+
+## Main Files
+
+Backend safety:
+
+- `src-tauri/src/paths.rs`: safe relative path joining
+- `src-tauri/src/space_fs/helpers.rs`: hidden path denial and etag helpers
+- `src-tauri/src/io_atomic.rs`: atomic writes and copies
+- `src-tauri/src/net.rs`: SSRF-style URL host checks
+- `src-tauri/src/ai_rig/helpers.rs`: AI base URL validation and HTTP helpers
+- `src-tauri/src/ai_rig/tools.rs`: AI tool path and size limits
+- `src-tauri/src/ai_rig/local_secrets.rs`: per-space AI secrets store
+- `src-tauri/src/license/`: license storage and Gumroad verification
+- `src-tauri/src/glyph_paths.rs`: controlled `.glyph/` paths
+- `src-tauri/src/space/watcher.rs`: watcher and local-change suppression
+
+Frontend safety:
+
+- `src/lib/tauri.ts`: typed IPC boundary
+- `src/lib/settings.ts`: settings normalization
+- `src/components/preview/MarkdownEditorPane.tsx`: save conflict handling
+- `src/hooks/useGitSync.ts`: editor flush before sync
+
+## Invariant 1: Notes Live as Files
+
+Markdown files are the source of truth for note content.
+
+Allowed derived state:
+
+- `.glyph/glyph.sqlite`
+- `.glyph/databases.json`
+- `.glyph/cache/ai/`
+- `.glyph/Glyph/ai_history/`
+- appearance and pinned-file stores
+- app settings stores
+
+Derived state must be rebuildable or disposable where practical. The SQLite index must never become the only copy of a note.
+
+## Invariant 2: Space Paths Stay Inside the Space
+
+Any user-controlled path that points into a space must pass through:
+
+```rust
+deny_hidden_rel_path(&rel)?;
+let abs = paths::join_under(&root, &rel)?;
+```
+
+`join_under()` rejects:
+
+- absolute paths
+- parent directory components
+- root directory components
+- platform prefixes
+
+`deny_hidden_rel_path()` rejects any path component starting with `.`.
+
+Together, those helpers protect:
+
+- files outside the selected folder
+- `.glyph/`
+- hidden files and folders
+
+Do not manually concatenate paths. Do not canonicalize a user path and then strip prefixes unless you have checked the exact race and symlink behavior you need.
+
+## Invariant 3: `.glyph/` Is App Metadata
+
+Normal workspace file APIs must not expose `.glyph/`.
+
+Only app-owned modules should read or write it:
+
+- `glyph_paths.rs`
+- index database code
+- database store code
+- AI history/secrets code
+- appearance stores
+- pinned files
+- Git sync config
+
+User-visible file tree commands hide dotfiles and reject hidden paths. If a feature needs to show `.glyph/` for diagnostics, build a dedicated diagnostic command that redacts secrets and does not reuse normal file APIs.
+
+## Invariant 4: Writes Are Crash-Safer
+
+Durable overwrites should use `io_atomic::write_atomic()`:
+
+1. Create parent directory.
+2. Write to a hidden temp file beside the destination.
+3. Sync the temp file.
+4. Rename temp file to destination.
+5. Sync the parent directory.
+
+Use `io_atomic::copy_atomic()` for duplicate/copy operations.
+
+Use `OpenOptions::create_new` when the operation must reserve a new file without overwriting, such as database row creation and open-or-create text commands.
+
+## Invariant 5: Editor Saves Check mtime
+
+`space_write_text` accepts `base_mtime_ms`. When present, Rust compares it with the on-disk mtime and rejects stale writes.
+
+`MarkdownEditorPane` handles this conflict by refreshing the file and retrying once. This is a last-writer strategy with explicit conflict detection. It is not a merge algorithm.
+
+Do not remove `base_mtime_ms` from editor saves.
+
+## Invariant 6: Local Writes and Watcher Events Do Not Loop
+
+Markdown writes call `mark_recent_local_change()` before writing. The watcher checks `has_recent_local_change()` and skips external reindex/event handling for recent local writes.
+
+The writer then emits `notes:external_changed` after indexing.
+
+This prevents duplicate indexing and reload loops while keeping the UI informed.
+
+## Invariant 7: SQLite Is Derived
+
+`.glyph/glyph.sqlite` stores derived rows for:
+
+- notes
+- links
+- tags
+- properties
+- relationships
+- FTS
+- tasks
+
+When parser behavior changes, rebuild the index. When schema changes, add a migration and increment `INDEX_DB_VERSION`.
+
+Never write a note only by updating SQLite. Write Markdown, then reindex.
+
+## Invariant 8: Database Rows Write Frontmatter
+
+Workspace databases store definitions in `.glyph/databases.json`. Rows come from notes.
+
+Editable cells update YAML frontmatter and reindex the note. Read-only columns stay read-only because they derive from filesystem paths, timestamps, or links.
+
+Do not add a database column that stores row data only in `databases.json` unless you intentionally design a new storage model.
+
+## Invariant 9: AI Tools Stay in the Space
+
+AI tools in `ai_rig/tools.rs` use their own path normalization:
+
+- normalize slashes
+- remove empty and current-directory segments
+- reject `..`
+- reject hidden components
+- join under active space
+
+They also cap:
+
+- read bytes
+- read chars
+- list size
+- search result size
+- batch file count
+
+Recursive delete and overwrite move require the `CONFIRM` token.
+
+Keep those limits when adding tools. If a tool can mutate files, use atomic writes and consider explicit index refresh behavior for Markdown.
+
+## Invariant 10: Network Hosts Need Validation
+
+`net.rs` blocks:
+
+- localhost
+- private IPv4
+- loopback
+- link-local
+- broadcast
+- documentation ranges
+- unspecified
+- multicast
+- private IPv6 and local IPv6 ranges
+
+It resolves DNS for non-literal hosts and rejects any forbidden address. It only allows HTTP(S) schemes.
+
+`ai_rig/helpers.rs` uses this for AI base URLs. HTTP URLs are blocked unless the profile enables `allow_private_hosts`, which exists for local providers such as Ollama, llama.cpp, and OpenCode.
+
+User-supplied network features should use `net::validate_url_host()` or a stricter wrapper.
+
+## Invariant 11: Secrets Stay Out of Logs and Normal File APIs
+
+Current AI secrets are stored per space by `ai_rig/local_secrets.rs` in:
+
+```text
+.glyph/Glyph/ai_secrets.json
+```
+
+Normal file APIs block `.glyph/`, so the file tree and AI tools cannot read this file through their standard paths. That does not make the file encrypted. Treat it as sensitive app metadata.
+
+Rules:
+
+- Never log API keys.
+- Never write API keys to AI history.
+- Never include secrets in context manifests.
+- Never expose `.glyph/Glyph/ai_secrets.json` through previews or file tree commands.
+- Consider OS keychain migration separately if the product requires encrypted local secret storage.
+
+## Invariant 12: License Keys Are Hashed and Masked
+
+License activation verifies through Gumroad. Local license records live in Tauri app config as `license.json`.
+
+The local record stores:
+
+- license state
+- trial window
+- activation and verification timestamps
+- hashed license key
+- masked license key
+- last error code
+
+It does not store the raw license key after activation. Activation failures record error state without storing the submitted raw key.
+
+## Invariant 13: Git Sync Flushes the Editor
+
+`useGitSync()` calls `saveCurrentEditor()` before `git_sync_run`.
+
+This keeps the active editor from being left out of a commit. Preserve this call when changing sync triggers or moving Git sync control.
+
+Git sync also refuses unsupported repository states and pauses auto-sync after repeated failures.
+
+## Invariant 14: Command Types Must Match Rust
+
+The TypeScript command map and Rust command registration must stay aligned.
+
+When adding commands:
+
+- Rust command function
+- `generate_handler!`
+- `TauriCommands`
+- frontend call sites
+
+When changing payload casing, check Rust command attributes such as `rename_all = "snake_case"`.
+
+## Invariant 15: Events Are Part of State Consistency
+
+Events keep surfaces synchronized:
+
+- `space:fs_changed`: file tree and removal handling
+- `notes:external_changed`: editor reload and cache invalidation
+- `settings:updated`: live settings propagation
+- `git_sync:status`: sync status updates
+- `ai:*`: chat streaming and timeline
+- `menu:*`: native menu actions
+
+If a backend command mutates data that multiple UI areas cache, emit an event or invalidate through the existing event path.
+
+## Operational Checks
+
+Run these checks before merging broad storage or runtime changes:
+
+1. Open a space with nested folders.
+2. Create, edit, rename, duplicate, and delete a note.
+3. Confirm the file tree refreshes.
+4. Confirm the note reappears in search after edit.
+5. Confirm tags and backlinks update after edit.
+6. Create or edit a database row and inspect the note frontmatter.
+7. Paste an image and reload the note.
+8. Trigger AI context with a folder and confirm hidden files stay excluded.
+9. Run Git sync after editing an active note.
+10. Close and reopen the app and confirm last space, settings, and recent spaces restore.
+
+## Security Review Prompts
+
+Ask these questions during review:
+
+- Does this code accept a path from React, AI, CLI output, or user text?
+- Does it pass through `join_under()` and hidden-path denial?
+- Does it write through `write_atomic()` or `create_new`?
+- Does it update derived state after changing Markdown?
+- Does it expose `.glyph/` directly or indirectly?
+- Does it place secrets in logs, JSON history, SQLite, or frontend state?
+- Does it accept a URL or base URL?
+- Does it validate host and scheme?
+- Does it emit an event for cached UI state?
+- Does it run blocking filesystem, SQLite, or Git work off the async runtime?
+
+## Known Tradeoffs
+
+- AI secrets currently live in a hidden per-space JSON file, not an OS keychain.
+- Editor conflict handling retries once and does not merge.
+- SQLite migrations are manual and versioned through `user_version`.
+- Database filters run over hydrated rows after source selection, so very large databases need careful limits.
+- AI tools can mutate files in create mode, within the active space and tool limits.
+
+Document these tradeoffs when a feature depends on them. Do not hide them behind generic safety language.

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,15 +7,16 @@
 
 ## Network Hardening
 
-- Web clipping blocks `localhost` and private IP ranges by default and uses strict timeouts and size limits.
-- AI providers validate `base_url` hosts similarly; non-HTTPS base URLs are blocked unless the profile explicitly enables `allow_private_hosts` (intended for local providers like Ollama).
+- `src-tauri/src/net.rs` rejects `localhost`, private IPs, loopback, link-local, documentation ranges, multicast, unspecified hosts, and non-HTTP(S) schemes.
+- AI provider `base_url` values pass through that host validation. Plain HTTP is blocked unless the profile enables `allow_private_hosts`, which is intended for local providers such as Ollama and llama.cpp.
 
 ## Secrets Handling
 
-- AI API keys are stored in the OS keychain via the Rust `keyring` crate.
-- Secrets are not written to the space or to `ai.json` (legacy secrets are migrated on load when possible).
+- AI API keys are stored per space in `.glyph/Glyph/ai_secrets.json` by `src-tauri/src/ai_rig/local_secrets.rs`.
+- Normal workspace file APIs block hidden `.glyph/` paths, so the file tree, previews, and AI tools cannot read that file through standard space-relative access.
+- Secrets are not written to `ai.json`, SQLite index rows, or AI history logs.
 
 ## Audit Logs
 
-- AI requests/responses are optionally logged under `space/cache/ai/` without secrets.
-- Logs include the user-approved context manifest and an `outcome` field (applied/rejected/created_*).
+- Completed and cancelled AI requests write per-run audit JSON under `.glyph/cache/ai/` and chat history under `.glyph/Glyph/ai_history/`.
+- Audit JSON includes request messages, context manifest, truncated context, truncated response, tool events, and an `outcome` field currently initialized as `null`.

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -20,7 +20,7 @@ function commandMatchesQuery(command: Command, normalizedQuery: string) {
 	const queryTokens = command.hideWhenQueryEmpty
 		? tokens.filter((token) => token !== "setting" && token !== "settings")
 		: tokens;
-	if (command.hideWhenQueryEmpty && queryTokens.length === 0) return false;
+	if (command.hideWhenQueryEmpty && queryTokens.length === 0) return true;
 	const haystack = [
 		command.label,
 		command.category ?? "",

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -14,6 +14,24 @@ import { useCommandSearch } from "./useCommandSearch";
 
 export type { Command } from "./commandPaletteHelpers";
 
+function commandMatchesQuery(command: Command, normalizedQuery: string) {
+	if (!normalizedQuery) return !command.hideWhenQueryEmpty;
+	const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+	const queryTokens = command.hideWhenQueryEmpty
+		? tokens.filter((token) => token !== "setting" && token !== "settings")
+		: tokens;
+	if (command.hideWhenQueryEmpty && queryTokens.length === 0) return false;
+	const haystack = [
+		command.label,
+		command.category ?? "",
+		command.id,
+		...(command.searchTerms ?? []),
+	]
+		.join(" ")
+		.toLowerCase();
+	return queryTokens.every((token) => haystack.includes(token));
+}
+
 interface CommandPaletteProps {
 	open: boolean;
 	initialTab?: Tab;
@@ -59,16 +77,7 @@ export function CommandPalette({
 	const filtered = useMemo(() => {
 		if (activeTab !== "commands") return [];
 		const q = query.trim().toLowerCase();
-		const matches = q
-			? commands.filter((cmd) => {
-					const category = cmd.category?.toLowerCase() ?? "";
-					return (
-						cmd.label.toLowerCase().includes(q) ||
-						category.includes(q) ||
-						cmd.id.toLowerCase().includes(q)
-					);
-				})
-			: commands;
+		const matches = commands.filter((cmd) => commandMatchesQuery(cmd, q));
 		return matches.filter((cmd) => cmd.enabled !== false);
 	}, [commands, query, activeTab]);
 

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -5,16 +5,47 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { memo } from "react";
+import { memo, useMemo, useState } from "react";
 import { useUILayoutContext } from "../../contexts";
 import { useLicenseStatus } from "../../lib/license";
 import { cn } from "../../lib/utils";
+import { Search, X } from "../Icons";
 import { SETTINGS_TABS, type SettingsTab } from "../settings/settingsConfig";
+import {
+	scrollToSettingsSearchEntry,
+	searchSettingsEntries,
+} from "../settings/settingsSearch";
 import { Button } from "../ui/shadcn/button";
 
 export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 	const { settingsTab, setSettingsTab, closeSettings } = useUILayoutContext();
 	const { status: licenseStatus } = useLicenseStatus(false);
+	const [settingsSearchQuery, setSettingsSearchQuery] = useState("");
+	const [settingsSearchActive, setSettingsSearchActive] = useState(false);
+	const settingsSearchResults = useMemo(
+		() => searchSettingsEntries(settingsSearchQuery, 8),
+		[settingsSearchQuery],
+	);
+	const hasSearchQuery =
+		settingsSearchActive && settingsSearchQuery.trim().length > 0;
+
+	const selectSettingsTab = (tab: SettingsTab) => {
+		setSettingsTab(tab);
+	};
+
+	const selectSearchResult = (
+		result: (typeof settingsSearchResults)[number],
+	) => {
+		setSettingsSearchActive(false);
+		setSettingsSearchQuery("");
+		setSettingsTab(result.tab);
+		scrollToSettingsSearchEntry(result);
+	};
+
+	const clearSettingsSearch = () => {
+		setSettingsSearchActive(false);
+		setSettingsSearchQuery("");
+	};
 
 	return (
 		<>
@@ -29,29 +60,102 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 						<span className="sidebarQuickActionLabel">Back</span>
 					</button>
 				</div>
-				<div className="sidebarQuickActions settingsSidebarTabs">
-					{SETTINGS_TABS.map((tab) => (
+
+				<div className="settingsSidebarSearch">
+					<Search size={14} className="settingsSidebarSearchIcon" />
+					<input
+						type="search"
+						className="settingsSidebarSearchInput"
+						value={settingsSearchQuery}
+						onChange={(event) => {
+							const nextQuery = event.target.value;
+							setSettingsSearchQuery(nextQuery);
+							setSettingsSearchActive(nextQuery.trim().length > 0);
+						}}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" && settingsSearchResults[0]) {
+								event.preventDefault();
+								selectSearchResult(settingsSearchResults[0]);
+							}
+							if (event.key === "Escape" && settingsSearchQuery) {
+								event.preventDefault();
+								clearSettingsSearch();
+							}
+						}}
+						placeholder="Search settings"
+						aria-label="Search settings"
+					/>
+					{hasSearchQuery ? (
 						<button
-							key={tab.id}
 							type="button"
-							data-tab={tab.id}
-							className={cn(
-								"sidebarQuickActionBtn settingsTabButton",
-								settingsTab === tab.id && "settingsTabButtonActive",
-							)}
-							onClick={() => setSettingsTab(tab.id as SettingsTab)}
-							aria-pressed={settingsTab === tab.id}
-							aria-current={settingsTab === tab.id ? "page" : undefined}
+							className="settingsSidebarSearchClear"
+							onClick={clearSettingsSearch}
+							aria-label="Clear settings search"
 						>
-							<span className="settingsTabIcon" aria-hidden="true">
-								{tab.renderIcon()}
-							</span>
-							<span className="sidebarQuickActionLabel settingsTabLabel">
-								{tab.label}
-							</span>
+							<X size={13} />
 						</button>
-					))}
+					) : null}
 				</div>
+
+				{hasSearchQuery ? (
+					<div className="settingsSidebarSearchResults" aria-live="polite">
+						{settingsSearchResults.length > 0 ? (
+							settingsSearchResults.map((result) => (
+								<button
+									key={result.id}
+									type="button"
+									className={cn(
+										"settingsSearchResultButton",
+										settingsTab === result.tab &&
+											"settingsSearchResultButtonActive",
+									)}
+									onClick={() => selectSearchResult(result)}
+									aria-current={settingsTab === result.tab ? "page" : undefined}
+								>
+									<span className="settingsSearchResultTitle">
+										{result.title}
+									</span>
+									<span className="settingsSearchResultMeta">
+										{result.section
+											? `${result.tabLabel} / ${result.section}`
+											: result.tabLabel}
+									</span>
+									{result.description ? (
+										<span className="settingsSearchResultDescription">
+											{result.description}
+										</span>
+									) : null}
+								</button>
+							))
+						) : (
+							<div className="settingsSearchEmpty">No matching settings</div>
+						)}
+					</div>
+				) : (
+					<div className="sidebarQuickActions settingsSidebarTabs">
+						{SETTINGS_TABS.map((tab) => (
+							<button
+								key={tab.id}
+								type="button"
+								data-tab={tab.id}
+								className={cn(
+									"sidebarQuickActionBtn settingsTabButton",
+									settingsTab === tab.id && "settingsTabButtonActive",
+								)}
+								onClick={() => selectSettingsTab(tab.id)}
+								aria-pressed={settingsTab === tab.id}
+								aria-current={settingsTab === tab.id ? "page" : undefined}
+							>
+								<span className="settingsTabIcon" aria-hidden="true">
+									{tab.renderIcon()}
+								</span>
+								<span className="sidebarQuickActionLabel settingsTabLabel">
+									{tab.label}
+								</span>
+							</button>
+						))}
+					</div>
+				)}
 			</div>
 
 			<div className="settingsSidebarFooter">

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -10,7 +10,7 @@ import { useUILayoutContext } from "../../contexts";
 import { useLicenseStatus } from "../../lib/license";
 import { cn } from "../../lib/utils";
 import { Search, X } from "../Icons";
-import { SETTINGS_TABS, type SettingsTab } from "../settings/settingsConfig";
+import { SETTINGS_TABS } from "../settings/settingsConfig";
 import {
 	scrollToSettingsSearchEntry,
 	searchSettingsEntries,
@@ -28,10 +28,6 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 	);
 	const hasSearchQuery =
 		settingsSearchActive && settingsSearchQuery.trim().length > 0;
-
-	const selectSettingsTab = (tab: SettingsTab) => {
-		setSettingsTab(tab);
-	};
 
 	const selectSearchResult = (
 		result: (typeof settingsSearchResults)[number],
@@ -142,7 +138,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 									"sidebarQuickActionBtn settingsTabButton",
 									settingsTab === tab.id && "settingsTabButtonActive",
 								)}
-								onClick={() => selectSettingsTab(tab.id)}
+								onClick={() => setSettingsTab(tab.id)}
 								aria-pressed={settingsTab === tab.id}
 								aria-current={settingsTab === tab.id ? "page" : undefined}
 							>

--- a/src/components/app/commandPaletteHelpers.ts
+++ b/src/components/app/commandPaletteHelpers.ts
@@ -7,10 +7,12 @@ export interface Command {
 	label: string;
 	icon?: ReactNode;
 	category?: string;
+	searchTerms?: readonly string[];
 	shortcut?: Shortcut;
 	action: () => void | Promise<void>;
 	enabled?: boolean;
 	allowInEditable?: boolean;
+	hideWhenQueryEmpty?: boolean;
 }
 
 export type Tab = "commands" | "search";

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -48,6 +48,11 @@ import { isMarkdownPath, parentDir } from "../../utils/path";
 import { ChevronDown, ChevronUp } from "../Icons";
 import { EDITOR_ACTIONS } from "../editor/editorActions";
 import type { SettingsTab } from "../settings/settingsConfig";
+import {
+	SETTINGS_SEARCH_ENTRIES,
+	type SettingsSearchEntry,
+	scrollToSettingsSearchEntry,
+} from "../settings/settingsSearch";
 import type { Command } from "./CommandPalette";
 
 interface GitSyncCommandActions {
@@ -166,6 +171,50 @@ function buildEditorCommands({
 			dispatchEditorMenuAction({ action: action.id });
 		},
 	}));
+}
+
+const SETTINGS_TAB_LABELS = {
+	general: "General",
+	appearance: "Appearance",
+	shortcuts: "Shortcuts",
+	ai: "Glyph AI",
+	space: "Space",
+	git: "Git",
+	advanced: "Advanced",
+	about: "About",
+} as const satisfies Record<SettingsTab, string>;
+
+function settingsSearchCommandLabel({
+	section,
+	title,
+}: Pick<SettingsSearchEntry, "section" | "title">) {
+	return section && section !== title ? `${section}: ${title}` : title;
+}
+
+function buildSettingsSearchCommands(
+	openSettings: UseAppCommandsDeps["openSettings"],
+): Command[] {
+	return SETTINGS_SEARCH_ENTRIES.map((entry: SettingsSearchEntry) => {
+		const tabLabel = SETTINGS_TAB_LABELS[entry.tab];
+		return {
+			id: `settings-search:${entry.id}`,
+			label: settingsSearchCommandLabel(entry),
+			icon: <HugeiconsIcon icon={Settings01Icon} size={16} strokeWidth={0.9} />,
+			category: `Settings > ${tabLabel}`,
+			searchTerms: [
+				"settings",
+				tabLabel,
+				entry.section ?? "",
+				entry.description ?? "",
+				...(entry.keywords ?? []),
+			],
+			hideWhenQueryEmpty: true,
+			action: () => {
+				openSettings(entry.tab);
+				scrollToSettingsSearchEntry(entry);
+			},
+		};
+	});
 }
 
 function buildAiCommands({
@@ -320,6 +369,7 @@ export function useAppCommands({
 			spacePath,
 		});
 		const editorCommands = buildEditorCommands({ activeMarkdownTabPath });
+		const settingsSearchCommands = buildSettingsSearchCommands(openSettings);
 
 		const baseCommands: Command[] = [
 			{
@@ -783,7 +833,12 @@ export function useAppCommands({
 			},
 		];
 		return resolveCommandShortcuts(
-			[...baseCommands, ...aiCommands, ...editorCommands],
+			[
+				...baseCommands,
+				...settingsSearchCommands,
+				...aiCommands,
+				...editorCommands,
+			],
 			getBinding,
 		);
 	}, [

--- a/src/components/settings/SettingsScaffold.tsx
+++ b/src/components/settings/SettingsScaffold.tsx
@@ -36,7 +36,11 @@ export function SettingsSection({
 	aside,
 }: SettingsSectionProps) {
 	return (
-		<section id={id} className={cn("settingsSection", className)}>
+		<section
+			id={id}
+			className={cn("settingsSection", className)}
+			data-settings-section-title={title}
+		>
 			<div className="settingsSectionHeader">
 				<div className="settingsCardTitle">{title}</div>
 				{aside ? <div className="settingsCardActions">{aside}</div> : null}
@@ -58,6 +62,7 @@ export function SettingsRow({
 	interactive = true,
 }: SettingsRowProps) {
 	const CopyTag = htmlFor ? "label" : "div";
+	const rowTitle = typeof label === "string" ? label : undefined;
 
 	return (
 		<div
@@ -67,6 +72,7 @@ export function SettingsRow({
 				stacked && "settingsFieldStacked",
 				className,
 			)}
+			data-settings-row-title={rowTitle}
 		>
 			<CopyTag className="settingsFieldCopy" htmlFor={htmlFor}>
 				<div className="settingsLabel">{label}</div>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -1,0 +1,694 @@
+import { SETTINGS_TABS, type SettingsTab } from "./settingsConfig";
+
+export interface SettingsSearchEntry {
+	id: string;
+	tab: SettingsTab;
+	title: string;
+	section?: string;
+	description?: string;
+	keywords?: readonly string[];
+}
+
+export interface SettingsSearchMatch extends SettingsSearchEntry {
+	tabLabel: string;
+}
+
+const SETTINGS_SEARCH_TARGET_CLASS = "settingsSearchTarget";
+
+const SETTINGS_SEARCH_ITEMS = [
+	{
+		id: "general-license",
+		tab: "general",
+		title: "License",
+		description: "Trial status, license key, activation, and official build.",
+		keywords: ["trial", "activate", "activation", "subscription", "purchase"],
+	},
+	{
+		id: "general-trial-status",
+		tab: "general",
+		section: "License",
+		title: "Trial status",
+		description: "Remaining time on the current trial for this device.",
+		keywords: ["trial remaining", "expired"],
+	},
+	{
+		id: "general-activated",
+		tab: "general",
+		section: "License",
+		title: "Activated",
+		description: "Activation date for the local Glyph license.",
+		keywords: ["licensed", "license date"],
+	},
+	{
+		id: "general-license-key",
+		tab: "general",
+		section: "License",
+		title: "License key",
+		description: "View the masked license key stored locally.",
+		keywords: ["serial", "activation key"],
+	},
+	{
+		id: "general-activate-glyph",
+		tab: "general",
+		section: "License",
+		title: "Activate Glyph",
+		description: "Enter a license key to unlock Glyph permanently.",
+		keywords: ["activate", "buy", "official build"],
+	},
+	{
+		id: "general-official-build",
+		tab: "general",
+		section: "License",
+		title: "Official build",
+		description:
+			"Purchase an official license for support and automatic updates.",
+		keywords: ["community build", "buy", "updates"],
+	},
+	{
+		id: "general-license-help",
+		tab: "general",
+		section: "License",
+		title: "Help",
+		description: "Get help with licensing, lost keys, or purchase issues.",
+		keywords: ["support", "remove local activation"],
+	},
+	{
+		id: "appearance-theme-mode",
+		tab: "appearance",
+		section: "Theme",
+		title: "Select Theme",
+		description: "Choose system, light, or dark mode.",
+		keywords: ["mode", "system", "light", "dark"],
+	},
+	{
+		id: "appearance-light-theme",
+		tab: "appearance",
+		section: "Theme",
+		title: "Light theme",
+		keywords: ["theme", "color"],
+	},
+	{
+		id: "appearance-dark-theme",
+		tab: "appearance",
+		section: "Theme",
+		title: "Dark theme",
+		keywords: ["theme", "color"],
+	},
+	{
+		id: "appearance-translucent-app",
+		tab: "appearance",
+		section: "Theme",
+		title: "Translucent app",
+		keywords: ["window", "glass", "blur"],
+	},
+	{
+		id: "appearance-accent",
+		tab: "appearance",
+		section: "Accent",
+		title: "Palette",
+		description: "Set the app accent color.",
+		keywords: ["accent", "color", "palette"],
+	},
+	{
+		id: "appearance-interface-font",
+		tab: "appearance",
+		section: "Typography",
+		title: "Interface font",
+		keywords: ["font", "ui", "sans"],
+	},
+	{
+		id: "appearance-monospace-font",
+		tab: "appearance",
+		section: "Typography",
+		title: "Monospace font",
+		keywords: ["font", "code", "mono"],
+	},
+	{
+		id: "appearance-ui-font-size",
+		tab: "appearance",
+		section: "Typography",
+		title: "UI font size",
+		keywords: ["font", "text", "interface"],
+	},
+	{
+		id: "appearance-editor-font-size",
+		tab: "appearance",
+		section: "Typography",
+		title: "Editor font size",
+		keywords: ["font", "text", "notes"],
+	},
+	{
+		id: "shortcuts-customize",
+		tab: "shortcuts",
+		section: "Customize Shortcuts",
+		title: "Customize Shortcuts",
+		description: "Edit keyboard shortcuts.",
+		keywords: ["hotkeys", "keybindings", "commands"],
+	},
+	{
+		id: "shortcuts-search",
+		tab: "shortcuts",
+		section: "Customize Shortcuts",
+		title: "Search actions, categories, or shortcuts",
+		description:
+			"Filter shortcuts by action, category, binding, or description.",
+		keywords: ["filter", "find shortcuts", "shortcut search"],
+	},
+	{
+		id: "shortcuts-workspace",
+		tab: "shortcuts",
+		section: "Workspace",
+		title: "Workspace shortcuts",
+		keywords: ["space", "window", "workspace"],
+	},
+	{
+		id: "shortcuts-navigation",
+		tab: "shortcuts",
+		section: "Navigation",
+		title: "Navigation shortcuts",
+		keywords: ["move", "go", "navigate"],
+	},
+	{
+		id: "shortcuts-search-category",
+		tab: "shortcuts",
+		section: "Search",
+		title: "Search shortcuts",
+		keywords: ["find", "quick search", "command palette"],
+	},
+	{
+		id: "shortcuts-file-operations",
+		tab: "shortcuts",
+		section: "File Operations",
+		title: "File Operations shortcuts",
+		keywords: ["file", "folder", "rename", "delete"],
+	},
+	{
+		id: "shortcuts-tabs",
+		tab: "shortcuts",
+		section: "Tabs",
+		title: "Tabs shortcuts",
+		keywords: ["tab", "open tab", "close tab"],
+	},
+	{
+		id: "shortcuts-ai",
+		tab: "shortcuts",
+		section: "AI",
+		title: "AI shortcuts",
+		keywords: ["assistant", "chat", "glyph ai"],
+	},
+	{
+		id: "shortcuts-editor",
+		tab: "shortcuts",
+		section: "Editor",
+		title: "Editor shortcuts",
+		keywords: ["note", "markdown", "editing"],
+	},
+	{
+		id: "ai-features",
+		tab: "ai",
+		section: "Availability",
+		title: "AI features",
+		description: "Turn AI tools on or off across Glyph.",
+		keywords: ["assistant", "chat", "enable", "disable"],
+	},
+	{
+		id: "ai-configuration",
+		tab: "ai",
+		section: "Availability",
+		title: "Configuration",
+		keywords: ["providers", "models", "account"],
+	},
+	{
+		id: "ai-provider-service",
+		tab: "ai",
+		section: "Provider",
+		title: "Service",
+		keywords: ["provider", "openai", "anthropic", "ollama"],
+	},
+	{
+		id: "ai-provider-model",
+		tab: "ai",
+		section: "Provider",
+		title: "Model",
+		keywords: ["provider", "model", "assistant"],
+	},
+	{
+		id: "ai-reasoning-level",
+		tab: "ai",
+		section: "Provider",
+		title: "Reasoning level",
+		keywords: ["effort", "thinking"],
+	},
+	{
+		id: "ai-base-url",
+		tab: "ai",
+		section: "Provider",
+		title: "Base URL",
+		keywords: ["endpoint", "local", "server"],
+	},
+	{
+		id: "ai-local-network",
+		tab: "ai",
+		section: "Provider",
+		title: "Allow local network",
+		keywords: ["localhost", "lan", "network"],
+	},
+	{
+		id: "ai-api-key",
+		tab: "ai",
+		section: "API Key",
+		title: "Set key",
+		keywords: ["secret", "token", "credential", "update key"],
+	},
+	{
+		id: "ai-chatgpt-account",
+		tab: "ai",
+		section: "ChatGPT Account",
+		title: "ChatGPT Account",
+		keywords: ["codex", "account", "authentication", "rate limits"],
+	},
+	{
+		id: "ai-chatgpt-identity",
+		tab: "ai",
+		section: "ChatGPT Account",
+		title: "Identity",
+		description: "The connected account Glyph is currently using for Codex.",
+		keywords: ["email", "display name", "connect", "disconnect"],
+	},
+	{
+		id: "ai-chatgpt-authentication",
+		tab: "ai",
+		section: "ChatGPT Account",
+		title: "Authentication",
+		description: "How the current ChatGPT session is authenticated.",
+		keywords: ["auth mode", "session"],
+	},
+	{
+		id: "ai-chatgpt-rate-limits",
+		tab: "ai",
+		section: "ChatGPT Account",
+		title: "Rate limits",
+		description: "Review remaining capacity for the connected account.",
+		keywords: ["usage", "remaining", "resets"],
+	},
+	{
+		id: "space-daily-notes-folder",
+		tab: "space",
+		section: "Daily Notes",
+		title: "Folder",
+		description: "Choose where daily notes are created.",
+		keywords: ["journal", "today", "date"],
+	},
+	{
+		id: "space-quick-notes-folder",
+		tab: "space",
+		section: "Quick Notes",
+		title: "Folder",
+		description: "Choose where quick notes are saved.",
+		keywords: ["capture", "inbox"],
+	},
+	{
+		id: "space-attachments-location",
+		tab: "space",
+		section: "Attachments",
+		title: "Location",
+		keywords: ["assets", "files", "images", "folder"],
+	},
+	{
+		id: "space-template-folder",
+		tab: "space",
+		section: "Templates",
+		title: "Template folder",
+		keywords: ["templates", "folder"],
+	},
+	{
+		id: "space-default-daily-template",
+		tab: "space",
+		section: "Templates",
+		title: "Default daily note template",
+		keywords: ["templates", "daily notes"],
+	},
+	{
+		id: "space-search-index-status",
+		tab: "space",
+		section: "Search Index",
+		title: "Status",
+		keywords: ["index", "rebuild", "search"],
+	},
+	{
+		id: "git-availability",
+		tab: "git",
+		section: "Connection",
+		title: "Git availability",
+		keywords: ["sync", "repository"],
+	},
+	{
+		id: "git-repository-state",
+		tab: "git",
+		section: "Connection",
+		title: "Repository state",
+		keywords: ["repo", "sync", "branch"],
+	},
+	{
+		id: "git-how-it-works",
+		tab: "git",
+		section: "Connection",
+		title: "How it works",
+		description: "Review remote connection details for the current repository.",
+		keywords: ["remote url", "initialize git", "credentials"],
+	},
+	{
+		id: "git-branch",
+		tab: "git",
+		section: "Connection",
+		title: "Branch",
+		keywords: ["repo", "sync"],
+	},
+	{
+		id: "git-automatic-sync",
+		tab: "git",
+		section: "Sync",
+		title: "Automatic sync",
+		keywords: ["auto", "git"],
+	},
+	{
+		id: "git-sync-interval",
+		tab: "git",
+		section: "Sync",
+		title: "Interval",
+		keywords: ["frequency", "minutes"],
+	},
+	{
+		id: "git-sync-actions",
+		tab: "git",
+		section: "Sync",
+		title: "Actions",
+		keywords: ["run", "sync now", "push", "pull"],
+	},
+	{
+		id: "git-conflict-policy",
+		tab: "git",
+		section: "Conflict Resolution",
+		title: "Policy",
+		keywords: ["merge", "conflict"],
+	},
+	{
+		id: "git-include-templates",
+		tab: "git",
+		section: "Content",
+		title: "Include templates",
+		keywords: ["sync", "templates"],
+	},
+	{
+		id: "git-include-attachments",
+		tab: "git",
+		section: "Content",
+		title: "Include attachments",
+		keywords: ["sync", "assets", "files"],
+	},
+	{
+		id: "git-include-non-markdown",
+		tab: "git",
+		section: "Content",
+		title: "Include non-markdown files",
+		keywords: ["sync", "files"],
+	},
+	{
+		id: "advanced-table-of-contents",
+		tab: "advanced",
+		section: "Editor",
+		title: "Table of contents",
+		keywords: ["toc", "outline"],
+	},
+	{
+		id: "advanced-people-tags",
+		tab: "advanced",
+		section: "Editor",
+		title: "People mentions as tags",
+		keywords: ["mentions", "people", "tags"],
+	},
+	{
+		id: "advanced-frontmatter",
+		tab: "advanced",
+		section: "Editor",
+		title: "Show frontmatter in editor",
+		keywords: ["properties", "yaml", "metadata"],
+	},
+	{
+		id: "advanced-colorful-headings",
+		tab: "advanced",
+		section: "Editor",
+		title: "Colorful headings",
+		keywords: ["editor", "color"],
+	},
+	{
+		id: "advanced-beautiful-tags",
+		tab: "advanced",
+		section: "Editor",
+		title: "Beautiful Tags",
+		keywords: ["tags", "editor"],
+	},
+	{
+		id: "advanced-editor-width",
+		tab: "advanced",
+		section: "Editor",
+		title: "Editor width",
+		keywords: ["compact", "comfortable", "wide"],
+	},
+	{
+		id: "advanced-collapsible-headings",
+		tab: "advanced",
+		section: "Editor",
+		title: "Collapsible headings",
+		keywords: ["fold", "collapse", "expand"],
+	},
+	{
+		id: "advanced-vim-keybindings",
+		tab: "advanced",
+		section: "Editor",
+		title: "Vim keybindings",
+		keywords: ["vim", "keyboard", "modal"],
+	},
+	{
+		id: "advanced-ai-tools",
+		tab: "advanced",
+		section: "AI",
+		title: "AI chat has access to tools",
+		keywords: ["assistant", "tool calls"],
+	},
+	{
+		id: "advanced-folio-mode",
+		tab: "advanced",
+		section: "App",
+		title: "Folio Mode",
+		keywords: ["layout", "reading"],
+	},
+	{
+		id: "advanced-folder-counts",
+		tab: "advanced",
+		section: "App",
+		title: "Show folder file counts",
+		keywords: ["sidebar", "counts"],
+	},
+	{
+		id: "advanced-database-column-color",
+		tab: "advanced",
+		section: "Database",
+		title: "Show database column color",
+		keywords: ["collection", "database", "color"],
+	},
+	{
+		id: "about-app",
+		tab: "about",
+		title: "Glyph",
+		description: "View Glyph app name, version, attribution, and quick links.",
+		keywords: ["about", "version", "karat sidhu"],
+	},
+	{
+		id: "about-website",
+		tab: "about",
+		title: "Website",
+		description: "Open the Glyph website.",
+		keywords: ["glyphformac.com", "home"],
+	},
+	{
+		id: "about-release-notes",
+		tab: "about",
+		title: "Release Notes",
+		description: "Open published release notes.",
+		keywords: ["changelog", "updates"],
+	},
+	{
+		id: "about-discord",
+		tab: "about",
+		title: "Discord",
+		description: "Open the Glyph community Discord.",
+		keywords: ["community", "support", "feedback"],
+	},
+	{
+		id: "about-terms",
+		tab: "about",
+		title: "Terms",
+		description: "Open the Glyph terms page.",
+		keywords: ["legal", "terms of service"],
+	},
+	{
+		id: "about-privacy",
+		tab: "about",
+		title: "Privacy",
+		description: "Open the Glyph privacy page.",
+		keywords: ["legal", "privacy policy"],
+	},
+	{
+		id: "about-updates",
+		tab: "about",
+		section: "Updates",
+		title: "App updates",
+		keywords: ["release", "version", "update"],
+	},
+	{
+		id: "about-license-status",
+		tab: "about",
+		section: "Updates",
+		title: "License status",
+		description: "Review whether this build can use automatic updates.",
+		keywords: ["official build", "community build"],
+	},
+	{
+		id: "about-community-build",
+		tab: "about",
+		section: "Updates",
+		title: "Community build",
+		keywords: ["license", "build"],
+	},
+	{
+		id: "about-update-status",
+		tab: "about",
+		section: "Updates",
+		title: "Status",
+		description: "Latest updater activity from this window.",
+		keywords: ["checking", "ready", "latest version"],
+	},
+	{
+		id: "about-changelog",
+		tab: "about",
+		section: "Changelog",
+		title: "Changelog",
+		keywords: ["release notes", "version", "updates"],
+	},
+] as const satisfies readonly SettingsSearchEntry[];
+
+const SETTINGS_TAB_ENTRIES = SETTINGS_TABS.map((tab) => ({
+	id: `${tab.id}-settings`,
+	tab: tab.id,
+	title: `${tab.label} settings`,
+	description: `Open ${tab.label} settings.`,
+	keywords: [tab.label],
+})) satisfies readonly SettingsSearchEntry[];
+
+export const SETTINGS_SEARCH_ENTRIES = [
+	...SETTINGS_TAB_ENTRIES,
+	...SETTINGS_SEARCH_ITEMS,
+] as const satisfies readonly SettingsSearchEntry[];
+
+const TAB_LABEL_BY_ID = new Map<SettingsTab, string>(
+	SETTINGS_TABS.map((tab) => [tab.id, tab.label]),
+);
+
+function normalizeSearchText(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function buildHaystack(entry: SettingsSearchEntry): string {
+	const tabLabel = TAB_LABEL_BY_ID.get(entry.tab) ?? entry.tab;
+	return [
+		entry.title,
+		entry.section ?? "",
+		tabLabel,
+		entry.description ?? "",
+		...(entry.keywords ?? []),
+	]
+		.join(" ")
+		.toLowerCase();
+}
+
+function scoreSettingsEntry(entry: SettingsSearchEntry, query: string): number {
+	const title = entry.title.toLowerCase();
+	const section = entry.section?.toLowerCase() ?? "";
+	if (title === query) return 0;
+	if (title.startsWith(query)) return 1;
+	if (title.includes(query)) return 2;
+	if (section.includes(query)) return 3;
+	return 4;
+}
+
+export function searchSettingsEntries(
+	query: string,
+	limit = SETTINGS_SEARCH_ENTRIES.length,
+): SettingsSearchMatch[] {
+	const normalizedQuery = normalizeSearchText(query);
+	if (!normalizedQuery) return [];
+	const tokens = normalizedQuery.split(/\s+/).filter(Boolean);
+	return SETTINGS_SEARCH_ENTRIES.filter((entry) => {
+		const haystack = buildHaystack(entry);
+		return tokens.every((token) => haystack.includes(token));
+	})
+		.sort((a, b) => {
+			const byScore =
+				scoreSettingsEntry(a, normalizedQuery) -
+				scoreSettingsEntry(b, normalizedQuery);
+			if (byScore !== 0) return byScore;
+			return a.title.localeCompare(b.title);
+		})
+		.slice(0, limit)
+		.map((entry) => ({
+			...entry,
+			tabLabel: TAB_LABEL_BY_ID.get(entry.tab) ?? entry.tab,
+		}));
+}
+
+function findSettingsTarget(
+	root: ParentNode,
+	entry: SettingsSearchEntry,
+): HTMLElement | null {
+	const rows = Array.from(
+		root.querySelectorAll<HTMLElement>("[data-settings-row-title]"),
+	);
+	const matchingRow = rows.find((row) => {
+		if (row.dataset.settingsRowTitle !== entry.title) return false;
+		if (!entry.section) return true;
+		const section = row.closest<HTMLElement>("[data-settings-section-title]");
+		return section?.dataset.settingsSectionTitle === entry.section;
+	});
+	if (matchingRow) return matchingRow;
+
+	const sections = Array.from(
+		root.querySelectorAll<HTMLElement>("[data-settings-section-title]"),
+	);
+	return (
+		sections.find(
+			(section) =>
+				section.dataset.settingsSectionTitle === entry.section ||
+				section.dataset.settingsSectionTitle === entry.title,
+		) ?? null
+	);
+}
+
+export function scrollToSettingsSearchEntry(entry: SettingsSearchEntry) {
+	window.setTimeout(() => {
+		const root = document.querySelector<HTMLElement>(".settingsTabPanel");
+		if (!root) return;
+		for (const active of root.querySelectorAll(
+			`.${SETTINGS_SEARCH_TARGET_CLASS}`,
+		)) {
+			active.classList.remove(SETTINGS_SEARCH_TARGET_CLASS);
+		}
+		const target = findSettingsTarget(root, entry);
+		if (!target) return;
+		target.classList.add(SETTINGS_SEARCH_TARGET_CLASS);
+		target.scrollIntoView({ block: "center", behavior: "smooth" });
+		window.setTimeout(() => {
+			target.classList.remove(SETTINGS_SEARCH_TARGET_CLASS);
+		}, 1600);
+	}, 80);
+}

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -647,6 +647,12 @@ export function searchSettingsEntries(
 		}));
 }
 
+const SETTINGS_SEARCH_HIGHLIGHT_DURATION_MS = 1600;
+const SETTINGS_SEARCH_WAIT_TIMEOUT_MS = 5000;
+
+let settingsSearchRequestId = 0;
+let clearActiveSettingsSearchTarget: (() => void) | null = null;
+
 function findSettingsTarget(
 	root: ParentNode,
 	entry: SettingsSearchEntry,
@@ -674,21 +680,99 @@ function findSettingsTarget(
 	);
 }
 
+function clearSettingsSearchTargets(root: ParentNode) {
+	for (const active of root.querySelectorAll(
+		`.${SETTINGS_SEARCH_TARGET_CLASS}`,
+	)) {
+		active.classList.remove(SETTINGS_SEARCH_TARGET_CLASS);
+	}
+}
+
+function findSettingsTabPanel(entry: SettingsSearchEntry): HTMLElement | null {
+	const root = document.querySelector<HTMLElement>(".settingsTabPanel");
+	const tabLabel = TAB_LABEL_BY_ID.get(entry.tab);
+	const activeTitle = root
+		?.querySelector<HTMLElement>(".settingsPanelTitle")
+		?.textContent?.trim();
+	if (!root || (tabLabel && activeTitle !== tabLabel)) return null;
+	return root;
+}
+
 export function scrollToSettingsSearchEntry(entry: SettingsSearchEntry) {
-	window.setTimeout(() => {
-		const root = document.querySelector<HTMLElement>(".settingsTabPanel");
-		if (!root) return;
-		for (const active of root.querySelectorAll(
-			`.${SETTINGS_SEARCH_TARGET_CLASS}`,
-		)) {
-			active.classList.remove(SETTINGS_SEARCH_TARGET_CLASS);
+	settingsSearchRequestId += 1;
+	const requestId = settingsSearchRequestId;
+	clearActiveSettingsSearchTarget?.();
+	clearActiveSettingsSearchTarget = null;
+
+	let frameId: number | null = null;
+	let observer: MutationObserver | null = null;
+	let waitTimeoutId: number | null = null;
+
+	const cancelPendingScroll = () => {
+		if (frameId !== null) {
+			window.cancelAnimationFrame(frameId);
+			frameId = null;
 		}
+		observer?.disconnect();
+		observer = null;
+		if (waitTimeoutId !== null) {
+			window.clearTimeout(waitTimeoutId);
+			waitTimeoutId = null;
+		}
+	};
+
+	const revealTarget = () => {
+		if (requestId !== settingsSearchRequestId) {
+			cancelPendingScroll();
+			return true;
+		}
+
+		const root = findSettingsTabPanel(entry);
+		if (!root) return false;
 		const target = findSettingsTarget(root, entry);
-		if (!target) return;
+		if (!target) return false;
+
+		cancelPendingScroll();
+		clearSettingsSearchTargets(root);
 		target.classList.add(SETTINGS_SEARCH_TARGET_CLASS);
 		target.scrollIntoView({ block: "center", behavior: "smooth" });
-		window.setTimeout(() => {
+
+		let highlightTimeoutId: number | null = null;
+		const clearHighlight = () => {
+			if (highlightTimeoutId !== null) {
+				window.clearTimeout(highlightTimeoutId);
+				highlightTimeoutId = null;
+			}
 			target.classList.remove(SETTINGS_SEARCH_TARGET_CLASS);
-		}, 1600);
-	}, 80);
+		};
+		highlightTimeoutId = window.setTimeout(() => {
+			clearHighlight();
+			if (clearActiveSettingsSearchTarget === clearHighlight) {
+				clearActiveSettingsSearchTarget = null;
+			}
+		}, SETTINGS_SEARCH_HIGHLIGHT_DURATION_MS);
+		clearActiveSettingsSearchTarget = clearHighlight;
+		return true;
+	};
+
+	const scheduleReveal = () => {
+		if (frameId !== null) return;
+		frameId = window.requestAnimationFrame(() => {
+			frameId = null;
+			revealTarget();
+		});
+	};
+
+	if (revealTarget()) return;
+
+	const observerRoot = document.body ?? document.documentElement;
+	if (!observerRoot) return;
+
+	observer = new MutationObserver(scheduleReveal);
+	observer.observe(observerRoot, { childList: true, subtree: true });
+	scheduleReveal();
+	waitTimeoutId = window.setTimeout(
+		cancelPendingScroll,
+		SETTINGS_SEARCH_WAIT_TIMEOUT_MS,
+	);
 }

--- a/src/styles/app/09-settings-shell.css
+++ b/src/styles/app/09-settings-shell.css
@@ -41,6 +41,167 @@
 	color: var(--text-primary);
 }
 
+.settingsSidebarSearch {
+	position: relative;
+	display: flex;
+	align-items: center;
+	margin: 0 8px 6px;
+	height: 30px;
+	color: var(--text-tertiary);
+	-webkit-app-region: no-drag;
+}
+
+.settingsSidebarSearchIcon {
+	position: absolute;
+	left: 9px;
+	pointer-events: none;
+	color: var(--text-tertiary);
+}
+
+.settingsSidebarSearchInput {
+	width: 100%;
+	height: 30px;
+	min-width: 0;
+	border: 1px solid var(--border-default);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--bg-primary) 84%, transparent);
+	color: var(--text-primary);
+	font-size: 12px;
+	line-height: 1;
+	outline: none;
+	padding: 0 30px 0 30px;
+	transition: border-color var(--transition-fast), background
+		var(--transition-fast);
+}
+
+.settingsSidebarSearchInput::placeholder {
+	color: var(--text-tertiary);
+}
+
+.settingsSidebarSearchInput:focus {
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 38%,
+		var(--border-default)
+	);
+	background: var(--bg-primary);
+}
+
+.settingsSidebarSearchClear {
+	position: absolute;
+	right: 5px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	border: 0;
+	border-radius: 6px;
+	background: transparent;
+	color: var(--text-tertiary);
+	cursor: pointer;
+}
+
+.settingsSidebarSearchClear:hover,
+.settingsSidebarSearchClear:focus-visible {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.settingsSidebarSearchResults {
+	display: flex;
+	flex: 1;
+	min-height: 0;
+	flex-direction: column;
+	gap: 3px;
+	overflow-y: auto;
+	padding: 2px 8px 12px;
+	-webkit-app-region: no-drag;
+}
+
+.settingsSearchResultButton {
+	display: flex;
+	width: 100%;
+	min-width: 0;
+	min-height: 48px;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 4px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--text-primary);
+	cursor: pointer;
+	padding: 8px 9px;
+	text-align: left;
+	line-height: normal;
+}
+
+.settingsSearchResultButton:hover,
+.settingsSearchResultButton:focus-visible {
+	background: var(--bg-hover);
+	outline: none;
+}
+
+.settingsSearchResultButtonActive {
+	background: var(--bg-active);
+}
+
+.settingsSearchResultTitle {
+	display: block;
+	width: 100%;
+	min-height: 17px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 12px;
+	font-weight: var(--font-semibold);
+	line-height: 17px;
+}
+
+.settingsSearchResultMeta {
+	display: block;
+	width: 100%;
+	min-height: 14px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 10px;
+	font-weight: var(--font-semibold);
+	line-height: 14px;
+	color: var(--interactive-accent);
+}
+
+.settingsSearchResultDescription {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+	overflow: hidden;
+	color: var(--text-secondary);
+	font-size: 11px;
+	line-height: 1.35;
+}
+
+.settingsSearchEmpty {
+	padding: 10px 8px;
+	color: var(--text-tertiary);
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.settingsField.settingsSearchTarget,
+.settingsSection.settingsSearchTarget .settingsCard {
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 34%,
+		var(--border-default)
+	);
+	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+	transition: background var(--transition-base), border-color
+		var(--transition-base);
+}
+
 .settingsSidebarTabs {
 	gap: 2px;
 	padding: 4px 8px 12px;
@@ -251,6 +412,12 @@
 	display: flex;
 	flex-direction: column;
 	gap: 34px;
+}
+
+.settingsSearchTarget {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 44%, transparent);
+	outline-offset: 3px;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
Adds end-to-end settings search across the sidebar and command palette, ships a full architecture documentation set under `docs/architecture/`, and updates `AGENTS.md` guidance.

## Searchable settings
- Sidebar settings now include a search input with live, ranked results that highlight matching sections and rows.
- Command palette surfaces individual settings entries (not just panes) when queried, so users can jump directly to a specific setting.
- `SettingsScaffold` tags sections/rows for scroll-to-target highlighting when navigated from search or the palette.
- New shared search index at [src/components/settings/settingsSearch.ts](file:///Users/karat/Developer/Glyph/src/components/settings/settingsSearch.ts) centralizes searchable metadata for every settings row.
- Adds styles for the settings search UI and the highlighted scroll target in [src/styles/app/09-settings-shell.css](file:///Users/karat/Developer/Glyph/src/styles/app/09-settings-shell.css).

### Files touched
- [src/components/app/CommandPalette.tsx](file:///Users/karat/Developer/Glyph/src/components/app/CommandPalette.tsx)
- [src/components/app/SidebarSettingsContent.tsx](file:///Users/karat/Developer/Glyph/src/components/app/SidebarSettingsContent.tsx)
- [src/components/app/commandPaletteHelpers.ts](file:///Users/karat/Developer/Glyph/src/components/app/commandPaletteHelpers.ts)
- [src/components/app/useAppCommands.tsx](file:///Users/karat/Developer/Glyph/src/components/app/useAppCommands.tsx)
- [src/components/settings/SettingsScaffold.tsx](file:///Users/karat/Developer/Glyph/src/components/settings/SettingsScaffold.tsx)

## Architecture documentation
Adds ten numbered manuals under `docs/architecture/`:
1. System overview
2. Spaces, storage, filesystem
3. Frontend shell & state
4. IPC & native runtime
5. Editor, markdown, autosave
6. Index, search, graph, tasks
7. Databases & frontmatter
8. AI runtime, tools, history
9. Settings, menus, git sync, native windows
10. Security and operational invariants

Also refreshes [docs/security.md](file:///Users/karat/Developer/Glyph/docs/security.md) to align with the new manuals.

## AGENTS.md
Small contributor-facing guidance tweaks.

## Test plan
- [ ] Open Sidebar → Settings; type queries (`accent`, `daily`, `model`) and confirm filtered rows + scroll-to-highlight.
- [ ] Open Command Palette; query settings keywords and confirm direct jump to setting.
- [ ] Skim each `docs/architecture/0X-*.md` for rendering.
- [ ] `pnpm check && pnpm build && cd src-tauri && cargo check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable settings sidebar with keyboard navigation, in-panel result highlighting, and quick-jump behavior.
  * Improved command palette search using tokenized matching and custom search-term indexing, plus built-in settings-search commands.

* **Documentation**
  * Added extensive architecture guides covering system design, storage, frontend shell, IPC/runtime, editor/autosave, indexing, databases, AI runtime, settings/menus/git, and security/operational invariants.
  * Updated security docs with concrete runtime rules for network validation, secrets handling, and audit logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->