### PR TITLE
0.5.0 subtle improvements

### DIFF
--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -161,14 +161,23 @@ fn linked_note_wikilink_value(raw: &str) -> Option<String> {
     if trimmed.is_empty() {
         return None;
     }
-    let inner = trimmed
-        .strip_prefix("[[")
-        .and_then(|value| value.strip_suffix("]]"))
-        .unwrap_or(trimmed)
-        .split('|')
-        .next()
-        .unwrap_or(trimmed)
-        .trim();
+
+    let starts_wrapped = trimmed.starts_with("[[");
+    let ends_wrapped = trimmed.ends_with("]]");
+    if starts_wrapped != ends_wrapped {
+        return None;
+    }
+
+    let value = if starts_wrapped && ends_wrapped {
+        trimmed
+            .strip_prefix("[[")
+            .and_then(|value| value.strip_suffix("]]"))
+            .unwrap_or(trimmed)
+    } else {
+        trimmed
+    };
+
+    let inner = value.split('|').next().unwrap_or(value).trim();
     let target = inner.split('#').next().unwrap_or(inner).trim();
     if target.is_empty() {
         return None;

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -130,6 +130,14 @@ fn yaml_value_from_cell(
                 .map(|item| Value::String(item.clone()))
                 .collect(),
         )),
+        "linked_notes" => Ok(Value::Sequence(
+            value
+                .value_list
+                .iter()
+                .filter_map(|item| linked_note_wikilink_value(item))
+                .map(Value::String)
+                .collect(),
+        )),
         "property" => match column.property_kind.as_deref().unwrap_or("text") {
             "checkbox" => Ok(Value::Bool(value.value_bool.unwrap_or(false))),
             "tags" | "relation" | "multi_select" => Ok(Value::Sequence(
@@ -141,11 +149,31 @@ fn yaml_value_from_cell(
             )),
             _ => Ok(Value::String(value.value_text.clone().unwrap_or_default())),
         },
-        "path" | "folder" | "created" | "updated" | "linked_notes" => {
+        "path" | "folder" | "created" | "updated" => {
             Err(format!("{} columns are read-only", column.column_type))
         }
         other => Err(format!("unsupported column type '{other}'")),
     }
+}
+
+fn linked_note_wikilink_value(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let inner = trimmed
+        .strip_prefix("[[")
+        .and_then(|value| value.strip_suffix("]]"))
+        .unwrap_or(trimmed)
+        .split('|')
+        .next()
+        .unwrap_or(trimmed)
+        .trim();
+    let target = inner.split('#').next().unwrap_or(inner).trim();
+    if target.is_empty() {
+        return None;
+    }
+    Some(format!("[[{target}]]"))
 }
 
 fn apply_cell_update_to_markdown(
@@ -163,6 +191,9 @@ fn apply_cell_update_to_markdown(
         "tags" => {
             mapping.insert(key("tags"), yaml_value_from_cell(column, value)?);
         }
+        "linked_notes" => {
+            mapping.insert(key("linked_notes"), yaml_value_from_cell(column, value)?);
+        }
         "property" => {
             let property_key = column
                 .property_key
@@ -170,7 +201,7 @@ fn apply_cell_update_to_markdown(
                 .ok_or_else(|| "property column is missing property_key".to_string())?;
             mapping.insert(key(&property_key), yaml_value_from_cell(column, value)?);
         }
-        "path" | "folder" | "created" | "updated" | "linked_notes" => {
+        "path" | "folder" | "created" | "updated" => {
             return Err(format!("{} columns are read-only", column.column_type))
         }
         other => return Err(format!("unsupported column type '{other}'")),
@@ -232,7 +263,7 @@ fn write_new_markdown_note(
 
 fn validate_editable_column(row: &DatabaseRow, column: &DatabaseColumn) -> Result<(), String> {
     match column.column_type.as_str() {
-        "title" | "tags" => Ok(()),
+        "title" | "tags" | "linked_notes" => Ok(()),
         "property" => {
             let property_key = column
                 .property_key
@@ -244,7 +275,7 @@ fn validate_editable_column(row: &DatabaseRow, column: &DatabaseColumn) -> Resul
                 Err("unknown property column".to_string())
             }
         }
-        "path" | "folder" | "created" | "updated" | "linked_notes" => {
+        "path" | "folder" | "created" | "updated" => {
             Err(format!("{} columns are read-only", column.column_type))
         }
         other => Err(format!("unsupported column type '{other}'")),

--- a/src-tauri/src/databases/query.rs
+++ b/src-tauri/src/databases/query.rs
@@ -815,8 +815,16 @@ fn hydrate_rows_by_paths(
             .map_err(|e| e.to_string())?;
         while let Some(row) = link_rows.next().map_err(|e| e.to_string())? {
             let note_id = row.get::<_, String>(0).map_err(|e| e.to_string())?;
-            let to_id = row.get::<_, Option<String>>(1).map_err(|e| e.to_string())?;
-            let to_title = row.get::<_, Option<String>>(2).map_err(|e| e.to_string())?;
+            let to_id = row
+                .get::<_, Option<String>>(1)
+                .map_err(|e| e.to_string())?
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+            let to_title = row
+                .get::<_, Option<String>>(2)
+                .map_err(|e| e.to_string())?
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
             let Some(target) = to_id.or(to_title) else {
                 continue;
             };

--- a/src-tauri/src/databases/query.rs
+++ b/src-tauri/src/databases/query.rs
@@ -806,7 +806,8 @@ fn hydrate_rows_by_paths(
 
         let mut link_stmt = conn
             .prepare(&format!(
-                "SELECT from_id, to_id FROM links WHERE from_id IN ({placeholders}) AND to_id IS NOT NULL"
+                "SELECT from_id, to_id, to_title FROM links
+                 WHERE from_id IN ({placeholders}) AND (to_id IS NOT NULL OR to_title IS NOT NULL)"
             ))
             .map_err(|e| e.to_string())?;
         let mut link_rows = link_stmt
@@ -814,7 +815,11 @@ fn hydrate_rows_by_paths(
             .map_err(|e| e.to_string())?;
         while let Some(row) = link_rows.next().map_err(|e| e.to_string())? {
             let note_id = row.get::<_, String>(0).map_err(|e| e.to_string())?;
-            let target = row.get::<_, String>(1).map_err(|e| e.to_string())?;
+            let to_id = row.get::<_, Option<String>>(1).map_err(|e| e.to_string())?;
+            let to_title = row.get::<_, Option<String>>(2).map_err(|e| e.to_string())?;
+            let Some(target) = to_id.or(to_title) else {
+                continue;
+            };
             if let Some(entry) = row_map.get_mut(&note_id) {
                 entry.linked_notes.push(target);
             }

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -7,6 +7,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { APP_TAGLINE } from "../../lib/copy";
+import { normalizeRelPath } from "../../utils/path";
 import { File, X } from "../Icons";
 import { Button } from "../ui/shadcn/button";
 import { ModelSelector } from "./ModelSelector";
@@ -25,6 +26,7 @@ interface AIComposerProps {
 	scheduleComposerInputResize: () => void;
 	profiles: ReturnType<typeof useAiProfiles>;
 	context: ReturnType<typeof useAiContext>;
+	activeFilePath: string | null;
 	showAddPanel: boolean;
 	panelQuery: string;
 	addPanelOpen: boolean;
@@ -50,6 +52,7 @@ export function AIComposer({
 	scheduleComposerInputResize,
 	profiles,
 	context,
+	activeFilePath,
 	showAddPanel,
 	panelQuery,
 	addPanelOpen,
@@ -69,6 +72,15 @@ export function AIComposer({
 		scheduleComposerInputResize();
 		window.requestAnimationFrame(() => composerInputRef.current?.focus());
 	};
+	const suggestedFilePath = activeFilePath
+		? normalizeRelPath(activeFilePath)
+		: "";
+	const showActiveFileSuggestion =
+		Boolean(suggestedFilePath) &&
+		!context.hasContext("file", suggestedFilePath);
+	const suggestedFileLabel = suggestedFilePath
+		? fileNameFromPath(suggestedFilePath)
+		: "";
 
 	return (
 		<>
@@ -118,11 +130,28 @@ export function AIComposer({
 			) : null}
 			<div className="aiComposer">
 				<div className="aiComposerInputShell">
-					{context.attachedFolders.length > 0 && (
+					{(context.attachedFolders.length > 0 || showActiveFileSuggestion) && (
 						<div
 							className="aiComposerContextStrip"
 							aria-label="Attached context"
 						>
+							{showActiveFileSuggestion ? (
+								<button
+									type="button"
+									className="aiContextChip aiContextChipSuggestion"
+									onClick={() => onAddContext("file", suggestedFilePath)}
+									aria-label={`Add ${suggestedFileLabel} to context`}
+									title={`Add ${suggestedFilePath} to context`}
+									disabled={isAwaitingResponse}
+								>
+									<span className="aiContextChipIcon">
+										<File size={12} />
+									</span>
+									<span className="aiContextChipLabel">
+										{truncateLabel(suggestedFileLabel, 28)}
+									</span>
+								</button>
+							) : null}
 							{context.attachedFolders.map((item) => {
 								const chipLabel =
 									item.kind === "file"

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -41,7 +41,7 @@ export async function prefetchAIPanelData(): Promise<void> {
 
 export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 	const { aiAssistantMode } = useAISidebarContext();
-	const { openSettings } = useUILayoutContext();
+	const { activeMarkdownTabPath, openSettings } = useUILayoutContext();
 	const isChatMode = aiAssistantMode === "chat";
 
 	const [input, setInput] = useState("");
@@ -445,6 +445,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 					scheduleComposerInputResize={scheduleResize}
 					profiles={profiles}
 					context={context}
+					activeFilePath={activeMarkdownTabPath}
 					showAddPanel={showAddPanel}
 					panelQuery={panelQuery}
 					addPanelOpen={addPanelOpen}

--- a/src/components/ai/useAiContext.ts
+++ b/src/components/ai/useAiContext.ts
@@ -121,6 +121,16 @@ export function useAiContext(contextSearch = "") {
 		[],
 	);
 
+	const hasContext = useCallback(
+		(kind: ContextEntryKind, rawPath: string) => {
+			const path = normalizeRelPath(rawPath);
+			return attachedFolders.some(
+				(item) => item.kind === kind && item.path === path,
+			);
+		},
+		[attachedFolders],
+	);
+
 	const visibleSuggestions = useMemo(() => {
 		const q = contextSearch.trim().toLowerCase();
 		if (!q) return [];
@@ -213,6 +223,7 @@ export function useAiContext(contextSearch = "") {
 		attachedFolders,
 		addContext,
 		removeContext,
+		hasContext,
 		resolveMentionsFromInput,
 		folderIndexError:
 			indexQuery.error != null ? extractErrorMessage(indexQuery.error) : "",

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -10,7 +10,13 @@ import {
 	subDays,
 } from "date-fns";
 import { m, useReducedMotion } from "motion/react";
-import { memo, useCallback, useMemo, useState } from "react";
+import {
+	type KeyboardEvent,
+	memo,
+	useCallback,
+	useMemo,
+	useState,
+} from "react";
 import { useFileTreeContext } from "../../contexts";
 import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -25,7 +31,7 @@ import {
 	resolveTagIconName,
 	tagIconOverridesFromAppearance,
 } from "../../lib/tagIcons";
-import type { AllDocsItem } from "../../lib/tauri";
+import type { AllDocsItem, NoteTaskSummary } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
@@ -64,9 +70,18 @@ function folderLabel(notePath: string): string {
 type PreviewLineKind = "heading" | "quote" | "task" | "list" | "code" | "body";
 
 type PreviewLine = {
+	key: string;
 	kind: PreviewLineKind;
 	text: string;
 };
+
+function pushPreviewLine(
+	parsed: PreviewLine[],
+	kind: PreviewLineKind,
+	text: string,
+) {
+	parsed.push({ key: `${kind}:${parsed.length}:${text}`, kind, text });
+}
 
 function previewLines(preview: string, title: string): PreviewLine[] {
 	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
@@ -83,21 +98,21 @@ function previewLines(preview: string, title: string): PreviewLine[] {
 
 		if (inFence) {
 			const text = normalizeInlineMarkdown(line);
-			if (text) parsed.push({ kind: "code", text });
+			if (text) pushPreviewLine(parsed, "code", text);
 			continue;
 		}
 
 		const headingMatch = line.match(/^#{1,6}\s+(.*)$/);
 		if (headingMatch?.[1]) {
 			const text = normalizeInlineMarkdown(headingMatch[1]);
-			if (text) parsed.push({ kind: "heading", text });
+			if (text) pushPreviewLine(parsed, "heading", text);
 			continue;
 		}
 
 		const quoteMatch = line.match(/^>\s?(.*)$/);
 		if (quoteMatch?.[1]) {
 			const text = normalizeInlineMarkdown(quoteMatch[1]);
-			if (text) parsed.push({ kind: "quote", text });
+			if (text) pushPreviewLine(parsed, "quote", text);
 			continue;
 		}
 
@@ -106,19 +121,19 @@ function previewLines(preview: string, title: string): PreviewLine[] {
 		);
 		if (taskMatch?.[1]) {
 			const text = normalizeInlineMarkdown(taskMatch[1]);
-			if (text) parsed.push({ kind: "task", text });
+			if (text) pushPreviewLine(parsed, "task", text);
 			continue;
 		}
 
 		const listMatch = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
 		if (listMatch?.[1]) {
 			const text = normalizeInlineMarkdown(listMatch[1]);
-			if (text) parsed.push({ kind: "list", text });
+			if (text) pushPreviewLine(parsed, "list", text);
 			continue;
 		}
 
 		const text = normalizeInlineMarkdown(line);
-		if (text) parsed.push({ kind: "body", text });
+		if (text) pushPreviewLine(parsed, "body", text);
 	}
 
 	const filtered = parsed.filter((line) => {
@@ -171,6 +186,216 @@ const SECTION_ORDER: Array<{ id: AllDocsSection["id"]; label: string }> = [
 	{ id: "this-month", label: "This Month" },
 	{ id: "earlier", label: "Earlier" },
 ];
+
+interface AllDocsCardProps {
+	notePath: string;
+	title: string;
+	preview: PreviewLine[];
+	tags: string[];
+	extraTagCount: number;
+	pathLabel: string;
+	updatedAt: string;
+	taskSummary: NoteTaskSummary | undefined;
+	taskCount: number;
+	selected: boolean;
+	animationIndex: number;
+	shouldReduceMotion: boolean;
+	springPreset: typeof springPresets.snappy;
+	iconNameForTag: (tag: string) => string;
+	updatedTimeframe: (iso: string) => string;
+	formatTagLabel: (tag: string) => string;
+	TaskProgressComponent: typeof TaskProgressIndicator;
+	onSelect: () => void;
+	onPrefetch: () => void;
+	onOpen: () => void;
+}
+
+type PreparedAllDocsCardProps = Omit<
+	AllDocsCardProps,
+	| "shouldReduceMotion"
+	| "springPreset"
+	| "iconNameForTag"
+	| "updatedTimeframe"
+	| "formatTagLabel"
+	| "TaskProgressComponent"
+>;
+
+interface PrepareAllDocsCardPropsArgs {
+	note: AllDocsItem;
+	index: number;
+	sectionIndex: number;
+	selectedNotePath: string | null;
+	taskSummariesByPath: Record<string, NoteTaskSummary>;
+	showTaskProgressIndicator: boolean;
+	selectNote: (notePath: string) => void;
+	onOpenFile: AllDocsPaneProps["onOpenFile"];
+}
+
+function prepareAllDocsCardProps({
+	note,
+	index,
+	sectionIndex,
+	selectedNotePath,
+	taskSummariesByPath,
+	showTaskProgressIndicator,
+	selectNote,
+	onOpenFile,
+}: PrepareAllDocsCardPropsArgs): PreparedAllDocsCardProps {
+	const noteTitle = note.title.trim() || titleFromPath(note.note_path);
+	const taskSummary = showTaskProgressIndicator
+		? taskSummariesByPath[note.note_path]
+		: undefined;
+
+	return {
+		notePath: note.note_path,
+		title: noteTitle,
+		preview: previewLines(note.preview, noteTitle),
+		tags: note.tags.slice(0, 1),
+		extraTagCount: Math.max(note.tags.length - 1, 0),
+		pathLabel: folderLabel(note.note_path),
+		updatedAt: note.updated,
+		taskSummary,
+		taskCount: taskSummary?.total_count ?? 0,
+		selected: selectedNotePath === note.note_path,
+		animationIndex: sectionIndex * 12 + index,
+		onSelect: () => selectNote(note.note_path),
+		onPrefetch: () => prefetchNote(note.note_path),
+		onOpen: () => void onOpenFile(note.note_path),
+	};
+}
+
+function AllDocsCard({
+	notePath,
+	title,
+	preview,
+	tags,
+	extraTagCount,
+	pathLabel,
+	updatedAt,
+	taskSummary,
+	taskCount,
+	selected,
+	animationIndex,
+	shouldReduceMotion,
+	springPreset,
+	iconNameForTag,
+	updatedTimeframe,
+	formatTagLabel,
+	TaskProgressComponent,
+	onSelect,
+	onPrefetch,
+	onOpen,
+}: AllDocsCardProps) {
+	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			onOpen();
+			return;
+		}
+		if (event.key === " ") {
+			event.preventDefault();
+			onSelect();
+		}
+	};
+
+	return (
+		<m.button
+			type="button"
+			className="allDocsCard"
+			data-state={selected ? "selected" : undefined}
+			aria-label={`Open ${title}`}
+			onClick={onSelect}
+			onMouseEnter={onPrefetch}
+			onFocus={onPrefetch}
+			onDoubleClick={onOpen}
+			onKeyDown={handleKeyDown}
+			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={
+				shouldReduceMotion
+					? { duration: 0 }
+					: {
+							...springPreset,
+							delay: Math.min(animationIndex * 0.02, 0.18),
+						}
+			}
+			title="Double-click to open note"
+		>
+			<div className="allDocsCardSurface">
+				<div className="allDocsCardTop">
+					<span className="allDocsCardTitle" title={title}>
+						{title}
+					</span>
+					{taskSummary && taskCount > 0 ? (
+						<span className="allDocsCardTaskSummary is-top">
+							<TaskProgressComponent
+								summary={taskSummary}
+								className="allDocsCardTaskProgress"
+							/>
+							<span className="allDocsCardTaskText">
+								{taskSummary.completed_count}/{taskCount}
+							</span>
+						</span>
+					) : null}
+				</div>
+				{preview.length > 0 ? (
+					<div className="allDocsCardPreview">
+						{preview.map((line) => (
+							<div
+								key={`${notePath}:preview:${line.key}`}
+								className={`allDocsCardPreviewLine is-${line.kind}`}
+							>
+								{line.text}
+							</div>
+						))}
+					</div>
+				) : (
+					<div className="allDocsCardPreview is-placeholder">
+						No preview yet
+					</div>
+				)}
+				<div className="allDocsCardFooter">
+					<div className="allDocsCardMetaRow">
+						<span className="allDocsCardPath" title={notePath}>
+							<HugeiconsIcon
+								icon={Folder01Icon}
+								className="allDocsCardPathIcon"
+								size={12}
+								strokeWidth={1.2}
+							/>
+							<span className="allDocsCardPathLabel">{pathLabel}</span>
+						</span>
+						<span className="allDocsCardTime">
+							{updatedTimeframe(updatedAt)}
+						</span>
+					</div>
+					{tags.length > 0 ? (
+						<div className="allDocsCardSignals">
+							<div className="allDocsCardTags">
+								{tags.map((tag) => (
+									<span key={`${notePath}:${tag}`} className="allDocsCardTag">
+										<DatabaseColumnIcon
+											iconName={iconNameForTag(tag)}
+											className="allDocsCardTagIcon"
+											size={11}
+											strokeWidth={1.2}
+										/>
+										{formatTagLabel(tag)}
+									</span>
+								))}
+								{extraTagCount > 0 ? (
+									<span className="allDocsCardTag is-muted">
+										+{extraTagCount}
+									</span>
+								) : null}
+							</div>
+						</div>
+					) : null}
+				</div>
+			</div>
+		</m.button>
+	);
+}
 
 export const AllDocsPane = memo(function AllDocsPane({
 	onOpenFile,
@@ -276,138 +501,28 @@ export const AllDocsPane = memo(function AllDocsPane({
 						</div>
 						<div className="allDocsGrid">
 							{section.notes.map((note, index) => {
-								const noteTitle =
-									note.title.trim() || titleFromPath(note.note_path);
-								const preview = previewLines(note.preview, noteTitle);
-								const visibleTags = note.tags.slice(0, 1);
-								const extraTagCount = Math.max(
-									note.tags.length - visibleTags.length,
-									0,
-								);
-								const notePath = folderLabel(note.note_path);
-								const animationIndex = sectionIndex * 12 + index;
-								const taskSummary = taskSummariesByPath[note.note_path];
-								const taskCount = taskSummary?.total_count ?? 0;
+								const cardProps = prepareAllDocsCardProps({
+									note,
+									index,
+									sectionIndex,
+									selectedNotePath,
+									taskSummariesByPath,
+									showTaskProgressIndicator,
+									selectNote: setSelectedNotePath,
+									onOpenFile,
+								});
 
 								return (
-									<m.button
+									<AllDocsCard
 										key={note.note_path}
-										type="button"
-										className="allDocsCard"
-										data-state={
-											selectedNotePath === note.note_path
-												? "selected"
-												: undefined
-										}
-										aria-label={`Open ${noteTitle}`}
-										onClick={() => setSelectedNotePath(note.note_path)}
-										onMouseEnter={() => prefetchNote(note.note_path)}
-										onFocus={() => prefetchNote(note.note_path)}
-										onDoubleClick={() => void onOpenFile(note.note_path)}
-										onKeyDown={(event) => {
-											if (event.key === "Enter") {
-												event.preventDefault();
-												void onOpenFile(note.note_path);
-												return;
-											}
-											if (event.key === " ") {
-												event.preventDefault();
-												setSelectedNotePath(note.note_path);
-											}
-										}}
-										initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
-										animate={{ opacity: 1, y: 0 }}
-										transition={
-											shouldReduceMotion
-												? { duration: 0 }
-												: {
-														...springPresets.snappy,
-														delay: Math.min(animationIndex * 0.02, 0.18),
-													}
-										}
-										title="Double-click to open note"
-									>
-										<div className="allDocsCardSurface">
-											<div className="allDocsCardTop">
-												<span className="allDocsCardTitle" title={noteTitle}>
-													{noteTitle}
-												</span>
-												{taskSummary && taskCount > 0 ? (
-													<span className="allDocsCardTaskSummary is-top">
-														<TaskProgressIndicator
-															summary={taskSummary}
-															className="allDocsCardTaskProgress"
-														/>
-														<span className="allDocsCardTaskText">
-															{taskSummary.completed_count}/{taskCount}
-														</span>
-													</span>
-												) : null}
-											</div>
-											{preview.length > 0 ? (
-												<div className="allDocsCardPreview">
-													{preview.map((line, lineIndex) => (
-														<div
-															key={`${note.note_path}:preview:${lineIndex}`}
-															className={`allDocsCardPreviewLine is-${line.kind}`}
-														>
-															{line.text}
-														</div>
-													))}
-												</div>
-											) : (
-												<div className="allDocsCardPreview is-placeholder">
-													No preview yet
-												</div>
-											)}
-											<div className="allDocsCardFooter">
-												<div className="allDocsCardMetaRow">
-													<span
-														className="allDocsCardPath"
-														title={note.note_path}
-													>
-														<HugeiconsIcon
-															icon={Folder01Icon}
-															className="allDocsCardPathIcon"
-															size={12}
-															strokeWidth={1.2}
-														/>
-														<span className="allDocsCardPathLabel">
-															{notePath}
-														</span>
-													</span>
-													<span className="allDocsCardTime">
-														{updatedTimeframe(note.updated)}
-													</span>
-												</div>
-												{visibleTags.length > 0 ? (
-													<div className="allDocsCardSignals">
-														<div className="allDocsCardTags">
-															{visibleTags.map((tag) => (
-																<span
-																	key={`${note.note_path}:${tag}`}
-																	className="allDocsCardTag"
-																>
-																	<DatabaseColumnIcon
-																		iconName={iconNameForTag(tag)}
-																		className="allDocsCardTagIcon"
-																		size={11}
-																		strokeWidth={1.2}
-																	/>
-																	{formatDatabaseTagLabel(tag)}
-																</span>
-															))}
-															{extraTagCount > 0 ? (
-																<span className="allDocsCardTag is-muted">
-																	+{extraTagCount}
-																</span>
-															) : null}
-														</div>
-													</div>
-												) : null}
-											</div>
-										</div>
-									</m.button>
+										{...cardProps}
+										shouldReduceMotion={shouldReduceMotion}
+										springPreset={springPresets.snappy}
+										iconNameForTag={iconNameForTag}
+										updatedTimeframe={updatedTimeframe}
+										formatTagLabel={formatDatabaseTagLabel}
+										TaskProgressComponent={TaskProgressIndicator}
+									/>
 								);
 							})}
 						</div>

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -12,6 +12,8 @@ import {
 import { m, useReducedMotion } from "motion/react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
+import { useTaskProgressIndicatorSetting } from "../../hooks/useTaskProgressIndicatorSetting";
+import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import {
 	loadAllDocs,
@@ -27,6 +29,7 @@ import type { AllDocsItem } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
+import { TaskProgressIndicator } from "../tasks/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
 
 interface AllDocsPaneProps {
@@ -58,7 +61,7 @@ function folderLabel(notePath: string): string {
 	return parentFolders[parentFolders.length - 1] ?? "Workspace root";
 }
 
-type PreviewLineKind = "heading" | "quote" | "list" | "code" | "body";
+type PreviewLineKind = "heading" | "quote" | "task" | "list" | "code" | "body";
 
 type PreviewLine = {
 	kind: PreviewLineKind;
@@ -103,7 +106,7 @@ function previewLines(preview: string, title: string): PreviewLine[] {
 		);
 		if (taskMatch?.[1]) {
 			const text = normalizeInlineMarkdown(taskMatch[1]);
-			if (text) parsed.push({ kind: "list", text });
+			if (text) parsed.push({ kind: "task", text });
 			continue;
 		}
 
@@ -179,6 +182,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 	const { beautifulTags, tagAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
+	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const queryClient = useQueryClient();
 	const normalizedFolderPrefix = useMemo(
 		() => normalizeFolderPrefix(folderPrefix),
@@ -190,6 +194,13 @@ export const AllDocsPane = memo(function AllDocsPane({
 		initialData: initialNotes ?? undefined,
 	});
 	const notes = notesQuery.data ?? [];
+	const notePaths = useMemo(() => notes.map((note) => note.note_path), [notes]);
+	const showTaskProgressIndicator = useTaskProgressIndicatorSetting();
+	const taskSummariesByPath = useTaskSummariesForPaths(
+		notePaths,
+		showTaskProgressIndicator,
+		taskSummaryRefreshKey,
+	);
 	const tagIconOverrides = useMemo(
 		() => tagIconOverridesFromAppearance(tagAppearance),
 		[tagAppearance],
@@ -206,6 +217,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 		void queryClient.invalidateQueries({
 			queryKey: navigationQueryKeys.allDocsList(normalizedFolderPrefix),
 		});
+		setTaskSummaryRefreshKey((key) => key + 1);
 	});
 
 	const sections = useMemo<AllDocsSection[]>(() => {
@@ -248,7 +260,11 @@ export const AllDocsPane = memo(function AllDocsPane({
 
 	return (
 		<section className="allDocsPane">
-			<h1 className="allDocsTitle">{title}</h1>
+			<header className="allDocsHeader">
+				<div className="allDocsHeadingGroup">
+					<h1 className="allDocsTitle">{title}</h1>
+				</div>
+			</header>
 			<div className="allDocsSections">
 				{notes.length === 0 ? (
 					<div className="databaseLoadingState">{emptyStateMessage}</div>
@@ -270,6 +286,8 @@ export const AllDocsPane = memo(function AllDocsPane({
 								);
 								const notePath = folderLabel(note.note_path);
 								const animationIndex = sectionIndex * 12 + index;
+								const taskSummary = taskSummariesByPath[note.note_path];
+								const taskCount = taskSummary?.total_count ?? 0;
 
 								return (
 									<m.button
@@ -310,29 +328,22 @@ export const AllDocsPane = memo(function AllDocsPane({
 										title="Double-click to open note"
 									>
 										<div className="allDocsCardSurface">
-											<span className="allDocsCardTitle" title={noteTitle}>
-												{noteTitle}
-											</span>
-											<div className="allDocsCardMetaRow">
-												<span
-													className="allDocsCardPath"
-													title={note.note_path}
-												>
-													<HugeiconsIcon
-														icon={Folder01Icon}
-														className="allDocsCardPathIcon"
-														size={12}
-														strokeWidth={1.2}
-													/>
-													<span className="allDocsCardPathLabel">
-														{notePath}
+											<div className="allDocsCardTop">
+												<span className="allDocsCardTitle" title={noteTitle}>
+													{noteTitle}
+												</span>
+												{taskSummary && taskCount > 0 ? (
+													<span className="allDocsCardTaskSummary is-top">
+														<TaskProgressIndicator
+															summary={taskSummary}
+															className="allDocsCardTaskProgress"
+														/>
+														<span className="allDocsCardTaskText">
+															{taskSummary.completed_count}/{taskCount}
+														</span>
 													</span>
-												</span>
-												<span className="allDocsCardTime">
-													{updatedTimeframe(note.updated)}
-												</span>
+												) : null}
 											</div>
-											<span className="allDocsCardDivider" aria-hidden="true" />
 											{preview.length > 0 ? (
 												<div className="allDocsCardPreview">
 													{preview.map((line, lineIndex) => (
@@ -349,29 +360,52 @@ export const AllDocsPane = memo(function AllDocsPane({
 													No preview yet
 												</div>
 											)}
-											{visibleTags.length > 0 ? (
-												<div className="allDocsCardTags">
-													{visibleTags.map((tag) => (
-														<span
-															key={`${note.note_path}:${tag}`}
-															className="allDocsCardTag"
-														>
-															<DatabaseColumnIcon
-																iconName={iconNameForTag(tag)}
-																className="allDocsCardTagIcon"
-																size={11}
-																strokeWidth={1.2}
-															/>
-															{formatDatabaseTagLabel(tag)}
+											<div className="allDocsCardFooter">
+												<div className="allDocsCardMetaRow">
+													<span
+														className="allDocsCardPath"
+														title={note.note_path}
+													>
+														<HugeiconsIcon
+															icon={Folder01Icon}
+															className="allDocsCardPathIcon"
+															size={12}
+															strokeWidth={1.2}
+														/>
+														<span className="allDocsCardPathLabel">
+															{notePath}
 														</span>
-													))}
-													{extraTagCount > 0 ? (
-														<span className="allDocsCardTag is-muted">
-															+{extraTagCount}
-														</span>
-													) : null}
+													</span>
+													<span className="allDocsCardTime">
+														{updatedTimeframe(note.updated)}
+													</span>
 												</div>
-											) : null}
+												{visibleTags.length > 0 ? (
+													<div className="allDocsCardSignals">
+														<div className="allDocsCardTags">
+															{visibleTags.map((tag) => (
+																<span
+																	key={`${note.note_path}:${tag}`}
+																	className="allDocsCardTag"
+																>
+																	<DatabaseColumnIcon
+																		iconName={iconNameForTag(tag)}
+																		className="allDocsCardTagIcon"
+																		size={11}
+																		strokeWidth={1.2}
+																	/>
+																	{formatDatabaseTagLabel(tag)}
+																</span>
+															))}
+															{extraTagCount > 0 ? (
+																<span className="allDocsCardTag is-muted">
+																	+{extraTagCount}
+																</span>
+															) : null}
+														</div>
+													</div>
+												) : null}
+											</div>
 										</div>
 									</m.button>
 								);

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../lib/tagIcons";
 import { X } from "../Icons";
 import { Toggle } from "../base/toggle/toggle";
+import { useWikiLinkAutocomplete } from "../editor/hooks/useWikiLinkAutocomplete";
 import {
 	normalizeTagDraftPrefix,
 	normalizeTagToken,
@@ -225,9 +226,27 @@ function listDraft(row: DatabaseRow, column: DatabaseColumn): string {
 
 function isListLikeColumn(column: DatabaseColumn): boolean {
 	return (
+		column.type === "linked_notes" ||
 		column.property_kind === "relation" ||
 		column.property_kind === "multi_select"
 	);
+}
+
+function supportsWikiLinkAutocomplete(column: DatabaseColumn): boolean {
+	return (
+		column.type === "property" &&
+		(column.property_kind == null || column.property_kind === "text")
+	);
+}
+
+function normalizeLinkedNoteListValue(value: string): string {
+	const trimmed = value.trim();
+	const inner =
+		trimmed.startsWith("[[") && trimmed.endsWith("]]")
+			? trimmed.slice(2, -2)
+			: trimmed;
+	const target = inner.split("|")[0]?.split("#")[0]?.trim();
+	return target ?? "";
 }
 
 function uniqueValues(values: string[]): string[] {
@@ -279,6 +298,7 @@ function DatabaseCellEditor({
 	const tagInputRef = useRef<HTMLInputElement | null>(null);
 	const valueFieldRef = useRef<HTMLDivElement | null>(null);
 	const valueInputRef = useRef<HTMLInputElement | null>(null);
+	const textInputRef = useRef<HTMLInputElement | null>(null);
 	const focusTagInput = useCallback((element: HTMLInputElement | null) => {
 		tagInputRef.current = element;
 		if (element) {
@@ -292,6 +312,7 @@ function DatabaseCellEditor({
 		}
 	}, []);
 	const focusTextInput = useCallback((element: HTMLInputElement | null) => {
+		textInputRef.current = element;
 		if (element) {
 			element.focus();
 			element.select();
@@ -303,6 +324,7 @@ function DatabaseCellEditor({
 		column.type === "property" && column.property_kind === "status";
 	const isPriorityColumn =
 		column.type === "property" && column.property_kind === "priority";
+	const isLinkedNotesColumn = column.type === "linked_notes";
 	const isListLike = isListLikeColumn(column);
 	const toneStyleForValue = (value: string) =>
 		databaseValueToneStyleForColor(value, laneColors[value] ?? null);
@@ -383,6 +405,12 @@ function DatabaseCellEditor({
 			})
 			.slice(0, 6);
 	}, [column.type, draft, valueOptions]);
+	const wikiLinkAutocomplete = useWikiLinkAutocomplete({
+		enabled: supportsWikiLinkAutocomplete(column),
+		inputRef: textInputRef,
+		value: draft,
+		onChange: setDraft,
+	});
 
 	const handleSelectRow = () => {
 		onSelectRow?.(row.note_path);
@@ -432,7 +460,9 @@ function DatabaseCellEditor({
 	};
 
 	const addListValue = async (rawValue: string) => {
-		const next = rawValue.trim();
+		const next = isLinkedNotesColumn
+			? normalizeLinkedNoteListValue(rawValue)
+			: rawValue.trim();
 		if (!next) return;
 		const currentValues = uniqueValues(cellValue.value_list);
 		const lowerCurrent = new Set(
@@ -445,6 +475,15 @@ function DatabaseCellEditor({
 		setValueDraft("");
 		await saveListValues([...currentValues, next]);
 	};
+	const linkedNoteListAutocomplete = useWikiLinkAutocomplete({
+		enabled: isLinkedNotesColumn,
+		inputRef: valueInputRef,
+		value: valueDraft,
+		onChange: setValueDraft,
+		onSelectItem: (item) => {
+			void addListValue(item.insertText).catch(handleTagSaveError);
+		},
+	});
 
 	const removeListValue = async (valueToRemove: string) => {
 		const normalized = valueToRemove.trim().toLowerCase();
@@ -490,7 +529,11 @@ function DatabaseCellEditor({
 					kind: column.property_kind ?? cellValue.kind,
 					value_list: draft
 						.split(",")
-						.map((value) => value.trim())
+						.map((value) =>
+							isLinkedNotesColumn
+								? normalizeLinkedNoteListValue(value)
+								: value.trim(),
+						)
 						.filter(Boolean),
 				});
 				onClose();
@@ -839,7 +882,14 @@ function DatabaseCellEditor({
 							cellValue.value_list.length > 0 ? "" : "Add or choose a value"
 						}
 						onFocus={handleSelectRow}
-						onChange={(event) => setValueDraft(event.target.value)}
+						onChange={(event) => {
+							const nextValue = event.target.value;
+							setValueDraft(nextValue);
+							linkedNoteListAutocomplete.refresh(
+								nextValue,
+								event.currentTarget.selectionStart,
+							);
+						}}
 						onBlur={(event) => {
 							const relatedTarget = event.relatedTarget as Node | null;
 							if (
@@ -864,8 +914,13 @@ function DatabaseCellEditor({
 						onClick={(event) => {
 							handleSelectRow();
 							event.stopPropagation();
+							linkedNoteListAutocomplete.refresh(
+								event.currentTarget.value,
+								event.currentTarget.selectionStart,
+							);
 						}}
 						onKeyDown={(event) => {
+							if (linkedNoteListAutocomplete.handleKeyDown(event)) return;
 							if (event.key === "Enter" || event.key === ",") {
 								event.preventDefault();
 								void addListValue(valueDraft).catch(handleTagSaveError);
@@ -887,7 +942,31 @@ function DatabaseCellEditor({
 						}}
 					/>
 				</div>
-				{valueSuggestions.length > 0 ? (
+				{linkedNoteListAutocomplete.items.length > 0 ? (
+					<div className="wikiLinkSuggestionMenu databaseWikiLinkSuggestions">
+						{linkedNoteListAutocomplete.items.map((item, index) => (
+							<button
+								key={item.path}
+								type="button"
+								className={[
+									"wikiLinkSuggestionItem",
+									index === linkedNoteListAutocomplete.activeIndex
+										? "active"
+										: "",
+								]
+									.filter(Boolean)
+									.join(" ")}
+								onMouseDown={(event) => {
+									event.preventDefault();
+									linkedNoteListAutocomplete.select(item);
+								}}
+							>
+								<span className="wikiLinkSuggestionTitle">{item.title}</span>
+								<span className="wikiLinkSuggestionPath">{item.path}</span>
+							</button>
+						))}
+					</div>
+				) : valueSuggestions.length > 0 ? (
 					<div className="notePropertySuggestions databaseTagSuggestions">
 						<div className="notePropertySuggestionsLabel">Suggested values</div>
 						<div className="notePropertySuggestionList">
@@ -927,18 +1006,34 @@ function DatabaseCellEditor({
 							: "text"
 				}
 				value={draft}
-				onChange={(event) => setDraft(event.target.value)}
+				onChange={(event) => {
+					const nextValue = event.target.value;
+					setDraft(nextValue);
+					wikiLinkAutocomplete.refresh(
+						nextValue,
+						event.currentTarget.selectionStart,
+					);
+				}}
 				onBlur={() => void commitText()}
 				onFocus={(event) => {
 					handleSelectRow();
 					event.currentTarget.select();
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
 				}}
 				onClick={(event) => {
 					handleSelectRow();
 					event.stopPropagation();
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
 				}}
 				onDoubleClick={(event) => event.stopPropagation()}
 				onKeyDown={(event) => {
+					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
 					if (event.key === "Enter") {
 						event.preventDefault();
 						void commitText();
@@ -949,7 +1044,29 @@ function DatabaseCellEditor({
 					}
 				}}
 			/>
-			{textSuggestions.length > 0 ? (
+			{wikiLinkAutocomplete.items.length > 0 ? (
+				<div className="wikiLinkSuggestionMenu databaseWikiLinkSuggestions">
+					{wikiLinkAutocomplete.items.map((item, index) => (
+						<button
+							key={item.path}
+							type="button"
+							className={[
+								"wikiLinkSuggestionItem",
+								index === wikiLinkAutocomplete.activeIndex ? "active" : "",
+							]
+								.filter(Boolean)
+								.join(" ")}
+							onMouseDown={(event) => {
+								event.preventDefault();
+								wikiLinkAutocomplete.select(item);
+							}}
+						>
+							<span className="wikiLinkSuggestionTitle">{item.title}</span>
+							<span className="wikiLinkSuggestionPath">{item.path}</span>
+						</button>
+					))}
+				</div>
+			) : textSuggestions.length > 0 ? (
 				<div className="notePropertySuggestions databaseTagSuggestions">
 					<div className="notePropertySuggestionsLabel">Suggested values</div>
 					<div className="notePropertySuggestionList">

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -123,7 +123,7 @@ const builtInColumns: DatabaseColumn[] = [
 		label: "Linked Notes",
 		icon: defaultDatabaseColumnIconName({
 			type: "linked_notes",
-			property_kind: null,
+			property_kind: "relation",
 		}),
 		width: 220,
 		visible: false,

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -127,6 +127,7 @@ const builtInColumns: DatabaseColumn[] = [
 		}),
 		width: 220,
 		visible: false,
+		property_kind: "relation",
 	},
 	{
 		id: "created",

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, RefObject } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "../../../lib/tauri";
 
 const WIKI_LINK_SUGGESTION_LIMIT = 8;
@@ -111,6 +111,12 @@ export function useWikiLinkAutocomplete({
 		},
 		[close, enabled],
 	);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input || document.activeElement !== input) return;
+		refresh(value, input.selectionStart);
+	}, [inputRef, refresh, value]);
 
 	const select = useCallback(
 		(item: WikiLinkSuggestion) => {

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -1,0 +1,178 @@
+import type { KeyboardEvent, RefObject } from "react";
+import { useCallback, useRef, useState } from "react";
+import { invoke } from "../../../lib/tauri";
+
+const WIKI_LINK_SUGGESTION_LIMIT = 8;
+
+export interface WikiLinkSuggestion {
+	path: string;
+	title: string;
+	insertText: string;
+}
+
+interface WikiLinkRange {
+	from: number;
+	to: number;
+	query: string;
+}
+
+interface UseWikiLinkAutocompleteOptions {
+	enabled: boolean;
+	inputRef: RefObject<HTMLInputElement | null>;
+	value: string;
+	onChange: (value: string) => void;
+	onSelectItem?: (item: WikiLinkSuggestion) => void;
+}
+
+function findActiveWikiLinkRange(
+	value: string,
+	selectionStart: number | null,
+): WikiLinkRange | null {
+	if (selectionStart == null) return null;
+	const beforeCursor = value.slice(0, selectionStart);
+	const openIndex = beforeCursor.lastIndexOf("[[");
+	if (openIndex < 0) return null;
+
+	const afterOpen = beforeCursor.slice(openIndex + 2);
+	if (afterOpen.includes("]]") || afterOpen.includes("\n")) return null;
+	if (afterOpen.includes("[") || afterOpen.includes("]")) return null;
+
+	return {
+		from: openIndex,
+		to: selectionStart,
+		query: afterOpen.trim(),
+	};
+}
+
+export function useWikiLinkAutocomplete({
+	enabled,
+	inputRef,
+	value,
+	onChange,
+	onSelectItem,
+}: UseWikiLinkAutocompleteOptions) {
+	const requestIdRef = useRef(0);
+	const [range, setRange] = useState<WikiLinkRange | null>(null);
+	const [items, setItems] = useState<WikiLinkSuggestion[]>([]);
+	const [activeIndex, setActiveIndex] = useState(0);
+
+	const close = useCallback(() => {
+		requestIdRef.current += 1;
+		setRange(null);
+		setItems([]);
+		setActiveIndex(0);
+	}, []);
+
+	const refresh = useCallback(
+		(nextValue: string, selectionStart: number | null) => {
+			if (!enabled) {
+				close();
+				return;
+			}
+
+			const nextRange = findActiveWikiLinkRange(nextValue, selectionStart);
+			if (!nextRange) {
+				close();
+				return;
+			}
+
+			const requestId = requestIdRef.current + 1;
+			requestIdRef.current = requestId;
+			setRange(nextRange);
+			setActiveIndex(0);
+			setItems([]);
+
+			void invoke("space_suggest_links", {
+				request: {
+					query: nextRange.query,
+					markdown_only: true,
+					include_pdf: false,
+					include_images: false,
+					strip_markdown_ext: true,
+					relative_to_source: false,
+					limit: WIKI_LINK_SUGGESTION_LIMIT,
+				},
+			})
+				.then((results) => {
+					if (requestIdRef.current !== requestId) return;
+					setItems(
+						results.map((item) => ({
+							path: item.path,
+							title: item.title || item.path,
+							insertText: item.insert_text,
+						})),
+					);
+				})
+				.catch((error) => {
+					if (requestIdRef.current !== requestId) return;
+					console.warn("Failed to load wikilink suggestions", error);
+					setItems([]);
+				});
+		},
+		[close, enabled],
+	);
+
+	const select = useCallback(
+		(item: WikiLinkSuggestion) => {
+			if (onSelectItem) {
+				onSelectItem(item);
+				close();
+				return;
+			}
+			if (!range) return;
+			const markdown = `[[${item.insertText}]]`;
+			const nextValue = `${value.slice(0, range.from)}${markdown}${value.slice(
+				range.to,
+			)}`;
+			const nextCursor = range.from + markdown.length;
+			onChange(nextValue);
+			close();
+			requestAnimationFrame(() => {
+				const input = inputRef.current;
+				if (!input) return;
+				input.focus();
+				input.setSelectionRange(nextCursor, nextCursor);
+			});
+		},
+		[close, inputRef, onChange, onSelectItem, range, value],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLInputElement>) => {
+			if (!items.length) return false;
+			if (event.key === "ArrowDown") {
+				event.preventDefault();
+				setActiveIndex((current) => (current + 1) % items.length);
+				return true;
+			}
+			if (event.key === "ArrowUp") {
+				event.preventDefault();
+				setActiveIndex(
+					(current) => (current - 1 + items.length) % items.length,
+				);
+				return true;
+			}
+			if (event.key === "Enter" || event.key === "Tab") {
+				event.preventDefault();
+				select(items[activeIndex] ?? items[0]);
+				return true;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				close();
+				return true;
+			}
+			return false;
+		},
+		[activeIndex, close, items, select],
+	);
+
+	return {
+		activeIndex,
+		close,
+		handleKeyDown,
+		items,
+		refresh,
+		select,
+	};
+}

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
 	priorityColorKey,
 	priorityOptionsWithCustomValues,
@@ -21,7 +21,9 @@ import {
 	DropdownMenuTrigger,
 } from "../../ui/shadcn/dropdown-menu";
 import { Input } from "../../ui/shadcn/input";
+import { useWikiLinkAutocomplete } from "../hooks/useWikiLinkAutocomplete";
 import { EDITOR_TEXT_COLORS, type EditorTextColor } from "../textColors";
+import { WikiLinkedText } from "./WikiLinkedText";
 import { buildTagSuggestions, formatTagLabel } from "./utils";
 
 interface NotePropertyValueFieldProps {
@@ -59,6 +61,13 @@ export function NotePropertyValueField({
 }: NotePropertyValueFieldProps) {
 	const textValue = property.value_text ?? "";
 	const [textDraft, setTextDraft] = useState(textValue);
+	const textInputRef = useRef<HTMLInputElement | null>(null);
+	const wikiLinkAutocomplete = useWikiLinkAutocomplete({
+		enabled: property.kind === "text" && !readOnly,
+		inputRef: textInputRef,
+		value: textDraft,
+		onChange: setTextDraft,
+	});
 
 	useEffect(() => {
 		setTextDraft(textValue);
@@ -106,7 +115,7 @@ export function NotePropertyValueField({
 		}
 		return (
 			<span style={{ color: "var(--text-primary)" }}>
-				{property.value_text ?? ""}
+				<WikiLinkedText value={property.value_text ?? ""} />
 			</span>
 		);
 	}
@@ -325,26 +334,74 @@ export function NotePropertyValueField({
 	}
 
 	return (
-		<Input
-			className="plainTextInput notePropertyFieldInput"
-			style={{ color: "var(--text-primary)" }}
-			type={
-				property.kind === "date"
-					? "date"
-					: property.kind === "url"
-						? "url"
-						: "text"
-			}
-			value={textDraft}
-			placeholder="Value"
-			aria-label={`${property.key || "Property"} value`}
-			onChange={(event) => setTextDraft(event.target.value)}
-			onBlur={commitTextDraft}
-			onKeyDown={(event) => {
-				if (event.key !== "Enter") return;
-				event.preventDefault();
-				event.currentTarget.blur();
-			}}
-		/>
+		<div className="notePropertyTextEditor">
+			<Input
+				ref={(node) => {
+					textInputRef.current = node;
+				}}
+				className="plainTextInput notePropertyFieldInput"
+				style={{ color: "var(--text-primary)" }}
+				type={
+					property.kind === "date"
+						? "date"
+						: property.kind === "url"
+							? "url"
+							: "text"
+				}
+				value={textDraft}
+				placeholder="Value"
+				aria-label={`${property.key || "Property"} value`}
+				onChange={(event) => {
+					const nextValue = event.target.value;
+					setTextDraft(nextValue);
+					wikiLinkAutocomplete.refresh(
+						nextValue,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onBlur={commitTextDraft}
+				onFocus={(event) => {
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onClick={(event) => {
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onKeyDown={(event) => {
+					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
+					if (event.key !== "Enter") return;
+					event.preventDefault();
+					event.currentTarget.blur();
+				}}
+			/>
+			{wikiLinkAutocomplete.items.length > 0 ? (
+				<div className="wikiLinkSuggestionMenu notePropertyWikiLinkSuggestions">
+					{wikiLinkAutocomplete.items.map((item, itemIndex) => (
+						<button
+							key={item.path}
+							type="button"
+							className={[
+								"wikiLinkSuggestionItem",
+								itemIndex === wikiLinkAutocomplete.activeIndex ? "active" : "",
+							]
+								.filter(Boolean)
+								.join(" ")}
+							onMouseDown={(event) => {
+								event.preventDefault();
+								wikiLinkAutocomplete.select(item);
+							}}
+						>
+							<span className="wikiLinkSuggestionTitle">{item.title}</span>
+							<span className="wikiLinkSuggestionPath">{item.path}</span>
+						</button>
+					))}
+				</div>
+			) : null}
+		</div>
 	);
 }

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import {
+	type WikiLinkClickDetail,
+	dispatchWikiLinkClick,
+} from "../markdown/editorEvents";
+import { findWikiLinkSpans, parseWikiLink } from "../markdown/wikiLinkCodec";
+
+function displayNameForTarget(target: string): string {
+	return target.split("/").pop()?.replace(/\.md$/i, "") || target;
+}
+
+function clickDetailFromRaw(raw: string): WikiLinkClickDetail | null {
+	const parsed = parseWikiLink(raw);
+	if (!parsed) return null;
+	return {
+		raw: parsed.raw,
+		target: parsed.target,
+		alias: parsed.alias,
+		anchorKind: parsed.anchorKind,
+		anchor: parsed.anchor,
+		unresolved: parsed.unresolved,
+		embed: parsed.embed,
+	};
+}
+
+export function WikiLinkedText({ value }: { value: string }) {
+	const spans = findWikiLinkSpans(value);
+	if (!spans.length) return <>{value}</>;
+
+	const nodes: ReactNode[] = [];
+	let cursor = 0;
+	for (const span of spans) {
+		if (cursor < span.start) {
+			nodes.push(value.slice(cursor, span.start));
+		}
+		const detail = clickDetailFromRaw(span.raw);
+		if (!detail) {
+			nodes.push(span.raw);
+		} else {
+			nodes.push(
+				<button
+					key={`${span.start}:${span.end}`}
+					type="button"
+					className="wikiLink notePropertyWikiLink"
+					data-target={detail.target}
+					data-unresolved={String(detail.unresolved)}
+					onClick={() => dispatchWikiLinkClick(detail)}
+					title={detail.target}
+				>
+					<span className="wikiLinkIcon" aria-hidden="true" />
+					{detail.alias || displayNameForTarget(detail.target)}
+				</button>,
+			);
+		}
+		cursor = span.end;
+	}
+	if (cursor < value.length) {
+		nodes.push(value.slice(cursor));
+	}
+	return <span className="notePropertyWikiText">{nodes}</span>;
+}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -604,9 +604,8 @@ export function MarkdownEditorPane({
 		const handleToggleInfoSidebar = (event: Event) => {
 			const detail = (event as CustomEvent<ToggleNoteInfoSidebarDetail>).detail;
 			if (!detail?.path || detail.path !== relPath) return;
-			const nextOpen = !infoPanelOpen;
-			if (nextOpen) setAiPanelOpen(false);
-			setInfoPanelOpen(nextOpen);
+			setAiPanelOpen(() => false);
+			setInfoPanelOpen((open) => !open);
 		};
 		window.addEventListener(FORCE_NOTE_EDIT_MODE_EVENT, handleForceEditMode);
 		window.addEventListener(OPEN_LOCAL_GRAPH_EVENT, handleOpenLocalGraph);
@@ -625,7 +624,7 @@ export function MarkdownEditorPane({
 				handleToggleInfoSidebar,
 			);
 		};
-	}, [infoPanelOpen, relPath, setAiPanelOpen]);
+	}, [relPath, setAiPanelOpen]);
 
 	useEffect(() => {
 		if (aiPanelOpen) setInfoPanelOpen(false);
@@ -753,10 +752,9 @@ export function MarkdownEditorPane({
 	);
 
 	const toggleInfoPanel = useCallback(() => {
-		const nextOpen = !infoPanelOpen;
-		if (nextOpen) setAiPanelOpen(false);
-		setInfoPanelOpen(nextOpen);
-	}, [infoPanelOpen, setAiPanelOpen]);
+		setAiPanelOpen(() => false);
+		setInfoPanelOpen((open) => !open);
+	}, [setAiPanelOpen]);
 
 	const handleEditorActionsMenu = useCallback(
 		(event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -805,9 +803,8 @@ export function MarkdownEditorPane({
 								openSettings("ai");
 								return;
 							}
-							const nextOpen = !aiPanelOpen;
-							if (nextOpen) setInfoPanelOpen(false);
-							setAiPanelOpen(nextOpen);
+							setInfoPanelOpen(() => false);
+							setAiPanelOpen((open) => !open);
 						}}
 						aria-label={
 							aiEnabled

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -604,11 +604,9 @@ export function MarkdownEditorPane({
 		const handleToggleInfoSidebar = (event: Event) => {
 			const detail = (event as CustomEvent<ToggleNoteInfoSidebarDetail>).detail;
 			if (!detail?.path || detail.path !== relPath) return;
-			setInfoPanelOpen((open) => {
-				const nextOpen = !open;
-				if (nextOpen) setAiPanelOpen(false);
-				return nextOpen;
-			});
+			const nextOpen = !infoPanelOpen;
+			if (nextOpen) setAiPanelOpen(false);
+			setInfoPanelOpen(nextOpen);
 		};
 		window.addEventListener(FORCE_NOTE_EDIT_MODE_EVENT, handleForceEditMode);
 		window.addEventListener(OPEN_LOCAL_GRAPH_EVENT, handleOpenLocalGraph);
@@ -627,7 +625,7 @@ export function MarkdownEditorPane({
 				handleToggleInfoSidebar,
 			);
 		};
-	}, [relPath, setAiPanelOpen]);
+	}, [infoPanelOpen, relPath, setAiPanelOpen]);
 
 	useEffect(() => {
 		if (aiPanelOpen) setInfoPanelOpen(false);
@@ -755,12 +753,10 @@ export function MarkdownEditorPane({
 	);
 
 	const toggleInfoPanel = useCallback(() => {
-		setInfoPanelOpen((open) => {
-			const nextOpen = !open;
-			if (nextOpen) setAiPanelOpen(false);
-			return nextOpen;
-		});
-	}, [setAiPanelOpen]);
+		const nextOpen = !infoPanelOpen;
+		if (nextOpen) setAiPanelOpen(false);
+		setInfoPanelOpen(nextOpen);
+	}, [infoPanelOpen, setAiPanelOpen]);
 
 	const handleEditorActionsMenu = useCallback(
 		(event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -809,11 +805,9 @@ export function MarkdownEditorPane({
 								openSettings("ai");
 								return;
 							}
-							setAiPanelOpen((open) => {
-								const nextOpen = !open;
-								if (nextOpen) setInfoPanelOpen(false);
-								return nextOpen;
-							});
+							const nextOpen = !aiPanelOpen;
+							if (nextOpen) setInfoPanelOpen(false);
+							setAiPanelOpen(nextOpen);
 						}}
 						aria-label={
 							aiEnabled

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -31,8 +31,7 @@ export function isColumnEditable(column: DatabaseColumn): boolean {
 		column.type === "path" ||
 		column.type === "folder" ||
 		column.type === "created" ||
-		column.type === "updated" ||
-		column.type === "linked_notes"
+		column.type === "updated"
 	) {
 		return false;
 	}

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -7,6 +7,7 @@
 	--all-docs-card-title-size: 0.9rem;
 	--all-docs-card-preview-size: 0.78rem;
 	--all-docs-card-meta-size: 0.68rem;
+
 	display: flex;
 	flex: 1;
 	flex-direction: column;
@@ -404,6 +405,7 @@
 	.allDocsPane {
 		--all-docs-card-min-width: 144px;
 		--all-docs-card-min-height: 176px;
+
 		padding: 18px;
 	}
 

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -1,12 +1,34 @@
 .allDocsPane {
+	--all-docs-card-min-width: 184px;
+	--all-docs-card-min-height: 184px;
+	--all-docs-card-aspect: 1 / 1;
+	--all-docs-card-padding: 12px;
+	--all-docs-card-gap: 10px;
+	--all-docs-card-title-size: 0.9rem;
+	--all-docs-card-preview-size: 0.78rem;
+	--all-docs-card-meta-size: 0.68rem;
 	display: flex;
 	flex: 1;
 	flex-direction: column;
 	min-height: 0;
 	overflow-y: auto;
 	padding: clamp(20px, 2.8vw, 32px);
-	background: var(--bg-primary);
+	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-secondary));
 	gap: 18px;
+}
+
+.allDocsHeader {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.allDocsHeadingGroup {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 5px;
 }
 
 .allDocsTitle {
@@ -19,8 +41,11 @@
 
 .allDocsGrid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(176px, 1fr));
-	gap: 18px 16px;
+	grid-template-columns: repeat(
+			auto-fill,
+			minmax(var(--all-docs-card-min-width), 1fr)
+		);
+	gap: var(--all-docs-card-gap);
 	align-content: start;
 }
 
@@ -44,10 +69,10 @@
 }
 
 .allDocsSectionTitle {
-	font-size: 0.92rem;
+	font-size: 0.82rem;
 	font-weight: var(--font-semibold);
-	letter-spacing: 0.01em;
-	color: var(--text-primary);
+	letter-spacing: 0;
+	color: color-mix(in srgb, var(--text-primary) 88%, var(--text-secondary));
 }
 
 .allDocsCard {
@@ -82,49 +107,43 @@
 }
 
 .allDocsCardSurface {
+	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: 9px;
+	gap: 10px;
 	width: 100%;
-	aspect-ratio: 0.82 / 1;
-	min-height: 214px;
+	aspect-ratio: var(--all-docs-card-aspect);
+	min-height: var(--all-docs-card-min-height);
 	min-width: 0;
-	padding: 14px;
+	padding: var(--all-docs-card-padding);
 	border-radius: 8px;
-	background: var(--bg-primary);
-	outline: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
-	box-shadow: 0 12px 24px -20px
-		color-mix(in srgb, var(--text-primary) 42%, transparent), 0 3px 10px -8px
-		color-mix(in srgb, var(--text-primary) 28%, transparent);
+	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
+	border: 1px solid color-mix(in srgb, var(--text-primary) 9%, transparent);
+	box-shadow: 0 10px 22px -18px rgb(30 41 59 / 0.26);
 	overflow: hidden;
-	transition: background-color 120ms ease, outline-color 120ms ease, transform
+	transition: background-color 120ms ease, border-color 120ms ease, transform
 		120ms ease, box-shadow 120ms ease;
 }
 
 .allDocsCard:hover .allDocsCardSurface {
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--bg-hover) 94%, var(--bg-primary)) 0%,
-		color-mix(in srgb, var(--bg-hover) 82%, var(--bg-secondary)) 100%
-	);
-	outline-color: color-mix(in srgb, var(--text-primary) 14%, transparent);
-	box-shadow: 0 16px 30px -22px
-		color-mix(in srgb, var(--text-primary) 48%, transparent), 0 5px 14px -10px
-		color-mix(in srgb, var(--text-primary) 32%, transparent);
+	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-hover));
+	border-color: color-mix(in srgb, var(--text-primary) 14%, transparent);
+	box-shadow: 0 12px 24px -18px rgb(30 41 59 / 0.3);
 	transform: translateY(-1px);
 }
 
 .allDocsCard[data-state="selected"] .allDocsCardSurface {
-	outline: 1.5px solid
-		color-mix(in srgb, var(--interactive-accent) 40%, transparent);
-	background: linear-gradient(
-		180deg,
-		color-mix(in srgb, var(--interactive-accent) 8%, var(--bg-primary)) 0%,
-		color-mix(in srgb, var(--interactive-accent) 4%, var(--bg-secondary)) 100%
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 48%,
+		var(--text-primary)
 	);
-	box-shadow: 0 14px 28px -22px
-		color-mix(in srgb, var(--interactive-accent) 44%, transparent), 0 4px 12px
-		-10px color-mix(in srgb, var(--text-primary) 28%, transparent);
+	background: color-mix(
+		in srgb,
+		var(--bg-primary) 92%,
+		var(--interactive-accent)
+	);
+	box-shadow: 0 10px 22px -18px rgb(30 41 59 / 0.28);
 }
 
 .allDocsCard:focus-visible .allDocsCardSurface {
@@ -132,28 +151,116 @@
 		color-mix(in srgb, var(--interactive-accent) 24%, transparent);
 }
 
+.dark .allDocsCardSurface {
+	box-shadow: 0 10px 20px -18px rgb(2 6 23 / 0.86);
+}
+
+.dark .allDocsCard:hover .allDocsCardSurface {
+	box-shadow: 0 12px 22px -18px rgb(2 6 23 / 0.92);
+}
+
+.dark .allDocsCard[data-state="selected"] .allDocsCardSurface {
+	box-shadow: 0 10px 20px -18px rgb(2 6 23 / 0.9);
+}
+
+.dark .allDocsCard:focus-visible .allDocsCardSurface {
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+}
+
+.allDocsCardTop {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: start;
+	gap: 10px;
+	min-width: 0;
+}
+
 .allDocsCardTitle {
 	min-width: 0;
-	display: block;
-	flex: 0 0 auto;
-	font-size: 0.92rem;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	font-size: var(--all-docs-card-title-size);
 	font-weight: var(--font-semibold);
-	line-height: 1.32;
+	line-height: 1.3;
 	color: var(--text-primary);
-	overflow: visible;
+	overflow: hidden;
 	overflow-wrap: anywhere;
 	white-space: normal;
+}
+
+.allDocsCardPreview {
+	display: flex;
+	flex: 1 1 auto;
+	min-height: 0;
+	flex-direction: column;
+	gap: 3px;
+	overflow: hidden;
+	color: var(--text-secondary);
+	font-size: var(--all-docs-card-preview-size);
+	line-height: 1.45;
+	overflow-wrap: anywhere;
+	white-space: normal;
+}
+
+.allDocsCardPreviewLine {
+	display: block;
+	line-height: inherit;
+}
+
+.allDocsCardPreviewLine.is-heading {
+	font-weight: var(--font-semibold);
+	color: color-mix(in srgb, var(--text-primary) 92%, var(--text-secondary));
+}
+
+.allDocsCardPreviewLine.is-quote {
+	padding-left: 8px;
+	border-left: 2px solid
+		color-mix(in srgb, var(--border-light) 88%, transparent);
+	color: color-mix(in srgb, var(--text-secondary) 70%, var(--text-tertiary));
+}
+
+.allDocsCardPreviewLine.is-task::before {
+	content: "□";
+	margin-right: 5px;
+	color: var(--text-tertiary);
+}
+
+.allDocsCardPreviewLine.is-list {
+	color: var(--text-secondary);
+}
+
+.allDocsCardPreviewLine.is-code {
+	font-family: var(--font-mono, ui-monospace, monospace);
+	color: color-mix(in srgb, var(--text-secondary) 88%, var(--text-tertiary));
+}
+
+.allDocsCardPreview.is-placeholder {
+	color: var(--text-tertiary);
+	font-style: italic;
+}
+
+.allDocsCardFooter {
+	display: flex;
+	flex: 0 0 auto;
+	flex-direction: column;
+	gap: 8px;
+	min-width: 0;
+	margin-top: auto;
+	padding-top: 9px;
+	border-top: 1px solid color-mix(in srgb, var(--text-primary) 7%, transparent);
 }
 
 .allDocsCardMetaRow {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
 	align-items: center;
-	gap: 5px;
+	gap: 6px;
 	min-width: 0;
-	font-size: 0.68rem;
-	line-height: 1.2;
 	color: var(--text-tertiary);
+	font-size: var(--all-docs-card-meta-size);
+	line-height: 1.25;
 }
 
 .allDocsCardPath {
@@ -199,65 +306,57 @@
 	opacity: 0.72;
 }
 
-.allDocsCardDivider {
-	flex: 0 0 auto;
-	height: 1px;
-	margin: 1px 0 4px;
-	background: color-mix(in srgb, var(--text-primary) 12%, transparent);
-}
-
-.allDocsCardPreview {
+.allDocsCardSignals {
 	display: flex;
-	flex-direction: column;
-	gap: 2px;
-	flex: 1 1 auto;
-	min-height: 0;
-	font-size: 0.76rem;
-	line-height: 1.4;
-	color: var(--text-secondary);
-	overflow: hidden;
-	overflow-wrap: anywhere;
-	white-space: normal;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	min-width: 0;
 }
 
-.allDocsCardPreviewLine {
-	display: block;
-	line-height: inherit;
+.allDocsCardTaskSummary {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	gap: 4px;
+	color: color-mix(in srgb, var(--interactive-accent) 62%, var(--text-primary));
+	font-size: var(--all-docs-card-meta-size);
+	font-weight: var(--font-medium);
+	line-height: 1.25;
 }
 
-.allDocsCardPreviewLine.is-heading {
-	font-weight: var(--font-semibold);
-	color: var(--text-primary);
+.allDocsCardTaskSummary.is-top {
+	justify-self: end;
+	padding-top: 1px;
 }
 
-.allDocsCardPreviewLine.is-quote {
-	padding-left: 6px;
-	border-left: 2px solid
-		color-mix(in srgb, var(--border-light) 88%, transparent);
-	color: var(--text-tertiary);
+.allDocsCardTaskProgress {
+	width: 14px;
+	height: 14px;
 }
 
-.allDocsCardPreviewLine.is-list {
-	color: var(--text-secondary);
+.allDocsCardTaskProgress .markdownEditorTaskProgressRing {
+	width: 13px;
+	height: 13px;
+	border-width: 2px;
 }
 
-.allDocsCardPreviewLine.is-code {
-	font-family: var(--font-mono, ui-monospace, monospace);
-	color: color-mix(in srgb, var(--text-secondary) 88%, var(--text-tertiary));
+.allDocsCardTaskProgress .markdownEditorTaskProgressPie {
+	width: 6px;
+	height: 6px;
 }
 
-.allDocsCardPreview.is-placeholder {
-	color: var(--text-tertiary);
-	font-style: italic;
+.allDocsCardTaskText {
+	white-space: nowrap;
 }
 
 .allDocsCardTags {
 	display: flex;
-	flex: 0 0 auto;
+	flex: 1 1 auto;
 	flex-wrap: nowrap;
+	justify-content: flex-end;
 	gap: 5px;
 	min-width: 0;
-	margin-top: auto;
 	overflow: hidden;
 }
 
@@ -266,23 +365,26 @@
 	align-items: center;
 	gap: 4px;
 	max-width: 100%;
-	flex: 0 0 auto;
+	flex: 0 1 auto;
+	min-width: 0;
 	padding: 2px 7px;
 	border: 0;
-	border-radius: 4px;
+	border-radius: var(--pill-radius);
 	background: color-mix(
 		in srgb,
 		var(--interactive-accent) 9%,
 		var(--bg-primary)
 	);
 	color: color-mix(in srgb, var(--interactive-accent) 62%, var(--text-primary));
-	font-size: 0.68rem;
+	font-size: var(--all-docs-card-meta-size);
 	font-weight: var(--font-medium);
-	line-height: 1.2;
+	line-height: 1.25;
 	white-space: nowrap;
+	box-shadow: var(--pill-shadow);
 }
 
 .allDocsCardTag.is-muted {
+	flex: 0 0 auto;
 	background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
 	color: var(--text-tertiary);
 }
@@ -293,17 +395,19 @@
 }
 
 @media (max-width: 900px) {
-	.allDocsGrid {
-		grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+	.allDocsPane {
+		--all-docs-card-min-width: 160px;
 	}
 }
 
 @media (max-width: 640px) {
 	.allDocsPane {
+		--all-docs-card-min-width: 144px;
+		--all-docs-card-min-height: 176px;
 		padding: 18px;
 	}
 
-	.allDocsGrid {
-		grid-template-columns: repeat(auto-fill, minmax(144px, 1fr));
+	.allDocsHeader {
+		align-items: flex-start;
 	}
 }

--- a/src/styles/app/21-ai-composer-context.css
+++ b/src/styles/app/21-ai-composer-context.css
@@ -46,6 +46,24 @@
 	color: var(--text-primary);
 }
 
+.aiPanel .aiContextChipSuggestion {
+	color: var(--text-tertiary);
+	background: transparent;
+	box-shadow: none;
+	opacity: 0.68;
+}
+
+.aiPanel .aiContextChipSuggestion:hover:not(:disabled) {
+	color: var(--text-secondary);
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+	opacity: 1;
+}
+
+.aiPanel .aiContextChipSuggestion:disabled {
+	cursor: default;
+	opacity: 0.35;
+}
+
 .aiPanel .aiContextChip:hover .aiContextChipClose {
 	color: var(--text-primary);
 }

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -229,12 +229,41 @@ input.notePropertyValue {
 	min-width: 0;
 }
 
+.notePropertyTextEditor {
+	position: relative;
+	min-width: 0;
+	width: 100%;
+}
+
+.notePropertyTextEditor .notePropertyWikiLinkSuggestions {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	width: 280px;
+	max-width: min(280px, calc(100vw - 40px));
+	z-index: 40;
+}
+
 .notePropertyValueStatic {
 	color: var(--text-primary);
 	min-width: 0;
 	overflow-wrap: break-word;
 	font-size: 12.5px;
 	line-height: 1.35;
+}
+
+.notePropertyWikiText {
+	display: inline;
+	white-space: normal;
+}
+
+.notePropertyWikiLink {
+	margin: 0 2px;
+	vertical-align: baseline;
+}
+
+.notePropertyRow:has(.notePropertyWikiLinkSuggestions) {
+	z-index: 5;
 }
 
 .notePropertyKindBadge {

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -151,7 +151,8 @@
 	border-top: 1px solid color-mix(in srgb, var(--border-light) 60%, transparent);
 }
 
-.databaseBodyCell:has(.databaseTagSuggestions) {
+.databaseBodyCell:has(.databaseTagSuggestions),
+.databaseBodyCell:has(.databaseWikiLinkSuggestions) {
 	z-index: 4;
 }
 
@@ -302,6 +303,16 @@
 	border-color: transparent;
 }
 
+.databaseTagEditor .databaseWikiLinkSuggestions {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: auto;
+	right: 0;
+	width: 280px;
+	max-width: min(280px, calc(100vw - 40px));
+	z-index: 30;
+}
+
 .databaseCellPill {
 	--database-tone: var(--interactive-accent);
 
@@ -412,7 +423,8 @@
 	transition: background-color 120ms ease;
 }
 
-.databaseRow:has(.databaseTagSuggestions) {
+.databaseRow:has(.databaseTagSuggestions),
+.databaseRow:has(.databaseWikiLinkSuggestions) {
 	z-index: 4;
 }
 


### PR DESCRIPTION
PR: 0.5.0 — Subtle Improvements

Branch: 0.5.0/subtle-improvements → main
Commit: fb8258a
Create PR: https://github.com/SidhuK/Glyph/pull/new/0.5.0/subtle-improvements

---

Summary

A focused round of UX polish and small feature additions for the 0.5.0 line. Touches the AI composer, the All Docs pane, database cells, and note properties — adds wiki-link autocomplete to more surfaces, surfaces the active file as quick AI context, restyles the All Docs cards, and fixes a sidebar interaction bug.

Highlights

🤖 AI Composer — active-file context suggestion
The currently open markdown tab is now offered as a one-click context chip in the AI composer so you can attach the file you're actually looking at without searching for it.

- New activeFilePath prop on AIComposer, fed by activeMarkdownTabPath from UILayoutContext via AIPanel.
- Suggestion chip is hidden when the file is already attached — gated by a new hasContext(kind, path) helper on useAiContext.
- Paths are normalized through normalizeRelPath so duplicates can't slip in.
- New styling in [21-ai-composer-context.css](file:///Users/karat/Developer/Glyph/src/styles/app/21-ai-composer-context.css) for the suggestion chip variant.

Files: [AIComposer.tsx](file:///Users/karat/Developer/Glyph/src/components/ai/AIComposer.tsx), [AIPanel.tsx](file:///Users/karat/Developer/Glyph/src/components/ai/AIPanel.tsx), [useAiContext.ts](file:///Users/karat/Developer/Glyph/src/components/ai/useAiContext.ts)

🐛 Bugfix — Note Info sidebar no longer closes the AI sidebar
Opening the note info sidebar previously triggered the AI sidebar to close. Interaction is now decoupled — both panels can coexist as expected.

File: [MarkdownEditorPane.tsx](file:///Users/karat/Developer/Glyph/src/components/preview/MarkdownEditorPane.tsx)

🔗 Wiki-link autocomplete in more places
The wiki-link [[…]] autocomplete is now reusable and wired into database cells and note property values, so cross-linking works the same everywhere — not just in the main editor.

- New shared hook [useWikiLinkAutocomplete.ts](file:///Users/karat/Developer/Glyph/src/components/editor/hooks/useWikiLinkAutocomplete.ts) — single source of truth for [[…]] suggestion logic, applicable to any text input.
- New [WikiLinkedText.tsx](file:///Users/karat/Developer/Glyph/src/components/editor/noteProperties/WikiLinkedText.tsx) — renders inline wiki-links inside property values.
- DatabaseCell now supports wiki-link autocomplete for plain-text property columns and treats linked_notes columns as list-like, with normalized [[Note]] parsing.
- NotePropertyValueField integrates the hook and renders linked text via WikiLinkedText.

Files: [DatabaseCell.tsx](file:///Users/karat/Developer/Glyph/src/components/database/DatabaseCell.tsx), [NotePropertyValueField.tsx](file:///Users/karat/Developer/Glyph/src/components/editor/noteProperties/NotePropertyValueField.tsx)

🧹 All Docs pane — cleaned UI + task progress
The All Docs view got a visual cleanup and now surfaces per-note task progress.

- New allDocsHeader / allDocsHeadingGroup structure for a calmer header.
- Card grid restyled in [15-all-docs.css](file:///Users/karat/Developer/Glyph/src/styles/app/15-all-docs.css) (+282 / −95 lines).
- Task previews now render with a dedicated task line kind instead of being treated as plain list items.
- Integrates useTaskProgressIndicatorSetting + useTaskSummariesForPaths to show a TaskProgressIndicator on cards.
- Live-updates via a taskSummaryRefreshKey when the underlying tree changes.

File: [AllDocsPane.tsx](file:///Users/karat/Developer/Glyph/src/components/app/AllDocsPane.tsx)

🗄️ Database — minor backend tweaks
Small adjustments in databases/commands.rs and databases/query.rs to support the linked-notes column behavior on the frontend.

Files Changed (17 files, +873 / −192)

Area
Files
AI
AIComposer.tsx, AIPanel.tsx, useAiContext.ts, 21-ai-composer-context.css
All Docs
AllDocsPane.tsx, 15-all-docs.css
Database
DatabaseCell.tsx, DatabaseViewOptionsPopover.tsx, 47-database-table-dialogs.css, lib/database/config.ts, databases/commands.rs, databases/query.rs
Editor / Properties
useWikiLinkAutocomplete.ts (new), WikiLinkedText.tsx (new), NotePropertyValueField.tsx, 24-node-note-properties.css
Preview
MarkdownEditorPane.tsx

Testing Notes

- AI composer: open a markdown file → AI panel → confirm the active file appears as a suggestion chip; click to attach; verify the suggestion disappears once attached and reappears after removing it; switch to another file and verify the suggestion updates.
- Sidebar bugfix: open the AI sidebar, then toggle the note info sidebar — both should remain open.
- Wiki-links: type [[ inside a database text cell and inside a note property field — autocomplete suggestions should appear; selecting one inserts [[Note]]; existing values render as clickable links.
- All Docs: open the All Docs pane and verify cards show task progress where applicable; create/complete a task and confirm the card refreshes.

Risk

Low — changes are additive UI improvements plus one targeted bugfix. No data migrations, no schema changes. The database backend tweaks are minor and scoped to support the new linked-notes cell behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki-link autocomplete ( [[...]] ) when editing text properties and linked-notes lists
  * Linked-notes columns are now editable
  * AI composer suggests the active file as context

* **Improvements**
  * All Docs shows per-note task progress and receives refreshed card styling
  * Text properties render wiki-style links for navigation
  * Linked-note resolution improved to better match targets by id or title

* **Style**
  * New styling for suggestion chips and wiki-link suggestion dropdowns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SidhuK/Glyph/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->