### PR TITLE
fix: normalize Rig AI base URLs

### DIFF
--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -75,6 +75,11 @@ pub fn parse_base_url(profile: &AiProfile) -> Result<Url, String> {
     Ok(url)
 }
 
+pub fn parse_rig_base_url(profile: &AiProfile) -> Result<String, String> {
+    let url = parse_base_url(profile)?;
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
 pub fn parse_ollama_base_url(profile: &AiProfile) -> Result<Url, String> {
     let mut url = parse_base_url(profile)?;
     let trimmed_path = url.path().trim_end_matches('/').to_string();
@@ -88,6 +93,11 @@ pub fn parse_ollama_base_url(profile: &AiProfile) -> Result<Url, String> {
         url.set_path(&normalized_path);
     }
     Ok(url)
+}
+
+pub fn parse_rig_ollama_base_url(profile: &AiProfile) -> Result<String, String> {
+    let url = parse_ollama_base_url(profile)?;
+    Ok(url.as_str().trim_end_matches('/').to_string())
 }
 
 pub fn ollama_api_url(profile: &AiProfile, path: &str) -> Result<Url, String> {
@@ -330,6 +340,7 @@ pub fn derive_chat_title(messages: &[AiMessage]) -> String {
 mod tests {
     use super::{
         alternate_openai_base_url, default_base_url, ollama_api_url, parse_ollama_base_url,
+        parse_rig_base_url, parse_rig_ollama_base_url,
     };
     use crate::ai_rig::types::{AiProfile, AiProviderKind};
 
@@ -339,6 +350,19 @@ mod tests {
             name: "Ollama".to_string(),
             provider: AiProviderKind::Ollama,
             model: "llama3.2".to_string(),
+            base_url: base_url.map(str::to_string),
+            headers: Vec::new(),
+            allow_private_hosts: true,
+            reasoning_effort: None,
+        }
+    }
+
+    fn openai_compat_profile(base_url: Option<&str>) -> AiProfile {
+        AiProfile {
+            id: "openai_compat".to_string(),
+            name: "OpenAI Compatible".to_string(),
+            provider: AiProviderKind::OpenaiCompat,
+            model: "local-model".to_string(),
             base_url: base_url.map(str::to_string),
             headers: Vec::new(),
             allow_private_hosts: true,
@@ -383,6 +407,27 @@ mod tests {
         let profile = ollama_profile(Some("http://localhost:11434/v1"));
         let url = parse_ollama_base_url(&profile).expect("ollama url should parse");
         assert_eq!(url.as_str(), "http://localhost:11434/");
+    }
+
+    #[test]
+    fn parse_rig_base_url_strips_trailing_slash() {
+        let profile = openai_compat_profile(Some("http://192.168.68.84:1263/v1"));
+        let url = parse_rig_base_url(&profile).expect("openai-compatible url should parse");
+        assert_eq!(url, "http://192.168.68.84:1263/v1");
+    }
+
+    #[test]
+    fn parse_rig_base_url_strips_explicit_trailing_slash() {
+        let profile = openai_compat_profile(Some("http://192.168.68.84:1263/v1/"));
+        let url = parse_rig_base_url(&profile).expect("openai-compatible url should parse");
+        assert_eq!(url, "http://192.168.68.84:1263/v1");
+    }
+
+    #[test]
+    fn parse_rig_ollama_base_url_strips_root_trailing_slash() {
+        let profile = ollama_profile(Some("http://localhost:11434"));
+        let url = parse_rig_ollama_base_url(&profile).expect("ollama url should parse");
+        assert_eq!(url, "http://localhost:11434");
     }
 
     #[test]

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -431,6 +431,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_rig_ollama_base_url_preserves_proxy_prefix() {
+        let profile = ollama_profile(Some("http://localhost:11434/ollama/v1"));
+        let url = parse_rig_ollama_base_url(&profile).expect("ollama url should parse");
+        assert_eq!(url, "http://localhost:11434/ollama");
+    }
+
+    #[test]
     fn parse_ollama_base_url_preserves_proxy_prefix() {
         let profile = ollama_profile(Some("http://localhost:11434/ollama/v1"));
         let url = parse_ollama_base_url(&profile).expect("ollama url should parse");

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -99,14 +99,12 @@ pub async fn run_with_rig(
         .base_url
         .as_deref()
         .map(|_| parse_rig_base_url(profile))
-        .transpose()
-        .map_err(|e| e.to_string())?;
+        .transpose()?;
     let custom_ollama_base_url = profile
         .base_url
         .as_deref()
         .map(|_| parse_rig_ollama_base_url(profile))
-        .transpose()
-        .map_err(|e| e.to_string())?;
+        .transpose()?;
 
     let _ = app.emit(
         "ai:status",
@@ -405,14 +403,12 @@ pub async fn generate_chat_title_with_rig(
         .base_url
         .as_deref()
         .map(|_| parse_rig_base_url(profile))
-        .transpose()
-        .map_err(|e| e.to_string())?;
+        .transpose()?;
     let custom_ollama_base_url = profile
         .base_url
         .as_deref()
         .map(|_| parse_rig_ollama_base_url(profile))
-        .transpose()
-        .map_err(|e| e.to_string())?;
+        .transpose()?;
 
     let user_text = messages
         .iter()

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -16,7 +16,9 @@ use rig::{
 };
 
 use crate::ai_rig::{
-    helpers::{alternate_openai_base_url, default_base_url, parse_base_url, parse_ollama_base_url},
+    helpers::{
+        alternate_openai_base_url, default_base_url, parse_rig_base_url, parse_rig_ollama_base_url,
+    },
     types::{
         AiAssistantMode, AiChunkEvent, AiMessage, AiProfile, AiProviderKind, AiStoredToolEvent,
     },
@@ -96,17 +98,15 @@ pub async fn run_with_rig(
     let custom_base_url = profile
         .base_url
         .as_deref()
-        .map(|_| parse_base_url(profile))
+        .map(|_| parse_rig_base_url(profile))
         .transpose()
-        .map_err(|e| e.to_string())?
-        .map(|u| u.to_string());
+        .map_err(|e| e.to_string())?;
     let custom_ollama_base_url = profile
         .base_url
         .as_deref()
-        .map(|_| parse_ollama_base_url(profile))
+        .map(|_| parse_rig_ollama_base_url(profile))
         .transpose()
-        .map_err(|e| e.to_string())?
-        .map(|u| u.to_string());
+        .map_err(|e| e.to_string())?;
 
     let _ = app.emit(
         "ai:status",
@@ -404,17 +404,15 @@ pub async fn generate_chat_title_with_rig(
     let custom_base_url = profile
         .base_url
         .as_deref()
-        .map(|_| parse_base_url(profile))
+        .map(|_| parse_rig_base_url(profile))
         .transpose()
-        .map_err(|e| e.to_string())?
-        .map(|u| u.to_string());
+        .map_err(|e| e.to_string())?;
     let custom_ollama_base_url = profile
         .base_url
         .as_deref()
-        .map(|_| parse_ollama_base_url(profile))
+        .map(|_| parse_rig_ollama_base_url(profile))
         .transpose()
-        .map_err(|e| e.to_string())?
-        .map(|u| u.to_string());
+        .map_err(|e| e.to_string())?;
 
     let user_text = messages
         .iter()


### PR DESCRIPTION
## Summary

Normalize Rig AI base URLs to prevent malformed URL construction. 

## Related Issues

Closes #152 

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URL parsing and normalization for AI provider endpoints, including OpenAI-compatible and Ollama.
  * Trailing slash handling is now more consistent, including special handling around `/v1`.
  * Ollama proxy path prefixes are preserved correctly when deriving the base endpoint.

* **Tests**
  * Added/updated unit tests covering the new base URL normalization rules, including scenarios for `/v1` and proxy-prefix preservation.
  * Added a test factory for OpenAI-compatible profiles with private hosts enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->