### PR TITLE
Polish settings UI and release shortcuts

### DIFF
--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -10,7 +10,7 @@ import { useUILayoutContext } from "../../contexts";
 import { useLicenseStatus } from "../../lib/license";
 import { cn } from "../../lib/utils";
 import { Search, X } from "../Icons";
-import { SETTINGS_TABS } from "../settings/settingsConfig";
+import { SETTINGS_TAB_GROUPS } from "../settings/settingsConfig";
 import {
 	scrollToSettingsSearchEntry,
 	searchSettingsEntries,
@@ -129,26 +129,40 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 					</div>
 				) : (
 					<div className="sidebarQuickActions settingsSidebarTabs">
-						{SETTINGS_TABS.map((tab) => (
-							<button
-								key={tab.id}
-								type="button"
-								data-tab={tab.id}
-								className={cn(
-									"sidebarQuickActionBtn settingsTabButton",
-									settingsTab === tab.id && "settingsTabButtonActive",
-								)}
-								onClick={() => setSettingsTab(tab.id)}
-								aria-pressed={settingsTab === tab.id}
-								aria-current={settingsTab === tab.id ? "page" : undefined}
+						{SETTINGS_TAB_GROUPS.map((group) => (
+							<section
+								key={group.id}
+								className="settingsSidebarTabGroup"
+								aria-labelledby={`settings-sidebar-group-${group.id}`}
 							>
-								<span className="settingsTabIcon" aria-hidden="true">
-									{tab.renderIcon()}
-								</span>
-								<span className="sidebarQuickActionLabel settingsTabLabel">
-									{tab.label}
-								</span>
-							</button>
+								<h3
+									id={`settings-sidebar-group-${group.id}`}
+									className="settingsSidebarTabGroupHeading"
+								>
+									{group.label}
+								</h3>
+								{group.tabs.map((tab) => (
+									<button
+										key={tab.id}
+										type="button"
+										data-tab={tab.id}
+										className={cn(
+											"sidebarQuickActionBtn settingsTabButton",
+											settingsTab === tab.id && "settingsTabButtonActive",
+										)}
+										onClick={() => setSettingsTab(tab.id)}
+										aria-pressed={settingsTab === tab.id}
+										aria-current={settingsTab === tab.id ? "page" : undefined}
+									>
+										<span className="settingsTabIcon" aria-hidden="true">
+											{tab.renderIcon()}
+										</span>
+										<span className="sidebarQuickActionLabel settingsTabLabel">
+											{tab.label}
+										</span>
+									</button>
+								))}
+							</section>
 						))}
 					</div>
 				)}

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -27,7 +27,7 @@ export interface SettingsTabMeta {
 	renderIcon: () => ReactElement;
 }
 
-interface SettingsTabGroup {
+export interface SettingsTabGroup {
 	id: string;
 	label: string;
 	tabs: SettingsTabMeta[];
@@ -94,28 +94,24 @@ const SETTINGS_TAB_IDS = new Set<SettingsTab>(
 	SETTINGS_TABS.map((tab) => tab.id),
 );
 
-const SETTINGS_TAB_GROUPS: SettingsTabGroup[] = [
+export const SETTINGS_TAB_GROUPS: SettingsTabGroup[] = [
 	{
-		id: "workspace",
-		label: "Workspace",
+		id: "application",
+		label: "Application",
 		tabs: SETTINGS_TABS.filter(
 			(tab) =>
 				tab.id === "general" ||
 				tab.id === "appearance" ||
 				tab.id === "shortcuts" ||
-				tab.id === "space",
+				tab.id === "advanced" ||
+				tab.id === "about",
 		),
 	},
 	{
-		id: "services",
-		label: "Features",
-		tabs: SETTINGS_TABS.filter((tab) => tab.id === "ai" || tab.id === "git"),
-	},
-	{
-		id: "system",
-		label: "System",
+		id: "workspace",
+		label: "Workspace",
 		tabs: SETTINGS_TABS.filter(
-			(tab) => tab.id === "advanced" || tab.id === "about",
+			(tab) => tab.id === "space" || tab.id === "git" || tab.id === "ai",
 		),
 	},
 ];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -209,6 +209,27 @@ function ThemeAndTypographyBridge() {
 	return null;
 }
 
+if (import.meta.env.PROD) {
+	document.addEventListener("contextmenu", (e) => {
+		const target = e.target;
+		if (
+			target instanceof Element &&
+			target.closest(
+				'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]',
+			)
+		) {
+			return;
+		}
+		e.preventDefault();
+	});
+	document.addEventListener("keydown", (e) => {
+		const key = e.key.toLowerCase();
+		if (key === "f5" || ((e.ctrlKey || e.metaKey) && key === "r")) {
+			e.preventDefault();
+		}
+	});
+}
+
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Missing #root element");
 

--- a/src/styles/app/09-settings-shell.css
+++ b/src/styles/app/09-settings-shell.css
@@ -203,8 +203,25 @@
 }
 
 .settingsSidebarTabs {
+	gap: 14px;
+	padding: 8px 8px 12px;
+}
+
+.settingsSidebarTabGroup {
+	display: flex;
+	flex-direction: column;
 	gap: 2px;
-	padding: 4px 8px 12px;
+	min-width: 0;
+}
+
+.settingsSidebarTabGroupHeading {
+	margin: 0;
+	padding: 0 8px 5px;
+	color: var(--text-tertiary);
+	font-size: 10px;
+	font-weight: var(--font-semibold);
+	line-height: 1.2;
+	text-transform: uppercase;
 }
 
 .settingsFeedbackCard {

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -3,10 +3,14 @@
 	background: var(--bg-primary);
 }
 
+.mainTabsBarWrap:has(.mainTabsBar[data-empty-state="true"]) {
+	background: var(--bg-canvas, var(--bg-primary));
+}
+
 .mainTabsEmptyDragRegion {
 	height: 40px;
 	flex-shrink: 0;
-	background: var(--bg-primary);
+	background: var(--bg-canvas, var(--bg-primary));
 }
 
 .mainTabsBar {
@@ -32,7 +36,7 @@
 }
 
 .mainTabsBar[data-empty-state="true"] {
-	background: var(--bg-primary);
+	background: var(--bg-canvas, var(--bg-primary));
 }
 
 .mainTabNavControls {


### PR DESCRIPTION
 ## Summary

  This PR tightens up a few small UI and release-behavior details:

  - Groups settings navigation into clearer Application and Workspace sections.
  - Adds lightweight section styling for settings sidebar groups.
  - Makes the empty main tab/drag area use --bg-canvas so it visually matches the rest of the empty window.
  - Blocks right-click context menu and reload shortcuts in production builds only, while keeping dev behavior unchanged.

  ## Details

  ### Settings sidebar

  The settings sidebar now renders from SETTINGS_TAB_GROUPS instead of a flat tab list. This keeps the navigation easier to scan without changing the
  underlying tab metadata or settings routing.

  Current grouping:

  - Application: General, Appearance, Shortcuts, Advanced, About
  - Workspace: Space, Git, AI

  ### Empty tab bar polish

  When no tabs are open, the main tabs area now uses the canvas background token instead of forcing the primary background. This makes the empty editor
  surface feel more cohesive.

  ### Production shortcut handling

  In release builds, the app now prevents:

  - right-click context menu
  - F5
  - Cmd+R
  - Ctrl+R

  This is gated behind import.meta.env.PROD, so Vite/Tauri dev reload behavior is unaffected.

  ## Testing

  - pnpm check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Settings sidebar now displays tabs grouped with headings for easier navigation.
  * Adjusted spacing and styling for settings groups; updated empty-state tab bar and drag-region backgrounds.

* **Changes**
  * Disabled browser context menu and page-reload shortcuts in production, while still allowing right-click on input-like elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->