### PR TITLE
implemented-multiple windows for different spaces

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,13 @@
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "default",
 	"description": "Capability for the main window",
-	"windows": ["main", "quick-note", "quick-task", "external-markdown-*"],
+	"windows": [
+		"main",
+		"space-*",
+		"quick-note",
+		"quick-task",
+		"external-markdown-*"
+	],
 	"permissions": [
 		"core:default",
 		"core:window:allow-close",

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -110,14 +110,20 @@ fn emit_profiles_updated(app: &AppHandle) {
     let _ = app.emit("ai:profiles-updated", ());
 }
 
+fn ai_space_root(space_state: &SpaceState, window: &WebviewWindow) -> Result<PathBuf, String> {
+    space_state
+        .root_for_window(window)
+        .map_err(|_| "Open a space to manage AI settings".to_string())
+}
+
 #[tauri::command]
 pub async fn ai_profiles_list(
     app: AppHandle,
     window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Vec<AiProfile>, String> {
-    let store =
-        normalized_store_for_space(&app, space_state.root_for_window(&window).ok().as_deref())?;
+    let space_root = ai_space_root(&space_state, &window)?;
+    let store = normalized_store_for_space(&app, Some(&space_root))?;
     Ok(store.profiles)
 }
 
@@ -127,8 +133,8 @@ pub async fn ai_active_profile_get(
     window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Option<String>, String> {
-    let store =
-        normalized_store_for_space(&app, space_state.root_for_window(&window).ok().as_deref())?;
+    let space_root = ai_space_root(&space_state, &window)?;
+    let store = normalized_store_for_space(&app, Some(&space_root))?;
     Ok(store
         .active_profile_id
         .or_else(|| store.profiles.first().map(|p| p.id.clone())))
@@ -141,9 +147,9 @@ pub async fn ai_active_profile_set(
     space_state: State<'_, SpaceState>,
     id: Option<String>,
 ) -> Result<(), String> {
-    let space_root = space_state.root_for_window(&window).ok();
-    let path = store_path_for_space(&app, space_root.as_deref())?;
-    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
+    let space_root = ai_space_root(&space_state, &window)?;
+    let path = store_path_for_space(&app, Some(&space_root))?;
+    let mut store = normalized_store_for_space(&app, Some(&space_root))?;
     store.active_profile_id = id.filter(|candidate| {
         store
             .profiles
@@ -162,9 +168,9 @@ pub async fn ai_profile_upsert(
     space_state: State<'_, SpaceState>,
     profile: AiProfile,
 ) -> Result<AiProfile, String> {
-    let space_root = space_state.root_for_window(&window).ok();
-    let path = store_path_for_space(&app, space_root.as_deref())?;
-    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
+    let space_root = ai_space_root(&space_state, &window)?;
+    let path = store_path_for_space(&app, Some(&space_root))?;
+    let mut store = normalized_store_for_space(&app, Some(&space_root))?;
 
     let mut next = profile;
     next.id = next.provider.key().to_string();
@@ -198,12 +204,10 @@ pub async fn ai_profile_delete(
     space_state: State<'_, SpaceState>,
     id: String,
 ) -> Result<(), String> {
-    let space_root = space_state.root_for_window(&window).ok();
-    let path = store_path_for_space(&app, space_root.as_deref())?;
-    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
-    if let Some(root) = space_root {
-        let _ = local_secrets::secret_clear(&root, &id);
-    }
+    let space_root = ai_space_root(&space_state, &window)?;
+    let path = store_path_for_space(&app, Some(&space_root))?;
+    let mut store = normalized_store_for_space(&app, Some(&space_root))?;
+    let _ = local_secrets::secret_clear(&space_root, &id);
     if let Some(profile) = store.profiles.iter_mut().find(|profile| profile.id == id) {
         profile.model.clear();
         profile.base_url = None;
@@ -327,8 +331,8 @@ pub async fn ai_chat_start(
         request.audit = true;
     }
 
-    let space_root = space_state.root_for_window(&window).ok();
-    let store = normalized_store_for_space(&app, space_root.as_deref())?;
+    let space_root = ai_space_root(&space_state, &window)?;
+    let store = normalized_store_for_space(&app, Some(&space_root))?;
 
     let profile = store
         .profiles
@@ -356,9 +360,9 @@ pub async fn ai_chat_start(
         let ai_state_for_task = app_for_task.state::<AiState>();
         let codex_state = app_for_task.state::<crate::ai_codex::state::CodexState>();
 
-        let api_key = space_root
-            .as_deref()
-            .and_then(|root| local_secrets::secret_get(root, &profile.id).ok().flatten());
+        let api_key = local_secrets::secret_get(&space_root, &profile.id)
+            .ok()
+            .flatten();
         let (system, messages) =
             split_system_and_messages(request.messages.clone(), request.context.clone());
 
@@ -372,7 +376,7 @@ pub async fn ai_chat_start(
             &system,
             &messages,
             &request.mode,
-            space_root.as_deref(),
+            Some(space_root.as_path()),
             request.thread_id.as_deref(),
         )
         .await;
@@ -389,7 +393,7 @@ pub async fn ai_chat_start(
                     &system,
                     &messages,
                     &request.mode,
-                    space_root.as_deref(),
+                    Some(space_root.as_path()),
                     request.thread_id.as_deref(),
                 )
                 .await;
@@ -405,28 +409,26 @@ pub async fn ai_chat_start(
                         cancelled,
                     },
                 );
-                if let Some(root) = space_root {
-                    let title = runtime::generate_chat_title_with_rig(
-                        &profile,
-                        api_key.as_deref(),
-                        request.context.as_deref(),
-                        &request.messages,
-                        &full,
-                    )
-                    .await
-                    .ok();
-                    write_audit_log(&AuditLogParams {
-                        space_root: &root,
-                        job_id: &job_id_for_task,
-                        history_id: &history_id,
-                        profile: &profile,
-                        request: &request,
-                        response: &full,
-                        title: title.as_deref(),
-                        cancelled,
-                        tool_events: &tool_events,
-                    });
-                }
+                let title = runtime::generate_chat_title_with_rig(
+                    &profile,
+                    api_key.as_deref(),
+                    request.context.as_deref(),
+                    &request.messages,
+                    &full,
+                )
+                .await
+                .ok();
+                write_audit_log(&AuditLogParams {
+                    space_root: &space_root,
+                    job_id: &job_id_for_task,
+                    history_id: &history_id,
+                    profile: &profile,
+                    request: &request,
+                    response: &full,
+                    title: title.as_deref(),
+                    cancelled,
+                    tool_events: &tool_events,
+                });
                 if !cancelled {
                     let _ = app_for_task
                         .notification()

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewWindow};
 use tauri_plugin_notification::NotificationExt;
 use tracing::warn;
 
@@ -10,7 +10,9 @@ use super::history;
 use super::local_secrets;
 use super::runtime;
 use super::state::AiState;
-use super::store::{ensure_default_profiles, read_store, store_path, write_store, AiStore};
+use super::store::{
+    ensure_default_profiles, read_store, store_path_for_space, write_store, AiStore,
+};
 use super::types::{
     AiAssistantMode, AiChatRequest, AiChatStartResult, AiDoneEvent, AiErrorEvent, AiMessage,
     AiProfile, AiStoredToolEvent,
@@ -93,19 +95,11 @@ pub fn refresh_provider_support_on_startup(app: AppHandle) {
     });
 }
 
-fn normalized_store(app: &AppHandle) -> Result<AiStore, String> {
-    let path = store_path(app)?;
-    let mut store = read_store(&path);
-    ensure_default_profiles(&mut store);
-    let _ = write_store(&path, &store);
-    Ok(store)
-}
-
 fn normalized_store_for_space(
     app: &AppHandle,
-    _space_root: Option<&std::path::Path>,
+    space_root: Option<&std::path::Path>,
 ) -> Result<AiStore, String> {
-    let path = store_path(app)?;
+    let path = store_path_for_space(app, space_root)?;
     let mut store = read_store(&path);
     ensure_default_profiles(&mut store);
     let _ = write_store(&path, &store);
@@ -117,23 +111,39 @@ fn emit_profiles_updated(app: &AppHandle) {
 }
 
 #[tauri::command]
-pub async fn ai_profiles_list(app: AppHandle) -> Result<Vec<AiProfile>, String> {
-    let store = normalized_store(&app)?;
+pub async fn ai_profiles_list(
+    app: AppHandle,
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+) -> Result<Vec<AiProfile>, String> {
+    let store =
+        normalized_store_for_space(&app, space_state.root_for_window(&window).ok().as_deref())?;
     Ok(store.profiles)
 }
 
 #[tauri::command]
-pub async fn ai_active_profile_get(app: AppHandle) -> Result<Option<String>, String> {
-    let store = normalized_store(&app)?;
+pub async fn ai_active_profile_get(
+    app: AppHandle,
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+) -> Result<Option<String>, String> {
+    let store =
+        normalized_store_for_space(&app, space_state.root_for_window(&window).ok().as_deref())?;
     Ok(store
         .active_profile_id
         .or_else(|| store.profiles.first().map(|p| p.id.clone())))
 }
 
 #[tauri::command]
-pub async fn ai_active_profile_set(app: AppHandle, id: Option<String>) -> Result<(), String> {
-    let path = store_path(&app)?;
-    let mut store = normalized_store(&app)?;
+pub async fn ai_active_profile_set(
+    app: AppHandle,
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+    id: Option<String>,
+) -> Result<(), String> {
+    let space_root = space_state.root_for_window(&window).ok();
+    let path = store_path_for_space(&app, space_root.as_deref())?;
+    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
     store.active_profile_id = id.filter(|candidate| {
         store
             .profiles
@@ -146,9 +156,15 @@ pub async fn ai_active_profile_set(app: AppHandle, id: Option<String>) -> Result
 }
 
 #[tauri::command]
-pub async fn ai_profile_upsert(app: AppHandle, profile: AiProfile) -> Result<AiProfile, String> {
-    let path = store_path(&app)?;
-    let mut store = normalized_store(&app)?;
+pub async fn ai_profile_upsert(
+    app: AppHandle,
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+    profile: AiProfile,
+) -> Result<AiProfile, String> {
+    let space_root = space_state.root_for_window(&window).ok();
+    let path = store_path_for_space(&app, space_root.as_deref())?;
+    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
 
     let mut next = profile;
     next.id = next.provider.key().to_string();
@@ -178,12 +194,14 @@ pub async fn ai_profile_upsert(app: AppHandle, profile: AiProfile) -> Result<AiP
 #[tauri::command]
 pub async fn ai_profile_delete(
     app: AppHandle,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     id: String,
 ) -> Result<(), String> {
-    let path = store_path(&app)?;
-    let mut store = normalized_store_for_space(&app, space_state.current_root().ok().as_deref())?;
-    if let Ok(root) = space_state.current_root() {
+    let space_root = space_state.root_for_window(&window).ok();
+    let path = store_path_for_space(&app, space_root.as_deref())?;
+    let mut store = normalized_store_for_space(&app, space_root.as_deref())?;
+    if let Some(root) = space_root {
         let _ = local_secrets::secret_clear(&root, &id);
     }
     if let Some(profile) = store.profiles.iter_mut().find(|profile| profile.id == id) {
@@ -210,12 +228,13 @@ pub async fn ai_profile_delete(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_set(
     app: AppHandle,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
     api_key: String,
 ) -> Result<(), String> {
     let root = space_state
-        .current_root()
+        .root_for_window(&window)
         .map_err(|_| "Open a space to store API keys locally".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_set(&root, &profile_id, api_key.trim())
@@ -224,11 +243,12 @@ pub async fn ai_secret_set(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_clear(
     app: AppHandle,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
 ) -> Result<(), String> {
     let root = space_state
-        .current_root()
+        .root_for_window(&window)
         .map_err(|_| "Open a space to manage API keys".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_clear(&root, &profile_id)
@@ -237,10 +257,11 @@ pub async fn ai_secret_clear(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_status(
     app: AppHandle,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
 ) -> Result<bool, String> {
-    let root = match space_state.current_root() {
+    let root = match space_state.root_for_window(&window) {
         Ok(root) => root,
         Err(_) => return Ok(false),
     };
@@ -251,10 +272,11 @@ pub async fn ai_secret_status(
 #[tauri::command]
 pub async fn ai_secret_list(
     app: AppHandle,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Vec<String>, String> {
     let root = space_state
-        .current_root()
+        .root_for_window(&window)
         .map_err(|_| "Open a space to manage API keys".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_ids(&root)
@@ -279,6 +301,7 @@ pub async fn ai_provider_support(app: AppHandle) -> Result<ProviderSupportDocume
 #[tauri::command]
 pub async fn ai_chat_start(
     ai_state: State<'_, AiState>,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     app: AppHandle,
     mut request: AiChatRequest,
@@ -304,7 +327,7 @@ pub async fn ai_chat_start(
         request.audit = true;
     }
 
-    let space_root = space_state.current_root().ok();
+    let space_root = space_state.root_for_window(&window).ok();
     let store = normalized_store_for_space(&app, space_root.as_deref())?;
 
     let profile = store
@@ -444,18 +467,20 @@ pub async fn ai_chat_cancel(ai_state: State<'_, AiState>, job_id: String) -> Res
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_chat_history_list(
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     limit: Option<u32>,
 ) -> Result<Vec<history::AiChatHistorySummary>, String> {
-    history::ai_chat_history_list(space_state, limit).await
+    history::ai_chat_history_list(window, space_state, limit).await
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_chat_history_get(
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     job_id: String,
 ) -> Result<history::AiChatHistoryDetail, String> {
-    history::ai_chat_history_get(space_state, job_id).await
+    history::ai_chat_history_get(window, space_state, job_id).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/ai_rig/context.rs
+++ b/src-tauri/src/ai_rig/context.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -169,9 +169,10 @@ fn list_files(root: &Path, dir: &str, limit: usize) -> Result<Vec<String>, Strin
 
 #[tauri::command]
 pub async fn ai_context_index(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<AiContextIndexResponse, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let files = list_files(&root, "", DEFAULT_FILE_LIST_LIMIT)?;
         let mut dirs = std::collections::BTreeSet::<String>::new();
@@ -217,10 +218,11 @@ pub async fn ai_context_index(
 
 #[tauri::command]
 pub async fn ai_context_build(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: AiContextBuildRequest,
 ) -> Result<AiContextBuildResponse, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut remaining = request
             .char_budget
@@ -317,10 +319,11 @@ pub async fn ai_context_build(
 
 #[tauri::command]
 pub async fn ai_context_resolve_paths(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     attachments: Vec<AiContextAttachment>,
 ) -> Result<Vec<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut out: Vec<String> = Vec::new();
         let mut seen = std::collections::BTreeSet::<String>::new();

--- a/src-tauri/src/ai_rig/history.rs
+++ b/src-tauri/src/ai_rig/history.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{glyph_paths, space::SpaceState};
 
@@ -60,10 +60,11 @@ pub struct AiChatHistoryDetail {
 }
 
 pub async fn ai_chat_history_list(
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     limit: Option<u32>,
 ) -> Result<Vec<AiChatHistorySummary>, String> {
-    let root = space_state.current_root()?;
+    let root = space_state.root_for_window(&window)?;
     let limit = limit
         .unwrap_or(DEFAULT_LIMIT as u32)
         .max(1)
@@ -75,11 +76,12 @@ pub async fn ai_chat_history_list(
 }
 
 pub async fn ai_chat_history_get(
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     job_id: String,
 ) -> Result<AiChatHistoryDetail, String> {
     let _ = uuid::Uuid::parse_str(&job_id).map_err(|_| "invalid job_id".to_string())?;
-    let root = space_state.current_root()?;
+    let root = space_state.root_for_window(&window)?;
 
     tauri::async_runtime::spawn_blocking(move || get_history_impl(&root, &job_id))
         .await

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -576,8 +576,10 @@ pub async fn ai_models_list(
     profile_id: String,
     provider: Option<AiProviderKind>,
 ) -> Result<Vec<AiModel>, String> {
-    let space_root = space_state.root_for_window(&window).ok();
-    let path = store_path_for_space(&app, space_root.as_deref())?;
+    let space_root = space_state
+        .root_for_window(&window)
+        .map_err(|_| "Open a space to manage AI settings".to_string())?;
+    let path = store_path_for_space(&app, Some(&space_root))?;
     let mut store = read_store(&path);
     ensure_default_profiles(&mut store);
     let _ = write_store(&path, &store);
@@ -591,9 +593,9 @@ pub async fn ai_models_list(
     let effective_provider = provider.unwrap_or_else(|| profile.provider.clone());
 
     let client = http_client()?;
-    let api_key = space_root
-        .as_deref()
-        .and_then(|root| local_secrets::secret_get(root, &profile.id).ok().flatten())
+    let api_key = local_secrets::secret_get(&space_root, &profile.id)
+        .ok()
+        .flatten()
         .unwrap_or_default();
     let api_key = api_key.trim().to_string();
 
@@ -618,23 +620,8 @@ pub async fn ai_models_list(
         AiProviderKind::Gemini => list_gemini(&client, &profile, &api_key).await,
         AiProviderKind::CodexChatgpt => list_codex_models(codex_state.inner()),
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
-        AiProviderKind::ClaudeCode => {
-            let root = space_root
-                .as_deref()
-                .ok_or_else(|| "Open a space to load Claude Code models".to_string())?;
-            crate::ai_claude_code::list_models(root, &profile)
-        }
-        AiProviderKind::Opencode => {
-            let root = space_root
-                .as_deref()
-                .ok_or_else(|| "Open a space to load OpenCode models".to_string())?;
-            crate::ai_opencode::list_models(root).await
-        }
-        AiProviderKind::Pi => {
-            let root = space_root
-                .as_deref()
-                .ok_or_else(|| "Open a space to load PI models".to_string())?;
-            crate::ai_pi::list_models(root).await
-        }
+        AiProviderKind::ClaudeCode => crate::ai_claude_code::list_models(&space_root, &profile),
+        AiProviderKind::Opencode => crate::ai_opencode::list_models(&space_root).await,
+        AiProviderKind::Pi => crate::ai_pi::list_models(&space_root).await,
     }
 }

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -1,10 +1,10 @@
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, State, WebviewWindow};
 
 use super::helpers::{
     alternate_openai_base_url, apply_extra_headers, http_client, ollama_api_url, parse_base_url,
 };
 use super::local_secrets;
-use super::store::{ensure_default_profiles, read_store, store_path, write_store};
+use super::store::{ensure_default_profiles, read_store, store_path_for_space, write_store};
 use super::types::{AiModel, AiProviderKind, AiReasoningEffortOption};
 use crate::ai_codex::{state::CodexState, transport::rpc_call};
 use crate::space::SpaceState;
@@ -571,14 +571,15 @@ fn list_codex_models(codex_state: &CodexState) -> Result<Vec<AiModel>, String> {
 pub async fn ai_models_list(
     app: AppHandle,
     codex_state: State<'_, CodexState>,
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
     provider: Option<AiProviderKind>,
 ) -> Result<Vec<AiModel>, String> {
-    let path = store_path(&app)?;
+    let space_root = space_state.root_for_window(&window).ok();
+    let path = store_path_for_space(&app, space_root.as_deref())?;
     let mut store = read_store(&path);
     ensure_default_profiles(&mut store);
-    let space_root = space_state.current_root().ok();
     let _ = write_store(&path, &store);
 
     let profile = store

--- a/src-tauri/src/ai_rig/store.rs
+++ b/src-tauri/src/ai_rig/store.rs
@@ -1,4 +1,4 @@
-use crate::io_atomic;
+use crate::{glyph_paths, io_atomic};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::{path::Path, path::PathBuf};
@@ -17,6 +17,13 @@ pub struct AiStore {
 pub fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
     Ok(dir.join("ai.json"))
+}
+
+pub fn store_path_for_space(app: &AppHandle, space_root: Option<&Path>) -> Result<PathBuf, String> {
+    match space_root {
+        Some(root) => Ok(glyph_paths::ensure_glyph_app_dir(root)?.join("ai.json")),
+        None => store_path(app),
+    }
 }
 
 pub fn read_store(path: &Path) -> AiStore {

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -248,22 +247,8 @@ fn write_new_markdown_note(
     if let Some(parent) = abs.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let mut file = match std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(&abs)
-    {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
-        Err(error) => return Err(error.to_string()),
-    };
-    file.write_all(markdown.as_bytes())
-        .and_then(|_| file.sync_all())
-        .map_err(|e| e.to_string())?;
-    if let Some(parent) = abs.parent() {
-        std::fs::File::open(parent)
-            .and_then(|dir| dir.sync_all())
-            .map_err(|e| e.to_string())?;
+    if !io_atomic::write_atomic_create_new(&abs, markdown.as_bytes()).map_err(|e| e.to_string())? {
+        return Ok(false);
     }
     mark_recent_local_change(recent_local_changes, rel_path);
     index_note(root, rel_path, markdown)?;

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use serde_yaml::{Mapping, Value};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 use uuid::Uuid;
 
 use crate::index::index_note;
@@ -494,8 +494,11 @@ fn backlink_note_paths(root: &Path, note_path: &str) -> Result<Vec<String>, Stri
 }
 
 #[tauri::command(rename_all = "snake_case")]
-pub async fn databases_list(state: State<'_, SpaceState>) -> Result<Vec<DatabaseSummary>, String> {
-    let root = state.current_root()?;
+pub async fn databases_list(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<Vec<DatabaseSummary>, String> {
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -510,10 +513,11 @@ pub async fn databases_list(state: State<'_, SpaceState>) -> Result<Vec<Database
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_get(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let store = bootstrap_defaults(load_store(&root)?);
         let database = store
@@ -529,10 +533,11 @@ pub async fn databases_get(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_create(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     name: String,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -573,10 +578,11 @@ pub async fn databases_create(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_update(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database: DatabaseDefinition,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -609,10 +615,11 @@ pub async fn databases_update(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_delete(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -636,13 +643,14 @@ pub async fn databases_delete(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_query_rows(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
     view_id: String,
     offset: Option<u32>,
     limit: Option<u32>,
 ) -> Result<super::types::DatabaseQueryResult, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let store = bootstrap_defaults(load_store(&root)?);
         let database = store
@@ -671,13 +679,14 @@ pub async fn databases_query_rows(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_update_cell(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_path: String,
     column: DatabaseColumn,
     value: DatabaseCellValue,
 ) -> Result<DatabaseRow, String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     tauri::async_runtime::spawn_blocking(move || {
         let existing_row = row_by_path(&root, &note_path)?;
         validate_editable_column(&existing_row, &column)?;
@@ -695,14 +704,15 @@ pub async fn databases_update_cell(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_create_row(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
     title: Option<String>,
     initial_values: Option<Vec<DatabaseCreateRowInitialValue>>,
 ) -> Result<DatabaseCreateRowResult, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
-    let recent_local_changes = state.recent_local_changes();
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
             .lock()
@@ -756,11 +766,12 @@ pub async fn databases_create_row(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_preview_context(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_path: String,
     _space_path: Option<String>,
 ) -> Result<DatabasePreviewContext, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let markdown = read_note_markdown(&root, &note_path)?;
         let row = row_by_path(&root, &note_path)?;
@@ -788,9 +799,10 @@ pub async fn databases_preview_context(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_status_colors_get(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -804,11 +816,12 @@ pub async fn databases_status_colors_get(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_status_color_set(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     status: String,
     color: Option<String>,
 ) -> Result<BTreeMap<String, String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex

--- a/src-tauri/src/file_tree_appearance/commands.rs
+++ b/src-tauri/src/file_tree_appearance/commands.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::space::SpaceState;
 use crate::space_fs::helpers::deny_hidden_rel_path;
@@ -11,9 +11,10 @@ use super::types::FileTreeAppearance;
 
 #[tauri::command]
 pub async fn file_tree_appearance_list(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, FileTreeAppearance>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         Ok(load_store(&root)?.entries)
     })
@@ -23,12 +24,13 @@ pub async fn file_tree_appearance_list(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_set(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     color: Option<String>,
     icon: Option<String>,
 ) -> Result<Option<FileTreeAppearance>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);
@@ -58,11 +60,12 @@ pub async fn file_tree_appearance_set(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_rename_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let from_rel = PathBuf::from(&from_path);
@@ -94,10 +97,11 @@ pub async fn file_tree_appearance_rename_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_delete_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);

--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, State, WebviewWindow};
 
 use crate::space::state::SpaceState;
 
@@ -8,44 +8,49 @@ use super::GitSyncState;
 
 #[tauri::command]
 pub fn git_sync_status_read(
+    window: WebviewWindow,
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
 ) -> Result<GitSyncStatus, String> {
-    service::read_status(git_state, space_state)
+    service::read_status(git_state, space_state, window.label())
 }
 
 #[tauri::command]
 pub fn git_sync_config_read(
+    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Option<GitSyncConfig>, String> {
-    service::read_config(&space_state)
+    service::read_config(&space_state, window.label())
 }
 
 #[tauri::command]
 pub fn git_sync_config_update(
     app: AppHandle,
+    window: WebviewWindow,
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
     patch: GitSyncConfigPatch,
 ) -> Result<GitSyncConfig, String> {
-    service::update_git_sync_config(app, &git_state, &space_state, patch)
+    service::update_git_sync_config(app, &git_state, &space_state, window.label(), patch)
 }
 
 #[tauri::command]
 pub async fn git_sync_run(
     app: AppHandle,
+    window: WebviewWindow,
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
     request: GitSyncRunRequest,
 ) -> Result<GitSyncStatus, String> {
-    service::run_git_sync(app, &git_state, &space_state, request)
+    service::run_git_sync(app, &git_state, &space_state, window.label(), request)
 }
 
 #[tauri::command]
 pub fn git_sync_disconnect(
     app: AppHandle,
+    window: WebviewWindow,
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
 ) -> Result<GitSyncStatus, String> {
-    service::disconnect_git_sync(app, &git_state, &space_state)
+    service::disconnect_git_sync(app, &git_state, &space_state, window.label())
 }

--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tauri::{AppHandle, Emitter, State};
 
-use crate::space::state::SpaceState;
+use crate::space::state::{is_no_space_session_error, SpaceState};
 
 use super::git::{
     ahead_behind_counts, commit_all, fetch_remote, git_is_installed, has_head_commit,
@@ -319,7 +319,8 @@ pub fn read_status_internal(
 ) -> Result<GitSyncStatus, String> {
     let space_root = match space_state.root_for_window_label(window_label) {
         Ok(root) => root,
-        Err(_) => return Ok(GitSyncStatus::default()),
+        Err(error) if is_no_space_session_error(&error) => return Ok(GitSyncStatus::default()),
+        Err(error) => return Err(error),
     };
     read_status_for_root(git_state, Some(&space_root))
 }
@@ -575,7 +576,8 @@ pub fn read_config(
 ) -> Result<Option<GitSyncConfig>, String> {
     let space_root = match space_state.root_for_window_label(window_label) {
         Ok(root) => root,
-        Err(_) => return Ok(None),
+        Err(error) if is_no_space_session_error(&error) => return Ok(None),
+        Err(error) => return Err(error),
     };
     load_store(&space_root)
 }

--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -37,27 +38,34 @@ impl Default for RuntimeStatus {
 
 #[derive(Clone, Default)]
 pub struct GitSyncState {
-    runtime: Arc<Mutex<RuntimeStatus>>,
+    runtime: Arc<Mutex<HashMap<String, RuntimeStatus>>>,
 }
 
 struct SyncResetGuard {
-    runtime: Arc<Mutex<RuntimeStatus>>,
+    runtime: Arc<Mutex<HashMap<String, RuntimeStatus>>>,
+    key: String,
 }
 
 impl SyncResetGuard {
-    fn new(runtime: Arc<Mutex<RuntimeStatus>>) -> Self {
-        Self { runtime }
+    fn new(runtime: Arc<Mutex<HashMap<String, RuntimeStatus>>>, key: String) -> Self {
+        Self { runtime, key }
     }
 }
 
 impl Drop for SyncResetGuard {
     fn drop(&mut self) {
-        if let Ok(mut runtime) = self.runtime.lock() {
-            if runtime.is_syncing {
-                *runtime = RuntimeStatus::default();
+        if let Ok(mut runtimes) = self.runtime.lock() {
+            if let Some(runtime) = runtimes.get_mut(&self.key) {
+                if runtime.is_syncing {
+                    *runtime = RuntimeStatus::default();
+                }
             }
         }
     }
+}
+
+fn runtime_key(space_root: &Path) -> String {
+    space_root.to_string_lossy().to_string()
 }
 
 fn now_ms() -> i64 {
@@ -67,29 +75,32 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-fn emit_status(app: &AppHandle, status: &GitSyncStatus) {
-    let _ = app.emit("git_sync:status", status.clone());
+fn emit_status(app: &AppHandle, window_label: &str, status: &GitSyncStatus) {
+    let _ = app.emit_to(window_label, "git_sync:status", status.clone());
 }
 
 fn set_runtime(
     app: &AppHandle,
     git_state: &GitSyncState,
     space_root: &Path,
+    window_label: &str,
     phase: GitSyncPhase,
     is_syncing: bool,
     message: Option<String>,
 ) -> Result<(), String> {
     {
-        let mut runtime = git_state
+        let key = runtime_key(space_root);
+        let mut runtimes = git_state
             .runtime
             .lock()
             .map_err(|_| "git sync state poisoned".to_string())?;
+        let runtime = runtimes.entry(key).or_default();
         runtime.phase = phase;
         runtime.is_syncing = is_syncing;
         runtime.message = message;
     }
     let status = read_status_for_root(git_state, Some(space_root))?;
-    emit_status(app, &status);
+    emit_status(app, window_label, &status);
     Ok(())
 }
 
@@ -286,7 +297,9 @@ fn read_status_for_root(
         .runtime
         .lock()
         .map_err(|_| "git sync state poisoned".to_string())?
-        .clone();
+        .get(&runtime_key(space_root))
+        .cloned()
+        .unwrap_or_default();
     let health = if git_installed {
         inspect_repo_health(space_root, &inspection, config.as_ref())?
     } else {
@@ -302,8 +315,9 @@ fn read_status_for_root(
 pub fn read_status_internal(
     git_state: &GitSyncState,
     space_state: &SpaceState,
+    window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = match space_state.current_root() {
+    let space_root = match space_state.root_for_window_label(window_label) {
         Ok(root) => root,
         Err(_) => return Ok(GitSyncStatus::default()),
     };
@@ -318,9 +332,10 @@ pub fn update_git_sync_config(
     app: AppHandle,
     git_state: &GitSyncState,
     space_state: &SpaceState,
+    window_label: &str,
     patch: GitSyncConfigPatch,
 ) -> Result<GitSyncConfig, String> {
-    let space_root = space_state.current_root()?;
+    let space_root = space_state.root_for_window_label(window_label)?;
     let mut config = load_config(&space_root)?;
     if let Some(enabled) = patch.enabled {
         config.enabled = enabled;
@@ -338,8 +353,8 @@ pub fn update_git_sync_config(
         config.paused = paused;
     }
     save_store(&space_root, &config)?;
-    let status = read_status_internal(git_state, space_state)?;
-    emit_status(&app, &status);
+    let status = read_status_internal(git_state, space_state, window_label)?;
+    emit_status(&app, window_label, &status);
     Ok(config)
 }
 
@@ -347,18 +362,19 @@ pub fn disconnect_git_sync(
     app: AppHandle,
     git_state: &GitSyncState,
     space_state: &SpaceState,
+    window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = space_state.current_root()?;
+    let space_root = space_state.root_for_window_label(window_label)?;
     delete_store(&space_root)?;
     {
-        let mut runtime = git_state
+        let mut runtimes = git_state
             .runtime
             .lock()
             .map_err(|_| "git sync state poisoned".to_string())?;
-        *runtime = RuntimeStatus::default();
+        runtimes.insert(runtime_key(&space_root), RuntimeStatus::default());
     }
-    let status = read_status_internal(git_state, space_state)?;
-    emit_status(&app, &status);
+    let status = read_status_internal(git_state, space_state, window_label)?;
+    emit_status(&app, window_label, &status);
     Ok(status)
 }
 
@@ -366,22 +382,24 @@ pub fn run_git_sync(
     app: AppHandle,
     git_state: &GitSyncState,
     space_state: &SpaceState,
+    window_label: &str,
     request: GitSyncRunRequest,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = space_state.current_root()?;
+    let space_root = space_state.root_for_window_label(window_label)?;
     if !git_is_installed() {
         return Err("Git is not installed on this system.".to_string());
     }
     let config = load_config(&space_root)?;
     if request.mode == GitSyncRunMode::Auto && (!config.enabled || config.paused) {
-        return read_status_internal(git_state, space_state);
+        return read_status_internal(git_state, space_state, window_label);
     }
 
     {
-        let mut runtime = git_state
+        let mut runtimes = git_state
             .runtime
             .lock()
             .map_err(|_| "git sync state poisoned".to_string())?;
+        let runtime = runtimes.entry(runtime_key(&space_root)).or_default();
         if runtime.is_syncing {
             return read_status_for_root(git_state, Some(&space_root));
         }
@@ -390,11 +408,14 @@ pub fn run_git_sync(
         runtime.message = Some("Fetching remote changes".to_string());
     }
     let initial = read_status_for_root(git_state, Some(&space_root))?;
-    emit_status(&app, &initial);
+    emit_status(&app, window_label, &initial);
 
     let git_state = git_state.clone();
+    let window_label = window_label.to_string();
     tauri::async_runtime::spawn_blocking(move || {
-        if let Err(error) = run_git_sync_background(app, git_state, space_root, request) {
+        if let Err(error) =
+            run_git_sync_background(app, git_state, space_root, window_label, request)
+        {
             tracing::error!("git sync background task failed: {error}");
         }
     });
@@ -406,9 +427,10 @@ fn run_git_sync_background(
     app: AppHandle,
     git_state: GitSyncState,
     space_root: PathBuf,
+    window_label: String,
     request: GitSyncRunRequest,
 ) -> Result<(), String> {
-    let _sync_guard = SyncResetGuard::new(Arc::clone(&git_state.runtime));
+    let _sync_guard = SyncResetGuard::new(Arc::clone(&git_state.runtime), runtime_key(&space_root));
     let mut config = load_config(&space_root)?;
     let is_auto = request.mode == GitSyncRunMode::Auto;
 
@@ -447,6 +469,7 @@ fn run_git_sync_background(
             &app,
             &git_state,
             &space_root,
+            &window_label,
             GitSyncPhase::Fetching,
             true,
             Some("Fetching remote changes".to_string()),
@@ -457,6 +480,7 @@ fn run_git_sync_background(
             &app,
             &git_state,
             &space_root,
+            &window_label,
             GitSyncPhase::Committing,
             true,
             Some("Preparing local snapshot".to_string()),
@@ -471,6 +495,7 @@ fn run_git_sync_background(
                 &app,
                 &git_state,
                 &space_root,
+                &window_label,
                 GitSyncPhase::Pulling,
                 true,
                 Some("Merging remote changes".to_string()),
@@ -490,6 +515,7 @@ fn run_git_sync_background(
             &app,
             &git_state,
             &space_root,
+            &window_label,
             GitSyncPhase::Pushing,
             true,
             Some("Pushing to remote".to_string()),
@@ -510,12 +536,13 @@ fn run_git_sync_background(
                 &app,
                 &git_state,
                 &space_root,
+                &window_label,
                 GitSyncPhase::Success,
                 false,
                 Some("Sync complete".to_string()),
             );
             let status = read_status_for_root(&git_state, Some(&space_root))?;
-            emit_status(&app, &status);
+            emit_status(&app, &window_label, &status);
             Ok(())
         }
         Err(error) => {
@@ -532,6 +559,7 @@ fn run_git_sync_background(
                 &app,
                 &git_state,
                 &space_root,
+                &window_label,
                 GitSyncPhase::Error,
                 false,
                 Some(error.clone()),
@@ -541,8 +569,11 @@ fn run_git_sync_background(
     }
 }
 
-pub fn read_config(space_state: &SpaceState) -> Result<Option<GitSyncConfig>, String> {
-    let space_root = match space_state.current_root() {
+pub fn read_config(
+    space_state: &SpaceState,
+    window_label: &str,
+) -> Result<Option<GitSyncConfig>, String> {
+    let space_root = match space_state.root_for_window_label(window_label) {
         Ok(root) => root,
         Err(_) => return Ok(None),
     };
@@ -552,6 +583,7 @@ pub fn read_config(space_state: &SpaceState) -> Result<Option<GitSyncConfig>, St
 pub fn read_status(
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
+    window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    read_status_internal(&git_state, &space_state)
+    read_status_internal(&git_state, &space_state, window_label)
 }

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use chrono::{DateTime, Duration, Local, NaiveDate};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter, State, WebviewWindow};
 use tauri_plugin_notification::NotificationExt;
 
 use crate::space::state::mark_recent_local_change;
@@ -28,6 +28,7 @@ use crate::index::{people_mentions_as_tags_enabled, set_people_mentions_as_tags_
 
 #[derive(Serialize, Clone)]
 struct NoteChangeEvent {
+    space_path: String,
     rel_path: String,
     removed: bool,
 }
@@ -344,9 +345,10 @@ fn rewrite_task_dates(body: &str, scheduled_date: &str, due_date: &str) -> Strin
 #[tauri::command]
 pub async fn index_rebuild(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<IndexRebuildResult, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let res = tauri::async_runtime::spawn_blocking(move || rebuild(&root))
         .await
         .map_err(|e| e.to_string())??;
@@ -361,10 +363,11 @@ pub async fn index_rebuild(
 
 #[tauri::command]
 pub async fn search(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     query: String,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
         hybrid_search(&conn, &query, &[], 50)
@@ -375,10 +378,11 @@ pub async fn search(
 
 #[tauri::command]
 pub async fn search_advanced(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: SearchAdvancedRequest,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
         run_search_advanced(&conn, request)
@@ -389,11 +393,12 @@ pub async fn search_advanced(
 
 #[tauri::command]
 pub async fn search_parse_and_run(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     raw_query: String,
     limit: Option<u32>,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let req = parse_raw_search_query(&raw_query, limit);
         let conn = open_db(&root)?;
@@ -411,11 +416,12 @@ pub fn index_set_people_mentions_as_tags_enabled(enabled: bool) -> Result<(), St
 
 #[tauri::command]
 pub async fn all_docs_list(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     folder_prefix: Option<String>,
 ) -> Result<Vec<AllDocsItem>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let limit = limit.unwrap_or(2_000).clamp(1, 5_000) as i64;
     let folder_prefix = folder_prefix
         .map(|value| value.trim().trim_matches('/').replace('\\', "/"))
@@ -502,10 +508,11 @@ pub async fn all_docs_list(
 
 #[tauri::command]
 pub async fn all_docs_count(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     folder_prefix: Option<String>,
 ) -> Result<u32, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let folder_prefix = folder_prefix
         .map(|value| value.trim().trim_matches('/').replace('\\', "/"))
         .filter(|value| !value.is_empty());
@@ -533,13 +540,14 @@ pub async fn all_docs_count(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn calendar_query_range(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     start_date: String,
     end_date: String,
     selected_date: String,
     daily_notes_folder: Option<String>,
 ) -> Result<CalendarRangeResponse, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let start = parse_calendar_date(&start_date)?;
     let end = parse_calendar_date(&end_date)?;
     let selected = parse_calendar_date(&selected_date)?;
@@ -825,11 +833,12 @@ pub async fn calendar_query_range(
 
 #[tauri::command]
 pub async fn tags_list(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
 ) -> Result<Vec<TagCount>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let limit = limit.unwrap_or(200).min(2000) as i64;
     let offset = offset.unwrap_or(0) as i64;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<TagCount>, String> {
@@ -877,11 +886,12 @@ fn list_tags(
 
 #[tauri::command]
 pub async fn people_list(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
 ) -> Result<Vec<PersonCount>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let limit = limit.unwrap_or(200).min(2000) as i64;
     let offset = offset.unwrap_or(0) as i64;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<PersonCount>, String> {
@@ -1031,12 +1041,15 @@ mod tests {
 #[tauri::command(rename_all = "snake_case")]
 pub async fn task_set_checked(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     task_id: String,
     checked: bool,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let space_path = root.to_string_lossy().to_string();
+    let window_label = window.label().to_string();
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     let note_path = tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let conn = open_db(&root)?;
         let mut stmt = conn
@@ -1057,9 +1070,11 @@ pub async fn task_set_checked(
     })
     .await
     .map_err(|e| e.to_string())??;
-    let _ = app.emit(
+    let _ = app.emit_to(
+        window_label,
         "notes:external_changed",
         NoteChangeEvent {
+            space_path,
             rel_path: note_path,
             removed: false,
         },
@@ -1069,12 +1084,13 @@ pub async fn task_set_checked(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn tasks_query_global(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     filter: Option<GlobalTaskFilter>,
     today_date: Option<String>,
     limit: Option<u32>,
 ) -> Result<Vec<IndexedTask>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let filter = filter.unwrap_or(GlobalTaskFilter::All).as_str().to_string();
     let today_date = normalized_task_query_date(today_date)?;
     let limit = limit.unwrap_or(500).clamp(1, 2_000) as i64;
@@ -1129,13 +1145,16 @@ pub async fn tasks_query_global(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn task_set_dates(
     app: AppHandle,
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     task_id: String,
     scheduled_date: Option<String>,
     due_date: Option<String>,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let space_path = root.to_string_lossy().to_string();
+    let window_label = window.label().to_string();
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     let note_path = tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let conn = open_db(&root)?;
         let mut stmt = conn
@@ -1162,9 +1181,11 @@ pub async fn task_set_dates(
     })
     .await
     .map_err(|e| e.to_string())??;
-    let _ = app.emit(
+    let _ = app.emit_to(
+        window_label,
         "notes:external_changed",
         NoteChangeEvent {
+            space_path,
             rel_path: note_path,
             removed: false,
         },
@@ -1231,10 +1252,11 @@ pub fn task_summary(markdown: String) -> NoteTaskSummary {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn task_summaries_for_paths(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_paths: Vec<String>,
 ) -> Result<Vec<NoteTaskSummaryItem>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<NoteTaskSummaryItem>, String> {
         let paths = note_paths
             .into_iter()
@@ -1250,11 +1272,12 @@ pub async fn task_summaries_for_paths(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn backlinks(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
     _space_path: Option<String>,
 ) -> Result<Vec<BacklinkItem>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<BacklinkItem>, String> {
         let conn = open_db(&root)?;
         let stem = Path::new(&note_id)
@@ -1298,10 +1321,11 @@ pub async fn backlinks(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn note_relationships(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
 ) -> Result<Vec<NoteRelationship>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<NoteRelationship>, String> {
         let conn = open_db(&root)?;
         query_note_relationships(&conn, &note_id)
@@ -1567,10 +1591,11 @@ fn local_graph_tag_expansion_for_seed_nodes(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn note_local_graph(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
 ) -> Result<LocalNoteGraph, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<LocalNoteGraph, String> {
         let conn = open_db(&root)?;
         local_note_graph_for_conn(&conn, &note_id)

--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -15,6 +15,21 @@ fn is_unsupported_sync_error(error: &io::Error) -> bool {
     }
 }
 
+fn is_recoverable_hard_link_error(error: &io::Error) -> bool {
+    match error.raw_os_error() {
+        // Unix EXDEV, Windows ERROR_NOT_SAME_DEVICE.
+        Some(18) | Some(17) => true,
+        // macOS ENOTSUP/EOPNOTSUPP, Linux ENOTSUP/EOPNOTSUPP.
+        Some(45) | Some(102) | Some(95) => true,
+        // Windows ERROR_INVALID_FUNCTION/ERROR_NOT_SUPPORTED.
+        Some(1) | Some(50) => true,
+        _ => matches!(
+            error.kind(),
+            io::ErrorKind::Unsupported | io::ErrorKind::CrossesDevices
+        ),
+    }
+}
+
 fn sync_all_best_effort(file: &File) -> io::Result<()> {
     match file.sync_all() {
         Ok(()) => Ok(()),
@@ -90,6 +105,34 @@ pub fn write_atomic_create_new(dest: &Path, bytes: &[u8]) -> io::Result<bool> {
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
             let _ = std::fs::remove_file(&tmp);
             Ok(false)
+        }
+        Err(error) if is_recoverable_hard_link_error(&error) => {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(dest)
+            {
+                Ok(mut f) => {
+                    if let Err(write_error) =
+                        f.write_all(bytes).and_then(|()| sync_all_best_effort(&f))
+                    {
+                        let _ = std::fs::remove_file(&tmp);
+                        let _ = std::fs::remove_file(dest);
+                        return Err(write_error);
+                    }
+                }
+                Err(create_error) if create_error.kind() == io::ErrorKind::AlreadyExists => {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Ok(false);
+                }
+                Err(create_error) => {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(create_error);
+                }
+            }
+            std::fs::remove_file(&tmp)?;
+            fsync_dir(parent)?;
+            Ok(true)
         }
         Err(error) => {
             let _ = std::fs::remove_file(&tmp);

--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -116,6 +116,7 @@ pub fn write_atomic_create_new(dest: &Path, bytes: &[u8]) -> io::Result<bool> {
                     if let Err(write_error) =
                         f.write_all(bytes).and_then(|()| sync_all_best_effort(&f))
                     {
+                        drop(f);
                         let _ = std::fs::remove_file(&tmp);
                         let _ = std::fs::remove_file(dest);
                         return Err(write_error);

--- a/src-tauri/src/io_atomic.rs
+++ b/src-tauri/src/io_atomic.rs
@@ -67,6 +67,37 @@ pub fn write_atomic(dest: &Path, bytes: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+pub fn write_atomic_create_new(dest: &Path, bytes: &[u8]) -> io::Result<bool> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+
+    let tmp = unique_tmp_path(dest)?;
+
+    {
+        let mut f = File::create(&tmp)?;
+        f.write_all(bytes)?;
+        sync_all_best_effort(&f)?;
+    }
+
+    match std::fs::hard_link(&tmp, dest) {
+        Ok(()) => {
+            std::fs::remove_file(&tmp)?;
+            fsync_dir(parent)?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let _ = std::fs::remove_file(&tmp);
+            Ok(false)
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&tmp);
+            Err(error)
+        }
+    }
+}
+
 pub fn copy_atomic(src: &Path, dest: &Path) -> io::Result<()> {
     let parent = dest
         .parent()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1042,6 +1042,14 @@ fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::W
     })
 }
 
+fn target_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
+    focused_space_host_window(app).or_else(|| {
+        app.webview_windows()
+            .into_iter()
+            .find(|(label, _window)| is_space_host_window_label(label))
+    })
+}
+
 fn sync_fallback_space_to_focused_window(app: &tauri::AppHandle) {
     let Some(space_state) = app.try_state::<space::SpaceState>() else {
         return;
@@ -1473,21 +1481,19 @@ pub fn run() {
                 if current_path.as_deref() == Some(path.as_str()) {
                     return;
                 }
-                if let Some((label, _window)) = focused_space_host_window(app) {
+                if let Some((label, _window)) = target_space_host_window(app) {
                     let _ = app.emit_to(
                         label,
                         "menu:open_recent_space",
                         OpenRecentSpacePayload { path },
                     );
-                } else {
-                    let _ = app.emit("menu:open_recent_space", OpenRecentSpacePayload { path });
                 }
             }
             id => {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                if let Some((label, _window)) = focused_space_host_window(app) {
+                if let Some((label, _window)) = target_space_host_window(app) {
                     let _ = app.emit_to(
                         label,
                         "menu:app_command",
@@ -1495,14 +1501,7 @@ pub fn run() {
                             command_id: command.id,
                         },
                     );
-                    return;
                 }
-                let _ = app.emit(
-                    "menu:app_command",
-                    AppCommandPayload {
-                        command_id: command.id,
-                    },
-                );
             }
         })
         .setup(|app| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1044,9 +1044,15 @@ fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::W
 
 fn target_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
     focused_space_host_window(app).or_else(|| {
-        app.webview_windows()
-            .into_iter()
-            .find(|(label, _window)| is_space_host_window_label(label))
+        let space_state = app.try_state::<space::SpaceState>()?;
+        let current_root = space_state.current_root().ok()?;
+        app.webview_windows().into_iter().find(|(label, _window)| {
+            is_space_host_window_label(label)
+                && space_state
+                    .root_for_window_label(label)
+                    .map(|root| root == current_root)
+                    .unwrap_or(false)
+        })
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,11 +64,7 @@ fn init_tracing() {
 }
 
 fn space_is_open(state: &space::SpaceState) -> bool {
-    state
-        .current
-        .lock()
-        .map(|guard| guard.is_some())
-        .unwrap_or(false)
+    !state.session_roots().is_empty()
 }
 
 fn set_menu_item_enabled<R: tauri::Runtime>(
@@ -1351,7 +1347,7 @@ fn set_menu_shortcuts(
 }
 
 #[cfg(target_os = "macos")]
-fn apply_main_window_vibrancy(
+pub(crate) fn apply_main_window_vibrancy(
     window: &tauri::WebviewWindow,
     theme: Option<&str>,
 ) -> Result<(), String> {
@@ -1364,7 +1360,7 @@ fn apply_main_window_vibrancy(
 }
 
 #[cfg(not(target_os = "macos"))]
-fn apply_main_window_vibrancy(
+pub(crate) fn apply_main_window_vibrancy(
     _window: &tauri::WebviewWindow,
     _theme: Option<&str>,
 ) -> Result<(), String> {
@@ -1438,34 +1434,49 @@ pub fn run() {
                 let Some(space_state) = app.try_state::<space::SpaceState>() else {
                     return;
                 };
-                let current_path = space_state.current.lock().ok().and_then(|guard| {
-                    guard
-                        .as_ref()
-                        .map(|path| path.to_string_lossy().to_string())
-                });
+                let current_path = app
+                    .webview_windows()
+                    .into_iter()
+                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
+                    .and_then(|(label, _window)| {
+                        space_state
+                            .root_for_window_label(&label)
+                            .ok()
+                            .map(|path| path.to_string_lossy().to_string())
+                    });
                 if current_path.as_deref() == Some(path.as_str()) {
                     return;
                 }
-                let _ = app.emit("menu:open_recent_space", OpenRecentSpacePayload { path });
+                if let Some((label, _window)) = app
+                    .webview_windows()
+                    .into_iter()
+                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
+                {
+                    let _ = app.emit_to(
+                        label,
+                        "menu:open_recent_space",
+                        OpenRecentSpacePayload { path },
+                    );
+                } else {
+                    let _ = app.emit("menu:open_recent_space", OpenRecentSpacePayload { path });
+                }
             }
             id => {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                if command.id == "close-active-tab" {
-                    if let Some((label, _window)) = app
-                        .webview_windows()
-                        .into_iter()
-                        .find(|(_label, window)| window.is_focused().unwrap_or(false))
-                    {
-                        let _ = app.emit_to(
-                            label,
-                            "menu:app_command",
-                            AppCommandPayload {
-                                command_id: command.id,
-                            },
-                        );
-                    }
+                if let Some((label, _window)) = app
+                    .webview_windows()
+                    .into_iter()
+                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
+                {
+                    let _ = app.emit_to(
+                        label,
+                        "menu:app_command",
+                        AppCommandPayload {
+                            command_id: command.id,
+                        },
+                    );
                     return;
                 }
                 let _ = app.emit(
@@ -1542,6 +1553,15 @@ pub fn run() {
                         }
                     }
                     _ => {}
+                }
+            }
+
+            if space::commands::is_space_window(window.label()) {
+                if let WindowEvent::Destroyed = event {
+                    let state = window.state::<space::SpaceState>();
+                    if let Err(error) = state.remove_window_session(window.label()) {
+                        warn!("Failed to forget space window session: {error}");
+                    }
                 }
             }
 
@@ -1688,6 +1708,7 @@ pub fn run() {
             git_sync::commands::git_sync_disconnect,
             space::commands::space_create,
             space::commands::space_open,
+            space::commands::space_open_window,
             space::commands::space_get_current,
             space::commands::space_show_onboarding_note,
             space::commands::space_close

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1032,7 +1032,30 @@ fn quick_task_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
     Ok(window)
 }
 
+fn is_space_host_window_label(label: &str) -> bool {
+    label == "main" || space::commands::is_space_window(label)
+}
+
+fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
+    app.webview_windows().into_iter().find(|(label, window)| {
+        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
+    })
+}
+
+fn sync_fallback_space_to_focused_window(app: &tauri::AppHandle) {
+    let Some(space_state) = app.try_state::<space::SpaceState>() else {
+        return;
+    };
+    let focused_root = focused_space_host_window(app)
+        .and_then(|(_label, window)| space_state.root_for_window(&window).ok());
+    let Some(root) = focused_root else {
+        return;
+    };
+    let _ = space_state.set_current_root(root);
+}
+
 fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
+    sync_fallback_space_to_focused_window(app);
     let window = quick_note_window(app)?;
     let _ = window.center();
     window.show().map_err(|error| error.to_string())?;
@@ -1041,6 +1064,7 @@ fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> 
 }
 
 fn show_quick_task_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
+    sync_fallback_space_to_focused_window(app);
     let window = quick_task_window(app)?;
     let _ = window.center();
     window.show().map_err(|error| error.to_string())?;
@@ -1437,7 +1461,9 @@ pub fn run() {
                 let current_path = app
                     .webview_windows()
                     .into_iter()
-                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
+                    .find(|(label, window)| {
+                        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
+                    })
                     .and_then(|(label, _window)| {
                         space_state
                             .root_for_window_label(&label)
@@ -1447,11 +1473,7 @@ pub fn run() {
                 if current_path.as_deref() == Some(path.as_str()) {
                     return;
                 }
-                if let Some((label, _window)) = app
-                    .webview_windows()
-                    .into_iter()
-                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
-                {
+                if let Some((label, _window)) = focused_space_host_window(app) {
                     let _ = app.emit_to(
                         label,
                         "menu:open_recent_space",
@@ -1465,11 +1487,7 @@ pub fn run() {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                if let Some((label, _window)) = app
-                    .webview_windows()
-                    .into_iter()
-                    .find(|(_label, window)| window.is_focused().unwrap_or(false))
-                {
+                if let Some((label, _window)) = focused_space_host_window(app) {
                     let _ = app.emit_to(
                         label,
                         "menu:app_command",
@@ -1559,8 +1577,11 @@ pub fn run() {
             if space::commands::is_space_window(window.label()) {
                 if let WindowEvent::Destroyed = event {
                     let state = window.state::<space::SpaceState>();
-                    if let Err(error) = state.remove_window_session(window.label()) {
-                        warn!("Failed to forget space window session: {error}");
+                    match state.remove_window_session(window.label()) {
+                        Ok(()) => {
+                            space::commands::update_close_space_menu(window.app_handle(), &state)
+                        }
+                        Err(error) => warn!("Failed to forget space window session: {error}"),
                     }
                 }
             }
@@ -1710,6 +1731,7 @@ pub fn run() {
             space::commands::space_open,
             space::commands::space_open_window,
             space::commands::space_get_current,
+            space::commands::space_get_current_info,
             space::commands::space_show_onboarding_note,
             space::commands::space_close
         ])

--- a/src-tauri/src/pinned_files/commands.rs
+++ b/src-tauri/src/pinned_files/commands.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::space::SpaceState;
 use crate::space_fs::helpers::deny_hidden_rel_path;
@@ -10,8 +10,11 @@ use super::store::{
 };
 
 #[tauri::command]
-pub async fn pinned_files_list(state: State<'_, SpaceState>) -> Result<Vec<String>, String> {
-    let root = state.current_root()?;
+pub async fn pinned_files_list(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<Vec<String>, String> {
+    let root = state.root_for_window(&window)?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let _guard = pinned_files_mutex
@@ -29,10 +32,11 @@ pub async fn pinned_files_list(state: State<'_, SpaceState>) -> Result<Vec<Strin
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_toggle(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);
@@ -54,11 +58,12 @@ pub async fn pinned_files_toggle(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_rename_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let from_rel = PathBuf::from(&from_path);
@@ -87,10 +92,11 @@ pub async fn pinned_files_rename_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_delete_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,20 +1,62 @@
 use std::path::{Path, PathBuf};
-use tauri::State;
+use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    paths,
+    paths, utils,
 };
 
 use super::helpers::{
     canonicalize_dir, create_or_open_impl, ensure_onboarding_note_for_command, SpaceInfo,
 };
 use super::state::SpaceState;
-use super::watcher::set_notes_watcher;
+use super::watcher::create_notes_watcher;
+
+pub(crate) const SPACE_WINDOW_PREFIX: &str = "space-";
+
+pub(crate) fn is_space_window(label: &str) -> bool {
+    label.starts_with(SPACE_WINDOW_PREFIX)
+}
+
+fn space_window_label(root: &Path) -> String {
+    let hash = utils::sha256_hex(root.to_string_lossy().as_bytes());
+    format!("{SPACE_WINDOW_PREFIX}{}", &hash[..16])
+}
+
+fn space_window_title(root: &Path) -> String {
+    root.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.trim().is_empty())
+        .map(|name| format!("{name} - Glyph"))
+        .unwrap_or_else(|| "Glyph".to_string())
+}
+
+fn install_window_session(
+    app: tauri::AppHandle,
+    state: &SpaceState,
+    window_label: String,
+    root: PathBuf,
+) -> Result<(), String> {
+    let recent_local_changes = state.new_recent_local_changes();
+    let watcher = create_notes_watcher(
+        app,
+        root.clone(),
+        window_label.clone(),
+        recent_local_changes.clone(),
+    )?;
+    state.set_window_session(window_label, root, watcher, recent_local_changes)
+}
+
+fn focus_window(window: &tauri::WebviewWindow) -> Result<(), String> {
+    window.show().map_err(|error| error.to_string())?;
+    window.unminimize().map_err(|error| error.to_string())?;
+    window.set_focus().map_err(|error| error.to_string())
+}
 
 #[tauri::command]
 pub async fn space_create(
     app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<SpaceInfo, String> {
@@ -34,7 +76,12 @@ pub async fn space_create(
         .map_err(|_| "space state poisoned".to_string())?;
     *guard = Some(PathBuf::from(&info.root));
     drop(guard);
-    let _ = set_notes_watcher(&state, app.clone(), PathBuf::from(&info.root));
+    install_window_session(
+        app.clone(),
+        &state,
+        window.label().to_string(),
+        PathBuf::from(&info.root),
+    )?;
     let _ = crate::set_space_close_menu_enabled(&app, true);
     Ok(info)
 }
@@ -42,6 +89,7 @@ pub async fn space_create(
 #[tauri::command]
 pub async fn space_open(
     app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<SpaceInfo, String> {
@@ -60,20 +108,33 @@ pub async fn space_open(
         .map_err(|_| "space state poisoned".to_string())?;
     *guard = Some(PathBuf::from(&info.root));
     drop(guard);
-    let _ = set_notes_watcher(&state, app.clone(), PathBuf::from(&info.root));
+    install_window_session(
+        app.clone(),
+        &state,
+        window.label().to_string(),
+        PathBuf::from(&info.root),
+    )?;
     let _ = crate::set_space_close_menu_enabled(&app, true);
     Ok(info)
 }
 
 #[tauri::command]
-pub fn space_get_current(state: State<'_, SpaceState>) -> Option<String> {
-    let guard = state.current.lock().ok()?;
-    guard.as_ref().map(|p| p.to_string_lossy().to_string())
+pub fn space_get_current(
+    window: tauri::WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Option<String> {
+    state
+        .root_for_window(&window)
+        .ok()
+        .map(|path| path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
-pub async fn space_show_onboarding_note(state: State<'_, SpaceState>) -> Result<String, String> {
-    let root = state.current_root()?;
+pub async fn space_show_onboarding_note(
+    window: tauri::WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<String, String> {
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let note_path = ensure_onboarding_note_for_command(&root)?;
         let abs = paths::join_under(&root, Path::new(&note_path))?;
@@ -87,20 +148,63 @@ pub async fn space_show_onboarding_note(state: State<'_, SpaceState>) -> Result<
 }
 
 #[tauri::command]
-pub fn space_close(app: tauri::AppHandle, state: State<'_, SpaceState>) -> Result<(), String> {
-    {
-        let mut guard = state
-            .current
-            .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        *guard = None;
-    }
-    let mut watcher_guard = state
-        .notes_watcher
-        .lock()
-        .map_err(|_| "space watcher state poisoned".to_string())?;
-    *watcher_guard = None;
+pub fn space_close(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<(), String> {
+    state.remove_window_session(window.label())?;
     reset_schema_cache();
-    let _ = crate::set_space_close_menu_enabled(&app, false);
+    let _ = crate::set_space_close_menu_enabled(&app, !state.session_roots().is_empty());
     Ok(())
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_open_window(
+    app: tauri::AppHandle,
+    state: State<'_, SpaceState>,
+    path: String,
+    create: Option<bool>,
+) -> Result<SpaceInfo, String> {
+    let root = PathBuf::from(path);
+    let should_create = create.unwrap_or(false);
+    let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
+        if should_create {
+            std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+        }
+        let root = canonicalize_dir(&root)?;
+        create_or_open_impl(&root)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    let root = PathBuf::from(&info.root);
+    let label = space_window_label(&root);
+    install_window_session(app.clone(), &state, label.clone(), root.clone())?;
+
+    if let Some(window) = app.get_webview_window(&label) {
+        focus_window(&window)?;
+        return Ok(info);
+    }
+
+    let window = WebviewWindowBuilder::new(
+        &app,
+        &label,
+        WebviewUrl::App(format!("index.html?window={label}").into()),
+    )
+    .title(space_window_title(&root))
+    .inner_size(800.0, 600.0)
+    .min_inner_size(680.0, 460.0)
+    .decorations(true)
+    .title_bar_style(tauri::TitleBarStyle::Overlay)
+    .hidden_title(true)
+    .transparent(true)
+    .shadow(true)
+    .center()
+    .build()
+    .map_err(|error| error.to_string())?;
+
+    focus_window(&window)?;
+    let _ = crate::set_space_close_menu_enabled(&app, true);
+    Ok(info)
 }

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -53,6 +53,10 @@ fn focus_window(window: &tauri::WebviewWindow) -> Result<(), String> {
     window.set_focus().map_err(|error| error.to_string())
 }
 
+pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState) {
+    let _ = crate::set_space_close_menu_enabled(app, !state.session_roots().is_empty());
+}
+
 #[tauri::command]
 pub async fn space_create(
     app: tauri::AppHandle,
@@ -70,19 +74,16 @@ pub async fn space_create(
     .map_err(|e| e.to_string())??;
 
     reset_schema_cache();
-    let mut guard = state
-        .current
-        .lock()
-        .map_err(|_| "space state poisoned".to_string())?;
-    *guard = Some(PathBuf::from(&info.root));
-    drop(guard);
     install_window_session(
         app.clone(),
         &state,
         window.label().to_string(),
         PathBuf::from(&info.root),
     )?;
-    let _ = crate::set_space_close_menu_enabled(&app, true);
+    if window.label() == "main" {
+        state.set_current_root(PathBuf::from(&info.root))?;
+    }
+    update_close_space_menu(&app, &state);
     Ok(info)
 }
 
@@ -102,19 +103,16 @@ pub async fn space_open(
     .map_err(|e| e.to_string())??;
 
     reset_schema_cache();
-    let mut guard = state
-        .current
-        .lock()
-        .map_err(|_| "space state poisoned".to_string())?;
-    *guard = Some(PathBuf::from(&info.root));
-    drop(guard);
     install_window_session(
         app.clone(),
         &state,
         window.label().to_string(),
         PathBuf::from(&info.root),
     )?;
-    let _ = crate::set_space_close_menu_enabled(&app, true);
+    if window.label() == "main" {
+        state.set_current_root(PathBuf::from(&info.root))?;
+    }
+    update_close_space_menu(&app, &state);
     Ok(info)
 }
 
@@ -127,6 +125,19 @@ pub fn space_get_current(
         .root_for_window(&window)
         .ok()
         .map(|path| path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn space_get_current_info(
+    window: tauri::WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<Option<SpaceInfo>, String> {
+    let Ok(root) = state.root_for_window(&window) else {
+        return Ok(None);
+    };
+    tauri::async_runtime::spawn_blocking(move || create_or_open_impl(&root).map(Some))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
@@ -155,7 +166,7 @@ pub fn space_close(
 ) -> Result<(), String> {
     state.remove_window_session(window.label())?;
     reset_schema_cache();
-    let _ = crate::set_space_close_menu_enabled(&app, !state.session_roots().is_empty());
+    update_close_space_menu(&app, &state);
     Ok(())
 }
 
@@ -180,14 +191,15 @@ pub async fn space_open_window(
 
     let root = PathBuf::from(&info.root);
     let label = space_window_label(&root);
-    install_window_session(app.clone(), &state, label.clone(), root.clone())?;
 
     if let Some(window) = app.get_webview_window(&label) {
         focus_window(&window)?;
         return Ok(info);
     }
 
-    let window = WebviewWindowBuilder::new(
+    install_window_session(app.clone(), &state, label.clone(), root.clone())?;
+
+    let window = match WebviewWindowBuilder::new(
         &app,
         &label,
         WebviewUrl::App(format!("index.html?window={label}").into()),
@@ -202,9 +214,15 @@ pub async fn space_open_window(
     .shadow(true)
     .center()
     .build()
-    .map_err(|error| error.to_string())?;
+    {
+        Ok(window) => window,
+        Err(error) => {
+            let _ = state.remove_window_session(&label);
+            return Err(error.to_string());
+        }
+    };
 
     focus_window(&window)?;
-    let _ = crate::set_space_close_menu_enabled(&app, true);
+    update_close_space_menu(&app, &state);
     Ok(info)
 }

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -50,9 +50,29 @@ pub(crate) fn has_recent_local_change(changes: &RecentLocalChanges, rel_path: &s
     guard.contains_key(&normalized)
 }
 
+pub(crate) struct SpaceSession {
+    pub(crate) root: PathBuf,
+    pub(crate) _notes_watcher: Option<notify::RecommendedWatcher>,
+    pub(crate) recent_local_changes: RecentLocalChanges,
+}
+
+impl SpaceSession {
+    fn new(
+        root: PathBuf,
+        notes_watcher: notify::RecommendedWatcher,
+        recent_local_changes: RecentLocalChanges,
+    ) -> Self {
+        Self {
+            root,
+            _notes_watcher: Some(notes_watcher),
+            recent_local_changes,
+        }
+    }
+}
+
 pub struct SpaceState {
     pub(crate) current: Mutex<Option<PathBuf>>,
-    pub(crate) notes_watcher: Mutex<Option<notify::RecommendedWatcher>>,
+    pub(crate) sessions: Mutex<HashMap<String, SpaceSession>>,
     recent_local_changes: RecentLocalChanges,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
@@ -63,7 +83,7 @@ impl Default for SpaceState {
     fn default() -> Self {
         Self {
             current: Mutex::new(None),
-            notes_watcher: Mutex::new(None),
+            sessions: Mutex::new(HashMap::new()),
             recent_local_changes: Arc::new(Mutex::new(HashMap::new())),
             db_store_mutex: Arc::new(Mutex::new(())),
             file_tree_appearance_mutex: Arc::new(Mutex::new(())),
@@ -73,8 +93,88 @@ impl Default for SpaceState {
 }
 
 impl SpaceState {
-    pub(crate) fn recent_local_changes(&self) -> RecentLocalChanges {
-        Arc::clone(&self.recent_local_changes)
+    pub(crate) fn new_recent_local_changes(&self) -> RecentLocalChanges {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    pub(crate) fn recent_local_changes_for_window(&self, window_label: &str) -> RecentLocalChanges {
+        self.sessions
+            .lock()
+            .ok()
+            .and_then(|sessions| {
+                sessions
+                    .get(window_label)
+                    .map(|session| Arc::clone(&session.recent_local_changes))
+            })
+            .unwrap_or_else(|| Arc::clone(&self.recent_local_changes))
+    }
+
+    pub(crate) fn set_window_session(
+        &self,
+        window_label: String,
+        root: PathBuf,
+        notes_watcher: notify::RecommendedWatcher,
+        recent_local_changes: RecentLocalChanges,
+    ) -> Result<(), String> {
+        self.sessions
+            .lock()
+            .map_err(|_| "space sessions state poisoned".to_string())?
+            .insert(
+                window_label,
+                SpaceSession::new(root.clone(), notes_watcher, recent_local_changes),
+            );
+        let mut current = self
+            .current
+            .lock()
+            .map_err(|_| "space state poisoned".to_string())?;
+        *current = Some(root);
+        Ok(())
+    }
+
+    pub(crate) fn remove_window_session(&self, window_label: &str) -> Result<(), String> {
+        let next_current = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|_| "space sessions state poisoned".to_string())?;
+            sessions.remove(window_label);
+            sessions.values().next().map(|session| session.root.clone())
+        };
+        let mut current = self
+            .current
+            .lock()
+            .map_err(|_| "space state poisoned".to_string())?;
+        *current = next_current;
+        Ok(())
+    }
+
+    pub(crate) fn root_for_window_label(&self, window_label: &str) -> Result<PathBuf, String> {
+        if let Some(root) = self
+            .sessions
+            .lock()
+            .map_err(|_| "space sessions state poisoned".to_string())?
+            .get(window_label)
+            .map(|session| session.root.clone())
+        {
+            return Ok(root);
+        }
+        self.current_root()
+    }
+
+    pub fn root_for_window(&self, window: &tauri::WebviewWindow) -> Result<PathBuf, String> {
+        self.root_for_window_label(window.label())
+    }
+
+    pub(crate) fn session_roots(&self) -> Vec<PathBuf> {
+        self.sessions
+            .lock()
+            .map(|sessions| {
+                sessions
+                    .values()
+                    .map(|session| session.root.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default()
     }
 
     pub(crate) fn db_store_mutex(&self) -> Arc<Mutex<()>> {

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 const RECENT_LOCAL_CHANGE_TTL: Duration = Duration::from_secs(2);
+pub(crate) const NO_SPACE_SESSION_FOR_WINDOW: &str = "no space session for window";
 
 pub(crate) type RecentLocalChanges = Arc<Mutex<HashMap<String, Instant>>>;
 
@@ -73,7 +74,6 @@ impl SpaceSession {
 pub struct SpaceState {
     pub(crate) current: Mutex<Option<PathBuf>>,
     pub(crate) sessions: Mutex<HashMap<String, SpaceSession>>,
-    recent_local_changes: RecentLocalChanges,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
     pinned_files_mutex: Arc<Mutex<()>>,
@@ -84,7 +84,6 @@ impl Default for SpaceState {
         Self {
             current: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
-            recent_local_changes: Arc::new(Mutex::new(HashMap::new())),
             db_store_mutex: Arc::new(Mutex::new(())),
             file_tree_appearance_mutex: Arc::new(Mutex::new(())),
             pinned_files_mutex: Arc::new(Mutex::new(())),
@@ -98,15 +97,22 @@ impl SpaceState {
     }
 
     pub(crate) fn recent_local_changes_for_window(&self, window_label: &str) -> RecentLocalChanges {
-        self.sessions
-            .lock()
-            .ok()
-            .and_then(|sessions| {
-                sessions
-                    .get(window_label)
-                    .map(|session| Arc::clone(&session.recent_local_changes))
-            })
-            .unwrap_or_else(|| Arc::clone(&self.recent_local_changes))
+        let Ok(sessions) = self.sessions.lock() else {
+            return Arc::new(Mutex::new(HashMap::new()));
+        };
+        if let Some(session) = sessions.get(window_label) {
+            return Arc::clone(&session.recent_local_changes);
+        }
+        let current_root = self.current.lock().ok().and_then(|guard| guard.clone());
+        if let Some(current_root) = current_root {
+            if let Some(session) = sessions
+                .values()
+                .find(|session| session.root == current_root)
+            {
+                return Arc::clone(&session.recent_local_changes);
+            }
+        }
+        Arc::new(Mutex::new(HashMap::new()))
     }
 
     pub(crate) fn set_window_session(
@@ -121,8 +127,12 @@ impl SpaceState {
             .map_err(|_| "space sessions state poisoned".to_string())?
             .insert(
                 window_label,
-                SpaceSession::new(root.clone(), notes_watcher, recent_local_changes),
+                SpaceSession::new(root, notes_watcher, recent_local_changes),
             );
+        Ok(())
+    }
+
+    pub(crate) fn set_current_root(&self, root: PathBuf) -> Result<(), String> {
         let mut current = self
             .current
             .lock()
@@ -132,19 +142,20 @@ impl SpaceState {
     }
 
     pub(crate) fn remove_window_session(&self, window_label: &str) -> Result<(), String> {
-        let next_current = {
+        let removed_root = {
             let mut sessions = self
                 .sessions
                 .lock()
                 .map_err(|_| "space sessions state poisoned".to_string())?;
-            sessions.remove(window_label);
-            sessions.values().next().map(|session| session.root.clone())
+            sessions.remove(window_label).map(|session| session.root)
         };
         let mut current = self
             .current
             .lock()
             .map_err(|_| "space state poisoned".to_string())?;
-        *current = next_current;
+        if removed_root.as_ref() == current.as_ref() {
+            *current = None;
+        }
         Ok(())
     }
 
@@ -158,11 +169,20 @@ impl SpaceState {
         {
             return Ok(root);
         }
-        self.current_root()
+        Err(format!("{NO_SPACE_SESSION_FOR_WINDOW}: {window_label}"))
     }
 
     pub fn root_for_window(&self, window: &tauri::WebviewWindow) -> Result<PathBuf, String> {
-        self.root_for_window_label(window.label())
+        match self.root_for_window_label(window.label()) {
+            Ok(root) => Ok(root),
+            Err(error)
+                if matches!(window.label(), "quick-note" | "quick-task")
+                    && is_no_space_session_error(&error) =>
+            {
+                self.current_root()
+            }
+            Err(error) => Err(error),
+        }
     }
 
     pub(crate) fn session_roots(&self) -> Vec<PathBuf> {
@@ -198,4 +218,8 @@ impl SpaceState {
             .clone()
             .ok_or_else(|| "no space open (select or create a space first)".to_string())
     }
+}
+
+pub(crate) fn is_no_space_session_error(error: &str) -> bool {
+    error.starts_with(NO_SPACE_SESSION_FOR_WINDOW)
 }

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -7,27 +7,23 @@ use tauri::Emitter;
 
 use crate::{index, utils};
 
-use super::state::{has_recent_local_change, SpaceState};
+use super::state::{has_recent_local_change, RecentLocalChanges};
 
 #[derive(Serialize, Clone)]
 struct ExternalChangeEvent {
+    space_path: String,
     rel_path: String,
     removed: bool,
 }
 
 const DEBOUNCE_MS: u64 = 100;
 
-pub fn set_notes_watcher(
-    state: &SpaceState,
+pub fn create_notes_watcher(
     app: tauri::AppHandle,
     root: PathBuf,
-) -> Result<(), String> {
-    let mut guard = state
-        .notes_watcher
-        .lock()
-        .map_err(|_| "space watcher state poisoned".to_string())?;
-    *guard = None;
-
+    window_label: String,
+    recent_local_changes: RecentLocalChanges,
+) -> Result<notify::RecommendedWatcher, String> {
     let (idx_tx, idx_rx) = std_mpsc::channel::<(String, bool)>();
 
     let root_idx = root.clone();
@@ -67,7 +63,7 @@ pub fn set_notes_watcher(
 
     let app2 = app.clone();
     let root2 = root.clone();
-    let recent_local_changes = state.recent_local_changes();
+    let space_path = root.to_string_lossy().to_string();
 
     let watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
         let event = match res {
@@ -104,18 +100,22 @@ pub fn set_notes_watcher(
             {
                 let _ = idx_tx.send((rel_s.clone(), is_remove));
 
-                let _ = app2.emit(
+                let _ = app2.emit_to(
+                    &window_label,
                     "notes:external_changed",
                     ExternalChangeEvent {
+                        space_path: space_path.clone(),
                         rel_path: rel_s.clone(),
                         removed: is_remove,
                     },
                 );
             }
 
-            let _ = app2.emit(
+            let _ = app2.emit_to(
+                &window_label,
                 "space:fs_changed",
                 ExternalChangeEvent {
+                    space_path: space_path.clone(),
                     rel_path: rel_s,
                     removed: is_remove,
                 },
@@ -129,6 +129,5 @@ pub fn set_notes_watcher(
         .watch(&root, notify::RecursiveMode::Recursive)
         .map_err(|e: notify::Error| e.to_string())?;
 
-    *guard = Some(watcher);
-    Ok(())
+    Ok(watcher)
 }

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -331,10 +331,11 @@ fn resolve_standard_wikilink_target(entries: &[FileEntry], target: &str) -> Opti
 
 #[tauri::command]
 pub async fn space_resolve_wikilink(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     target: String,
 ) -> Result<Option<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         Ok(resolve_standard_wikilink_target(&entries, &target))
@@ -345,10 +346,11 @@ pub async fn space_resolve_wikilink(
 
 #[tauri::command]
 pub async fn space_resolve_image_wikilink(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     target: String,
 ) -> Result<Option<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         Ok(resolve_image_wikilink_target(&entries, &target))
@@ -359,11 +361,12 @@ pub async fn space_resolve_image_wikilink(
 
 #[tauri::command]
 pub async fn space_resolve_markdown_link(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     href: String,
     source_path: String,
 ) -> Result<Option<String>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         let raw = href
@@ -520,10 +523,11 @@ mod tests {
 
 #[tauri::command]
 pub async fn space_suggest_links(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: LinkSuggestRequest,
 ) -> Result<Vec<LinkSuggestionItem>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let markdown_only = request.markdown_only.unwrap_or(false);
         let include_pdf = request.include_pdf.unwrap_or(false);

--- a/src-tauri/src/space_fs/list.rs
+++ b/src-tauri/src/space_fs/list.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -20,12 +20,13 @@ fn metadata_timestamps(metadata: &std::fs::Metadata) -> (Option<String>, Option<
 
 #[tauri::command]
 pub async fn space_list_markdown_files(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     recursive: Option<bool>,
     limit: Option<u32>,
 ) -> Result<Vec<FsEntry>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let dir = dir.unwrap_or_default();
     let recursive = recursive.unwrap_or(true);
     let limit = limit.unwrap_or(2_000).min(50_000) as usize;
@@ -135,11 +136,12 @@ pub async fn space_list_markdown_files(
 
 #[tauri::command]
 pub async fn space_list_non_markdown_files(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     limit: Option<u32>,
 ) -> Result<FsEntryList, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let dir = dir.unwrap_or_default();
     let limit = limit.unwrap_or(5_000).min(50_000) as usize;
 
@@ -218,10 +220,11 @@ pub async fn space_list_non_markdown_files(
 
 #[tauri::command]
 pub async fn space_list_dir(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
 ) -> Result<Vec<FsEntry>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let dir = dir.unwrap_or_default();
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<FsEntry>, String> {
         let rel = if dir.trim().is_empty() {

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::io::{ErrorKind, Write};
 use std::path::PathBuf;
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::paths;
 use crate::space::SpaceState;
@@ -94,13 +94,14 @@ fn parse_data_url(data_url: &str) -> Result<(String, Vec<u8>), String> {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_save_pasted_image(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     source_path: String,
     target_dir: String,
     data_url: String,
     alt: Option<String>,
 ) -> Result<SavedPastedImage, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<SavedPastedImage, String> {
         let source_rel = PathBuf::from(normalize_rel_path(&source_path));
         let target_rel = PathBuf::from(normalize_rel_path(&target_dir));

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -1,10 +1,10 @@
 use base64::Engine;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::io::{ErrorKind, Write};
 use std::path::PathBuf;
 use tauri::{State, WebviewWindow};
 
+use crate::io_atomic;
 use crate::paths;
 use crate::space::SpaceState;
 
@@ -125,17 +125,8 @@ pub async fn space_save_pasted_image(
         if let Some(parent) = asset_abs.parent() {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&asset_abs)
-        {
-            Ok(mut file) => {
-                file.write_all(&bytes).map_err(|e| e.to_string())?;
-            }
-            Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
-            Err(error) => return Err(error.to_string()),
-        }
+        let _ =
+            io_atomic::write_atomic_create_new(&asset_abs, &bytes).map_err(|e| e.to_string())?;
 
         let asset_rel_string = asset_rel.to_string_lossy().replace('\\', "/");
         let source_dir = parent_dir(&source_rel.to_string_lossy());

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashSet,
     path::{Path, PathBuf},
 };
-use tauri::{Emitter, State};
+use tauri::{Emitter, State, WebviewWindow};
 
 use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
 use crate::{index, paths, space::SpaceState, utils};
@@ -15,6 +15,7 @@ use super::trash::move_path_to_trash;
 
 #[derive(Serialize, Clone)]
 struct NoteChangeEvent {
+    space_path: String,
     rel_path: String,
     removed: bool,
 }
@@ -216,8 +217,12 @@ fn remove_markdown_notes_from_index(
 }
 
 #[tauri::command]
-pub async fn space_create_dir(state: State<'_, SpaceState>, path: String) -> Result<(), String> {
-    let root = state.current_root()?;
+pub async fn space_create_dir(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    path: String,
+) -> Result<(), String> {
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -231,20 +236,25 @@ pub async fn space_create_dir(state: State<'_, SpaceState>, path: String) -> Res
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_duplicate_path(
     app: tauri::AppHandle,
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<FsEntry, String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let space_path = root.to_string_lossy().to_string();
+    let window_label = window.label().to_string();
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     let entry = tauri::async_runtime::spawn_blocking(move || {
         duplicate_file_under_root(&root, Path::new(&path), &recent_local_changes)
     })
     .await
     .map_err(|e| e.to_string())??;
     if entry.is_markdown {
-        let _ = app.emit(
+        let _ = app.emit_to(
+            window_label,
             "notes:external_changed",
             NoteChangeEvent {
+                space_path,
                 rel_path: entry.rel_path.clone(),
                 removed: false,
             },
@@ -255,10 +265,11 @@ pub async fn space_duplicate_path(
 
 #[tauri::command]
 pub async fn space_resolve_abs_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<String, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -295,8 +306,12 @@ fn reveal_file_manager_path(_abs: &Path) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn space_reveal_path(state: State<'_, SpaceState>, path: String) -> Result<(), String> {
-    let root = state.current_root()?;
+pub async fn space_reveal_path(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    path: String,
+) -> Result<(), String> {
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -315,12 +330,13 @@ pub async fn space_reveal_path(state: State<'_, SpaceState>, path: String) -> Re
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_rename_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<LinkRewriteResult, String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     tauri::async_runtime::spawn_blocking(move || -> Result<LinkRewriteResult, String> {
         let from_rel = PathBuf::from(&from_path);
         let to_rel = PathBuf::from(&to_path);
@@ -451,12 +467,13 @@ fn reindex_after_rename(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_delete_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     recursive: Option<bool>,
 ) -> Result<(), String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         if rel.as_os_str().is_empty() {
@@ -482,10 +499,11 @@ pub async fn space_delete_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_relativize_path(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     abs_path: String,
 ) -> Result<String, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let root = root.canonicalize().map_err(|e| e.to_string())?;
         let abs_input = PathBuf::from(abs_path);

--- a/src-tauri/src/space_fs/read_write/preview.rs
+++ b/src-tauri/src/space_fs/read_write/preview.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use std::{io::Read, path::PathBuf};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState};
 
@@ -29,11 +29,12 @@ fn mime_for_preview_ext(ext: &str) -> Option<&'static str> {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_read_text_preview(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     max_bytes: Option<u32>,
 ) -> Result<TextFilePreviewDoc, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<TextFilePreviewDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -75,11 +76,12 @@ pub async fn space_read_text_preview(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_read_binary_preview(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     max_bytes: Option<u32>,
 ) -> Result<BinaryFilePreviewDoc, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<BinaryFilePreviewDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;

--- a/src-tauri/src/space_fs/read_write/text.rs
+++ b/src-tauri/src/space_fs/read_write/text.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::{ffi::OsStr, io::Write, path::PathBuf};
+use std::{ffi::OsStr, path::PathBuf};
 use tauri::{Emitter, State, WebviewWindow};
 
 use crate::space::state::mark_recent_local_change;
@@ -175,21 +175,11 @@ pub async fn space_open_or_create_text(
         if let Some(parent) = abs.parent() {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&abs)
-        {
-            Ok(mut file) => {
-                file.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                return Ok(OpenOrCreateTextResult {
-                    created: false,
-                    mtime_ms: file_mtime_ms(&abs),
-                });
-            }
-            Err(error) => return Err(error.to_string()),
+        if !io_atomic::write_atomic_create_new(&abs, text.as_bytes()).map_err(|e| e.to_string())? {
+            return Ok(OpenOrCreateTextResult {
+                created: false,
+                mtime_ms: file_mtime_ms(&abs),
+            });
         }
         Ok(OpenOrCreateTextResult {
             created: true,

--- a/src-tauri/src/space_fs/read_write/text.rs
+++ b/src-tauri/src/space_fs/read_write/text.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::{ffi::OsStr, io::Write, path::PathBuf};
-use tauri::{Emitter, State};
+use tauri::{Emitter, State, WebviewWindow};
 
 use crate::space::state::mark_recent_local_change;
 use crate::{index, io_atomic, paths, space::SpaceState};
@@ -12,16 +12,18 @@ use super::super::types::{
 
 #[derive(Serialize, Clone)]
 struct NoteChangeEvent {
+    space_path: String,
     rel_path: String,
     removed: bool,
 }
 
 #[tauri::command]
 pub async fn space_read_text(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<TextFileDoc, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<TextFileDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -42,10 +44,11 @@ pub async fn space_read_text(
 
 #[tauri::command]
 pub async fn space_read_texts_batch(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     paths: Vec<String>,
 ) -> Result<Vec<TextFileDocBatch>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<TextFileDocBatch>, String> {
         let mut results = Vec::with_capacity(paths.len());
         for path in paths {
@@ -84,13 +87,16 @@ pub async fn space_read_texts_batch(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_write_text(
     app: tauri::AppHandle,
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     text: String,
     base_mtime_ms: Option<u64>,
 ) -> Result<TextFileWriteResult, String> {
-    let root = state.current_root()?;
-    let recent_local_changes = state.recent_local_changes();
+    let root = state.root_for_window(&window)?;
+    let space_path = root.to_string_lossy().to_string();
+    let window_label = window.label().to_string();
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
     let event_rel_path = PathBuf::from(&path).to_string_lossy().to_string();
     let should_emit_note_change = PathBuf::from(&path).extension() == Some(OsStr::new("md"));
     let result =
@@ -132,9 +138,11 @@ pub async fn space_write_text(
     if should_emit_note_change {
         // Local writes are filtered out by the filesystem watcher, so publish the
         // same note-change event here after the note has been indexed.
-        let _ = app.emit(
+        let _ = app.emit_to(
+            window_label,
             "notes:external_changed",
             NoteChangeEvent {
+                space_path,
                 rel_path: event_rel_path,
                 removed: false,
             },
@@ -146,11 +154,12 @@ pub async fn space_write_text(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_open_or_create_text(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     text: String,
 ) -> Result<OpenOrCreateTextResult, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<OpenOrCreateTextResult, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;

--- a/src-tauri/src/space_fs/summary.rs
+++ b/src-tauri/src/space_fs/summary.rs
@@ -1,5 +1,5 @@
 use std::{cmp::Reverse, collections::BinaryHeap, ffi::OsStr, path::PathBuf};
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState};
 
@@ -8,6 +8,7 @@ use super::types::{DirChildSummary, RecentMarkdown};
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_dir_children_summary(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     preview_limit: Option<u32>,
@@ -15,7 +16,7 @@ pub async fn space_dir_children_summary(
     const MAX_PREVIEW_LIMIT: usize = 20;
     const MAX_SCAN_FILES: usize = 200_000;
 
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     let dir = dir.unwrap_or_default();
     let limit = preview_limit
         .unwrap_or(5)

--- a/src-tauri/src/tag_appearance/commands.rs
+++ b/src-tauri/src/tag_appearance/commands.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 use crate::space::SpaceState;
 
@@ -15,9 +15,10 @@ fn tag_appearance_mutex() -> &'static Mutex<()> {
 
 #[tauri::command]
 pub async fn tag_appearance_list(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, TagAppearance>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let _guard = tag_appearance_mutex()
             .lock()
@@ -30,11 +31,12 @@ pub async fn tag_appearance_list(
 
 #[tauri::command]
 pub async fn tag_appearance_set(
+    window: WebviewWindow,
     state: State<'_, SpaceState>,
     tag: String,
     icon: Option<String>,
 ) -> Result<Option<TagAppearance>, String> {
-    let root = state.current_root()?;
+    let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let tag = normalize_tag_key(&tag)?;
         let _guard = tag_appearance_mutex()

--- a/src/components/settings/SpaceSettingsPane.test.tsx
+++ b/src/components/settings/SpaceSettingsPane.test.tsx
@@ -188,6 +188,7 @@ describe("SpaceSettingsPane", () => {
 
 		expect(setEditorAttachmentStorageModeMock).toHaveBeenCalledWith(
 			"specific-folder",
+			{ spacePath: "/spaces/test" },
 		);
 		expect(getAttachmentsSection().textContent).toContain("Browse");
 		expect(getAttachmentsSection().textContent).toContain("assets");
@@ -200,6 +201,7 @@ describe("SpaceSettingsPane", () => {
 
 		expect(setEditorAttachmentStorageModeMock).toHaveBeenCalledWith(
 			"space-root",
+			{ spacePath: "/spaces/test" },
 		);
 		expect(getAttachmentsSection().textContent).not.toContain("Browse");
 	});

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -3,7 +3,6 @@ import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type AttachmentStorageMode,
 	DEFAULT_QUICK_NOTES_FOLDER,
-	getDailyNotesFolder,
 	loadSettings,
 	setDailyNotesFolder,
 	setEditorAttachmentFolder,
@@ -121,12 +120,9 @@ export function SpaceSettingsPane() {
 		try {
 			const currentSpace = await invoke("space_get_current");
 			const settingsScope = { spacePath: currentSpace };
-			const [dailyFolder, settings] = await Promise.all([
-				getDailyNotesFolder(settingsScope),
-				loadSettings(settingsScope),
-			]);
+			const settings = await loadSettings(settingsScope);
 			setCurrentSpacePath(currentSpace);
-			setDailyNotesFolderState(dailyFolder);
+			setDailyNotesFolderState(settings.dailyNotes.folder);
 			setQuickNotesFolderState(settings.quickNotes.folder);
 			setAttachmentStorageModeState(settings.editor.attachmentStorageMode);
 			setAttachmentFolderState(

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -104,11 +104,12 @@ export function SpaceSettingsPane() {
 		setAttachmentsLoading(true);
 		setQuickNotesLoading(true);
 		try {
-			const [dailyFolder, settings] = await Promise.all([
+			const [dailyFolder, settings, currentSpace] = await Promise.all([
 				getDailyNotesFolder(),
 				loadSettings(),
+				invoke("space_get_current"),
 			]);
-			setCurrentSpacePath(settings.currentSpacePath);
+			setCurrentSpacePath(currentSpace);
 			setDailyNotesFolderState(dailyFolder);
 			setQuickNotesFolderState(settings.quickNotes.folder);
 			setAttachmentStorageModeState(settings.editor.attachmentStorageMode);

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -27,7 +27,12 @@ const ATTACHMENT_LOCATION_OPTIONS: Array<{
 	{ label: "Same folder as note", value: "note-folder" },
 ];
 
-async function selectFolderRelativeToSpace(): Promise<string | null> {
+interface SpaceFolderSelection {
+	relativePath: string;
+	spacePath: string;
+}
+
+async function selectFolderRelativeToSpace(): Promise<SpaceFolderSelection | null> {
 	const { open } = await import("@tauri-apps/plugin-dialog");
 	const selected = await open({
 		directory: true,
@@ -55,7 +60,17 @@ async function selectFolderRelativeToSpace(): Promise<string | null> {
 		throw new Error("Selected folder must be inside the current space.");
 	}
 
-	return normSelected.slice(normSpace.length).replace(/^\/+/, "");
+	return {
+		relativePath: normSelected.slice(normSpace.length).replace(/^\/+/, ""),
+		spacePath: currentSpace,
+	};
+}
+
+function requireSpacePath(spacePath: string | null): string {
+	if (!spacePath) {
+		throw new Error("No space is currently open.");
+	}
+	return spacePath;
 }
 
 export function SpaceSettingsPane() {
@@ -104,10 +119,11 @@ export function SpaceSettingsPane() {
 		setAttachmentsLoading(true);
 		setQuickNotesLoading(true);
 		try {
-			const [dailyFolder, settings, currentSpace] = await Promise.all([
-				getDailyNotesFolder(),
-				loadSettings(),
-				invoke("space_get_current"),
+			const currentSpace = await invoke("space_get_current");
+			const settingsScope = { spacePath: currentSpace };
+			const [dailyFolder, settings] = await Promise.all([
+				getDailyNotesFolder(settingsScope),
+				loadSettings(settingsScope),
 			]);
 			setCurrentSpacePath(currentSpace);
 			setDailyNotesFolderState(dailyFolder);
@@ -132,10 +148,13 @@ export function SpaceSettingsPane() {
 	const handleBrowseFolder = useCallback(async () => {
 		setDailyNotesError(null);
 		try {
-			const relativePath = await selectFolderRelativeToSpace();
-			if (relativePath === null) return;
-			await setDailyNotesFolder(relativePath || null);
-			setDailyNotesFolderState(relativePath || null);
+			const selection = await selectFolderRelativeToSpace();
+			if (selection === null) return;
+			await setDailyNotesFolder(selection.relativePath || null, {
+				spacePath: selection.spacePath,
+			});
+			setCurrentSpacePath(selection.spacePath);
+			setDailyNotesFolderState(selection.relativePath || null);
 		} catch (cause) {
 			setDailyNotesError(
 				cause instanceof Error ? cause.message : "Failed to select folder",
@@ -146,23 +165,27 @@ export function SpaceSettingsPane() {
 	const handleClearFolder = useCallback(async () => {
 		setDailyNotesError(null);
 		try {
-			await setDailyNotesFolder(null);
+			const spacePath = requireSpacePath(currentSpacePath);
+			await setDailyNotesFolder(null, { spacePath });
 			setDailyNotesFolderState(null);
 		} catch (cause) {
 			setDailyNotesError(
 				cause instanceof Error ? cause.message : "Failed to clear folder",
 			);
 		}
-	}, []);
+	}, [currentSpacePath]);
 
 	const handleAttachmentModeChange = useCallback(
 		async (nextMode: AttachmentStorageMode) => {
 			setAttachmentError(null);
 			try {
-				await setEditorAttachmentStorageMode(nextMode);
+				const spacePath = requireSpacePath(currentSpacePath);
+				await setEditorAttachmentStorageMode(nextMode, { spacePath });
 				setAttachmentStorageModeState(nextMode);
 				if (nextMode === "specific-folder" && !attachmentFolder) {
-					await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER);
+					await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, {
+						spacePath,
+					});
 					setAttachmentFolderState(DEFAULT_ATTACHMENT_FOLDER);
 				}
 			} catch (cause) {
@@ -171,16 +194,21 @@ export function SpaceSettingsPane() {
 				);
 			}
 		},
-		[attachmentFolder],
+		[attachmentFolder, currentSpacePath],
 	);
 
 	const handleBrowseAttachmentFolder = useCallback(async () => {
 		setAttachmentError(null);
 		try {
-			const relativePath = await selectFolderRelativeToSpace();
-			if (relativePath === null) return;
-			await setEditorAttachmentFolder(relativePath);
-			setAttachmentFolderState(relativePath || DEFAULT_ATTACHMENT_FOLDER);
+			const selection = await selectFolderRelativeToSpace();
+			if (selection === null) return;
+			await setEditorAttachmentFolder(selection.relativePath, {
+				spacePath: selection.spacePath,
+			});
+			setCurrentSpacePath(selection.spacePath);
+			setAttachmentFolderState(
+				selection.relativePath || DEFAULT_ATTACHMENT_FOLDER,
+			);
 		} catch (cause) {
 			setAttachmentError(
 				cause instanceof Error ? cause.message : "Failed to select folder",
@@ -191,22 +219,29 @@ export function SpaceSettingsPane() {
 	const handleResetAttachmentFolder = useCallback(async () => {
 		setAttachmentError(null);
 		try {
-			await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER);
+			const spacePath = requireSpacePath(currentSpacePath);
+			await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, { spacePath });
 			setAttachmentFolderState(DEFAULT_ATTACHMENT_FOLDER);
 		} catch (cause) {
 			setAttachmentError(
 				cause instanceof Error ? cause.message : "Failed to reset folder",
 			);
 		}
-	}, []);
+	}, [currentSpacePath]);
 
 	const handleBrowseQuickNotesFolder = useCallback(async () => {
 		setQuickNotesError(null);
 		try {
-			const relativePath = await selectFolderRelativeToSpace();
-			if (relativePath === null) return;
-			await setQuickNotesFolder(relativePath || DEFAULT_QUICK_NOTES_FOLDER);
-			setQuickNotesFolderState(relativePath || DEFAULT_QUICK_NOTES_FOLDER);
+			const selection = await selectFolderRelativeToSpace();
+			if (selection === null) return;
+			await setQuickNotesFolder(
+				selection.relativePath || DEFAULT_QUICK_NOTES_FOLDER,
+				{ spacePath: selection.spacePath },
+			);
+			setCurrentSpacePath(selection.spacePath);
+			setQuickNotesFolderState(
+				selection.relativePath || DEFAULT_QUICK_NOTES_FOLDER,
+			);
 		} catch (cause) {
 			setQuickNotesError(
 				cause instanceof Error
@@ -219,7 +254,8 @@ export function SpaceSettingsPane() {
 	const handleResetQuickNotesFolder = useCallback(async () => {
 		setQuickNotesError(null);
 		try {
-			await setQuickNotesFolder(DEFAULT_QUICK_NOTES_FOLDER);
+			const spacePath = requireSpacePath(currentSpacePath);
+			await setQuickNotesFolder(DEFAULT_QUICK_NOTES_FOLDER, { spacePath });
 			setQuickNotesFolderState(DEFAULT_QUICK_NOTES_FOLDER);
 		} catch (cause) {
 			setQuickNotesError(
@@ -228,7 +264,7 @@ export function SpaceSettingsPane() {
 					: "Failed to reset quick notes folder",
 			);
 		}
-	}, []);
+	}, [currentSpacePath]);
 
 	return (
 		<div className="settingsPane">

--- a/src/components/settings/TemplatesSettingsPane.tsx
+++ b/src/components/settings/TemplatesSettingsPane.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	getDailyNoteTemplate,
 	getTemplatesFolder,
-	loadSettings,
 	setDailyNoteTemplate,
 	setTemplatesFolder,
 } from "../../lib/settings";
@@ -54,12 +53,7 @@ function toDisplayPath(value: string, folder: string | null): string {
 async function ensureCurrentSpaceOpen(): Promise<string | null> {
 	const currentSpacePath = await invoke("space_get_current");
 	if (currentSpacePath) return currentSpacePath;
-	const settings = await loadSettings();
-	if (!settings.currentSpacePath) return null;
-	const opened = await invoke("space_open", {
-		path: settings.currentSpacePath,
-	});
-	return opened.root;
+	return null;
 }
 
 export function TemplateSettingsSections() {

--- a/src/components/settings/TemplatesSettingsPane.tsx
+++ b/src/components/settings/TemplatesSettingsPane.tsx
@@ -18,6 +18,7 @@ interface TemplateOption {
 }
 
 interface TemplatesSettingsState {
+	currentSpacePath: string | null;
 	templatesFolder: string | null;
 	dailyNoteTemplatePath: string | null;
 	loading: boolean;
@@ -31,6 +32,7 @@ interface TemplateLibraryState {
 }
 
 const INITIAL_TEMPLATES_SETTINGS_STATE: TemplatesSettingsState = {
+	currentSpacePath: null,
 	templatesFolder: null,
 	dailyNoteTemplatePath: null,
 	loading: true,
@@ -56,6 +58,13 @@ async function ensureCurrentSpaceOpen(): Promise<string | null> {
 	return null;
 }
 
+function requireSpacePath(spacePath: string | null): string {
+	if (!spacePath) {
+		throw new Error("No space is currently open.");
+	}
+	return spacePath;
+}
+
 export function TemplateSettingsSections() {
 	const [settingsState, setSettingsState] = useState<TemplatesSettingsState>(
 		INITIAL_TEMPLATES_SETTINGS_STATE,
@@ -63,8 +72,13 @@ export function TemplateSettingsSections() {
 	const [templateLibraryState, setTemplateLibraryState] =
 		useState<TemplateLibraryState>(INITIAL_TEMPLATE_LIBRARY_STATE);
 	const latestDailyTemplateWriteIdRef = useRef(0);
-	const { templatesFolder, dailyNoteTemplatePath, loading, error } =
-		settingsState;
+	const {
+		currentSpacePath,
+		templatesFolder,
+		dailyNoteTemplatePath,
+		loading,
+		error,
+	} = settingsState;
 	const {
 		templates,
 		loading: templatesLoading,
@@ -80,12 +94,15 @@ export function TemplateSettingsSections() {
 		let cancelled = false;
 		void (async () => {
 			try {
+				const currentSpace = await ensureCurrentSpaceOpen();
+				const settingsScope = { spacePath: currentSpace };
 				const [folder, dailyTemplate] = await Promise.all([
-					getTemplatesFolder(),
-					getDailyNoteTemplate(),
+					getTemplatesFolder(settingsScope),
+					getDailyNoteTemplate(settingsScope),
 				]);
 				if (cancelled) return;
 				setSettingsState({
+					currentSpacePath: currentSpace,
 					templatesFolder: folder,
 					dailyNoteTemplatePath: dailyTemplate,
 					loading: false,
@@ -117,7 +134,9 @@ export function TemplateSettingsSections() {
 					...current,
 					dailyNoteTemplatePath: null,
 				}));
-				void setDailyNoteTemplate(null).catch((cause) => {
+				void setDailyNoteTemplate(null, {
+					spacePath: currentSpacePath,
+				}).catch((cause) => {
 					if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 					setSettingsState((current) => ({
 						...current,
@@ -161,7 +180,9 @@ export function TemplateSettingsSections() {
 					)
 				) {
 					const writeId = beginDailyTemplateWrite();
-					void setDailyNoteTemplate(null)
+					void setDailyNoteTemplate(null, {
+						spacePath: currentSpacePath,
+					})
 						.then(() => {
 							if (
 								cancelled ||
@@ -203,7 +224,12 @@ export function TemplateSettingsSections() {
 		return () => {
 			cancelled = true;
 		};
-	}, [beginDailyTemplateWrite, dailyNoteTemplatePath, templatesFolder]);
+	}, [
+		beginDailyTemplateWrite,
+		currentSpacePath,
+		dailyNoteTemplatePath,
+		templatesFolder,
+	]);
 
 	const handleBrowseFolder = useCallback(async () => {
 		let writeId: number | null = null;
@@ -236,12 +262,13 @@ export function TemplateSettingsSections() {
 			const relativePath = normSelected
 				.slice(normSpace.length)
 				.replace(/^\/+/, "");
-			await setTemplatesFolder(relativePath);
+			await setTemplatesFolder(relativePath, { spacePath: currentSpacePath });
 			writeId = beginDailyTemplateWrite();
-			await setDailyNoteTemplate(null);
+			await setDailyNoteTemplate(null, { spacePath: currentSpacePath });
 			if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 			setSettingsState((current) => ({
 				...current,
+				currentSpacePath,
 				templatesFolder: relativePath,
 				dailyNoteTemplatePath: null,
 			}));
@@ -265,7 +292,8 @@ export function TemplateSettingsSections() {
 	const handleClearFolder = useCallback(async () => {
 		setSettingsState((current) => ({ ...current, error: null }));
 		try {
-			await setTemplatesFolder(null);
+			const spacePath = requireSpacePath(currentSpacePath);
+			await setTemplatesFolder(null, { spacePath });
 			setSettingsState((current) => ({
 				...current,
 				templatesFolder: null,
@@ -280,7 +308,7 @@ export function TemplateSettingsSections() {
 						: "Failed to clear template folder",
 			}));
 		}
-	}, []);
+	}, [currentSpacePath]);
 
 	const handleDailyTemplateChange = useCallback(
 		async (value: string) => {
@@ -288,7 +316,8 @@ export function TemplateSettingsSections() {
 			const writeId = beginDailyTemplateWrite();
 			setSettingsState((current) => ({ ...current, error: null }));
 			try {
-				await setDailyNoteTemplate(next);
+				const spacePath = requireSpacePath(currentSpacePath);
+				await setDailyNoteTemplate(next, { spacePath });
 				if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 				setSettingsState((current) => ({
 					...current,
@@ -305,7 +334,7 @@ export function TemplateSettingsSections() {
 				}));
 			}
 		},
-		[beginDailyTemplateWrite],
+		[beginDailyTemplateWrite, currentSpacePath],
 	);
 
 	const summary = useMemo(() => {

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -1,3 +1,4 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	type ReactNode,
 	createContext,
@@ -13,12 +14,20 @@ import { clearInlineImageHydrationCache } from "../components/editor/hooks/useHy
 import { extractErrorMessage } from "../lib/errorUtils";
 import { invalidateNavigationPrefetch } from "../lib/navigationPrefetch";
 import {
-	clearCurrentSpacePath,
 	loadSettings,
 	setCurrentSpacePath,
 	updateOnboardingSettings,
 } from "../lib/settings";
 import { type AppInfo, invoke } from "../lib/tauri";
+import { SPACE_WINDOW_PREFIX } from "../lib/windowLabels";
+
+function isSpaceWindow(): boolean {
+	try {
+		return getCurrentWindow().label.startsWith(SPACE_WINDOW_PREFIX);
+	} catch {
+		return false;
+	}
+}
 
 export interface SpaceContextValue {
 	info: AppInfo | null;
@@ -139,7 +148,18 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 					);
 				}
 
-				if (settings.currentSpacePath) {
+				const currentWindowSpacePath = await invoke("space_get_current");
+				if (currentWindowSpacePath) {
+					const spaceInfo = await invoke("space_open", {
+						path: currentWindowSpacePath,
+					});
+					if (!cancelled) {
+						setSpacePath(spaceInfo.root);
+						setLastSpacePath(spaceInfo.root);
+						setSpaceSchemaVersion(spaceInfo.schema_version);
+						setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+					}
+				} else if (settings.currentSpacePath && !isSpaceWindow()) {
 					try {
 						const spaceInfo = await invoke("space_open", {
 							path: settings.currentSpacePath,
@@ -181,18 +201,12 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			isOpeningSpaceRef.current = true;
 			setError("");
 			try {
-				if (spacePath) {
-					await invoke("space_close");
-					await clearCurrentSpacePath();
-					clearAiPanelCaches();
-					clearInlineImageHydrationCache();
-					invalidateNavigationPrefetch();
-					setSpacePath(null);
-					setSpaceSchemaVersion(null);
-					setOnboardingNotePath(null);
-				}
-				const spaceInfo =
-					mode === "create"
+				const spaceInfo = spacePath
+					? await invoke("space_open_window", {
+							path,
+							create: mode === "create",
+						})
+					: mode === "create"
 						? await invoke("space_create", { path })
 						: await invoke("space_open", { path });
 				await setCurrentSpacePath(spaceInfo.root);
@@ -204,9 +218,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				);
 				void updateOnboardingSettings({ launcherSeen: true });
 				setLastSpacePath(spaceInfo.root);
-				setSpacePath(spaceInfo.root);
-				setSpaceSchemaVersion(spaceInfo.schema_version);
-				setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+				if (!spacePath) {
+					setSpacePath(spaceInfo.root);
+					setSpaceSchemaVersion(spaceInfo.schema_version);
+					setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+				}
 			} catch (err) {
 				setError(extractErrorMessage(err));
 			} finally {
@@ -220,7 +236,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		setError("");
 		try {
 			await invoke("space_close");
-			await clearCurrentSpacePath();
 			clearAiPanelCaches();
 			clearInlineImageHydrationCache();
 			invalidateNavigationPrefetch();

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -148,16 +148,15 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 					);
 				}
 
-				const currentWindowSpacePath = await invoke("space_get_current");
-				if (currentWindowSpacePath) {
-					const spaceInfo = await invoke("space_open", {
-						path: currentWindowSpacePath,
-					});
+				const currentWindowSpaceInfo = await invoke("space_get_current_info");
+				if (currentWindowSpaceInfo) {
 					if (!cancelled) {
-						setSpacePath(spaceInfo.root);
-						setLastSpacePath(spaceInfo.root);
-						setSpaceSchemaVersion(spaceInfo.schema_version);
-						setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+						setSpacePath(currentWindowSpaceInfo.root);
+						setLastSpacePath(currentWindowSpaceInfo.root);
+						setSpaceSchemaVersion(currentWindowSpaceInfo.schema_version);
+						setOnboardingNotePath(
+							currentWindowSpaceInfo.onboarding_note_path ?? null,
+						);
 					}
 				} else if (settings.currentSpacePath && !isSpaceWindow()) {
 					try {
@@ -201,7 +200,8 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			isOpeningSpaceRef.current = true;
 			setError("");
 			try {
-				const spaceInfo = spacePath
+				const sessionSpacePath = await invoke("space_get_current");
+				const spaceInfo = sessionSpacePath
 					? await invoke("space_open_window", {
 							path,
 							create: mode === "create",
@@ -218,7 +218,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				);
 				void updateOnboardingSettings({ launcherSeen: true });
 				setLastSpacePath(spaceInfo.root);
-				if (!spacePath) {
+				if (!sessionSpacePath) {
 					setSpacePath(spaceInfo.root);
 					setSpaceSchemaVersion(spaceInfo.schema_version);
 					setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
@@ -229,7 +229,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				isOpeningSpaceRef.current = false;
 			}
 		},
-		[spacePath],
+		[],
 	);
 
 	const closeSpace = useCallback(async () => {

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -9,6 +9,7 @@ import {
 	useEffect,
 	useMemo,
 	useReducer,
+	useRef,
 } from "react";
 import {
 	DEFAULT_FOLIO_SCOPE,
@@ -225,6 +226,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 export function UIProvider({ children }: { children: ReactNode }) {
 	const { spacePath } = useSpace();
 	const [state, dispatch] = useReducer(uiReducer, initialUIState);
+	const spacePathRef = useRef(spacePath);
 	const {
 		sidebarCollapsed,
 		sidebarWidth,
@@ -245,6 +247,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 	} = state;
 
 	useEffect(() => {
+		spacePathRef.current = spacePath;
 		dispatch({ type: "onSpacePathChanged", hasSpace: Boolean(spacePath) });
 	}, [spacePath]);
 
@@ -290,7 +293,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		let cancelled = false;
 		const loadAndApplySettings = async () => {
 			try {
-				const s = await loadSettings();
+				const s = await loadSettings({ spacePath: spacePathRef.current });
 				if (cancelled) return;
 				dispatch({
 					type: "hydrateSettings",
@@ -335,7 +338,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			try {
 				await reloadFromDisk();
 				if (cancelled) return;
-				const s = await loadSettings();
+				const s = await loadSettings({ spacePath });
 				if (cancelled) return;
 				dispatch({
 					type: "setDailyNotesFolder",

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -249,6 +249,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 	}, [spacePath]);
 
 	useTauriEvent("settings:updated", (payload) => {
+		if (payload.spacePath && payload.spacePath !== spacePath) return;
 		const nextEnabled = payload.ui?.aiEnabled;
 		if (typeof nextEnabled === "boolean") {
 			dispatch({ type: "setAiEnabled", value: nextEnabled });

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -254,6 +254,62 @@ describe("attachment storage settings", () => {
 	});
 });
 
+describe("space-scoped settings", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("does not inherit legacy global space settings for a fresh space", async () => {
+		storeState.set("dailyNotes.folder", "Old Daily");
+		storeState.set("quickNotes.folder", "Old Quick");
+		storeState.set("templates.folder", "Old Templates");
+		storeState.set("templates.dailyNoteTemplate", "Old Templates/Daily.md");
+		storeState.set("editor.attachmentStorageMode", "specific-folder");
+		storeState.set("editor.attachmentFolder", "old-assets");
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings({ spacePath: "/spaces/fresh" });
+
+		expect(settings.dailyNotes.folder).toBeNull();
+		expect(settings.quickNotes.folder).toBe("Quick Notes");
+		expect(settings.templates.folder).toBeNull();
+		expect(settings.templates.dailyNoteTemplate).toBeNull();
+		expect(settings.editor.attachmentStorageMode).toBe("note-folder");
+		expect(settings.editor.attachmentFolder).toBe("assets");
+	});
+
+	it("persists folder settings under the explicit space path", async () => {
+		const {
+			setDailyNotesFolder,
+			setEditorAttachmentStorageMode,
+			setQuickNotesFolder,
+			setTemplatesFolder,
+		} = await import("./settings");
+
+		await setDailyNotesFolder("Daily", { spacePath: "/spaces/work" });
+		await setQuickNotesFolder("Inbox", { spacePath: "/spaces/work" });
+		await setTemplatesFolder("Templates", { spacePath: "/spaces/work" });
+		await setEditorAttachmentStorageMode("specific-folder", {
+			spacePath: "/spaces/work",
+		});
+
+		expect(storeState.get("space.scopedSettings")).toEqual({
+			"/spaces/work": {
+				dailyNotesFolder: "Daily",
+				quickNotesFolder: "Inbox",
+				templatesFolder: "Templates",
+				attachmentStorageMode: "specific-folder",
+			},
+		});
+		expect(storeState.has("dailyNotes.folder")).toBe(false);
+		expect(storeState.has("quickNotes.folder")).toBe(false);
+		expect(storeState.has("templates.folder")).toBe(false);
+		expect(storeState.has("editor.attachmentStorageMode")).toBe(false);
+	});
+});
+
 describe("shortcut settings", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -118,6 +118,10 @@ interface TaskSourceSetting {
 	folders: string[];
 }
 
+function defaultTaskSourceSetting(): TaskSourceSetting {
+	return { mode: "space", folders: [] };
+}
+
 interface DatabaseSettings {
 	showColumnColor: boolean;
 }
@@ -375,6 +379,27 @@ interface SpaceScopedSettings {
 
 type SpaceScopedSettingsMap = Record<string, SpaceScopedSettings>;
 
+export interface SettingsScope {
+	spacePath?: string | null;
+}
+
+let spaceScopedSettingsWriteQueue: Promise<unknown> = Promise.resolve();
+
+async function withSpaceScopedSettingsWriteLock<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	const locks =
+		typeof navigator !== "undefined" && "locks" in navigator
+			? navigator.locks
+			: null;
+	if (locks) {
+		return locks.request("glyph-space-scoped-settings", operation);
+	}
+	const run = spaceScopedSettingsWriteQueue.then(operation, operation);
+	spaceScopedSettingsWriteQueue = run.catch(() => {});
+	return run;
+}
+
 const KEYS = {
 	currentSpacePath: "space.currentPath",
 	recentSpaces: "space.recent",
@@ -585,7 +610,11 @@ function normalizeSpaceScopedSettingsMap(
 	return out;
 }
 
-async function activeSpacePath(): Promise<string | null> {
+async function activeSpacePath(scope?: SettingsScope): Promise<string | null> {
+	if (scope && "spacePath" in scope) {
+		const path = scope.spacePath?.trim();
+		return path || null;
+	}
 	try {
 		return await invoke("space_get_current");
 	} catch {
@@ -595,16 +624,19 @@ async function activeSpacePath(): Promise<string | null> {
 
 async function updateActiveSpaceSettings(
 	patch: SpaceScopedSettings,
+	scope?: SettingsScope,
 ): Promise<string | null> {
-	const spacePath = await activeSpacePath();
+	const spacePath = await activeSpacePath(scope);
 	if (!spacePath) return null;
-	const store = await getStore();
-	const map = normalizeSpaceScopedSettingsMap(
-		await store.get<unknown>(KEYS.spaceScopedSettings),
-	);
-	map[spacePath] = { ...map[spacePath], ...patch };
-	await store.set(KEYS.spaceScopedSettings, map);
-	await store.save();
+	await withSpaceScopedSettingsWriteLock(async () => {
+		const store = await getStore();
+		const map = normalizeSpaceScopedSettingsMap(
+			await store.get<unknown>(KEYS.spaceScopedSettings),
+		);
+		map[spacePath] = { ...map[spacePath], ...patch };
+		await store.set(KEYS.spaceScopedSettings, map);
+		await store.save();
+	});
 	return spacePath;
 }
 
@@ -679,7 +711,9 @@ function isRecentFileArray(value: unknown): value is RecentFile[] {
 	);
 }
 
-export async function loadSettings(): Promise<AppSettings> {
+export async function loadSettings(
+	scope?: SettingsScope,
+): Promise<AppSettings> {
 	const store = await getStore();
 	const [
 		currentSpacePathRaw,
@@ -766,13 +800,16 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<unknown>(KEYS.shortcutsBindings),
 		store.get<unknown>(KEYS.spaceScopedSettings),
 	]);
-	const currentSpacePath = currentSpacePathRaw ?? null;
 	const scopedSettings = normalizeSpaceScopedSettingsMap(
 		rawSpaceScopedSettings,
 	);
-	const activeScopedSettings = await activeSpacePath().then((spacePath) =>
-		spacePath ? scopedSettings[spacePath] : undefined,
-	);
+	const activeSettingsSpacePath = await activeSpacePath(scope);
+	const currentSpacePath =
+		activeSettingsSpacePath ?? currentSpacePathRaw ?? null;
+	const activeScopedSettings = activeSettingsSpacePath
+		? scopedSettings[activeSettingsSpacePath]
+		: undefined;
+	const hasActiveSpace = Boolean(activeSettingsSpacePath);
 	const recentSpaces = recentSpacesRaw ?? [];
 	const recentFiles = isRecentFileArray(rawRecentFiles) ? rawRecentFiles : [];
 	const onboarding: OnboardingSettings = {
@@ -814,46 +851,43 @@ export async function loadSettings(): Promise<AppSettings> {
 			? rawShowFileTreeFolderCounts
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
-	const dailyNotesFolder =
-		activeScopedSettings && "dailyNotesFolder" in activeScopedSettings
-			? (activeScopedSettings.dailyNotesFolder ?? null)
-			: typeof dailyNotesFolderRaw === "string"
-				? normalizeRelPath(dailyNotesFolderRaw) || null
-				: null;
-	const quickNotesFolder =
-		activeScopedSettings?.quickNotesFolder ??
-		normalizeQuickNotesFolder(rawQuickNotesFolder);
-	const templatesFolder =
-		activeScopedSettings && "templatesFolder" in activeScopedSettings
-			? (activeScopedSettings.templatesFolder ?? null)
-			: typeof templatesFolderRaw === "string"
-				? normalizeRelPath(templatesFolderRaw)
-				: null;
-	const templatesDailyNoteTemplate =
-		activeScopedSettings && "templatesDailyNoteTemplate" in activeScopedSettings
-			? (activeScopedSettings.templatesDailyNoteTemplate ?? null)
-			: typeof templatesDailyNoteTemplateRaw === "string"
-				? normalizeRelPath(templatesDailyNoteTemplateRaw) || null
-				: null;
-	const taskSource =
-		activeScopedSettings?.taskSource ??
-		normalizeTaskSourceSetting(taskSourceRaw);
+	const dailyNotesFolder = hasActiveSpace
+		? (activeScopedSettings?.dailyNotesFolder ?? null)
+		: typeof dailyNotesFolderRaw === "string"
+			? normalizeRelPath(dailyNotesFolderRaw) || null
+			: null;
+	const quickNotesFolder = hasActiveSpace
+		? (activeScopedSettings?.quickNotesFolder ?? DEFAULT_QUICK_NOTES_FOLDER)
+		: normalizeQuickNotesFolder(rawQuickNotesFolder);
+	const templatesFolder = hasActiveSpace
+		? (activeScopedSettings?.templatesFolder ?? null)
+		: typeof templatesFolderRaw === "string"
+			? normalizeRelPath(templatesFolderRaw)
+			: null;
+	const templatesDailyNoteTemplate = hasActiveSpace
+		? (activeScopedSettings?.templatesDailyNoteTemplate ?? null)
+		: typeof templatesDailyNoteTemplateRaw === "string"
+			? normalizeRelPath(templatesDailyNoteTemplateRaw) || null
+			: null;
+	const taskSource = hasActiveSpace
+		? (activeScopedSettings?.taskSource ?? defaultTaskSourceSetting())
+		: normalizeTaskSourceSetting(taskSourceRaw);
 	const shortcutBindings = sanitizeShortcutBindings(rawShortcutBindings);
 	const shortcuts: ShortcutSettings = {
 		version:
 			rawShortcutSettingsVersion === 1 ? 1 : DEFAULT_SHORTCUT_SETTINGS.version,
 		bindings: shortcutBindings,
 	};
-	const attachmentStorageMode =
-		activeScopedSettings?.attachmentStorageMode ??
-		asAttachmentStorageMode(rawEditorAttachmentStorageMode);
-	const attachmentFolder =
-		activeScopedSettings && "attachmentFolder" in activeScopedSettings
-			? (activeScopedSettings.attachmentFolder ?? DEFAULT_ATTACHMENT_FOLDER)
-			: typeof rawEditorAttachmentFolder === "string"
-				? normalizeRelPath(rawEditorAttachmentFolder) ||
-					DEFAULT_ATTACHMENT_FOLDER
-				: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
+	const attachmentStorageMode = hasActiveSpace
+		? (activeScopedSettings?.attachmentStorageMode ??
+			DEFAULT_EDITOR_SETTINGS.attachmentStorageMode)
+		: asAttachmentStorageMode(rawEditorAttachmentStorageMode);
+	const attachmentFolder = hasActiveSpace
+		? (activeScopedSettings?.attachmentFolder ??
+			DEFAULT_EDITOR_SETTINGS.attachmentFolder)
+		: typeof rawEditorAttachmentFolder === "string"
+			? normalizeRelPath(rawEditorAttachmentFolder) || DEFAULT_ATTACHMENT_FOLDER
+			: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
 	const editor: EditorSettings = {
 		showCollapsibleHeadings:
 			typeof rawEditorShowCollapsibleHeadings === "boolean"
@@ -1233,11 +1267,15 @@ export async function setEditorWidthMode(mode: EditorWidthMode): Promise<void> {
 
 export async function setEditorAttachmentStorageMode(
 	mode: AttachmentStorageMode,
+	scope?: SettingsScope,
 ): Promise<void> {
 	const nextMode = asAttachmentStorageMode(mode);
-	const spacePath = await updateActiveSpaceSettings({
-		attachmentStorageMode: nextMode,
-	});
+	const spacePath = await updateActiveSpaceSettings(
+		{
+			attachmentStorageMode: nextMode,
+		},
+		scope,
+	);
 	if (spacePath) {
 		void emitSettingsUpdated({
 			spacePath,
@@ -1255,14 +1293,18 @@ export async function setEditorAttachmentStorageMode(
 
 export async function setEditorAttachmentFolder(
 	folder: string | null,
+	scope?: SettingsScope,
 ): Promise<void> {
 	const nextFolder =
 		typeof folder === "string"
 			? normalizeRelPath(folder) || DEFAULT_ATTACHMENT_FOLDER
 			: DEFAULT_ATTACHMENT_FOLDER;
-	const spacePath = await updateActiveSpaceSettings({
-		attachmentFolder: nextFolder,
-	});
+	const spacePath = await updateActiveSpaceSettings(
+		{
+			attachmentFolder: nextFolder,
+		},
+		scope,
+	);
 	if (spacePath) {
 		void emitSettingsUpdated({
 			spacePath,
@@ -1298,18 +1340,24 @@ export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
 	});
 }
 
-export async function getDailyNotesFolder(): Promise<string | null> {
-	return (await loadSettings()).dailyNotes.folder;
+export async function getDailyNotesFolder(
+	scope?: SettingsScope,
+): Promise<string | null> {
+	return (await loadSettings(scope)).dailyNotes.folder;
 }
 
 export async function setDailyNotesFolder(
 	folder: string | null,
+	scope?: SettingsScope,
 ): Promise<void> {
 	const nextFolder =
 		typeof folder === "string" ? normalizeRelPath(folder) || null : null;
-	const spacePath = await updateActiveSpaceSettings({
-		dailyNotesFolder: nextFolder,
-	});
+	const spacePath = await updateActiveSpaceSettings(
+		{
+			dailyNotesFolder: nextFolder,
+		},
+		scope,
+	);
 	if (spacePath) {
 		void emitSettingsUpdated({ spacePath, dailyNotes: { folder: nextFolder } });
 		return;
@@ -1324,11 +1372,17 @@ export async function setDailyNotesFolder(
 	void emitSettingsUpdated({ dailyNotes: { folder: nextFolder } });
 }
 
-export async function setQuickNotesFolder(folder: string): Promise<void> {
+export async function setQuickNotesFolder(
+	folder: string,
+	scope?: SettingsScope,
+): Promise<void> {
 	const nextFolder = normalizeQuickNotesFolder(folder);
-	const spacePath = await updateActiveSpaceSettings({
-		quickNotesFolder: nextFolder,
-	});
+	const spacePath = await updateActiveSpaceSettings(
+		{
+			quickNotesFolder: nextFolder,
+		},
+		scope,
+	);
 	if (spacePath) {
 		void emitSettingsUpdated({ spacePath, quickNotes: { folder: nextFolder } });
 		return;
@@ -1339,17 +1393,23 @@ export async function setQuickNotesFolder(folder: string): Promise<void> {
 	void emitSettingsUpdated({ quickNotes: { folder: nextFolder } });
 }
 
-export async function getTemplatesFolder(): Promise<string | null> {
-	return (await loadSettings()).templates.folder;
+export async function getTemplatesFolder(
+	scope?: SettingsScope,
+): Promise<string | null> {
+	return (await loadSettings(scope)).templates.folder;
 }
 
-export async function setTemplatesFolder(folder: string | null): Promise<void> {
+export async function setTemplatesFolder(
+	folder: string | null,
+	scope?: SettingsScope,
+): Promise<void> {
 	const nextFolder =
 		typeof folder === "string" ? normalizeRelPath(folder) : null;
-	const spacePath = await updateActiveSpaceSettings({
-		templatesFolder: nextFolder,
-		templatesDailyNoteTemplate: nextFolder === null ? null : undefined,
-	});
+	const scopedPatch: SpaceScopedSettings = { templatesFolder: nextFolder };
+	if (nextFolder === null) {
+		scopedPatch.templatesDailyNoteTemplate = null;
+	}
+	const spacePath = await updateActiveSpaceSettings(scopedPatch, scope);
 	if (spacePath) {
 		void emitSettingsUpdated({
 			spacePath,
@@ -1376,20 +1436,26 @@ export async function setTemplatesFolder(folder: string | null): Promise<void> {
 	});
 }
 
-export async function getDailyNoteTemplate(): Promise<string | null> {
-	return (await loadSettings()).templates.dailyNoteTemplate;
+export async function getDailyNoteTemplate(
+	scope?: SettingsScope,
+): Promise<string | null> {
+	return (await loadSettings(scope)).templates.dailyNoteTemplate;
 }
 
 export async function setDailyNoteTemplate(
 	templatePath: string | null,
+	scope?: SettingsScope,
 ): Promise<void> {
 	const nextPath =
 		typeof templatePath === "string"
 			? normalizeRelPath(templatePath) || null
 			: null;
-	const spacePath = await updateActiveSpaceSettings({
-		templatesDailyNoteTemplate: nextPath,
-	});
+	const spacePath = await updateActiveSpaceSettings(
+		{
+			templatesDailyNoteTemplate: nextPath,
+		},
+		scope,
+	);
 	if (spacePath) {
 		void emitSettingsUpdated({
 			spacePath,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,4 +1,5 @@
-import { emit } from "@tauri-apps/api/event";
+import { emit, emitTo } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LazyStore } from "@tauri-apps/plugin-store";
 import { normalizeRelPath } from "../utils/path";
 import {
@@ -13,6 +14,7 @@ import {
 	type ShortcutActionId,
 	isShortcutActionId,
 } from "./shortcuts/registry";
+import { invoke } from "./tauri";
 import type { AiAssistantMode } from "./tauri";
 import {
 	type UiDarkThemeId,
@@ -256,6 +258,7 @@ function asUiEditorFontSize(value: unknown): UiFontSize {
 }
 
 async function emitSettingsUpdated(payload: {
+	spacePath?: string;
 	ui?: {
 		theme?: ThemeMode;
 		autoUpdateCheckInterval?: AutoUpdateCheckInterval;
@@ -306,6 +309,10 @@ async function emitSettingsUpdated(payload: {
 	onboarding?: Partial<OnboardingSettings>;
 }): Promise<void> {
 	try {
+		if (payload.spacePath) {
+			await emitTo(getCurrentWindow().label, "settings:updated", payload);
+			return;
+		}
 		await emit("settings:updated", payload);
 	} catch {
 		// best-effort cross-window sync
@@ -356,6 +363,18 @@ interface AppSettings {
 	database: DatabaseSettings;
 }
 
+interface SpaceScopedSettings {
+	dailyNotesFolder?: string | null;
+	quickNotesFolder?: string;
+	templatesFolder?: string | null;
+	templatesDailyNoteTemplate?: string | null;
+	taskSource?: TaskSourceSetting;
+	attachmentStorageMode?: AttachmentStorageMode;
+	attachmentFolder?: string | null;
+}
+
+type SpaceScopedSettingsMap = Record<string, SpaceScopedSettings>;
+
 const KEYS = {
 	currentSpacePath: "space.currentPath",
 	recentSpaces: "space.recent",
@@ -394,6 +413,7 @@ const KEYS = {
 	shortcutsVersion: "shortcuts.version",
 	shortcutsBindings: "shortcuts.bindings",
 	databaseShowColumnColor: "database.showColumnColor",
+	spaceScopedSettings: "space.scopedSettings",
 	onboardingLauncherSeen: "onboarding.launcherSeen",
 	onboardingStarterDismissed: "onboarding.starterDismissed",
 	onboardingCreatedFirstNote: "onboarding.createdFirstNote",
@@ -505,6 +525,87 @@ function sanitizeShortcutBindings(bindings: unknown): ShortcutBindings {
 		next[action.id] = effectiveBinding;
 	}
 	return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeSpaceScopedSettings(value: unknown): SpaceScopedSettings {
+	if (!isRecord(value)) return {};
+	const out: SpaceScopedSettings = {};
+	if ("dailyNotesFolder" in value) {
+		out.dailyNotesFolder =
+			typeof value.dailyNotesFolder === "string"
+				? normalizeRelPath(value.dailyNotesFolder) || null
+				: null;
+	}
+	if (typeof value.quickNotesFolder === "string") {
+		out.quickNotesFolder = normalizeQuickNotesFolder(value.quickNotesFolder);
+	}
+	if ("templatesFolder" in value) {
+		out.templatesFolder =
+			typeof value.templatesFolder === "string"
+				? normalizeRelPath(value.templatesFolder)
+				: null;
+	}
+	if ("templatesDailyNoteTemplate" in value) {
+		out.templatesDailyNoteTemplate =
+			typeof value.templatesDailyNoteTemplate === "string"
+				? normalizeRelPath(value.templatesDailyNoteTemplate) || null
+				: null;
+	}
+	if ("taskSource" in value) {
+		out.taskSource = normalizeTaskSourceSetting(value.taskSource);
+	}
+	if ("attachmentStorageMode" in value) {
+		out.attachmentStorageMode = asAttachmentStorageMode(
+			value.attachmentStorageMode,
+		);
+	}
+	if ("attachmentFolder" in value) {
+		out.attachmentFolder =
+			typeof value.attachmentFolder === "string"
+				? normalizeRelPath(value.attachmentFolder) || DEFAULT_ATTACHMENT_FOLDER
+				: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
+	}
+	return out;
+}
+
+function normalizeSpaceScopedSettingsMap(
+	value: unknown,
+): SpaceScopedSettingsMap {
+	if (!isRecord(value)) return {};
+	const out: SpaceScopedSettingsMap = {};
+	for (const [spacePath, settings] of Object.entries(value)) {
+		const key = spacePath.trim();
+		if (!key) continue;
+		out[key] = normalizeSpaceScopedSettings(settings);
+	}
+	return out;
+}
+
+async function activeSpacePath(): Promise<string | null> {
+	try {
+		return await invoke("space_get_current");
+	} catch {
+		return null;
+	}
+}
+
+async function updateActiveSpaceSettings(
+	patch: SpaceScopedSettings,
+): Promise<string | null> {
+	const spacePath = await activeSpacePath();
+	if (!spacePath) return null;
+	const store = await getStore();
+	const map = normalizeSpaceScopedSettingsMap(
+		await store.get<unknown>(KEYS.spaceScopedSettings),
+	);
+	map[spacePath] = { ...map[spacePath], ...patch };
+	await store.set(KEYS.spaceScopedSettings, map);
+	await store.save();
+	return spacePath;
 }
 
 export function findShortcutConflict(
@@ -621,6 +722,7 @@ export async function loadSettings(): Promise<AppSettings> {
 		rawDatabaseShowColumnColor,
 		rawShortcutSettingsVersion,
 		rawShortcutBindings,
+		rawSpaceScopedSettings,
 	] = await Promise.all([
 		store.get<string | null>(KEYS.currentSpacePath),
 		store.get<string[] | null>(KEYS.recentSpaces),
@@ -662,8 +764,15 @@ export async function loadSettings(): Promise<AppSettings> {
 		store.get<boolean | null>(KEYS.databaseShowColumnColor),
 		store.get<number | null>(KEYS.shortcutsVersion),
 		store.get<unknown>(KEYS.shortcutsBindings),
+		store.get<unknown>(KEYS.spaceScopedSettings),
 	]);
 	const currentSpacePath = currentSpacePathRaw ?? null;
+	const scopedSettings = normalizeSpaceScopedSettingsMap(
+		rawSpaceScopedSettings,
+	);
+	const activeScopedSettings = await activeSpacePath().then((spacePath) =>
+		spacePath ? scopedSettings[spacePath] : undefined,
+	);
 	const recentSpaces = recentSpacesRaw ?? [];
 	const recentFiles = isRecentFileArray(rawRecentFiles) ? rawRecentFiles : [];
 	const onboarding: OnboardingSettings = {
@@ -706,32 +815,45 @@ export async function loadSettings(): Promise<AppSettings> {
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
 	const dailyNotesFolder =
-		typeof dailyNotesFolderRaw === "string"
-			? normalizeRelPath(dailyNotesFolderRaw) || null
-			: null;
-	const quickNotesFolder = normalizeQuickNotesFolder(rawQuickNotesFolder);
+		activeScopedSettings && "dailyNotesFolder" in activeScopedSettings
+			? (activeScopedSettings.dailyNotesFolder ?? null)
+			: typeof dailyNotesFolderRaw === "string"
+				? normalizeRelPath(dailyNotesFolderRaw) || null
+				: null;
+	const quickNotesFolder =
+		activeScopedSettings?.quickNotesFolder ??
+		normalizeQuickNotesFolder(rawQuickNotesFolder);
 	const templatesFolder =
-		typeof templatesFolderRaw === "string"
-			? normalizeRelPath(templatesFolderRaw)
-			: null;
+		activeScopedSettings && "templatesFolder" in activeScopedSettings
+			? (activeScopedSettings.templatesFolder ?? null)
+			: typeof templatesFolderRaw === "string"
+				? normalizeRelPath(templatesFolderRaw)
+				: null;
 	const templatesDailyNoteTemplate =
-		typeof templatesDailyNoteTemplateRaw === "string"
-			? normalizeRelPath(templatesDailyNoteTemplateRaw) || null
-			: null;
-	const taskSource = normalizeTaskSourceSetting(taskSourceRaw);
+		activeScopedSettings && "templatesDailyNoteTemplate" in activeScopedSettings
+			? (activeScopedSettings.templatesDailyNoteTemplate ?? null)
+			: typeof templatesDailyNoteTemplateRaw === "string"
+				? normalizeRelPath(templatesDailyNoteTemplateRaw) || null
+				: null;
+	const taskSource =
+		activeScopedSettings?.taskSource ??
+		normalizeTaskSourceSetting(taskSourceRaw);
 	const shortcutBindings = sanitizeShortcutBindings(rawShortcutBindings);
 	const shortcuts: ShortcutSettings = {
 		version:
 			rawShortcutSettingsVersion === 1 ? 1 : DEFAULT_SHORTCUT_SETTINGS.version,
 		bindings: shortcutBindings,
 	};
-	const attachmentStorageMode = asAttachmentStorageMode(
-		rawEditorAttachmentStorageMode,
-	);
+	const attachmentStorageMode =
+		activeScopedSettings?.attachmentStorageMode ??
+		asAttachmentStorageMode(rawEditorAttachmentStorageMode);
 	const attachmentFolder =
-		typeof rawEditorAttachmentFolder === "string"
-			? normalizeRelPath(rawEditorAttachmentFolder) || DEFAULT_ATTACHMENT_FOLDER
-			: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
+		activeScopedSettings && "attachmentFolder" in activeScopedSettings
+			? (activeScopedSettings.attachmentFolder ?? DEFAULT_ATTACHMENT_FOLDER)
+			: typeof rawEditorAttachmentFolder === "string"
+				? normalizeRelPath(rawEditorAttachmentFolder) ||
+					DEFAULT_ATTACHMENT_FOLDER
+				: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
 	const editor: EditorSettings = {
 		showCollapsibleHeadings:
 			typeof rawEditorShowCollapsibleHeadings === "boolean"
@@ -1112,8 +1234,18 @@ export async function setEditorWidthMode(mode: EditorWidthMode): Promise<void> {
 export async function setEditorAttachmentStorageMode(
 	mode: AttachmentStorageMode,
 ): Promise<void> {
-	const store = await getStore();
 	const nextMode = asAttachmentStorageMode(mode);
+	const spacePath = await updateActiveSpaceSettings({
+		attachmentStorageMode: nextMode,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({
+			spacePath,
+			editor: { attachmentStorageMode: nextMode },
+		});
+		return;
+	}
+	const store = await getStore();
 	await store.set(KEYS.editorAttachmentStorageMode, nextMode);
 	await store.save();
 	void emitSettingsUpdated({
@@ -1124,11 +1256,21 @@ export async function setEditorAttachmentStorageMode(
 export async function setEditorAttachmentFolder(
 	folder: string | null,
 ): Promise<void> {
-	const store = await getStore();
 	const nextFolder =
 		typeof folder === "string"
 			? normalizeRelPath(folder) || DEFAULT_ATTACHMENT_FOLDER
 			: DEFAULT_ATTACHMENT_FOLDER;
+	const spacePath = await updateActiveSpaceSettings({
+		attachmentFolder: nextFolder,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({
+			spacePath,
+			editor: { attachmentFolder: nextFolder },
+		});
+		return;
+	}
+	const store = await getStore();
 	await store.set(KEYS.editorAttachmentFolder, nextFolder);
 	await store.save();
 	void emitSettingsUpdated({
@@ -1157,16 +1299,22 @@ export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
 }
 
 export async function getDailyNotesFolder(): Promise<string | null> {
-	const store = await getStore();
-	return (await store.get<string | null>(KEYS.dailyNotesFolder)) ?? null;
+	return (await loadSettings()).dailyNotes.folder;
 }
 
 export async function setDailyNotesFolder(
 	folder: string | null,
 ): Promise<void> {
-	const store = await getStore();
 	const nextFolder =
 		typeof folder === "string" ? normalizeRelPath(folder) || null : null;
+	const spacePath = await updateActiveSpaceSettings({
+		dailyNotesFolder: nextFolder,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({ spacePath, dailyNotes: { folder: nextFolder } });
+		return;
+	}
+	const store = await getStore();
 	if (nextFolder === null) {
 		await store.delete(KEYS.dailyNotesFolder);
 	} else {
@@ -1177,22 +1325,42 @@ export async function setDailyNotesFolder(
 }
 
 export async function setQuickNotesFolder(folder: string): Promise<void> {
-	const store = await getStore();
 	const nextFolder = normalizeQuickNotesFolder(folder);
+	const spacePath = await updateActiveSpaceSettings({
+		quickNotesFolder: nextFolder,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({ spacePath, quickNotes: { folder: nextFolder } });
+		return;
+	}
+	const store = await getStore();
 	await store.set(KEYS.quickNotesFolder, nextFolder);
 	await store.save();
 	void emitSettingsUpdated({ quickNotes: { folder: nextFolder } });
 }
 
 export async function getTemplatesFolder(): Promise<string | null> {
-	const store = await getStore();
-	return (await store.get<string | null>(KEYS.templatesFolder)) ?? null;
+	return (await loadSettings()).templates.folder;
 }
 
 export async function setTemplatesFolder(folder: string | null): Promise<void> {
-	const store = await getStore();
 	const nextFolder =
 		typeof folder === "string" ? normalizeRelPath(folder) : null;
+	const spacePath = await updateActiveSpaceSettings({
+		templatesFolder: nextFolder,
+		templatesDailyNoteTemplate: nextFolder === null ? null : undefined,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({
+			spacePath,
+			templates: {
+				folder: nextFolder,
+				dailyNoteTemplate: nextFolder === null ? null : undefined,
+			},
+		});
+		return;
+	}
+	const store = await getStore();
 	if (nextFolder === null) {
 		await store.delete(KEYS.templatesFolder);
 		await store.delete(KEYS.templatesDailyNoteTemplate);
@@ -1209,20 +1377,27 @@ export async function setTemplatesFolder(folder: string | null): Promise<void> {
 }
 
 export async function getDailyNoteTemplate(): Promise<string | null> {
-	const store = await getStore();
-	return (
-		(await store.get<string | null>(KEYS.templatesDailyNoteTemplate)) ?? null
-	);
+	return (await loadSettings()).templates.dailyNoteTemplate;
 }
 
 export async function setDailyNoteTemplate(
 	templatePath: string | null,
 ): Promise<void> {
-	const store = await getStore();
 	const nextPath =
 		typeof templatePath === "string"
 			? normalizeRelPath(templatePath) || null
 			: null;
+	const spacePath = await updateActiveSpaceSettings({
+		templatesDailyNoteTemplate: nextPath,
+	});
+	if (spacePath) {
+		void emitSettingsUpdated({
+			spacePath,
+			templates: { dailyNoteTemplate: nextPath },
+		});
+		return;
+	}
+	const store = await getStore();
 	if (nextPath === null) {
 		await store.delete(KEYS.templatesDailyNoteTemplate);
 	} else {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -790,6 +790,7 @@ interface TauriCommands {
 		SpaceInfo
 	>;
 	space_get_current: CommandDef<void, string | null>;
+	space_get_current_info: CommandDef<void, SpaceInfo | null>;
 	space_show_onboarding_note: CommandDef<void, string>;
 	space_close: CommandDef<void, void>;
 	space_list_dir: CommandDef<{ dir?: string | null }, FsEntry[]>;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -785,6 +785,10 @@ interface TauriCommands {
 	license_clear_local: CommandDef<void, LicenseActivateResult>;
 	space_create: CommandDef<{ path: string }, SpaceInfo>;
 	space_open: CommandDef<{ path: string }, SpaceInfo>;
+	space_open_window: CommandDef<
+		{ path: string; create?: boolean | null },
+		SpaceInfo
+	>;
 	space_get_current: CommandDef<void, string | null>;
 	space_show_onboarding_note: CommandDef<void, string>;
 	space_close: CommandDef<void, void>;

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -62,9 +62,18 @@ type TauriEventMap = {
 		payload?: unknown;
 		error?: string;
 	};
-	"notes:external_changed": { rel_path: string; removed: boolean };
-	"space:fs_changed": { rel_path: string; removed: boolean };
+	"notes:external_changed": {
+		space_path?: string;
+		rel_path: string;
+		removed: boolean;
+	};
+	"space:fs_changed": {
+		space_path?: string;
+		rel_path: string;
+		removed: boolean;
+	};
 	"settings:updated": {
+		spacePath?: string;
 		ui?: {
 			theme?: string;
 			autoUpdateCheckInterval?: AutoUpdateCheckInterval;

--- a/src/lib/windowLabels.ts
+++ b/src/lib/windowLabels.ts
@@ -1,4 +1,5 @@
 export const MAIN_WINDOW_LABEL = "main";
+export const SPACE_WINDOW_PREFIX = "space-";
 export const QUICK_NOTE_WINDOW_LABEL = "quick-note";
 export const QUICK_TASK_WINDOW_LABEL = "quick-task";
 export const EXTERNAL_MARKDOWN_WINDOW_PREFIX = "external-markdown-";


### PR DESCRIPTION
- Added per-space windows using space-* window labels, so opening a different space from an already-open space creates/focuses a separate window instead
    of replacing the current one.

  - Refactored backend space state from one global active root to per-window space sessions.
  - Scoped file tree, notes, databases, index/search, pinned files, tag/file appearances, Git sync, and AI commands to the calling window’s space.
  - Made space-dependent settings stay isolated per space:
      - daily notes folder
      - quick notes folder
      - templates folder
      - daily note template
      - attachment storage mode/folder
      - AI profile/config/secrets

  - Kept global settings global where appropriate, like app appearance/licensing/Codex account support state.
  - Fixed the reported toast by removing the new-space-window apply_vibrancy() call that was being made off the main thread path.

  Verification passed:

  - pnpm check
  - pnpm build
  - pnpm test
  - cd src-tauri && cargo check
  - cd src-tauri && cargo clippy passed with existing warnings only
  - git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * True multi-space support: open and manage multiple spaces in separate windows with focused-window behavior.
  * Per-space settings and templates; UI respects active space and browsing returns space-scoped paths.
  * Window-scoped AI, file, database, and git operations so actions and history are isolated per space.
  * Safer atomic "create new" writes to avoid collisions.

* **Bug Fixes**
  * Prevent cross-space/settings/event leakage; external file/change events target the correct window and space.

* **Tests**
  * Added tests for space-scoped settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->