### PR TITLE
changed the new note button icon in databases

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1598,7 +1598,6 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
- "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-store",
@@ -2359,18 +2358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "mac-notification-sys"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621"
-dependencies = [
- "cc",
- "objc2",
- "objc2-foundation",
- "time",
-]
-
-[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,20 +2580,6 @@ dependencies = [
  "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "notify-rust"
-version = "4.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6442248665a5aa2514e794af3b39661a8e73033b1cc5e59899e1276117ee4400"
-dependencies = [
- "futures-lite",
- "log",
- "mac-notification-sys",
- "serde",
- "tauri-winrt-notification",
- "zbus",
 ]
 
 [[package]]
@@ -3243,7 +3216,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3371,15 +3344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4803,25 +4767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-notification"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
-dependencies = [
- "log",
- "notify-rust",
- "rand 0.9.3",
- "serde",
- "serde_json",
- "serde_repr",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "time",
- "url",
-]
-
-[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,18 +4946,6 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.11+spec-1.1.0",
-]
-
-[[package]]
-name = "tauri-winrt-notification"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
-dependencies = [
- "quick-xml 0.37.5",
- "thiserror 2.0.18",
- "windows",
- "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,6 @@ tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-store = "2"
-tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,7 +19,6 @@
 		"core:window:allow-show",
 		"core:menu:default",
 		"dialog:default",
-		"notification:default",
 		{
 			"identifier": "opener:allow-open-path",
 			"allow": [

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -1,5 +1,4 @@
 use tauri::{AppHandle, Emitter, Manager, State, WebviewWindow};
-use tauri_plugin_notification::NotificationExt;
 use tracing::warn;
 
 use crate::space::SpaceState;
@@ -429,14 +428,6 @@ pub async fn ai_chat_start(
                     cancelled,
                     tool_events: &tool_events,
                 });
-                if !cancelled {
-                    let _ = app_for_task
-                        .notification()
-                        .builder()
-                        .title("Glyph")
-                        .body("AI response ready")
-                        .show();
-                }
                 ai_state_for_task.finish(&job_id_for_task);
             }
             Err(message) => {
@@ -447,12 +438,6 @@ pub async fn ai_chat_start(
                         message,
                     },
                 );
-                let _ = app_for_task
-                    .notification()
-                    .builder()
-                    .title("Glyph")
-                    .body("AI request failed")
-                    .show();
                 ai_state_for_task.finish(&job_id_for_task);
             }
         }

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use chrono::{DateTime, Duration, Local, NaiveDate};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State, WebviewWindow};
-use tauri_plugin_notification::NotificationExt;
 
 use crate::space::state::mark_recent_local_change;
 use crate::space::SpaceState;
@@ -344,7 +343,6 @@ fn rewrite_task_dates(body: &str, scheduled_date: &str, due_date: &str) -> Strin
 
 #[tauri::command]
 pub async fn index_rebuild(
-    app: AppHandle,
     window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<IndexRebuildResult, String> {
@@ -352,12 +350,6 @@ pub async fn index_rebuild(
     let res = tauri::async_runtime::spawn_blocking(move || rebuild(&root))
         .await
         .map_err(|e| e.to_string())??;
-    let _ = app
-        .notification()
-        .builder()
-        .title("Glyph")
-        .body(format!("Index rebuilt ({})", res.indexed))
-        .show();
     Ok(res)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1611,7 +1611,6 @@ pub fn run() {
         .manage(QuickTaskShortcutState::default())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_store::Builder::default().build())

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -1,7 +1,7 @@
 import {
 	LibraryIcon,
 	MoreVerticalIcon,
-	PencilEdit02Icon,
+	NoteIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { emit } from "@tauri-apps/api/event";
@@ -1010,21 +1010,19 @@ function DatabasesPaneContent({
 						>
 							<Trash2 size={14} />
 						</Button>
-						<Button
+						<button
 							type="button"
-							variant="ghost"
-							size="icon-sm"
 							className="databaseToolbarChip is-accent"
 							onClick={() => void handleCreateRow()}
 							title="New note"
-							aria-label="New note"
 						>
 							<HugeiconsIcon
-								icon={PencilEdit02Icon}
+								icon={NoteIcon}
 								size={14}
 								strokeWidth={0.9}
 							/>
-						</Button>
+							New Note
+						</button>
 					</div>
 				) : null}
 			</div>

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -1016,11 +1016,7 @@ function DatabasesPaneContent({
 							onClick={() => void handleCreateRow()}
 							title="New note"
 						>
-							<HugeiconsIcon
-								icon={NoteIcon}
-								size={14}
-								strokeWidth={0.9}
-							/>
+							<HugeiconsIcon icon={NoteIcon} size={14} strokeWidth={0.9} />
 							New Note
 						</button>
 					</div>

--- a/src/components/settings/SettingsScaffold.tsx
+++ b/src/components/settings/SettingsScaffold.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import type { ReactNode } from "react";
+import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
 import { Toggle } from "../base/toggle/toggle";
 
 interface SettingsSectionProps {
@@ -64,6 +64,38 @@ export function SettingsRow({
 	const CopyTag = htmlFor ? "label" : "div";
 	const rowTitle = typeof label === "string" ? label : undefined;
 
+	const tryToggleRowCheckbox = (
+		target: EventTarget | null,
+		currentTarget: HTMLDivElement,
+	) => {
+		const el = target as HTMLElement | null;
+		if (!el) return false;
+		if (el.closest(".uiToggle")) return false;
+		if (el.closest("button, a, input, select, textarea")) return false;
+		if (el.closest("label")) return false;
+		const input = currentTarget.querySelector<HTMLInputElement>(
+			'input[type="checkbox"]',
+		);
+		if (input && !input.disabled) {
+			input.click();
+			return true;
+		}
+		return false;
+	};
+
+	const handleRowClick = (event: MouseEvent<HTMLDivElement>) => {
+		if (!interactive) return;
+		tryToggleRowCheckbox(event.target, event.currentTarget);
+	};
+
+	const handleRowKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (!interactive) return;
+		if (event.key !== "Enter" && event.key !== " ") return;
+		if (tryToggleRowCheckbox(event.target, event.currentTarget)) {
+			event.preventDefault();
+		}
+	};
+
 	return (
 		<div
 			className={cn(
@@ -73,6 +105,8 @@ export function SettingsRow({
 				className,
 			)}
 			data-settings-row-title={rowTitle}
+			onClick={handleRowClick}
+			onKeyDown={handleRowKeyDown}
 		>
 			<CopyTag className="settingsFieldCopy" htmlFor={htmlFor}>
 				<div className="settingsLabel">{label}</div>

--- a/src/components/settings/SettingsScaffold.tsx
+++ b/src/components/settings/SettingsScaffold.tsx
@@ -107,6 +107,8 @@ export function SettingsRow({
 			data-settings-row-title={rowTitle}
 			onClick={handleRowClick}
 			onKeyDown={handleRowKeyDown}
+			role={interactive ? "button" : undefined}
+			tabIndex={interactive ? 0 : undefined}
 		>
 			<CopyTag className="settingsFieldCopy" htmlFor={htmlFor}>
 				<div className="settingsLabel">{label}</div>

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -1,6 +1,47 @@
 {
 	"versions": [
 		{
+			"version": "0.6.0",
+			"sections": [
+				{
+					"category": "Added",
+					"items": [
+						"Multi-space support: open and manage multiple spaces in separate windows. AI, file, database, and git operations stay scoped to the active window.",
+						"Open external Markdown files from Finder into standalone Glyph windows. Glyph registers .md, .markdown, and .mdown associations on macOS."
+					]
+				},
+				{
+					"category": "Improved",
+					"items": [
+						"Default accent switched from cerulean to neutral across the settings constant, appearance fallback, and appearance settings pane initializer.",
+						"The default light and dark themes give the editor its own surface, separate from the sidebar. Light mode text uses a deeper warm ink. Dark mode text uses solid off-white instead of translucent white. Dark backgrounds shifted from flat gray to a cooler indigo. Borders softened to match.",
+						"Paper grain texture shows across the empty editor and large background areas.",
+						"Sidebar and editor surfaces blend more smoothly into each other.",
+						"Window top and bottom edges carry a faint gradient that reads as light from above.",
+						"Floating panels in light mode cast soft warm shadows. In dark mode they cast deep cool shadows with a thin top highlight. Dark popovers and tooltips now float with an inner highlight and outer glow instead of reading flat.",
+						"Database toolbar New Note button uses a plus icon and a plain chip button, consistent with the rest of the toolbar.",
+						"Settings toggle rows are fully clickable. You can click the label or the row itself to flip the switch. Hover shows a subtle highlight. Clicks still pass through to text fields, links, and the toggle's own label. Disabled toggles show a not-allowed cursor."
+					]
+				},
+				{
+					"category": "Fixed",
+					"items": [
+						"External file and change events no longer leak across spaces. Each event targets the correct window and space.",
+						"Settings sidebar groups tabs under Application and Workspace headings.",
+						"Release builds block the right-click context menu and F5 / Cmd+R / Ctrl+R reload shortcuts. Dev mode is unaffected.",
+						"Safer atomic writes when creating new files to avoid collisions.",
+						"Tests for space-scoped settings."
+					]
+				},
+				{
+					"category": "Removed",
+					"items": [
+						"OS notifications for index rebuilds and AI chat results. The Tauri notification plugin, dependency, and default capability are removed. In-app toasts remain for copy errors, failed file actions, and extraction failures."
+					]
+				}
+			]
+		},
+		{
 			"version": "0.5.5",
 			"sections": [
 				{

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -19,7 +19,7 @@
 						"Sidebar and editor surfaces blend more smoothly into each other.",
 						"Window top and bottom edges carry a faint gradient that reads as light from above.",
 						"Floating panels in light mode cast soft warm shadows. In dark mode they cast deep cool shadows with a thin top highlight. Dark popovers and tooltips now float with an inner highlight and outer glow instead of reading flat.",
-						"Database toolbar New Note button uses a plus icon and a plain chip button, consistent with the rest of the toolbar.",
+						"Database toolbar New Note button uses a note-style icon and a plain chip button, consistent with the rest of the toolbar.",
 						"Settings toggle rows are fully clickable. You can click the label or the row itself to flip the switch. Hover shows a subtle highlight. Clicks still pass through to text fields, links, and the toggle's own label. Disabled toggles show a not-allowed cursor."
 					]
 				},

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -92,6 +92,22 @@
 	background: transparent;
 }
 
+.settingsFieldInteractive {
+	transition: background-color 140ms ease;
+}
+
+.settingsFieldInteractive:has(input[type="checkbox"]) {
+	cursor: pointer;
+}
+
+.settingsFieldInteractive:has(input[type="checkbox"]:not(:disabled)):hover {
+	background: color-mix(in srgb, var(--bg-secondary) 38%, transparent);
+}
+
+.settingsFieldInteractive:has(input[type="checkbox"]:disabled) {
+	cursor: not-allowed;
+}
+
 .settingsField::after {
 	content: "";
 	position: absolute;


### PR DESCRIPTION
## v0.6.0 Polish — clickable toggle rows, consistent DB button, no OS notifications

**Branch:** `0.6/ui-polishing`
**Base:** `main`

---

### Changes

**Clickable settings toggle rows**

The entire toggle row now responds to clicks — tap the label or the row body to flip the switch. Hover shows a subtle highlight. Clicks still pass through to text fields, links, and the toggle's own label. Disabled toggles show a not-allowed cursor.

- `src/components/settings/SettingsScaffold.tsx` — `tryToggleRowCheckbox` delegates to the hidden checkbox when a click lands on non-interactive areas of the row. Handles keyboard Enter/Space too.
- `src/styles/app/10-settings-controls.css` — `.settingsFieldInteractive` hover, cursor, and disabled states.

**Database toolbar New Note button**

The database toolbar's New Note button now matches the other chip buttons in that toolbar. Swapped the shadcn `<Button variant="ghost" size="sm">` for a plain `<button>` with `className="databaseToolbarChip is-accent"`. Changed icon from `PencilEdit02Icon` to `NoteIcon` and added visible "New Note" text alongside it.

- `src/components/databases/DatabasesPane.tsx`

**OS notifications removed**

The Tauri notification plugin has been fully removed from the project. AI chat result and index rebuild notifications were the only two call sites. In-app toasts remain for copy errors, failed file actions, and extraction failures.

Files touched:
- `src-tauri/Cargo.toml` — `tauri-plugin-notification` dependency removed
- `src-tauri/Cargo.lock` — lockfile regenerated
- `src-tauri/capabilities/default.json` — notification permission removed
- `src-tauri/src/lib.rs` — `.plugin(tauri_plugin_notification::init())` removed
- `src-tauri/src/ai_rig/commands.rs` — removed `.notification()` calls on AI success and failure
- `src-tauri/src/index/commands.rs` — removed `.notification()` call after index rebuild; `app` parameter no longer needed so the function signature dropped it

**Release notes**

- `src/data/release-notes.json` — 0.6.0 entry added covering multi-space windows, external MD files, theme overhaul, clickable toggles, DB button, notification removal, and the bug fixes already shipped in main.

---

### Testing notes

- Settings toggles: click the row body away from the toggle itself, verify the switch flips. Tab to a toggle row and press Enter/Space.
- Hover on a disabled toggle row shows `not-allowed` cursor.
- Database toolbar: New Note button uses a plus-icon (NoteIcon) and reads "New Note". Matches the chip style of view-tab-create and similar buttons.
- No more OS notification popup after AI chat completes or after an index rebuild. In-app toasts unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings rows now support keyboard and mouse interaction for toggling controls.

* **Improvements**
  * Enhanced interactive styling for settings fields with visual feedback.
  * Expanded file path access to include Home, Downloads, Documents, and Desktop.
  * Refined New Note button design in the databases panel.

* **Removed**
  * System-level notification popups have been disabled; in-app toasts remain.

* **Documentation**
  * Added release notes entry for version 0.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->