### PR TITLE
Bugfixes - 0.7.1

### DIFF
--- a/Glyph.icon/icon.json
+++ b/Glyph.icon/icon.json
@@ -1,85 +1,68 @@
 {
-  "fill" : {
-    "automatic-gradient" : "extended-gray:1.00000,1.00000"
-  },
-  "groups" : [
-    {
-      "layers" : [
-        {
-          "glass" : false,
-          "image-name" : "_-2.png",
-          "name" : "_-2",
-          "position" : {
-            "scale" : 0.8,
-            "translation-in-points" : [
-              0.39999999999997726,
-              192.3750000000001
-            ]
-          }
-        },
-        {
-          "glass" : false,
-          "image-name" : "_-4.png",
-          "name" : "_-4",
-          "position" : {
-            "scale" : 0.8,
-            "translation-in-points" : [
-              255.4794996282542,
-              192.375
-            ]
-          }
-        },
-        {
-          "glass" : false,
-          "image-name" : "_-3.png",
-          "name" : "_-3",
-          "position" : {
-            "scale" : 0.8,
-            "translation-in-points" : [
-              -244.59970642547694,
-              192.3750000000001
-            ]
-          }
-        },
-        {
-          "glass" : false,
-          "image-name" : "Rectangle 2-2 2.png",
-          "name" : "Rectangle 2-2 2",
-          "position" : {
-            "scale" : 0.6,
-            "translation-in-points" : [
-              1.5,
-              199.0750000000005
-            ]
-          }
-        },
-        {
-          "glass" : false,
-          "image-name" : "Rectangle 3-2.svg",
-          "name" : "Rectangle 3-2",
-          "position" : {
-            "scale" : 0.6,
-            "translation-in-points" : [
-              0,
-              198.07500000000027
-            ]
-          }
-        }
-      ],
-      "shadow" : {
-        "kind" : "neutral",
-        "opacity" : 0.5
-      },
-      "translucency" : {
-        "enabled" : true,
-        "value" : 0.5
-      }
-    }
-  ],
-  "supported-platforms" : {
-    "circles" : [
-      "watchOS"
-    ],
-    "squares" : "shared"
-  }
+	"fill": {
+		"automatic-gradient": "extended-gray:1.00000,1.00000"
+	},
+	"groups": [
+		{
+			"layers": [
+				{
+					"glass": false,
+					"image-name": "_-2.png",
+					"name": "_-2",
+					"position": {
+						"scale": 0.8,
+						"translation-in-points": [0.39999999999997726, 192.3750000000001]
+					}
+				},
+				{
+					"glass": false,
+					"image-name": "_-4.png",
+					"name": "_-4",
+					"position": {
+						"scale": 0.8,
+						"translation-in-points": [255.4794996282542, 192.375]
+					}
+				},
+				{
+					"glass": false,
+					"image-name": "_-3.png",
+					"name": "_-3",
+					"position": {
+						"scale": 0.8,
+						"translation-in-points": [-244.59970642547694, 192.3750000000001]
+					}
+				},
+				{
+					"glass": false,
+					"image-name": "Rectangle 2-2 2.png",
+					"name": "Rectangle 2-2 2",
+					"position": {
+						"scale": 0.6,
+						"translation-in-points": [1.5, 199.0750000000005]
+					}
+				},
+				{
+					"glass": false,
+					"image-name": "Rectangle 3-2.svg",
+					"name": "Rectangle 3-2",
+					"position": {
+						"scale": 0.6,
+						"translation-in-points": [0, 198.07500000000027]
+					}
+				}
+			],
+			"shadow": {
+				"kind": "neutral",
+				"opacity": 0.5
+			},
+			"translucency": {
+				"enabled": true,
+				"value": 0.5
+			}
+		}
+	],
+	"supported-platforms": {
+		"circles": ["watchOS"],
+		"squares": "shared"
+	}
 }

--- a/src/components/app/WelcomeScreen.tsx
+++ b/src/components/app/WelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import glyphIconUrl from "../../../src-tauri/icons/icon.png";
 
 interface WelcomeScreenProps {
@@ -23,110 +23,32 @@ export function WelcomeScreen({ onOpenSpace }: WelcomeScreenProps) {
 		}
 	}, [onOpenSpace]);
 
-	const handleBrandContentKeyDown = useCallback(
-		(event: KeyboardEvent<HTMLElement>) => {
-			const scrollAmounts: Partial<Record<string, number>> = {
-				ArrowUp: -40,
-				ArrowDown: 40,
-				PageUp: -event.currentTarget.clientHeight,
-				PageDown: event.currentTarget.clientHeight,
-			};
-			const amount = scrollAmounts[event.key];
-
-			if (amount !== undefined) {
-				event.preventDefault();
-				event.currentTarget.scrollBy({ top: amount, behavior: "smooth" });
-				return;
-			}
-
-			if (event.key === "Home") {
-				event.preventDefault();
-				event.currentTarget.scrollTo({ top: 0, behavior: "smooth" });
-				return;
-			}
-
-			if (event.key === "End") {
-				event.preventDefault();
-				event.currentTarget.scrollTo({
-					top: event.currentTarget.scrollHeight,
-					behavior: "smooth",
-				});
-			}
-		},
-		[],
-	);
-
 	return (
-		<div className={`welcomeEmptyState${isOpening ? " is-opening" : ""}`}>
-			<section className="welcomeBrandPane" aria-labelledby="welcome-title">
-				<section
-					className="welcomeBrandContent"
-					aria-label="Welcome information"
-					/* biome-ignore lint/a11y/noNoninteractiveTabindex: This scroll region must be focusable for keyboard scrolling. */
-					tabIndex={0}
-					onKeyDown={handleBrandContentKeyDown}
-				>
-					<img
-						className="welcomeCornerGlyph"
-						src={glyphIconUrl}
-						alt=""
-						aria-hidden="true"
-					/>
-					<p className="welcomeKicker">Plain Markdown. Local files.</p>
-					<h1 id="welcome-title" className="welcomeHeading">
-						Start using Glyph
-					</h1>
-					<div className="welcomeFeatureList">
-						<div className="welcomeFeature">
-							<span className="welcomeFeatureMark" aria-hidden="true" />
-							<div>
-								<h2>Pick a folder.</h2>
-								<p>Open existing Markdown notes or create a clean workspace.</p>
-							</div>
-						</div>
-						<div className="welcomeFeature">
-							<span className="welcomeFeatureMark" aria-hidden="true" />
-							<div>
-								<h2>Keep files local.</h2>
-								<p>Glyph stores notes on your machine.</p>
-							</div>
-						</div>
-						<div className="welcomeFeature">
-							<span className="welcomeFeatureMark" aria-hidden="true" />
-							<div>
-								<h2>Work in one place.</h2>
-								<p>Write notes, track tasks, and bring AI the right context.</p>
-							</div>
-						</div>
-					</div>
-					<div className="welcomeDivider" aria-hidden="true" />
-				</section>
-			</section>
-			<div className="welcomeActionPane">
-				<div className="welcomeActionHint" aria-hidden="true">
-					<span>click this to begin</span>
-					<svg
-						className="welcomeActionScribble"
-						viewBox="0 0 640 1280"
-						xmlns="http://www.w3.org/2000/svg"
-						aria-hidden="true"
-						focusable="false"
-					>
-						<path
-							d="M448.6 3c-3.4 8.2-11.2 48.7-18.5 96.5-16.1 105-57.1 388.1-74 511-1.7 12.1-7.6 54.6-13 94.5-23.9 173.4-40.1 302.4-44.6 354.4l-.7 7.9-6.2-.7c-10.9-1.1-32.3-5.5-57.1-11.8-13.2-3.4-26.5-6.2-29.6-6.4-4.2-.2-6.8-1-10.4-3.3-2.7-1.7-6-3.1-7.3-3.1-2.3 0-2.4.3-2 4.3.5 4.2 4.7 13.1 22 46.7 8.6 16.7 18.8 38.8 24.8 54 11.3 28.3 17.4 47.9 30 96.5 4.6 17.5 6.3 22.6 9.3 26.8 1 1.5 2.3 4.3 2.8 6.2 1.3 4.4 2.9 4.4 6.8-.1 4.1-4.6 6-7.7 21.1-33.9 32.7-56.5 53.2-84.6 96.9-132.4 26.3-28.9 30.4-34.2 28.5-37.2-1.1-1.8-9.4-.5-15.8 2.4l-5.8 2.7 1.6-2.5c.9-1.3 1.6-3.3 1.6-4.4 0-4.7-6.9-5.5-32-3.7-22.3 1.6-35 2-53.4 1.8-10.8-.2-11.8-.4-11.3-2 6.3-21.4 12.9-50.9 18.7-83.2 9.5-53.6 22.8-139.6 38-245.5 3.8-26.4 7.6-52.7 8.4-58.5.9-5.8 5.2-36.3 9.6-67.8 4.4-31.4 11.6-82.7 16-114 23.3-165.9 38.8-285.4 45.4-351.2 5.2-51.2 6-63.7 6-96.5.1-33.6-.7-46.1-2.9-49.2-1.3-1.7-1.5-1.6-2.9 1.7zM238.1 1088.4c15.5 8.2 34.4 14.7 53.2 18.3 14.4 2.8 46.9 2.5 60.3-.5 8.8-1.9 18.5-4.9 25.9-7.8 1.1-.4-1.6 2.1-6 5.7-21.7 17.5-45.6 45.3-62.7 72.9-9.6 15.5-22.9 43.6-27 57-.3.8-1-4.5-1.7-11.8-4.2-46.4-20.2-92-45.3-129.5-3.2-4.8-5.7-8.7-5.4-8.7.2 0 4.1 2 8.7 4.4z"
-							fill="currentColor"
-						/>
-					</svg>
-				</div>
+		<div className="welcomeScreen">
+			<div className="welcomeScreenBody">
+				<img
+					className="welcomeScreenIcon"
+					src={glyphIconUrl}
+					alt=""
+					aria-hidden="true"
+				/>
+				<h1 className="welcomeScreenTitle">
+					Glyph
+					<span className="welcomeScreenTitleSub">Write. Reflect. Discover.</span>
+				</h1>
+				<p className="welcomeScreenSub">
+					Open your current notes folder or create a new workspace.
+				</p>
 				<button
 					type="button"
-					className="welcomeActionBtn"
+					className="welcomeScreenBtn"
 					onClick={handleOpen}
 					disabled={isOpening}
 					aria-busy={isOpening}
 				>
 					{isOpening ? "Opening..." : "Open Folder"}
 				</button>
+				<p className="welcomeScreenKicker">Plain Markdown. Local files.</p>
 			</div>
 		</div>
 	);

--- a/src/components/app/WelcomeScreen.tsx
+++ b/src/components/app/WelcomeScreen.tsx
@@ -34,7 +34,9 @@ export function WelcomeScreen({ onOpenSpace }: WelcomeScreenProps) {
 				/>
 				<h1 className="welcomeScreenTitle">
 					Glyph
-					<span className="welcomeScreenTitleSub">Write. Reflect. Discover.</span>
+					<span className="welcomeScreenTitleSub">
+						Write. Reflect. Discover.
+					</span>
 				</h1>
 				<p className="welcomeScreenSub">
 					Open your current notes folder or create a new workspace.

--- a/src/components/database/DatabaseViewOptionsCardFieldsPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsCardFieldsPanel.tsx
@@ -13,6 +13,14 @@ const CARD_FIELDS: CardFieldEntry[] = [
 	{ id: "tags", label: "Tags" },
 ];
 
+const CARD_FIELD_IDS = new Set(CARD_FIELDS.map((field) => field.id));
+const TITLE_ONLY_CARD_FIELDS = ["__glyph_title_only__"];
+
+export function visibleCardFieldCount(fields: string[] | undefined): number | null {
+	if (!fields || fields.length === 0) return null;
+	return fields.filter((field) => CARD_FIELD_IDS.has(field)).length;
+}
+
 interface CardFieldsPanelProps {
 	fields: string[] | undefined;
 	onChange: (fields: string[]) => void;
@@ -20,7 +28,9 @@ interface CardFieldsPanelProps {
 
 export function CardFieldsPanel({ fields, onChange }: CardFieldsPanelProps) {
 	const active = new Set(
-		fields && fields.length > 0 ? fields : CARD_FIELDS.map((field) => field.id),
+		fields && fields.length > 0
+			? fields.filter((field) => CARD_FIELD_IDS.has(field))
+			: CARD_FIELDS.map((field) => field.id),
 	);
 
 	const toggleField = (fieldId: string, enabled: boolean) => {
@@ -30,7 +40,7 @@ export function CardFieldsPanel({ fields, onChange }: CardFieldsPanelProps) {
 		} else {
 			next.delete(fieldId);
 		}
-		onChange(Array.from(next));
+		onChange(next.size === 0 ? TITLE_ONLY_CARD_FIELDS : Array.from(next));
 	};
 
 	return (

--- a/src/components/database/DatabaseViewOptionsCardFieldsPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsCardFieldsPanel.tsx
@@ -16,7 +16,9 @@ const CARD_FIELDS: CardFieldEntry[] = [
 const CARD_FIELD_IDS = new Set(CARD_FIELDS.map((field) => field.id));
 const TITLE_ONLY_CARD_FIELDS = ["__glyph_title_only__"];
 
-export function visibleCardFieldCount(fields: string[] | undefined): number | null {
+export function visibleCardFieldCount(
+	fields: string[] | undefined,
+): number | null {
 	if (!fields || fields.length === 0) return null;
 	return fields.filter((field) => CARD_FIELD_IDS.has(field)).length;
 }

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -28,7 +28,10 @@ import { extractErrorMessage } from "../../lib/errorUtils";
 import { ChevronRight, RefreshCw, Search } from "../Icons";
 import { Button } from "../ui/shadcn/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
-import { CardFieldsPanel } from "./DatabaseViewOptionsCardFieldsPanel";
+import {
+	CardFieldsPanel,
+	visibleCardFieldCount,
+} from "./DatabaseViewOptionsCardFieldsPanel";
 import {
 	type ColumnMenuEntry,
 	ColumnsPanel,
@@ -43,6 +46,13 @@ import {
 } from "./databaseViewPresets";
 
 type OptionsPanel = "source" | "columns" | "filters" | "sort" | "card_fields";
+
+function cardFieldsLabel(fields: string[] | undefined): string {
+	const fieldCount = visibleCardFieldCount(fields);
+	if (fieldCount === null) return "All shown";
+	if (fieldCount === 0) return "Title only";
+	return `${fieldCount} shown`;
+}
 
 interface DatabaseViewOptionsPopoverProps {
 	config: DatabaseConfig;
@@ -457,6 +467,7 @@ export function DatabaseViewOptionsPopover({
 				...config.view,
 				search: "",
 				board_group_by: null,
+				board_card_fields: undefined,
 			},
 			columns: defaultColumns,
 			sorts: [],
@@ -614,7 +625,7 @@ export function DatabaseViewOptionsPopover({
 								/>
 							}
 							label="Card fields"
-							value={`${(config.view.board_card_fields?.length ?? 0) > 0 ? config.view.board_card_fields?.length : "All"} shown`}
+							value={cardFieldsLabel(config.view.board_card_fields)}
 							active={activePanel === "card_fields"}
 							onClick={() => togglePanel("card_fields")}
 						/>

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -208,21 +208,25 @@ vi.mock("./useHydrateInlineImages", () => ({
 }));
 
 function Harness({
+	markdown = "keep this line\nremove this line",
 	onChange,
 	onState,
 	pasteMarkdownBehavior = "plain-text",
+	relPath = "notes/test.md",
 }: {
+	markdown?: string;
 	onChange: (nextMarkdown: string) => void;
 	onState?: (state: {
 		colorfulHeadings: boolean;
 		showFrontmatterInEditor: boolean;
 	}) => void;
 	pasteMarkdownBehavior?: "plain-text" | "smart-markdown";
+	relPath?: string;
 }) {
 	const state = useNoteEditor({
-		markdown: "keep this line\nremove this line",
+		markdown,
 		mode: "rich",
-		relPath: "notes/test.md",
+		relPath,
 		pasteMarkdownBehavior,
 		onChange,
 	});
@@ -443,6 +447,57 @@ describe("useNoteEditor", () => {
 		});
 
 		expect(onChange).toHaveBeenCalledWith("keep this line");
+	});
+
+	it("flushes pending edits with the previous note context when the path changes", async () => {
+		const oldOnChange = vi.fn();
+		const newOnChange = vi.fn();
+		mockEditor.getMarkdown.mockReturnValue("typed old body");
+
+		await act(async () => {
+			root.render(
+				<Harness
+					markdown={"---\ntitle: Old\n---\nold body"}
+					relPath="notes/old.md"
+					onChange={oldOnChange}
+				/>,
+			);
+		});
+
+		const options = getEditorOptions() as {
+			onTransaction?: (payload: {
+				editor: typeof mockEditor;
+				transaction: { docChanged: boolean };
+			}) => void;
+		} | null;
+
+		await act(async () => {
+			options?.onTransaction?.({
+				editor: mockEditor,
+				transaction: { docChanged: true },
+			});
+		});
+
+		await act(async () => {
+			root.render(
+				<Harness
+					markdown={"---\ntitle: New\n---\nnew body"}
+					relPath="notes/new.md"
+					onChange={newOnChange}
+				/>,
+			);
+		});
+
+		expect(oldOnChange).toHaveBeenCalledWith(
+			"---\ntitle: Old\n---\ntyped old body",
+		);
+		expect(newOnChange).not.toHaveBeenCalled();
+
+		await act(async () => {
+			await flushMarkdownSyncWork();
+		});
+
+		expect(newOnChange).not.toHaveBeenCalled();
 	});
 
 	it("tracks colorful headings from settings and live updates", async () => {

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -4,7 +4,13 @@ import { MarkdownManager } from "@tiptap/markdown";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { useEditor } from "@tiptap/react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+} from "react";
 import { useState } from "react";
 import {
 	joinYamlFrontmatter,
@@ -251,6 +257,14 @@ interface UseNoteEditorOptions {
 	onChange: (nextMarkdown: string) => void;
 }
 
+interface PendingMarkdownSync {
+	instance: NonNullable<ReturnType<typeof useEditor>>;
+	frontmatter: string | null;
+	lastEmittedMarkdown: string;
+	onChange: (nextMarkdown: string) => void;
+	relPath: string;
+}
+
 function expandMarkdownLinkForEditing(
 	view: EditorView,
 	link: HTMLAnchorElement,
@@ -416,9 +430,7 @@ export function useNoteEditor({
 	const attachmentStorageModeRef = useRef<AttachmentStorageMode>("note-folder");
 	const attachmentFolderRef = useRef<string | null>(DEFAULT_ATTACHMENT_FOLDER);
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null);
-	const pendingMarkdownEditorRef = useRef<NonNullable<
-		ReturnType<typeof useEditor>
-	> | null>(null);
+	const pendingMarkdownSyncRef = useRef<PendingMarkdownSync | null>(null);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
 	const markdownSyncFrameRef = useRef<number | null>(null);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
@@ -528,25 +540,39 @@ export function useNoteEditor({
 		}
 	}, []);
 
-	const flushMarkdownSync = useCallback(() => {
+	const flushMarkdownSync = useCallback((expectedRelPath?: string) => {
 		clearScheduledMarkdownSync();
-		const instance = pendingMarkdownEditorRef.current;
-		pendingMarkdownEditorRef.current = null;
-		if (!instance || modeRef.current !== "rich" || !instance.isEditable) return;
+		const pending = pendingMarkdownSyncRef.current;
+		pendingMarkdownSyncRef.current = null;
+		if (!pending) {
+			return;
+		}
+		if (expectedRelPath !== undefined && pending.relPath !== expectedRelPath) {
+			return;
+		}
+		const { instance } = pending;
 		const nextBody = postprocessMarkdownFromEditor(instance.getMarkdown());
-		lastAppliedBodyRef.current = preprocessMarkdownForEditor(nextBody);
 		const nextMarkdown = joinYamlFrontmatter(
-			frontmatterRef.current,
+			pending.frontmatter,
 			normalizeBody(nextBody),
 		);
-		if (nextMarkdown === lastEmittedMarkdownRef.current) return;
-		lastEmittedMarkdownRef.current = nextMarkdown;
-		onChangeRef.current(nextMarkdown);
+		if (pending.relPath === relPathRef.current) {
+			lastAppliedBodyRef.current = preprocessMarkdownForEditor(nextBody);
+			lastEmittedMarkdownRef.current = nextMarkdown;
+		}
+		if (nextMarkdown === pending.lastEmittedMarkdown) return;
+		pending.onChange(nextMarkdown);
 	}, [clearScheduledMarkdownSync]);
 
 	const scheduleMarkdownSync = useCallback(
 		(instance: NonNullable<ReturnType<typeof useEditor>>) => {
-			pendingMarkdownEditorRef.current = instance;
+			pendingMarkdownSyncRef.current = {
+				instance,
+				frontmatter: frontmatterRef.current,
+				lastEmittedMarkdown: lastEmittedMarkdownRef.current,
+				onChange: onChangeRef.current,
+				relPath: relPathRef.current,
+			};
 			clearScheduledMarkdownSync();
 			markdownSyncTimeoutRef.current = window.setTimeout(() => {
 				markdownSyncTimeoutRef.current = null;
@@ -558,6 +584,12 @@ export function useNoteEditor({
 		},
 		[clearScheduledMarkdownSync, flushMarkdownSync],
 	);
+
+	useLayoutEffect(() => {
+		return () => {
+			flushMarkdownSync(relPath);
+		};
+	}, [flushMarkdownSync, relPath]);
 
 	const editor = useEditor(
 		{
@@ -734,12 +766,12 @@ export function useNoteEditor({
 		if (!editor) return;
 		if (markdown === lastEmittedMarkdownRef.current) return;
 		if (editorBody === lastAppliedBodyRef.current) return;
-		flushMarkdownSync();
+		flushMarkdownSync(relPath);
 		suppressUpdateRef.current = true;
 		editor.commands.setContent(editorBody, { contentType: "markdown" });
 		lastAppliedBodyRef.current = editorBody;
 		lastEmittedMarkdownRef.current = markdown;
-	}, [editor, editorBody, flushMarkdownSync, markdown]);
+	}, [editor, editorBody, flushMarkdownSync, markdown, relPath]);
 
 	useEffect(() => {
 		return () => {

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -540,29 +540,35 @@ export function useNoteEditor({
 		}
 	}, []);
 
-	const flushMarkdownSync = useCallback((expectedRelPath?: string) => {
-		clearScheduledMarkdownSync();
-		const pending = pendingMarkdownSyncRef.current;
-		pendingMarkdownSyncRef.current = null;
-		if (!pending) {
-			return;
-		}
-		if (expectedRelPath !== undefined && pending.relPath !== expectedRelPath) {
-			return;
-		}
-		const { instance } = pending;
-		const nextBody = postprocessMarkdownFromEditor(instance.getMarkdown());
-		const nextMarkdown = joinYamlFrontmatter(
-			pending.frontmatter,
-			normalizeBody(nextBody),
-		);
-		if (pending.relPath === relPathRef.current) {
-			lastAppliedBodyRef.current = preprocessMarkdownForEditor(nextBody);
-			lastEmittedMarkdownRef.current = nextMarkdown;
-		}
-		if (nextMarkdown === pending.lastEmittedMarkdown) return;
-		pending.onChange(nextMarkdown);
-	}, [clearScheduledMarkdownSync]);
+	const flushMarkdownSync = useCallback(
+		(expectedRelPath?: string) => {
+			clearScheduledMarkdownSync();
+			const pending = pendingMarkdownSyncRef.current;
+			pendingMarkdownSyncRef.current = null;
+			if (!pending) {
+				return;
+			}
+			if (
+				expectedRelPath !== undefined &&
+				pending.relPath !== expectedRelPath
+			) {
+				return;
+			}
+			const { instance } = pending;
+			const nextBody = postprocessMarkdownFromEditor(instance.getMarkdown());
+			const nextMarkdown = joinYamlFrontmatter(
+				pending.frontmatter,
+				normalizeBody(nextBody),
+			);
+			if (pending.relPath === relPathRef.current) {
+				lastAppliedBodyRef.current = preprocessMarkdownForEditor(nextBody);
+				lastEmittedMarkdownRef.current = nextMarkdown;
+			}
+			if (nextMarkdown === pending.lastEmittedMarkdown) return;
+			pending.onChange(nextMarkdown);
+		},
+		[clearScheduledMarkdownSync],
+	);
 
 	const scheduleMarkdownSync = useCallback(
 		(instance: NonNullable<ReturnType<typeof useEditor>>) => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -479,13 +479,13 @@ export function MarkdownEditorPane({
 			sessionId = documentSessionRef.current,
 		): Promise<boolean> => {
 			const applySaveState = (saved: string, mtimeMs: number) => {
-				if (path !== relPath || !isCurrentSession(sessionId)) return;
 				setPrefetchedNote(path, {
 					rel_path: path,
 					text: saved,
 					etag: "",
 					mtime_ms: mtimeMs,
 				});
+				if (path !== relPath || !isCurrentSession(sessionId)) return;
 				savedTextRef.current = saved;
 				mtimeRef.current = mtimeMs;
 				setSavedText(saved);

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -479,13 +479,13 @@ export function MarkdownEditorPane({
 			sessionId = documentSessionRef.current,
 		): Promise<boolean> => {
 			const applySaveState = (saved: string, mtimeMs: number) => {
+				if (path !== relPath || !isCurrentSession(sessionId)) return;
 				setPrefetchedNote(path, {
 					rel_path: path,
 					text: saved,
 					etag: "",
 					mtime_ms: mtimeMs,
 				});
-				if (path !== relPath || !isCurrentSession(sessionId)) return;
 				savedTextRef.current = saved;
 				mtimeRef.current = mtimeMs;
 				setSavedText(saved);

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -1,6 +1,25 @@
 {
 	"versions": [
 		{
+			"version": "0.7.1",
+			"sections": [
+				{
+					"category": "Improved",
+					"items": [
+						"The welcome screen is more minimal.",
+						"Folio mode uses a cleaner UI."
+					]
+				},
+				{
+					"category": "Fixed",
+					"items": [
+						"Kanban card field toggles now keep an empty selection as Title only. Missing card field settings still default to All shown, and Restore defaults clears the override.",
+						"Debounced markdown sync in `useNoteEditor.ts` now flushes the pending body for the file it started from, so switching notes no longer saves stale content."
+					]
+				}
+			]
+		},
+		{
 			"version": "0.7.0",
 			"sections": [
 				{

--- a/src/data/release-notes.json
+++ b/src/data/release-notes.json
@@ -14,7 +14,7 @@
 					"category": "Fixed",
 					"items": [
 						"Kanban card field toggles now keep an empty selection as Title only. Missing card field settings still default to All shown, and Restore defaults clears the override.",
-						"Debounced markdown sync in `useNoteEditor.ts` now flushes the pending body for the file it started from, so switching notes no longer saves stale content."
+						"Debounced markdown sync now flushes the pending body for the file it started from, so switching notes no longer saves stale content."
 					]
 				}
 			]

--- a/src/styles/app/14-welcome.css
+++ b/src/styles/app/14-welcome.css
@@ -1,309 +1,70 @@
-.welcomeEmptyState {
-	--welcome-page-bg: var(--bg-primary);
-	--welcome-page-muted: color-mix(in srgb, var(--text-primary) 46%, transparent);
-	--welcome-brand-bg: color-mix(
-		in srgb,
-		var(--text-primary) 10%,
-		var(--bg-primary)
-	);
-	--welcome-brand-text: var(--text-primary);
-	--welcome-brand-muted: color-mix(
-		in srgb,
-		var(--text-primary) 52%,
-		var(--bg-primary)
-	);
-	--welcome-brand-heading: color-mix(
-		in srgb,
-		var(--text-primary) 75%,
-		var(--text-secondary)
-	);
-	--welcome-brand-grid: color-mix(in srgb, var(--text-primary) 8%, transparent);
-	--welcome-brand-line: color-mix(in srgb, var(--text-primary) 15%, transparent);
-	--welcome-brand-accent: color-mix(
-		in srgb,
-		var(--interactive-accent) 76%,
-		var(--status-success-fg, var(--text-primary))
-	);
-	--welcome-action-bg: var(--text-primary);
-	--welcome-action-bg-hover: color-mix(in srgb, var(--text-primary) 88%, black);
-	--welcome-action-fg: var(--bg-primary);
-
-	flex: 1;
-	width: 100%;
-	min-height: 0;
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-	background: var(--welcome-page-bg);
-	cursor: default;
-	overflow: hidden;
-	padding: 0;
-	text-align: left;
+.welcomeScreen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--bg-primary);
+  text-align: center;
 }
 
-.welcomeBrandPane {
-	min-width: 0;
-	position: relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	overflow: hidden;
-	padding: clamp(20px, 4vw, 72px);
-	background: var(--welcome-page-bg);
+.welcomeScreenBody {
+  max-width: 480px;
 }
 
-.welcomeBrandContent {
-	position: relative;
-	width: min(72%, 680px);
-	min-width: 0;
-	max-height: calc(100% - 24px);
-	padding: clamp(28px, 4.4vw, 78px);
-	overflow: auto;
-	border-radius: 14px;
-	background: var(--welcome-brand-bg);
-	color: var(--welcome-brand-text);
-	scrollbar-width: thin;
-	scrollbar-color: color-mix(
-			in srgb,
-			var(--welcome-brand-text) 32%,
-			transparent
-		)
-		transparent;
+.welcomeScreenIcon {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 16px;
+  object-fit: contain;
+  pointer-events: none;
 }
 
-.welcomeBrandContent::before {
-	content: "";
-	position: absolute;
-	inset: 0;
-	background: linear-gradient(var(--welcome-brand-grid) 1px, transparent 1px),
-		linear-gradient(90deg, var(--welcome-brand-grid) 1px, transparent 1px);
-	background-size: 96px 96px;
-	opacity: 0.5;
+.welcomeScreenKicker {
+  margin: 20px 0 0;
+  color: var(--text-secondary);
+  font-size: calc(var(--text-base) * 0.85);
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
-.welcomeBrandContent::after {
-	content: "";
-	position: absolute;
-	right: 12%;
-	top: 14%;
-	width: 38%;
-	height: 1px;
-	background: var(--welcome-brand-line);
+.welcomeScreenTitle {
+  margin: 0 0 16px;
+  color: var(--text-primary);
+  font-size: calc(var(--text-base) * 2.4);
+  font-weight: 650;
+  line-height: 1.15;
 }
 
-.welcomeCornerGlyph,
-.welcomeKicker,
-.welcomeHeading,
-.welcomeFeatureList,
-.welcomeDivider {
-	position: relative;
-	z-index: 1;
+.welcomeScreenTitleSub {
+  display: block;
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: calc(var(--text-base) * 1.05);
+  font-weight: 500;
+  letter-spacing: 0.02em;
 }
 
-.welcomeCornerGlyph {
-	position: absolute;
-	top: clamp(22px, 3vw, 42px);
-	right: clamp(22px, 3vw, 42px);
-	width: clamp(26px, 2.6vw, 36px);
-	height: clamp(26px, 2.6vw, 36px);
-	object-fit: contain;
-	pointer-events: none;
+.welcomeScreenSub {
+  margin: 0 0 32px;
+  color: var(--text-secondary);
+  font-size: calc(var(--text-base) * 0.95);
+  line-height: 1.5;
 }
 
-.welcomeKicker {
-	margin: 0 0 clamp(18px, 2.4vw, 32px);
-	color: var(--welcome-brand-accent);
-	font-size: calc(var(--text-base) * 0.9);
-	font-weight: 650;
+.welcomeScreenBtn {
+  min-width: 160px;
+  padding: 10px 24px;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  font-size: calc(var(--text-base) * 0.9);
+  font-weight: var(--font-medium);
+  cursor: pointer;
 }
 
-.welcomeHeading {
-	max-width: 560px;
-	margin: 0 0 clamp(26px, 3.4vw, 46px);
-	color: var(--welcome-brand-heading);
-	font-size: calc(var(--text-base) * 4);
-	font-weight: 650;
-	letter-spacing: 0;
-	line-height: 1.05;
-}
-
-.welcomeFeatureList {
-	display: grid;
-	gap: clamp(14px, 2vw, 26px);
-	max-width: 600px;
-}
-
-.welcomeFeature {
-	display: grid;
-	grid-template-columns: 18px 1fr;
-	gap: clamp(10px, 1.4vw, 18px);
-}
-
-.welcomeFeatureMark {
-	position: relative;
-	width: var(--icon-md);
-	height: var(--icon-md);
-	margin-top: 3px;
-}
-
-.welcomeFeatureMark::before {
-	content: "";
-	position: absolute;
-	left: 2px;
-	top: 3px;
-	width: calc(var(--icon-md) * 0.57);
-	height: calc(var(--icon-md) * 0.29);
-	border-bottom: 1.5px solid var(--welcome-brand-text);
-	border-left: 1.5px solid var(--welcome-brand-text);
-	transform: rotate(-45deg);
-}
-
-.welcomeFeature h2 {
-	margin: 0 0 6px;
-	color: var(--welcome-brand-text);
-	font-size: calc(var(--text-base) * 1.1);
-	font-weight: 650;
-	line-height: 1.35;
-}
-
-.welcomeFeature p {
-	margin: 0;
-	color: var(--welcome-brand-muted);
-	font-size: calc(var(--text-base) * 0.9);
-	line-height: 1.5;
-}
-
-.welcomeDivider {
-	width: min(560px, 100%);
-	height: clamp(18px, 3vw, 40px);
-	margin: clamp(22px, 3vw, 42px) 0 0;
-	background-image: radial-gradient(
-		color-mix(in srgb, var(--welcome-brand-text) 18%, transparent) 1px,
-		transparent 1px
-	);
-	background-size: 8px 8px;
-}
-
-.welcomeActionPane {
-	min-width: 0;
-	position: relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: clamp(20px, 4vw, 72px);
-	background: var(--welcome-page-bg);
-}
-
-.welcomeActionHint {
-	position: absolute;
-	left: calc(50% - clamp(18px, 2vw, 34px));
-	top: calc(50% - clamp(194px, 17vw, 262px));
-	color: color-mix(in srgb, var(--welcome-page-muted) 82%, transparent);
-	transform: rotate(8deg);
-	pointer-events: none;
-}
-
-.welcomeActionHint span {
-	display: block;
-	margin: 0 0 4px 2px;
-	color: var(--welcome-page-muted);
-	font-family: "Comic Sans MS", "Bradley Hand", cursive;
-	font-size: calc(var(--text-base) * 1.1);
-	font-weight: 600;
-	letter-spacing: 0;
-	transform: rotate(-13deg);
-	white-space: nowrap;
-}
-
-.welcomeActionScribble {
-	display: block;
-	width: clamp(54px, 6vw, 92px);
-}
-
-.welcomeActionBtn {
-	width: min(220px, 100%);
-	min-height: 42px;
-	color: var(--welcome-action-fg);
-	background: var(--welcome-action-bg);
-	border: 1px solid var(--welcome-action-bg);
-	padding: 10px 24px;
-	border-radius: var(--radius-md);
-	font-size: calc(var(--text-base) * 0.9);
-	font-weight: var(--font-medium);
-	cursor: pointer;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.welcomeActionBtn:hover {
-	color: var(--welcome-action-fg);
-	background: var(--welcome-action-bg-hover);
-	border-color: var(--welcome-action-bg-hover);
-}
-
-.welcomeActionBtn:disabled {
-	cursor: wait;
-	opacity: 0.7;
-}
-
-@media (max-width: 640px) {
-	.welcomeEmptyState {
-		grid-template-columns: 1fr;
-	}
-
-	.welcomeBrandPane {
-		padding: 24px;
-	}
-
-	.welcomeBrandContent {
-		width: 100%;
-		min-width: 0;
-		max-height: none;
-	}
-
-	.welcomeActionPane {
-		padding: 28px;
-	}
-
-	.welcomeActionHint {
-		left: calc(50% - 20px);
-		top: calc(50% - 188px);
-	}
-
-	.welcomeActionScribble {
-		width: 62px;
-	}
-}
-
-@media (max-height: 620px) {
-	.welcomeActionHint {
-		top: calc(50% - 160px);
-	}
-
-	.welcomeActionScribble {
-		width: clamp(48px, 5vw, 68px);
-	}
-}
-
-@media (max-height: 760px) {
-	.welcomeBrandContent {
-		padding: clamp(22px, 3.2vw, 48px);
-	}
-
-	.welcomeKicker {
-		margin-bottom: 14px;
-	}
-
-	.welcomeHeading {
-		margin-bottom: 22px;
-		font-size: calc(var(--text-base) * 3);
-	}
-
-	.welcomeFeatureList {
-		gap: 12px;
-	}
-
-	.welcomeDivider {
-		margin-top: 18px;
-	}
+.welcomeScreenBtn:disabled {
+  cursor: wait;
+  opacity: 0.5;
 }

--- a/src/styles/app/14-welcome.css
+++ b/src/styles/app/14-welcome.css
@@ -1,70 +1,70 @@
 .welcomeScreen {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
-  background: var(--bg-primary);
-  text-align: center;
+	flex: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	background: var(--bg-primary);
+	text-align: center;
 }
 
 .welcomeScreenBody {
-  max-width: 480px;
+	max-width: 480px;
 }
 
 .welcomeScreenIcon {
-  width: 48px;
-  height: 48px;
-  margin: 0 auto 16px;
-  object-fit: contain;
-  pointer-events: none;
+	width: 48px;
+	height: 48px;
+	margin: 0 auto 16px;
+	object-fit: contain;
+	pointer-events: none;
 }
 
 .welcomeScreenKicker {
-  margin: 20px 0 0;
-  color: var(--text-secondary);
-  font-size: calc(var(--text-base) * 0.85);
-  font-weight: 500;
-  letter-spacing: 0.02em;
+	margin: 20px 0 0;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.85);
+	font-weight: 500;
+	letter-spacing: 0.02em;
 }
 
 .welcomeScreenTitle {
-  margin: 0 0 16px;
-  color: var(--text-primary);
-  font-size: calc(var(--text-base) * 2.4);
-  font-weight: 650;
-  line-height: 1.15;
+	margin: 0 0 16px;
+	color: var(--text-primary);
+	font-size: calc(var(--text-base) * 2.4);
+	font-weight: 650;
+	line-height: 1.15;
 }
 
 .welcomeScreenTitleSub {
-  display: block;
-  margin-top: 8px;
-  color: var(--text-secondary);
-  font-size: calc(var(--text-base) * 1.05);
-  font-weight: 500;
-  letter-spacing: 0.02em;
+	display: block;
+	margin-top: 8px;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 1.05);
+	font-weight: 500;
+	letter-spacing: 0.02em;
 }
 
 .welcomeScreenSub {
-  margin: 0 0 32px;
-  color: var(--text-secondary);
-  font-size: calc(var(--text-base) * 0.95);
-  line-height: 1.5;
+	margin: 0 0 32px;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.95);
+	line-height: 1.5;
 }
 
 .welcomeScreenBtn {
-  min-width: 160px;
-  padding: 10px 24px;
-  color: var(--text-primary);
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-primary);
-  border-radius: var(--radius-md);
-  font-size: calc(var(--text-base) * 0.9);
-  font-weight: var(--font-medium);
-  cursor: pointer;
+	min-width: 160px;
+	padding: 10px 24px;
+	color: var(--text-primary);
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-primary);
+	border-radius: var(--radius-md);
+	font-size: calc(var(--text-base) * 0.9);
+	font-weight: var(--font-medium);
+	cursor: pointer;
 }
 
 .welcomeScreenBtn:disabled {
-  cursor: wait;
-  opacity: 0.5;
+	cursor: wait;
+	opacity: 0.5;
 }

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -252,21 +252,6 @@
 	background: color-mix(in srgb, var(--interactive-accent) 12%, var(--bg-hover));
 }
 
-.folioNoteRow[data-state="selected"] .folioNoteTitle,
-.folioNoteRow[data-state="selected"] .folioFileName {
-	font-weight: var(--font-semibold);
-}
-
-.folioNoteRow[data-state="selected"] .folioNoteTitleIcon,
-.folioNoteRow[data-state="selected"] .folioNoteFileIcon {
-	opacity: 1;
-}
-
-.folioNoteRow[data-state="selected"] svg,
-.folioNoteRow[data-state="selected"] svg * {
-	stroke-width: 1.2;
-}
-
 .folioNoteRow[data-kind="file"] {
 	min-height: 42px;
 	justify-content: center;


### PR DESCRIPTION
## What changed

### Welcome screen

The old two-pane layout is gone. The brand pane, feature list, SVG scribble arrow, and keyboard-scrollable content area all got cut. The new screen is a single centered block: Glyph icon, title with "Write. Reflect. Discover.", a one-line description, the Open Folder button, and a kicker. The CSS dropped from ~300 lines to ~70.

### Kanban card field toggles

Card field selections in board view now filter against known field IDs. Toggling every field off stores the selection as "Title only" instead of falling back to "All shown." The popover label reflects the actual state: "All shown," "Title only," or a count. Restoring defaults now clears the override entirely.

### Editor debounce flush

`useNoteEditor` now snapshots the full context—frontmatter, `onChange`, `relPath`, and last emitted markdown—at the moment the sync gets scheduled. A `useLayoutEffect` cleanup flushes the pending sync for the file it started from. Before this, switching notes could flush the pending body against the new file, overwriting it with stale content.

### Folio mode

Removed selected-row styling that bumped font weight and stroke width. The selection state still highlights the background, but the text and icons stay unchanged.

### Misc

- Release notes added for v0.7.1
- `icon.json` formatting normalized
- `README.md` logo extension fixed to lowercase `.png`
- Website image compressed
- `MarkdownEditorPane` prefetches the saved note before the path/session check so the file tree reflects the change even when the editor navigates away


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced card field selection UI with improved visibility indicators.

* **Bug Fixes**
  * Fixed markdown sync to correctly flush pending edits when switching between notes.
  * Improved Kanban card field toggle to preserve empty selection as title-only.

* **Style**
  * Redesigned welcome screen layout for a cleaner, more streamlined appearance.
  * Refined folio mode selected item styling.

* **Tests**
  * Added test coverage for markdown sync behavior across different note contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->