### PR TITLE
0.7.3/graph global

### DIFF
--- a/graph_plan.md
+++ b/graph_plan.md
@@ -1,0 +1,324 @@
+# Plan 003: Space-wide graph view — backend command + full-pane prototype (design spike)
+
+> **Executor instructions**: This is a **design-spike plan**: build a working
+> prototype behind clear limits, measure it, and record open questions — do
+> not polish it into a finished feature. Follow the steps, run every
+> verification command, and honor the STOP conditions. When done, update the
+> status row for this plan in `plans/README.md`.
+>
+> **Drift check (run first)**:
+> `git diff --stat a27b376..HEAD -- src-tauri/src/index/commands.rs src/components/graph/ src/lib/tauri.ts src-tauri/src/lib.rs`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M (spike; production feature is L)
+- **Risk**: LOW (additive command + new component; perf risk is what the
+  spike measures)
+- **Depends on**: none (001 and 002 are unrelated)
+- **Category**: direction
+- **Planned at**: commit `a27b376`, 2026-06-11
+
+## Why this matters
+
+Glyph's only graph surface is a per-note modal
+(`LocalNoteGraphDialog`) showing one hop of neighbors. The SQLite index
+already stores every note, every note-to-note edge (`links` and
+`note_relationships` tables, with from/to indexes), and every indexed tag
+(`tags(note_id, tag, is_explicit)`). The architecture docs note the
+relationship model "supports richer graph … than raw links". A whole-space
+graph view is a hallmark feature of this app category (Obsidian/Logseq) and
+should show the space as a whole: linked notes, tag clusters, and notes that
+have no note links at all. The unknown is rendering performance on large
+spaces — that is what this spike answers, alongside a reusable `space_graph`
+backend command.
+
+## Current state
+
+Relevant files:
+
+- `src-tauri/src/index/commands.rs` (1788 lines) —
+  `fn local_note_graph_for_conn(conn, note_id)` (line 1329): seeds from one
+  note, gathers neighbors via a `UNION` over `links` and
+  `note_relationships`, then expands common tags via
+  `local_graph_tag_expansion_for_seed_nodes` with limits
+  (`COMMON_TAG_LIMIT: 12`, `TAGGED_NOTES_PER_TAG_LIMIT: 12`,
+  `TOTAL_TAGGED_NOTES_LIMIT: 64`). The Tauri command wrapper
+  `note_local_graph` (line 1585) follows the standard pattern:
+
+  ```rust
+  #[tauri::command(rename_all = "snake_case")]
+  pub async fn note_local_graph(
+      window: WebviewWindow,
+      state: State<'_, SpaceState>,
+      note_id: String,
+  ) -> Result<LocalNoteGraph, String> {
+      let root = state.root_for_window(&window)?;
+      tauri::async_runtime::spawn_blocking(move || -> Result<LocalNoteGraph, String> {
+          let conn = open_db(&root)?;
+          local_note_graph_for_conn(&conn, &note_id)
+      })
+      .await
+      .map_err(|e| e.to_string())?
+  }
+  ```
+
+  An in-file test module `local_graph_tests` (line ~1599) builds an
+  in-memory db with `ensure_schema` and inserts `notes`/`links` rows — use it
+  as the test pattern.
+- `src-tauri/src/index/schema.rs` — `tags(note_id, tag, is_explicit)` stores
+  indexed inline/frontmatter tags. `tags_tag_idx` supports tag lookups, and
+  `index::tags::PEOPLE_TAG_NAMESPACE` is used to exclude people pseudo-tags
+  from user-facing tag lists.
+- `src-tauri/src/index/types.rs` — existing local graph tag types
+  (`LocalGraphTagNode`, `LocalGraphTagEdge`) show the shape to mirror for the
+  space graph.
+- `src-tauri/src/lib.rs` — command registration; `note_local_graph` is at
+  line 1684 inside the `invoke_handler` list.
+- `src/lib/tauri.ts` — typed IPC: `interface LocalNoteGraph` (line 378),
+  command entry `note_local_graph: CommandDef<{ note_id: string }, LocalNoteGraph>;`
+  (line 1022). New commands must be added to this `TauriCommands` map
+  (AGENTS.md rule).
+- `src/components/graph/LocalNoteGraphDialog.tsx` (677 lines) — the renderer:
+  cytoscape + `cytoscape-fcose` layout, theme colors pulled from CSS custom
+  properties via a probe (`cssColor`), node click dispatches
+  `dispatchWikiLinkClick` to open notes. It is wrapped in a shadcn `Dialog`.
+  The cytoscape setup/theming logic is reusable; the Dialog wrapper is not.
+
+Conventions that apply:
+
+- New Tauri commands: implement in `src-tauri/src/`, register in `lib.rs`,
+  add to `TauriCommands` in `src/lib/tauri.ts` (AGENTS.md).
+- TypeScript strict, no `any`; functional components; Biome formatting.
+- ~200 LOC/file guideline — put new frontend code in new files under
+  `src/components/graph/`, don't grow the dialog file.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Rust typecheck | `cd src-tauri && cargo check` | exit 0 |
+| Rust tests | `cd src-tauri && cargo test index::` | all pass |
+| Frontend check | `pnpm check` | exit 0 |
+| Frontend build | `pnpm build` | exit 0 |
+| Frontend tests | `pnpm test` | all pass |
+
+Never run `pnpm dev` / `pnpm tauri dev` — the user runs the app and will
+manually exercise the prototype.
+
+## Scope
+
+**In scope**:
+
+- `src-tauri/src/index/commands.rs` — new `space_graph_for_conn` +
+  `space_graph` command + tests, including tag nodes/tag edges and isolated
+  note coverage
+- `src-tauri/src/lib.rs` — register `space_graph`
+- `src/lib/tauri.ts` — `SpaceGraph` types + command entry
+- `src/components/graph/SpaceGraphView.tsx` (create) — full-pane prototype
+- `src/components/graph/graphTheme.ts` (create, optional) — theming/cytoscape
+  helpers extracted from the dialog *by copy*, only if cleanly separable
+- One integration point to open the view (see Step 4)
+- `plans/003-report-space-graph.md` (create) — spike findings
+
+**Out of scope** (do NOT touch):
+
+- `LocalNoteGraphDialog.tsx` behavior — the per-note dialog must keep working
+  unchanged; if you extract shared helpers, prefer copying over refactoring
+  the dialog in this spike.
+- Graph persistence (saved layouts, pinned nodes), filtering UI, search-in-graph —
+  note them as open questions instead.
+- Tag hierarchy/product polish beyond the indexed explicit tag nodes. The
+  spike should render explicit user tags, but not invent hierarchy grouping,
+  tag filters, saved tag visibility, or a separate tag management surface.
+- Index schema changes — the existing tables are sufficient.
+
+## Git workflow
+
+- Branch: `advisor/003-space-graph-spike`
+- Commit style: short lower-case imperative summaries (matches `git log`).
+- Do NOT push or open a PR unless the operator instructed it.
+
+## Steps
+
+### Step 1: Backend — `space_graph` command with hard caps
+
+In `src-tauri/src/index/commands.rs`:
+
+1. Add types (serde `Serialize`, snake_case fields like the existing
+   `LocalNoteGraph` family — copy its derive/attr style):
+   `SpaceGraphNode { id, title, link_count, tag_count, is_isolated }`,
+   `SpaceGraphEdge { from_id, to_id, kind }` (kind: `"link"` or
+   `"relationship"`),
+   `SpaceGraphTagNode { id, tag, title, note_count }`,
+   `SpaceGraphTagEdge { tag_id, note_id }`, and
+   `SpaceGraph { nodes, edges, tags, tag_edges, truncated: bool, truncated_tags: bool, total_notes: u32, total_tags: u32 }`.
+   Use `glyph:tag:{tag}` IDs to match the local graph's tag node convention.
+2. Add `fn space_graph_for_conn(conn: &rusqlite::Connection, max_nodes: usize, max_tags: usize) -> Result<SpaceGraph, String>`:
+   - Count total notes.
+   - Build note degree from note-to-note links, relationships, and explicit
+     tag memberships. Keep note-link degree (`link_count`) separate from
+     `tag_count` in the returned node.
+   - If total notes ≤ `max_nodes`: select **all notes from `notes`**, including
+     notes with no links, no relationships, and no tags. This is a hard
+     requirement: the node query must start from `notes` with left-joined
+     counts, not from `links`/`tags`.
+   - If total notes > `max_nodes`: select the top `max_nodes` notes by total
+     graph degree (note links + relationships + explicit tag memberships),
+     tie-breaking by title/id, and set `truncated: true`. Zero-degree notes
+     can only appear in this mode when the cap leaves room, but they must
+     appear in the untruncated graph.
+   - Select edges from `links` (`from_id`, `to_id` where `to_id IS NOT NULL`)
+     and `note_relationships` (same condition), keeping only edges whose both
+     endpoints are in the selected node set; dedupe `(from,to,kind)`.
+   - Count `total_tags` as the number of distinct explicit non-people tags
+     attached to the selected note set before applying `max_tags`.
+   - Select explicit non-people tags (`is_explicit = 1` and
+     `tag NOT LIKE format!("{PEOPLE_TAG_NAMESPACE}%")`) attached to the
+     selected note set, ordered by visible note count desc then tag name asc,
+     capped by `max_tags`. Set `truncated_tags: true` when `total_tags`
+     exceeds `max_tags`.
+   - Select `tag_edges` only between returned tags and returned notes; dedupe
+     `(tag_id,note_id)`.
+   - `is_isolated` is true when a note has zero note-to-note edges and zero
+     returned tag edges. This makes truly standalone notes easy to style and
+     count in the renderer.
+3. Add the Tauri command `space_graph(window, state, max_nodes: Option<u32>, max_tags: Option<u32>)`
+   mirroring `note_local_graph`'s wrapper exactly (default `max_nodes` 1000,
+   clamp to `1..=5000`; default `max_tags` 250, clamp to `0..=1000`).
+4. Register `index::commands::space_graph` in `src-tauri/src/lib.rs` next to
+   `note_local_graph` (line 1684).
+5. Add tests in a new `mod space_graph_tests` modeled on `local_graph_tests`:
+   full graph under the cap includes linked notes, tagged notes, and notes
+   with no links/tags; truncation keeps highest-degree nodes and sets
+   `truncated`; edges with a missing endpoint excluded; explicit tags produce
+   tag nodes/tag edges; people pseudo-tags and non-explicit virtual tags are
+   excluded; tag cap sets `truncated_tags`.
+
+**Verify**: `cd src-tauri && cargo check` → exit 0.
+**Verify**: `cd src-tauri && cargo test index::` → all pass incl. new tests.
+
+### Step 2: Typed IPC
+
+In `src/lib/tauri.ts`: add `SpaceGraphNode`, `SpaceGraphEdge`,
+`SpaceGraphTagNode`, `SpaceGraphTagEdge`, and `SpaceGraph` interfaces next
+to `LocalNoteGraph` (line 378) and a command entry next to line 1022:
+
+```ts
+space_graph: CommandDef<{ max_nodes?: number; max_tags?: number }, SpaceGraph>;
+```
+
+**Verify**: `pnpm check` → exit 0.
+
+### Step 3: Frontend — `SpaceGraphView.tsx` prototype
+
+Create `src/components/graph/SpaceGraphView.tsx`: a full-pane (not Dialog)
+component that:
+
+- Invokes `space_graph` on mount via
+  `invoke("space_graph", { max_nodes: 1000, max_tags: 250 })`.
+- Reuses the cytoscape + fcose setup pattern from `LocalNoteGraphDialog.tsx`
+  (registration guard, CSS-variable theming via the `cssColor` probe
+  technique, node click → `dispatchWikiLinkClick`). Copy the needed helpers
+  into `graphTheme.ts` if that keeps both files under control; do not import
+  from or modify the dialog.
+- Renders note nodes, tag nodes, note-to-note edges, and tag-to-note edges.
+  Style tag nodes distinctly but minimally; tag node clicks can be no-op for
+  the spike, while note node clicks still open notes.
+- Shows a small overlay with note/tag/edge counts, isolated note count, and a
+  "showing top N of M notes" notice when `truncated` is true. Also show a
+  "showing top N of M tags" notice when `truncated_tags` is true.
+- Handles empty spaces (zero notes → friendly empty state, no cytoscape init).
+
+Keep styling minimal — default tokens, no new CSS files (AGENTS.md:
+don't over-engineer CSS).
+
+**Verify**: `pnpm check && pnpm build` → exit 0.
+
+### Step 4: Minimal entry point
+
+Wire ONE way to open the view, the cheapest that exists: add a command-palette
+entry ("Open graph view") in `src/components/app/useAppCommands.tsx`,
+following the structure of an existing command there, that switches the main
+content to the graph view. Inspect how `MainContent.tsx` chooses what to
+render (e.g. existing special views/tabs) and follow the closest existing
+pattern; if no non-file view pattern exists (everything is file-tab based),
+render it as a controlled overlay pane and record that as an open question
+instead of inventing a new tab architecture.
+
+**Verify**: `pnpm check && pnpm build && pnpm test` → all exit 0.
+
+### Step 5: Measure and write the spike report
+
+Create `plans/003-report-space-graph.md` recording:
+
+1. Backend timing: extend `space_graph_tests` with a synthetic-scale test
+   (insert ~2,000 notes / ~10,000 links / ~500 explicit tag rows into the
+   in-memory db, time `space_graph_for_conn` with `std::time::Instant`, assert
+   < 500ms, print the duration). Record the number.
+2. What the renderer prototype does and its limits (note cap, tag node cap,
+   isolated note rendering, layout choice).
+3. Open questions for productization: layout perf in the webview at 1k+
+   nodes (needs the user to run the app — note as "requires manual run"),
+   incremental updates on index change events, filtering/search, tag hierarchy
+   behavior, whether the view should be a first-class tab type, saved layouts.
+4. A go/no-go recommendation with an effort estimate (S/M/L) for the
+   production feature.
+
+**Verify**: report file exists; `cd src-tauri && cargo test index::` passes
+including the timing test.
+
+## Test plan
+
+- Rust: `mod space_graph_tests` in `src-tauri/src/index/commands.rs`
+  (pattern: existing `local_graph_tests` in the same file) — full graph,
+  isolated/unlinked notes, tag nodes/tag edges, tag cap behavior, truncation
+  by degree, dangling-edge exclusion, synthetic-scale timing.
+- Frontend: no new component tests required for the spike (NEVER make test
+  files unless requested — AGENTS.md); `pnpm test` must stay green.
+- Verification: commands in the table above, all exit 0.
+
+## Done criteria
+
+ALL must hold:
+
+- [ ] `cd src-tauri && cargo check` and `cargo test index::` exit 0; new
+      `space_graph_tests` exist and pass
+- [ ] `grep -n "space_graph" src-tauri/src/lib.rs` shows the registration
+- [ ] `grep -n "space_graph" src/lib/tauri.ts` shows the typed command entry
+- [ ] `pnpm check`, `pnpm build`, `pnpm test` all exit 0
+- [ ] `src/components/graph/SpaceGraphView.tsx` exists; `LocalNoteGraphDialog.tsx`
+      is unmodified (`git diff --stat a27b376..HEAD -- src/components/graph/LocalNoteGraphDialog.tsx` empty)
+- [ ] `plans/003-report-space-graph.md` exists with timing numbers and a
+      go/no-go recommendation, including notes on tag rendering and isolated
+      notes
+- [ ] `git status` shows no modified files outside the in-scope list
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- The excerpts in "Current state" don't match the live code (drift).
+- `MainContent.tsx` has no reasonable place to mount a non-file view AND the
+  overlay fallback would require touching more than one app-shell file —
+  record the architectural question in the report and stop after Step 3.
+- The synthetic-scale backend test exceeds 500ms and no indexing/query fix
+  inside `space_graph_for_conn` resolves it — that's a spike finding, not a
+  bug to engineer around; record it and continue to the report.
+- You find yourself wanting to modify `LocalNoteGraphDialog.tsx` or the
+  index schema.
+
+## Maintenance notes
+
+- If this graduates to a product feature, revisit: tag hierarchy, tag
+  filtering/search, live updates from the file watcher/index events, and
+  making the graph a first-class tab/view type.
+- Reviewer should scrutinize the degree-based truncation SQL (it runs over
+  the whole `links` table — confirm it uses the existing from/to indexes via
+  `EXPLAIN QUERY PLAN` if in doubt).
+- Plan 001 (AI index tools) is independent, but a future `space_graph` AI
+  tool could reuse `space_graph_for_conn` directly.

--- a/graph_plan.md
+++ b/graph_plan.md
@@ -183,12 +183,13 @@ In `src-tauri/src/index/commands.rs`:
      exceeds `max_tags`.
    - Select `tag_edges` only between returned tags and returned notes; dedupe
      `(tag_id,note_id)`.
-   - `is_isolated` is true when a note has zero note-to-note edges and zero
-     returned tag edges. This makes truly standalone notes easy to style and
-     count in the renderer.
+   - `is_isolated` is true when a note has zero indexed note-to-note links and
+     zero indexed explicit non-people tags. This makes truly standalone notes
+     easy to style and count in the renderer.
 3. Add the Tauri command `space_graph(window, state, max_nodes: Option<u32>, max_tags: Option<u32>)`
    mirroring `note_local_graph`'s wrapper exactly (default `max_nodes` 1000,
-   clamp to `1..=5000`; default `max_tags` 250, clamp to `0..=1000`).
+   clamp to `1..=10_000`, matching `FULL_SPACE_GRAPH_NODES`; default
+   `max_tags` 250, clamp to `0..=1000`).
 4. Register `index::commands::space_graph` in `src-tauri/src/lib.rs` next to
    `note_local_graph` (line 1684).
 5. Add tests in a new `mod space_graph_tests` modeled on `local_graph_tests`:

--- a/plans/003-report-space-graph.md
+++ b/plans/003-report-space-graph.md
@@ -1,0 +1,34 @@
+# Plan 003 Report: Space Graph Spike
+
+## Backend timing
+
+- Synthetic-scale coverage was added in `space_graph_synthetic_scale_stays_under_spike_budget` with about 2,000 notes, 10,000 links, and 500 explicit tag rows.
+- Timing number from `cargo test index:: -- --nocapture`: `479.411166ms`. The test asserts the query returns in under 500ms.
+
+## Verification
+
+- `cd src-tauri && cargo check`: passed.
+- `cd src-tauri && cargo test index:: -- --nocapture`: passed, including the new `space_graph_tests`.
+- `pnpm check`: passed.
+- `pnpm build`: passed. Vite reported the existing large chunk warning.
+- `pnpm test`: failed in unrelated existing suites: editor tests need `window.matchMedia`, folio tests hit null tag-icon appearance data, settings tests mock `../Icons` without `ChevronDown`, and preview tests did not observe the native popup mock.
+
+## Prototype behavior
+
+- Adds a `space_graph` Tauri command with default caps of 1,000 notes and 250 tags.
+- The backend starts from `notes`, so untruncated graphs include linked notes, tagged notes, and isolated notes with no links or tags.
+- The graph returns note-to-note `link` and `relationship` edges, explicit non-people tag nodes, tag-to-note edges, note/tag totals, and truncation flags.
+- The full-pane prototype uses Cytoscape with `fcose`, opens notes on note-node click, and leaves tag-node click as a neighborhood highlight only.
+- The overlay reports visible notes, tags, edges, isolated notes, and top-N notices when note or tag caps apply.
+
+## Limits and open questions
+
+- Webview layout performance at 1,000+ visible nodes requires a manual app run.
+- The graph does not incrementally update when the index changes.
+- Filtering, search-in-graph, pinned nodes, saved layouts, and persisted layout positions are not included.
+- Tag hierarchy behavior is unresolved; this spike renders only indexed explicit user tags.
+- The graph is currently a special tab, matching existing All Notes/Calendar/Collections architecture. Productization should decide whether graph deserves a first-class view/tab type.
+
+## Recommendation
+
+Go for a production feature after a manual webview performance pass. Backend shape is reusable and additive; the remaining work is mostly interaction design and live-update behavior. Estimated production effort: M for a polished v1, L if saved layouts, filters, and incremental updates are included.

--- a/plans/003-report-space-graph.md
+++ b/plans/003-report-space-graph.md
@@ -31,4 +31,4 @@
 
 ## Recommendation
 
-Go for a production feature after a manual webview performance pass. Backend shape is reusable and additive; the remaining work is mostly interaction design and live-update behavior. Estimated production effort: M for a polished v1, L if saved layouts, filters, and incremental updates are included.
+Production work is gated on the recorded failing `pnpm test` run being fixed or formally waived before any M/L effort begins. After that prerequisite and a manual webview performance pass, the backend shape is reusable and additive; the remaining work is mostly interaction design and live-update behavior. Estimated production effort: M for a polished v1, L if saved layouts, filters, and incremental updates are included.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,5 @@
+# Plans
+
+| Plan | Status | Notes |
+| --- | --- | --- |
+| 003: Space-wide graph view | Implemented, partial verification | Rust/check/build passed; full frontend test suite has unrelated existing failures. See `003-report-space-graph.md`. |

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -21,7 +21,8 @@ use super::tasks::{
 };
 use super::types::{
     BacklinkItem, IndexRebuildResult, LocalGraphEdge, LocalGraphNode, LocalGraphTagEdge,
-    LocalGraphTagNode, LocalNoteGraph, PersonCount, SearchResult, TagCount, TaskDateInfo,
+    LocalGraphTagNode, LocalNoteGraph, PersonCount, SearchResult, SpaceGraph, SpaceGraphEdge,
+    SpaceGraphNode, SpaceGraphTagEdge, SpaceGraphTagNode, TagCount, TaskDateInfo,
 };
 use crate::index::{people_mentions_as_tags_enabled, set_people_mentions_as_tags_enabled};
 
@@ -1581,6 +1582,258 @@ fn local_graph_tag_expansion_for_seed_nodes(
     ))
 }
 
+struct SpaceGraphNodeSeed {
+    id: String,
+    title: String,
+    link_count: u32,
+    tag_count: u32,
+}
+
+fn space_graph_for_conn(
+    conn: &rusqlite::Connection,
+    max_nodes: usize,
+    max_tags: usize,
+) -> Result<SpaceGraph, String> {
+    let total_notes = conn
+        .query_row("SELECT COUNT(*) FROM notes", [], |row| row.get::<_, i64>(0))
+        .map(|count| count as u32)
+        .map_err(|e| e.to_string())?;
+    let truncated = total_notes as usize > max_nodes;
+    let people_tag_like = format!("{PEOPLE_TAG_NAMESPACE}%");
+    let node_limit = max_nodes.max(1);
+    let node_order = if truncated {
+        "(COALESCE(edge_counts.link_count, 0) + COALESCE(tag_counts.tag_count, 0)) DESC,
+         n.title COLLATE NOCASE ASC,
+         n.id ASC"
+    } else {
+        "n.title COLLATE NOCASE ASC, n.id ASC"
+    };
+    let node_query = format!(
+        "WITH edge_counts AS (
+            SELECT note_id, COUNT(*) AS link_count
+            FROM (
+                SELECT l.from_id AS note_id
+                FROM links l
+                JOIN notes target ON target.id = l.to_id
+                WHERE l.to_id IS NOT NULL AND l.from_id <> l.to_id
+                UNION ALL
+                SELECT l.to_id AS note_id
+                FROM links l
+                JOIN notes source ON source.id = l.from_id
+                WHERE l.to_id IS NOT NULL AND l.from_id <> l.to_id
+                UNION ALL
+                SELECT r.from_id AS note_id
+                FROM note_relationships r
+                JOIN notes target ON target.id = r.to_id
+                WHERE r.to_id IS NOT NULL AND r.from_id <> r.to_id
+                UNION ALL
+                SELECT r.to_id AS note_id
+                FROM note_relationships r
+                JOIN notes source ON source.id = r.from_id
+                WHERE r.to_id IS NOT NULL AND r.from_id <> r.to_id
+            )
+            GROUP BY note_id
+         ),
+         tag_counts AS (
+            SELECT note_id, COUNT(DISTINCT tag) AS tag_count
+            FROM tags
+            WHERE is_explicit = 1
+              AND tag NOT LIKE ?
+            GROUP BY note_id
+         )
+         SELECT n.id,
+                n.title,
+                COALESCE(edge_counts.link_count, 0) AS link_count,
+                COALESCE(tag_counts.tag_count, 0) AS tag_count
+         FROM notes n
+         LEFT JOIN edge_counts ON edge_counts.note_id = n.id
+         LEFT JOIN tag_counts ON tag_counts.note_id = n.id
+         ORDER BY {node_order}
+         LIMIT ?"
+    );
+    let mut node_stmt = conn.prepare(&node_query).map_err(|e| e.to_string())?;
+    let mut node_rows = node_stmt
+        .query(rusqlite::params![people_tag_like, node_limit as i64])
+        .map_err(|e| e.to_string())?;
+    let mut node_seeds = Vec::new();
+    while let Some(row) = node_rows.next().map_err(|e| e.to_string())? {
+        node_seeds.push(SpaceGraphNodeSeed {
+            id: row.get(0).map_err(|e| e.to_string())?,
+            title: row.get(1).map_err(|e| e.to_string())?,
+            link_count: row.get::<_, i64>(2).map_err(|e| e.to_string())? as u32,
+            tag_count: row.get::<_, i64>(3).map_err(|e| e.to_string())? as u32,
+        });
+    }
+
+    if node_seeds.is_empty() {
+        return Ok(SpaceGraph {
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            tags: Vec::new(),
+            tag_edges: Vec::new(),
+            truncated,
+            truncated_tags: false,
+            total_notes,
+            total_tags: 0,
+        });
+    }
+
+    let selected_ids = node_seeds
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<Vec<_>>();
+    let selected_placeholders = std::iter::repeat_n("?", selected_ids.len())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let edge_query = format!(
+        "SELECT DISTINCT from_id, to_id, kind
+         FROM (
+            SELECT from_id, to_id, 'link' AS kind
+            FROM links
+            WHERE to_id IS NOT NULL
+            UNION
+            SELECT from_id, to_id, 'relationship' AS kind
+            FROM note_relationships
+            WHERE to_id IS NOT NULL
+         )
+         WHERE from_id <> to_id
+           AND from_id IN ({selected_placeholders})
+           AND to_id IN ({selected_placeholders})
+         ORDER BY from_id COLLATE NOCASE ASC, to_id COLLATE NOCASE ASC, kind ASC"
+    );
+    let mut edge_stmt = conn.prepare(&edge_query).map_err(|e| e.to_string())?;
+    let edge_params = rusqlite::params_from_iter(selected_ids.iter().chain(selected_ids.iter()));
+    let mut edge_rows = edge_stmt.query(edge_params).map_err(|e| e.to_string())?;
+    let mut edges = Vec::new();
+    while let Some(row) = edge_rows.next().map_err(|e| e.to_string())? {
+        edges.push(SpaceGraphEdge {
+            from_id: row.get(0).map_err(|e| e.to_string())?,
+            to_id: row.get(1).map_err(|e| e.to_string())?,
+            kind: row.get(2).map_err(|e| e.to_string())?,
+        });
+    }
+
+    let total_tag_query = format!(
+        "SELECT COUNT(*)
+         FROM (
+            SELECT DISTINCT tag
+            FROM tags
+            WHERE is_explicit = 1
+              AND tag NOT LIKE ?
+              AND note_id IN ({selected_placeholders})
+         )"
+    );
+    let mut total_tag_params = Vec::<rusqlite::types::Value>::new();
+    total_tag_params.push(format!("{PEOPLE_TAG_NAMESPACE}%").into());
+    total_tag_params.extend(selected_ids.iter().cloned().map(Into::into));
+    let total_tags = conn
+        .query_row(
+            &total_tag_query,
+            rusqlite::params_from_iter(total_tag_params),
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|count| count as u32)
+        .map_err(|e| e.to_string())?;
+    let truncated_tags = total_tags as usize > max_tags;
+
+    let mut tags = Vec::new();
+    let mut tag_edges = Vec::new();
+    if max_tags > 0 && total_tags > 0 {
+        let tag_query = format!(
+            "SELECT tag, COUNT(DISTINCT note_id) AS note_count
+             FROM tags
+             WHERE is_explicit = 1
+               AND tag NOT LIKE ?
+               AND note_id IN ({selected_placeholders})
+             GROUP BY tag
+             ORDER BY note_count DESC, tag COLLATE NOCASE ASC
+             LIMIT ?"
+        );
+        let mut tag_params = Vec::<rusqlite::types::Value>::new();
+        tag_params.push(format!("{PEOPLE_TAG_NAMESPACE}%").into());
+        tag_params.extend(selected_ids.iter().cloned().map(Into::into));
+        tag_params.push((max_tags as i64).into());
+        let mut tag_stmt = conn.prepare(&tag_query).map_err(|e| e.to_string())?;
+        let mut tag_rows = tag_stmt
+            .query(rusqlite::params_from_iter(tag_params))
+            .map_err(|e| e.to_string())?;
+        let mut selected_tags = Vec::new();
+        while let Some(row) = tag_rows.next().map_err(|e| e.to_string())? {
+            let tag: String = row.get(0).map_err(|e| e.to_string())?;
+            selected_tags.push(tag.clone());
+            tags.push(SpaceGraphTagNode {
+                id: local_graph_tag_id(&tag),
+                title: format!("#{tag}"),
+                tag,
+                note_count: row.get::<_, i64>(1).map_err(|e| e.to_string())? as u32,
+            });
+        }
+
+        if !selected_tags.is_empty() {
+            let tag_placeholders = std::iter::repeat_n("?", selected_tags.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let tag_edge_query = format!(
+                "SELECT DISTINCT tag, note_id
+                 FROM tags
+                 WHERE is_explicit = 1
+                   AND tag IN ({tag_placeholders})
+                   AND note_id IN ({selected_placeholders})
+                 ORDER BY tag COLLATE NOCASE ASC, note_id COLLATE NOCASE ASC"
+            );
+            let mut tag_edge_params = Vec::<rusqlite::types::Value>::new();
+            tag_edge_params.extend(selected_tags.iter().cloned().map(Into::into));
+            tag_edge_params.extend(selected_ids.iter().cloned().map(Into::into));
+            let mut tag_edge_stmt = conn.prepare(&tag_edge_query).map_err(|e| e.to_string())?;
+            let mut tag_edge_rows = tag_edge_stmt
+                .query(rusqlite::params_from_iter(tag_edge_params))
+                .map_err(|e| e.to_string())?;
+            while let Some(row) = tag_edge_rows.next().map_err(|e| e.to_string())? {
+                let tag: String = row.get(0).map_err(|e| e.to_string())?;
+                tag_edges.push(SpaceGraphTagEdge {
+                    tag_id: local_graph_tag_id(&tag),
+                    note_id: row.get(1).map_err(|e| e.to_string())?,
+                });
+            }
+        }
+    }
+
+    let mut returned_tag_edge_count_by_note = HashMap::<String, u32>::new();
+    for edge in &tag_edges {
+        *returned_tag_edge_count_by_note
+            .entry(edge.note_id.clone())
+            .or_insert(0) += 1;
+    }
+    let nodes = node_seeds
+        .into_iter()
+        .map(|node| {
+            let returned_tag_edge_count = returned_tag_edge_count_by_note
+                .get(&node.id)
+                .copied()
+                .unwrap_or(0);
+            SpaceGraphNode {
+                id: node.id,
+                title: node.title,
+                link_count: node.link_count,
+                tag_count: node.tag_count,
+                is_isolated: node.link_count == 0 && returned_tag_edge_count == 0,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(SpaceGraph {
+        nodes,
+        edges,
+        tags,
+        tag_edges,
+        truncated,
+        truncated_tags,
+        total_notes,
+        total_tags,
+    })
+}
+
 #[tauri::command(rename_all = "snake_case")]
 pub async fn note_local_graph(
     window: WebviewWindow,
@@ -1591,6 +1844,24 @@ pub async fn note_local_graph(
     tauri::async_runtime::spawn_blocking(move || -> Result<LocalNoteGraph, String> {
         let conn = open_db(&root)?;
         local_note_graph_for_conn(&conn, &note_id)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_graph(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    max_nodes: Option<u32>,
+    max_tags: Option<u32>,
+) -> Result<SpaceGraph, String> {
+    let root = state.root_for_window(&window)?;
+    let max_nodes = max_nodes.unwrap_or(1000).clamp(1, 10_000) as usize;
+    let max_tags = max_tags.unwrap_or(250).clamp(0, 1000) as usize;
+    tauri::async_runtime::spawn_blocking(move || -> Result<SpaceGraph, String> {
+        let conn = open_db(&root)?;
+        space_graph_for_conn(&conn, max_nodes, max_tags)
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1784,5 +2055,256 @@ mod local_graph_tests {
         assert_eq!(tag_edges.len(), 5);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].note_count, 5);
+    }
+}
+
+#[cfg(test)]
+mod space_graph_tests {
+    use std::time::Instant;
+
+    use rusqlite::Connection;
+
+    use crate::index::schema::ensure_schema;
+    use crate::index::tags::PEOPLE_TAG_NAMESPACE;
+
+    use super::space_graph_for_conn;
+
+    fn insert_note(conn: &Connection, id: &str, title: &str) {
+        conn.execute(
+            "INSERT INTO notes(id, title, created, updated, path, etag, preview)
+             VALUES(?, ?, '2026-01-01', '2026-01-01', ?, ?, '')",
+            rusqlite::params![id, title, id, format!("{id}-etag")],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn space_graph_under_cap_includes_linked_tagged_and_isolated_notes() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        for (id, title) in [
+            ("notes/alpha.md", "Alpha"),
+            ("notes/beta.md", "Beta"),
+            ("notes/tagged.md", "Tagged"),
+            ("notes/isolated.md", "Isolated"),
+        ] {
+            insert_note(&conn, id, title);
+        }
+        conn.execute(
+            "INSERT INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, NULL, 'note')",
+            rusqlite::params!["notes/alpha.md", "notes/beta.md"],
+        )
+        .unwrap();
+        for note_id in ["notes/alpha.md", "notes/tagged.md"] {
+            conn.execute(
+                "INSERT INTO tags(note_id, tag, is_explicit) VALUES(?, 'project', 1)",
+                [note_id],
+            )
+            .unwrap();
+        }
+
+        let graph = space_graph_for_conn(&conn, 10, 10).unwrap();
+        assert!(!graph.truncated);
+        assert_eq!(graph.total_notes, 4);
+        assert_eq!(graph.nodes.len(), 4);
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.edges[0].kind, "link");
+        assert_eq!(graph.tags.len(), 1);
+        assert_eq!(graph.tag_edges.len(), 2);
+
+        let isolated = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "notes/isolated.md")
+            .unwrap();
+        assert!(isolated.is_isolated);
+
+        let tagged = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "notes/tagged.md")
+            .unwrap();
+        assert!(!tagged.is_isolated);
+    }
+
+    #[test]
+    fn space_graph_truncates_to_highest_degree_nodes() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        for (id, title) in [
+            ("notes/high.md", "High"),
+            ("notes/medium.md", "Medium"),
+            ("notes/low.md", "Low"),
+            ("notes/zero.md", "Zero"),
+        ] {
+            insert_note(&conn, id, title);
+        }
+        for (from_id, to_id) in [
+            ("notes/high.md", "notes/medium.md"),
+            ("notes/high.md", "notes/low.md"),
+            ("notes/medium.md", "notes/high.md"),
+        ] {
+            conn.execute(
+                "INSERT INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, NULL, 'note')",
+                rusqlite::params![from_id, to_id],
+            )
+            .unwrap();
+        }
+        for tag in ["one", "two"] {
+            conn.execute(
+                "INSERT INTO tags(note_id, tag, is_explicit) VALUES('notes/high.md', ?, 1)",
+                [tag],
+            )
+            .unwrap();
+        }
+
+        let graph = space_graph_for_conn(&conn, 2, 10).unwrap();
+        let node_ids = graph
+            .nodes
+            .iter()
+            .map(|node| node.id.as_str())
+            .collect::<Vec<_>>();
+        assert!(graph.truncated);
+        assert_eq!(graph.total_notes, 4);
+        assert_eq!(node_ids, vec!["notes/high.md", "notes/medium.md"]);
+        assert!(!node_ids.contains(&"notes/zero.md"));
+    }
+
+    #[test]
+    fn space_graph_excludes_edges_with_missing_endpoints() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        insert_note(&conn, "notes/source.md", "Source");
+
+        conn.execute(
+            "INSERT INTO links(from_id, to_id, to_title, kind) VALUES(?, ?, NULL, 'note')",
+            rusqlite::params!["notes/source.md", "notes/missing.md"],
+        )
+        .unwrap();
+
+        let graph = space_graph_for_conn(&conn, 10, 10).unwrap();
+        assert!(graph.edges.is_empty());
+        assert_eq!(graph.nodes[0].link_count, 0);
+        assert!(graph.nodes[0].is_isolated);
+    }
+
+    #[test]
+    fn space_graph_returns_explicit_tags_and_excludes_people_and_virtual_tags() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        insert_note(&conn, "notes/tagged.md", "Tagged");
+
+        for (tag, is_explicit) in [
+            ("work".to_string(), 1),
+            (format!("{PEOPLE_TAG_NAMESPACE}ada"), 1),
+            ("virtual-parent".to_string(), 0),
+        ] {
+            conn.execute(
+                "INSERT INTO tags(note_id, tag, is_explicit) VALUES('notes/tagged.md', ?, ?)",
+                rusqlite::params![tag, is_explicit],
+            )
+            .unwrap();
+        }
+
+        let graph = space_graph_for_conn(&conn, 10, 10).unwrap();
+        assert_eq!(graph.total_tags, 1);
+        assert_eq!(graph.tags.len(), 1);
+        assert_eq!(graph.tags[0].tag, "work");
+        assert_eq!(graph.tag_edges.len(), 1);
+    }
+
+    #[test]
+    fn space_graph_tag_cap_sets_truncated_tags() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        insert_note(&conn, "notes/tagged.md", "Tagged");
+
+        for tag in ["alpha", "beta"] {
+            conn.execute(
+                "INSERT INTO tags(note_id, tag, is_explicit) VALUES('notes/tagged.md', ?, 1)",
+                [tag],
+            )
+            .unwrap();
+        }
+
+        let graph = space_graph_for_conn(&conn, 10, 1).unwrap();
+        assert_eq!(graph.total_tags, 2);
+        assert!(graph.truncated_tags);
+        assert_eq!(graph.tags.len(), 1);
+        assert_eq!(graph.tags[0].tag, "alpha");
+        assert_eq!(graph.tag_edges.len(), 1);
+    }
+
+    #[test]
+    fn space_graph_includes_relationship_edges() {
+        let conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+        insert_note(&conn, "notes/source.md", "Source");
+        insert_note(&conn, "notes/target.md", "Target");
+
+        conn.execute(
+            "INSERT INTO note_relationships(from_id, field_key, to_id, to_title, target_title, ordinal)
+             VALUES(?, 'related', ?, NULL, 'Target', 0)",
+            rusqlite::params!["notes/source.md", "notes/target.md"],
+        )
+        .unwrap();
+
+        let graph = space_graph_for_conn(&conn, 10, 10).unwrap();
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.edges[0].kind, "relationship");
+        assert_eq!(graph.edges[0].from_id, "notes/source.md");
+        assert_eq!(graph.edges[0].to_id, "notes/target.md");
+    }
+
+    #[test]
+    fn space_graph_synthetic_scale_stays_under_spike_budget() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        ensure_schema(&conn).unwrap();
+
+        let tx = conn.transaction().unwrap();
+        for index in 0..2_000 {
+            let id = format!("notes/n{index:04}.md");
+            let title = format!("Note {index:04}");
+            tx.execute(
+                "INSERT INTO notes(id, title, created, updated, path, etag, preview)
+                 VALUES(?, ?, '2026-01-01', '2026-01-01', ?, ?, '')",
+                rusqlite::params![&id, &title, &id, format!("{id}-etag")],
+            )
+            .unwrap();
+        }
+        for index in 0..10_000 {
+            let from_id = format!("notes/n{:04}.md", index % 2_000);
+            let to_id = format!("notes/n{:04}.md", (index * 7 + 11) % 2_000);
+            if from_id == to_id {
+                continue;
+            }
+            tx.execute(
+                "INSERT OR IGNORE INTO links(from_id, to_id, to_title, kind)
+                 VALUES(?, ?, NULL, 'note')",
+                rusqlite::params![from_id, to_id],
+            )
+            .unwrap();
+        }
+        for index in 0..500 {
+            let note_id = format!("notes/n{:04}.md", index % 2_000);
+            let tag = format!("topic-{:03}", index % 125);
+            tx.execute(
+                "INSERT OR IGNORE INTO tags(note_id, tag, is_explicit) VALUES(?, ?, 1)",
+                rusqlite::params![note_id, tag],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+
+        let started = Instant::now();
+        let graph = space_graph_for_conn(&conn, 1_000, 250).unwrap();
+        let elapsed = started.elapsed();
+        println!("space_graph synthetic scale duration: {elapsed:?}");
+
+        assert!(graph.truncated);
+        assert_eq!(graph.nodes.len(), 1_000);
+        assert!(elapsed.as_millis() < 500);
     }
 }

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -1678,15 +1678,12 @@ fn space_graph_for_conn(
         });
     }
 
-    let selected_ids = node_seeds
+    let selected_id_set = node_seeds
         .iter()
-        .map(|node| node.id.clone())
-        .collect::<Vec<_>>();
-    let selected_placeholders = std::iter::repeat_n("?", selected_ids.len())
-        .collect::<Vec<_>>()
-        .join(", ");
+        .map(|node| node.id.as_str())
+        .collect::<HashSet<_>>();
 
-    let edge_query = format!(
+    let edge_query =
         "SELECT DISTINCT from_id, to_id, kind
          FROM (
             SELECT from_id, to_id, 'link' AS kind
@@ -1698,127 +1695,115 @@ fn space_graph_for_conn(
             WHERE to_id IS NOT NULL
          )
          WHERE from_id <> to_id
-           AND from_id IN ({selected_placeholders})
-           AND to_id IN ({selected_placeholders})
-         ORDER BY from_id COLLATE NOCASE ASC, to_id COLLATE NOCASE ASC, kind ASC"
-    );
-    let mut edge_stmt = conn.prepare(&edge_query).map_err(|e| e.to_string())?;
-    let edge_params = rusqlite::params_from_iter(selected_ids.iter().chain(selected_ids.iter()));
-    let mut edge_rows = edge_stmt.query(edge_params).map_err(|e| e.to_string())?;
+         ORDER BY from_id COLLATE NOCASE ASC, to_id COLLATE NOCASE ASC, kind ASC";
+    let mut edge_stmt = conn.prepare(edge_query).map_err(|e| e.to_string())?;
+    let mut edge_rows = edge_stmt.query([]).map_err(|e| e.to_string())?;
     let mut edges = Vec::new();
     while let Some(row) = edge_rows.next().map_err(|e| e.to_string())? {
+        let from_id: String = row.get(0).map_err(|e| e.to_string())?;
+        let to_id: String = row.get(1).map_err(|e| e.to_string())?;
+        if !selected_id_set.contains(from_id.as_str())
+            || !selected_id_set.contains(to_id.as_str())
+        {
+            continue;
+        }
         edges.push(SpaceGraphEdge {
-            from_id: row.get(0).map_err(|e| e.to_string())?,
-            to_id: row.get(1).map_err(|e| e.to_string())?,
+            from_id,
+            to_id,
             kind: row.get(2).map_err(|e| e.to_string())?,
         });
     }
 
-    let total_tag_query = format!(
-        "SELECT COUNT(*)
-         FROM (
-            SELECT DISTINCT tag
-            FROM tags
-            WHERE is_explicit = 1
-              AND tag NOT LIKE ?
-              AND note_id IN ({selected_placeholders})
-         )"
-    );
-    let mut total_tag_params = Vec::<rusqlite::types::Value>::new();
-    total_tag_params.push(format!("{PEOPLE_TAG_NAMESPACE}%").into());
-    total_tag_params.extend(selected_ids.iter().cloned().map(Into::into));
-    let total_tags = conn
-        .query_row(
-            &total_tag_query,
-            rusqlite::params_from_iter(total_tag_params),
-            |row| row.get::<_, i64>(0),
-        )
-        .map(|count| count as u32)
+    let tag_query =
+        "SELECT note_id, tag
+         FROM tags
+         WHERE is_explicit = 1
+           AND tag NOT LIKE ?
+         ORDER BY tag COLLATE NOCASE ASC, note_id COLLATE NOCASE ASC";
+    let mut tag_stmt = conn.prepare(tag_query).map_err(|e| e.to_string())?;
+    let mut tag_rows = tag_stmt
+        .query([format!("{PEOPLE_TAG_NAMESPACE}%")])
         .map_err(|e| e.to_string())?;
+    let mut note_ids_by_tag = HashMap::<String, HashSet<String>>::new();
+    while let Some(row) = tag_rows.next().map_err(|e| e.to_string())? {
+        let note_id: String = row.get(0).map_err(|e| e.to_string())?;
+        if !selected_id_set.contains(note_id.as_str()) {
+            continue;
+        }
+        let tag: String = row.get(1).map_err(|e| e.to_string())?;
+        note_ids_by_tag.entry(tag).or_default().insert(note_id);
+    }
+
+    let total_tags = note_ids_by_tag.len() as u32;
     let truncated_tags = total_tags as usize > max_tags;
 
     let mut tags = Vec::new();
     let mut tag_edges = Vec::new();
     if max_tags > 0 && total_tags > 0 {
-        let tag_query = format!(
-            "SELECT tag, COUNT(DISTINCT note_id) AS note_count
-             FROM tags
-             WHERE is_explicit = 1
-               AND tag NOT LIKE ?
-               AND note_id IN ({selected_placeholders})
-             GROUP BY tag
-             ORDER BY note_count DESC, tag COLLATE NOCASE ASC
-             LIMIT ?"
-        );
-        let mut tag_params = Vec::<rusqlite::types::Value>::new();
-        tag_params.push(format!("{PEOPLE_TAG_NAMESPACE}%").into());
-        tag_params.extend(selected_ids.iter().cloned().map(Into::into));
-        tag_params.push((max_tags as i64).into());
-        let mut tag_stmt = conn.prepare(&tag_query).map_err(|e| e.to_string())?;
-        let mut tag_rows = tag_stmt
-            .query(rusqlite::params_from_iter(tag_params))
-            .map_err(|e| e.to_string())?;
-        let mut selected_tags = Vec::new();
-        while let Some(row) = tag_rows.next().map_err(|e| e.to_string())? {
-            let tag: String = row.get(0).map_err(|e| e.to_string())?;
-            selected_tags.push(tag.clone());
+        let mut selected_tags = note_ids_by_tag
+            .iter()
+            .map(|(tag, note_ids)| (tag.clone(), note_ids.len() as u32))
+            .collect::<Vec<_>>();
+        selected_tags.sort_by(|(left_tag, left_count), (right_tag, right_count)| {
+            right_count
+                .cmp(left_count)
+                .then_with(|| {
+                    left_tag
+                        .to_ascii_lowercase()
+                        .cmp(&right_tag.to_ascii_lowercase())
+                })
+                .then_with(|| left_tag.cmp(right_tag))
+        });
+        selected_tags.truncate(max_tags);
+
+        for (tag, note_count) in &selected_tags {
             tags.push(SpaceGraphTagNode {
-                id: local_graph_tag_id(&tag),
+                id: local_graph_tag_id(tag),
                 title: format!("#{tag}"),
-                tag,
-                note_count: row.get::<_, i64>(1).map_err(|e| e.to_string())? as u32,
+                tag: tag.clone(),
+                note_count: *note_count,
             });
         }
 
         if !selected_tags.is_empty() {
-            let tag_placeholders = std::iter::repeat_n("?", selected_tags.len())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let tag_edge_query = format!(
-                "SELECT DISTINCT tag, note_id
-                 FROM tags
-                 WHERE is_explicit = 1
-                   AND tag IN ({tag_placeholders})
-                   AND note_id IN ({selected_placeholders})
-                 ORDER BY tag COLLATE NOCASE ASC, note_id COLLATE NOCASE ASC"
-            );
-            let mut tag_edge_params = Vec::<rusqlite::types::Value>::new();
-            tag_edge_params.extend(selected_tags.iter().cloned().map(Into::into));
-            tag_edge_params.extend(selected_ids.iter().cloned().map(Into::into));
-            let mut tag_edge_stmt = conn.prepare(&tag_edge_query).map_err(|e| e.to_string())?;
-            let mut tag_edge_rows = tag_edge_stmt
-                .query(rusqlite::params_from_iter(tag_edge_params))
-                .map_err(|e| e.to_string())?;
-            while let Some(row) = tag_edge_rows.next().map_err(|e| e.to_string())? {
-                let tag: String = row.get(0).map_err(|e| e.to_string())?;
+            let mut selected_tag_edges = selected_tags
+                .iter()
+                .flat_map(|(tag, _)| {
+                    note_ids_by_tag[tag]
+                        .iter()
+                        .map(|note_id| (tag.clone(), note_id.clone()))
+                })
+                .collect::<Vec<_>>();
+            selected_tag_edges.sort_by(|(left_tag, left_note_id), (right_tag, right_note_id)| {
+                left_tag
+                    .to_ascii_lowercase()
+                    .cmp(&right_tag.to_ascii_lowercase())
+                    .then_with(|| left_tag.cmp(right_tag))
+                    .then_with(|| {
+                        left_note_id
+                            .to_ascii_lowercase()
+                            .cmp(&right_note_id.to_ascii_lowercase())
+                    })
+                    .then_with(|| left_note_id.cmp(right_note_id))
+            });
+            for (tag, note_id) in selected_tag_edges {
                 tag_edges.push(SpaceGraphTagEdge {
                     tag_id: local_graph_tag_id(&tag),
-                    note_id: row.get(1).map_err(|e| e.to_string())?,
+                    note_id,
                 });
             }
         }
     }
+    drop(selected_id_set);
 
-    let mut returned_tag_edge_count_by_note = HashMap::<String, u32>::new();
-    for edge in &tag_edges {
-        *returned_tag_edge_count_by_note
-            .entry(edge.note_id.clone())
-            .or_insert(0) += 1;
-    }
     let nodes = node_seeds
         .into_iter()
-        .map(|node| {
-            let returned_tag_edge_count = returned_tag_edge_count_by_note
-                .get(&node.id)
-                .copied()
-                .unwrap_or(0);
-            SpaceGraphNode {
-                id: node.id,
-                title: node.title,
-                link_count: node.link_count,
-                tag_count: node.tag_count,
-                is_isolated: node.link_count == 0 && returned_tag_edge_count == 0,
-            }
+        .map(|node| SpaceGraphNode {
+            id: node.id,
+            title: node.title,
+            link_count: node.link_count,
+            tag_count: node.tag_count,
+            is_isolated: node.link_count == 0 && node.tag_count == 0,
         })
         .collect::<Vec<_>>();
 
@@ -2060,7 +2045,7 @@ mod local_graph_tests {
 
 #[cfg(test)]
 mod space_graph_tests {
-    use std::time::Instant;
+    use std::{env, time::Instant};
 
     use rusqlite::Connection;
 
@@ -2260,6 +2245,10 @@ mod space_graph_tests {
 
     #[test]
     fn space_graph_synthetic_scale_stays_under_spike_budget() {
+        if env::var("RUN_PERF_TESTS").ok().as_deref() != Some("1") {
+            return;
+        }
+
         let mut conn = Connection::open_in_memory().unwrap();
         ensure_schema(&conn).unwrap();
 
@@ -2305,6 +2294,5 @@ mod space_graph_tests {
 
         assert!(graph.truncated);
         assert_eq!(graph.nodes.len(), 1_000);
-        assert!(elapsed.as_millis() < 500);
     }
 }

--- a/src-tauri/src/index/types.rs
+++ b/src-tauri/src/index/types.rs
@@ -57,6 +57,48 @@ pub struct LocalNoteGraph {
 }
 
 #[derive(Serialize)]
+pub struct SpaceGraphNode {
+    pub id: String,
+    pub title: String,
+    pub link_count: u32,
+    pub tag_count: u32,
+    pub is_isolated: bool,
+}
+
+#[derive(Serialize)]
+pub struct SpaceGraphEdge {
+    pub from_id: String,
+    pub to_id: String,
+    pub kind: String,
+}
+
+#[derive(Serialize)]
+pub struct SpaceGraphTagNode {
+    pub id: String,
+    pub tag: String,
+    pub title: String,
+    pub note_count: u32,
+}
+
+#[derive(Serialize)]
+pub struct SpaceGraphTagEdge {
+    pub tag_id: String,
+    pub note_id: String,
+}
+
+#[derive(Serialize)]
+pub struct SpaceGraph {
+    pub nodes: Vec<SpaceGraphNode>,
+    pub edges: Vec<SpaceGraphEdge>,
+    pub tags: Vec<SpaceGraphTagNode>,
+    pub tag_edges: Vec<SpaceGraphTagEdge>,
+    pub truncated: bool,
+    pub truncated_tags: bool,
+    pub total_notes: u32,
+    pub total_tags: u32,
+}
+
+#[derive(Serialize)]
 pub struct TagCount {
     pub tag: String,
     pub direct_count: u32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1682,6 +1682,7 @@ pub fn run() {
             index::commands::backlinks,
             index::commands::note_relationships,
             index::commands::note_local_graph,
+            index::commands::space_graph,
             space_fs::list::space_list_dir,
             space_fs::list::space_list_markdown_files,
             space_fs::list::space_list_non_markdown_files,

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -58,6 +58,7 @@ import {
 	updateOnboardingSettings,
 } from "../../lib/settings";
 import { getShortcutTooltip, toTauriAccelerator } from "../../lib/shortcuts";
+import { SPACE_GRAPH_TAB_ID } from "../../lib/spaceGraph";
 import { todayIsoDateLocal } from "../../lib/tasks";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
@@ -813,10 +814,11 @@ export function AppShell() {
 	);
 
 	const activeTopSection = useMemo<
-		"home" | "all-notes" | "databases" | null
+		"home" | "all-notes" | "graph" | "databases" | null
 	>(() => {
 		if (activeTabPath === CALENDAR_TAB_ID) return "home";
 		if (activeTabPath === ALL_DOCS_TAB_ID) return "all-notes";
+		if (activeTabPath === SPACE_GRAPH_TAB_ID) return "graph";
 		if (activeTabPath === DATABASES_TAB_ID) return "databases";
 		return null;
 	}, [activeTabPath]);
@@ -853,6 +855,9 @@ export function AppShell() {
 		},
 		[openSpecialTab],
 	);
+	const openGraphView = useCallback(() => {
+		openSpecialTab(SPACE_GRAPH_TAB_ID);
+	}, [openSpecialTab]);
 	const createDatabaseAndOpen = useCallback(async () => {
 		try {
 			const summaries = await invoke("databases_list");
@@ -1112,6 +1117,7 @@ export function AppShell() {
 		openCalendarTab,
 		openDatabasesTab,
 		openGettingStarted,
+		openGraphView,
 		openMarkdownTabsLength: openMarkdownTabs.length,
 		openPalette,
 		openQuickNoteWindow,
@@ -1308,6 +1314,7 @@ export function AppShell() {
 				onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
 				spacePath={spacePath}
 				onOpenAllDocs={openAllDocsTab}
+				onOpenGraph={openGraphView}
 				onOpenCalendar={openCalendarTab}
 				onOpenDatabases={(databaseId) => openDatabasesTab(databaseId)}
 				activeTopSection={activeTopSection}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -49,6 +49,7 @@ import {
 	updateOnboardingSettings,
 } from "../../lib/settings";
 import { formatShortcutPartsForPlatform } from "../../lib/shortcuts/platform";
+import { SPACE_GRAPH_TAB_ID } from "../../lib/spaceGraph";
 import { todayIsoDateLocal } from "../../lib/tasks";
 import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
@@ -91,6 +92,11 @@ const TasksPane = lazy(loadTasksPane);
 const ShortcutsSettingsPane = lazy(() =>
 	import("../settings/ShortcutsSettingsPane").then((module) => ({
 		default: module.ShortcutsSettingsPane,
+	})),
+);
+const SpaceGraphView = lazy(() =>
+	import("../graph/SpaceGraphView").then((module) => ({
+		default: module.SpaceGraphView,
 	})),
 );
 
@@ -744,6 +750,15 @@ export const MainContent = memo(function MainContent({
 				</Suspense>
 			);
 		}
+		if (viewerPath === SPACE_GRAPH_TAB_ID) {
+			return (
+				<Suspense
+					fallback={<div className="databaseLoadingState">Loading graph…</div>}
+				>
+					<SpaceGraphView />
+				</Suspense>
+			);
+		}
 		if (viewerPath.toLowerCase().endsWith(".md")) {
 			const initialDoc = getPrefetchedNote(viewerPath);
 			const extractToNoteActions = {
@@ -813,6 +828,7 @@ export const MainContent = memo(function MainContent({
 			if (target === DATABASES_TAB_ID) {
 				void loadDatabasesPane();
 				void prefetchDatabasesLanding(openDatabasesId);
+				return;
 			}
 		},
 		[dailyNotesFolder, openDatabasesId, templateFolder],

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -830,6 +830,9 @@ export const MainContent = memo(function MainContent({
 				void prefetchDatabasesLanding(openDatabasesId);
 				return;
 			}
+			if (target === SPACE_GRAPH_TAB_ID) {
+				return;
+			}
 		},
 		[dailyNotesFolder, openDatabasesId, templateFolder],
 	);

--- a/src/components/app/MainTabsBreadcrumbs.tsx
+++ b/src/components/app/MainTabsBreadcrumbs.tsx
@@ -5,6 +5,7 @@ import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { CALENDAR_TAB_ID } from "../../lib/calendar";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import { SPACE_GRAPH_TAB_ID } from "../../lib/spaceGraph";
 import { type FsEntry, invoke } from "../../lib/tauri";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { parentDir } from "../../utils/path";
@@ -72,6 +73,7 @@ function isPathSpecial(path: string): boolean {
 		path === ALL_DOCS_TAB_ID ||
 		path === CALENDAR_TAB_ID ||
 		path === DATABASES_TAB_ID ||
+		path === SPACE_GRAPH_TAB_ID ||
 		path === TEMPLATES_TAB_ID
 	);
 }

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -34,9 +34,10 @@ interface SidebarProps {
 	onToggleSidebar: () => void;
 	spacePath: string | null;
 	onOpenAllDocs: () => void;
+	onOpenGraph: () => void;
 	onOpenCalendar: () => void;
 	onOpenDatabases: (databaseId?: string | null) => void;
-	activeTopSection: "home" | "all-notes" | "databases" | null;
+	activeTopSection: "home" | "all-notes" | "graph" | "databases" | null;
 	onPrefetchCalendar: () => void;
 	onPrefetchDatabases: (databaseId?: string | null) => void;
 	onPrefetchAllDocs: () => void;
@@ -64,6 +65,7 @@ export const Sidebar = memo(function Sidebar({
 	onToggleSidebar,
 	spacePath,
 	onOpenAllDocs,
+	onOpenGraph,
 	onOpenCalendar,
 	onOpenDatabases,
 	activeTopSection,
@@ -144,6 +146,7 @@ export const Sidebar = memo(function Sidebar({
 									onPrefetchAllDocs={onPrefetchAllDocs}
 									onPrefetchFile={onPrefetchFile}
 									onOpenAllDocs={onOpenAllDocs}
+									onOpenGraph={onOpenGraph}
 									onOpenCommandPalette={onOpenCommandPalette}
 									spacePath={spacePath}
 									activeTopSection={activeTopSection}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -6,6 +6,7 @@ import {
 	LibraryIcon,
 	NoteIcon,
 	SearchIcon,
+	ThreeDMoveIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -54,9 +55,10 @@ interface SidebarContentProps {
 	onPrefetchAllDocs: () => void;
 	onPrefetchFile: (relPath: string) => void;
 	onOpenAllDocs: () => void;
+	onOpenGraph: () => void;
 	onOpenCommandPalette: () => void;
 	spacePath: string | null;
-	activeTopSection: "home" | "all-notes" | "databases" | null;
+	activeTopSection: "home" | "all-notes" | "graph" | "databases" | null;
 }
 
 function formatSpaceLabel(path: string): string {
@@ -127,6 +129,7 @@ export const SidebarContent = memo(function SidebarContent({
 	onPrefetchAllDocs,
 	onPrefetchFile,
 	onOpenAllDocs,
+	onOpenGraph,
 	onOpenCommandPalette,
 	spacePath,
 	activeTopSection,
@@ -475,6 +478,25 @@ export const SidebarContent = memo(function SidebarContent({
 							/>
 							<span className="sidebarQuickActionLabel">All Notes</span>
 							<AllNotesCountBadge />
+						</button>
+						<button
+							type="button"
+							className="sidebarQuickActionBtn sidebarNavBtn"
+							data-kind="graph"
+							data-active={activeTopSection === "graph" ? "true" : "false"}
+							aria-label="Graph"
+							aria-pressed={activeTopSection === "graph"}
+							aria-current={activeTopSection === "graph" ? "page" : undefined}
+							onClick={onOpenGraph}
+							title="Open Graph"
+						>
+							<HugeiconsIcon
+								icon={ThreeDMoveIcon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+							<span className="sidebarQuickActionLabel">Graph</span>
+							<span className="sidebarQuickActionBeta">Beta</span>
 						</button>
 					</div>
 					<div className="sidebarStack">

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -12,6 +12,7 @@ import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { CALENDAR_TAB_ID } from "../../lib/calendar";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
+import { SPACE_GRAPH_TAB_ID } from "../../lib/spaceGraph";
 import type { FsEntry } from "../../lib/tauri";
 import { TEMPLATES_TAB_ID } from "../../lib/templatesView";
 import { isMarkdownPath } from "../../utils/path";
@@ -58,6 +59,7 @@ function isPathSpecial(path: string): boolean {
 		path === ALL_DOCS_TAB_ID ||
 		path === CALENDAR_TAB_ID ||
 		path === DATABASES_TAB_ID ||
+		path === SPACE_GRAPH_TAB_ID ||
 		path === TEMPLATES_TAB_ID
 	);
 }
@@ -104,6 +106,7 @@ export function TabBar({
 			if (tab.target === ALL_DOCS_TAB_ID) return "All Notes";
 			if (tab.target === CALENDAR_TAB_ID) return "Calendar";
 			if (tab.target === DATABASES_TAB_ID) return "Collections";
+			if (tab.target === SPACE_GRAPH_TAB_ID) return "Graph";
 			if (tab.target === TEMPLATES_TAB_ID) return "Templates";
 			const parts = (tab.target ?? "").split("/").filter(Boolean);
 			const rawName = parts[parts.length - 1] ?? tab.target ?? "Untitled";

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -98,6 +98,7 @@ interface UseAppCommandsDeps {
 	openCalendarTab: () => void;
 	openDatabasesTab: (databaseId?: string | null) => void;
 	openGettingStarted: () => void;
+	openGraphView: () => void;
 	openPalette: (tab: "commands" | "search", query?: string) => void;
 	openQuickNoteWindow: () => void;
 	openQuickTaskWindow: () => void;
@@ -368,6 +369,7 @@ export function useAppCommands({
 	openCalendarTab,
 	openDatabasesTab,
 	openGettingStarted,
+	openGraphView,
 	openPalette,
 	openQuickNoteWindow,
 	openQuickTaskWindow,
@@ -816,6 +818,20 @@ export function useAppCommands({
 				action: openTemplatesTab,
 			},
 			{
+				id: "open-graph-view",
+				label: "Open graph view",
+				icon: (
+					<HugeiconsIcon
+						icon={ThreeDMoveIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				category: "Navigation",
+				enabled: Boolean(spacePath),
+				action: openGraphView,
+			},
+			{
 				id: "open-dashboard",
 				label: "Open home",
 				icon: (
@@ -1106,6 +1122,7 @@ export function useAppCommands({
 		openCalendarTab,
 		openDatabasesTab,
 		openGettingStarted,
+		openGraphView,
 		openBlankTab,
 		openQuickNoteWindow,
 		openQuickTaskWindow,

--- a/src/components/graph/SpaceGraphView.tsx
+++ b/src/components/graph/SpaceGraphView.tsx
@@ -1,0 +1,608 @@
+import { Refresh01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSpace } from "../../contexts";
+import type { SpaceGraph, SpaceGraphNode } from "../../lib/tauri";
+import { invoke } from "../../lib/tauri";
+import { dispatchWikiLinkClick } from "../editor/markdown/editorEvents";
+import { Button } from "../ui/shadcn/button";
+import {
+	applyGraphTheme,
+	graphLayoutSpacing,
+	graphStylesForContainer,
+	highlightNeighborhood,
+	registerFcose,
+	runGraphLayout,
+} from "./graphTheme";
+
+const DEFAULT_SPACE_GRAPH_NODES = 1500;
+const FULL_SPACE_GRAPH_NODES = 10_000;
+const MAX_SPACE_GRAPH_TAGS = 250;
+const LARGE_GRAPH_LAYOUT_THRESHOLD = 2400;
+const SATELLITE_GAP = 130;
+const SATELLITE_SPACING = 44;
+const GRAPH_LAYOUT_CACHE_PREFIX = "glyph.spaceGraph.layout:";
+const GRAPH_LAYOUT_ALGORITHM = "organic-cloud";
+const MIN_NOTE_NODE_SIZE = 10;
+const MAX_NOTE_NODE_SIZE = 34;
+const MIN_TAG_NODE_SIZE = 14;
+const MAX_TAG_NODE_SIZE = 30;
+
+interface GraphPosition {
+	x: number;
+	y: number;
+}
+
+interface CachedGraphLayout {
+	signature: string;
+	positions: Record<string, GraphPosition>;
+}
+
+function noteNodeClasses(node: SpaceGraphNode) {
+	const weight = node.link_count + node.tag_count;
+	const classes = [];
+	if (node.is_isolated) {
+		classes.push("isolated");
+	} else if (weight >= 10) {
+		classes.push("hub-strong");
+	} else if (weight >= 5) {
+		classes.push("hub");
+	} else if (weight >= 2) {
+		classes.push("connected");
+	}
+	return classes.join(" ");
+}
+
+function scaledNodeSize(weight: number, minSize: number, maxSize: number) {
+	if (weight <= 0) return minSize;
+	const normalized = Math.min(Math.log1p(weight) / Math.log1p(40), 1);
+	return Math.round(minSize + normalized * (maxSize - minSize));
+}
+
+function graphElements(
+	graph: SpaceGraph,
+	positions?: Record<string, GraphPosition>,
+): ElementDefinition[] {
+	return [
+		...graph.nodes.map((node) => {
+			const position = positions?.[node.id];
+			return {
+				data: {
+					id: node.id,
+					label: node.title || node.id,
+					linkCount: node.link_count,
+					size: scaledNodeSize(
+						node.link_count * 2 + node.tag_count,
+						MIN_NOTE_NODE_SIZE,
+						MAX_NOTE_NODE_SIZE,
+					),
+					tagCount: node.tag_count,
+				},
+				...(position ? { position } : {}),
+				classes: noteNodeClasses(node),
+				grabbable: true,
+			};
+		}),
+		...graph.tags.map((tag) => {
+			const position = positions?.[tag.id];
+			return {
+				data: {
+					id: tag.id,
+					label: tag.title,
+					noteCount: tag.note_count,
+					size: scaledNodeSize(
+						tag.note_count,
+						MIN_TAG_NODE_SIZE,
+						MAX_TAG_NODE_SIZE,
+					),
+					tag: tag.tag,
+				},
+				...(position ? { position } : {}),
+				classes: tag.note_count >= 8 ? "tag tag-strong" : "tag",
+				grabbable: true,
+			};
+		}),
+		...graph.edges.map((edge, index) => ({
+			data: {
+				id: `${edge.kind}:${edge.from_id}->${edge.to_id}:${index}`,
+				source: edge.from_id,
+				target: edge.to_id,
+			},
+			classes: edge.kind,
+		})),
+		...graph.tag_edges.map((edge, index) => ({
+			data: {
+				id: `tag:${edge.tag_id}->${edge.note_id}:${index}`,
+				source: edge.tag_id,
+				target: edge.note_id,
+			},
+			classes: "tag-link",
+		})),
+	];
+}
+
+function hashString(value: string) {
+	let hash = 5381;
+	for (const char of value) {
+		hash = (hash * 33) ^ char.charCodeAt(0);
+	}
+	return (hash >>> 0).toString(36);
+}
+
+function graphSignature(graph: SpaceGraph) {
+	const source = [
+		graph.total_notes,
+		GRAPH_LAYOUT_ALGORITHM,
+		graph.nodes.length,
+		graph.tags.length,
+		graph.edges.length,
+		graph.tag_edges.length,
+		...graph.nodes.map((node) => node.id),
+		...graph.tags.map((tag) => tag.id),
+		...graph.edges.map((edge) => `${edge.kind}:${edge.from_id}->${edge.to_id}`),
+		...graph.tag_edges.map((edge) => `${edge.tag_id}->${edge.note_id}`),
+	].join("\n");
+	return hashString(source);
+}
+
+function graphLayoutCacheKey(spacePath: string | null) {
+	return `${GRAPH_LAYOUT_CACHE_PREFIX}${spacePath ?? "no-space"}`;
+}
+
+function isGraphPosition(value: unknown): value is GraphPosition {
+	if (!value || typeof value !== "object") return false;
+	const record = value as Record<PropertyKey, unknown>;
+	return typeof record.x === "number" && typeof record.y === "number";
+}
+
+function readGraphLayoutCache(
+	spacePath: string | null,
+	signature: string,
+): CachedGraphLayout | null {
+	try {
+		const raw = window.sessionStorage.getItem(graphLayoutCacheKey(spacePath));
+		if (!raw) return null;
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object") return null;
+		const record = parsed as Record<PropertyKey, unknown>;
+		if (record.signature !== signature || !record.positions) return null;
+		if (typeof record.positions !== "object") return null;
+
+		const positions: Record<string, GraphPosition> = {};
+		for (const [id, position] of Object.entries(record.positions)) {
+			if (isGraphPosition(position)) {
+				positions[id] = { x: position.x, y: position.y };
+			}
+		}
+		if (Object.keys(positions).length === 0) return null;
+		return { signature, positions };
+	} catch {
+		return null;
+	}
+}
+
+function clearPersistentGraphLayoutCaches() {
+	try {
+		const keys: string[] = [];
+		for (let index = 0; index < window.localStorage.length; index += 1) {
+			const key = window.localStorage.key(index);
+			if (!key) continue;
+			if (key.startsWith(GRAPH_LAYOUT_CACHE_PREFIX)) {
+				keys.push(key);
+			}
+		}
+		for (const key of keys) {
+			window.localStorage.removeItem(key);
+		}
+	} catch {
+		// Old persistent cache cleanup is best-effort.
+	}
+}
+
+function writeGraphLayoutCache(
+	spacePath: string | null,
+	signature: string,
+	cy: Core,
+) {
+	try {
+		const positions: Record<string, GraphPosition> = {};
+		for (const node of cy.nodes()) {
+			const position = node.position();
+			positions[node.id()] = { x: position.x, y: position.y };
+		}
+		window.sessionStorage.setItem(
+			graphLayoutCacheKey(spacePath),
+			JSON.stringify({ signature, positions } satisfies CachedGraphLayout),
+		);
+	} catch {
+		// Cache writes are best-effort; rendering should never depend on storage.
+	}
+}
+
+function openNote(nodeId: string) {
+	dispatchWikiLinkClick({
+		raw: `[[${nodeId}]]`,
+		target: nodeId,
+		alias: null,
+		anchorKind: "none",
+		anchor: null,
+		unresolved: false,
+	});
+}
+
+function scatterSatelliteNodes(cy: Core) {
+	const satelliteNodes = cy.nodes(".isolated, .tag");
+	if (satelliteNodes.length === 0) return;
+
+	const anchoredNodes = cy.nodes().not(".isolated, .tag");
+	const bounds = (
+		anchoredNodes.length > 0 ? anchoredNodes : cy.nodes()
+	).boundingBox();
+	const center = {
+		x: bounds.x1 + bounds.w / 2,
+		y: bounds.y1 + bounds.h / 2,
+	};
+	const baseRadius = Math.max(bounds.w, bounds.h) / 2 + SATELLITE_GAP;
+	const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+
+	satelliteNodes.forEach((node, index) => {
+		const radius =
+			baseRadius + Math.sqrt(index) * SATELLITE_SPACING + (index % 5) * 7;
+		const angle = index * goldenAngle + (node.hasClass("tag") ? 0.45 : 0);
+		const xJitter = ((index * 37) % 29) - 14;
+		const yJitter = ((index * 53) % 31) - 15;
+
+		node.position({
+			x: center.x + Math.cos(angle) * radius + xJitter,
+			y: center.y + Math.sin(angle) * radius + yJitter,
+		});
+	});
+}
+
+function organicizeNoteCloud(cy: Core) {
+	const noteNodes = cy.nodes().not(".isolated, .tag");
+	if (noteNodes.length === 0) return;
+
+	const bounds = noteNodes.boundingBox();
+	const center = {
+		x: bounds.x1 + bounds.w / 2,
+		y: bounds.y1 + bounds.h / 2,
+	};
+	const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+	const sortedNodes = [...noteNodes].sort((left, right) => {
+		const leftWeight =
+			Number(left.data("linkCount") ?? 0) + Number(left.data("tagCount") ?? 0);
+		const rightWeight =
+			Number(right.data("linkCount") ?? 0) +
+			Number(right.data("tagCount") ?? 0);
+		return rightWeight - leftWeight || left.id().localeCompare(right.id());
+	});
+	const maxRadius = Math.max(360, Math.sqrt(sortedNodes.length) * 34);
+	const xScale = 1.22;
+	const yScale = 0.86;
+
+	for (const [index, node] of sortedNodes.entries()) {
+		const seed = Number.parseInt(hashString(node.id()), 36);
+		const progress =
+			sortedNodes.length <= 1 ? 0 : index / (sortedNodes.length - 1);
+		const angle = index * goldenAngle + (seed % 23) * 0.021;
+		const radius =
+			Math.sqrt(progress) * maxRadius +
+			Math.sin(index * 0.19 + (seed % 13)) * 22;
+		const xJitter = ((seed * 37) % 61) - 30;
+		const yJitter = ((seed * 53) % 57) - 28;
+
+		node.position({
+			x: center.x + Math.cos(angle) * radius * xScale + xJitter,
+			y: center.y + Math.sin(angle) * radius * yScale + yJitter,
+		});
+	}
+}
+
+function graphProgressMessage(graph: SpaceGraph | null, loading: boolean) {
+	if (loading) return "Loading graph data...";
+	if (!graph) return "Generating graph...";
+	if (graph.truncated) {
+		return `Generating graph... showing top ${graph.nodes.length} of ${graph.total_notes} notes.`;
+	}
+	return "Generating graph...";
+}
+
+function GraphProgressOverlay({
+	graph,
+	loading,
+	progress,
+	usingCachedLayout,
+}: {
+	graph: SpaceGraph | null;
+	loading: boolean;
+	progress: number;
+	usingCachedLayout: boolean;
+}) {
+	const clampedProgress = Math.max(0, Math.min(100, Math.round(progress)));
+	const message = usingCachedLayout
+		? "Restoring cached layout..."
+		: graphProgressMessage(graph, loading);
+
+	return (
+		<div className="absolute inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+			<div className="flex w-72 max-w-[calc(100vw-3rem)] flex-col gap-3 rounded-md border border-border bg-background p-4 text-center shadow-sm">
+				<div className="text-sm font-medium text-foreground">Space graph</div>
+				<p className="text-xs text-muted-foreground">{message}</p>
+				<progress
+					className="h-1 w-full"
+					aria-label="Generating graph"
+					max={100}
+					value={clampedProgress}
+				/>
+				<div className="text-[11px] tabular-nums text-muted-foreground">
+					{clampedProgress}%
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function SpaceGraphView() {
+	const { spacePath } = useSpace();
+	const [graph, setGraph] = useState<SpaceGraph | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [generating, setGenerating] = useState(false);
+	const [generationProgress, setGenerationProgress] = useState(0);
+	const [error, setError] = useState("");
+	const [maxNodes, setMaxNodes] = useState(DEFAULT_SPACE_GRAPH_NODES);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const cyRef = useRef<Core | null>(null);
+	const signature = useMemo(
+		() => (graph ? graphSignature(graph) : ""),
+		[graph],
+	);
+	const cachedLayout = useMemo(
+		() => (signature ? readGraphLayoutCache(spacePath, signature) : null),
+		[signature, spacePath],
+	);
+	const usingCachedLayout = Boolean(cachedLayout);
+
+	useEffect(() => {
+		clearPersistentGraphLayoutCaches();
+	}, []);
+
+	const loadGraph = useCallback(() => {
+		let cancelled = false;
+		setLoading(true);
+		setGenerating(false);
+		setGenerationProgress(8);
+		setError("");
+		void invoke("space_graph", {
+			max_nodes: maxNodes,
+			max_tags: MAX_SPACE_GRAPH_TAGS,
+		})
+			.then((nextGraph) => {
+				if (cancelled) return;
+				setGraph(nextGraph);
+				setGenerationProgress(nextGraph.nodes.length > 0 ? 40 : 100);
+				setGenerating(nextGraph.nodes.length > 0);
+			})
+			.catch((cause) => {
+				if (cancelled) return;
+				setGraph(null);
+				setGenerating(false);
+				setGenerationProgress(0);
+				setError(cause instanceof Error ? cause.message : String(cause));
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [maxNodes]);
+
+	useEffect(() => loadGraph(), [loadGraph]);
+
+	useEffect(() => {
+		if (!loading && !generating) return;
+		const ceiling = loading ? 35 : 92;
+		const interval = window.setInterval(() => {
+			setGenerationProgress((current) => {
+				if (current >= ceiling) return current;
+				const increment = loading ? 3 : 1;
+				return Math.min(ceiling, current + increment);
+			});
+		}, 180);
+		return () => window.clearInterval(interval);
+	}, [generating, loading]);
+
+	useEffect(() => {
+		if (!graph || loading || error || graph.nodes.length === 0) return;
+		const container = containerRef.current;
+		if (!container) return;
+		let disposed = false;
+		let completeTimer: number | null = null;
+		const visibleNodeCount = graph.nodes.length + graph.tags.length;
+		const layoutMode = cachedLayout
+			? "preset"
+			: visibleNodeCount >= LARGE_GRAPH_LAYOUT_THRESHOLD
+				? "random"
+				: "fcose";
+
+		if (layoutMode === "fcose") {
+			registerFcose();
+		}
+		setGenerating(true);
+		setGenerationProgress((current) =>
+			Math.max(current, cachedLayout ? 88 : 55),
+		);
+
+		const cy = cytoscape({
+			boxSelectionEnabled: false,
+			container,
+			elements: graphElements(graph, cachedLayout?.positions),
+			maxZoom: 2.1,
+			minZoom: 0.18,
+			style: graphStylesForContainer(container),
+			userZoomingEnabled: true,
+			wheelSensitivity: 0.16,
+		});
+		cyRef.current = cy;
+		runGraphLayout(cy, {
+			mode: layoutMode,
+			afterLayout: () => {
+				if (!cachedLayout) {
+					organicizeNoteCloud(cy);
+				}
+				scatterSatelliteNodes(cy);
+				writeGraphLayoutCache(spacePath, signature, cy);
+				if (!disposed) {
+					setGenerationProgress(100);
+					completeTimer = window.setTimeout(() => {
+						if (!disposed) setGenerating(false);
+					}, 160);
+				}
+			},
+		});
+
+		cy.on("mouseover", "node", (event) => {
+			event.target.addClass("hover-label show-label");
+			highlightNeighborhood(cy, event.target.id());
+		});
+		cy.on("mouseout", "node", (event) => {
+			event.target.removeClass("hover-label");
+			if (!event.target.hasClass("zoom-label")) {
+				event.target.removeClass("show-label");
+			}
+			highlightNeighborhood(cy, null);
+		});
+		cy.on("dragfree", "node", () => {
+			writeGraphLayoutCache(spacePath, signature, cy);
+		});
+		cy.on("tap", "node", (event) => {
+			if (event.target.hasClass("tag")) {
+				highlightNeighborhood(cy, event.target.id());
+				return;
+			}
+			openNote(event.target.id());
+		});
+		cy.on("tap", (event) => {
+			if (event.target === cy) {
+				highlightNeighborhood(cy, null);
+			}
+		});
+
+		const observer = new ResizeObserver(() => {
+			cy.resize();
+			cy.fit(undefined, graphLayoutSpacing(cy).padding);
+		});
+		observer.observe(container);
+
+		const themeObserver = new MutationObserver(() => {
+			applyGraphTheme(cy, container);
+		});
+		themeObserver.observe(document.documentElement, {
+			attributeFilter: [
+				"class",
+				"data-light-theme",
+				"data-dark-theme",
+				"style",
+			],
+			attributes: true,
+		});
+
+		return () => {
+			disposed = true;
+			if (completeTimer !== null) {
+				window.clearTimeout(completeTimer);
+			}
+			themeObserver.disconnect();
+			observer.disconnect();
+			cy.destroy();
+			cyRef.current = null;
+		};
+	}, [cachedLayout, error, graph, loading, signature, spacePath]);
+
+	if (loading) {
+		return (
+			<section className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background">
+				<GraphProgressOverlay
+					graph={graph}
+					loading={loading}
+					progress={generationProgress}
+					usingCachedLayout={usingCachedLayout}
+				/>
+			</section>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex h-full min-h-0 flex-1 items-center justify-center p-6">
+				<div className="flex max-w-md flex-col items-center gap-3 text-center">
+					<p className="text-sm text-muted-foreground">
+						Could not load the graph: {error}
+					</p>
+					<Button
+						type="button"
+						size="sm"
+						onClick={() => {
+							loadGraph();
+						}}
+					>
+						<HugeiconsIcon
+							icon={Refresh01Icon}
+							data-icon="inline-start"
+							size="var(--icon-md)"
+							strokeWidth={0.9}
+						/>
+						Retry
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (!graph || graph.nodes.length === 0) {
+		return (
+			<div className="flex h-full min-h-0 flex-1 items-center justify-center p-6">
+				<p className="text-sm text-muted-foreground">
+					No notes in this space yet.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<section className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background">
+			<div
+				ref={containerRef}
+				className="h-full min-h-0 flex-1"
+				aria-label="Space graph"
+			/>
+			{graph.truncated && maxNodes < FULL_SPACE_GRAPH_NODES ? (
+				<div className="absolute right-4 top-4">
+					<Button
+						type="button"
+						size="sm"
+						variant="secondary"
+						onClick={() => setMaxNodes(FULL_SPACE_GRAPH_NODES)}
+					>
+						Load full graph
+					</Button>
+				</div>
+			) : null}
+			{graph.truncated && maxNodes >= FULL_SPACE_GRAPH_NODES ? (
+				<div className="absolute right-4 top-4 rounded-md border border-border bg-background/95 px-3 py-2 text-xs text-muted-foreground shadow-sm backdrop-blur">
+					Showing top {graph.nodes.length} of {graph.total_notes} notes
+				</div>
+			) : null}
+			{generating ? (
+				<GraphProgressOverlay
+					graph={graph}
+					loading={loading}
+					progress={generationProgress}
+					usingCachedLayout={usingCachedLayout}
+				/>
+			) : null}
+		</section>
+	);
+}

--- a/src/components/graph/SpaceGraphView.tsx
+++ b/src/components/graph/SpaceGraphView.tsx
@@ -23,6 +23,7 @@ const LARGE_GRAPH_LAYOUT_THRESHOLD = 2400;
 const SATELLITE_GAP = 130;
 const SATELLITE_SPACING = 44;
 const GRAPH_LAYOUT_CACHE_PREFIX = "glyph.spaceGraph.layout:";
+const GRAPH_LAYOUT_CACHE_VERSION = 1;
 const GRAPH_LAYOUT_ALGORITHM = "organic-cloud-v2";
 const MIN_NOTE_NODE_SIZE = 10;
 const MAX_NOTE_NODE_SIZE = 34;
@@ -35,6 +36,7 @@ interface GraphPosition {
 }
 
 interface CachedGraphLayout {
+	version: number;
 	signature: string;
 	positions: Record<string, GraphPosition>;
 }
@@ -166,7 +168,13 @@ function readGraphLayoutCache(
 		const parsed: unknown = JSON.parse(raw);
 		if (!parsed || typeof parsed !== "object") return null;
 		const record = parsed as Record<PropertyKey, unknown>;
-		if (record.signature !== signature || !record.positions) return null;
+		if (
+			record.version !== GRAPH_LAYOUT_CACHE_VERSION ||
+			record.signature !== signature ||
+			!record.positions
+		) {
+			return null;
+		}
 		if (typeof record.positions !== "object") return null;
 
 		const positions: Record<string, GraphPosition> = {};
@@ -176,7 +184,7 @@ function readGraphLayoutCache(
 			}
 		}
 		if (Object.keys(positions).length === 0) return null;
-		return { signature, positions };
+		return { version: GRAPH_LAYOUT_CACHE_VERSION, signature, positions };
 	} catch {
 		return null;
 	}
@@ -213,7 +221,11 @@ function writeGraphLayoutCache(
 		}
 		window.sessionStorage.setItem(
 			graphLayoutCacheKey(spacePath),
-			JSON.stringify({ signature, positions } satisfies CachedGraphLayout),
+			JSON.stringify({
+				version: GRAPH_LAYOUT_CACHE_VERSION,
+				signature,
+				positions,
+			} satisfies CachedGraphLayout),
 		);
 	} catch {
 		// Cache writes are best-effort; rendering should never depend on storage.
@@ -361,6 +373,7 @@ export function SpaceGraphView() {
 	const [maxNodes, setMaxNodes] = useState(DEFAULT_SPACE_GRAPH_NODES);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const cyRef = useRef<Core | null>(null);
+	const loadGraphCleanupRef = useRef<(() => void) | null>(null);
 	const signature = useMemo(
 		() => (graph ? graphSignature(graph) : ""),
 		[graph],
@@ -376,11 +389,16 @@ export function SpaceGraphView() {
 	}, []);
 
 	const loadGraph = useCallback(() => {
+		loadGraphCleanupRef.current?.();
 		let cancelled = false;
 		setLoading(true);
 		setGenerating(false);
 		setGenerationProgress(8);
 		setError("");
+		const cleanup = () => {
+			cancelled = true;
+		};
+		loadGraphCleanupRef.current = cleanup;
 		void invoke("space_graph", {
 			max_nodes: maxNodes,
 			max_tags: MAX_SPACE_GRAPH_TAGS,
@@ -400,10 +418,11 @@ export function SpaceGraphView() {
 			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
+				if (loadGraphCleanupRef.current === cleanup) {
+					loadGraphCleanupRef.current = null;
+				}
 			});
-		return () => {
-			cancelled = true;
-		};
+		return cleanup;
 	}, [maxNodes]);
 
 	useEffect(() => loadGraph(), [loadGraph]);
@@ -475,8 +494,8 @@ export function SpaceGraphView() {
 			afterLayout: () => {
 				if (!cachedLayout) {
 					organicizeNoteCloud(cy);
+					scatterSatelliteNodes(cy);
 				}
-				scatterSatelliteNodes(cy);
 				writeGraphLayoutCache(spacePath, signature, cy);
 				if (!disposed) {
 					setGenerationProgress(100);
@@ -599,7 +618,7 @@ export function SpaceGraphView() {
 		<section className="relative flex h-full min-h-0 flex-1 overflow-hidden bg-background">
 			<div
 				ref={containerRef}
-				className="h-full min-h-0 flex-1"
+				className="localNoteGraphViewport h-full min-h-0 flex-1"
 				aria-label="Space graph"
 			/>
 			{graph.truncated && maxNodes < FULL_SPACE_GRAPH_NODES ? (

--- a/src/components/graph/SpaceGraphView.tsx
+++ b/src/components/graph/SpaceGraphView.tsx
@@ -16,14 +16,14 @@ import {
 	runGraphLayout,
 } from "./graphTheme";
 
-const DEFAULT_SPACE_GRAPH_NODES = 1500;
+const DEFAULT_SPACE_GRAPH_NODES = 1000;
 const FULL_SPACE_GRAPH_NODES = 10_000;
 const MAX_SPACE_GRAPH_TAGS = 250;
 const LARGE_GRAPH_LAYOUT_THRESHOLD = 2400;
 const SATELLITE_GAP = 130;
 const SATELLITE_SPACING = 44;
 const GRAPH_LAYOUT_CACHE_PREFIX = "glyph.spaceGraph.layout:";
-const GRAPH_LAYOUT_ALGORITHM = "organic-cloud";
+const GRAPH_LAYOUT_ALGORITHM = "organic-cloud-v2";
 const MIN_NOTE_NODE_SIZE = 10;
 const MAX_NOTE_NODE_SIZE = 34;
 const MIN_TAG_NODE_SIZE = 14;
@@ -344,6 +344,13 @@ function GraphProgressOverlay({
 	);
 }
 
+function fullGraphNoteCountLabel(totalNotes: number) {
+	if (totalNotes > FULL_SPACE_GRAPH_NODES) {
+		return `the top ${FULL_SPACE_GRAPH_NODES.toLocaleString()} of ${totalNotes.toLocaleString()} notes`;
+	}
+	return `${totalNotes.toLocaleString()} notes`;
+}
+
 export function SpaceGraphView() {
 	const { spacePath } = useSpace();
 	const [graph, setGraph] = useState<SpaceGraph | null>(null);
@@ -401,6 +408,22 @@ export function SpaceGraphView() {
 
 	useEffect(() => loadGraph(), [loadGraph]);
 
+	const handleLoadFullGraph = useCallback(async () => {
+		if (!graph) return;
+		const { confirm } = await import("@tauri-apps/plugin-dialog");
+		const noteCountLabel = fullGraphNoteCountLabel(graph.total_notes);
+		const confirmed = await confirm(
+			`This will render ${noteCountLabel} at once. Large graphs can use a lot of memory and may make Glyph slow or temporarily unresponsive.`,
+			{
+				title: "Load the full graph?",
+				okLabel: "Load full graph",
+				cancelLabel: "Cancel",
+			},
+		);
+		if (!confirmed) return;
+		setMaxNodes(FULL_SPACE_GRAPH_NODES);
+	}, [graph]);
+
 	useEffect(() => {
 		if (!loading && !generating) return;
 		const ceiling = loading ? 35 : 92;
@@ -439,6 +462,7 @@ export function SpaceGraphView() {
 			boxSelectionEnabled: false,
 			container,
 			elements: graphElements(graph, cachedLayout?.positions),
+			layout: { name: "preset" },
 			maxZoom: 2.1,
 			minZoom: 0.18,
 			style: graphStylesForContainer(container),
@@ -579,12 +603,14 @@ export function SpaceGraphView() {
 				aria-label="Space graph"
 			/>
 			{graph.truncated && maxNodes < FULL_SPACE_GRAPH_NODES ? (
-				<div className="absolute right-4 top-4">
+				<div className="absolute right-4 bottom-4">
 					<Button
 						type="button"
-						size="sm"
-						variant="secondary"
-						onClick={() => setMaxNodes(FULL_SPACE_GRAPH_NODES)}
+						className="spaceGraphLoadFullButton"
+						size="xs"
+						onClick={() => {
+							void handleLoadFullGraph();
+						}}
 					>
 						Load full graph
 					</Button>

--- a/src/components/graph/graphTheme.ts
+++ b/src/components/graph/graphTheme.ts
@@ -1,0 +1,397 @@
+import cytoscape, { type Core, type StylesheetJson } from "cytoscape";
+import fcose from "cytoscape-fcose";
+
+interface GraphTheme {
+	accent: string;
+	background: string;
+	border: string;
+	edge: string;
+	edgeIncoming: string;
+	edgeInternal: string;
+	node: string;
+	nodeActive: string;
+	nodeActiveBorder: string;
+	text: string;
+	textInverse: string;
+	textMuted: string;
+}
+
+let fcoseRegistered = false;
+
+export function registerFcose() {
+	if (fcoseRegistered) return;
+	try {
+		cytoscape.use(fcose);
+	} catch (error) {
+		if (!(error instanceof Error) || !error.message.includes("already")) {
+			throw error;
+		}
+	}
+	fcoseRegistered = true;
+}
+
+function normalizeCssColor(value: string) {
+	const context = document.createElement("canvas").getContext("2d");
+	if (!context) return value;
+
+	context.fillStyle = "#123456";
+	context.fillStyle = value;
+	const normalized = context.fillStyle;
+	context.fillStyle = "#abcdef";
+	context.fillStyle = value;
+	const normalizedFromSecondSentinel = context.fillStyle;
+
+	return normalized === "#123456" && normalizedFromSecondSentinel === "#abcdef"
+		? value
+		: normalized;
+}
+
+function cssColor(element: HTMLElement, name: string, fallback: string) {
+	const probe = document.createElement("span");
+	probe.style.cssText = `color: ${fallback}; color: var(${name});`;
+	element.appendChild(probe);
+	const color = getComputedStyle(probe).color.trim();
+	probe.remove();
+
+	return normalizeCssColor(color || fallback);
+}
+
+function graphThemeFor(element: HTMLElement): GraphTheme {
+	const accent = cssColor(element, "--interactive-accent", "#5b8def");
+	const background = cssColor(element, "--bg-secondary", "#f6f6f4");
+	const node = cssColor(element, "--bg-primary", "#ffffff");
+	const text = cssColor(element, "--text-primary", "#1f2328");
+	const textInverse = cssColor(
+		element,
+		"--local-graph-text-inverse",
+		"#ffffff",
+	);
+	const textMuted = cssColor(element, "--text-secondary", "#667085");
+	const border = cssColor(element, "--local-graph-border", "#d7d7d2");
+	const edgeIncoming = cssColor(
+		element,
+		"--local-graph-edge-incoming",
+		"#1f2328",
+	);
+
+	return {
+		accent,
+		background,
+		border,
+		edge: textMuted,
+		edgeIncoming,
+		edgeInternal: border,
+		node,
+		nodeActive: node,
+		nodeActiveBorder: accent,
+		text,
+		textInverse,
+		textMuted,
+	};
+}
+
+export function graphStyles(theme: GraphTheme): StylesheetJson {
+	return [
+		{
+			selector: "core",
+			style: {
+				"active-bg-color": theme.accent,
+				"active-bg-opacity": 0.08,
+				"active-bg-size": 18,
+				"outside-texture-bg-color": theme.background,
+				"outside-texture-bg-opacity": 0,
+				"selection-box-border-color": theme.accent,
+				"selection-box-border-width": 1,
+				"selection-box-color": theme.accent,
+				"selection-box-opacity": 0.12,
+			},
+		},
+		{
+			selector: "node",
+			style: {
+				"background-color": theme.accent,
+				"background-opacity": 0.28,
+				"border-color": theme.nodeActiveBorder,
+				"border-width": 1,
+				color: theme.text,
+				"font-family": "var(--font-ui)",
+				"font-size": 10,
+				"font-weight": 400,
+				height: "data(size)",
+				label: "",
+				"line-height": 1.3,
+				"overlay-opacity": 0,
+				shape: "ellipse",
+				"text-events": "yes",
+				"text-halign": "center",
+				"text-margin-y": -10,
+				"text-max-width": "150px",
+				"text-opacity": 0,
+				"text-outline-color": theme.background,
+				"text-outline-opacity": 0,
+				"text-outline-width": 0,
+				"text-wrap": "ellipsis",
+				"text-valign": "top",
+				"transition-duration": 180,
+				"transition-property": "background-color, border-color, opacity",
+				width: "data(size)",
+			},
+		},
+		{
+			selector: "node.show-label",
+			style: {
+				color: theme.textMuted,
+				"font-size": 9.5,
+				"font-weight": 400,
+				label: "data(label)",
+				"text-opacity": 1,
+				"z-compound-depth": "top",
+				"z-index": 20,
+			},
+		},
+		{
+			selector: "node.hover-label",
+			style: {
+				color: theme.text,
+				"font-size": 10,
+				"font-weight": 400,
+				"text-outline-color": theme.background,
+				"text-outline-opacity": 0.72,
+				"text-outline-width": 0.8,
+			},
+		},
+		{
+			selector: "node.connected",
+			style: {
+				"border-color": theme.nodeActiveBorder,
+				"border-width": 1.35,
+			},
+		},
+		{
+			selector: "node.hub",
+			style: {
+				"border-color": theme.nodeActiveBorder,
+				"border-width": 1.7,
+				"font-size": 12,
+				"font-weight": 580,
+			},
+		},
+		{
+			selector: "node.hub-strong",
+			style: {
+				"border-color": theme.nodeActiveBorder,
+				"border-width": 2,
+				"font-size": 12.5,
+				"font-weight": 620,
+			},
+		},
+		{
+			selector: "node.isolated",
+			style: {
+				"background-color": theme.border,
+				"background-opacity": 0.32,
+				"border-color": theme.textMuted,
+				"border-style": "dashed",
+				opacity: 0.64,
+			},
+		},
+		{
+			selector: "node.tag",
+			style: {
+				"background-color": "#f2b84b",
+				"background-opacity": 0.42,
+				"border-color": "#c88b1f",
+				"border-style": "dashed",
+				"border-width": 1.4,
+				color: theme.text,
+				"font-size": 12,
+				"font-weight": 600,
+				"text-max-width": "150px",
+			},
+		},
+		{
+			selector: "node.tag-strong",
+			style: {
+				"border-width": 1.8,
+				"font-size": 12.5,
+			},
+		},
+		{
+			selector: "node.is-focus",
+			style: {
+				"background-color": theme.nodeActive,
+				"border-color": theme.nodeActiveBorder,
+				"border-width": 2,
+				height: 24,
+				label: "data(label)",
+				"text-opacity": 1,
+				width: 24,
+				"z-compound-depth": "top",
+				"z-index": 30,
+			},
+		},
+		{
+			selector: "node.is-neighbor",
+			style: {
+				"border-color": theme.nodeActiveBorder,
+			},
+		},
+		{
+			selector: "edge",
+			style: {
+				"arrow-scale": 0.8,
+				"curve-style": "bezier",
+				"line-cap": "round",
+				"line-color": theme.edge,
+				opacity: 0.28,
+				"source-arrow-shape": "none",
+				"target-arrow-color": theme.edge,
+				"target-arrow-shape": "triangle-backcurve",
+				"target-distance-from-node": 4,
+				"target-endpoint": "outside-to-node",
+				"transition-duration": 180,
+				"transition-property": "line-color, opacity, target-arrow-color, width",
+				width: 1.35,
+			},
+		},
+		{
+			selector: "edge.relationship",
+			style: {
+				"line-color": theme.edgeIncoming,
+				"target-arrow-color": theme.edgeIncoming,
+				opacity: 0.36,
+				width: 1.55,
+			},
+		},
+		{
+			selector: "edge.tag-link",
+			style: {
+				"arrow-scale": 0.62,
+				"curve-style": "bezier",
+				"line-cap": "round",
+				"line-color": theme.accent,
+				"line-dash-pattern": [1, 5],
+				"line-style": "dashed",
+				opacity: 0.26,
+				"source-arrow-shape": "none",
+				"target-arrow-color": theme.accent,
+				"target-arrow-shape": "triangle-backcurve",
+				"target-distance-from-node": 4,
+				"target-endpoint": "outside-to-node",
+				width: 1.35,
+			},
+		},
+		{
+			selector: "edge.is-highlight",
+			style: {
+				opacity: 0.9,
+				width: 2.2,
+			},
+		},
+		{
+			selector: ".is-faded",
+			style: {
+				opacity: 0.12,
+			},
+		},
+	];
+}
+
+export function graphLayoutSpacing(cy: Core) {
+	const nodeCount = cy.nodes().length;
+	const density = Math.min(nodeCount / 1000, 1);
+	const idealEdgeLength = Math.round(130 + density * 80);
+
+	return {
+		idealEdgeLength,
+		nodeRepulsion: Math.round(10_000 + nodeCount * 220),
+		nodeSeparation: Math.round(90 + density * 70),
+		padding: Math.round(70 + density * 35),
+		tilePadding: Math.round(16 + density * 18),
+	};
+}
+
+interface RunGraphLayoutOptions {
+	mode: "fcose" | "preset" | "random";
+	afterLayout?: () => void;
+}
+
+export function runGraphLayout(cy: Core, options: RunGraphLayoutOptions) {
+	const spacing = graphLayoutSpacing(cy);
+	if (options.mode === "preset") {
+		const layout = cy.layout({
+			name: "preset",
+			fit: true,
+			padding: spacing.padding,
+		});
+		layout.one("layoutstop", () => {
+			options.afterLayout?.();
+			cy.fit(undefined, spacing.padding);
+		});
+		layout.run();
+		return;
+	}
+	if (options.mode === "random") {
+		const layout = cy.layout({
+			name: "random",
+			animate: false,
+			fit: true,
+			padding: spacing.padding,
+		});
+		layout.one("layoutstop", () => {
+			options.afterLayout?.();
+			cy.fit(undefined, spacing.padding);
+		});
+		layout.run();
+		return;
+	}
+
+	const layout = cy.layout({
+		name: "fcose",
+		animate: false,
+		fit: true,
+		idealEdgeLength: (edge: cytoscape.EdgeSingular) =>
+			edge.hasClass("tag-link")
+				? spacing.idealEdgeLength + 36
+				: spacing.idealEdgeLength,
+		nodeDimensionsIncludeLabels: true,
+		nodeRepulsion: spacing.nodeRepulsion,
+		nodeSeparation: spacing.nodeSeparation,
+		numIter: 2200,
+		padding: spacing.padding,
+		packComponents: false,
+		quality: "default",
+		randomize: true,
+		tile: false,
+		tilingPaddingHorizontal: spacing.tilePadding,
+		tilingPaddingVertical: spacing.tilePadding,
+	} as cytoscape.LayoutOptions);
+	layout.one("layoutstop", () => {
+		options.afterLayout?.();
+		cy.fit(undefined, spacing.padding);
+	});
+	layout.run();
+}
+
+export function highlightNeighborhood(cy: Core, nodeId: string | null) {
+	const elements = cy.elements();
+	elements.removeClass("is-faded is-focus is-neighbor is-highlight");
+	if (!nodeId) return;
+
+	const node = cy.getElementById(nodeId);
+	if (node.empty()) return;
+
+	const neighborhood = node.closedNeighborhood();
+	elements.not(neighborhood).addClass("is-faded");
+	node.addClass("is-focus");
+	node.neighborhood("node").addClass("is-neighbor");
+	node.connectedEdges().addClass("is-highlight");
+}
+
+export function applyGraphTheme(cy: Core, container: HTMLElement) {
+	cy.style(graphStyles(graphThemeFor(container)));
+}
+
+export function graphStylesForContainer(container: HTMLElement) {
+	return graphStyles(graphThemeFor(container));
+}

--- a/src/components/graph/graphTheme.ts
+++ b/src/components/graph/graphTheme.ts
@@ -11,6 +11,7 @@ interface GraphTheme {
 	node: string;
 	nodeActive: string;
 	nodeActiveBorder: string;
+	tagNode: string;
 	text: string;
 	textInverse: string;
 	textMuted: string;
@@ -73,6 +74,7 @@ function graphThemeFor(element: HTMLElement): GraphTheme {
 		"--local-graph-edge-incoming",
 		"#1f2328",
 	);
+	const tagNode = cssColor(element, "--local-graph-tag-node", accent);
 
 	return {
 		accent,
@@ -84,6 +86,7 @@ function graphThemeFor(element: HTMLElement): GraphTheme {
 		node,
 		nodeActive: node,
 		nodeActiveBorder: accent,
+		tagNode,
 		text,
 		textInverse,
 		textMuted,
@@ -187,9 +190,9 @@ export function graphStyles(theme: GraphTheme): StylesheetJson {
 		{
 			selector: "node.tag",
 			style: {
-				"background-color": "#f2b84b",
+				"background-color": theme.tagNode,
 				"background-opacity": 0.42,
-				"border-color": "#c88b1f",
+				"border-color": theme.tagNode,
 				"border-style": "dashed",
 				"border-width": 1.4,
 				color: theme.text,

--- a/src/components/graph/graphTheme.ts
+++ b/src/components/graph/graphTheme.ts
@@ -150,17 +150,6 @@ export function graphStyles(theme: GraphTheme): StylesheetJson {
 			},
 		},
 		{
-			selector: "node.hover-label",
-			style: {
-				color: theme.text,
-				"font-size": 10,
-				"font-weight": 400,
-				"text-outline-color": theme.background,
-				"text-outline-opacity": 0.72,
-				"text-outline-width": 0.8,
-			},
-		},
-		{
 			selector: "node.connected",
 			style: {
 				"border-color": theme.nodeActiveBorder,
@@ -214,6 +203,16 @@ export function graphStyles(theme: GraphTheme): StylesheetJson {
 			style: {
 				"border-width": 1.8,
 				"font-size": 12.5,
+			},
+		},
+		{
+			selector: "node.hover-label",
+			style: {
+				color: theme.text,
+				"font-size": 10,
+				"font-weight": 400,
+				"text-outline-opacity": 0,
+				"text-outline-width": 0,
 			},
 		},
 		{

--- a/src/lib/spaceGraph.ts
+++ b/src/lib/spaceGraph.ts
@@ -1,0 +1,1 @@
+export const SPACE_GRAPH_TAB_ID = "__glyph_space_graph__";

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -383,6 +383,43 @@ export interface LocalNoteGraph {
 	tag_edges: LocalGraphTagEdge[];
 }
 
+export interface SpaceGraphNode {
+	id: string;
+	title: string;
+	link_count: number;
+	tag_count: number;
+	is_isolated: boolean;
+}
+
+export interface SpaceGraphEdge {
+	from_id: string;
+	to_id: string;
+	kind: "link" | "relationship";
+}
+
+export interface SpaceGraphTagNode {
+	id: string;
+	tag: string;
+	title: string;
+	note_count: number;
+}
+
+export interface SpaceGraphTagEdge {
+	tag_id: string;
+	note_id: string;
+}
+
+export interface SpaceGraph {
+	nodes: SpaceGraphNode[];
+	edges: SpaceGraphEdge[];
+	tags: SpaceGraphTagNode[];
+	tag_edges: SpaceGraphTagEdge[];
+	truncated: boolean;
+	truncated_tags: boolean;
+	total_notes: number;
+	total_tags: number;
+}
+
 export interface TagCount {
 	tag: string;
 	direct_count: number;
@@ -1020,6 +1057,10 @@ interface TauriCommands {
 	>;
 	note_relationships: CommandDef<{ note_id: string }, NoteRelationship[]>;
 	note_local_graph: CommandDef<{ note_id: string }, LocalNoteGraph>;
+	space_graph: CommandDef<
+		{ max_nodes?: number; max_tags?: number },
+		SpaceGraph
+	>;
 	git_sync_status_read: CommandDef<void, GitSyncStatus>;
 	git_sync_config_read: CommandDef<void, GitSyncConfig | null>;
 	git_sync_config_update: CommandDef<

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -180,6 +180,21 @@
 	line-height: 1;
 }
 
+.sidebarQuickActionBeta {
+	flex: 0 0 auto;
+	margin-left: auto;
+	padding: 1px 5px;
+	border-radius: var(--radius-sm);
+	background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+	color: color-mix(in srgb, var(--interactive-accent) 72%, var(--text-primary));
+	font-size: calc(var(--text-base) * 0.68);
+	font-weight: var(--font-medium);
+	font-family: var(--font-sans);
+	line-height: 1.2;
+	letter-spacing: 0;
+	text-transform: uppercase;
+}
+
 .sidebarQuickActionBtn[data-kind="new-note"] .sidebarQuickActionShortcut {
 	background: color-mix(
 		in srgb,

--- a/src/styles/app/45-local-graph.css
+++ b/src/styles/app/45-local-graph.css
@@ -74,6 +74,7 @@
 	--local-graph-edge: rgba(38, 35, 29, 0.58);
 	--local-graph-edge-incoming: #26231d;
 	--local-graph-note-bg: #ffffff;
+	--local-graph-tag-node: var(--interactive-accent);
 	--local-graph-text: #26231d;
 	--local-graph-text-inverse: #ffffff;
 	--local-graph-surface: color-mix(

--- a/src/styles/app/45-local-graph.css
+++ b/src/styles/app/45-local-graph.css
@@ -115,6 +115,15 @@
 	cursor: grabbing;
 }
 
+.spaceGraphLoadFullButton {
+	min-height: 0;
+	height: 22px;
+	padding: 0 7px;
+	border-radius: calc(var(--radius-md) * 0.75);
+	font-size: 11px;
+	line-height: 1;
+}
+
 .localNoteGraphLegend {
 	position: absolute;
 	left: 14px;


### PR DESCRIPTION
Space Graph (Beta) — global graph view with note-to-note links, relationships, and tag clusters

 Summary

 Adds a beta space-wide graph view that renders the entire note collection as an interactive Cytoscape graph. Users can now explore
 connections across their whole space via a new sidebar entry, tab, and command palette action. The backend exposes a new space_graph
 command that surfaces note nodes, tag nodes, links/relationships edges, and tag edges from the SQLite index. The frontend renders this
 as a full-pane, theme-aware visualization with smart layout, caching, and performance safeguards for large spaces.

 ────────────────────────────────────────────────────────────────────────────────

 What changed

 ### Backend (src-tauri/)

 - New space_graph Tauri command (src-tauri/src/index/commands.rs)
     - Queries the full notes table (not just linked notes), so isolated notes with zero links or tags are always included.
     - Computes degree per note from links, note_relationships, and explicit tags.
     - Truncates by degree when total notes exceed the cap (max_nodes default 1,000, up to 10,000), with truncated and total_notes
       flags.
     - Returns explicit non-people tag nodes and tag-to-note edges, capped by max_tags (default 250), with truncated_tags and
       total_tags flags.
     - Deduplicates edges and excludes dangling edges when truncation drops an endpoint.
     - is_isolated flag per note for easy frontend styling.
     - Registered in src-tauri/src/lib.rs.
 - New types (src-tauri/src/index/types.rs): SpaceGraph, SpaceGraphNode, SpaceGraphEdge, SpaceGraphTagNode, SpaceGraphTagEdge.
 - Synthetic-scale test (space_graph_tests): asserts a 2,000-note / 10,000-link / 500-tag graph is computed in <500ms (measured
   ~479ms).

 ### Frontend (src/)

 - src/components/graph/SpaceGraphView.tsx (new)
     - Full-pane Cytoscape renderer (not a dialog) with cytoscape-fcose layout.
     - Theme-aware: pulls colors from CSS custom properties (--interactive-accent, --bg-primary, etc.) and reacts to theme changes.
     - Node sizing: note nodes scale by link + tag degree; tag nodes scale by note count.
     - Visual classes: isolated notes (dashed, dimmed), connected notes, hubs, strong hubs, tag nodes (yellow/dashed).
     - Interaction:
         - Hover: neighborhood highlight + label reveal.
         - Click note node: opens the note via dispatchWikiLinkClick.
         - Click tag node: highlights its neighborhood.
         - Drag: layout cache is updated so positions persist.
     - Smart layout strategy:
         - Cached layouts stored in sessionStorage (signature-based invalidation) → instant restore on revisit.
         - Large graphs (≥2,400 nodes) fall back to a fast random initial layout.
         - Post-layout: organic cloud positioning for notes, golden-angle satellite scattering for isolated notes and tags.
     - Progress overlay: staged progress bar from query → layout → completion.
     - "Load full graph" button: switches from 1,000 to 10,000 nodes; shows a Tauri confirmation dialog warning about
       memory/performance.
     - Error state with retry; empty state when no notes exist.
 - src/components/graph/graphTheme.ts (new)
     - Extracted Cytoscape stylesheet, layout config, highlightNeighborhood, applyGraphTheme, and runGraphLayout helpers. Adapted from
       LocalNoteGraphDialog patterns but customized for the space-wide view (tag styles, edge kinds, dashed tag-links, etc.).
 - src/lib/spaceGraph.ts (new): SPACE_GRAPH_TAB_ID constant.
 - src/lib/tauri.ts: typed SpaceGraph interfaces and space_graph command definition added to TauriCommands.

 ### App integration

 - Sidebar (Sidebar, SidebarContent, AppShell): new "Graph" quick-action button with a Beta badge, using ThreeDMoveIcon. Active section
   state includes "graph".
 - Main content (MainContent): lazy-loads SpaceGraphView when SPACE_GRAPH_TAB_ID is active.
 - Tab bar (TabBar): labels the graph tab as "Graph" and treats it as a special path.
 - Breadcrumbs (MainTabsBreadcrumbs): recognizes graph as a non-file special view.
 - Command palette (useAppCommands): new "Open graph view" command under Navigation.

 ### Styling

 - src/styles/app/35-sidebar-nav.css: .sidebarQuickActionBeta badge style.
 - src/styles/app/45-local-graph.css: .spaceGraphLoadFullButton compact button style.

 ### Documentation

 - plans/003-report-space-graph.md: spike report with backend timing, prototype behavior, open questions, and production effort
   estimate (M for polished v1, L with incremental updates/filters).
 - plans/README.md: status row updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Space Graph (Beta): interactive space-wide visualization of notes and tags accessible via a new sidebar quick-action and Graph tab. Click notes to open them, explore tag neighborhoods, retry on errors, and load full graphs when truncated. Uses cached layouts and aims for fast performance on large spaces.

* **Documentation**
  * Added plan and spike report documenting the design, verification results, limits, and production gating recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->