### PR TITLE
Cleanups and Fixes - New Component for Calendar added

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"next-themes": "^0.4.6",
 		"radix-ui": "^1.4.3",
 		"react": "^19.1.0",
+		"react-day-picker": "^10.0.1",
 		"react-dom": "^19.1.0",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.2.4
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.10)(react@19.2.4)
       react-dom:
         specifier: ^19.1.0
         version: 19.2.4(react@19.2.4)
@@ -379,6 +382,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@dnd-kit/abstract@0.4.0':
     resolution: {integrity: sha512-loEEJxKT5oLOLeRBJVTO9qpgvvW/Qq902xO20v1JMbpANuN/NLurUdpxIwNpVz+RtOSyzznnbc7lO7psmOhc9A==}
@@ -2411,6 +2417,16 @@ packages:
       '@types/react-dom':
         optional: true
 
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -2899,6 +2915,8 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@date-fns/tz@1.5.0': {}
 
   '@dnd-kit/abstract@0.4.0':
     dependencies:
@@ -4886,6 +4904,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
+
+  react-day-picker@10.0.1(@types/react@19.2.10)(react@19.2.4):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.1.0
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.10
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:

--- a/src-tauri/src/index/calendar.rs
+++ b/src-tauri/src/index/calendar.rs
@@ -1,0 +1,327 @@
+use std::collections::HashMap;
+
+use chrono::{Days, NaiveDate};
+use rusqlite::Connection;
+use serde::Serialize;
+use tauri::{State, WebviewWindow};
+
+use crate::space::SpaceState;
+
+use super::db::open_db;
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CalendarNoteKind {
+    Daily,
+    Created,
+    Edited,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarDayActivity {
+    pub date: String,
+    pub has_daily_note: bool,
+    pub has_created: bool,
+    pub has_edited: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalendarDateNote {
+    pub path: String,
+    pub title: String,
+    pub kinds: Vec<CalendarNoteKind>,
+}
+
+#[derive(Clone)]
+struct CalendarNoteEvent {
+    date: String,
+    path: String,
+    title: String,
+    kind: CalendarNoteKind,
+}
+
+fn parse_iso_date(value: &str) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.len() != 10 {
+        return Err(format!("Invalid ISO date: {value}"));
+    }
+    let bytes = trimmed.as_bytes();
+    for (index, byte) in bytes.iter().enumerate() {
+        let valid = match index {
+            4 | 7 => *byte == b'-',
+            _ => byte.is_ascii_digit(),
+        };
+        if !valid {
+            return Err(format!("Invalid ISO date: {value}"));
+        }
+    }
+    Ok(trimmed.to_string())
+}
+
+fn parse_iso_naive_date(value: &str) -> Result<NaiveDate, String> {
+    let date = parse_iso_date(value)?;
+    NaiveDate::parse_from_str(&date, "%Y-%m-%d").map_err(|_| format!("Invalid ISO date: {value}"))
+}
+
+fn date_key(date: NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}
+
+fn expanded_date_prefilter(from_date: &str, to_date: &str) -> Result<(String, String), String> {
+    let from = parse_iso_naive_date(from_date)?
+        .checked_sub_days(Days::new(1))
+        .ok_or_else(|| "from_date is out of range".to_string())?;
+    let to = parse_iso_naive_date(to_date)?
+        .checked_add_days(Days::new(1))
+        .ok_or_else(|| "to_date is out of range".to_string())?;
+    Ok((date_key(from), date_key(to)))
+}
+
+fn local_date_key_from_timestamp(value: &str) -> Option<String> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .map(|parsed| date_key(parsed.with_timezone(&chrono::Local).date_naive()))
+        .ok()
+}
+
+fn normalize_daily_note_folder(folder: Option<String>) -> Option<String> {
+    folder
+        .map(|value| value.trim().trim_matches('/').replace('\\', "/"))
+        .filter(|value| !value.is_empty())
+}
+
+fn daily_note_path_for_date(folder: Option<&str>, date: &str) -> String {
+    match folder.filter(|value| !value.is_empty()) {
+        Some(folder) => format!("{folder}/{date}.md"),
+        None => format!("{date}.md"),
+    }
+}
+
+fn daily_note_glob(folder: Option<&str>) -> String {
+    match folder.filter(|value| !value.is_empty()) {
+        Some(folder) => format!("{folder}/????-??-??.md"),
+        None => "????-??-??.md".to_string(),
+    }
+}
+
+fn date_from_daily_note_path(path: &str) -> Option<String> {
+    let normalized = path.replace('\\', "/");
+    let stem = normalized.rsplit('/').next()?;
+    let date = stem.strip_suffix(".md")?;
+    parse_iso_date(date).ok()
+}
+
+fn collect_daily_note_events(
+    conn: &Connection,
+    from_date: &str,
+    to_date: &str,
+    daily_folder: Option<&str>,
+    events: &mut Vec<CalendarNoteEvent>,
+) -> Result<(), String> {
+    let daily_glob = daily_note_glob(daily_folder);
+    let mut stmt = conn
+        .prepare("SELECT path, title FROM notes WHERE path GLOB ?")
+        .map_err(|e| e.to_string())?;
+    let mut rows = stmt.query([&daily_glob]).map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let path: String = row.get(0).map_err(|e| e.to_string())?;
+        let Some(date) = date_from_daily_note_path(&path) else {
+            continue;
+        };
+        if date.as_str() < from_date || date.as_str() > to_date {
+            continue;
+        }
+        events.push(CalendarNoteEvent {
+            date,
+            path,
+            title: row.get(1).map_err(|e| e.to_string())?,
+            kind: CalendarNoteKind::Daily,
+        });
+    }
+    Ok(())
+}
+
+fn collect_timestamp_events(
+    conn: &Connection,
+    timestamp_column: &str,
+    kind: CalendarNoteKind,
+    from_date: &str,
+    to_date: &str,
+    events: &mut Vec<CalendarNoteEvent>,
+) -> Result<(), String> {
+    let (prefilter_from_date, prefilter_to_date) = expanded_date_prefilter(from_date, to_date)?;
+    let sql = format!(
+        "SELECT path, title, {timestamp_column}
+         FROM notes
+         WHERE substr({timestamp_column}, 1, 10) BETWEEN ?1 AND ?2"
+    );
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let mut rows = stmt
+        .query(rusqlite::params![&prefilter_from_date, &prefilter_to_date])
+        .map_err(|e| e.to_string())?;
+    while let Some(row) = rows.next().map_err(|e| e.to_string())? {
+        let timestamp: String = row.get(2).map_err(|e| e.to_string())?;
+        let Some(date) = local_date_key_from_timestamp(&timestamp) else {
+            continue;
+        };
+        if date.as_str() < from_date || date.as_str() > to_date {
+            continue;
+        }
+        events.push(CalendarNoteEvent {
+            date,
+            path: row.get(0).map_err(|e| e.to_string())?,
+            title: row.get(1).map_err(|e| e.to_string())?,
+            kind,
+        });
+    }
+    Ok(())
+}
+
+fn query_calendar_events(
+    conn: &Connection,
+    from_date: &str,
+    to_date: &str,
+    daily_folder: Option<&str>,
+) -> Result<Vec<CalendarNoteEvent>, String> {
+    let mut events = Vec::new();
+    collect_daily_note_events(conn, from_date, to_date, daily_folder, &mut events)?;
+    collect_timestamp_events(
+        conn,
+        "created",
+        CalendarNoteKind::Created,
+        from_date,
+        to_date,
+        &mut events,
+    )?;
+    collect_timestamp_events(
+        conn,
+        "updated",
+        CalendarNoteKind::Edited,
+        from_date,
+        to_date,
+        &mut events,
+    )?;
+    Ok(events)
+}
+
+fn day_activity(date: &str) -> CalendarDayActivity {
+    CalendarDayActivity {
+        date: date.to_string(),
+        has_daily_note: false,
+        has_created: false,
+        has_edited: false,
+    }
+}
+
+fn mark_day_activity(day: &mut CalendarDayActivity, kind: CalendarNoteKind) {
+    match kind {
+        CalendarNoteKind::Daily => day.has_daily_note = true,
+        CalendarNoteKind::Created => day.has_created = true,
+        CalendarNoteKind::Edited => day.has_edited = true,
+    }
+}
+
+fn query_calendar_activity(
+    conn: &Connection,
+    from_date: &str,
+    to_date: &str,
+    daily_folder: Option<&str>,
+) -> Result<Vec<CalendarDayActivity>, String> {
+    let mut days: HashMap<String, CalendarDayActivity> = HashMap::new();
+    for event in query_calendar_events(conn, from_date, to_date, daily_folder)? {
+        let day = days
+            .entry(event.date.clone())
+            .or_insert_with(|| day_activity(&event.date));
+        mark_day_activity(day, event.kind);
+    }
+    let mut out: Vec<CalendarDayActivity> = days.into_values().collect();
+    out.sort_by(|left, right| left.date.cmp(&right.date));
+    Ok(out)
+}
+
+fn kind_sort_order(kind: CalendarNoteKind) -> u8 {
+    match kind {
+        CalendarNoteKind::Daily => 0,
+        CalendarNoteKind::Created => 1,
+        CalendarNoteKind::Edited => 2,
+    }
+}
+
+fn query_calendar_notes_for_date(
+    conn: &Connection,
+    date: &str,
+    daily_folder: Option<&str>,
+) -> Result<Vec<CalendarDateNote>, String> {
+    let daily_path = daily_note_path_for_date(daily_folder, date);
+    let mut by_path: HashMap<String, CalendarDateNote> = HashMap::new();
+
+    for event in query_calendar_events(conn, date, date, daily_folder)? {
+        let entry = by_path
+            .entry(event.path.clone())
+            .or_insert_with(|| CalendarDateNote {
+                path: event.path,
+                title: event.title,
+                kinds: Vec::new(),
+            });
+        if !entry.kinds.contains(&event.kind) {
+            entry.kinds.push(event.kind);
+        }
+    }
+
+    let mut out: Vec<CalendarDateNote> = by_path.into_values().collect();
+    for note in &mut out {
+        note.kinds.sort_by_key(|kind| kind_sort_order(*kind));
+    }
+    out.sort_by(|left, right| {
+        let left_daily = left.path == daily_path || left.kinds.contains(&CalendarNoteKind::Daily);
+        let right_daily =
+            right.path == daily_path || right.kinds.contains(&CalendarNoteKind::Daily);
+        right_daily
+            .cmp(&left_daily)
+            .then_with(|| left.title.to_lowercase().cmp(&right.title.to_lowercase()))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    Ok(out)
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn index_calendar_activity(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    from_date: String,
+    to_date: String,
+    daily_note_folder: Option<String>,
+) -> Result<Vec<CalendarDayActivity>, String> {
+    let from_date = parse_iso_date(&from_date)?;
+    let to_date = parse_iso_date(&to_date)?;
+    if from_date > to_date {
+        return Err("from_date must be on or before to_date".to_string());
+    }
+    let root = state.root_for_window(&window)?;
+    let daily_note_folder = normalize_daily_note_folder(daily_note_folder);
+    tauri::async_runtime::spawn_blocking(move || -> Result<Vec<CalendarDayActivity>, String> {
+        let conn = open_db(&root)?;
+        query_calendar_activity(&conn, &from_date, &to_date, daily_note_folder.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn index_calendar_notes_for_date(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    date: String,
+    daily_note_folder: Option<String>,
+) -> Result<Vec<CalendarDateNote>, String> {
+    let date = parse_iso_date(&date)?;
+    let root = state.root_for_window(&window)?;
+    let daily_note_folder = normalize_daily_note_folder(daily_note_folder);
+    tauri::async_runtime::spawn_blocking(move || -> Result<Vec<CalendarDateNote>, String> {
+        let conn = open_db(&root)?;
+        query_calendar_notes_for_date(&conn, &date, daily_note_folder.as_deref())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}

--- a/src-tauri/src/index/calendar.rs
+++ b/src-tauri/src/index/calendar.rs
@@ -42,6 +42,21 @@ struct CalendarNoteEvent {
     kind: CalendarNoteKind,
 }
 
+#[derive(Clone, Copy)]
+enum TimestampColumn {
+    Created,
+    Updated,
+}
+
+impl TimestampColumn {
+    fn sql_name(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Updated => "updated",
+        }
+    }
+}
+
 fn parse_iso_date(value: &str) -> Result<String, String> {
     let trimmed = value.trim();
     if trimmed.len() != 10 {
@@ -144,13 +159,14 @@ fn collect_daily_note_events(
 
 fn collect_timestamp_events(
     conn: &Connection,
-    timestamp_column: &str,
+    timestamp_column: TimestampColumn,
     kind: CalendarNoteKind,
     from_date: &str,
     to_date: &str,
     events: &mut Vec<CalendarNoteEvent>,
 ) -> Result<(), String> {
     let (prefilter_from_date, prefilter_to_date) = expanded_date_prefilter(from_date, to_date)?;
+    let timestamp_column = timestamp_column.sql_name();
     let sql = format!(
         "SELECT path, title, {timestamp_column}
          FROM notes
@@ -188,7 +204,7 @@ fn query_calendar_events(
     collect_daily_note_events(conn, from_date, to_date, daily_folder, &mut events)?;
     collect_timestamp_events(
         conn,
-        "created",
+        TimestampColumn::Created,
         CalendarNoteKind::Created,
         from_date,
         to_date,
@@ -196,7 +212,7 @@ fn query_calendar_events(
     )?;
     collect_timestamp_events(
         conn,
-        "updated",
+        TimestampColumn::Updated,
         CalendarNoteKind::Edited,
         from_date,
         to_date,

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -16,9 +16,10 @@ use super::search_advanced::{run_search_advanced, SearchAdvancedRequest};
 use super::search_hybrid::hybrid_search;
 use super::tags::{people_tag_to_handle, tag_depth, PEOPLE_TAG_NAMESPACE};
 use super::types::{
-    BacklinkItem, IndexRebuildResult, LocalConnectionsEdge, LocalConnectionsNode, LocalConnectionsTagEdge,
-    LocalConnectionsTagNode, LocalNoteConnections, PersonCount, SearchResult, SpaceConnectionKind, SpaceConnections,
-    SpaceConnectionsEdge, SpaceConnectionsNode, SpaceConnectionsTagEdge, SpaceConnectionsTagNode, TagCount,
+    BacklinkItem, IndexRebuildResult, LocalConnectionsEdge, LocalConnectionsNode,
+    LocalConnectionsTagEdge, LocalConnectionsTagNode, LocalNoteConnections, PersonCount,
+    SearchResult, SpaceConnectionKind, SpaceConnections, SpaceConnectionsEdge,
+    SpaceConnectionsNode, SpaceConnectionsTagEdge, SpaceConnectionsTagNode, TagCount,
 };
 use crate::index::{people_mentions_as_tags_enabled, set_people_mentions_as_tags_enabled};
 
@@ -1328,7 +1329,8 @@ mod local_connections_tests {
             "notes/neighbor.md".to_string(),
         ];
         let (tags, tagged_nodes, tag_edges) =
-            local_connections_tag_expansion_for_seed_nodes(&conn, &seed_node_ids, 12, 12, 5).unwrap();
+            local_connections_tag_expansion_for_seed_nodes(&conn, &seed_node_ids, 12, 12, 5)
+                .unwrap();
 
         assert_eq!(tagged_nodes.len(), 5);
         assert_eq!(tag_edges.len(), 5);

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -1,3 +1,4 @@
+pub mod calendar;
 pub mod checklists;
 pub mod commands;
 pub(crate) mod db;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -993,6 +993,33 @@ fn is_space_host_window_label(label: &str) -> bool {
     label == "main" || space::commands::is_space_window(label)
 }
 
+fn is_auxiliary_persisted_window(label: &str) -> bool {
+    label == "settings" || label == QUICK_NOTE_WINDOW_LABEL || label == "quick-task"
+}
+
+fn destroy_auxiliary_persisted_windows(app: &tauri::AppHandle) {
+    for (label, window) in app.webview_windows() {
+        if is_auxiliary_persisted_window(&label) {
+            let _ = window.destroy();
+        }
+    }
+}
+
+fn prepare_host_window_close(window: &tauri::Window) {
+    if !is_space_host_window_label(window.label()) {
+        return;
+    }
+    let app = window.app_handle();
+    let host_count = app
+        .webview_windows()
+        .into_iter()
+        .filter(|(label, _)| is_space_host_window_label(label))
+        .count();
+    if host_count <= 1 {
+        destroy_auxiliary_persisted_windows(&app);
+    }
+}
+
 fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
     app.webview_windows().into_iter().find(|(label, window)| {
         is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
@@ -1452,13 +1479,9 @@ pub fn run() {
                 }
             }
 
-            #[cfg(target_os = "macos")]
-            if window.label() == "main" {
-                if let WindowEvent::CloseRequested { api, .. } = event {
-                    // Keep app alive on macOS when the last window is closed.
-                    // Dock activation can then restore this window.
-                    api.prevent_close();
-                    let _ = window.hide();
+            if is_space_host_window_label(window.label()) {
+                if let WindowEvent::CloseRequested { .. } = event {
+                    prepare_host_window_close(window);
                 }
             }
         })
@@ -1545,6 +1568,8 @@ pub fn run() {
             index::commands::index_set_people_mentions_as_tags_enabled,
             index::commands::all_docs_list,
             index::commands::all_docs_count,
+            index::calendar::index_calendar_activity,
+            index::calendar::index_calendar_notes_for_date,
             index::commands::tags_list,
             index::commands::people_list,
             index::commands::task_summary,
@@ -1598,13 +1623,5 @@ pub fn run() {
                 return;
             }
 
-            #[cfg(target_os = "macos")]
-            if let RunEvent::Reopen { .. } = event {
-                if let Some(window) = app_handle.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.unminimize();
-                    let _ = window.set_focus();
-                }
-            }
         });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,7 @@
 @import "./styles/app/30-markdown-editor-pane.css";
 @import "./styles/app/31-responsive.css";
 @import "./styles/app/32-command-palette.css";
+@import "./styles/app/48-calendar-palette.css";
 @import "./styles/app/33-model-combobox.css";
 @import "./styles/app/35-sidebar-nav.css";
 @import "./styles/app/37-database-pickers.css";

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -34,6 +34,7 @@ import {
 	dispatchFileTreeStartRename,
 	dispatchPathRemoved,
 } from "../../lib/appEvents";
+import { invalidateCalendarPrefetch } from "../../lib/calendarActivity";
 import {
 	INITIAL_DATABASES_OPEN_REQUEST,
 	consumeCreateCollectionDialog,
@@ -62,6 +63,10 @@ import { LayoutAlignLeft } from "../Icons";
 import { dispatchAiContextAttach } from "../ai/aiContextEvents";
 import { MainContent } from "./MainContent";
 import { Sidebar } from "./Sidebar";
+import {
+	CalendarPaletteController,
+	preloadCalendarPalette,
+} from "./CalendarPaletteController";
 import {
 	TemplatePickerDialog,
 	type TemplatePickerItem,
@@ -150,6 +155,7 @@ export function AppShell() {
 	>(null);
 	const [moveTargetDirs, setMoveTargetDirs] = useState<string[]>([]);
 	const [commandPaletteMounted, setCommandPaletteMounted] = useState(false);
+	const [calendarOpen, setCalendarOpen] = useState(false);
 	const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
 	const [templatePickerDirPath, setTemplatePickerDirPath] = useState("");
 	const [templatePickerItems, setTemplatePickerItems] = useState<
@@ -216,6 +222,7 @@ export function AppShell() {
 			void loadCommandPalette().then(() => {
 				if (!cancelled) setCommandPaletteMounted(true);
 			});
+			preloadCalendarPalette();
 		}, 500);
 		return () => {
 			cancelled = true;
@@ -425,7 +432,7 @@ export function AppShell() {
 		});
 	});
 
-	const { openOrCreateDailyNote } = useDailyNote({
+	const { openOrCreateDailyNote, openOrCreateDailyNoteAtDate } = useDailyNote({
 		onOpenFile: (path) => openWorkspaceFile(path),
 		setError,
 		spacePath,
@@ -551,6 +558,32 @@ export function AppShell() {
 		}
 		void handleOpenDailyNote();
 	}, [dailyNotesFolder, handleOpenDailyNote, spacePath]);
+
+	const openCalendar = useCallback(() => {
+		if (!spacePath) return;
+		setCalendarOpen(true);
+	}, [spacePath]);
+
+	const closeCalendar = useCallback(() => {
+		setCalendarOpen(false);
+	}, []);
+
+	const handleOpenDailyNoteAtDate = useCallback(
+		async (date: string) => {
+			if (!dailyNotesFolder) {
+				setDailyNoteSetupNoticeRequest((value) => value + 1);
+				return;
+			}
+			try {
+				await openOrCreateDailyNoteAtDate(dailyNotesFolder, date);
+			} catch (e) {
+				setError(
+					`Failed to open daily note: ${e instanceof Error ? e.message : String(e)}`,
+				);
+			}
+		},
+		[dailyNotesFolder, openOrCreateDailyNoteAtDate, setError],
+	);
 
 	const fsRefreshQueueRef = useRef<Set<string>>(new Set());
 	const fsRefreshTimerRef = useRef<number | null>(null);
@@ -725,6 +758,7 @@ export function AppShell() {
 				const changed = [...fsRefreshQueueRef.current];
 				fsRefreshQueueRef.current.clear();
 				if (!changed.length) return;
+				invalidateCalendarPrefetch();
 				invalidateAllDocsPrefetch();
 				const dirs = new Set<string>([""]);
 				for (const rel of changed) {
@@ -740,6 +774,7 @@ export function AppShell() {
 	useTauriEvent("space:fs_changed", handleSpaceFsChanged);
 	useTauriEvent("notes:external_changed", (payload) => {
 		const relPath = normalizeRelPath(payload.rel_path);
+		invalidateCalendarPrefetch();
 		invalidateAllDocsPrefetch();
 		invalidateDatabaseRowsPrefetch();
 		if (relPath) {
@@ -1208,6 +1243,7 @@ export function AppShell() {
 				onPrefetchAllDocs={prefetchAllDocsTab}
 				onPrefetchFile={prefetchWorkspaceFile}
 				onOpenCommandPalette={openCommandPalette}
+				onOpenCalendar={openCalendar}
 			/>
 			<div
 				ref={sidebarResize.resizeRef}
@@ -1276,6 +1312,14 @@ export function AppShell() {
 					/>
 				</Suspense>
 			) : null}
+			<CalendarPaletteController
+				open={calendarOpen}
+				onClose={closeCalendar}
+				spacePath={spacePath}
+				dailyNoteFolder={dailyNotesFolder}
+				onOpenNote={(path) => void openWorkspaceFile(path)}
+				onOpenDailyNoteAtDate={(date) => void handleOpenDailyNoteAtDate(date)}
+			/>
 			<TemplatePickerDialog
 				open={templatePickerOpen}
 				templates={templatePickerItems}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -61,12 +61,12 @@ import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { LayoutAlignLeft } from "../Icons";
 import { dispatchAiContextAttach } from "../ai/aiContextEvents";
-import { MainContent } from "./MainContent";
-import { Sidebar } from "./Sidebar";
 import {
 	CalendarPaletteController,
 	preloadCalendarPalette,
 } from "./CalendarPaletteController";
+import { MainContent } from "./MainContent";
+import { Sidebar } from "./Sidebar";
 import {
 	TemplatePickerDialog,
 	type TemplatePickerItem,

--- a/src/components/app/CalendarPalette.tsx
+++ b/src/components/app/CalendarPalette.tsx
@@ -1,0 +1,359 @@
+import { NoteIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQuery } from "@tanstack/react-query";
+import { format, parseISO } from "date-fns";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	activityMapFromRows,
+	calendarQueryKeys,
+	dateHasNotes,
+	loadCalendarActivity,
+	loadCalendarNotesForDate,
+	monthDateRange,
+} from "../../lib/calendarActivity";
+import { getTodayDateString } from "../../lib/dailyNotes";
+import type { CalendarDateNote, CalendarDayActivity } from "../../lib/tauri";
+import { cn } from "@/lib/utils";
+import { Calendar } from "../ui/shadcn/calendar";
+import { Dialog, DialogContent, DialogTitle } from "../ui/shadcn/dialog";
+
+interface CalendarPaletteProps {
+	open: boolean;
+	onClose: () => void;
+	spacePath: string | null;
+	dailyNoteFolder: string | null;
+	onOpenNote: (path: string) => void;
+	onOpenDailyNoteAtDate: (date: string) => void;
+}
+
+const CALENDAR_DAY_CELL = "calendarPaletteDayCell";
+
+function formatSelectedDateParts(date: string): {
+	title: string;
+	weekday: string;
+} {
+	const parsed = parseISO(date);
+	return {
+		title: format(parsed, "MMMM d"),
+		weekday: format(parsed, "EEEE"),
+	};
+}
+
+function NoteDayButton({
+	day,
+	modifiers,
+	activityByDate,
+	className,
+	...props
+}: {
+	day: { date: Date; isoDate?: string };
+	modifiers: {
+		focused?: boolean;
+		selected?: boolean;
+		range_start?: boolean;
+		range_end?: boolean;
+		range_middle?: boolean;
+		today?: boolean;
+		outside?: boolean;
+	};
+	activityByDate: Map<string, CalendarDayActivity>;
+	className?: string;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) {
+	const dateKey = day.isoDate ?? format(day.date, "yyyy-MM-dd");
+	const hasNote = dateHasNotes(activityByDate.get(dateKey));
+	const ref = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (modifiers.focused) ref.current?.focus();
+	}, [modifiers.focused]);
+
+	const isSelected =
+		modifiers.selected &&
+		!modifiers.range_start &&
+		!modifiers.range_end &&
+		!modifiers.range_middle;
+
+	return (
+		<button
+			ref={ref}
+			type="button"
+			data-selected={isSelected ? "true" : "false"}
+			data-today={modifiers.today ? "true" : "false"}
+			data-outside={modifiers.outside ? "true" : "false"}
+			className={cn("calendarPaletteDayButton", className)}
+			{...props}
+		>
+			{day.date.getDate()}
+			<span
+				className="calendarPaletteNoteDot"
+				data-active={hasNote ? "true" : "false"}
+				aria-hidden="true"
+			/>
+		</button>
+	);
+}
+
+function CalendarCaptionButton({
+	onGoToToday,
+	className,
+	children,
+	style,
+	role,
+	"aria-live": ariaLive,
+}: {
+	onGoToToday: () => void;
+	className?: string;
+	children?: React.ReactNode;
+	style?: React.CSSProperties;
+	role?: React.AriaRole;
+	"aria-live"?: "off" | "polite" | "assertive";
+}) {
+	return (
+		<span className={className} aria-live={ariaLive} role={role} style={style}>
+			<button
+				type="button"
+				className="calendarPaletteCaptionButton"
+				onClick={onGoToToday}
+				aria-label="Go to today"
+			>
+				{children}
+			</button>
+		</span>
+	);
+}
+
+function dedupeNotesForList(notes: CalendarDateNote[]): CalendarDateNote[] {
+	const byPath = new Map<string, CalendarDateNote>();
+	for (const note of notes) {
+		const existing = byPath.get(note.path);
+		if (!existing) {
+			byPath.set(note.path, note);
+			continue;
+		}
+		const kinds = new Set([...existing.kinds, ...note.kinds]);
+		byPath.set(note.path, { ...existing, kinds: [...kinds] });
+	}
+	return [...byPath.values()].sort((left, right) => {
+		const leftDaily = left.kinds.includes("daily");
+		const rightDaily = right.kinds.includes("daily");
+		return (
+			Number(rightDaily) - Number(leftDaily) ||
+			left.title.toLowerCase().localeCompare(right.title.toLowerCase()) ||
+			left.path.localeCompare(right.path)
+		);
+	});
+}
+
+export function CalendarPalette({
+	open,
+	onClose,
+	spacePath,
+	dailyNoteFolder,
+	onOpenNote,
+	onOpenDailyNoteAtDate,
+}: CalendarPaletteProps) {
+	const [visibleMonth, setVisibleMonth] = useState(() => new Date());
+	const [selectedDate, setSelectedDate] = useState(() => getTodayDateString());
+	const canQuery = spacePath !== null;
+
+	const monthRange = useMemo(
+		() => monthDateRange(visibleMonth),
+		[visibleMonth],
+	);
+
+	const activityQuery = useQuery({
+		queryKey: calendarQueryKeys.activity(
+			spacePath ?? "",
+			monthRange.fromDate,
+			monthRange.toDate,
+			dailyNoteFolder,
+		),
+		queryFn: () => loadCalendarActivity(visibleMonth, dailyNoteFolder),
+		enabled: open && canQuery,
+		staleTime: 30_000,
+	});
+
+	const notesQuery = useQuery({
+		queryKey: calendarQueryKeys.notesForDate(
+			spacePath ?? "",
+			selectedDate,
+			dailyNoteFolder,
+		),
+		queryFn: () => loadCalendarNotesForDate(selectedDate, dailyNoteFolder),
+		enabled: open && canQuery && selectedDate.length > 0,
+		staleTime: 15_000,
+	});
+
+	const notesForList = useMemo(
+		() => dedupeNotesForList(notesQuery.data ?? []),
+		[notesQuery.data],
+	);
+
+	const activityByDate = useMemo(
+		() => activityMapFromRows(activityQuery.data ?? []),
+		[activityQuery.data],
+	);
+
+	const selectedDateValue = useMemo(
+		() => parseISO(selectedDate),
+		[selectedDate],
+	);
+
+	const selectedDateParts = useMemo(
+		() => formatSelectedDateParts(selectedDate),
+		[selectedDate],
+	);
+
+	const handleSelectDate = useCallback((date: Date | undefined) => {
+		if (!date) return;
+		setSelectedDate(format(date, "yyyy-MM-dd"));
+	}, []);
+
+	const handleGoToToday = useCallback(() => {
+		const today = getTodayDateString();
+		setVisibleMonth(parseISO(today));
+		setSelectedDate(today);
+	}, []);
+
+	const handleOpenDailyNote = useCallback(() => {
+		onClose();
+		onOpenDailyNoteAtDate(selectedDate);
+	}, [onClose, onOpenDailyNoteAtDate, selectedDate]);
+
+	const handleOpenNote = useCallback(
+		(path: string) => {
+			onClose();
+			onOpenNote(path);
+		},
+		[onClose, onOpenNote],
+	);
+
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent
+				className="calendarPalette top-[46%] gap-0 border-none bg-transparent p-0 shadow-none sm:max-w-[400px]"
+				showCloseButton={false}
+			>
+				<DialogTitle className="sr-only">Calendar</DialogTitle>
+
+				<Calendar
+					mode="single"
+					selected={selectedDateValue}
+					onSelect={handleSelectDate}
+					month={visibleMonth}
+					onMonthChange={setVisibleMonth}
+					showOutsideDays
+					fixedWeeks
+					className="calendarPaletteCalendar w-full bg-transparent p-0"
+					classNames={{
+						root: "w-full max-w-full",
+						months: "calendarPaletteMonths",
+						month: "calendarPaletteMonth",
+						nav: "calendarPaletteNav",
+						month_caption: "calendarPaletteMonthCaption",
+						caption_label: "calendarPaletteCaptionLabel",
+						button_previous: "calendarPaletteNavButton",
+						button_next: "calendarPaletteNavButton",
+						weekdays: "calendarPaletteWeekdays",
+						weekday: "calendarPaletteWeekday",
+						week: "calendarPaletteWeek",
+						weeks: "calendarPaletteWeeks",
+						month_grid: "calendarPaletteMonthGrid",
+						day: CALENDAR_DAY_CELL,
+						day_button: "calendarPaletteDayButton",
+						today: CALENDAR_DAY_CELL,
+						selected: CALENDAR_DAY_CELL,
+						outside: CALENDAR_DAY_CELL,
+						focused: CALENDAR_DAY_CELL,
+					}}
+					components={{
+						CaptionLabel: ({ children, className, ...props }) => (
+							<CalendarCaptionButton
+								className={className}
+								onGoToToday={handleGoToToday}
+								{...props}
+							>
+								{children}
+							</CalendarCaptionButton>
+						),
+						DayButton: ({ day, modifiers, ...props }) => (
+							<NoteDayButton
+								day={day}
+								modifiers={modifiers}
+								activityByDate={activityByDate}
+								{...props}
+							/>
+						),
+					}}
+				/>
+
+				<section className="calendarPaletteNotesPanel">
+					<div className="calendarPaletteNotesHeader">
+						<div className="calendarPaletteNotesHeading">
+							<h3 className="calendarPaletteNotesTitle">
+								{selectedDateParts.title}
+							</h3>
+							<p className="calendarPaletteNotesWeekday">
+								{selectedDateParts.weekday}
+							</p>
+						</div>
+						{dailyNoteFolder ? (
+							<button
+								type="button"
+								className="calendarPaletteDailyNoteButton"
+								onClick={handleOpenDailyNote}
+							>
+								Open daily note
+							</button>
+						) : null}
+					</div>
+
+					<div className="calendarPaletteNotesList">
+						{notesQuery.isLoading ? (
+							<p className="calendarPaletteNotesStatus">Loading notes…</p>
+						) : notesForList.length > 0 ? (
+							<ul className="calendarPaletteNotesItems">
+								{notesForList.map((note) => (
+									<li key={note.path}>
+										<button
+											type="button"
+											className="calendarPaletteNoteItem"
+											onClick={() => handleOpenNote(note.path)}
+										>
+											<span className="calendarPaletteNoteIcon">
+												<HugeiconsIcon
+													icon={NoteIcon}
+													size="var(--icon-md)"
+													strokeWidth={0.9}
+												/>
+											</span>
+											<span className="calendarPaletteNoteCopy">
+												<span className="calendarPaletteNoteTitle">
+													{note.title}
+												</span>
+												<span className="calendarPaletteNotePath">
+													{note.path}
+												</span>
+											</span>
+										</button>
+									</li>
+								))}
+							</ul>
+						) : (
+							<div className="calendarPaletteNotesEmpty">
+								<span className="calendarPaletteNotesEmptyIcon" aria-hidden="true">
+									<HugeiconsIcon
+										icon={NoteIcon}
+										size="var(--icon-xl)"
+										strokeWidth={0.9}
+									/>
+								</span>
+								<p className="calendarPaletteNotesEmptyTitle">No notes yet</p>
+							</div>
+						)}
+					</div>
+				</section>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/app/CalendarPalette.tsx
+++ b/src/components/app/CalendarPalette.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { NoteIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
@@ -13,7 +14,6 @@ import {
 } from "../../lib/calendarActivity";
 import { getTodayDateString } from "../../lib/dailyNotes";
 import type { CalendarDateNote, CalendarDayActivity } from "../../lib/tauri";
-import { cn } from "@/lib/utils";
 import { Calendar } from "../ui/shadcn/calendar";
 import { Dialog, DialogContent, DialogTitle } from "../ui/shadcn/dialog";
 
@@ -311,6 +311,13 @@ export function CalendarPalette({
 					<div className="calendarPaletteNotesList">
 						{notesQuery.isLoading ? (
 							<p className="calendarPaletteNotesStatus">Loading notes…</p>
+						) : notesQuery.isError ? (
+							<p className="calendarPaletteNotesStatus" role="alert">
+								Could not load notes:{" "}
+								{notesQuery.error instanceof Error
+									? notesQuery.error.message
+									: String(notesQuery.error)}
+							</p>
 						) : notesForList.length > 0 ? (
 							<ul className="calendarPaletteNotesItems">
 								{notesForList.map((note) => (
@@ -341,7 +348,10 @@ export function CalendarPalette({
 							</ul>
 						) : (
 							<div className="calendarPaletteNotesEmpty">
-								<span className="calendarPaletteNotesEmptyIcon" aria-hidden="true">
+								<span
+									className="calendarPaletteNotesEmptyIcon"
+									aria-hidden="true"
+								>
 									<HugeiconsIcon
 										icon={NoteIcon}
 										size="var(--icon-xl)"

--- a/src/components/app/CalendarPaletteController.tsx
+++ b/src/components/app/CalendarPaletteController.tsx
@@ -1,0 +1,61 @@
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+
+const loadCalendarPalette = () =>
+	import("./CalendarPalette").then((module) => ({
+		default: module.CalendarPalette,
+	}));
+
+const LazyCalendarPalette = lazy(loadCalendarPalette);
+
+interface CalendarPaletteControllerProps {
+	open: boolean;
+	onClose: () => void;
+	spacePath: string | null;
+	dailyNoteFolder: string | null;
+	onOpenNote: (path: string) => void;
+	onOpenDailyNoteAtDate: (date: string) => void;
+}
+
+export function preloadCalendarPalette(): void {
+	void loadCalendarPalette();
+}
+
+export function CalendarPaletteController({
+	open,
+	onClose,
+	spacePath,
+	dailyNoteFolder,
+	onOpenNote,
+	onOpenDailyNoteAtDate,
+}: CalendarPaletteControllerProps) {
+	const [mounted, setMounted] = useState(open);
+
+	useEffect(() => {
+		if (open) setMounted(true);
+	}, [open]);
+
+	const handleOpenNote = useCallback(
+		(path: string) => onOpenNote(path),
+		[onOpenNote],
+	);
+
+	const handleOpenDailyNoteAtDate = useCallback(
+		(date: string) => onOpenDailyNoteAtDate(date),
+		[onOpenDailyNoteAtDate],
+	);
+
+	if (!mounted) return null;
+
+	return (
+		<Suspense fallback={null}>
+			<LazyCalendarPalette
+				open={open}
+				onClose={onClose}
+				spacePath={spacePath}
+				dailyNoteFolder={dailyNoteFolder}
+				onOpenNote={handleOpenNote}
+				onOpenDailyNoteAtDate={handleOpenDailyNoteAtDate}
+			/>
+		</Suspense>
+	);
+}

--- a/src/components/app/CalendarPaletteController.tsx
+++ b/src/components/app/CalendarPaletteController.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, lazy, useEffect, useState } from "react";
 
 const loadCalendarPalette = () =>
 	import("./CalendarPalette").then((module) => ({
@@ -34,16 +34,6 @@ export function CalendarPaletteController({
 		if (open) setMounted(true);
 	}, [open]);
 
-	const handleOpenNote = useCallback(
-		(path: string) => onOpenNote(path),
-		[onOpenNote],
-	);
-
-	const handleOpenDailyNoteAtDate = useCallback(
-		(date: string) => onOpenDailyNoteAtDate(date),
-		[onOpenDailyNoteAtDate],
-	);
-
 	if (!mounted) return null;
 
 	return (
@@ -53,8 +43,8 @@ export function CalendarPaletteController({
 				onClose={onClose}
 				spacePath={spacePath}
 				dailyNoteFolder={dailyNoteFolder}
-				onOpenNote={handleOpenNote}
-				onOpenDailyNoteAtDate={handleOpenDailyNoteAtDate}
+				onOpenNote={onOpenNote}
+				onOpenDailyNoteAtDate={onOpenDailyNoteAtDate}
 			/>
 		</Suspense>
 	);

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -41,6 +41,7 @@ interface SidebarProps {
 	onPrefetchAllDocs: () => void;
 	onPrefetchFile: (relPath: string) => void;
 	onOpenCommandPalette: () => void;
+	onOpenCalendar: () => void;
 }
 
 export const Sidebar = memo(function Sidebar({
@@ -70,6 +71,7 @@ export const Sidebar = memo(function Sidebar({
 	onPrefetchAllDocs,
 	onPrefetchFile,
 	onOpenCommandPalette,
+	onOpenCalendar,
 }: SidebarProps) {
 	const { sidebarWidth, settingsMode } = useUILayoutContext();
 	const shouldReduceMotion = useReducedMotion();
@@ -142,6 +144,7 @@ export const Sidebar = memo(function Sidebar({
 									onOpenAllDocs={onOpenAllDocs}
 									onOpenConnections={onOpenConnections}
 									onOpenCommandPalette={onOpenCommandPalette}
+									onOpenCalendar={onOpenCalendar}
 									spacePath={spacePath}
 									activeTopSection={activeTopSection}
 								/>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../lib/navigationPrefetch";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
-import { ChevronDown, ChevronRight } from "../Icons";
+import { Calendar, ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
 import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
@@ -58,6 +58,7 @@ interface SidebarContentProps {
 	onOpenAllDocs: () => void;
 	onOpenConnections: () => void;
 	onOpenCommandPalette: () => void;
+	onOpenCalendar: () => void;
 	spacePath: string | null;
 	activeTopSection: "all-notes" | "connections" | "databases" | null;
 }
@@ -130,6 +131,7 @@ export const SidebarContent = memo(function SidebarContent({
 	onOpenAllDocs,
 	onOpenConnections,
 	onOpenCommandPalette,
+	onOpenCalendar,
 	spacePath,
 	activeTopSection,
 }: SidebarContentProps) {
@@ -358,7 +360,7 @@ export const SidebarContent = memo(function SidebarContent({
 		<>
 			<div className="sidebarSection sidebarSectionGrow">
 				<div className="sidebarSectionContent">
-					<div className="sidebarCommandSearch">
+					<div className="sidebarCommandSearchRow">
 						<button
 							type="button"
 							className="sidebarCommandSearchButton"
@@ -383,6 +385,15 @@ export const SidebarContent = memo(function SidebarContent({
 									{formatShortcutForPlatform(commandPaletteShortcut)}
 								</span>
 							) : null}
+						</button>
+						<button
+							type="button"
+							className="sidebarCalendarButton"
+							onClick={onOpenCalendar}
+							aria-label="Open calendar"
+							title="Open calendar"
+						>
+							<Calendar size="var(--icon-md)" />
 						</button>
 					</div>
 					<div className="sidebarNavRow">

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -27,6 +27,7 @@ import { ColoredText } from "./coloredText";
 import { HeadingCollapse } from "./headingCollapse";
 import { HighlightedText } from "./highlightedText";
 import { MarkdownImage } from "./markdownImage";
+import { MarkdownImageLivePreview } from "./markdownImageLivePreview";
 import { MarkdownLinkAutocomplete } from "./markdownLinkAutocomplete";
 import { MermaidPreview } from "./mermaidPreview";
 import { NoteSearch } from "./noteSearch";
@@ -47,21 +48,6 @@ function parseCalloutMarker(
 	const rawTitle = (match[2] ?? "").trim();
 	const title = rawTitle || `${kind.slice(0, 1).toUpperCase()}${kind.slice(1)}`;
 	return { kind, title };
-}
-
-function parseStandaloneMarkdownImage(
-	text: string,
-): { alt: string; src: string; title: string } | null {
-	const trimmed = text.trim();
-	const match = trimmed.match(/^!\[([^\]\n]*)\]\((.+?)(?:\s+"([^"]*)")?\)$/);
-	if (!match) return null;
-	const src = (match[2] ?? "").trim();
-	if (!src) return null;
-	return {
-		alt: (match[1] ?? "").trim(),
-		src,
-		title: (match[3] ?? "").trim(),
-	};
 }
 
 const CalloutDecorations = Extension.create({
@@ -556,71 +542,6 @@ const TaskDetailShortcut = Extension.create({
 	},
 });
 
-const MarkdownImageShortcut = Extension.create({
-	name: "markdown-image-shortcut",
-	addProseMirrorPlugins() {
-		const key = new PluginKey("markdown-image-shortcut");
-		return [
-			new Plugin({
-				key,
-				appendTransaction(transactions, _oldState, newState) {
-					if (!transactions.some((tr) => tr.docChanged)) return null;
-
-					const paragraph = newState.schema.nodes.paragraph;
-					const image = newState.schema.nodes.image;
-					if (!paragraph || !image) return null;
-
-					const replacements: Array<{
-						pos: number;
-						size: number;
-						alt: string;
-						src: string;
-						title: string;
-					}> = [];
-
-					visitChangedNodes(transactions, newState, (node, pos) => {
-						if (node.type !== paragraph || node.childCount !== 1) return;
-						if (node.firstChild?.type.name !== "text") return;
-						const parsed = parseStandaloneMarkdownImage(node.textContent ?? "");
-						if (!parsed) return;
-						const $pos = newState.doc.resolve(pos);
-						const parent = $pos.parent;
-						if (parent.type.name === "listItem") return;
-						const index = $pos.index();
-						if (!parent.canReplaceWith(index, index + 1, image)) return;
-						replacements.push({
-							pos,
-							size: node.nodeSize,
-							alt: parsed.alt,
-							src: parsed.src,
-							title: parsed.title,
-						});
-					});
-
-					if (!replacements.length) return null;
-
-					let tr = newState.tr;
-					for (let i = replacements.length - 1; i >= 0; i -= 1) {
-						const replacement = replacements[i];
-						tr = tr.replaceWith(
-							replacement.pos,
-							replacement.pos + replacement.size,
-							image.create({
-								src: replacement.src,
-								alt: replacement.alt,
-								title: replacement.title,
-								originSrc: replacement.src,
-							}),
-						);
-					}
-
-					return tr.docChanged ? tr : null;
-				},
-			}),
-		];
-	},
-});
-
 const TableEnterNavigation = Extension.create({
 	name: "table-enter-navigation",
 	addKeyboardShortcuts() {
@@ -771,7 +692,7 @@ export function createEditorExtensions(
 					TaskListMarkdownShortcut,
 					TaskDetailShortcut,
 					MarkdownLinkSyntaxCollapse,
-					MarkdownImageShortcut,
+					MarkdownImageLivePreview,
 					NoteSearch,
 					TableEnterNavigation,
 				]

--- a/src/components/editor/extensions/markdownImage.integration.test.ts
+++ b/src/components/editor/extensions/markdownImage.integration.test.ts
@@ -1,7 +1,23 @@
+// @vitest-environment jsdom
+
+import { Editor } from "@tiptap/core";
 import { MarkdownManager } from "@tiptap/markdown";
+import { NodeSelection } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it } from "vitest";
+import { createEditorExtensions } from "./index";
 import { MarkdownImage } from "./markdownImage";
+
+function findImagePos(editor: Editor) {
+	let imagePos = -1;
+	editor.state.doc.descendants((node, pos) => {
+		if (imagePos !== -1) return false;
+		if (node.type.name !== "image") return true;
+		imagePos = pos;
+		return false;
+	});
+	return imagePos;
+}
 
 describe("MarkdownImage markdown manager integration", () => {
 	it("parses image markdown into an image node and serializes back", () => {
@@ -20,5 +36,65 @@ describe("MarkdownImage markdown manager integration", () => {
 
 		const output = manager.serialize(json);
 		expect(output).toContain("![Alt text](../assets/example.png)");
+	});
+
+	it("renders a standalone markdown image when the editor opens", () => {
+		const element = document.createElement("div");
+		document.body.appendChild(element);
+		const editor = new Editor({
+			extensions: createEditorExtensions({
+				enableSlashCommand: false,
+				enableWikiLinks: false,
+				enableMarkdownLinkAutocomplete: false,
+			}),
+			content: "![](img.png)",
+			contentType: "markdown",
+			element,
+		});
+
+		try {
+			const image = element.querySelector("img");
+			expect(image?.getAttribute("src")).toBe("img.png");
+			expect(element.textContent).not.toContain("![](img.png)");
+		} finally {
+			editor.destroy();
+			element.remove();
+		}
+	});
+
+	it("collapses expanded image markdown when the selection moves away", () => {
+		const element = document.createElement("div");
+		document.body.appendChild(element);
+		const editor = new Editor({
+			extensions: createEditorExtensions({
+				enableSlashCommand: false,
+				enableWikiLinks: false,
+				enableMarkdownLinkAutocomplete: false,
+			}),
+			content: ["![](img.png)", "", "after"].join("\n"),
+			contentType: "markdown",
+			element,
+		});
+
+		try {
+			const imagePos = findImagePos(editor);
+			expect(imagePos).toBeGreaterThanOrEqual(0);
+			editor.view.dispatch(
+				editor.state.tr.setSelection(
+					NodeSelection.create(editor.state.doc, imagePos),
+				),
+			);
+			expect(element.textContent).toContain("![](img.png)");
+
+			editor.commands.setTextSelection(editor.state.doc.content.size);
+
+			const image = element.querySelector("img");
+			expect(image?.getAttribute("src")).toBe("img.png");
+			expect(element.textContent).not.toContain("![](img.png)");
+			expect(editor.state.selection.empty).toBe(true);
+		} finally {
+			editor.destroy();
+			element.remove();
+		}
 	});
 });

--- a/src/components/editor/extensions/markdownImage.ts
+++ b/src/components/editor/extensions/markdownImage.ts
@@ -12,7 +12,7 @@ function getTokenField(
 	return typeof attributeValue === "string" ? attributeValue : null;
 }
 
-function encodeMarkdownImageSrc(src: string): string {
+export function encodeMarkdownImageSrc(src: string): string {
 	const trimmed = src.trim();
 	if (!trimmed) return "";
 	try {

--- a/src/components/editor/extensions/markdownImageLivePreview.ts
+++ b/src/components/editor/extensions/markdownImageLivePreview.ts
@@ -1,0 +1,215 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey, Selection, TextSelection } from "@tiptap/pm/state";
+
+export const markdownImagePreviewPluginKey = new PluginKey(
+	"markdown-image-preview",
+);
+
+function parseStandaloneMarkdownImage(
+	text: string,
+): { alt: string; src: string; title: string } | null {
+	const trimmed = text.trim();
+	const match = trimmed.match(/^!\[([^\]\n]*)\]\((.+?)(?:\s+"([^"]*)")?\)$/);
+	if (!match) return null;
+	const src = (match[2] ?? "").trim();
+	if (!src) return null;
+	return {
+		alt: (match[1] ?? "").trim(),
+		src,
+		title: (match[3] ?? "").trim(),
+	};
+}
+
+function buildImageMarkdown(attrs: Record<string, unknown>): string | null {
+	const originSrc =
+		typeof attrs.originSrc === "string" && attrs.originSrc.trim()
+			? attrs.originSrc.trim()
+			: typeof attrs.src === "string"
+				? attrs.src.trim()
+				: "";
+	if (!originSrc) return null;
+	const alt = typeof attrs.alt === "string" ? attrs.alt.trim() : "";
+	const title = typeof attrs.title === "string" ? attrs.title.trim() : "";
+	return title
+		? `![${alt}](${originSrc} "${title}")`
+		: `![${alt}](${originSrc})`;
+}
+
+type ExpandOp = {
+	kind: "expand";
+	pos: number;
+	size: number;
+	markdown: string;
+};
+
+type CollapseOp = {
+	kind: "collapse";
+	pos: number;
+	size: number;
+	alt: string;
+	src: string;
+	title: string;
+};
+
+type PreviewOp = ExpandOp | CollapseOp;
+
+export const MarkdownImageLivePreview = Extension.create({
+	name: "markdown-image-live-preview",
+	addProseMirrorPlugins() {
+		const editor = this.editor;
+		return [
+			new Plugin({
+				key: markdownImagePreviewPluginKey,
+				appendTransaction(transactions, oldState, newState) {
+					if (!editor?.isEditable) return null;
+					const selectionChanged = transactions.some((tr) => tr.selectionSet);
+					const relevant =
+						selectionChanged || transactions.some((tr) => tr.docChanged);
+					if (!relevant) return null;
+					if (
+						transactions.some(
+							(tr) => tr.getMeta(markdownImagePreviewPluginKey) === "applied",
+						)
+					) {
+						return null;
+					}
+
+					const paragraph = newState.schema.nodes.paragraph;
+					const image = newState.schema.nodes.image;
+					if (!paragraph || !image) return null;
+
+					const { from: selFrom, to: selTo } = newState.selection;
+					const ops: PreviewOp[] = [];
+
+					newState.doc.descendants((node, pos) => {
+						const start = pos;
+						const end = pos + node.nodeSize;
+						const caretInside = selFrom < end && selTo > start;
+
+						if (node.type === image) {
+							if (!caretInside || !selectionChanged) return false;
+							if (oldState.doc.nodeAt(pos)?.type !== image) return false;
+							const markdown = buildImageMarkdown(
+								node.attrs as Record<string, unknown>,
+							);
+							if (!markdown) return false;
+							const $pos = newState.doc.resolve(pos);
+							const index = $pos.index();
+							if (!$pos.parent.canReplaceWith(index, index + 1, paragraph)) {
+								return false;
+							}
+							ops.push({
+								kind: "expand",
+								pos,
+								size: node.nodeSize,
+								markdown,
+							});
+							return false;
+						}
+
+						if (
+							node.type === paragraph &&
+							node.childCount === 1 &&
+							node.firstChild?.type.name === "text"
+						) {
+							if (caretInside) return false;
+							const parsed = parseStandaloneMarkdownImage(
+								node.textContent ?? "",
+							);
+							if (!parsed) return false;
+							const $pos = newState.doc.resolve(pos);
+							if ($pos.parent.type.name === "listItem") return false;
+							const index = $pos.index();
+							if (!$pos.parent.canReplaceWith(index, index + 1, image)) {
+								return false;
+							}
+							ops.push({
+								kind: "collapse",
+								pos,
+								size: node.nodeSize,
+								alt: parsed.alt,
+								src: parsed.src,
+								title: parsed.title,
+							});
+							return false;
+						}
+
+						return undefined;
+					});
+
+					if (!ops.length) return null;
+
+					ops.sort((a, b) => b.pos - a.pos);
+					const expandOps = ops.filter(
+						(op): op is ExpandOp => op.kind === "expand",
+					);
+					const collapseOps = ops.filter(
+						(op): op is CollapseOp => op.kind === "collapse",
+					);
+					const selectionHead = newState.selection.head;
+
+					let tr = newState.tr;
+					for (const op of ops) {
+						if (op.kind === "collapse") {
+							tr = tr.replaceWith(
+								op.pos,
+								op.pos + op.size,
+								image.create({
+									src: op.src,
+									alt: op.alt,
+									title: op.title,
+									originSrc: op.src,
+								}),
+							);
+						} else {
+							tr = tr.replaceWith(
+								op.pos,
+								op.pos + op.size,
+								paragraph.create(null, newState.schema.text(op.markdown)),
+							);
+						}
+					}
+
+					if (!tr.docChanged) return null;
+
+					if (expandOps.length === 1) {
+						const op = expandOps[0];
+						const base = tr.mapping.map(op.pos, -1) + 1;
+						const srcOffset = op.markdown.indexOf("](") + 2;
+						const srcEndOffset = op.markdown.indexOf(")", srcOffset);
+						const srcStart = base + srcOffset;
+						const srcEnd =
+							base + (srcEndOffset === -1 ? srcOffset : srcEndOffset);
+						try {
+							tr = tr.setSelection(
+								TextSelection.create(tr.doc, srcStart, srcEnd),
+							);
+						} catch {
+							// Leave the mapped selection untouched.
+						}
+					}
+
+					if (!expandOps.length && collapseOps.length) {
+						const collapsedStart = Math.min(...collapseOps.map((op) => op.pos));
+						const bias = selectionHead <= collapsedStart ? -1 : 1;
+						const mappedHead = Math.max(
+							0,
+							Math.min(tr.doc.content.size, tr.mapping.map(selectionHead, bias)),
+						);
+						try {
+							tr = tr.setSelection(
+								Selection.near(tr.doc.resolve(mappedHead), bias),
+							);
+						} catch {
+							// Leave the mapped selection untouched.
+						}
+					}
+
+					tr.setMeta(markdownImagePreviewPluginKey, "applied");
+					tr.setMeta("addToHistory", false);
+					return tr;
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/extensions/markdownImageLivePreview.ts
+++ b/src/components/editor/extensions/markdownImageLivePreview.ts
@@ -1,5 +1,13 @@
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey, Selection, TextSelection } from "@tiptap/pm/state";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import {
+	type EditorState,
+	Plugin,
+	PluginKey,
+	Selection,
+	TextSelection,
+} from "@tiptap/pm/state";
+import { encodeMarkdownImageSrc } from "./markdownImage";
 
 export const markdownImagePreviewPluginKey = new PluginKey(
 	"markdown-image-preview",
@@ -30,9 +38,10 @@ function buildImageMarkdown(attrs: Record<string, unknown>): string | null {
 	if (!originSrc) return null;
 	const alt = typeof attrs.alt === "string" ? attrs.alt.trim() : "";
 	const title = typeof attrs.title === "string" ? attrs.title.trim() : "";
+	const encodedSrc = encodeMarkdownImageSrc(originSrc);
 	return title
-		? `![${alt}](${originSrc} "${title}")`
-		: `![${alt}](${originSrc})`;
+		? `![${alt}](${encodedSrc} "${title}")`
+		: `![${alt}](${encodedSrc})`;
 }
 
 type ExpandOp = {
@@ -53,6 +62,45 @@ type CollapseOp = {
 
 type PreviewOp = ExpandOp | CollapseOp;
 
+type ScanRange = {
+	from: number;
+	to: number;
+};
+
+function selectionScanRanges(
+	oldState: EditorState,
+	newState: EditorState,
+): ScanRange[] {
+	const ranges: ScanRange[] = [];
+	const seen = new Set<string>();
+
+	const addRange = (from: number, to: number) => {
+		const boundedFrom = Math.max(0, Math.min(from, newState.doc.content.size));
+		const boundedTo = Math.max(
+			boundedFrom,
+			Math.min(to, newState.doc.content.size),
+		);
+		if (boundedFrom === boundedTo) return;
+		const key = `${boundedFrom}:${boundedTo}`;
+		if (seen.has(key)) return;
+		seen.add(key);
+		ranges.push({ from: boundedFrom, to: boundedTo });
+	};
+
+	const addSelection = (selection: Selection) => {
+		addRange(selection.from, selection.to);
+		for (const pos of [selection.from, selection.to]) {
+			const $pos = newState.doc.resolve(pos);
+			if ($pos.depth === 0) continue;
+			addRange($pos.before($pos.depth), $pos.after($pos.depth));
+		}
+	};
+
+	addSelection(oldState.selection);
+	addSelection(newState.selection);
+	return ranges;
+}
+
 export const MarkdownImageLivePreview = Extension.create({
 	name: "markdown-image-live-preview",
 	addProseMirrorPlugins() {
@@ -63,8 +111,8 @@ export const MarkdownImageLivePreview = Extension.create({
 				appendTransaction(transactions, oldState, newState) {
 					if (!editor?.isEditable) return null;
 					const selectionChanged = transactions.some((tr) => tr.selectionSet);
-					const relevant =
-						selectionChanged || transactions.some((tr) => tr.docChanged);
+					const docChanged = transactions.some((tr) => tr.docChanged);
+					const relevant = selectionChanged || docChanged;
 					if (!relevant) return null;
 					if (
 						transactions.some(
@@ -80,8 +128,11 @@ export const MarkdownImageLivePreview = Extension.create({
 
 					const { from: selFrom, to: selTo } = newState.selection;
 					const ops: PreviewOp[] = [];
+					const visitedPositions = new Set<number>();
 
-					newState.doc.descendants((node, pos) => {
+					const visitNode = (node: ProseMirrorNode, pos: number) => {
+						if (visitedPositions.has(pos)) return false;
+						visitedPositions.add(pos);
 						const start = pos;
 						const end = pos + node.nodeSize;
 						const caretInside = selFrom < end && selTo > start;
@@ -135,7 +186,15 @@ export const MarkdownImageLivePreview = Extension.create({
 						}
 
 						return undefined;
-					});
+					};
+
+					if (docChanged) {
+						newState.doc.descendants(visitNode);
+					} else {
+						for (const range of selectionScanRanges(oldState, newState)) {
+							newState.doc.nodesBetween(range.from, range.to, visitNode);
+						}
+					}
 
 					if (!ops.length) return null;
 
@@ -194,7 +253,10 @@ export const MarkdownImageLivePreview = Extension.create({
 						const bias = selectionHead <= collapsedStart ? -1 : 1;
 						const mappedHead = Math.max(
 							0,
-							Math.min(tr.doc.content.size, tr.mapping.map(selectionHead, bias)),
+							Math.min(
+								tr.doc.content.size,
+								tr.mapping.map(selectionHead, bias),
+							),
 						);
 						try {
 							tr = tr.setSelection(
@@ -206,6 +268,7 @@ export const MarkdownImageLivePreview = Extension.create({
 					}
 
 					tr.setMeta(markdownImagePreviewPluginKey, "applied");
+					// Selection-driven preview toggles should not pollute the user's undo stack.
 					tr.setMeta("addToHistory", false);
 					return tr;
 				},

--- a/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
+++ b/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
@@ -1,0 +1,387 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type FsEntry, invoke } from "../../lib/tauri";
+import { parentDir } from "../../utils/path";
+import { ChevronRight } from "../Icons";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
+
+export const QUICK_NOTE_TARGET_VALUE = "__quick-note-today__";
+
+export interface QuickNoteTarget {
+	value: string;
+	path: string;
+	label: string;
+	detail: string;
+}
+
+interface BreadcrumbPart {
+	label: string;
+	path: string;
+	kind: "folder" | "file";
+}
+
+interface QuickNoteTargetBreadcrumbsProps {
+	selectedTarget: QuickNoteTarget;
+	quickNotesFolder: string;
+	todayQuickNotePath: string;
+	onSelectTarget: (target: QuickNoteTarget) => void;
+}
+
+const ROOT_PATH_KEY = "__root__";
+
+function stripFileExtension(name: string) {
+	if (!name || name.startsWith(".")) return name;
+	const withoutExt = name.replace(/\.[^./]+$/, "");
+	return withoutExt || name;
+}
+
+function savedLabel(path: string) {
+	const name = path.split("/").filter(Boolean).pop() ?? path;
+	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
+}
+
+function targetDetail(path: string) {
+	return parentDir(path) || "Space root";
+}
+
+function sortTargetEntries(entries: FsEntry[]) {
+	return [...entries]
+		.filter((entry) => entry.kind === "dir" || entry.is_markdown)
+		.sort((a, b) => {
+			if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+			return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+		});
+}
+
+function menuTitleForDir(path: string) {
+	if (!path) return "Space";
+	const parts = path.split("/").filter(Boolean);
+	return parts[parts.length - 1] ?? "Space";
+}
+
+function breadcrumbPartsForTarget(
+	path: string,
+	targetValue: string,
+	todayQuickNotePath: string,
+): BreadcrumbPart[] {
+	return [
+		{ label: "Space", path: "", kind: "folder" },
+		...path
+			.split("/")
+			.filter(Boolean)
+			.map((segment, index, segments): BreadcrumbPart => {
+				const segmentPath = segments.slice(0, index + 1).join("/");
+				const isFile = index === segments.length - 1;
+				let label = isFile ? stripFileExtension(segment) : segment;
+				if (
+					isFile &&
+					targetValue === QUICK_NOTE_TARGET_VALUE &&
+					path === todayQuickNotePath
+				) {
+					label = "Today's quick note";
+				}
+				return {
+					label,
+					path: segmentPath,
+					kind: isFile ? "file" : "folder",
+				};
+			}),
+	];
+}
+
+function fileTarget(path: string): QuickNoteTarget {
+	return {
+		value: path,
+		path,
+		label: savedLabel(path),
+		detail: targetDetail(path),
+	};
+}
+
+function todayQuickNoteTarget(todayQuickNotePath: string): QuickNoteTarget {
+	return {
+		value: QUICK_NOTE_TARGET_VALUE,
+		path: todayQuickNotePath,
+		label: "Today's quick note",
+		detail: targetDetail(todayQuickNotePath),
+	};
+}
+
+function entryLabel(entry: FsEntry) {
+	return entry.is_markdown ? entry.name.replace(/\.[^./]+$/, "") : entry.name;
+}
+
+function TargetBreadcrumbMenuItem({
+	entry,
+	childrenByDir,
+	onLoadDir,
+	onSelectTarget,
+}: {
+	entry: FsEntry;
+	childrenByDir: Record<string, FsEntry[] | undefined>;
+	onLoadDir: (dirPath: string) => Promise<void>;
+	onSelectTarget: (target: QuickNoteTarget) => void;
+}) {
+	const childEntries = childrenByDir[entry.rel_path];
+	const loading = childEntries === undefined;
+	const isDir = entry.kind === "dir";
+
+	if (!isDir) {
+		return (
+			<DropdownMenuItem
+				key={entry.rel_path || ROOT_PATH_KEY}
+				className="quickNoteTargetMenuItem"
+				title={entry.rel_path || entry.name}
+				onSelect={() => onSelectTarget(fileTarget(entry.rel_path))}
+			>
+				<span className="quickNoteTargetMenuItemLabel">
+					{entryLabel(entry)}
+				</span>
+			</DropdownMenuItem>
+		);
+	}
+
+	return (
+		<DropdownMenuSub
+			onOpenChange={(open) => {
+				if (open && loading) void onLoadDir(entry.rel_path);
+			}}
+		>
+			<DropdownMenuSubTrigger className="quickNoteTargetMenuItem">
+				<span className="quickNoteTargetMenuItemLabel">{entry.name}</span>
+			</DropdownMenuSubTrigger>
+			<DropdownMenuSubContent className="quickNoteTargetMenu" sideOffset={4}>
+				{loading ? null : childEntries.length === 0 ? (
+					<div className="quickNoteTargetMenuState">Empty folder</div>
+				) : (
+					<>
+						{childEntries.slice(0, 40).map((child) => (
+							<TargetBreadcrumbMenuItem
+								key={child.rel_path || ROOT_PATH_KEY}
+								entry={child}
+								childrenByDir={childrenByDir}
+								onLoadDir={onLoadDir}
+								onSelectTarget={onSelectTarget}
+							/>
+						))}
+						{childEntries.length > 40 ? (
+							<div className="quickNoteTargetMenuState">
+								+{childEntries.length - 40} more
+							</div>
+						) : null}
+					</>
+				)}
+			</DropdownMenuSubContent>
+		</DropdownMenuSub>
+	);
+}
+
+function TargetBreadcrumbEntryMenu({
+	open,
+	dirPath,
+	entries,
+	loading,
+	quickNotesFolder,
+	todayQuickNotePath,
+	selectedTargetValue,
+	onOpenChange,
+	onLoadDir,
+	onSelectTarget,
+	childrenByDir,
+}: {
+	open: boolean;
+	dirPath: string;
+	entries: FsEntry[];
+	loading: boolean;
+	quickNotesFolder: string;
+	todayQuickNotePath: string;
+	selectedTargetValue: string;
+	onOpenChange: (open: boolean) => void;
+	onLoadDir: (dirPath: string) => Promise<void>;
+	onSelectTarget: (target: QuickNoteTarget) => void;
+	childrenByDir: Record<string, FsEntry[] | undefined>;
+}) {
+	const showTodayQuickNote = dirPath === quickNotesFolder;
+
+	return (
+		<DropdownMenu
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (nextOpen && loading) void onLoadDir(dirPath);
+				onOpenChange(nextOpen);
+			}}
+		>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className="quickNoteTargetSepButton"
+					aria-label={`Browse ${menuTitleForDir(dirPath)}`}
+				>
+					<ChevronRight
+						size="var(--icon-xs)"
+						className="quickNoteTargetSep"
+						aria-hidden="true"
+					/>
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				side="top"
+				className="quickNoteTargetMenu"
+			>
+				<DropdownMenuLabel className="quickNoteTargetMenuLabel">
+					{menuTitleForDir(dirPath)}
+				</DropdownMenuLabel>
+				{showTodayQuickNote ? (
+					<DropdownMenuItem
+						className="quickNoteTargetMenuItem"
+						title={todayQuickNotePath}
+						data-selected={
+							selectedTargetValue === QUICK_NOTE_TARGET_VALUE
+								? "true"
+								: undefined
+						}
+						onSelect={() =>
+							onSelectTarget(todayQuickNoteTarget(todayQuickNotePath))
+						}
+					>
+						<span className="quickNoteTargetMenuItemLabel">
+							Today&apos;s quick note
+						</span>
+					</DropdownMenuItem>
+				) : null}
+				{loading ? null : entries.length === 0 ? (
+					<div className="quickNoteTargetMenuState">Empty folder</div>
+				) : (
+					entries.map((entry) => (
+						<TargetBreadcrumbMenuItem
+							key={entry.rel_path || ROOT_PATH_KEY}
+							entry={entry}
+							childrenByDir={childrenByDir}
+							onLoadDir={onLoadDir}
+							onSelectTarget={onSelectTarget}
+						/>
+					))
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export function QuickNoteTargetBreadcrumbs({
+	selectedTarget,
+	quickNotesFolder,
+	todayQuickNotePath,
+	onSelectTarget,
+}: QuickNoteTargetBreadcrumbsProps) {
+	const [childrenByDir, setChildrenByDir] = useState<
+		Record<string, FsEntry[] | undefined>
+	>({});
+	const childrenByDirRef = useRef(childrenByDir);
+	childrenByDirRef.current = childrenByDir;
+	const [openMenuKey, setOpenMenuKey] = useState<string | null>(null);
+	const breadcrumbParts = breadcrumbPartsForTarget(
+		selectedTarget.path,
+		selectedTarget.value,
+		todayQuickNotePath,
+	);
+
+	const loadDir = useCallback(async (dirPath: string) => {
+		if (childrenByDirRef.current[dirPath] !== undefined) return;
+		try {
+			const entries = await invoke(
+				"space_list_dir",
+				dirPath ? { dir: dirPath } : {},
+			);
+			setChildrenByDir((current) => ({
+				...current,
+				[dirPath]: sortTargetEntries(entries),
+			}));
+		} catch {
+			setChildrenByDir((current) => ({
+				...current,
+				[dirPath]: [],
+			}));
+		}
+	}, []);
+
+	useEffect(() => {
+		const segments = selectedTarget.path.split("/").filter(Boolean);
+		const dirsToLoad = [
+			"",
+			...segments
+				.slice(0, -1)
+				.map((_, index) => segments.slice(0, index + 1).join("/")),
+		];
+		for (const dirPath of dirsToLoad) {
+			void loadDir(dirPath);
+		}
+	}, [selectedTarget.path, loadDir]);
+
+	const handleSelectTarget = useCallback(
+		(target: QuickNoteTarget) => {
+			onSelectTarget(target);
+			setOpenMenuKey(null);
+		},
+		[onSelectTarget],
+	);
+
+	return (
+		<nav
+			className="quickNoteTargetBreadcrumb"
+			data-open="true"
+			aria-label="Quick note destination"
+		>
+			{breadcrumbParts.map((part, index) => {
+				const isCurrent = index === breadcrumbParts.length - 1;
+				const menuDirPath = breadcrumbParts[index - 1]?.path ?? "";
+				const menuEntries = childrenByDir[menuDirPath];
+				const menuItems = menuEntries ?? [];
+				const menuKey = `${index}:${menuDirPath || ROOT_PATH_KEY}`;
+
+				return (
+					<span
+						key={part.path || ROOT_PATH_KEY}
+						className="quickNoteTargetItem"
+						data-current={isCurrent ? "true" : undefined}
+					>
+						{index > 0 ? (
+							<TargetBreadcrumbEntryMenu
+								open={openMenuKey === menuKey}
+								dirPath={menuDirPath}
+								entries={menuItems}
+								loading={menuEntries === undefined}
+								quickNotesFolder={quickNotesFolder}
+								todayQuickNotePath={todayQuickNotePath}
+								selectedTargetValue={selectedTarget.value}
+								onOpenChange={(open) => {
+									setOpenMenuKey(open ? menuKey : null);
+								}}
+								onLoadDir={loadDir}
+								onSelectTarget={handleSelectTarget}
+								childrenByDir={childrenByDir}
+							/>
+						) : null}
+						<button
+							type="button"
+							className="quickNoteTargetButton"
+							aria-current={isCurrent ? "page" : undefined}
+							aria-disabled={isCurrent}
+							title={part.path || "Space"}
+						>
+							<span className="quickNoteTargetLabel">{part.label}</span>
+						</button>
+					</span>
+				);
+			})}
+		</nav>
+	);
+}

--- a/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
+++ b/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
@@ -305,7 +305,8 @@ export function QuickNoteTargetBreadcrumbs({
 				...current,
 				[dirPath]: sortTargetEntries(entries),
 			}));
-		} catch {
+		} catch (cause) {
+			console.error("Failed to load quick note target directory", cause);
 			setChildrenByDir((current) => ({
 				...current,
 				[dirPath]: [],
@@ -370,15 +371,13 @@ export function QuickNoteTargetBreadcrumbs({
 								childrenByDir={childrenByDir}
 							/>
 						) : null}
-						<button
-							type="button"
+						<span
 							className="quickNoteTargetButton"
 							aria-current={isCurrent ? "page" : undefined}
-							aria-disabled={isCurrent}
 							title={part.path || "Space"}
 						>
 							<span className="quickNoteTargetLabel">{part.label}</span>
-						</button>
+						</span>
 					</span>
 				);
 			})}

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -9,26 +9,15 @@ import {
 } from "react";
 import { isMissingFileError } from "../../lib/fsErrors";
 import { loadSettings, reloadFromDisk } from "../../lib/settings";
-import { type FsEntry, invoke } from "../../lib/tauri";
+import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename, parentDir } from "../../utils/path";
-import { ChevronDown, FileText, Save } from "../Icons";
-
-const QUICK_NOTE_TARGET_VALUE = "__quick-note-today__";
-const MARKDOWN_TARGET_LIMIT = 2000;
-
-interface QuickNoteTarget {
-	value: string;
-	path: string;
-	label: string;
-	detail: string;
-}
-
-interface QuickNoteTargetGroup {
-	folder: string;
-	label: string;
-	targets: QuickNoteTarget[];
-}
+import { FileText, Save } from "../Icons";
+import {
+	QUICK_NOTE_TARGET_VALUE,
+	type QuickNoteTarget,
+	QuickNoteTargetBreadcrumbs,
+} from "./QuickNoteTargetBreadcrumbs";
 
 function pad(value: number): string {
 	return value.toString().padStart(2, "0");
@@ -86,50 +75,14 @@ function savedLabel(path: string) {
 	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
 }
 
-function targetDetail(path: string) {
-	return parentDir(path) || "Space root";
-}
-
 function quickNoteTarget(folder: string): QuickNoteTarget {
 	const path = quickNotePath(folder);
 	return {
 		value: QUICK_NOTE_TARGET_VALUE,
 		path,
 		label: "Today's quick note",
-		detail: targetDetail(path),
+		detail: parentDir(path) || "Space root",
 	};
-}
-
-function fileTarget(entry: FsEntry): QuickNoteTarget {
-	return {
-		value: entry.rel_path,
-		path: entry.rel_path,
-		label: savedLabel(entry.rel_path),
-		detail: targetDetail(entry.rel_path),
-	};
-}
-
-function sortMarkdownFiles(files: FsEntry[]): FsEntry[] {
-	return [...files].sort((a, b) => {
-		const folderCompare = parentDir(a.rel_path).localeCompare(
-			parentDir(b.rel_path),
-		);
-		if (folderCompare !== 0) return folderCompare;
-		return savedLabel(a.rel_path).localeCompare(savedLabel(b.rel_path));
-	});
-}
-
-function groupTargets(targets: QuickNoteTarget[]): QuickNoteTargetGroup[] {
-	const groups = new Map<string, QuickNoteTarget[]>();
-	for (const target of targets) {
-		const folder = parentDir(target.path);
-		groups.set(folder, [...(groups.get(folder) ?? []), target]);
-	}
-	return [...groups.entries()].map(([folder, groupTargets]) => ({
-		folder,
-		label: folder || "Space root",
-		targets: groupTargets,
-	}));
 }
 
 export function QuickNoteWindow() {
@@ -138,45 +91,30 @@ export function QuickNoteWindow() {
 	const [status, setStatus] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [targetValue, setTargetValue] = useState(QUICK_NOTE_TARGET_VALUE);
-	const [targetsOpen, setTargetsOpen] = useState(false);
-	const [fileTargets, setFileTargets] = useState<QuickNoteTarget[]>([]);
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-	const targetSelectorRef = useRef<HTMLDivElement | null>(null);
-	const targetTriggerRef = useRef<HTMLButtonElement | null>(null);
 
 	const hasText = draft.trim().length > 0;
-	const defaultTarget = useMemo(() => quickNoteTarget(folder), [folder]);
-	const groupedFileTargets = useMemo(
-		() => groupTargets(fileTargets),
-		[fileTargets],
-	);
-	const selectedTarget =
-		targetValue === QUICK_NOTE_TARGET_VALUE
-			? defaultTarget
-			: (fileTargets.find((target) => target.value === targetValue) ??
-				defaultTarget);
+	const todayQuickNotePath = useMemo(() => quickNotePath(folder), [folder]);
+	const selectedTarget = useMemo((): QuickNoteTarget => {
+		if (targetValue === QUICK_NOTE_TARGET_VALUE) {
+			return quickNoteTarget(folder);
+		}
+		return {
+			value: targetValue,
+			path: targetValue,
+			label: savedLabel(targetValue),
+			detail: parentDir(targetValue) || "Space root",
+		};
+	}, [folder, targetValue]);
 	const isMac =
 		navigator.platform.toLowerCase().includes("mac") ||
 		navigator.userAgent.includes("Mac");
 	const shortcutLabel = isMac ? "⌘+Enter" : "Ctrl+Enter";
 	const shortcutModifierLabel = isMac ? "⌘" : "Ctrl";
 
-	const chooseTarget = useCallback((value: string) => {
-		setTargetValue(value);
-		setTargetsOpen(false);
+	const chooseTarget = useCallback((target: QuickNoteTarget) => {
+		setTargetValue(target.value);
 		window.setTimeout(() => textareaRef.current?.focus(), 20);
-	}, []);
-
-	const focusTargetOption = useCallback((position: "first" | "last") => {
-		window.requestAnimationFrame(() => {
-			const options =
-				targetSelectorRef.current?.querySelectorAll<HTMLButtonElement>(
-					".quickNoteTargetMenu .quickNoteTargetOption",
-				);
-			const nextOption =
-				position === "first" ? options?.[0] : options?.[options.length - 1];
-			nextOption?.focus();
-		});
 	}, []);
 
 	const refreshSettings = useCallback(async (withReload = false) => {
@@ -187,56 +125,18 @@ export function QuickNoteWindow() {
 		return nextFolder;
 	}, []);
 
-	const refreshTargets = useCallback(async (nextFolder: string) => {
-		try {
-			const files = await invoke("space_list_markdown_files", {
-				recursive: true,
-				limit: MARKDOWN_TARGET_LIMIT,
-			});
-			const defaultPath = quickNotePath(nextFolder);
-			setFileTargets(
-				sortMarkdownFiles(files)
-					.filter((entry) => entry.rel_path !== defaultPath)
-					.map(fileTarget),
-			);
-		} catch (cause) {
-			setStatus(cause instanceof Error ? cause.message : String(cause));
-		}
-	}, []);
-
 	useEffect(() => {
-		void refreshSettings()
-			.then((nextFolder) => refreshTargets(nextFolder))
-			.catch(() => {});
+		void refreshSettings().catch(() => {});
 		const focusTimer = window.setTimeout(
 			() => textareaRef.current?.focus(),
 			80,
 		);
 		return () => window.clearTimeout(focusTimer);
-	}, [refreshSettings, refreshTargets]);
-
-	useEffect(() => {
-		if (!targetsOpen) return;
-		const handlePointerDown = (event: PointerEvent) => {
-			if (
-				event.target instanceof Node &&
-				targetSelectorRef.current?.contains(event.target)
-			) {
-				return;
-			}
-			setTargetsOpen(false);
-		};
-		document.addEventListener("pointerdown", handlePointerDown);
-		return () => {
-			document.removeEventListener("pointerdown", handlePointerDown);
-		};
-	}, [targetsOpen]);
+	}, [refreshSettings]);
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.quickNotes?.folder === "string") {
-			const nextFolder = payload.quickNotes.folder;
-			setFolder(nextFolder);
-			void refreshTargets(nextFolder);
+			setFolder(payload.quickNotes.folder);
 		}
 	});
 
@@ -253,7 +153,6 @@ export function QuickNoteWindow() {
 			setDraft("");
 			setStatus(`Saved ${savedLabel(path)}`);
 			void emit("quick-note:open_note", { path }).catch(() => {});
-			void refreshTargets(folder);
 			window.setTimeout(() => setStatus(""), 1600);
 			window.setTimeout(() => textareaRef.current?.focus(), 20);
 		} catch (cause) {
@@ -261,16 +160,12 @@ export function QuickNoteWindow() {
 		} finally {
 			setSaving(false);
 		}
-	}, [draft, folder, refreshTargets, saving, selectedTarget]);
+	}, [draft, folder, saving, selectedTarget]);
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
 		const primary = event.metaKey || event.ctrlKey;
 		if (event.key === "Escape") {
 			event.preventDefault();
-			if (targetsOpen) {
-				setTargetsOpen(false);
-				return;
-			}
 			void invoke("hide_quick_note_window");
 			return;
 		}
@@ -278,40 +173,6 @@ export function QuickNoteWindow() {
 			event.preventDefault();
 			void save();
 		}
-	};
-
-	const handleTargetTriggerKeyDown = (
-		event: KeyboardEvent<HTMLButtonElement>,
-	) => {
-		if (event.key === "Escape") {
-			event.preventDefault();
-			setTargetsOpen(false);
-			return;
-		}
-		if (
-			event.key === "Enter" ||
-			event.key === " " ||
-			event.key === "ArrowDown" ||
-			event.key === "ArrowUp"
-		) {
-			event.preventDefault();
-			setTargetsOpen(true);
-			void refreshTargets(folder);
-			if (event.key === "ArrowDown") {
-				focusTargetOption("first");
-			} else if (event.key === "ArrowUp") {
-				focusTargetOption("last");
-			}
-		}
-	};
-
-	const handleTargetOptionKeyDown = (
-		event: KeyboardEvent<HTMLButtonElement>,
-	) => {
-		if (event.key !== "Escape") return;
-		event.preventDefault();
-		setTargetsOpen(false);
-		window.setTimeout(() => targetTriggerRef.current?.focus(), 20);
 	};
 
 	return (
@@ -328,84 +189,21 @@ export function QuickNoteWindow() {
 			/>
 			<div className="quickNoteEditorChrome">
 				<div className="quickNoteTargetGroup">
-					<FileText size="var(--icon-md)" aria-hidden="true" />
-					<div className="quickNoteTargetSelectWrap" ref={targetSelectorRef}>
-						<button
-							ref={targetTriggerRef}
-							type="button"
-							className="quickNoteTargetTrigger"
-							aria-label="Quick note destination"
-							aria-expanded={targetsOpen}
-							aria-haspopup="listbox"
-							title={selectedTarget.path}
-							onClick={() => {
-								setTargetsOpen((open) => !open);
-								void refreshTargets(folder);
-							}}
-							onKeyDown={handleTargetTriggerKeyDown}
-						>
-							<span className="quickNoteTargetTriggerText">
-								{selectedTarget.label}
-							</span>
-							<span className="quickNoteTargetTriggerDetail">
-								{selectedTarget.detail}
-							</span>
-							<ChevronDown size="var(--icon-sm)" aria-hidden="true" />
-						</button>
-						{targetsOpen ? (
-							<div
-								className="quickNoteTargetMenu"
-								aria-label="Quick note destination"
-							>
-								<button
-									type="button"
-									className={
-										selectedTarget.value === defaultTarget.value
-											? "quickNoteTargetOption is-selected"
-											: "quickNoteTargetOption"
-									}
-									aria-selected={selectedTarget.value === defaultTarget.value}
-									onClick={() => chooseTarget(defaultTarget.value)}
-									onKeyDown={handleTargetOptionKeyDown}
-								>
-									<span className="quickNoteTargetOptionLabel">
-										{defaultTarget.label}
-									</span>
-									<span className="quickNoteTargetOptionDetail">
-										{defaultTarget.detail}
-									</span>
-								</button>
-								{groupedFileTargets.map((group) => (
-									<div
-										key={group.folder || "__root__"}
-										className="quickNoteTargetMenuGroup"
-									>
-										<div className="quickNoteTargetMenuGroupLabel">
-											{group.label}
-										</div>
-										{group.targets.map((target) => (
-											<button
-												key={target.value}
-												type="button"
-												className={
-													selectedTarget.value === target.value
-														? "quickNoteTargetOption is-selected"
-														: "quickNoteTargetOption"
-												}
-												aria-selected={selectedTarget.value === target.value}
-												onClick={() => chooseTarget(target.value)}
-												onKeyDown={handleTargetOptionKeyDown}
-											>
-												<span className="quickNoteTargetOptionLabel">
-													{target.label}
-												</span>
-											</button>
-										))}
-									</div>
-								))}
-							</div>
-						) : null}
-					</div>
+					<button
+						type="button"
+						className="quickNoteTargetResetButton"
+						aria-label="Reset to today's quick note"
+						title="Today's quick note"
+						onClick={() => chooseTarget(quickNoteTarget(folder))}
+					>
+						<FileText size="var(--icon-md)" aria-hidden="true" />
+					</button>
+					<QuickNoteTargetBreadcrumbs
+						selectedTarget={selectedTarget}
+						quickNotesFolder={folder}
+						todayQuickNotePath={todayQuickNotePath}
+						onSelectTarget={chooseTarget}
+					/>
 				</div>
 				<div className="quickNoteActionGroup">
 					<div className="quickNoteStatus" aria-live="polite">

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -92,6 +92,8 @@ export function QuickNoteWindow() {
 	const [saving, setSaving] = useState(false);
 	const [targetValue, setTargetValue] = useState(QUICK_NOTE_TARGET_VALUE);
 	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const statusTimerRef = useRef<number | null>(null);
+	const focusTimerRef = useRef<number | null>(null);
 
 	const hasText = draft.trim().length > 0;
 	const todayQuickNotePath = useMemo(() => quickNotePath(folder), [folder]);
@@ -126,13 +128,26 @@ export function QuickNoteWindow() {
 	}, []);
 
 	useEffect(() => {
-		void refreshSettings().catch(() => {});
+		void refreshSettings().catch((cause) => {
+			console.error("Failed to load quick note settings", cause);
+		});
 		const focusTimer = window.setTimeout(
 			() => textareaRef.current?.focus(),
 			80,
 		);
 		return () => window.clearTimeout(focusTimer);
 	}, [refreshSettings]);
+
+	useEffect(() => {
+		return () => {
+			if (statusTimerRef.current !== null) {
+				window.clearTimeout(statusTimerRef.current);
+			}
+			if (focusTimerRef.current !== null) {
+				window.clearTimeout(focusTimerRef.current);
+			}
+		};
+	}, []);
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.quickNotes?.folder === "string") {
@@ -153,14 +168,23 @@ export function QuickNoteWindow() {
 			setDraft("");
 			setStatus(`Saved ${savedLabel(path)}`);
 			void emit("quick-note:open_note", { path }).catch(() => {});
-			window.setTimeout(() => setStatus(""), 1600);
-			window.setTimeout(() => textareaRef.current?.focus(), 20);
+			if (statusTimerRef.current !== null) {
+				window.clearTimeout(statusTimerRef.current);
+			}
+			if (focusTimerRef.current !== null) {
+				window.clearTimeout(focusTimerRef.current);
+			}
+			statusTimerRef.current = window.setTimeout(() => setStatus(""), 1600);
+			focusTimerRef.current = window.setTimeout(
+				() => textareaRef.current?.focus(),
+				20,
+			);
 		} catch (cause) {
 			setStatus(cause instanceof Error ? cause.message : String(cause));
 		} finally {
 			setSaving(false);
 		}
-	}, [draft, folder, saving, selectedTarget]);
+	}, [draft, folder, saving, selectedTarget.path, selectedTarget.value]);
 
 	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
 		const primary = event.metaKey || event.ctrlKey;

--- a/src/components/ui/shadcn/button.tsx
+++ b/src/components/ui/shadcn/button.tsx
@@ -68,4 +68,4 @@ function Button({
 	);
 }
 
-export { Button };
+export { Button, buttonVariants };

--- a/src/components/ui/shadcn/calendar.tsx
+++ b/src/components/ui/shadcn/calendar.tsx
@@ -1,0 +1,219 @@
+import {
+	ArrowDown,
+	ArrowLeft01Icon,
+	ArrowRight,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import * as React from "react";
+import {
+	type DayButton,
+	DayPicker,
+	getDefaultClassNames,
+} from "react-day-picker";
+
+import { Button, buttonVariants } from "@/components/ui/shadcn/button";
+import { cn } from "@/lib/utils";
+
+function Calendar({
+	className,
+	classNames,
+	showOutsideDays = true,
+	captionLayout = "label",
+	buttonVariant = "ghost",
+	formatters,
+	components,
+	...props
+}: React.ComponentProps<typeof DayPicker> & {
+	buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+}) {
+	const defaultClassNames = getDefaultClassNames();
+
+	return (
+		<DayPicker
+			showOutsideDays={showOutsideDays}
+			className={cn(
+				"group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
+				String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+				String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+				className,
+			)}
+			captionLayout={captionLayout}
+			formatters={{
+				formatMonthDropdown: (date) =>
+					date.toLocaleString("default", { month: "short" }),
+				...formatters,
+			}}
+			classNames={{
+				root: cn("w-fit", defaultClassNames.root),
+				months: cn(
+					"relative flex flex-col gap-4 md:flex-row",
+					defaultClassNames.months,
+				),
+				month: cn("flex w-full flex-col gap-4", defaultClassNames.month),
+				nav: cn(
+					"absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+					defaultClassNames.nav,
+				),
+				button_previous: cn(
+					buttonVariants({ variant: buttonVariant }),
+					"size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+					defaultClassNames.button_previous,
+				),
+				button_next: cn(
+					buttonVariants({ variant: buttonVariant }),
+					"size-(--cell-size) p-0 select-none aria-disabled:opacity-50",
+					defaultClassNames.button_next,
+				),
+				month_caption: cn(
+					"flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)",
+					defaultClassNames.month_caption,
+				),
+				dropdowns: cn(
+					"flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium",
+					defaultClassNames.dropdowns,
+				),
+				dropdown_root: cn(
+					"relative rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50",
+					defaultClassNames.dropdown_root,
+				),
+				dropdown: cn(
+					"absolute inset-0 bg-popover opacity-0",
+					defaultClassNames.dropdown,
+				),
+				caption_label: cn(
+					"font-medium select-none",
+					captionLayout === "label"
+						? "text-sm"
+						: "flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
+					defaultClassNames.caption_label,
+				),
+				month_grid: "w-full border-collapse",
+				weekdays: cn("flex", defaultClassNames.weekdays),
+				weekday: cn(
+					"flex-1 rounded-md text-[0.8rem] font-normal text-muted-foreground select-none",
+					defaultClassNames.weekday,
+				),
+				week: cn("mt-2 flex w-full", defaultClassNames.week),
+				week_number_header: cn(
+					"w-(--cell-size) select-none",
+					defaultClassNames.week_number_header,
+				),
+				week_number: cn(
+					"text-[0.8rem] text-muted-foreground select-none",
+					defaultClassNames.week_number,
+				),
+				day: cn(
+					"group/day relative aspect-square h-full w-full p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-md",
+					props.showWeekNumber
+						? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-md"
+						: "[&:first-child[data-selected=true]_button]:rounded-l-md",
+					defaultClassNames.day,
+				),
+				range_start: cn(
+					"rounded-l-md bg-accent",
+					defaultClassNames.range_start,
+				),
+				range_middle: cn("rounded-none", defaultClassNames.range_middle),
+				range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
+				today: cn(
+					"rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none",
+					defaultClassNames.today,
+				),
+				outside: cn(
+					"text-muted-foreground aria-selected:text-muted-foreground",
+					defaultClassNames.outside,
+				),
+				disabled: cn(
+					"text-muted-foreground opacity-50",
+					defaultClassNames.disabled,
+				),
+				hidden: cn("invisible", defaultClassNames.hidden),
+				...classNames,
+			}}
+			components={{
+				Root: ({ className, rootRef, ...props }) => {
+					return (
+						<div
+							data-slot="calendar"
+							ref={rootRef}
+							className={cn(className)}
+							{...props}
+						/>
+					);
+				},
+				Chevron: ({ className, orientation, ...props }) => {
+					const icon =
+						orientation === "left"
+							? ArrowLeft01Icon
+							: orientation === "right"
+								? ArrowRight
+								: ArrowDown;
+					return (
+						<HugeiconsIcon
+							icon={icon}
+							strokeWidth={0.9}
+							className={cn("size-4", className)}
+							{...props}
+						/>
+					);
+				},
+				DayButton: CalendarDayButton,
+				WeekNumber: ({ children, ...props }) => {
+					return (
+						<td {...props}>
+							<div className="flex size-(--cell-size) items-center justify-center text-center">
+								{children}
+							</div>
+						</td>
+					);
+				},
+				...components,
+			}}
+			{...props}
+		/>
+	);
+}
+
+function CalendarDayButton({
+	className,
+	day,
+	modifiers,
+	children,
+	...props
+}: React.ComponentProps<typeof DayButton>) {
+	const defaultClassNames = getDefaultClassNames();
+
+	const ref = React.useRef<HTMLButtonElement>(null);
+	React.useEffect(() => {
+		if (modifiers.focused) ref.current?.focus();
+	}, [modifiers.focused]);
+
+	return (
+		<Button
+			ref={ref}
+			variant="ghost"
+			size="icon"
+			static
+			data-day={day.date.toLocaleDateString()}
+			data-selected-single={
+				modifiers.selected &&
+				!modifiers.range_start &&
+				!modifiers.range_end &&
+				!modifiers.range_middle
+			}
+			data-range-start={modifiers.range_start}
+			data-range-end={modifiers.range_end}
+			data-range-middle={modifiers.range_middle}
+			className={cn(
+				"flex aspect-square size-auto h-auto w-full min-h-(--cell-size) min-w-(--cell-size) flex-col gap-1 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 data-[range-end=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:rounded-md data-[range-start=true]:rounded-l-md data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground dark:hover:text-accent-foreground",
+				defaultClassNames.day,
+				className,
+			)}
+			{...props}
+		>
+			{children ?? day.date.getDate()}
+		</Button>
+	);
+}
+
+export { Calendar, CalendarDayButton };

--- a/src/hooks/useTaskSummariesForPaths.ts
+++ b/src/hooks/useTaskSummariesForPaths.ts
@@ -1,10 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { peekCachedMarkdownDoc } from "../components/preview/markdownCache";
-import {
-	EMPTY_CHECKLIST_SUMMARY,
-	summarizeChecklistsFromMarkdown,
-} from "../lib/checklistSummary";
+import { summarizeChecklistsFromMarkdown } from "../lib/checklistSummary";
 import { navigationQueryKeys } from "../lib/navigationPrefetch";
 import { type NoteTaskSummary, invoke } from "../lib/tauri";
 

--- a/src/lib/calendarActivity.ts
+++ b/src/lib/calendarActivity.ts
@@ -1,0 +1,83 @@
+import { endOfMonth, format, startOfMonth } from "date-fns";
+import { queryClient } from "./queryClient";
+import type { CalendarDateNote, CalendarDayActivity } from "./tauri";
+import { invoke } from "./tauri";
+
+export const calendarQueryKeys = {
+	all: ["calendar"] as const,
+	activity: (
+		spacePath: string,
+		fromDate: string,
+		toDate: string,
+		dailyNoteFolder: string | null,
+	) =>
+		[
+			...calendarQueryKeys.all,
+			"activity",
+			spacePath,
+			fromDate,
+			toDate,
+			dailyNoteFolder ?? "__none__",
+		] as const,
+	notesForDate: (
+		spacePath: string,
+		date: string,
+		dailyNoteFolder: string | null,
+	) =>
+		[
+			...calendarQueryKeys.all,
+			"notes",
+			spacePath,
+			date,
+			dailyNoteFolder ?? "__none__",
+		] as const,
+};
+
+export function monthDateRange(month: Date): {
+	fromDate: string;
+	toDate: string;
+} {
+	return {
+		fromDate: format(startOfMonth(month), "yyyy-MM-dd"),
+		toDate: format(endOfMonth(month), "yyyy-MM-dd"),
+	};
+}
+
+export function dateHasNotes(
+	activity: CalendarDayActivity | undefined,
+): boolean {
+	if (!activity) return false;
+	return activity.hasDailyNote || activity.hasCreated || activity.hasEdited;
+}
+
+export function activityMapFromRows(
+	rows: CalendarDayActivity[],
+): Map<string, CalendarDayActivity> {
+	return new Map(rows.map((row) => [row.date, row]));
+}
+
+export async function loadCalendarActivity(
+	month: Date,
+	dailyNoteFolder: string | null,
+): Promise<CalendarDayActivity[]> {
+	const { fromDate, toDate } = monthDateRange(month);
+	return invoke("index_calendar_activity", {
+		from_date: fromDate,
+		to_date: toDate,
+		daily_note_folder: dailyNoteFolder,
+	});
+}
+
+export async function loadCalendarNotesForDate(
+	date: string,
+	dailyNoteFolder: string | null,
+): Promise<CalendarDateNote[]> {
+	return invoke("index_calendar_notes_for_date", {
+		date,
+		daily_note_folder: dailyNoteFolder,
+	});
+}
+
+export function invalidateCalendarPrefetch(): void {
+	void queryClient.invalidateQueries({ queryKey: calendarQueryKeys.all });
+}

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -495,10 +495,7 @@ function cachedTaskSummaryForPath(path: string): NoteTaskSummary | undefined {
 	return undefined;
 }
 
-function taskSummariesEqual(
-	left: NoteTaskSummary,
-	right: NoteTaskSummary,
-) {
+function taskSummariesEqual(left: NoteTaskSummary, right: NoteTaskSummary) {
 	return (
 		left?.total_count === right.total_count &&
 		left.completed_count === right.completed_count &&

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -327,6 +327,19 @@ export interface AllDocsItem {
 	people?: string[];
 }
 
+export interface CalendarDayActivity {
+	date: string;
+	hasDailyNote: boolean;
+	hasCreated: boolean;
+	hasEdited: boolean;
+}
+
+export interface CalendarDateNote {
+	path: string;
+	title: string;
+	kinds: Array<"daily" | "created" | "edited">;
+}
+
 export interface SearchAdvancedRequest {
 	query?: string | null;
 	tags?: string[];
@@ -927,6 +940,21 @@ interface TauriCommands {
 		AllDocsItem[]
 	>;
 	all_docs_count: CommandDef<{ folder_prefix?: string | null }, number>;
+	index_calendar_activity: CommandDef<
+		{
+			from_date: string;
+			to_date: string;
+			daily_note_folder?: string | null;
+		},
+		CalendarDayActivity[]
+	>;
+	index_calendar_notes_for_date: CommandDef<
+		{
+			date: string;
+			daily_note_folder?: string | null;
+		},
+		CalendarDateNote[]
+	>;
 	tags_list: CommandDef<
 		{ limit?: number | null; offset?: number | null },
 		TagCount[]

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -419,19 +419,18 @@ input.notePropertyValue {
 }
 
 .propertyValueText > span {
-	overflow: visible;
-	white-space: normal;
+	white-space: nowrap;
 }
 
 .notePropertyStatusStatic {
-	max-width: 100%;
+	max-width: none;
 }
 
 .notePropertyStatusTrigger {
 	display: inline-flex;
 	align-items: center;
 	justify-content: flex-start;
-	max-width: 100%;
+	max-width: none;
 	padding: 0;
 	border: 0;
 	background: transparent;
@@ -439,8 +438,25 @@ input.notePropertyValue {
 	cursor: pointer;
 }
 
+.notePropertyStatusTrigger:not(.databaseStatusTrigger) .propertyValueText {
+	max-width: none;
+	flex-shrink: 0;
+}
+
 .databaseStatusTrigger {
 	width: 100%;
+	max-width: 100%;
+}
+
+.databaseStatusTrigger .propertyValueText {
+	min-width: 0;
+	max-width: 100%;
+}
+
+.databaseStatusTrigger .propertyValueText > span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .notePropertyStatusTrigger:hover .propertyValueText,

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -334,16 +334,15 @@
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h4::before,
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h5::before,
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h6::before {
-	position: absolute;
-	top: auto;
-	bottom: 0;
-	left: calc(
-		-1 *
-		(var(--heading-level-rail-width) + var(--heading-rail-gap)) +
-		2px
+	display: inline-block;
+	width: var(--heading-level-rail-width);
+	margin-left: calc(
+		-1 * (var(--heading-level-rail-width) + var(--heading-rail-gap))
 	);
+	margin-right: var(--heading-rail-gap);
+	vertical-align: baseline;
+	text-align: right;
 	font-size: calc(var(--editor-font-size) * 0.8);
-	line-height: 1;
 	font-weight: var(--font-medium);
 	letter-spacing: 0.025em;
 	color: color-mix(in srgb, var(--text-tertiary) 86%, transparent);
@@ -352,17 +351,14 @@
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h1::before {
 	content: "H1";
-	bottom: 6px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h2::before {
 	content: "H2";
-	bottom: 5px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h3::before {
 	content: "H3";
-	bottom: 4px;
 }
 
 .tiptapHostInline:not(.is-preview) .tiptapContentInline h4::before {

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -337,7 +337,8 @@
 	display: inline-block;
 	width: var(--heading-level-rail-width);
 	margin-left: calc(
-		-1 * (var(--heading-level-rail-width) + var(--heading-rail-gap))
+		-1 *
+		(var(--heading-level-rail-width) + var(--heading-rail-gap))
 	);
 	margin-right: var(--heading-rail-gap);
 	vertical-align: baseline;

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -77,6 +77,52 @@
 	padding: 4px 8px 0;
 }
 
+.sidebarCommandSearchRow {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	width: 100%;
+	padding: 8px;
+}
+
+.sidebarCommandSearchRow .sidebarCommandSearchButton {
+	flex: 1;
+	min-width: 0;
+}
+
+.sidebarCalendarButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 30px;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	background: var(--bg-tertiary);
+	color: var(--text-secondary);
+	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast),
+		border-color var(--transition-fast);
+}
+
+.sidebarCalendarButton > svg {
+	display: block;
+}
+
+.sidebarCalendarButton:hover {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+	border-color: var(--border-light);
+}
+
+.sidebarCalendarButton:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 2px;
+}
+
 .sidebarCommandSearch {
 	width: 100%;
 	padding: 8px 8px 8px;
@@ -129,45 +175,37 @@
 .sidebarCommandSearchShortcut {
 	display: inline-flex;
 	align-items: center;
-	justify-content: center;
 	flex: 0 0 auto;
-	min-width: 20px;
-	height: 20px;
 	margin-left: auto;
-	padding: 0 6px;
-	border: 1px solid var(--border-light);
-	border-radius: var(--radius-sm);
-	background: var(--bg-secondary);
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-medium);
 	font-family: var(--font-sans);
 	line-height: 1;
+	letter-spacing: 0.02em;
 }
 
 .sidebarQuickActionShortcut {
 	display: inline-flex;
 	align-items: center;
-	justify-content: center;
 	flex: 0 0 auto;
-	min-width: 20px;
-	height: 20px;
 	margin-left: auto;
-	padding: 0 6px;
-	border: 1px solid var(--border-light);
-	border-radius: var(--radius-sm);
-	background: var(--bg-secondary);
-	color: var(--text-tertiary);
+	color: var(--text-secondary);
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-medium);
 	font-family: var(--font-sans);
 	line-height: 1;
+	letter-spacing: 0.02em;
 	opacity: 0;
 	transition: opacity var(--transition-fast);
 }
 
 .sidebarQuickActionBtn:hover .sidebarQuickActionShortcut {
 	opacity: 1;
+}
+
+.sidebarQuickActionBtn[data-kind="new-note"] .sidebarQuickActionShortcut {
+	color: var(--text-inverse);
 }
 
 .sidebarQuickActionCount {
@@ -178,20 +216,6 @@
 	font-weight: var(--font-medium);
 	font-family: var(--font-sans);
 	line-height: 1;
-}
-
-.sidebarQuickActionBtn[data-kind="new-note"] .sidebarQuickActionShortcut {
-	background: color-mix(
-		in srgb,
-		var(--interactive-accent) 88%,
-		var(--text-primary)
-	);
-	border-color: color-mix(
-		in srgb,
-		var(--interactive-accent) 75%,
-		var(--text-primary)
-	);
-	color: var(--text-inverse);
 }
 
 .sidebarNavBtn {
@@ -226,6 +250,7 @@
 .sidebarQuickActionBtn[data-kind="new-note"] {
 	background: var(--interactive-accent);
 	color: var(--text-inverse);
+	margin-bottom: 6px;
 }
 
 .sidebarQuickActionBtn[data-kind="new-note"] > svg {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -76,12 +76,15 @@
 	background: transparent;
 }
 
-.databaseBoardLane[data-workflow-state="done"] {
+.databaseBoardLane[data-show-column-color="true"][data-workflow-state="done"] {
 	background: color-mix(in srgb, var(--database-tone) 5%, var(--bg-secondary));
 }
 
 .databaseBoardLane[data-workflow-state="archived"] {
 	opacity: 0.82;
+}
+
+.databaseBoardLane[data-show-column-color="true"][data-workflow-state="archived"] {
 	background: color-mix(in srgb, var(--text-tertiary) 7%, var(--bg-secondary));
 }
 

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -66,144 +66,189 @@
 	pointer-events: auto;
 }
 
-.quickNoteTargetGroup > svg {
+.quickNoteTargetResetButton {
 	flex: 0 0 auto;
-	color: currentcolor;
-}
-
-.quickNoteTargetSelectWrap {
-	position: relative;
-	min-width: 0;
-	max-width: 100%;
-}
-
-.quickNoteTargetTrigger {
-	width: 100%;
-	min-width: 190px;
-	max-width: 100%;
-	height: 30px;
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
-	padding: 0 8px;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	padding: 0;
 	border: 1px solid transparent;
-	border-radius: 7px;
-	outline: none;
-	background: color-mix(in srgb, var(--bg-primary) 82%, transparent);
-	color: var(--text-secondary);
-	font: inherit;
-	font-size: var(--text-sm);
-	line-height: 30px;
-	letter-spacing: 0;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: currentcolor;
 	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.quickNoteTargetTrigger:hover {
-	background: color-mix(in srgb, var(--bg-secondary) 88%, transparent);
+.quickNoteTargetResetButton:hover,
+.quickNoteTargetResetButton:focus-visible {
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
 	color: var(--text-primary);
+	outline: none;
 }
 
-.quickNoteTargetTrigger:focus-visible {
-	border-color: color-mix(in srgb, var(--interactive-accent) 44%, transparent);
-	box-shadow: 0 0 0 2px
-		color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+.quickNoteTargetBreadcrumb {
+	display: flex;
+	align-items: center;
+	gap: 0;
+	min-width: 0;
+	flex: 1 1 auto;
+	min-height: 28px;
+	max-height: 28px;
+	margin: 0;
+	padding: 0;
+	opacity: 1;
+	max-width: 100%;
+	width: auto;
+	justify-content: flex-start;
+	overflow-x: auto;
+	overflow-y: hidden;
+	scrollbar-width: none;
 }
 
-.quickNoteTargetTriggerText,
-.quickNoteTargetTriggerDetail,
-.quickNoteTargetOptionLabel,
-.quickNoteTargetOptionDetail {
+.quickNoteTargetBreadcrumb::-webkit-scrollbar {
+	display: none;
+}
+
+.quickNoteTargetItem {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+	flex-shrink: 0;
+}
+
+.quickNoteTargetSep {
+	width: var(--icon-xs);
+	height: var(--icon-xs);
+	color: var(--text-quaternary);
+	opacity: 0.74;
+	flex-shrink: 0;
+	margin: 0;
+	transition: color var(--transition-fast), transform var(--transition-fast),
+		opacity var(--transition-fast);
+}
+
+.quickNoteTargetSepButton {
+	width: 20px;
+	height: 22px;
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-quaternary);
+	cursor: pointer;
+	transition: color var(--transition-fast);
+}
+
+.quickNoteTargetSepButton:hover,
+.quickNoteTargetSepButton:focus-visible,
+.quickNoteTargetSepButton[data-state="open"] {
+	color: var(--text-primary);
+	outline: none;
+}
+
+.quickNoteTargetSepButton:hover .quickNoteTargetSep,
+.quickNoteTargetSepButton:focus-visible .quickNoteTargetSep,
+.quickNoteTargetSepButton[data-state="open"] .quickNoteTargetSep {
+	color: currentcolor;
+	opacity: 1;
+	transform: translateX(1px);
+}
+
+.quickNoteTargetButton {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	max-width: min(34vw, 180px);
+	height: 22px;
+	min-width: 0;
+	padding: 0 7px;
+	border: 1px solid transparent;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.82);
+	font-weight: var(--font-medium);
+	line-height: 1;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: color var(--transition-fast);
+}
+
+.quickNoteTargetButton:hover:not(:disabled),
+.quickNoteTargetButton:focus-visible {
+	color: var(--text-primary);
+	outline: none;
+}
+
+.quickNoteTargetButton[aria-current="page"] {
+	color: var(--text-primary);
+	cursor: default;
+}
+
+.quickNoteTargetLabel,
+.quickNoteTargetMenuItemLabel {
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
-.quickNoteTargetTriggerText {
-	flex: 0 1 auto;
-	color: currentcolor;
-}
-
-.quickNoteTargetTriggerDetail {
-	flex: 1 1 auto;
-	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.9);
-}
-
-.quickNoteTargetTrigger > svg {
-	flex: 0 0 auto;
-	color: currentcolor;
-}
-
 .quickNoteTargetMenu {
-	position: absolute;
-	left: 0;
-	bottom: 38px;
-	z-index: 6;
-	width: min(360px, calc(100vw - 72px));
-	max-height: 230px;
+	width: min(280px, calc(100vw - 28px));
+	max-height: min(340px, var(--radix-dropdown-menu-content-available-height));
 	padding: 6px;
-	overflow-y: auto;
-	border: 1px solid color-mix(in srgb, var(--border-default) 74%, transparent);
-	border-radius: 10px;
+	border-color: color-mix(in srgb, var(--border-light) 68%, transparent);
+	border-radius: var(--radius-lg);
 	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
-	box-shadow: 0 18px 48px color-mix(in srgb, black 22%, transparent);
-	pointer-events: auto;
+	box-shadow: 0 12px 32px
+		color-mix(in srgb, var(--shadow-color, #000) 16%, transparent);
 }
 
-.quickNoteTargetOption {
-	width: 100%;
-	min-width: 0;
-	min-height: 30px;
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	padding: 5px 8px;
-	border: 0;
-	border-radius: 7px;
-	background: transparent;
-	color: var(--text-secondary);
-	font: inherit;
-	font-size: var(--text-sm);
-	line-height: 1.2;
+.quickNoteTargetMenuLabel {
+	padding: 6px 7px 5px;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.8);
+	font-weight: var(--font-semibold);
+	line-height: 1;
 	letter-spacing: 0;
-	text-align: left;
+	text-transform: uppercase;
+}
+
+.quickNoteTargetMenuItem {
+	min-height: 30px;
+	padding: 0 8px;
+	border-radius: var(--radius-md);
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.9);
+	font-weight: var(--font-medium);
 	cursor: pointer;
 }
 
-.quickNoteTargetOption:hover,
-.quickNoteTargetOption:focus-visible {
-	outline: none;
-	background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+.quickNoteTargetMenuItem:focus,
+.quickNoteTargetMenuItem[data-highlighted] {
+	background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
 	color: var(--text-primary);
 }
 
-.quickNoteTargetOption.is-selected {
+.quickNoteTargetMenuItem[data-selected="true"] {
 	background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
 	color: var(--text-primary);
 }
 
-.quickNoteTargetOptionLabel {
-	flex: 1 1 auto;
-}
-
-.quickNoteTargetOptionDetail {
-	flex: 0 1 auto;
+.quickNoteTargetMenuState {
+	padding: 8px;
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.9);
-}
-
-.quickNoteTargetMenuGroup {
-	margin-top: 4px;
-}
-
-.quickNoteTargetMenuGroupLabel {
-	padding: 7px 8px 4px;
-	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.8);
-	font-weight: var(--font-medium);
-	line-height: 1.2;
-	letter-spacing: 0;
+	line-height: 1.3;
 }
 
 .quickNoteActionGroup {

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -179,19 +179,12 @@
 	font-weight: var(--font-medium);
 	line-height: 1;
 	white-space: nowrap;
-	cursor: pointer;
+	cursor: default;
 	transition: color var(--transition-fast);
-}
-
-.quickNoteTargetButton:hover:not(:disabled),
-.quickNoteTargetButton:focus-visible {
-	color: var(--text-primary);
-	outline: none;
 }
 
 .quickNoteTargetButton[aria-current="page"] {
 	color: var(--text-primary);
-	cursor: default;
 }
 
 .quickNoteTargetLabel,

--- a/src/styles/app/48-calendar-palette.css
+++ b/src/styles/app/48-calendar-palette.css
@@ -1,0 +1,451 @@
+.calendarPalette {
+	width: min(400px, calc(100vw - 48px));
+	height: min(600px, 82vh);
+	overflow: hidden;
+	border-radius: var(--radius-2xl);
+	border: 1px solid var(--border-light);
+	background: var(--bg-primary);
+	box-shadow: var(--shadow-float);
+	display: flex;
+	flex-direction: column;
+}
+
+.calendarPaletteCalendar {
+	flex-shrink: 0;
+	width: 100%;
+	max-width: 100%;
+	padding: 16px 16px 14px;
+	border-bottom: 1px solid var(--border-light);
+	--cell-size: 2.5rem;
+}
+
+.calendarPaletteCalendar .calendarPaletteMonth,
+.calendarPaletteCalendar [data-slot="calendar"] {
+	width: 100%;
+	max-width: 100%;
+}
+
+.calendarPaletteMonths {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+}
+
+.calendarPaletteMonth {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	gap: 10px;
+}
+
+.calendarPaletteNav {
+	position: absolute;
+	inset-inline: 0;
+	top: 0;
+	z-index: 1;
+	display: flex;
+	width: 100%;
+	height: var(--cell-size);
+	align-items: center;
+	justify-content: flex-end;
+	gap: 2px;
+	pointer-events: none;
+}
+
+.calendarPaletteNav .calendarPaletteNavButton {
+	pointer-events: auto;
+}
+
+.calendarPaletteMonthCaption {
+	display: flex;
+	width: 100%;
+	height: var(--cell-size);
+	align-items: center;
+	justify-content: flex-start;
+	padding-inline: 2px;
+}
+
+.calendarPaletteCaptionLabel {
+	font-size: var(--text-md);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	color: var(--text-primary);
+}
+
+.calendarPaletteCaptionButton {
+	padding: 2px 6px;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	letter-spacing: inherit;
+	line-height: inherit;
+}
+
+.calendarPaletteCaptionButton:hover {
+	color: var(--interactive-accent);
+}
+
+.calendarPaletteCaptionButton:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 3px;
+}
+
+.calendarPaletteCalendar .calendarPaletteNavButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.85rem;
+	height: 1.85rem;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-tertiary);
+	box-shadow: none;
+	transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.calendarPaletteCalendar .calendarPaletteNavButton:hover:not(:disabled) {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+}
+
+.calendarPaletteCalendar .calendarPaletteNavButton:disabled {
+	opacity: 0.4;
+}
+
+.calendarPaletteCalendar .calendarPaletteNavButton:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 1px;
+}
+
+.calendarPaletteWeekdays {
+	gap: 0;
+}
+
+.calendarPaletteWeekday {
+	flex: 1;
+	padding-bottom: 4px;
+	font-size: 10px;
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.08em;
+	text-align: center;
+	text-transform: uppercase;
+	color: var(--text-tertiary);
+}
+
+.calendarPaletteMonthGrid,
+.calendarPaletteWeekdays,
+.calendarPaletteWeeks {
+	width: 100%;
+}
+
+.calendarPaletteWeek {
+	margin-top: 2px;
+	width: 100%;
+}
+
+.calendarPaletteDayCell {
+	position: relative;
+	flex: 1;
+	padding: 1px;
+	text-align: center;
+}
+
+.calendarPaletteDayButton {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--cell-size);
+	height: var(--cell-size);
+	margin: 0 auto;
+	border: 0;
+	border-radius: var(--radius-full);
+	background: transparent;
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast),
+		box-shadow var(--transition-fast);
+}
+
+.calendarPaletteDayButton[data-outside="true"] {
+	color: var(--text-tertiary);
+	font-weight: 400;
+}
+
+.calendarPaletteDayButton[data-today="true"]:not([data-selected="true"]) {
+	color: var(--interactive-accent);
+	font-weight: 600;
+	box-shadow: inset 0 0 0 1.5px
+		color-mix(in srgb, var(--interactive-accent) 45%, transparent);
+}
+
+.calendarPaletteDayButton:hover:not([data-selected="true"]):not(:disabled) {
+	background: var(--bg-hover);
+}
+
+.calendarPaletteDayButton[data-selected="true"] {
+	background: var(--interactive-accent);
+	color: var(--bg-primary);
+	font-weight: 600;
+}
+
+.calendarPaletteDayButton[data-selected="true"]:hover:not(:disabled) {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 90%,
+		var(--text-primary)
+	);
+}
+
+.calendarPaletteDayButton:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 1px;
+}
+
+.calendarPaletteNoteDot {
+	position: absolute;
+	bottom: 5px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 4px;
+	height: 4px;
+	border-radius: var(--radius-full);
+	background: transparent;
+}
+
+.calendarPaletteNoteDot[data-active="true"] {
+	background: var(--interactive-accent);
+}
+
+.calendarPaletteDayButton[data-today="true"]:not([data-selected="true"])
+	.calendarPaletteNoteDot[data-active="true"] {
+	bottom: 4px;
+}
+
+.calendarPaletteDayButton[data-selected="true"]
+	.calendarPaletteNoteDot[data-active="true"] {
+	background: var(--bg-primary);
+}
+
+.calendarPaletteNotesPanel {
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-tertiary));
+}
+
+.calendarPaletteNotesHeader {
+	position: relative;
+	z-index: 2;
+	flex-shrink: 0;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 12px 14px 10px;
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-tertiary));
+	backdrop-filter: blur(12px) saturate(1.01);
+	-webkit-backdrop-filter: blur(12px) saturate(1.01);
+}
+
+.calendarPaletteNotesHeader::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: -18px;
+	height: 18px;
+	pointer-events: none;
+	background: linear-gradient(
+		to bottom,
+		color-mix(in srgb, var(--bg-primary) 72%, transparent) 0%,
+		color-mix(in srgb, var(--bg-primary) 28%, transparent) 52%,
+		transparent 100%
+	);
+}
+
+.calendarPaletteNotesHeading {
+	min-width: 0;
+	flex: 1;
+}
+
+.calendarPaletteNotesTitle {
+	margin: 0;
+	font-size: var(--text-md);
+	font-weight: 600;
+	letter-spacing: -0.02em;
+	color: var(--text-primary);
+	text-wrap: balance;
+}
+
+.calendarPaletteNotesWeekday {
+	margin: 2px 0 0;
+	font-size: var(--text-xs);
+	color: var(--text-tertiary);
+}
+
+.calendarPaletteDailyNoteButton {
+	flex-shrink: 0;
+	height: 28px;
+	padding: 0 12px;
+	border: 1px solid
+		color-mix(in srgb, var(--interactive-accent) 22%, var(--border-light));
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+	font-size: 11px;
+	font-weight: var(--font-medium);
+	color: var(--interactive-accent);
+	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast),
+		border-color var(--transition-fast);
+}
+
+.calendarPaletteDailyNoteButton:hover {
+	background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 40%,
+		var(--border-light)
+	);
+}
+
+.calendarPaletteDailyNoteButton:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 2px;
+}
+
+.calendarPaletteNotesList {
+	position: relative;
+	z-index: 1;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	padding: 14px 8px 10px;
+	scrollbar-width: thin;
+	scrollbar-color: color-mix(in srgb, var(--text-tertiary) 36%, transparent)
+		transparent;
+}
+
+.calendarPaletteNotesItems {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.calendarPaletteNoteItem {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	min-width: 0;
+	min-height: 40px;
+	padding: 6px 10px;
+	border: 1px solid transparent;
+	border-radius: var(--radius-lg);
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+	cursor: pointer;
+	transition: background var(--transition-fast), border-color
+		var(--transition-fast);
+}
+
+.calendarPaletteNoteItem:hover {
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+	border-color: color-mix(in srgb, var(--border-light) 80%, transparent);
+}
+
+.calendarPaletteNoteItem:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 1px;
+}
+
+.calendarPaletteNoteIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: var(--icon-lg);
+	height: var(--icon-lg);
+	flex: 0 0 auto;
+	color: var(--text-secondary);
+}
+
+.calendarPaletteNoteCopy {
+	min-width: 0;
+	flex: 1;
+	overflow: hidden;
+}
+
+.calendarPaletteNoteTitle {
+	display: block;
+	font-size: var(--text-sm);
+	font-weight: 500;
+	color: var(--text-primary);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.calendarPaletteNotePath {
+	display: block;
+	margin-top: 1px;
+	font-size: 11px;
+	color: var(--text-tertiary);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.calendarPaletteNotesStatus {
+	margin: 0;
+	padding: 8px 10px;
+	font-size: var(--text-sm);
+	color: var(--text-tertiary);
+}
+
+.calendarPaletteNotesEmpty {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	padding: 16px;
+	text-align: center;
+}
+
+.calendarPaletteNotesEmptyIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-tertiary);
+}
+
+.calendarPaletteNotesEmptyTitle {
+	margin: 0;
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+	color: var(--text-secondary);
+}


### PR DESCRIPTION
What's Changed

 ### ✨ New Calendar Palette

 - Added a Calendar Palette accessible from the sidebar that visualizes note activity by day.
 - Backend: new src-tauri/src/index/calendar.rs indexes daily notes, creation dates, and edit dates from SQLite; exposes index_calendar_activity and index_calendar_notes_for_date commands.
 - Frontend: new CalendarPalette + CalendarPaletteController components, calendarActivity.ts query helpers, and calendar-palette.css.
 - Uses react-day-picker (v10) with a custom shadcn Calendar wrapper and Hugeicons arrows.
 - Days show activity dots for daily notes / created / edited notes.
 - Clicking a date lists related notes and supports jumping to the daily note for that date.
 - Activity cache is invalidated on filesystem changes.

 ### 🪟 Window Close Behavior

 - Closing the last space-host window now destroys auxiliary persisted windows (settings, quick note, quick task) so Cmd+W on the final window quits the app instead of leaving hidden utility windows behind.
 - Removed the old macOS-only prevent_close + Reopen behavior in favor of explicit lifecycle cleanup.

 ### 📝 Quick Note Improvements

 - Extracted QuickNoteTargetBreadcrumbs from the monolithic QuickNoteWindow.
 - New breadcrumb UI with folder/file dropdown navigation and a "Today's quick note" shortcut.
 - Fixed YAML/properties handling in quick notes.
 - Restyled quick-note window (46-quick-note.css).

 ### 🖼️ Editor Image Fixes

 - Replaced the old append-transaction markdown-image shortcut with a new MarkdownImageLivePreview extension.
 - Fixes images not working / not rendering inline correctly in the editor.
 - Adds an integration test for markdown image behavior.

 ### 🎨 UI Polish

 - Sidebar: cleaner spacing between "New note" and collections, cleaned-up shortcut labels.
 - Added a centered Calendar button next to the command-search field in the sidebar.
 - Editor heading rail (H1–H6) now aligns properly with heading text using inline-block layout instead of absolute positioning.
 - Note property/status pills no longer force a max-width; database status triggers still ellipsis correctly.
 - Database board (Kanban): done and archived column backgrounds now only tint when column coloring is enabled.

 ### ➕ Dependencies

 - Added react-day-picker@^10.0.1 (plus transitive @date-fns/tz).

 ### 🔧 Misc

 - Registered new Tauri commands and updated typed IPC wrapper (src/lib/tauri.ts).
 - Minor cleanup in index/commands.rs (formatting only).
 - Removed unused EMPTY_CHECKLIST_SUMMARY import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a calendar palette to browse and open notes by date (including daily-note opening when configured).
* **Bug Fixes**
  * Improved host-window closing behavior by cleaning up auxiliary windows; removed macOS re-open handling for the main window.
* **Style**
  * Added calendar palette styling and updated sidebar, quick-note destination UI, and various note/editor styling tweaks.
* **Developer Experience / Components**
  * Added shadcn calendar/day-button and buttonVariants exports.
* **Tests**
  * Expanded Markdown image integration tests for live preview behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->