### PR TITLE
releases-channel-alpha.etc

### DIFF
--- a/.github/workflows/notify-homebrew-tap.yml
+++ b/.github/workflows/notify-homebrew-tap.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   dispatch:
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch tap sync

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -82,48 +82,82 @@ jobs:
         run: |
           set -euo pipefail
 
-          latest_tag="$(git tag -l 'v*' --sort=-v:refname | head -n1 || true)"
           file_version="$(node -p "JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8')).version")"
-          tag_version="${latest_tag#v}"
-          if [ -z "${latest_tag}" ]; then
-            tag_version="0.0.0"
-          fi
-
-          version_order="$(node -e '
-            const [fileVersion, tagVersion] = process.argv.slice(1);
-            const valid = (v) => /^\d+\.\d+\.\d+$/.test(v);
-            if (!valid(fileVersion)) {
-              throw new Error(`Invalid app version: ${fileVersion}`);
+          version_payload="$(node - "${file_version}" <<'NODE'
+          const { execFileSync } = require("node:child_process");
+          const [fileVersion] = process.argv.slice(2);
+          const pattern = /^(\d+)\.(\d+)\.(\d+)(?:-alpha\.(\d+))?$/;
+          const parse = (version) => {
+            const match = pattern.exec(version);
+            if (!match) {
+              throw new Error(
+                `Invalid version: ${version}. Use x.y.z or x.y.z-alpha.N`,
+              );
             }
-            if (!valid(tagVersion)) {
-              throw new Error(`Invalid tag version: ${tagVersion}`);
-            }
-            const parse = (v) => v.split(".").map((x) => Number.parseInt(x, 10));
-            const av = parse(fileVersion);
-            const bv = parse(tagVersion);
-            const cmp =
-              av[0] - bv[0] ||
-              av[1] - bv[1] ||
-              av[2] - bv[2];
-            process.stdout.write(String(Math.sign(cmp)));
-          ' "${file_version}" "${tag_version}")"
+            return {
+              raw: version,
+              major: Number(match[1]),
+              minor: Number(match[2]),
+              patch: Number(match[3]),
+              alpha: match[4] === undefined ? null : Number(match[4]),
+            };
+          };
+          const compare = (left, right) =>
+            left.major - right.major ||
+            left.minor - right.minor ||
+            left.patch - right.patch ||
+            (left.alpha === null && right.alpha === null
+              ? 0
+              : left.alpha === null
+                ? 1
+                : right.alpha === null
+                  ? -1
+                  : left.alpha - right.alpha);
 
-          if ! [[ "${version_order}" =~ ^(-1|0|1)$ ]]; then
-            echo "Invalid version ordering result: ${version_order}"
-            exit 1
-          fi
+          const current = parse(fileVersion);
+          const tags = execFileSync("git", ["tag", "-l", "v*"], {
+            encoding: "utf8",
+          })
+            .split(/\r?\n/)
+            .map((tag) => tag.trim())
+            .filter(Boolean)
+            .map((tag) => ({ tag, version: tag.replace(/^v/, "") }))
+            .map(({ tag, version }) => ({ tag, parsed: parse(version) }))
+            .sort((a, b) => compare(b.parsed, a.parsed));
 
-          if [ "${version_order}" != "1" ]; then
-            echo "src-tauri/tauri.conf.json version (${file_version}) must be greater than latest tag (${latest_tag:-none})."
-            exit 1
-          fi
+          const latest = tags[0] ?? null;
+          if (latest && compare(current, latest.parsed) <= 0) {
+            throw new Error(
+              `src-tauri/tauri.conf.json version (${fileVersion}) must be greater than latest tag (${latest.tag}).`,
+            );
+          }
 
-          next_version="${file_version}"
-          next_tag="v${next_version}"
+          const channel = current.alpha === null ? "stable" : "alpha";
+          const latestStable = tags.find((item) => item.parsed.alpha === null) ?? null;
+          const previousNotesTag =
+            channel === "stable" ? (latestStable?.tag ?? "") : (latest?.tag ?? "");
+          const output = {
+            latestTag: previousNotesTag,
+            nextVersion: fileVersion,
+            nextTag: `v${fileVersion}`,
+            channel,
+            isPrerelease: channel === "alpha",
+          };
+          process.stdout.write(JSON.stringify(output));
+          NODE
+          )"
+
+          latest_tag="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).latestTag)' "${version_payload}")"
+          next_version="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).nextVersion)' "${version_payload}")"
+          next_tag="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).nextTag)' "${version_payload}")"
+          channel="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).channel)' "${version_payload}")"
+          is_prerelease="$(node -e 'process.stdout.write(String(JSON.parse(process.argv[1]).isPrerelease))' "${version_payload}")"
 
           echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
           echo "next_version=${next_version}" >> "$GITHUB_OUTPUT"
           echo "next_tag=${next_tag}" >> "$GITHUB_OUTPUT"
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${is_prerelease}" >> "$GITHUB_OUTPUT"
 
       - name: Sync version files
         env:
@@ -248,10 +282,102 @@ jobs:
           releaseName: "Glyph ${{ steps.version.outputs.next_tag }}"
           releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: false
-          prerelease: false
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
           includeUpdaterJson: true
 
+      - name: Publish updater manifest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANNEL: ${{ steps.version.outputs.channel }}
+          NEXT_TAG: ${{ steps.version.outputs.next_tag }}
+        run: |
+          set -euo pipefail
+
+          manifest_source="$(mktemp -d)"
+          manifest_worktree="$(mktemp -d)"
+          rm -rf "${manifest_worktree}"
+
+          node - "${manifest_source}/latest.json" <<'NODE'
+          const fs = require("node:fs");
+
+          async function main() {
+            const [outputPath] = process.argv.slice(2);
+            const repository = process.env.GITHUB_REPOSITORY;
+            const token = process.env.GITHUB_TOKEN;
+            const tag = process.env.NEXT_TAG;
+            const headers = {
+              Accept: "application/vnd.github+json",
+              Authorization: `Bearer ${token}`,
+              "X-GitHub-Api-Version": "2022-11-28",
+            };
+
+            const releaseResponse = await fetch(
+              `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+              { headers },
+            );
+            if (!releaseResponse.ok) {
+              throw new Error(
+                `Failed to load release ${tag}: ${releaseResponse.status} ${await releaseResponse.text()}`,
+              );
+            }
+
+            const release = await releaseResponse.json();
+            const asset = release.assets?.find((item) => item.name === "latest.json");
+            if (!asset) {
+              throw new Error(`Release ${tag} does not have a latest.json asset.`);
+            }
+
+            const assetResponse = await fetch(asset.url, {
+              headers: { ...headers, Accept: "application/octet-stream" },
+            });
+            if (!assetResponse.ok) {
+              throw new Error(
+                `Failed to download latest.json: ${assetResponse.status} ${await assetResponse.text()}`,
+              );
+            }
+
+            fs.writeFileSync(outputPath, Buffer.from(await assetResponse.arrayBuffer()));
+          }
+
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+
+          if git ls-remote --exit-code --heads origin update-manifests >/dev/null 2>&1; then
+            git fetch origin update-manifests:update-manifests
+            git worktree add "${manifest_worktree}" update-manifests
+          else
+            git worktree add --detach "${manifest_worktree}" HEAD
+            git -C "${manifest_worktree}" checkout --orphan update-manifests
+            git -C "${manifest_worktree}" rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          channels="${CHANNEL}"
+          if [ "${CHANNEL}" = "stable" ]; then
+            channels="stable alpha"
+          fi
+
+          for channel in ${channels}; do
+            mkdir -p "${manifest_worktree}/${channel}"
+            cp "${manifest_source}/latest.json" "${manifest_worktree}/${channel}/latest.json"
+            git -C "${manifest_worktree}" add "${channel}/latest.json"
+          done
+
+          git -C "${manifest_worktree}" config user.name "github-actions[bot]"
+          git -C "${manifest_worktree}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git -C "${manifest_worktree}" diff --cached --quiet; then
+            echo "Updater manifest is already current."
+            exit 0
+          fi
+
+          git -C "${manifest_worktree}" commit -m "Update ${CHANNEL} updater manifests for ${NEXT_TAG}"
+          git -C "${manifest_worktree}" push origin HEAD:update-manifests
+
       - name: Notify Homebrew tap
+        if: steps.version.outputs.channel == 'stable'
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
         run: |

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -122,7 +122,13 @@ jobs:
             .map((tag) => tag.trim())
             .filter(Boolean)
             .map((tag) => ({ tag, version: tag.replace(/^v/, "") }))
-            .map(({ tag, version }) => ({ tag, parsed: parse(version) }))
+            .flatMap(({ tag, version }) => {
+              try {
+                return [{ tag, parsed: parse(version) }];
+              } catch {
+                return [];
+              }
+            })
             .sort((a, b) => compare(b.parsed, a.parsed));
 
           const latest = tags[0] ?? null;
@@ -296,6 +302,7 @@ jobs:
           manifest_source="$(mktemp -d)"
           manifest_worktree="$(mktemp -d)"
           rm -rf "${manifest_worktree}"
+          trap 'git worktree remove --force "${manifest_worktree}" >/dev/null 2>&1 || rm -rf "${manifest_worktree}"' EXIT
 
           node - "${manifest_source}/latest.json" <<'NODE'
           const fs = require("node:fs");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod net;
 mod notes;
 mod paths;
 mod pinned_files;
+mod release_channels;
 mod space;
 mod space_fs;
 mod system_fonts;
@@ -1500,6 +1501,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             app_info,
+            release_channels::updater_check_release_channel,
             system_fonts_list,
             system_monospace_fonts_list,
             show_quick_note_window,

--- a/src-tauri/src/release_channels.rs
+++ b/src-tauri/src/release_channels.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+use tauri::{Manager, ResourceId, Runtime, Webview};
+use tauri_plugin_updater::UpdaterExt;
+use url::Url;
+
+const STABLE_UPDATE_ENDPOINT: &str =
+    "https://raw.githubusercontent.com/SidhuK/Glyph/update-manifests/stable/latest.json";
+const ALPHA_UPDATE_ENDPOINT: &str =
+    "https://raw.githubusercontent.com/SidhuK/Glyph/update-manifests/alpha/latest.json";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReleaseChannel {
+    Stable,
+    Alpha,
+}
+
+impl ReleaseChannel {
+    fn endpoint(&self) -> &'static str {
+        match self {
+            Self::Stable => STABLE_UPDATE_ENDPOINT,
+            Self::Alpha => ALPHA_UPDATE_ENDPOINT,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseChannelUpdate {
+    rid: ResourceId,
+    current_version: String,
+    version: String,
+    date: Option<String>,
+    body: Option<String>,
+    raw_json: serde_json::Value,
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn updater_check_release_channel<R: Runtime>(
+    webview: Webview<R>,
+    channel: ReleaseChannel,
+) -> Result<Option<ReleaseChannelUpdate>, String> {
+    let endpoint = Url::parse(channel.endpoint()).map_err(|error| error.to_string())?;
+    let updater = webview
+        .updater_builder()
+        .endpoints(vec![endpoint])
+        .map_err(|error| error.to_string())?
+        .build()
+        .map_err(|error| error.to_string())?;
+
+    let Some(update) = updater.check().await.map_err(|error| error.to_string())? else {
+        return Ok(None);
+    };
+
+    let date = update.date.as_ref().and_then(|date| {
+        date.format(&time::format_description::well_known::Rfc3339)
+            .ok()
+    });
+    let payload = ReleaseChannelUpdate {
+        current_version: update.current_version.clone(),
+        version: update.version.clone(),
+        date,
+        body: update.body.clone(),
+        raw_json: update.raw_json.clone(),
+        rid: webview.resources_table().add(update),
+    };
+
+    Ok(Some(payload))
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.7.4",
+	"version": "0.7.5",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",
@@ -57,7 +57,7 @@
 		"updater": {
 			"pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUzMDlDQjRBQkM2ODYzMEMKUldRTVkyaThTc3NKNHpsV1pzbXpnMFZPSXFKdnhWU082eFpjYU1nVlRWZjhuRVpQZXl5ekF6cGoK",
 			"endpoints": [
-				"https://github.com/SidhuK/Glyph/releases/latest/download/latest.json"
+				"https://raw.githubusercontent.com/SidhuK/Glyph/update-manifests/stable/latest.json"
 			]
 		}
 	}

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -18,7 +18,11 @@ import {
 import type { AppInfo } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { Button } from "../ui/shadcn/button";
-import { SettingsRow, SettingsSection, SettingsToggle } from "./SettingsScaffold";
+import {
+	SettingsRow,
+	SettingsSection,
+	SettingsToggle,
+} from "./SettingsScaffold";
 
 export function AboutSettingsPane() {
 	const { status: licenseStatus, loading: licenseLoading } =

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -7,7 +7,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
 import { useLicenseStatus } from "../../lib/license";
 import {
@@ -31,6 +31,7 @@ export function AboutSettingsPane() {
 	const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
 	const [releaseChannelState, setReleaseChannelState] =
 		useState<ReleaseChannel>("stable");
+	const releaseChannelTouchedRef = useRef(false);
 	const [isSavingReleaseChannel, setIsSavingReleaseChannel] = useState(false);
 	const [error, setError] = useState("");
 	const [updateStatus, setUpdateStatus] = useState("");
@@ -56,7 +57,9 @@ export function AboutSettingsPane() {
 		let cancelled = false;
 		void loadSettings()
 			.then((settings) => {
-				if (!cancelled) setReleaseChannelState(settings.ui.releaseChannel);
+				if (!cancelled && !releaseChannelTouchedRef.current) {
+					setReleaseChannelState(settings.ui.releaseChannel);
+				}
 			})
 			.catch(() => undefined);
 		return () => {
@@ -244,6 +247,7 @@ export function AboutSettingsPane() {
 										const nextChannel: ReleaseChannel = checked
 											? "alpha"
 											: "stable";
+										releaseChannelTouchedRef.current = true;
 										setError("");
 										setUpdateStatus("");
 										setReleaseChannelState(nextChannel);

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -10,16 +10,24 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useMemo, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
 import { useLicenseStatus } from "../../lib/license";
+import {
+	type ReleaseChannel,
+	loadSettings,
+	setReleaseChannel,
+} from "../../lib/settings";
 import type { AppInfo } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { Button } from "../ui/shadcn/button";
-import { SettingsRow, SettingsSection } from "./SettingsScaffold";
+import { SettingsRow, SettingsSection, SettingsToggle } from "./SettingsScaffold";
 
 export function AboutSettingsPane() {
 	const { status: licenseStatus, loading: licenseLoading } =
 		useLicenseStatus(false);
 	const autoUpdater = useUpdaterContext();
 	const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+	const [releaseChannelState, setReleaseChannelState] =
+		useState<ReleaseChannel>("stable");
+	const [isSavingReleaseChannel, setIsSavingReleaseChannel] = useState(false);
 	const [error, setError] = useState("");
 	const [updateStatus, setUpdateStatus] = useState("");
 	useEffect(() => {
@@ -35,6 +43,18 @@ export function AboutSettingsPane() {
 				}
 			}
 		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled) setReleaseChannelState(settings.ui.releaseChannel);
+			})
+			.catch(() => undefined);
 		return () => {
 			cancelled = true;
 		};
@@ -179,33 +199,67 @@ export function AboutSettingsPane() {
 							<p className="settingsHint">Unknown license status</p>
 						</SettingsRow>
 					) : licenseStatus.can_auto_update ? (
-						<SettingsRow
-							label="App updates"
-							description="Checks immediately and downloads the latest published version in the background. Installation only happens when you choose it."
-						>
-							<div className="settingsActions">
-								<Button
-									type="button"
-									size="sm"
-									disabled={autoUpdater.isChecking}
-									onClick={() => void handleCheckForUpdates()}
-								>
-									{autoUpdater.isChecking ? "Checking…" : "Check for Updates"}
-								</Button>
-								{autoUpdater.updateReady ? (
+						<>
+							<SettingsRow
+								label="App updates"
+								description="Checks immediately and downloads the latest published version in the background. Installation only happens when you choose it."
+							>
+								<div className="settingsActions">
 									<Button
 										type="button"
 										size="sm"
-										variant="outline"
-										onClick={autoUpdater.installAndRelaunch}
+										disabled={autoUpdater.isChecking}
+										onClick={() => void handleCheckForUpdates()}
 									>
-										{autoUpdater.updateVersion
-											? `Install ${autoUpdater.updateVersion}`
-											: "Install Update"}
+										{autoUpdater.isChecking ? "Checking…" : "Check for Updates"}
 									</Button>
-								) : null}
-							</div>
-						</SettingsRow>
+									{autoUpdater.updateReady ? (
+										<Button
+											type="button"
+											size="sm"
+											variant="outline"
+											onClick={autoUpdater.installAndRelaunch}
+										>
+											{autoUpdater.updateVersion
+												? `Install ${autoUpdater.updateVersion}`
+												: "Install Update"}
+										</Button>
+									) : null}
+								</div>
+							</SettingsRow>
+							<SettingsRow
+								label="Alpha releases"
+								description="Get early access to alpha builds. These may be unstable, so only turn this on if you’re comfortable testing unfinished releases."
+							>
+								<SettingsToggle
+									checked={releaseChannelState === "alpha"}
+									disabled={isSavingReleaseChannel}
+									ariaLabel="Alpha releases"
+									onCheckedChange={(checked) => {
+										const previous = releaseChannelState;
+										const nextChannel: ReleaseChannel = checked
+											? "alpha"
+											: "stable";
+										setError("");
+										setUpdateStatus("");
+										setReleaseChannelState(nextChannel);
+										setIsSavingReleaseChannel(true);
+										void setReleaseChannel(nextChannel)
+											.catch((cause) => {
+												setReleaseChannelState(previous);
+												setError(
+													cause instanceof Error
+														? cause.message
+														: "Failed to save release channel",
+												);
+											})
+											.finally(() => {
+												setIsSavingReleaseChannel(false);
+											});
+									}}
+								/>
+							</SettingsRow>
+						</>
 					) : (
 						<SettingsRow
 							label="Community build"

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -540,6 +540,14 @@ const SETTINGS_SEARCH_ITEMS = [
 		keywords: ["release", "version", "update"],
 	},
 	{
+		id: "about-alpha-releases",
+		tab: "about",
+		section: "Updates",
+		title: "Alpha releases",
+		description: "Receive early release builds before they become stable.",
+		keywords: ["alpha", "prerelease", "beta", "release channel"],
+	},
+	{
 		id: "about-license-status",
 		tab: "about",
 		section: "Updates",

--- a/src/hooks/useAutoUpdater.test.tsx
+++ b/src/hooks/useAutoUpdater.test.tsx
@@ -4,6 +4,10 @@ import { act, useEffect } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@tauri-apps/api/event", () => ({
+	listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
 vi.mock("@tauri-apps/api/window", () => ({
 	getCurrentWindow: () => ({
 		label: "main",
@@ -14,14 +18,28 @@ vi.mock("@tauri-apps/plugin-process", () => ({
 	relaunch: vi.fn(),
 }));
 
-const checkMock = vi.fn();
 vi.mock("@tauri-apps/plugin-updater", () => ({
-	check: checkMock,
+	Update: class {
+		version: string;
+		download = vi.fn().mockResolvedValue(undefined);
+		install = vi.fn().mockResolvedValue(undefined);
+
+		constructor(metadata: { version: string }) {
+			this.version = metadata.version;
+		}
+	},
 }));
 
 const setAutoUpdateLastCheckedAtMock = vi.fn();
+const loadSettingsMock = vi.fn();
 vi.mock("../lib/settings", () => ({
+	loadSettings: loadSettingsMock,
 	setAutoUpdateLastCheckedAt: setAutoUpdateLastCheckedAtMock,
+}));
+
+const invokeMock = vi.fn();
+vi.mock("../lib/tauri", () => ({
+	invoke: invokeMock,
 }));
 
 (
@@ -58,7 +76,12 @@ describe("useAutoUpdater", () => {
 		vi.stubEnv("DEV", false);
 
 		setAutoUpdateLastCheckedAtMock.mockResolvedValue(undefined);
-		checkMock.mockResolvedValue(null);
+		loadSettingsMock.mockResolvedValue({
+			ui: {
+				releaseChannel: "stable",
+			},
+		});
+		invokeMock.mockResolvedValue(null);
 
 		({ useAutoUpdater } = await import("./useAutoUpdater"));
 
@@ -84,7 +107,7 @@ describe("useAutoUpdater", () => {
 			await Promise.resolve();
 		});
 
-		expect(checkMock).not.toHaveBeenCalled();
+		expect(invokeMock).not.toHaveBeenCalled();
 	});
 
 	it("checks for updates when enabled", async () => {
@@ -106,7 +129,10 @@ describe("useAutoUpdater", () => {
 			await new Promise((resolve) => window.setTimeout(resolve, 0));
 		});
 
-		expect(checkMock).toHaveBeenCalledTimes(1);
+		expect(invokeMock).toHaveBeenCalledTimes(1);
+		expect(invokeMock).toHaveBeenCalledWith("updater_check_release_channel", {
+			channel: "stable",
+		});
 		expect(states).toContain(false);
 	});
 });

--- a/src/hooks/useAutoUpdater.test.tsx
+++ b/src/hooks/useAutoUpdater.test.tsx
@@ -135,4 +135,27 @@ describe("useAutoUpdater", () => {
 		});
 		expect(states).toContain(false);
 	});
+
+	it("reports updateReady when an update is available", async () => {
+		const states: boolean[] = [];
+		invokeMock.mockResolvedValue({ version: "1.2.3" });
+
+		await act(async () => {
+			root.render(
+				<Harness
+					enabled
+					onReady={(ready) => {
+						states.push(ready);
+					}}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			await new Promise((resolve) => window.setTimeout(resolve, 0));
+			await new Promise((resolve) => window.setTimeout(resolve, 0));
+		});
+
+		expect(states).toContain(true);
+	});
 });

--- a/src/hooks/useAutoUpdater.ts
+++ b/src/hooks/useAutoUpdater.ts
@@ -1,7 +1,7 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { Update } from "@tauri-apps/plugin-updater";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type ReleaseChannel,
 	loadSettings,
@@ -74,22 +74,31 @@ export interface AutoUpdaterState {
 export function useAutoUpdater(enabled = true): AutoUpdaterState {
 	const [releaseChannel, setReleaseChannelState] =
 		useState<ReleaseChannel>("stable");
+	const releaseChannelRef = useRef(releaseChannel);
+	const [releaseChannelLoaded, setReleaseChannelLoaded] = useState(false);
 	const [update, setUpdate] = useState<Update | null>(
 		cachedUpdate?.channel === "stable" ? cachedUpdate.update : null,
 	);
 	const [isChecking, setIsChecking] = useState(false);
 
 	const checkForUpdates = useCallback(async () => {
-		if (!enabled) return null;
+		if (!enabled || !releaseChannelLoaded) return null;
+		const requestedChannel = releaseChannel;
 		setIsChecking(true);
 		try {
-			const nextUpdate = await downloadUpdate(releaseChannel);
-			setUpdate(nextUpdate);
+			const nextUpdate = await downloadUpdate(requestedChannel);
+			if (releaseChannelRef.current === requestedChannel) {
+				setUpdate(nextUpdate);
+			}
 			return nextUpdate;
 		} finally {
 			setIsChecking(false);
 		}
-	}, [enabled, releaseChannel]);
+	}, [enabled, releaseChannel, releaseChannelLoaded]);
+
+	useEffect(() => {
+		releaseChannelRef.current = releaseChannel;
+	}, [releaseChannel]);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -97,7 +106,10 @@ export function useAutoUpdater(enabled = true): AutoUpdaterState {
 			.then((settings) => {
 				if (!cancelled) setReleaseChannelState(settings.ui.releaseChannel);
 			})
-			.catch(() => undefined);
+			.catch(() => undefined)
+			.finally(() => {
+				if (!cancelled) setReleaseChannelLoaded(true);
+			});
 		return () => {
 			cancelled = true;
 		};
@@ -107,11 +119,14 @@ export function useAutoUpdater(enabled = true): AutoUpdaterState {
 		const nextChannel = payload.ui?.releaseChannel;
 		if (!nextChannel) return;
 		setReleaseChannelState(nextChannel);
-		setUpdate(cachedUpdate?.channel === nextChannel ? cachedUpdate.update : null);
+		setReleaseChannelLoaded(true);
+		setUpdate(
+			cachedUpdate?.channel === nextChannel ? cachedUpdate.update : null,
+		);
 	});
 
 	useEffect(() => {
-		if (!enabled) {
+		if (!enabled || !releaseChannelLoaded) {
 			setUpdate(null);
 			return;
 		}
@@ -135,7 +150,7 @@ export function useAutoUpdater(enabled = true): AutoUpdaterState {
 		return () => {
 			window.clearInterval(intervalId);
 		};
-	}, [checkForUpdates, enabled, releaseChannel]);
+	}, [checkForUpdates, enabled, releaseChannel, releaseChannelLoaded]);
 
 	const installAndRelaunch = useCallback(() => {
 		if (!update) return;

--- a/src/hooks/useAutoUpdater.ts
+++ b/src/hooks/useAutoUpdater.ts
@@ -1,13 +1,20 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { type Update, check } from "@tauri-apps/plugin-updater";
+import { Update } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useState } from "react";
-import { setAutoUpdateLastCheckedAt } from "../lib/settings";
+import {
+	type ReleaseChannel,
+	loadSettings,
+	setAutoUpdateLastCheckedAt,
+} from "../lib/settings";
+import { invoke } from "../lib/tauri";
+import { useTauriEvent } from "../lib/tauriEvents";
 
 const THREE_HOURS_MS = 3 * 60 * 60 * 1000;
-let cachedUpdate: Update | null = null;
+let cachedUpdate: { channel: ReleaseChannel; update: Update } | null = null;
 let inFlightUpdateCheck: Promise<Update | null> | null = null;
-let launchCheckStarted = false;
+let inFlightChannel: ReleaseChannel | null = null;
+const launchCheckStarted = new Set<ReleaseChannel>();
 
 async function isMainWindow(): Promise<boolean> {
 	let windowLabel = "";
@@ -19,25 +26,37 @@ async function isMainWindow(): Promise<boolean> {
 	return windowLabel === "main";
 }
 
-async function downloadUpdate(): Promise<Update | null> {
-	if (import.meta.env.DEV || cachedUpdate) return cachedUpdate;
-	if (!(await isMainWindow())) return null;
-	if (inFlightUpdateCheck) return inFlightUpdateCheck;
+async function checkReleaseChannel(
+	channel: ReleaseChannel,
+): Promise<Update | null> {
+	const metadata = await invoke("updater_check_release_channel", { channel });
+	return metadata ? new Update(metadata) : null;
+}
 
+async function downloadUpdate(channel: ReleaseChannel): Promise<Update | null> {
+	if (import.meta.env.DEV) return null;
+	if (cachedUpdate?.channel === channel) return cachedUpdate.update;
+	if (!(await isMainWindow())) return null;
+	if (inFlightUpdateCheck && inFlightChannel === channel) {
+		return inFlightUpdateCheck;
+	}
+
+	inFlightChannel = channel;
 	inFlightUpdateCheck = (async () => {
 		try {
-			const update = await check();
+			const update = await checkReleaseChannel(channel);
 			await setAutoUpdateLastCheckedAt(Date.now());
 			if (!update) return null;
 
 			await update.download();
-			cachedUpdate = update;
+			cachedUpdate = { channel, update };
 			return update;
 		} catch (error) {
 			console.warn("Auto-update check/download failed", error);
 			return null;
 		} finally {
 			inFlightUpdateCheck = null;
+			inFlightChannel = null;
 		}
 	})();
 
@@ -53,36 +72,59 @@ export interface AutoUpdaterState {
 }
 
 export function useAutoUpdater(enabled = true): AutoUpdaterState {
-	const [update, setUpdate] = useState<Update | null>(cachedUpdate);
+	const [releaseChannel, setReleaseChannelState] =
+		useState<ReleaseChannel>("stable");
+	const [update, setUpdate] = useState<Update | null>(
+		cachedUpdate?.channel === "stable" ? cachedUpdate.update : null,
+	);
 	const [isChecking, setIsChecking] = useState(false);
 
 	const checkForUpdates = useCallback(async () => {
 		if (!enabled) return null;
 		setIsChecking(true);
 		try {
-			const nextUpdate = await downloadUpdate();
+			const nextUpdate = await downloadUpdate(releaseChannel);
 			setUpdate(nextUpdate);
 			return nextUpdate;
 		} finally {
 			setIsChecking(false);
 		}
-	}, [enabled]);
+	}, [enabled, releaseChannel]);
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled) setReleaseChannelState(settings.ui.releaseChannel);
+			})
+			.catch(() => undefined);
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		const nextChannel = payload.ui?.releaseChannel;
+		if (!nextChannel) return;
+		setReleaseChannelState(nextChannel);
+		setUpdate(cachedUpdate?.channel === nextChannel ? cachedUpdate.update : null);
+	});
 
 	useEffect(() => {
 		if (!enabled) {
 			setUpdate(null);
 			return;
 		}
-		if (cachedUpdate) {
-			setUpdate(cachedUpdate);
+		if (cachedUpdate?.channel === releaseChannel) {
+			setUpdate(cachedUpdate.update);
 		}
 
 		const runCheck = async () => {
 			await checkForUpdates();
 		};
 
-		if (!launchCheckStarted) {
-			launchCheckStarted = true;
+		if (!launchCheckStarted.has(releaseChannel)) {
+			launchCheckStarted.add(releaseChannel);
 			void runCheck();
 		}
 
@@ -93,7 +135,7 @@ export function useAutoUpdater(enabled = true): AutoUpdaterState {
 		return () => {
 			window.clearInterval(intervalId);
 		};
-	}, [checkForUpdates, enabled]);
+	}, [checkForUpdates, enabled, releaseChannel]);
 
 	const installAndRelaunch = useCallback(() => {
 		if (!update) return;

--- a/src/hooks/useAutoUpdater.ts
+++ b/src/hooks/useAutoUpdater.ts
@@ -55,8 +55,10 @@ async function downloadUpdate(channel: ReleaseChannel): Promise<Update | null> {
 			console.warn("Auto-update check/download failed", error);
 			return null;
 		} finally {
-			inFlightUpdateCheck = null;
-			inFlightChannel = null;
+			if (inFlightChannel === channel) {
+				inFlightUpdateCheck = null;
+				inFlightChannel = null;
+			}
 		}
 	})();
 
@@ -76,9 +78,7 @@ export function useAutoUpdater(enabled = true): AutoUpdaterState {
 		useState<ReleaseChannel>("stable");
 	const releaseChannelRef = useRef(releaseChannel);
 	const [releaseChannelLoaded, setReleaseChannelLoaded] = useState(false);
-	const [update, setUpdate] = useState<Update | null>(
-		cachedUpdate?.channel === "stable" ? cachedUpdate.update : null,
-	);
+	const [update, setUpdate] = useState<Update | null>(null);
 	const [isChecking, setIsChecking] = useState(false);
 
 	const checkForUpdates = useCallback(async () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -26,6 +26,8 @@ import {
 export type { AiAssistantMode } from "./tauri";
 export type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 
+export type ReleaseChannel = "stable" | "alpha";
+
 let storeInstance: LazyStore | null = null;
 let storeInitPromise: Promise<void> | null = null;
 let settingsEntriesCache: Map<string, unknown> | null = null;
@@ -344,11 +346,16 @@ function asUiEditorFontSize(value: unknown): UiFontSize {
 	return DEFAULT_EDITOR_FONT_SIZE;
 }
 
+function asReleaseChannel(value: unknown): ReleaseChannel {
+	return value === "alpha" ? "alpha" : "stable";
+}
+
 async function emitSettingsUpdated(payload: {
 	spacePath?: string;
 	ui?: {
 		theme?: ThemeMode;
 		autoUpdateCheckInterval?: AutoUpdateCheckInterval;
+		releaseChannel?: ReleaseChannel;
 		lightThemeId?: UiLightThemeId;
 		darkThemeId?: UiDarkThemeId;
 		accent?: UiAccent;
@@ -418,6 +425,7 @@ interface AppSettings {
 		aiEnabled: boolean;
 		theme: ThemeMode;
 		autoUpdateCheckInterval: AutoUpdateCheckInterval;
+		releaseChannel: ReleaseChannel;
 		lightThemeId: UiLightThemeId;
 		darkThemeId: UiDarkThemeId;
 		accent: UiAccent;
@@ -484,6 +492,7 @@ const KEYS = {
 	aiAssistantMode: "ui.aiAssistantMode",
 	theme: "ui.theme",
 	autoUpdateCheckInterval: "ui.autoUpdateCheckInterval",
+	releaseChannel: "updates.releaseChannel",
 	lightThemeId: "ui.lightThemeId",
 	darkThemeId: "ui.darkThemeId",
 	accent: "ui.accent",
@@ -797,6 +806,7 @@ export async function loadSettings(
 		entries,
 		KEYS.autoUpdateCheckInterval,
 	);
+	const rawReleaseChannel = getSettingValue(entries, KEYS.releaseChannel);
 	const rawLightThemeId = getSettingValue(entries, KEYS.lightThemeId);
 	const rawDarkThemeId = getSettingValue(entries, KEYS.darkThemeId);
 	const rawAccent = getSettingValue(entries, KEYS.accent);
@@ -902,6 +912,7 @@ export async function loadSettings(
 	const autoUpdateCheckInterval = asAutoUpdateCheckInterval(
 		rawAutoUpdateCheckInterval,
 	);
+	const releaseChannel = asReleaseChannel(rawReleaseChannel);
 	const lightThemeId = asUiLightThemeId(rawLightThemeId);
 	const darkThemeId = asUiDarkThemeId(rawDarkThemeId);
 	const accent = asUiAccent(rawAccent);
@@ -1009,6 +1020,7 @@ export async function loadSettings(
 			aiEnabled,
 			theme,
 			autoUpdateCheckInterval,
+			releaseChannel,
 			lightThemeId,
 			darkThemeId,
 			accent,
@@ -1555,6 +1567,16 @@ export async function setAutoUpdateLastCheckedAt(
 		await store.set(KEYS.autoUpdateLastCheckedAt, Math.floor(timestamp));
 	}
 	await saveSettingsStore(store);
+}
+
+export async function setReleaseChannel(
+	channel: ReleaseChannel,
+): Promise<void> {
+	const nextChannel = asReleaseChannel(channel);
+	const store = await getStore();
+	await store.set(KEYS.releaseChannel, nextChannel);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { releaseChannel: nextChannel } });
 }
 
 export async function getRecentFiles(): Promise<RecentFile[]> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -7,6 +7,15 @@ export interface AppInfo {
 	identifier: string;
 }
 
+export interface ReleaseChannelUpdate {
+	rid: number;
+	currentVersion: string;
+	version: string;
+	date?: string;
+	body?: string;
+	rawJson: Record<string, unknown>;
+}
+
 interface SpaceInfo {
 	root: string;
 	schema_version: number;
@@ -731,6 +740,10 @@ type CommandDef<Args, Result> = { args: Args; result: Result };
 
 interface TauriCommands {
 	app_info: CommandDef<void, AppInfo>;
+	updater_check_release_channel: CommandDef<
+		{ channel: "stable" | "alpha" },
+		ReleaseChannelUpdate | null
+	>;
 	system_fonts_list: CommandDef<void, string[]>;
 	system_monospace_fonts_list: CommandDef<void, string[]>;
 	set_markdown_menu_visible: CommandDef<{ visible: boolean }, void>;

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -4,6 +4,7 @@ import type {
 	AttachmentStorageMode,
 	AutoUpdateCheckInterval,
 	EditorWidthMode,
+	ReleaseChannel,
 	UiAccent,
 } from "./settings";
 import type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
@@ -75,6 +76,7 @@ type TauriEventMap = {
 		ui?: {
 			theme?: string;
 			autoUpdateCheckInterval?: AutoUpdateCheckInterval;
+			releaseChannel?: ReleaseChannel;
 			lightThemeId?: UiLightThemeId;
 			darkThemeId?: UiDarkThemeId;
 			accent?: UiAccent;


### PR DESCRIPTION
Update channels - categorized into alpha and stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an **Alpha releases** option to app settings.
  * Update checks and downloads now follow your selected release channel (Stable vs Alpha), so you only receive updates for the channel you choose.
  * Updated the updater manifest source to use the channel-specific feed.

* **Improvements**
  * Refined the updates settings UI to better present and manage release channel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->