### PR TITLE
Fix SSRF bypass via IPv4-mapped IPv6 addresses

### DIFF
--- a/src-tauri/src/net.rs
+++ b/src-tauri/src/net.rs
@@ -1,8 +1,8 @@
-use std::net::{IpAddr, ToSocketAddrs};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 
 use url::Url;
 
-fn is_forbidden_v4(v4: std::net::Ipv4Addr) -> bool {
+fn is_forbidden_v4(v4: Ipv4Addr) -> bool {
     v4.is_private()
         || v4.is_loopback()
         || v4.is_link_local()
@@ -10,6 +10,24 @@ fn is_forbidden_v4(v4: std::net::Ipv4Addr) -> bool {
         || v4.is_documentation()
         || v4.is_unspecified()
         || v4.is_multicast()
+}
+
+fn embedded_6to4_v4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = v6.octets();
+    if octets[0] == 0x20 && octets[1] == 0x02 {
+        return Some(Ipv4Addr::new(octets[2], octets[3], octets[4], octets[5]));
+    }
+    None
+}
+
+fn embedded_nat64_well_known_v4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
+    let octets = v6.octets();
+    if octets[..12] == [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0] {
+        return Some(Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ));
+    }
+    None
 }
 
 fn is_forbidden_ip(ip: IpAddr) -> bool {
@@ -26,6 +44,8 @@ fn is_forbidden_ip(ip: IpAddr) -> bool {
                 // considered loopback by Ipv6Addr::is_loopback(). Unwrap the
                 // inner IPv4 address and apply the same private-range checks.
                 || v6.to_ipv4_mapped().is_some_and(|v4| is_forbidden_v4(v4))
+                || embedded_6to4_v4(v6).is_some_and(|v4| is_forbidden_v4(v4))
+                || embedded_nat64_well_known_v4(v6).is_some_and(|v4| is_forbidden_v4(v4))
         }
     }
 }
@@ -124,6 +144,28 @@ mod tests {
     fn mapped_public_allowed() {
         // ::ffff:93.184.216.34 wraps a public IPv4 — should be allowed.
         assert!(check("http://[::ffff:93.184.216.34]/").is_ok());
+    }
+
+    #[test]
+    fn six_to_four_private_blocked() {
+        assert!(check("http://[2002:7f00:0001::]/").is_err());
+        assert!(check("http://[2002:0a00:0001::]/").is_err());
+    }
+
+    #[test]
+    fn six_to_four_public_allowed() {
+        assert!(check("http://[2002:5db8:d822::]/").is_ok());
+    }
+
+    #[test]
+    fn nat64_well_known_private_blocked() {
+        assert!(check("http://[64:ff9b::7f00:1]/").is_err());
+        assert!(check("http://[64:ff9b::a00:1]/").is_err());
+    }
+
+    #[test]
+    fn nat64_well_known_public_allowed() {
+        assert!(check("http://[64:ff9b::5db8:d822]/").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/net.rs
+++ b/src-tauri/src/net.rs
@@ -3,6 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 use url::Url;
 
 fn is_forbidden_v4(v4: Ipv4Addr) -> bool {
+    let octets = v4.octets();
     v4.is_private()
         || v4.is_loopback()
         || v4.is_link_local()
@@ -10,6 +11,9 @@ fn is_forbidden_v4(v4: Ipv4Addr) -> bool {
         || v4.is_documentation()
         || v4.is_unspecified()
         || v4.is_multicast()
+        || (octets[0] == 100 && (64..=127).contains(&octets[1]))
+        || (octets[0] == 198 && (octets[1] == 18 || octets[1] == 19))
+        || octets[0] >= 240
 }
 
 fn embedded_6to4_v4(v6: Ipv6Addr) -> Option<Ipv4Addr> {
@@ -144,6 +148,25 @@ mod tests {
     fn mapped_public_allowed() {
         // ::ffff:93.184.216.34 wraps a public IPv4 — should be allowed.
         assert!(check("http://[::ffff:93.184.216.34]/").is_ok());
+    }
+
+    #[test]
+    fn public_v6_allowed() {
+        assert!(check("http://[2606:4700:4700::1111]/").is_ok());
+    }
+
+    #[test]
+    fn special_v4_ranges_blocked() {
+        assert!(check("http://100.64.0.1/").is_err());
+        assert!(check("http://198.18.0.1/").is_err());
+        assert!(check("http://240.0.0.1/").is_err());
+    }
+
+    #[test]
+    fn mapped_special_v4_ranges_blocked() {
+        assert!(check("http://[::ffff:100.64.0.1]/").is_err());
+        assert!(check("http://[::ffff:198.18.0.1]/").is_err());
+        assert!(check("http://[::ffff:240.0.0.1]/").is_err());
     }
 
     #[test]

--- a/src-tauri/src/net.rs
+++ b/src-tauri/src/net.rs
@@ -2,23 +2,30 @@ use std::net::{IpAddr, ToSocketAddrs};
 
 use url::Url;
 
+fn is_forbidden_v4(v4: std::net::Ipv4Addr) -> bool {
+    v4.is_private()
+        || v4.is_loopback()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_unspecified()
+        || v4.is_multicast()
+}
+
 fn is_forbidden_ip(ip: IpAddr) -> bool {
     match ip {
-        IpAddr::V4(v4) => {
-            v4.is_private()
-                || v4.is_loopback()
-                || v4.is_link_local()
-                || v4.is_broadcast()
-                || v4.is_documentation()
-                || v4.is_unspecified()
-                || v4.is_multicast()
-        }
+        IpAddr::V4(v4) => is_forbidden_v4(v4),
         IpAddr::V6(v6) => {
             v6.is_loopback()
                 || v6.is_unicast_link_local()
                 || v6.is_unique_local()
                 || v6.is_unspecified()
                 || v6.is_multicast()
+                // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) can bypass the
+                // IPv6-only checks above because e.g. ::ffff:127.0.0.1 is not
+                // considered loopback by Ipv6Addr::is_loopback(). Unwrap the
+                // inner IPv4 address and apply the same private-range checks.
+                || v6.to_ipv4_mapped().is_some_and(|v4| is_forbidden_v4(v4))
         }
     }
 }
@@ -36,7 +43,13 @@ pub fn validate_url_host(url: &Url, allow_private_hosts: bool) -> Result<(), Str
     }
 
     // If the host is an IP literal, block private/loopback/etc directly.
-    if let Ok(ip) = host.parse::<IpAddr>() {
+    // url::Url::host_str() returns IPv6 addresses wrapped in brackets
+    // (e.g. "[::1]"), so strip them before parsing.
+    let ip_candidate = host
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(host);
+    if let Ok(ip) = ip_candidate.parse::<IpAddr>() {
         if is_forbidden_ip(ip) {
             return Err("forbidden host".to_string());
         }
@@ -61,4 +74,67 @@ pub fn validate_url_host(url: &Url, allow_private_hosts: bool) -> Result<(), Str
         return Err("forbidden host".to_string());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check(url_str: &str) -> Result<(), String> {
+        let url = Url::parse(url_str).unwrap();
+        validate_url_host(&url, false)
+    }
+
+    #[test]
+    fn public_ip_allowed() {
+        assert!(check("https://93.184.216.34/").is_ok());
+    }
+
+    #[test]
+    fn loopback_v4_blocked() {
+        assert!(check("http://127.0.0.1/").is_err());
+    }
+
+    #[test]
+    fn private_v4_blocked() {
+        assert!(check("http://10.0.0.1/").is_err());
+        assert!(check("http://192.168.1.1/").is_err());
+        assert!(check("http://172.16.0.1/").is_err());
+    }
+
+    #[test]
+    fn loopback_v6_blocked() {
+        assert!(check("http://[::1]/").is_err());
+    }
+
+    #[test]
+    fn mapped_loopback_blocked() {
+        // ::ffff:127.0.0.1 is an IPv4-mapped IPv6 address that wraps loopback.
+        assert!(check("http://[::ffff:127.0.0.1]/").is_err());
+    }
+
+    #[test]
+    fn mapped_private_blocked() {
+        assert!(check("http://[::ffff:10.0.0.1]/").is_err());
+        assert!(check("http://[::ffff:192.168.1.1]/").is_err());
+        assert!(check("http://[::ffff:172.16.0.1]/").is_err());
+    }
+
+    #[test]
+    fn mapped_public_allowed() {
+        // ::ffff:93.184.216.34 wraps a public IPv4 — should be allowed.
+        assert!(check("http://[::ffff:93.184.216.34]/").is_ok());
+    }
+
+    #[test]
+    fn localhost_string_blocked() {
+        assert!(check("http://localhost/").is_err());
+        assert!(check("http://LOCALHOST/").is_err());
+    }
+
+    #[test]
+    fn allow_private_hosts_flag() {
+        let url = Url::parse("http://127.0.0.1/").unwrap();
+        assert!(validate_url_host(&url, true).is_ok());
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.0-alpha.1",
+	"version": "0.8.0-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
The SSRF protection in validate_url_host had two related bugs:

1. IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1, ::ffff:10.0.0.1)
   were not checked against the IPv4 forbidden-range list. Rust's
   Ipv6Addr::is_loopback() only matches ::1, so ::ffff:127.0.0.1 slipped
   through all IPv6-specific checks, allowing requests to loopback and
   private networks.

2. url::Url::host_str() returns IPv6 addresses wrapped in brackets
   (e.g. "[::1]"), but the code parsed the raw host_str() with
   IpAddr::parse() which rejects brackets. This caused ALL IPv6 address
   URLs to fall through to the DNS lookup path, accidentally blocking
   legitimate public IPv6 addresses with "dns lookup failed".

Fixes:
- Extract is_forbidden_v4() and reuse it for both native IPv4 and the
  inner address of IPv4-mapped IPv6 via Ipv6Addr::to_ipv4_mapped().
- Strip bracket wrappers from host_str() before parsing as IpAddr so
  IPv6 literals are properly classified instead of falling through to
  DNS.
- Add unit tests covering IPv4, IPv6, IPv4-mapped (both forbidden and
  public), localhost, and the allow_private_hosts escape hatch.

Co-Authored-By: Karat Sidhu <karatsingh@gmail.com>## Summary

Describe the change and why it exists.

## Related Issues

Closes #

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced IP blocking to correctly evaluate IPv4 special ranges and apply the same rules to IPv4-mapped IPv6 and embedded IPv4 variants.
  * Fixed parsing of bracketed IPv6 host literals (for example, `[::1]`) so they’re evaluated and blocked correctly.

* **Tests**
  * Added comprehensive test coverage for allowed public IPs, blocked private/loopback/multicast ranges, hostname blocking, `allow_private_hosts` bypass behavior, and embedded/mapped IPv4 cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->