### PR TITLE
Sidebar alpha badge & update button refinements 0.8.0(alpha.2)

### DIFF
--- a/src/components/app/SidebarAlphaBadge.tsx
+++ b/src/components/app/SidebarAlphaBadge.tsx
@@ -1,0 +1,39 @@
+import { AlphaIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+import { type AppInfo, invoke } from "../../lib/tauri";
+
+function isAlphaVersion(version: string | undefined): boolean {
+	if (!version) return false;
+	return version.toLowerCase().includes("alpha");
+}
+
+export function SidebarAlphaBadge() {
+	const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		void (async () => {
+			try {
+				const info = await invoke("app_info");
+				if (!cancelled) setAppInfo(info);
+			} catch {
+				// silently ignore
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (!isAlphaVersion(appInfo?.version)) return null;
+
+	return (
+		<div className="sidebarAlphaBadgeRow">
+			<div className="sidebarAlphaBadge">
+				<HugeiconsIcon icon={AlphaIcon} size="10px" strokeWidth={1.8} />
+				<span className="sidebarAlphaBadgeText">Alpha</span>
+			</div>
+		</div>
+	);
+}

--- a/src/components/app/SidebarAlphaBadge.tsx
+++ b/src/components/app/SidebarAlphaBadge.tsx
@@ -29,7 +29,7 @@ export function SidebarAlphaBadge() {
 	if (!isAlphaVersion(appInfo?.version)) return null;
 
 	return (
-		<div className="sidebarAlphaBadgeRow">
+		<div className="sidebarFooterAlpha">
 			<div className="sidebarAlphaBadge">
 				<HugeiconsIcon icon={AlphaIcon} size="10px" strokeWidth={1.8} />
 				<span className="sidebarAlphaBadgeText">Alpha</span>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -26,6 +26,7 @@ import { Calendar, ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
 import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
+import { SidebarAlphaBadge } from "./SidebarAlphaBadge";
 
 interface SidebarContentProps {
 	onToggleDir: (dirPath: string) => void;
@@ -591,6 +592,9 @@ export const SidebarContent = memo(function SidebarContent({
 						</section>
 					</div>
 				</div>
+			</div>
+			<div className="sidebarFooterAlpha">
+				<SidebarAlphaBadge />
 			</div>
 			<LicenseStatusFooter />
 		</>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -593,9 +593,7 @@ export const SidebarContent = memo(function SidebarContent({
 					</div>
 				</div>
 			</div>
-			<div className="sidebarFooterAlpha">
-				<SidebarAlphaBadge />
-			</div>
+			<SidebarAlphaBadge />
 			<LicenseStatusFooter />
 		</>
 	);

--- a/src/components/app/SidebarHeader.tsx
+++ b/src/components/app/SidebarHeader.tsx
@@ -3,6 +3,7 @@ import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { LayoutAlignLeft } from "../Icons";
+import { SidebarAlphaBadge } from "./SidebarAlphaBadge";
 import { WindowChromeIconButton } from "./WindowChromeIconButton";
 import { WindowChromeUpdateButton } from "./WindowChromeUpdateButton";
 
@@ -29,6 +30,7 @@ export function SidebarHeader({
 			/>
 			<div className="sidebarHeader" data-tauri-drag-region>
 				<div className="sidebarActions">
+					<SidebarAlphaBadge />
 					<WindowChromeIconButton
 						ariaLabel={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
 						ariaPressed={!sidebarCollapsed}

--- a/src/components/app/SidebarHeader.tsx
+++ b/src/components/app/SidebarHeader.tsx
@@ -3,7 +3,6 @@ import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { LayoutAlignLeft } from "../Icons";
-import { SidebarAlphaBadge } from "./SidebarAlphaBadge";
 import { WindowChromeIconButton } from "./WindowChromeIconButton";
 import { WindowChromeUpdateButton } from "./WindowChromeUpdateButton";
 
@@ -30,7 +29,6 @@ export function SidebarHeader({
 			/>
 			<div className="sidebarHeader" data-tauri-drag-region>
 				<div className="sidebarActions">
-					<SidebarAlphaBadge />
 					<WindowChromeIconButton
 						ariaLabel={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
 						ariaPressed={!sidebarCollapsed}

--- a/src/components/app/WindowChromeUpdateButton.tsx
+++ b/src/components/app/WindowChromeUpdateButton.tsx
@@ -1,5 +1,3 @@
-import { DownloadSquare02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m } from "motion/react";
 
 interface WindowChromeUpdateButtonProps {
@@ -30,12 +28,7 @@ export function WindowChromeUpdateButton({
 						updateVersion ? `Install update ${updateVersion}` : "Install update"
 					}
 				>
-					<HugeiconsIcon
-						icon={DownloadSquare02Icon}
-						size="var(--icon-sm)"
-						strokeWidth={0.9}
-					/>
-					<span>UPDATE</span>
+					<span>Update available</span>
 				</m.button>
 			) : null}
 		</AnimatePresence>

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -121,16 +121,15 @@
 .windowChromeUpdateButton {
 	display: inline-flex;
 	align-items: center;
-	gap: 5px;
-	height: 24px;
-	padding: 0 8px 0 7px;
+	height: 20px;
+	padding: 0 6px 0 5px;
 	border: none;
-	border-radius: var(--radius-full);
-	background: var(--color-blue-dark-400);
+	border-radius: 8px;
+	background: rgb(0 112 249);
 	box-shadow: inset 0 0 0 0.5px color-mix(in srgb, white 28%, transparent);
 	color: white;
-	font-size: calc(var(--text-base) * 0.8);
-	font-weight: var(--font-bold);
+	font-size: calc(var(--text-base) * 0.85);
+	font-weight: var(--font-normal);
 	letter-spacing: 0.08em;
 	line-height: 1;
 	white-space: nowrap;
@@ -139,18 +138,13 @@
 }
 
 .windowChromeUpdateButton:hover {
-	background: color-mix(in srgb, var(--color-blue-dark-400) 82%, white);
+	background: color-mix(in srgb, rgb(0 112 249) 82%, white);
 }
 
 .windowChromeUpdateButton:focus-visible {
 	outline: 2px solid
-		color-mix(in srgb, var(--color-blue-dark-400) 40%, white 60%);
+		color-mix(in srgb, rgb(0 112 249) 40%, white 60%);
 	outline-offset: 2px;
-}
-
-.windowChromeUpdateButton svg {
-	width: var(--icon-sm);
-	height: var(--icon-sm);
 }
 
 .sidebarSection {

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -265,3 +265,34 @@
 .sidebarQuickActionBtn[data-kind="new-note"]:hover > svg {
 	color: var(--text-inverse);
 }
+
+/* ── Alpha version badge ── */
+.sidebarAlphaBadge {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	padding: 3px 8px 3px 6px;
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+	border: 1px solid
+		color-mix(in srgb, var(--interactive-accent) 24%, transparent);
+	color: var(--interactive-accent);
+	font-size: 9px;
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	line-height: 1;
+	pointer-events: none;
+	user-select: none;
+	white-space: nowrap;
+	box-shadow: var(--pill-shadow);
+}
+
+.sidebarAlphaBadge svg {
+	flex-shrink: 0;
+	color: currentColor;
+}
+
+.sidebarAlphaBadgeText {
+	white-space: nowrap;
+}

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -296,3 +296,10 @@
 .sidebarAlphaBadgeText {
 	white-space: nowrap;
 }
+
+/* ── Alpha badge in footer, right-aligned ── */
+.sidebarFooterAlpha {
+	display: flex;
+	justify-content: flex-end;
+	padding: 6px 12px 0;
+}


### PR DESCRIPTION
### Changes

 1. Alpha version badge (new)
 - Added SidebarAlphaBadge component — reads the app version via app_info and renders an "Alpha" pill badge in the
   sidebar footer when the version string contains "alpha".
 - Styled with accent-colored pill, subtle border + shadow, and an AlphaIcon from HugeIcons.
 - Self-hiding: returns null on non-alpha builds.

 2. Update button redesign
 - Simplified the window chrome update button: removed the download icon and shortened text from UPDATE → Update
   available.
 - Reduced height (24px → 20px), padding, and border-radius (full → 8px).
 - Switched background to a flat rgb(0 112 249) blue for a cleaner look.
 - Removed unused svg rule in sidebar CSS.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Alpha” version badge to the sidebar footer that automatically appears when the app is running an alpha build.
* **Style**
  * Updated the update notification button to use a “Update available” text label instead of an icon.
  * Refreshed sidebar styling for the update button and added dedicated styling for the alpha badge and its footer alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->