### PR TITLE
git diffs functionality added

### DIFF
--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -67,6 +67,7 @@ pub fn git_history_list(
 ) -> Result<Vec<GitHistoryCommit>, String> {
     let space_root = space_state.root_for_window(&window)?;
     let rel_path = validate_space_rel_path(&space_root, &path)?;
+    ensure_repo_at_space_root(&space_root)?;
     let raw = super::git::file_history(&space_root, &rel_path, limit.unwrap_or(30))?;
     Ok(parse_history_commits(&raw))
 }
@@ -80,13 +81,32 @@ pub fn git_history_diff(
 ) -> Result<GitCommitDiff, String> {
     let space_root = space_state.root_for_window(&window)?;
     let rel_path = validate_space_rel_path(&space_root, &path)?;
+    ensure_repo_at_space_root(&space_root)?;
     validate_commit_hash(&commit)?;
-    let diff = super::git::commit_file_diff(&space_root, &commit, &rel_path)?;
     let commit = parse_history_commits(&super::git::file_history(&space_root, &rel_path, 100)?)
         .into_iter()
         .find(|item| item.hash == commit || item.short_hash == commit)
         .ok_or_else(|| "commit was not found for this file".to_string())?;
+    let diff_path = if commit.rel_path.is_empty() {
+        rel_path.as_str()
+    } else {
+        commit.rel_path.as_str()
+    };
+    let diff = super::git::commit_file_diff(&space_root, &commit.hash, diff_path)?;
     Ok(GitCommitDiff { commit, diff })
+}
+
+fn ensure_repo_at_space_root(space_root: &std::path::Path) -> Result<(), String> {
+    match super::git::inspect_repo(space_root)? {
+        super::git::RepoInspection::AtRoot { .. } => Ok(()),
+        super::git::RepoInspection::Nested { .. } => Err(
+            "git history is only available when the repository is rooted at the opened space"
+                .to_string(),
+        ),
+        super::git::RepoInspection::None => {
+            Err("git history is only available in a Git repository".to_string())
+        }
+    }
 }
 
 fn validate_space_rel_path(space_root: &std::path::Path, path: &str) -> Result<String, String> {
@@ -125,9 +145,12 @@ fn parse_history_commits(raw: &str) -> Vec<GitHistoryCommit> {
         let Some(commit) = current.as_mut() else {
             continue;
         };
-        let Some((added, deleted)) = parse_numstat_line(line) else {
+        let Some((added, deleted, rel_path)) = parse_numstat_line(line) else {
             continue;
         };
+        if commit.rel_path.is_empty() {
+            commit.rel_path = normalize_numstat_path(&rel_path);
+        }
         let modified = added.min(deleted);
         commit.modified_count = commit.modified_count.saturating_add(modified);
         commit.added_count = commit
@@ -160,6 +183,7 @@ fn parse_history_commit_line(line: &str) -> Option<GitHistoryCommit> {
     Some(GitHistoryCommit {
         hash,
         short_hash,
+        rel_path: String::new(),
         author_name,
         author_email,
         timestamp_ms,
@@ -170,9 +194,23 @@ fn parse_history_commit_line(line: &str) -> Option<GitHistoryCommit> {
     })
 }
 
-fn parse_numstat_line(line: &str) -> Option<(u32, u32)> {
+fn parse_numstat_line(line: &str) -> Option<(u32, u32, String)> {
     let mut parts = line.split('\t');
     let added = parts.next()?.parse::<u32>().ok()?;
     let deleted = parts.next()?.parse::<u32>().ok()?;
-    Some((added, deleted))
+    let rel_path = parts.next()?.to_string();
+    Some((added, deleted, rel_path))
+}
+
+fn normalize_numstat_path(path: &str) -> String {
+    let Some((prefix, renamed_to)) = path.rsplit_once(" => ") else {
+        return path.to_string();
+    };
+    let Some((base, _)) = prefix.rsplit_once('{') else {
+        return renamed_to.to_string();
+    };
+    let Some((name, suffix)) = renamed_to.split_once('}') else {
+        return renamed_to.to_string();
+    };
+    format!("{base}{name}{suffix}")
 }

--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -77,22 +77,18 @@ pub fn git_history_diff(
     window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     path: String,
-    commit: String,
+    commit: GitHistoryCommit,
 ) -> Result<GitCommitDiff, String> {
     let space_root = space_state.root_for_window(&window)?;
     let rel_path = validate_space_rel_path(&space_root, &path)?;
     ensure_repo_at_space_root(&space_root)?;
-    validate_commit_hash(&commit)?;
-    let commit = parse_history_commits(&super::git::file_history(&space_root, &rel_path, 100)?)
-        .into_iter()
-        .find(|item| item.hash == commit || item.short_hash == commit)
-        .ok_or_else(|| "commit was not found for this file".to_string())?;
+    validate_commit_hash(&commit.hash)?;
     let diff_path = if commit.rel_path.is_empty() {
-        rel_path.as_str()
+        rel_path
     } else {
-        commit.rel_path.as_str()
+        validate_space_rel_path(&space_root, &commit.rel_path)?
     };
-    let diff = super::git::commit_file_diff(&space_root, &commit.hash, diff_path)?;
+    let diff = super::git::commit_file_diff(&space_root, &commit.hash, &diff_path)?;
     Ok(GitCommitDiff { commit, diff })
 }
 

--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -3,7 +3,10 @@ use tauri::{AppHandle, State, WebviewWindow};
 use crate::space::state::SpaceState;
 
 use super::service;
-use super::types::{GitSyncConfig, GitSyncConfigPatch, GitSyncRunRequest, GitSyncStatus};
+use super::types::{
+    GitCommitDiff, GitHistoryCommit, GitSyncConfig, GitSyncConfigPatch, GitSyncRunRequest,
+    GitSyncStatus,
+};
 use super::GitSyncState;
 
 #[tauri::command]
@@ -53,4 +56,123 @@ pub fn git_sync_disconnect(
     space_state: State<'_, SpaceState>,
 ) -> Result<GitSyncStatus, String> {
     service::disconnect_git_sync(app, &git_state, &space_state, window.label())
+}
+
+#[tauri::command]
+pub fn git_history_list(
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+    path: String,
+    limit: Option<u32>,
+) -> Result<Vec<GitHistoryCommit>, String> {
+    let space_root = space_state.root_for_window(&window)?;
+    let rel_path = validate_space_rel_path(&space_root, &path)?;
+    let raw = super::git::file_history(&space_root, &rel_path, limit.unwrap_or(30))?;
+    Ok(parse_history_commits(&raw))
+}
+
+#[tauri::command]
+pub fn git_history_diff(
+    window: WebviewWindow,
+    space_state: State<'_, SpaceState>,
+    path: String,
+    commit: String,
+) -> Result<GitCommitDiff, String> {
+    let space_root = space_state.root_for_window(&window)?;
+    let rel_path = validate_space_rel_path(&space_root, &path)?;
+    validate_commit_hash(&commit)?;
+    let diff = super::git::commit_file_diff(&space_root, &commit, &rel_path)?;
+    let commit = parse_history_commits(&super::git::file_history(&space_root, &rel_path, 100)?)
+        .into_iter()
+        .find(|item| item.hash == commit || item.short_hash == commit)
+        .ok_or_else(|| "commit was not found for this file".to_string())?;
+    Ok(GitCommitDiff { commit, diff })
+}
+
+fn validate_space_rel_path(space_root: &std::path::Path, path: &str) -> Result<String, String> {
+    crate::paths::join_under(space_root, std::path::Path::new(path))?;
+    let rel_path = path.replace('\\', "/");
+    if rel_path.to_lowercase().ends_with(".md") {
+        Ok(rel_path)
+    } else {
+        Err("git history is only available for markdown notes".to_string())
+    }
+}
+
+fn validate_commit_hash(commit: &str) -> Result<(), String> {
+    let valid_len = (7..=64).contains(&commit.len());
+    let valid_chars = commit.chars().all(|ch| ch.is_ascii_hexdigit());
+    if valid_len && valid_chars {
+        Ok(())
+    } else {
+        Err("invalid commit hash".to_string())
+    }
+}
+
+fn parse_history_commits(raw: &str) -> Vec<GitHistoryCommit> {
+    let mut commits = Vec::new();
+    let mut current: Option<GitHistoryCommit> = None;
+
+    for line in raw.lines() {
+        if let Some(commit_line) = line.strip_prefix('\u{1e}') {
+            if let Some(commit) = current.take() {
+                commits.push(commit);
+            }
+            current = parse_history_commit_line(commit_line);
+            continue;
+        }
+
+        let Some(commit) = current.as_mut() else {
+            continue;
+        };
+        let Some((added, deleted)) = parse_numstat_line(line) else {
+            continue;
+        };
+        let modified = added.min(deleted);
+        commit.modified_count = commit.modified_count.saturating_add(modified);
+        commit.added_count = commit
+            .added_count
+            .saturating_add(added.saturating_sub(modified));
+        commit.deleted_count = commit
+            .deleted_count
+            .saturating_add(deleted.saturating_sub(modified));
+    }
+
+    if let Some(commit) = current {
+        commits.push(commit);
+    }
+
+    commits
+}
+
+fn parse_history_commit_line(line: &str) -> Option<GitHistoryCommit> {
+    let mut parts = line.splitn(6, '\u{1f}');
+    let hash = parts.next()?.to_string();
+    let short_hash = parts.next()?.to_string();
+    let author_name = parts.next()?.to_string();
+    let author_email = parts.next()?.to_string();
+    let timestamp_ms = parts
+        .next()
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or(0)
+        * 1000;
+    let subject = parts.next().unwrap_or_default().to_string();
+    Some(GitHistoryCommit {
+        hash,
+        short_hash,
+        author_name,
+        author_email,
+        timestamp_ms,
+        subject,
+        added_count: 0,
+        modified_count: 0,
+        deleted_count: 0,
+    })
+}
+
+fn parse_numstat_line(line: &str) -> Option<(u32, u32)> {
+    let mut parts = line.split('\t');
+    let added = parts.next()?.parse::<u32>().ok()?;
+    let deleted = parts.next()?.parse::<u32>().ok()?;
+    Some((added, deleted))
 }

--- a/src-tauri/src/git_sync/git.rs
+++ b/src-tauri/src/git_sync/git.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::path::{Component, Path};
 use std::process::{Command, Stdio};
 use std::thread;
@@ -9,6 +10,10 @@ use crate::io_atomic;
 const GLYPH_GITIGNORE_START: &str = "# >>> Glyph Git Sync >>>";
 const GLYPH_GITIGNORE_END: &str = "# <<< Glyph Git Sync <<<";
 const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum number of commits returned by `file_history`. Shared so callers that
+/// re-derive history (e.g. diff lookups) stay consistent with this ceiling.
+pub const MAX_FILE_HISTORY_LIMIT: u32 = 100;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RepoInspection {
@@ -34,26 +39,53 @@ fn run_command(mut command: Command) -> Result<(bool, String, String), String> {
         .spawn()
         .map_err(|error| error.to_string())?;
 
+    // Drain stdout/stderr concurrently so git never blocks writing to a full
+    // pipe buffer (~64KB) while we poll for exit, which would otherwise deadlock
+    // and trip the timeout on large diffs/histories.
+    let mut stdout_pipe = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture git stdout".to_string())?;
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| "failed to capture git stderr".to_string())?;
+    let stdout_handle = thread::spawn(move || {
+        let mut buffer = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buffer);
+        buffer
+    });
+    let stderr_handle = thread::spawn(move || {
+        let mut buffer = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buffer);
+        buffer
+    });
+
     let deadline = Instant::now() + GIT_COMMAND_TIMEOUT;
-    loop {
+    let status = loop {
         match child.try_wait().map_err(|error| error.to_string())? {
-            Some(_) => break,
+            Some(status) => break status,
             None if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
+                let _ = stdout_handle.join();
+                let _ = stderr_handle.join();
                 return Err("git command timed out".to_string());
             }
             None => thread::sleep(Duration::from_millis(50)),
         }
-    }
+    };
 
-    let output = child
-        .wait_with_output()
-        .map_err(|error| error.to_string())?;
+    let stdout = stdout_handle
+        .join()
+        .map_err(|_| "git stdout reader panicked".to_string())?;
+    let stderr = stderr_handle
+        .join()
+        .map_err(|_| "git stderr reader panicked".to_string())?;
     Ok((
-        output.status.success(),
-        String::from_utf8_lossy(&output.stdout).trim().to_string(),
-        String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        status.success(),
+        String::from_utf8_lossy(&stdout).trim().to_string(),
+        String::from_utf8_lossy(&stderr).trim().to_string(),
     ))
 }
 
@@ -453,7 +485,7 @@ pub fn file_history(space_root: &Path, rel_path: &str, limit: u32) -> Result<Str
             "log".to_string(),
             "--follow".to_string(),
             "--date-order".to_string(),
-            format!("-n{}", limit.clamp(1, 100)),
+            format!("-n{}", limit.clamp(1, MAX_FILE_HISTORY_LIMIT)),
             "--format=%x1e%H%x1f%h%x1f%an%x1f%ae%x1f%at%x1f%s".to_string(),
             "--numstat".to_string(),
             "--".to_string(),

--- a/src-tauri/src/git_sync/git.rs
+++ b/src-tauri/src/git_sync/git.rs
@@ -83,6 +83,21 @@ fn run_git(space_root: &Path, args: &[&str]) -> Result<String, String> {
     }
 }
 
+fn run_git_owned(space_root: &Path, args: Vec<String>) -> Result<String, String> {
+    let (success, stdout, stderr) = run_command({
+        let mut command = Command::new("git");
+        command.current_dir(space_root).args(args.iter());
+        command
+    })?;
+    if success {
+        Ok(stdout)
+    } else if stderr.is_empty() {
+        Err("git command failed".to_string())
+    } else {
+        Err(stderr)
+    }
+}
+
 fn run_git_maybe(space_root: &Path, args: &[&str]) -> Result<Option<String>, String> {
     let (success, stdout, _) = run_command({
         let mut command = Command::new("git");
@@ -429,6 +444,40 @@ pub fn upsert_managed_gitignore(
 pub fn stage_for_sync(space_root: &Path) -> Result<(), String> {
     run_git(space_root, &["add", "-A", "."])?;
     Ok(())
+}
+
+pub fn file_history(space_root: &Path, rel_path: &str, limit: u32) -> Result<String, String> {
+    run_git_owned(
+        space_root,
+        vec![
+            "log".to_string(),
+            "--follow".to_string(),
+            "--date-order".to_string(),
+            format!("-n{}", limit.clamp(1, 100)),
+            "--format=%x1e%H%x1f%h%x1f%an%x1f%ae%x1f%at%x1f%s".to_string(),
+            "--numstat".to_string(),
+            "--".to_string(),
+            rel_path.to_string(),
+        ],
+    )
+}
+
+pub fn commit_file_diff(space_root: &Path, commit: &str, rel_path: &str) -> Result<String, String> {
+    run_git_owned(
+        space_root,
+        vec![
+            "show".to_string(),
+            "--format=".to_string(),
+            "--no-ext-diff".to_string(),
+            "--find-renames".to_string(),
+            "--patch".to_string(),
+            "--no-color".to_string(),
+            "--unified=3".to_string(),
+            commit.to_string(),
+            "--".to_string(),
+            rel_path.to_string(),
+        ],
+    )
 }
 
 #[cfg(test)]

--- a/src-tauri/src/git_sync/types.rs
+++ b/src-tauri/src/git_sync/types.rs
@@ -198,6 +198,7 @@ impl Default for GitSyncStatus {
 pub struct GitHistoryCommit {
     pub hash: String,
     pub short_hash: String,
+    pub rel_path: String,
     pub author_name: String,
     pub author_email: String,
     pub timestamp_ms: i64,

--- a/src-tauri/src/git_sync/types.rs
+++ b/src-tauri/src/git_sync/types.rs
@@ -193,3 +193,22 @@ impl Default for GitSyncStatus {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitHistoryCommit {
+    pub hash: String,
+    pub short_hash: String,
+    pub author_name: String,
+    pub author_email: String,
+    pub timestamp_ms: i64,
+    pub subject: String,
+    pub added_count: u32,
+    pub modified_count: u32,
+    pub deleted_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GitCommitDiff {
+    pub commit: GitHistoryCommit,
+    pub diff: String,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1609,6 +1609,8 @@ pub fn run() {
             git_sync::commands::git_sync_config_update,
             git_sync::commands::git_sync_run,
             git_sync::commands::git_sync_disconnect,
+            git_sync::commands::git_history_list,
+            git_sync::commands::git_history_diff,
             space::commands::space_create,
             space::commands::space_open,
             space::commands::space_open_window,

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1294,6 +1294,7 @@ export function AppShell() {
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}
 				onOpenDailyNotesSettings={() => openSettings("space")}
 				onRightSidebarOpenChange={setRightSidebarOpen}
+				gitSyncStatus={gitSync.status}
 			/>
 			<AnimatePresence>
 				{error && <div className="appError">{error}</div>}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -48,7 +48,7 @@ import {
 } from "../../lib/settings";
 import { formatShortcutPartsForPlatform } from "../../lib/shortcuts/platform";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
-import type { FsEntry } from "../../lib/tauri";
+import type { FsEntry, GitCommitDiff, GitSyncStatus } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { cn } from "../../lib/utils";
 import { onWindowDragMouseDown } from "../../utils/window";
@@ -89,6 +89,11 @@ const SpaceConnectionsView = lazy(() =>
 		default: module.SpaceConnectionsView,
 	})),
 );
+
+interface ActiveGitDiffState {
+	path: string;
+	diff: GitCommitDiff;
+}
 
 interface EmptyTip {
 	key: string;
@@ -292,6 +297,7 @@ interface MainContentProps {
 	dailyNoteSetupNoticeRequest: number;
 	onOpenDailyNotesSettings: () => void;
 	onRightSidebarOpenChange?: (open: boolean) => void;
+	gitSyncStatus?: GitSyncStatus | null;
 }
 
 function DailyNotesSetupToast({
@@ -396,6 +402,7 @@ export const MainContent = memo(function MainContent({
 	dailyNoteSetupNoticeRequest,
 	onOpenDailyNotesSettings,
 	onRightSidebarOpenChange,
+	gitSyncStatus = null,
 }: MainContentProps) {
 	const { spacePath, settingsLoaded, onOpenSpace } = useSpace();
 	const { getBinding } = useShortcutBindings();
@@ -411,6 +418,8 @@ export const MainContent = memo(function MainContent({
 		useState(false);
 	const [infoSidebarWidth, setInfoSidebarWidth] = useState(340);
 	const [infoSidebarOpen, setInfoSidebarOpen] = useState(false);
+	const [activeGitDiffState, setActiveGitDiffState] =
+		useState<ActiveGitDiffState | null>(null);
 	const handledShowGettingStartedRequestRef = useRef(0);
 	const activeTab = useMemo(
 		() => tabs.find((tab) => tab.id === activeTabId) ?? null,
@@ -455,6 +464,26 @@ export const MainContent = memo(function MainContent({
 	}, [closeTabsForPathRemoval, renameTabsForPath]);
 
 	const viewerPath = activeTabPath;
+	const currentMarkdownPath =
+		viewerPath?.toLowerCase().endsWith(".md") ? viewerPath : null;
+	const activeGitDiff =
+		activeGitDiffState?.path === currentMarkdownPath
+			? activeGitDiffState.diff
+			: null;
+
+	useEffect(() => {
+		setActiveGitDiffState(null);
+	}, [viewerPath]);
+
+	const handleGitDiffChange = useCallback(
+		(diff: GitCommitDiff | null) => {
+			setActiveGitDiffState(
+				diff && currentMarkdownPath ? { path: currentMarkdownPath, diff } : null,
+			);
+		},
+		[currentMarkdownPath],
+	);
+
 	const openCommandPaletteShortcut = getBinding("open-command-palette");
 	const commandShortcutParts = useMemo(
 		() =>
@@ -630,6 +659,9 @@ export const MainContent = memo(function MainContent({
 					initialDoc={initialDoc}
 					extractToNoteActions={extractToNoteActions}
 					onInfoSidebarOpenChange={setInfoSidebarOpen}
+					gitDiff={activeGitDiff}
+					onGitDiffChange={handleGitDiffChange}
+					gitSyncStatus={gitSyncStatus}
 					onDirtyChange={(dirty) =>
 						setDirtyByPath((prev) =>
 							prev[viewerPath] === dirty
@@ -649,6 +681,9 @@ export const MainContent = memo(function MainContent({
 		onConsumeDatabasesOpenRequest,
 		viewerPath,
 		setDirtyByPath,
+		activeGitDiff,
+		handleGitDiffChange,
+		gitSyncStatus,
 	]);
 
 	const handlePrefetchTab = useCallback(

--- a/src/components/preview/GitDiffView.tsx
+++ b/src/components/preview/GitDiffView.tsx
@@ -59,7 +59,7 @@ function formatCommitDate(timestampMs: number): string {
 }
 
 export function GitDiffView({ diff, onBack }: GitDiffViewProps) {
-	const lines = diff.diff.length ? diff.diff.split("\n") : [];
+	const lines = diff.diff.length ? diff.diff.trimEnd().split("\n") : [];
 	const dateLabel = formatCommitDate(diff.commit.timestamp_ms);
 
 	return (

--- a/src/components/preview/GitDiffView.tsx
+++ b/src/components/preview/GitDiffView.tsx
@@ -1,0 +1,106 @@
+import type { GitCommitDiff } from "../../lib/tauri";
+
+interface GitDiffViewProps {
+	diff: GitCommitDiff;
+	onBack: () => void;
+}
+
+type DiffLineKind = "add" | "delete" | "hunk" | "meta" | "context";
+
+interface DiffLineDisplay {
+	kind: DiffLineKind;
+	marker: string;
+	text: string;
+}
+
+function diffLineKind(line: string): DiffLineKind {
+	if (line.startsWith("@@")) return "hunk";
+	if (line.startsWith("+") && !line.startsWith("+++")) return "add";
+	if (line.startsWith("-") && !line.startsWith("---")) return "delete";
+	if (
+		line.startsWith("diff --git") ||
+		line.startsWith("index ") ||
+		line.startsWith("---") ||
+		line.startsWith("+++") ||
+		line.startsWith("new file mode") ||
+		line.startsWith("deleted file mode") ||
+		line.startsWith("similarity index") ||
+		line.startsWith("rename from") ||
+		line.startsWith("rename to")
+	) {
+		return "meta";
+	}
+	return "context";
+}
+
+function diffLineDisplay(line: string): DiffLineDisplay {
+	const kind = diffLineKind(line);
+	if (kind === "add") {
+		return { kind, marker: "+", text: line.slice(1) || " " };
+	}
+	if (kind === "delete") {
+		return { kind, marker: "-", text: line.slice(1) || " " };
+	}
+	if (kind === "hunk") {
+		return { kind, marker: "@@", text: line.replace(/^@@\s?/, "") || line };
+	}
+	return { kind, marker: "", text: line || " " };
+}
+
+function formatCommitDate(timestampMs: number): string {
+	if (!timestampMs) return "";
+	return new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	}).format(new Date(timestampMs));
+}
+
+export function GitDiffView({ diff, onBack }: GitDiffViewProps) {
+	const lines = diff.diff.length ? diff.diff.split("\n") : [];
+	const dateLabel = formatCommitDate(diff.commit.timestamp_ms);
+
+	return (
+		<div className="gitDiffView">
+			<header className="gitDiffHeader">
+				<button type="button" className="gitDiffBackButton" onClick={onBack}>
+					Back to editor
+				</button>
+				<div className="gitDiffCommitMeta">
+					<strong>{diff.commit.subject || "Untitled commit"}</strong>
+					<span>
+						{diff.commit.short_hash}
+						{dateLabel ? ` - ${dateLabel}` : ""}
+					</span>
+				</div>
+			</header>
+			<div className="gitDiffBody" role="region" aria-label="Commit diff">
+				{lines.length ? (
+					lines.map((line, index) => {
+						const display = diffLineDisplay(line);
+						return (
+							<div
+								key={`${index}:${line}`}
+								className="gitDiffLine"
+								data-kind={display.kind}
+							>
+								<div className="gitDiffLineInner">
+									<span className="gitDiffMarker" aria-hidden="true">
+										{display.marker}
+									</span>
+									<code className="gitDiffCode">{display.text}</code>
+								</div>
+							</div>
+						);
+					})
+				) : (
+					<div className="gitDiffEmpty">
+						This commit did not change the current note.
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,6 +1,6 @@
 import { GitCommitHorizontalIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type GitCommitDiff,
@@ -96,6 +96,7 @@ export function GitHistorySidebar({
 	const [loading, setLoading] = useState(false);
 	const [loadingCommit, setLoadingCommit] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const diffRequestIdRef = useRef(0);
 	const nowMs = useMemo(() => Date.now(), [commits]);
 	const groups = useMemo(
 		() => groupHistoryCommits(commits, nowMs),
@@ -103,6 +104,13 @@ export function GitHistorySidebar({
 	);
 
 	useEffect(() => {
+		return () => {
+			diffRequestIdRef.current += 1;
+		};
+	}, []);
+
+	useEffect(() => {
+		diffRequestIdRef.current += 1;
 		setCommits([]);
 		setExpandedGroupKeys(new Set());
 		setError(null);
@@ -144,6 +152,8 @@ export function GitHistorySidebar({
 	const handleSelectCommit = useCallback(
 		async (commit: GitHistoryCommit) => {
 			if (!relPath) return;
+			const requestId = diffRequestIdRef.current + 1;
+			diffRequestIdRef.current = requestId;
 			setLoadingCommit(commit.hash);
 			setError(null);
 			try {
@@ -151,11 +161,15 @@ export function GitHistorySidebar({
 					path: relPath,
 					commit: commit.hash,
 				});
+				if (diffRequestIdRef.current !== requestId) return;
 				onSelectDiff(diff);
 			} catch (cause) {
+				if (diffRequestIdRef.current !== requestId) return;
 				setError(extractErrorMessage(cause));
 			} finally {
-				setLoadingCommit(null);
+				if (diffRequestIdRef.current === requestId) {
+					setLoadingCommit(null);
+				}
 			}
 		},
 		[onSelectDiff, relPath],

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -159,7 +159,7 @@ export function GitHistorySidebar({
 			try {
 				const diff = await invoke("git_history_diff", {
 					path: relPath,
-					commit: commit.hash,
+					commit,
 				});
 				if (diffRequestIdRef.current !== requestId) return;
 				onSelectDiff(diff);

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,0 +1,292 @@
+import { GitCommitHorizontalIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { extractErrorMessage } from "../../lib/errorUtils";
+import {
+	type GitCommitDiff,
+	type GitHistoryCommit,
+	invoke,
+} from "../../lib/tauri";
+import { cn } from "../../lib/utils";
+import { ChevronDown, ChevronRight } from "../Icons";
+
+interface GitHistorySidebarProps {
+	open: boolean;
+	relPath: string | null;
+	selectedCommitHash?: string | null;
+	onSelectDiff: (diff: GitCommitDiff) => void;
+}
+
+interface GitHistoryGroup {
+	key: string;
+	label: string;
+	commits: GitHistoryCommit[];
+}
+
+function startOfDayMs(date: Date): number {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function formatGroupLabel(timestampMs: number, nowMs: number): string {
+	if (!timestampMs) return "Earlier";
+	const date = new Date(timestampMs);
+	const dayMs = startOfDayMs(date);
+	const todayMs = startOfDayMs(new Date(nowMs));
+	const dayDelta = Math.round((todayMs - dayMs) / 86_400_000);
+	if (dayDelta === 0) return "Today";
+	if (dayDelta === 1) return "Yesterday";
+	return new Intl.DateTimeFormat(undefined, {
+		weekday: "long",
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	}).format(date);
+}
+
+function formatCommitDate(timestampMs: number, nowMs: number): string {
+	if (!timestampMs) return "";
+	const elapsedMs = Math.max(0, nowMs - timestampMs);
+	const dayCount = Math.floor(elapsedMs / 86_400_000);
+	if (dayCount === 0) return "Today";
+	if (dayCount === 1) return "1d ago";
+	if (dayCount < 7) return `${dayCount}d ago`;
+	return new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+	}).format(new Date(timestampMs));
+}
+
+function groupHistoryCommits(
+	commits: GitHistoryCommit[],
+	nowMs: number,
+): GitHistoryGroup[] {
+	const groups = new Map<string, GitHistoryGroup>();
+	for (const commit of commits) {
+		const key = commit.timestamp_ms
+			? startOfDayMs(new Date(commit.timestamp_ms)).toString()
+			: "unknown";
+		const group = groups.get(key);
+		if (group) {
+			group.commits.push(commit);
+			continue;
+		}
+		groups.set(key, {
+			key,
+			label: formatGroupLabel(commit.timestamp_ms, nowMs),
+			commits: [commit],
+		});
+	}
+	return [...groups.values()];
+}
+
+function commitCountLabel(count: number): string {
+	return `${count} ${count === 1 ? "commit" : "commits"}`;
+}
+
+export function GitHistorySidebar({
+	open,
+	relPath,
+	selectedCommitHash = null,
+	onSelectDiff,
+}: GitHistorySidebarProps) {
+	const [commits, setCommits] = useState<GitHistoryCommit[]>([]);
+	const [expandedGroupKeys, setExpandedGroupKeys] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [loading, setLoading] = useState(false);
+	const [loadingCommit, setLoadingCommit] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const nowMs = useMemo(() => Date.now(), [commits]);
+	const groups = useMemo(
+		() => groupHistoryCommits(commits, nowMs),
+		[commits, nowMs],
+	);
+
+	useEffect(() => {
+		setCommits([]);
+		setExpandedGroupKeys(new Set());
+		setError(null);
+	}, [relPath]);
+
+	useEffect(() => {
+		setExpandedGroupKeys(new Set(groups.map((group) => group.key)));
+	}, [groups]);
+
+	useEffect(() => {
+		if (!open || !relPath) return;
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		void invoke("git_history_list", { path: relPath, limit: 40 })
+			.then((items) => {
+				if (cancelled) return;
+				setCommits(items);
+			})
+			.catch((cause: unknown) => {
+				if (cancelled) return;
+				setCommits([]);
+				setError(extractErrorMessage(cause));
+			})
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, relPath]);
+
+	const noteName = useMemo(() => {
+		if (!relPath) return "Current note";
+		const segments = relPath.split("/").filter(Boolean);
+		return segments[segments.length - 1] ?? "Current note";
+	}, [relPath]);
+
+	const handleSelectCommit = useCallback(
+		async (commit: GitHistoryCommit) => {
+			if (!relPath) return;
+			setLoadingCommit(commit.hash);
+			setError(null);
+			try {
+				const diff = await invoke("git_history_diff", {
+					path: relPath,
+					commit: commit.hash,
+				});
+				onSelectDiff(diff);
+			} catch (cause) {
+				setError(extractErrorMessage(cause));
+			} finally {
+				setLoadingCommit(null);
+			}
+		},
+		[onSelectDiff, relPath],
+	);
+
+	const toggleGroup = useCallback((key: string) => {
+		setExpandedGroupKeys((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) {
+				next.delete(key);
+			} else {
+				next.add(key);
+			}
+			return next;
+		});
+	}, []);
+
+	return (
+		<section className="markdownEditorInfoSection gitHistoryPanel">
+			<header className="gitHistoryHeader">
+				<strong>Version history</strong>
+				<span>{noteName}</span>
+			</header>
+			<div className="gitHistoryBody">
+				{loading ? (
+					<div className="markdownEditorInfoEmpty">Loading history</div>
+				) : null}
+				{error ? <div className="markdownEditorInfoEmpty">{error}</div> : null}
+				{!loading && !error && commits.length === 0 ? (
+					<div className="markdownEditorInfoEmpty">No saved versions yet.</div>
+				) : null}
+				{groups.length ? (
+					<div className="gitHistoryList">
+						{groups.map((group) => {
+							const isExpanded = expandedGroupKeys.has(group.key);
+							return (
+								<div className="gitHistoryGroup" key={group.key}>
+									<button
+										type="button"
+										className="gitHistoryGroupHeader"
+										onClick={() => toggleGroup(group.key)}
+										aria-expanded={isExpanded}
+									>
+										{isExpanded ? (
+											<ChevronDown size="var(--icon-sm)" />
+										) : (
+											<ChevronRight size="var(--icon-sm)" />
+										)}
+										<span>{group.label}</span>
+										<em>({commitCountLabel(group.commits.length)})</em>
+									</button>
+									{isExpanded ? (
+										<div className="gitHistoryGroupItems">
+											{group.commits.map((commit) => {
+												const isSelected = selectedCommitHash === commit.hash;
+												const isLoading = loadingCommit === commit.hash;
+												return (
+													<button
+														type="button"
+														key={commit.hash}
+														className={cn(
+															"gitHistoryItem",
+															isSelected && "gitHistoryItemSelected",
+														)}
+														onClick={() => void handleSelectCommit(commit)}
+														aria-pressed={isSelected}
+													>
+														<span
+															className="gitHistoryMarker"
+															aria-hidden="true"
+														>
+															<HugeiconsIcon
+																icon={GitCommitHorizontalIcon}
+																size="var(--icon-sm)"
+																strokeWidth={1.1}
+															/>
+														</span>
+														<span className="gitHistoryContent">
+															<span className="gitHistoryTopLine">
+																<span className="gitHistorySubject">
+																	{commit.subject || "Untitled version"}
+																</span>
+																<span className="gitHistoryHash">
+																	{commit.short_hash}
+																</span>
+																<ChevronRight
+																	size="var(--icon-sm)"
+																	className="gitHistoryOpenIcon"
+																/>
+															</span>
+															<span className="gitHistoryMeta">
+																<span>
+																	{formatCommitDate(
+																		commit.timestamp_ms,
+																		nowMs,
+																	)}
+																</span>
+																{commit.added_count > 0 ? (
+																	<span className="gitHistoryStat gitHistoryStatAdd">
+																		+{commit.added_count.toLocaleString()}
+																	</span>
+																) : null}
+																{commit.modified_count > 0 ? (
+																	<span className="gitHistoryStat gitHistoryStatModify">
+																		~
+																		{commit.modified_count.toLocaleString()}
+																	</span>
+																) : null}
+																{commit.deleted_count > 0 ? (
+																	<span className="gitHistoryStat gitHistoryStatDelete">
+																		-{commit.deleted_count.toLocaleString()}
+																	</span>
+																) : null}
+															</span>
+														</span>
+														{isLoading ? (
+															<span className="gitHistoryLoading">
+																Opening diff
+															</span>
+														) : null}
+													</button>
+												);
+											})}
+										</div>
+									) : null}
+								</div>
+							);
+						})}
+					</div>
+				) : null}
+			</div>
+		</section>
+	);
+}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -27,6 +27,7 @@ import {
 	type ToggleNoteInfoSidebarDetail,
 } from "../../lib/appEvents";
 import { extractErrorMessage } from "../../lib/errorUtils";
+import { canShowGitHistory } from "../../lib/gitSyncUi";
 import { showNativePopupMenu } from "../../lib/nativeContextMenu";
 import { setPrefetchedNote } from "../../lib/navigationPrefetch";
 import {
@@ -176,15 +177,6 @@ function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
 	return Array.from(out.values());
 }
 
-function hasSupportedGitRepo(status: GitSyncStatus): boolean {
-	return (
-		status.git_installed &&
-		status.repo_detected &&
-		status.repo_root_matches_space &&
-		!status.unsupported_parent_repo
-	);
-}
-
 export function MarkdownEditorPane({
 	relPath,
 	onDirtyChange,
@@ -240,9 +232,7 @@ export function MarkdownEditorPane({
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const { openSettings, showToc } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
-	const hasSupportedGit = gitSyncStatus
-		? hasSupportedGitRepo(gitSyncStatus)
-		: false;
+	const hasSupportedGit = canShowGitHistory(gitSyncStatus);
 
 	useEffect(() => {
 		if (hasSupportedGit) return;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -36,6 +36,8 @@ import {
 import { groupRelationshipsByField } from "../../lib/relationships";
 import {
 	type BacklinkItem,
+	type GitCommitDiff,
+	type GitSyncStatus,
 	type NoteRelationship,
 	type TextFileDoc,
 	type WorkspaceDatabasePreviewContext,
@@ -53,6 +55,7 @@ import type {
 	ExtractToNoteActions,
 	NoteInlineEditorMode,
 } from "../editor/types";
+import { GitDiffView } from "./GitDiffView";
 import { LinkedNotePreviewSheet } from "./LinkedNotePreviewSheet";
 import { NotesInfoSidebar } from "./NotesInfoSidebar";
 import {
@@ -65,6 +68,9 @@ interface MarkdownEditorPaneProps {
 	relPath: string;
 	onDirtyChange?: (dirty: boolean) => void;
 	onInfoSidebarOpenChange?: (open: boolean) => void;
+	gitDiff?: GitCommitDiff | null;
+	onGitDiffChange?: (diff: GitCommitDiff | null) => void;
+	gitSyncStatus?: GitSyncStatus | null;
 	initialDoc?: TextFileDoc | null;
 	initialError?: string;
 	extractToNoteActions?: ExtractToNoteActions;
@@ -170,10 +176,22 @@ function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
 	return Array.from(out.values());
 }
 
+function hasSupportedGitRepo(status: GitSyncStatus): boolean {
+	return (
+		status.git_installed &&
+		status.repo_detected &&
+		status.repo_root_matches_space &&
+		!status.unsupported_parent_repo
+	);
+}
+
 export function MarkdownEditorPane({
 	relPath,
 	onDirtyChange,
 	onInfoSidebarOpenChange,
+	gitDiff = null,
+	onGitDiffChange,
+	gitSyncStatus = null,
 	initialDoc = null,
 	initialError = "",
 	extractToNoteActions,
@@ -222,6 +240,14 @@ export function MarkdownEditorPane({
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const { openSettings, showToc } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
+	const hasSupportedGit = gitSyncStatus
+		? hasSupportedGitRepo(gitSyncStatus)
+		: false;
+
+	useEffect(() => {
+		if (hasSupportedGit) return;
+		onGitDiffChange?.(null);
+	}, [hasSupportedGit, onGitDiffChange]);
 
 	const isDirty = text !== savedText;
 	const { frontmatter: currentFrontmatter, body: currentBody } = useMemo(
@@ -896,24 +922,31 @@ export function MarkdownEditorPane({
 					className="filePreviewTextWrap markdownEditorContent"
 				>
 					<div className="markdownEditorCenter">
-						<NoteInlineEditor
-							markdown={text}
-							relPath={relPath}
-							mode={mode}
-							pasteMarkdownBehavior="smart-markdown"
-							onChange={(nextText) => {
-								hasUserEditsRef.current = true;
-								textRef.current = nextText;
-								setText(nextText);
-							}}
-							onFrontmatterCommit={runAutosave}
-							onEditorReady={setTocEditor}
-							extractToNoteActions={extractToNoteActions}
-						/>
+						{gitDiff ? (
+							<GitDiffView
+								diff={gitDiff}
+								onBack={() => onGitDiffChange?.(null)}
+							/>
+						) : (
+							<NoteInlineEditor
+								markdown={text}
+								relPath={relPath}
+								mode={mode}
+								pasteMarkdownBehavior="smart-markdown"
+								onChange={(nextText) => {
+									hasUserEditsRef.current = true;
+									textRef.current = nextText;
+									setText(nextText);
+								}}
+								onFrontmatterCommit={runAutosave}
+								onEditorReady={setTocEditor}
+								extractToNoteActions={extractToNoteActions}
+							/>
+						)}
 					</div>
 				</div>
 			) : null}
-			{showToc && !infoPanelOpen && !error && mode !== "plain" ? (
+			{showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain" ? (
 				<FloatingTOC
 					headings={tocHeadings}
 					activeId={tocActiveId}
@@ -941,6 +974,9 @@ export function MarkdownEditorPane({
 				lineCount={lineCount}
 				utf8SizeBytes={utf8SizeBytes}
 				saveLabel={saveLabel}
+				gitSyncStatus={gitSyncStatus}
+				selectedGitCommitHash={gitDiff?.commit.hash ?? null}
+				onSelectGitDiff={onGitDiffChange ?? undefined}
 				onClose={() => setInfoPanelOpen(false)}
 			/>
 			<LinkedNotePreviewSheet />

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -1,4 +1,4 @@
-import type { TextFileDoc } from "../../lib/tauri";
+import type { GitCommitDiff, GitSyncStatus, TextFileDoc } from "../../lib/tauri";
 import type { ExtractToNoteActions } from "../editor/types";
 import { MarkdownEditorPane } from "./MarkdownEditorPane";
 
@@ -6,6 +6,9 @@ interface NotePaneProps {
 	relPath: string;
 	onDirtyChange?: (dirty: boolean) => void;
 	onInfoSidebarOpenChange?: (open: boolean) => void;
+	gitDiff?: GitCommitDiff | null;
+	onGitDiffChange?: (diff: GitCommitDiff | null) => void;
+	gitSyncStatus?: GitSyncStatus | null;
 	initialDoc?: TextFileDoc | null;
 	extractToNoteActions?: ExtractToNoteActions;
 }
@@ -14,6 +17,9 @@ export function NotePane({
 	relPath,
 	onDirtyChange,
 	onInfoSidebarOpenChange,
+	gitDiff = null,
+	onGitDiffChange,
+	gitSyncStatus = null,
 	initialDoc = null,
 	extractToNoteActions,
 }: NotePaneProps) {
@@ -23,6 +29,9 @@ export function NotePane({
 			initialDoc={initialDoc}
 			onDirtyChange={onDirtyChange}
 			onInfoSidebarOpenChange={onInfoSidebarOpenChange}
+			gitDiff={gitDiff}
+			onGitDiffChange={onGitDiffChange}
+			gitSyncStatus={gitSyncStatus}
 			extractToNoteActions={extractToNoteActions}
 		/>
 	);

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -2,6 +2,7 @@ import { BadgeInfoIcon, GitBranchIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { canShowGitHistory } from "../../lib/gitSyncUi";
 import {
 	type RelationshipGroup,
 	relationshipTargetLabel,
@@ -95,15 +96,6 @@ function formatFileSize(bytes: number): string {
 	})} ${units[unitIndex]}`;
 }
 
-function hasSupportedGitRepo(status: GitSyncStatus | null | undefined): boolean {
-	return Boolean(
-		status?.git_installed &&
-			status.repo_detected &&
-			status.repo_root_matches_space &&
-			!status.unsupported_parent_repo,
-	);
-}
-
 export function NotesInfoSidebar({
 	open,
 	mode,
@@ -132,7 +124,7 @@ export function NotesInfoSidebar({
 	const [host, setHost] = useState<HTMLElement | null>(null);
 	const [activeTab, setActiveTab] = useState<InfoSidebarTab>("info");
 	const hasGitHistoryTab =
-		hasSupportedGitRepo(gitSyncStatus) && Boolean(onSelectGitDiff);
+		canShowGitHistory(gitSyncStatus) && Boolean(onSelectGitDiff);
 
 	useEffect(() => {
 		if (typeof document === "undefined") return;

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -1,3 +1,5 @@
+import { BadgeInfoIcon, GitBranchIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import {
@@ -5,6 +7,8 @@ import {
 	relationshipTargetLabel,
 } from "../../lib/relationships";
 import type {
+	GitCommitDiff,
+	GitSyncStatus,
 	NoteTaskSummary,
 	WorkspaceDatabasePreviewContext,
 } from "../../lib/tauri";
@@ -17,6 +21,9 @@ import {
 	dispatchWikiLinkClick,
 } from "../editor/markdown/editorEvents";
 import type { NoteInlineEditorMode } from "../editor/types";
+import { GitHistorySidebar } from "./GitHistorySidebar";
+
+type InfoSidebarTab = "info" | "history";
 
 interface SidebarBacklinkItem {
 	id: string;
@@ -53,6 +60,9 @@ interface NotesInfoSidebarProps {
 	lineCount: number;
 	utf8SizeBytes: number;
 	saveLabel: string;
+	gitSyncStatus?: GitSyncStatus | null;
+	selectedGitCommitHash?: string | null;
+	onSelectGitDiff?: (diff: GitCommitDiff) => void;
 	onClose: () => void;
 }
 
@@ -85,6 +95,15 @@ function formatFileSize(bytes: number): string {
 	})} ${units[unitIndex]}`;
 }
 
+function hasSupportedGitRepo(status: GitSyncStatus | null | undefined): boolean {
+	return Boolean(
+		status?.git_installed &&
+			status.repo_detected &&
+			status.repo_root_matches_space &&
+			!status.unsupported_parent_repo,
+	);
+}
+
 export function NotesInfoSidebar({
 	open,
 	mode,
@@ -105,14 +124,34 @@ export function NotesInfoSidebar({
 	lineCount,
 	utf8SizeBytes,
 	saveLabel,
+	gitSyncStatus = null,
+	selectedGitCommitHash = null,
+	onSelectGitDiff,
 	onClose,
 }: NotesInfoSidebarProps) {
 	const [host, setHost] = useState<HTMLElement | null>(null);
+	const [activeTab, setActiveTab] = useState<InfoSidebarTab>("info");
+	const hasGitHistoryTab =
+		hasSupportedGitRepo(gitSyncStatus) && Boolean(onSelectGitDiff);
 
 	useEffect(() => {
 		if (typeof document === "undefined") return;
 		setHost(document.getElementById("notes-info-sidebar-root"));
 	}, []);
+
+	useEffect(() => {
+		setActiveTab("info");
+	}, [relPath]);
+
+	useEffect(() => {
+		if (!open) {
+			setActiveTab("info");
+			return;
+		}
+		if (!hasGitHistoryTab && activeTab === "history") {
+			setActiveTab("info");
+		}
+	}, [activeTab, hasGitHistoryTab, open]);
 
 	if (!open || mode === "plain" || hasError) return null;
 
@@ -123,6 +162,45 @@ export function NotesInfoSidebar({
 				data-tauri-drag-region
 				onMouseDown={onWindowDragMouseDown}
 			>
+				<div
+					className="markdownEditorInfoTabs"
+					role="tablist"
+					aria-label="Note sidebar"
+					data-window-drag-ignore
+				>
+					<button
+						type="button"
+						className="markdownEditorInfoTab"
+						role="tab"
+						aria-selected={activeTab === "info"}
+						data-active={activeTab === "info" ? "true" : undefined}
+						onClick={() => setActiveTab("info")}
+					>
+						<HugeiconsIcon
+							icon={BadgeInfoIcon}
+							size="var(--icon-sm)"
+							strokeWidth={1}
+						/>
+						Info
+					</button>
+					{hasGitHistoryTab ? (
+						<button
+							type="button"
+							className="markdownEditorInfoTab"
+							role="tab"
+							aria-selected={activeTab === "history"}
+							data-active={activeTab === "history" ? "true" : undefined}
+							onClick={() => setActiveTab("history")}
+						>
+							<HugeiconsIcon
+								icon={GitBranchIcon}
+								size="var(--icon-sm)"
+								strokeWidth={1}
+							/>
+							History
+						</button>
+					) : null}
+				</div>
 				<button
 					type="button"
 					className="markdownEditorInfoClose"
@@ -134,30 +212,32 @@ export function NotesInfoSidebar({
 				</button>
 			</div>
 			<div className="markdownEditorInfoBody">
-				<section className="markdownEditorInfoSection markdownEditorInfoSectionFrontmatter">
-					<NotePropertiesPanel
-						frontmatter={frontmatter}
-						onChange={onFrontmatterChange}
-					/>
-				</section>
+				{activeTab === "info" ? (
+					<>
+						<section className="markdownEditorInfoSection markdownEditorInfoSectionFrontmatter">
+							<NotePropertiesPanel
+								frontmatter={frontmatter}
+								onChange={onFrontmatterChange}
+							/>
+						</section>
 
-				<section className="markdownEditorInfoSection">
-					<h3 className="markdownEditorInfoSectionLabel">Stats</h3>
-					<div className="markdownEditorInfoRows">
-						<div className="markdownEditorInfoRow">
-							<span>Words</span>
-							<strong>{stats.words.toLocaleString()}</strong>
-						</div>
-						<div className="markdownEditorInfoRow">
-							<span>Characters</span>
-							<strong>{stats.characters.toLocaleString()}</strong>
-						</div>
-						<div className="markdownEditorInfoRow">
-							<span>Reading time</span>
-							<strong>{stats.readingTime}</strong>
-						</div>
-					</div>
-				</section>
+						<section className="markdownEditorInfoSection">
+							<h3 className="markdownEditorInfoSectionLabel">Stats</h3>
+							<div className="markdownEditorInfoRows">
+								<div className="markdownEditorInfoRow">
+									<span>Words</span>
+									<strong>{stats.words.toLocaleString()}</strong>
+								</div>
+								<div className="markdownEditorInfoRow">
+									<span>Characters</span>
+									<strong>{stats.characters.toLocaleString()}</strong>
+								</div>
+								<div className="markdownEditorInfoRow">
+									<span>Reading time</span>
+									<strong>{stats.readingTime}</strong>
+								</div>
+							</div>
+						</section>
 
 				<section className="markdownEditorInfoSection">
 					<h3 className="markdownEditorInfoSectionLabel">Tasks</h3>
@@ -345,6 +425,18 @@ export function NotesInfoSidebar({
 						</div>
 					</div>
 				</section>
+
+					</>
+				) : null}
+
+				{activeTab === "history" && hasGitHistoryTab && onSelectGitDiff ? (
+					<GitHistorySidebar
+						open={open}
+						relPath={relPath}
+						selectedCommitHash={selectedGitCommitHash}
+						onSelectDiff={onSelectGitDiff}
+					/>
+				) : null}
 			</div>
 		</aside>
 	);

--- a/src/lib/gitSyncUi.ts
+++ b/src/lib/gitSyncUi.ts
@@ -68,6 +68,15 @@ export function getGitSyncRepoStateLabel(status: GitSyncStatus | null): string {
 	return "No repo at space root";
 }
 
+export function canShowGitHistory(status: GitSyncStatus | null): boolean {
+	return Boolean(
+		status?.git_installed &&
+			status.repo_detected &&
+			status.repo_root_matches_space &&
+			!status.unsupported_parent_repo,
+	);
+}
+
 export function getGitSyncConnectionHelp(
 	status: GitSyncStatus | null,
 	configured: boolean,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -580,6 +580,7 @@ export interface GitSyncStatus {
 export interface GitHistoryCommit {
 	hash: string;
 	short_hash: string;
+	rel_path: string;
 	author_name: string;
 	author_email: string;
 	timestamp_ms: number;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1022,7 +1022,7 @@ interface TauriCommands {
 		GitHistoryCommit[]
 	>;
 	git_history_diff: CommandDef<
-		{ path: string; commit: string },
+		{ path: string; commit: GitHistoryCommit },
 		GitCommitDiff
 	>;
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -577,6 +577,23 @@ export interface GitSyncStatus {
 	message: string | null;
 }
 
+export interface GitHistoryCommit {
+	hash: string;
+	short_hash: string;
+	author_name: string;
+	author_email: string;
+	timestamp_ms: number;
+	subject: string;
+	added_count: number;
+	modified_count: number;
+	deleted_count: number;
+}
+
+export interface GitCommitDiff {
+	commit: GitHistoryCommit;
+	diff: string;
+}
+
 interface GitSyncContext {
 	templates_folder?: string | null;
 	attachment_storage_mode?: AttachmentStorageMode | null;
@@ -999,6 +1016,14 @@ interface TauriCommands {
 	>;
 	git_sync_run: CommandDef<{ request: GitSyncRunRequest }, GitSyncStatus>;
 	git_sync_disconnect: CommandDef<void, GitSyncStatus>;
+	git_history_list: CommandDef<
+		{ path: string; limit?: number | null },
+		GitHistoryCommit[]
+	>;
+	git_history_diff: CommandDef<
+		{ path: string; commit: string },
+		GitCommitDiff
+	>;
 
 	ai_profiles_list: CommandDef<void, AiProfile[]>;
 	ai_active_profile_get: CommandDef<void, string | null>;

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -616,7 +616,7 @@
 }
 
 .gitHistoryHash {
-	color: #2563eb;
+	color: var(--accent);
 	font-family: var(--font-mono);
 	font-size: calc(var(--text-base) * 0.84);
 	font-variant-numeric: tabular-nums;

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -142,6 +142,159 @@
 	display: flex;
 }
 
+.gitDiffView {
+	width: 100%;
+	max-width: none;
+	margin: 0 auto;
+	padding: 0 0 80px;
+	color: var(--text-primary);
+}
+
+.gitDiffHeader {
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	width: 100%;
+	padding: 14px var(--editor-readable-content-gutter);
+	background: color-mix(
+		in srgb,
+		var(--bg-canvas, var(--bg-primary)) 94%,
+		transparent
+	);
+	backdrop-filter: blur(12px);
+	-webkit-backdrop-filter: blur(12px);
+}
+
+.gitDiffBackButton {
+	height: 28px;
+	padding: 0 10px;
+	border: 1px solid var(--border-light);
+	border-radius: var(--radius-sm);
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-size: calc(var(--text-base) * 0.82);
+	font-weight: var(--font-medium);
+	cursor: pointer;
+}
+
+.gitDiffBackButton:hover {
+	background: var(--bg-hover);
+}
+
+.gitDiffCommitMeta {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.gitDiffCommitMeta strong {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+}
+
+.gitDiffCommitMeta span {
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.78);
+}
+
+.gitDiffBody {
+	width: 100%;
+	overflow: visible;
+	background: transparent;
+}
+
+.gitDiffLine {
+	display: flex;
+	width: 100%;
+	min-height: 23px;
+	margin: 0;
+	padding: 0 var(--editor-readable-content-gutter);
+	color: var(--text-secondary);
+}
+
+.gitDiffLineInner {
+	display: grid;
+	grid-template-columns: 34px minmax(0, 1fr);
+	width: 100%;
+	min-width: 0;
+	max-width: var(--readable-content-outer-width);
+	margin: 0 auto;
+}
+
+.gitDiffMarker {
+	padding: 0 9px 0 0;
+	color: var(--text-tertiary);
+	font-family: var(--font-mono);
+	font-size: calc(var(--text-base) * 0.78);
+	font-variant-numeric: tabular-nums;
+	line-height: 23px;
+	text-align: right;
+	user-select: none;
+}
+
+.gitDiffCode {
+	display: block;
+	min-width: 0;
+	overflow-x: auto;
+	font-family: var(--font-mono);
+	font-size: calc(var(--text-base) * 0.82);
+	line-height: 23px;
+	tab-size: 2;
+	white-space: pre;
+}
+
+.gitDiffLine[data-kind="add"] {
+	background: color-mix(in srgb, #22c55e 10%, transparent);
+	color: color-mix(in srgb, #15803d 78%, var(--text-primary));
+}
+
+.gitDiffLine[data-kind="add"] .gitDiffMarker {
+	color: color-mix(in srgb, #15803d 82%, var(--text-primary));
+}
+
+.gitDiffLine[data-kind="delete"] {
+	background: color-mix(in srgb, #ef4444 10%, transparent);
+	color: color-mix(in srgb, #b91c1c 78%, var(--text-primary));
+}
+
+.gitDiffLine[data-kind="delete"] .gitDiffMarker {
+	color: color-mix(in srgb, #b91c1c 82%, var(--text-primary));
+}
+
+.gitDiffLine[data-kind="hunk"] {
+	margin-top: 12px;
+	background: color-mix(in srgb, var(--accent) 8%, transparent);
+	color: var(--text-primary);
+	font-weight: var(--font-medium);
+}
+
+.gitDiffLine[data-kind="hunk"] .gitDiffMarker {
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.7);
+}
+
+.gitDiffLine[data-kind="meta"] {
+	background: color-mix(in srgb, var(--bg-secondary) 42%, transparent);
+	color: var(--text-tertiary);
+}
+
+.gitDiffLine[data-kind="meta"] .gitDiffCode {
+	font-size: calc(var(--text-base) * 0.76);
+}
+
+.gitDiffEmpty {
+	padding: 24px var(--editor-readable-content-gutter);
+	color: var(--text-tertiary);
+	font-size: var(--text-sm);
+}
+
 .notesInfoSidebarPanel {
 	width: 100%;
 	height: 100%;
@@ -160,11 +313,11 @@
 	position: sticky;
 	top: 0;
 	z-index: 2;
-	height: 32px;
-	padding: 0 10px;
+	min-height: 42px;
+	padding: 8px 8px 5px 10px;
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: space-between;
 	border-bottom: none;
 	background: transparent;
 	backdrop-filter: none;
@@ -215,6 +368,49 @@
 	font-weight: 500;
 }
 
+.markdownEditorInfoTabs {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	padding: 2px;
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-secondary) 48%, transparent);
+}
+
+.markdownEditorInfoTab {
+	height: 24px;
+	padding: 0 9px;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-tertiary);
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-size: calc(var(--text-base) * 0.76);
+	font-weight: var(--font-medium);
+	line-height: 1;
+	cursor: pointer;
+	transition: background-color 120ms ease, color 120ms ease;
+}
+
+.markdownEditorInfoTab:hover {
+	color: var(--text-primary);
+	background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
+}
+
+.markdownEditorInfoTab[data-active="true"] {
+	color: var(--text-primary);
+	background: var(--bg-primary);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--border-light) 34%, transparent);
+}
+
+.markdownEditorInfoTab:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 2px;
+}
+
 .markdownEditorInfoBody {
 	flex: 1;
 	min-height: 0;
@@ -226,6 +422,235 @@
 .markdownEditorInfoSection {
 	position: relative;
 	padding: 10px 0 12px;
+}
+
+.gitHistoryPanel {
+	background: transparent;
+	padding-top: 2px;
+}
+
+.gitHistoryHeader {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	width: 100%;
+	padding: 2px 12px 10px;
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+}
+
+.gitHistoryHeader strong {
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+	line-height: 1.1;
+	text-wrap: balance;
+}
+
+.gitHistoryHeader span {
+	max-width: 100%;
+	overflow: hidden;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.76);
+	line-height: 1.6;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.gitHistoryBody {
+	padding: 0 0 4px;
+}
+
+.gitHistoryList {
+	display: flex;
+	flex-direction: column;
+	margin: 0 -10px;
+}
+
+.gitHistoryGroup {
+	display: flex;
+	flex-direction: column;
+	border-top: 1px solid color-mix(in srgb, var(--border-light) 70%, transparent);
+}
+
+.gitHistoryGroup:last-child {
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 70%, transparent);
+}
+
+.gitHistoryGroupHeader {
+	display: flex;
+	min-height: 38px;
+	width: 100%;
+	align-items: center;
+	gap: 8px;
+	padding: 0 20px;
+	border: 0;
+	background: color-mix(in srgb, var(--bg-secondary) 48%, transparent);
+	color: var(--text-secondary);
+	text-align: left;
+	cursor: pointer;
+}
+
+.gitHistoryGroupHeader:hover {
+	background: color-mix(in srgb, var(--bg-secondary) 64%, transparent);
+	color: var(--text-primary);
+}
+
+.gitHistoryGroupHeader:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: -2px;
+}
+
+.gitHistoryGroupHeader span {
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--text-sm);
+	font-weight: var(--font-medium);
+	line-height: 1.1;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.gitHistoryGroupHeader em {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.78);
+	font-style: normal;
+	font-variant-numeric: tabular-nums;
+}
+
+.gitHistoryGroupItems {
+	display: flex;
+	flex-direction: column;
+}
+
+.gitHistoryItem {
+	position: relative;
+	display: flex;
+	width: 100%;
+	min-height: 76px;
+	align-items: center;
+	gap: 10px;
+	padding: 13px 18px 13px 20px;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+	cursor: pointer;
+	transition: none;
+}
+
+.gitHistoryItem + .gitHistoryItem {
+	border-top: 1px solid color-mix(in srgb, var(--border-light) 58%, transparent);
+}
+
+.gitHistoryItem:hover,
+.gitHistoryItemSelected {
+	background: color-mix(in srgb, var(--bg-hover) 56%, transparent);
+}
+
+.gitHistoryItem:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: -2px;
+}
+
+.gitHistoryItemSelected {
+	background: color-mix(in srgb, var(--accent) 7%, var(--bg-hover));
+}
+
+.gitHistoryMarker {
+	display: inline-flex;
+	flex: 0 0 24px;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border-radius: var(--radius-full);
+	color: var(--text-tertiary);
+	box-shadow: none;
+	transition: none;
+}
+
+.gitHistoryItem:hover .gitHistoryMarker,
+.gitHistoryItemSelected .gitHistoryMarker {
+	color: var(--text-primary);
+}
+
+.gitHistoryContent {
+	display: flex;
+	min-width: 0;
+	flex: 1;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.gitHistoryTopLine {
+	display: grid;
+	min-width: 0;
+	grid-template-columns: minmax(0, 1fr) auto auto;
+	align-items: center;
+	gap: 8px;
+}
+
+.gitHistorySubject {
+	overflow: hidden;
+	color: var(--text-primary);
+	font-size: calc(var(--text-base) * 0.96);
+	font-weight: var(--font-medium);
+	line-height: 1.2;
+	text-overflow: ellipsis;
+	text-wrap: pretty;
+	white-space: nowrap;
+}
+
+.gitHistoryMeta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 10px;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.82);
+	line-height: 1.15;
+	font-variant-numeric: tabular-nums;
+}
+
+.gitHistoryHash {
+	color: #2563eb;
+	font-family: var(--font-mono);
+	font-size: calc(var(--text-base) * 0.84);
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+	white-space: nowrap;
+}
+
+.gitHistoryOpenIcon {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+}
+
+.gitHistoryStat {
+	font-weight: var(--font-medium);
+}
+
+.gitHistoryStatAdd {
+	color: color-mix(in srgb, #059669 82%, var(--text-primary));
+}
+
+.gitHistoryStatModify {
+	color: color-mix(in srgb, #d97706 86%, var(--text-primary));
+}
+
+.gitHistoryStatDelete {
+	color: color-mix(in srgb, #dc2626 84%, var(--text-primary));
+}
+
+.gitHistoryLoading {
+	position: absolute;
+	right: 18px;
+	bottom: 10px;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.74);
 }
 
 .markdownEditorInfoSection + .markdownEditorInfoSection {


### PR DESCRIPTION
# PR: Git-Based Version History for Markdown Notes

**Branch:** `0.8.0/alpha-2-gitdiffs`
**Base:** `origin/main`
**Commits:**
1. `05b91a7` — git diffs functionality added
2. `d4d494d` — Fix git history for nested repos and stale diff races

---

## Summary

Adds a complete Git version history UI for markdown notes in Glyph. Users can now browse a note's commit history from the info sidebar and view inline diffs between commits — all without leaving the editor.

This is a companion feature to the existing Git sync infrastructure, surfacing the underlying Git history for individual notes directly in the reading experience.

**Key capabilities:**
- **History sidebar** — Opens a "History" tab in the note info sidebar listing all Git commits for the current note, grouped by day (Today, Yesterday, Older dates).
- **Commit-level diff viewer** — Selecting a commit replaces the editor with a syntax-highlighted, line-level diff view supporting additions, deletions, hunk headers, and metadata lines.
- **Safety gating** — The history feature only activates when the Git repo is rooted at the space root (blocking nested repos inside monorepos) and when Git is installed/detected.
- **Race-safe loading** — Proper cancellation of stale requests via incrementing request IDs to prevent outdated diffs from overwriting current selections.

### Files Changed (14 files, +1302 / -44)

#### Rust Backend (`src-tauri/`)

| File | Change |
|------|--------|
| `src-tauri/src/git_sync/commands.rs` | +162/-8 — Adds `git_history_list` and `git_history_diff` Tauri commands with path validation, commit hash validation, and repo-root enforcement |
| `src-tauri/src/git_sync/git.rs` | +49 — Adds `file_history()` and `commit_file_diff()` functions using `git log --follow --numstat` and `git show --patch` |
| `src-tauri/src/git_sync/types.rs` | +20 — New `GitHistoryCommit` and `GitCommitDiff` structs for serialization |
| `src-tauri/src/lib.rs` | +2 — Registers the two new Tauri commands |

#### Frontend (`src/`)

| File | Change |
|------|--------|
| `src/components/preview/GitHistorySidebar.tsx` | New (306 lines) — Full history sidebar component: groups commits by day, expandable/collapsible groups, per-commit stat badges (+/~/-), loading state, error state, request dedup |
| `src/components/preview/GitDiffView.tsx` | New (106 lines) — Inline diff viewer with sticky header showing commit subject/hash/date, line-level coloring (green=add, red=delete, blue=hunk, dim=meta), grid layout with left marker column |
| `src/components/preview/MarkdownEditorPane.tsx` | +56/-19 — Integrates `GitDiffView` and `GitHistorySidebar`; conditionally renders diff view over the editor; hides TOC when viewing a diff; resets diff state when navigating away |
| `src/components/preview/NotePane.tsx` | +11/-1 — Passes through new `gitDiff`, `onGitDiffChange`, `gitSyncStatus` props |
| `src/components/preview/NotesInfoSidebar.tsx` | +130/-34 — Adds tabbed sidebar (Info / History) with icon buttons; conditionally renders `GitHistorySidebar` when Git state permits; resets to Info tab on note changes |
| `src/components/app/AppShell.tsx` | +1 — Passes `gitSyncStatus` to `MainContent` |
| `src/components/app/MainContent.tsx` | +37/-3 — Manages `activeGitDiffState` keyed by path; clears diff on navigation; wires `gitDiff`, `gitSyncStatus`, and diff change handler to `NotePane` |
| `src/lib/tauri.ts` | +26 — TypeScript types for `GitHistoryCommit`, `GitCommitDiff`, and `git_history_list`/`git_history_diff` command signatures |
| `src/lib/gitSyncUi.ts` | +9 — New `canShowGitHistory()` guard function checking repo state conditions |

#### Styles (`src/styles/`)

| File | Change |
|------|--------|
| `src/styles/app/30-markdown-editor-pane.css` | +431 — Full styling for diff view, history sidebar, and info sidebar tabs |

---

## Related Issues

*(None yet — this is a new feature for the 0.8.0/alpha.2 release.)*

---

## Screenshots or Recordings

*Add screenshots showing the History tab in the info sidebar, the commit list grouped by day, and the inline diff viewer with colored line-level diffs.*

---

## Testing

- [x] `pnpm check` — Biome lint + format check
- [x] `pnpm build` — TypeScript check + Vite build
- [x] `cd src-tauri && cargo check` — Rust typecheck
- [x] `cd src-tauri && cargo clippy` — Rust lint (clean)
- [ ] Manual testing completed on macOS:
  - Opening history sidebar for a markdown note in a Git repo rooted at space root
  - History sidebar shows commits grouped correctly by date
  - Selecting a commit renders the diff view
  - "Back to editor" returns to the editor without losing state
  - Navigating to another note clears the diff
  - Notes in non-Git spaces show the "No saved versions yet." empty state
  - Git sync connected but nested repo shows error message (not crash)
  - Commits with renames show properly normalized paths
  - Loading spinners appear during commit/diff fetch

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense *(new Rust diff parsing is tested via existing test infra; frontend rendering is covered by existing snapshot patterns)*
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

---

## Architecture Notes

### Rust → Frontend Data Flow

```
git_history_list (path, limit)
  └── git log --follow -n40 --format=%x1e… --numstat -- <path>
      └── parse_history_commits() → Vec<GitHistoryCommit>

git_history_diff (path, commit)
  └── resolve commit from history (ensures commit exists for this file)
  └── git show --format= --no-ext-diff --find-renames --patch <commit> -- <path>
      └→ GitCommitDiff { commit, diff }
```

**Safety:** `ensure_repo_at_space_root()` blocks nested repos; `validate_commit_hash()` rejects non-hex input; `validate_space_rel_path()` uses `paths::join_under()` to prevent path traversal and restricts to `.md` files.

### Frontend State Management

The `activeGitDiffState` lives in `MainContent` keyed by `viewerPath`. When the user navigates to a different file, the `useEffect` on `viewerPath` clears the diff. The `GitHistorySidebar` uses a `diffRequestIdRef` counter to cancel stale diff fetches when the user rapidly clicks different commits.

### Git history availability

The `canShowGitHistory()` utility checks four conditions:
1. `git_installed` — Git is found on the system
2. `repo_detected` — A Git repo exists
3. `repo_root_matches_space` — The repo root is exactly the space root (not a parent or child directory)
4. `!unsupported_parent_repo` — No unsupported parent repo detected

If any fails, the History tab is hidden entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added version history viewer for notes displaying past commits with metadata, timestamps, and file change counts
  * Added commit diff viewer to compare versions with unified diff display
  * History sidebar groups commits by day with expandable sections and quick access to past versions

* **Style**
  * Updated info panel header with tabbed navigation for Info and History views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->