### PR TITLE
refactor(git-sync): provide gitSyncStatus via context instead of prop…

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -17,6 +17,7 @@ import {
 	useAISidebarContext,
 	useEditorContext,
 	useFileTreeContext,
+	useGitSyncContext,
 	useSpace,
 	useUILayoutContext,
 	useUpdaterContext,
@@ -24,7 +25,6 @@ import {
 import { useCommandShortcuts } from "../../hooks/useCommandShortcuts";
 import { useDailyNote } from "../../hooks/useDailyNote";
 import { useFileTree } from "../../hooks/useFileTree";
-import { useGitSync } from "../../hooks/useGitSync";
 import { useMenuListeners } from "../../hooks/useMenuListeners";
 import { useResizablePanel } from "../../hooks/useResizablePanel";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
@@ -178,10 +178,7 @@ export function AppShell() {
 		},
 		[setSidebarCollapsedState, sidebarAutoCollapsed],
 	);
-	const gitSync = useGitSync({
-		spacePath,
-		saveCurrentEditor,
-	});
+	const gitSync = useGitSyncContext();
 	const lastGitSyncStatusRef = useRef<{
 		isSyncing: boolean;
 		phase: string;
@@ -1294,7 +1291,6 @@ export function AppShell() {
 				dailyNoteSetupNoticeRequest={dailyNoteSetupNoticeRequest}
 				onOpenDailyNotesSettings={() => openSettings("space")}
 				onRightSidebarOpenChange={setRightSidebarOpen}
-				gitSyncStatus={gitSync.status}
 			/>
 			<AnimatePresence>
 				{error && <div className="appError">{error}</div>}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -48,7 +48,7 @@ import {
 } from "../../lib/settings";
 import { formatShortcutPartsForPlatform } from "../../lib/shortcuts/platform";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
-import type { FsEntry, GitCommitDiff, GitSyncStatus } from "../../lib/tauri";
+import type { FsEntry, GitCommitDiff } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { cn } from "../../lib/utils";
 import { onWindowDragMouseDown } from "../../utils/window";
@@ -297,7 +297,6 @@ interface MainContentProps {
 	dailyNoteSetupNoticeRequest: number;
 	onOpenDailyNotesSettings: () => void;
 	onRightSidebarOpenChange?: (open: boolean) => void;
-	gitSyncStatus?: GitSyncStatus | null;
 }
 
 function DailyNotesSetupToast({
@@ -402,7 +401,6 @@ export const MainContent = memo(function MainContent({
 	dailyNoteSetupNoticeRequest,
 	onOpenDailyNotesSettings,
 	onRightSidebarOpenChange,
-	gitSyncStatus = null,
 }: MainContentProps) {
 	const { spacePath, settingsLoaded, onOpenSpace } = useSpace();
 	const { getBinding } = useShortcutBindings();
@@ -661,7 +659,6 @@ export const MainContent = memo(function MainContent({
 					onInfoSidebarOpenChange={setInfoSidebarOpen}
 					gitDiff={activeGitDiff}
 					onGitDiffChange={handleGitDiffChange}
-					gitSyncStatus={gitSyncStatus}
 					onDirtyChange={(dirty) =>
 						setDirtyByPath((prev) =>
 							prev[viewerPath] === dirty
@@ -683,7 +680,6 @@ export const MainContent = memo(function MainContent({
 		setDirtyByPath,
 		activeGitDiff,
 		handleGitDiffChange,
-		gitSyncStatus,
 	]);
 
 	const handlePrefetchTab = useCallback(

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -16,6 +16,7 @@ import {
 import {
 	useAISidebarContext,
 	useEditorRegistration,
+	useGitSyncContext,
 	useSpace,
 	useUILayoutContext,
 } from "../../contexts";
@@ -38,7 +39,6 @@ import { groupRelationshipsByField } from "../../lib/relationships";
 import {
 	type BacklinkItem,
 	type GitCommitDiff,
-	type GitSyncStatus,
 	type NoteRelationship,
 	type TextFileDoc,
 	type WorkspaceDatabasePreviewContext,
@@ -71,7 +71,6 @@ interface MarkdownEditorPaneProps {
 	onInfoSidebarOpenChange?: (open: boolean) => void;
 	gitDiff?: GitCommitDiff | null;
 	onGitDiffChange?: (diff: GitCommitDiff | null) => void;
-	gitSyncStatus?: GitSyncStatus | null;
 	initialDoc?: TextFileDoc | null;
 	initialError?: string;
 	extractToNoteActions?: ExtractToNoteActions;
@@ -183,7 +182,6 @@ export function MarkdownEditorPane({
 	onInfoSidebarOpenChange,
 	gitDiff = null,
 	onGitDiffChange,
-	gitSyncStatus = null,
 	initialDoc = null,
 	initialError = "",
 	extractToNoteActions,
@@ -232,6 +230,7 @@ export function MarkdownEditorPane({
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const { openSettings, showToc } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
+	const { status: gitSyncStatus } = useGitSyncContext();
 	const hasSupportedGit = canShowGitHistory(gitSyncStatus);
 
 	useEffect(() => {

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -1,4 +1,4 @@
-import type { GitCommitDiff, GitSyncStatus, TextFileDoc } from "../../lib/tauri";
+import type { GitCommitDiff, TextFileDoc } from "../../lib/tauri";
 import type { ExtractToNoteActions } from "../editor/types";
 import { MarkdownEditorPane } from "./MarkdownEditorPane";
 
@@ -8,7 +8,6 @@ interface NotePaneProps {
 	onInfoSidebarOpenChange?: (open: boolean) => void;
 	gitDiff?: GitCommitDiff | null;
 	onGitDiffChange?: (diff: GitCommitDiff | null) => void;
-	gitSyncStatus?: GitSyncStatus | null;
 	initialDoc?: TextFileDoc | null;
 	extractToNoteActions?: ExtractToNoteActions;
 }
@@ -19,7 +18,6 @@ export function NotePane({
 	onInfoSidebarOpenChange,
 	gitDiff = null,
 	onGitDiffChange,
-	gitSyncStatus = null,
 	initialDoc = null,
 	extractToNoteActions,
 }: NotePaneProps) {
@@ -31,7 +29,6 @@ export function NotePane({
 			onInfoSidebarOpenChange={onInfoSidebarOpenChange}
 			gitDiff={gitDiff}
 			onGitDiffChange={onGitDiffChange}
-			gitSyncStatus={gitSyncStatus}
 			extractToNoteActions={extractToNoteActions}
 		/>
 	);

--- a/src/contexts/GitSyncContext.tsx
+++ b/src/contexts/GitSyncContext.tsx
@@ -1,0 +1,36 @@
+import { type ReactNode, createContext, useContext } from "react";
+import { useGitSync } from "../hooks/useGitSync";
+import type { GitSyncStatus } from "../lib/tauri";
+import { useEditorContext } from "./EditorContext";
+import { useSpace } from "./SpaceContext";
+
+interface GitSyncController {
+	status: GitSyncStatus | null;
+	loading: boolean;
+	error: string;
+	refreshStatus: () => Promise<void>;
+	syncNow: () => Promise<GitSyncStatus>;
+	resumeAutoSync: () => Promise<void>;
+	openGitSettings: () => void;
+}
+
+const GitSyncContext = createContext<GitSyncController | null>(null);
+
+export function GitSyncProvider({ children }: { children: ReactNode }) {
+	const { spacePath } = useSpace();
+	const { saveCurrentEditor } = useEditorContext();
+	const gitSync = useGitSync({ spacePath, saveCurrentEditor });
+	return (
+		<GitSyncContext.Provider value={gitSync}>
+			{children}
+		</GitSyncContext.Provider>
+	);
+}
+
+export function useGitSyncContext(): GitSyncController {
+	const context = useContext(GitSyncContext);
+	if (!context) {
+		throw new Error("useGitSyncContext must be used within a GitSyncProvider");
+	}
+	return context;
+}

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -3,6 +3,7 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 import { queryClient } from "../lib/queryClient";
 import { EditorProvider } from "./EditorContext";
 import { FileTreeProvider } from "./FileTreeContext";
+import { GitSyncProvider } from "./GitSyncContext";
 import { SpaceProvider } from "./SpaceContext";
 import { UIProvider } from "./UIContext";
 export { useUpdaterContext } from "./UpdaterContext";
@@ -11,6 +12,7 @@ export { useSpace } from "./SpaceContext";
 export { useFileTreeContext } from "./FileTreeContext";
 export { useAISidebarContext, useUILayoutContext } from "./UIContext";
 export { useEditorContext, useEditorRegistration } from "./EditorContext";
+export { useGitSyncContext } from "./GitSyncContext";
 
 interface ProvidersErrorBoundaryState {
 	hasError: boolean;
@@ -52,7 +54,9 @@ export function AppProviders({ children }: { children: ReactNode }) {
 				<SpaceProvider>
 					<FileTreeProvider>
 						<UIProvider>
-							<EditorProvider>{children}</EditorProvider>
+							<EditorProvider>
+								<GitSyncProvider>{children}</GitSyncProvider>
+							</EditorProvider>
 						</UIProvider>
 					</FileTreeProvider>
 				</SpaceProvider>


### PR DESCRIPTION
… drilling

Introduce GitSyncContext that owns useGitSync and expose it through AppProviders. AppShell and MarkdownEditorPane now consume the context directly, removing the gitSyncStatus prop threaded through MainContent and NotePane.

Amp-Thread-ID: https://ampcode.com/threads/T-019ecea4-9d83-73ff-98d0-06a0194b0bdb

## Summary

Describe the change and why it exists.

## Related Issues

Closes #

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior

