### PR TITLE
TanStack Virtual + Infinite Query for large list performance [Release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"@hugeicons/react": "^1.1.6",
 		"@tanstack/react-query": "^5.100.9",
 		"@tanstack/react-table": "^8.21.3",
+		"@tanstack/react-virtual": "^3.14.3",
 		"@tauri-apps/api": "^2.10.1",
 		"@tauri-apps/plugin-dialog": "^2",
 		"@tauri-apps/plugin-opener": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.3
+        version: 3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
@@ -1564,9 +1567,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
@@ -3993,7 +4005,15 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@tauri-apps/api@2.10.1': {}
 

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -42,6 +42,7 @@ pub(crate) struct ProviderSupportEntry {
     display_name: String,
     #[serde(default)]
     url: Option<String>,
+    #[serde(default)]
     endpoints: HashMap<String, bool>,
 }
 

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -219,7 +219,7 @@ pub async fn all_docs_list(
             )));
         }
         sql.push_str(
-            "ORDER BY n.updated DESC LIMIT ? OFFSET ?
+            "ORDER BY n.updated DESC, n.id DESC LIMIT ? OFFSET ?
              ),
              tag_blob AS (
                  SELECT ordered_tags.note_id, GROUP_CONCAT(ordered_tags.tag, '\n') AS tags
@@ -248,7 +248,7 @@ pub async fn all_docs_list(
              FROM visible_notes vn
              LEFT JOIN tag_blob ON tag_blob.note_id = vn.id
              LEFT JOIN people_blob ON people_blob.note_id = vn.id
-             ORDER BY vn.updated DESC",
+             ORDER BY vn.updated DESC, vn.id DESC",
         );
         params.push(rusqlite::types::Value::from(limit));
         params.push(rusqlite::types::Value::from(offset));

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -194,10 +194,12 @@ pub async fn all_docs_list(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
+    offset: Option<u32>,
     folder_prefix: Option<String>,
 ) -> Result<Vec<AllDocsItem>, String> {
     let root = state.root_for_window(&window)?;
     let limit = limit.unwrap_or(2_000).clamp(1, 5_000) as i64;
+    let offset = offset.unwrap_or(0) as i64;
     let folder_prefix = folder_prefix
         .map(|value| value.trim().trim_matches('/').replace('\\', "/"))
         .filter(|value| !value.is_empty());
@@ -217,7 +219,7 @@ pub async fn all_docs_list(
             )));
         }
         sql.push_str(
-            "ORDER BY n.updated DESC LIMIT ?
+            "ORDER BY n.updated DESC LIMIT ? OFFSET ?
              ),
              tag_blob AS (
                  SELECT ordered_tags.note_id, GROUP_CONCAT(ordered_tags.tag, '\n') AS tags
@@ -249,6 +251,7 @@ pub async fn all_docs_list(
              ORDER BY vn.updated DESC",
         );
         params.push(rusqlite::types::Value::from(limit));
+        params.push(rusqlite::types::Value::from(offset));
         let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
         let mut rows = stmt
             .query(rusqlite::params_from_iter(params.iter()))

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.0-alpha.2",
+	"version": "0.8.0-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
 	isSameDay,
 	isSameMonth,
@@ -7,13 +8,22 @@ import {
 	subDays,
 } from "date-fns";
 import { m, useReducedMotion } from "motion/react";
-import { type KeyboardEvent, memo, useMemo, useState } from "react";
+import {
+	type KeyboardEvent,
+	memo,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useFileTreeContext } from "../../contexts";
 
+import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import {
-	loadAllDocs,
+	ALL_DOCS_PAGE_SIZE,
+	loadAllDocsPage,
 	navigationQueryKeys,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
@@ -124,6 +134,20 @@ type AllDocsSection = {
 	label: string;
 	notes: AllDocsItem[];
 };
+
+type VirtualAllDocsRow =
+	| {
+			id: string;
+			kind: "header";
+			label: string;
+		}
+	| {
+			id: string;
+			kind: "cards";
+			sectionIndex: number;
+			rowIndex: number;
+			notes: AllDocsItem[];
+		};
 
 function sectionForDate(iso: string): AllDocsSection["id"] {
 	const today = startOfToday();
@@ -316,15 +340,38 @@ export const AllDocsPane = memo(function AllDocsPane({
 }: AllDocsPaneProps) {
 	const { itemAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion() ?? false;
+	const paneRef = useRef<HTMLElement>(null);
 	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
+	const [paneWidth, setPaneWidth] = useState(0);
 	const queryClient = useQueryClient();
-	const notesQuery = useQuery({
-		queryKey: navigationQueryKeys.allDocsList(null),
-		queryFn: () => loadAllDocs(null),
-		initialData: initialNotes ?? undefined,
+	const notesQuery = useInfiniteQuery({
+		queryKey: navigationQueryKeys.allDocsPages(null),
+		queryFn: ({ pageParam }) => {
+			const offset = typeof pageParam === "number" ? pageParam : 0;
+			return loadAllDocsPage(null, offset);
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+		initialData: initialNotes
+			? {
+					pages: [
+						{
+							items: initialNotes.slice(0, ALL_DOCS_PAGE_SIZE),
+							nextOffset:
+								initialNotes.length >= ALL_DOCS_PAGE_SIZE
+									? ALL_DOCS_PAGE_SIZE
+									: null,
+						},
+					],
+					pageParams: [0],
+				}
+			: undefined,
 	});
-	const notes = notesQuery.data ?? [];
+	const notes = useMemo(
+		() => notesQuery.data?.pages.flatMap((page) => page.items) ?? [],
+		[notesQuery.data],
+	);
 	const notePaths = useMemo(() => notes.map((note) => note.note_path), [notes]);
 	const taskSummariesByPath = useTaskSummariesForPaths(
 		notePaths,
@@ -333,10 +380,23 @@ export const AllDocsPane = memo(function AllDocsPane({
 	);
 	useTauriEvent("notes:external_changed", () => {
 		void queryClient.invalidateQueries({
-			queryKey: navigationQueryKeys.allDocsList(null),
+			queryKey: navigationQueryKeys.allDocs(),
 		});
 		setTaskSummaryRefreshKey((key) => key + 1);
 	});
+
+	useEffect(() => {
+		const pane = paneRef.current;
+		if (!pane) return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			setPaneWidth(entry.contentRect.width);
+		});
+		observer.observe(pane);
+		setPaneWidth(pane.clientWidth);
+		return () => observer.disconnect();
+	}, []);
 
 	const sections = useMemo<AllDocsSection[]>(() => {
 		const buckets = new Map<string, AllDocsItem[]>();
@@ -352,6 +412,60 @@ export const AllDocsPane = memo(function AllDocsPane({
 			notes: buckets.get(section.id) ?? [],
 		})).filter((section) => section.notes.length > 0);
 	}, [notes]);
+
+	const columnCount = useMemo(() => {
+		const minCardWidth = paneWidth <= 640 ? 144 : paneWidth <= 900 ? 160 : 184;
+		const gap = 10;
+		return Math.max(1, Math.floor((paneWidth + gap) / (minCardWidth + gap)));
+	}, [paneWidth]);
+	const virtualRows = useMemo<VirtualAllDocsRow[]>(() => {
+		const rows: VirtualAllDocsRow[] = [];
+		for (const [sectionIndex, section] of sections.entries()) {
+			rows.push({
+				id: `header:${section.id}`,
+				kind: "header",
+				label: section.label,
+			});
+			for (
+				let startIndex = 0, rowIndex = 0;
+				startIndex < section.notes.length;
+				startIndex += columnCount, rowIndex += 1
+			) {
+				rows.push({
+					id: `cards:${section.id}:${rowIndex}`,
+					kind: "cards",
+					sectionIndex,
+					rowIndex,
+					notes: section.notes.slice(startIndex, startIndex + columnCount),
+				});
+			}
+		}
+		return rows;
+	}, [columnCount, sections]);
+	const cardEstimate = useMemo(() => {
+		if (paneWidth <= 0) return 200;
+		const gap = 10;
+		const width = (paneWidth - gap * (columnCount - 1)) / columnCount;
+		const minHeight = paneWidth <= 640 ? 176 : 184;
+		return Math.max(minHeight, width) + gap;
+	}, [columnCount, paneWidth]);
+	const rowVirtualizer = useVirtualizer<HTMLElement, HTMLDivElement>({
+		count: virtualRows.length,
+		estimateSize: (index) =>
+			virtualRows[index]?.kind === "header" ? 32 : cardEstimate,
+		getScrollElement: () => paneRef.current,
+		overscan: 5,
+	});
+	const virtualItems = rowVirtualizer.getVirtualItems();
+	useVirtualLoadMore({
+		hasMore: notesQuery.hasNextPage,
+		isLoading: notesQuery.isFetchingNextPage,
+		onLoadMore: notesQuery.fetchNextPage,
+		virtualItems,
+		totalItems: virtualRows.length,
+		remainingItems: 4,
+	});
+
 	if (notesQuery.isLoading) {
 		return <CanvasPaneAwait variant="all-docs" />;
 	}
@@ -368,49 +482,64 @@ export const AllDocsPane = memo(function AllDocsPane({
 	}
 
 	return (
-		<section className="allDocsPane">
+		<section ref={paneRef} className="allDocsPane">
 			<header className="allDocsHeader">
 				<div className="allDocsHeadingGroup">
 					<h1 className="allDocsTitle">All Notes</h1>
 				</div>
 			</header>
-			<div className="allDocsSections">
+			<div
+				className="allDocsSections is-virtualized"
+				style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+			>
 				{notes.length === 0 ? (
 					<div className="databaseLoadingState">
 						No notes yet. Create one to get started.
 					</div>
 				) : null}
-				{sections.map((section, sectionIndex) => (
-					<section key={section.id} className="allDocsSection">
-						<div className="allDocsSectionHeader">
-							<h2 className="allDocsSectionTitle">{section.label}</h2>
-						</div>
-						<div className="allDocsGrid">
-							{section.notes.map((note, index) => {
-								const cardProps = prepareAllDocsCardProps({
-									note,
-									index,
-									sectionIndex,
-									selectedNotePath,
-									taskSummariesByPath,
-									selectNote: setSelectedNotePath,
-									onOpenFile,
-								});
+				{virtualItems.map((virtualRow) => {
+					const row = virtualRows[virtualRow.index];
+					if (!row) return null;
+					return (
+						<div
+							key={virtualRow.key}
+							ref={(node) => rowVirtualizer.measureElement(node)}
+							className="allDocsVirtualRow"
+							style={{ transform: `translateY(${virtualRow.start}px)` }}
+						>
+							{row.kind === "header" ? (
+								<div className="allDocsSectionHeader">
+									<h2 className="allDocsSectionTitle">{row.label}</h2>
+								</div>
+							) : (
+								<div className="allDocsGrid">
+									{row.notes.map((note, index) => {
+										const cardProps = prepareAllDocsCardProps({
+											note,
+											index: row.rowIndex * columnCount + index,
+											sectionIndex: row.sectionIndex,
+											selectedNotePath,
+											taskSummariesByPath,
+											selectNote: setSelectedNotePath,
+											onOpenFile,
+										});
 
-								return (
-									<AllDocsCard
-										key={note.note_path}
-										{...cardProps}
-										noteAppearance={itemAppearance[note.note_path] ?? null}
-										shouldReduceMotion={shouldReduceMotion}
-										springPreset={springPresets.snappy}
-										TaskProgressComponent={TaskProgressIndicator}
-									/>
-								);
-							})}
+										return (
+											<AllDocsCard
+												key={note.note_path}
+												{...cardProps}
+												noteAppearance={itemAppearance[note.note_path] ?? null}
+												shouldReduceMotion={shouldReduceMotion}
+												springPreset={springPresets.snappy}
+												TaskProgressComponent={TaskProgressIndicator}
+											/>
+										);
+									})}
+								</div>
+							)}
 						</div>
-					</section>
-				))}
+					);
+				})}
 			</div>
 		</section>
 	);

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -140,14 +140,14 @@ type VirtualAllDocsRow =
 			id: string;
 			kind: "header";
 			label: string;
-		}
+	  }
 	| {
 			id: string;
 			kind: "cards";
 			sectionIndex: number;
 			rowIndex: number;
 			notes: AllDocsItem[];
-		};
+	  };
 
 function sectionForDate(iso: string): AllDocsSection["id"] {
 	const today = startOfToday();
@@ -503,6 +503,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 					return (
 						<div
 							key={virtualRow.key}
+							data-index={virtualRow.index}
 							ref={(node) => rowVirtualizer.measureElement(node)}
 							className="allDocsVirtualRow"
 							style={{ transform: `translateY(${virtualRow.start}px)` }}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -29,12 +29,10 @@ import {
 } from "../../lib/appEvents";
 import { APP_TAGLINE } from "../../lib/copy";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
-import { resolveSelectedViewId } from "../../lib/database/selectedViewStorage";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import {
 	getPrefetchedAllDocs,
 	getPrefetchedDatabaseDocument,
-	getPrefetchedDatabaseRows,
 	getPrefetchedNote,
 	prefetchAllDocs,
 	prefetchDatabasesLanding,
@@ -575,7 +573,6 @@ export const MainContent = memo(function MainContent({
 			if (cancelled) return;
 			void loadDatabasesPane();
 			void loadAllDocsPane();
-			void prefetchAllDocs(null);
 			void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
 		};
 		if (typeof window.requestIdleCallback === "function") {
@@ -615,17 +612,6 @@ export const MainContent = memo(function MainContent({
 			const initialDocument = initialDatabaseId
 				? getPrefetchedDatabaseDocument(initialDatabaseId)
 				: null;
-			const initialViewId =
-				initialDatabaseId && initialDocument
-					? resolveSelectedViewId(
-							initialDatabaseId,
-							initialDocument.database.views,
-						)
-					: null;
-			const initialRows =
-				initialViewId && initialDatabaseId
-					? getPrefetchedDatabaseRows(initialDatabaseId, initialViewId)
-					: null;
 			return (
 				<Suspense fallback={<CanvasPaneAwait variant="databases" />}>
 					<DatabasesPane
@@ -636,7 +622,6 @@ export const MainContent = memo(function MainContent({
 						databasesOpenRequest={databasesOpenRequest}
 						onConsumeOpenRequest={onConsumeDatabasesOpenRequest}
 						initialDocument={initialDocument}
-						initialRows={initialRows}
 					/>
 				</Suspense>
 			);

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -1,19 +1,8 @@
-import { PointerActivationConstraints } from "@dnd-kit/dom";
-import {
-	DragDropProvider,
-	type DragEndEvent,
-	KeyboardSensor,
-	PointerSensor,
-	useDraggable,
-	useDroppable,
-} from "@dnd-kit/react";
-import { Calendar03Icon, Tag01Icon } from "@hugeicons/core-free-icons";
+import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
+import { Calendar03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m, useReducedMotion } from "motion/react";
 import {
-	type MouseEvent,
-	type MutableRefObject,
-	type ReactNode,
 	useCallback,
 	useMemo,
 	useRef,
@@ -21,6 +10,7 @@ import {
 } from "react";
 import { useFileTreeContext } from "../../contexts";
 import { useDatabaseBoard } from "../../hooks/database/useDatabaseBoard";
+import { useSentinelLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 
 import {
@@ -36,16 +26,9 @@ import {
 	databaseCellValueFromRow,
 	formatDatabaseDateTime,
 } from "../../lib/database/config";
-import { databaseValueToneStyleForColor } from "../../lib/database/palette";
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
 import { extractErrorMessage } from "../../lib/errorUtils";
-import {
-	type NativeContextMenuItem,
-	showNativeContextMenu,
-	showNativePopupMenu,
-} from "../../lib/nativeContextMenu";
-import { priorityToneStyle } from "../../lib/priorityProperties";
-import { statusToneStyle } from "../../lib/statusProperties";
+import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import {
 	DEFAULT_TAG_ICON_NAME,
 	resolveTagIconName,
@@ -54,19 +37,9 @@ import {
 import type { NoteTaskSummary } from "../../lib/tauri";
 import { Plus } from "../Icons";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
-import {
-	EDITOR_TEXT_COLORS,
-	type EditorTextColor,
-	isEditorTextColor,
-} from "../editor/textColors";
-import {
-	PriorityPropertyPill,
-	priorityPropertyIconForValue,
-} from "../status/PriorityPropertyPill";
-import {
-	StatusPropertyPill,
-	statusPropertyIconForValue,
-} from "../status/StatusPropertyPill";
+import type { EditorTextColor } from "../editor/textColors";
+import { PriorityPropertyPill } from "../status/PriorityPropertyPill";
+import { StatusPropertyPill } from "../status/StatusPropertyPill";
 import { springPresets } from "../ui/animations";
 import { Button } from "../ui/shadcn/button";
 import {
@@ -77,13 +50,12 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "../ui/shadcn/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuTrigger,
-} from "../ui/shadcn/dropdown-menu";
 import { Input } from "../ui/shadcn/input";
 import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
+import {
+	DatabaseBoardCardView,
+	DatabaseBoardLaneView,
+} from "./DatabaseBoardViews";
 import {
 	DatabaseNoteAppearanceIcon,
 	databaseNoteAppearanceStyle,
@@ -120,6 +92,9 @@ interface DatabaseBoardProps {
 		| null;
 	onStatusColorChange?: (status: string, color: EditorTextColor | null) => void;
 	boardCardFields?: string[];
+	hasMoreRows?: boolean;
+	isLoadingMoreRows?: boolean;
+	onLoadMoreRows?: () => void | Promise<unknown>;
 	onSaveCell: (
 		notePath: string,
 		column: DatabaseColumn,
@@ -144,22 +119,6 @@ const EMPTY_TASK_SUMMARY: NoteTaskSummary = {
 	completed_count: 0,
 	open_count: 0,
 };
-const DATABASE_BOARD_CARD_SENSORS = [
-	PointerSensor.configure({
-		activationConstraints: [
-			new PointerActivationConstraints.Distance({ value: 5 }),
-		],
-	}),
-	KeyboardSensor,
-];
-
-function getLaneColor(
-	laneColors: Record<string, string>,
-	laneId: string,
-): EditorTextColor | null {
-	const color = laneColors[laneId];
-	return color && isEditorTextColor(color) ? color : null;
-}
 
 function isStatusBoardColumn(column: DatabaseColumn | null): boolean {
 	return column?.property_kind === "status";
@@ -221,301 +180,6 @@ function formatCompactBoardDateTime(value: string): string {
 	return `${month} ${day}, ${time}`;
 }
 
-function boardCardDragId(notePath: string, laneId: string): string {
-	return `${laneId}:${notePath}`;
-}
-
-interface DatabaseBoardLaneViewProps {
-	lane: DatabaseBoardLane;
-	laneIndex: number;
-	showColumnColor: boolean;
-	laneColors: Record<string, string>;
-	statusColors: Record<string, EditorTextColor>;
-	isStatusGroup: boolean;
-	isPriorityGroup: boolean;
-	isTagGroup: boolean;
-	shouldReduceMotion: boolean | null;
-	onLaneColorChange?:
-		| ((laneId: string, color: EditorTextColor | null) => void)
-		| null;
-	onAddLane?: () => void;
-	onRenameLane?: (lane: DatabaseBoardLane) => void;
-	reorderableLanes: DatabaseBoardLane[];
-	moveLaneToIndex: (sourceLaneId: string, targetIndex: number) => void;
-	children: ReactNode;
-}
-
-function DatabaseBoardLaneView({
-	lane,
-	laneIndex,
-	showColumnColor,
-	laneColors,
-	statusColors,
-	isStatusGroup,
-	isPriorityGroup,
-	isTagGroup,
-	shouldReduceMotion,
-	onLaneColorChange,
-	onAddLane,
-	onRenameLane,
-	reorderableLanes,
-	moveLaneToIndex,
-	children,
-}: DatabaseBoardLaneViewProps) {
-	const { ref, isDropTarget } = useDroppable({
-		id: lane.id,
-		data: { laneId: lane.id },
-		accept: "database-board-card",
-	});
-	const laneMenuItems = useMemo<NativeContextMenuItem[]>(
-		() => [
-			...(onRenameLane
-				? [
-						{
-							label: `Rename ${lane.label}`,
-							action: () => onRenameLane(lane),
-						},
-					]
-				: []),
-			...(onAddLane
-				? [
-						{
-							label: "Add lane",
-							action: onAddLane,
-						},
-					]
-				: []),
-			...(onRenameLane || onAddLane ? [{ type: "separator" as const }] : []),
-			...reorderableLanes.map((targetLane, index) => ({
-				label: `Position ${index + 1}: ${targetLane.label}`,
-				enabled: targetLane.id !== lane.id,
-				action: () => moveLaneToIndex(lane.id, index),
-			})),
-		],
-		[lane, moveLaneToIndex, onAddLane, onRenameLane, reorderableLanes],
-	);
-	const handleLaneContextMenu = useCallback(
-		(event: MouseEvent<HTMLButtonElement>) => {
-			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
-
-			void showNativeContextMenu(event, laneMenuItems).catch(
-				(error: unknown) => {
-					console.error("Failed to show board lane context menu", error);
-				},
-			);
-		},
-		[lane.id, laneMenuItems],
-	);
-	const handleLaneMenuClick = useCallback(
-		(event: MouseEvent<HTMLButtonElement>) => {
-			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
-
-			void showNativePopupMenu(event, laneMenuItems).catch((error: unknown) => {
-				console.error("Failed to show board lane context menu", error);
-			});
-		},
-		[lane.id, laneMenuItems],
-	);
-	const laneTitleContent = (
-		<>
-			{isStatusGroup || isPriorityGroup || isTagGroup ? (
-				<HugeiconsIcon
-					icon={
-						isStatusGroup
-							? statusPropertyIconForValue(lane.label)
-							: isPriorityGroup
-								? priorityPropertyIconForValue(lane.label)
-								: Tag01Icon
-					}
-					className="databaseBoardLaneTitleIcon"
-					size="var(--icon-sm)"
-					strokeWidth={1.2}
-					aria-hidden="true"
-				/>
-			) : (
-				<span className="databaseBoardLaneDot" />
-			)}
-			<div className="databaseBoardLaneTitle">{lane.label}</div>
-		</>
-	);
-
-	return (
-		<m.div
-			ref={ref}
-			className="databaseBoardLane"
-			data-show-column-color={showColumnColor ? "true" : "false"}
-			data-workflow-state={lane.workflowState}
-			style={
-				isStatusGroup
-					? statusToneStyle(lane.label, statusColors)
-					: isPriorityGroup
-						? priorityToneStyle(lane.label)
-						: databaseValueToneStyleForColor(
-								lane.id,
-								getLaneColor(laneColors, lane.id),
-							)
-			}
-			data-active={isDropTarget ? "true" : "false"}
-			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={
-				shouldReduceMotion
-					? { duration: 0 }
-					: {
-							...springPresets.snappy,
-							delay: Math.min(laneIndex * 0.04, 0.18),
-						}
-			}
-		>
-			<div className="databaseBoardLaneHeader">
-				{onLaneColorChange ? (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								className="databaseBoardLaneTitleGroup databaseBoardLaneTitleButton"
-								aria-label={`Set color for ${lane.label}`}
-								title={`Set color for ${lane.label}`}
-							>
-								{laneTitleContent}
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="start"
-							className="databaseBoardColorMenu"
-						>
-							<div className="databaseBoardColorRibbon">
-								{EDITOR_TEXT_COLORS.map((color) => (
-									<button
-										key={color.id}
-										type="button"
-										className="databaseBoardColorRibbonSwatch"
-										style={databaseValueToneStyleForColor(color.id, color.id)}
-										onClick={() => onLaneColorChange(lane.id, color.id)}
-										title={color.label}
-										aria-label={`Set ${lane.label} color to ${color.label}`}
-									/>
-								))}
-								<button
-									type="button"
-									className="databaseBoardColorRibbonClear"
-									onClick={() => onLaneColorChange(lane.id, null)}
-									title="Clear color"
-									aria-label={`Clear color for ${lane.label}`}
-								>
-									<span />
-								</button>
-							</div>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				) : (
-					<div className="databaseBoardLaneTitleGroup">{laneTitleContent}</div>
-				)}
-				<div className="databaseBoardLaneHeaderActions">
-					<button
-						type="button"
-						className="databaseBoardLaneHandle"
-						disabled={lane.id === DATABASE_BOARD_EMPTY_LANE_ID}
-						aria-label={
-							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
-								? "No value stays last"
-								: `Open ${lane.label} lane options`
-						}
-						title={
-							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
-								? "No value stays last"
-								: `Open ${lane.label} lane options`
-						}
-						aria-haspopup="menu"
-						onClick={handleLaneMenuClick}
-						onContextMenu={handleLaneContextMenu}
-					>
-						<span className="databaseBoardLaneHandleDots" />
-					</button>
-				</div>
-			</div>
-			<div className="databaseBoardLaneBody">{children}</div>
-		</m.div>
-	);
-}
-
-interface DatabaseBoardCardViewProps {
-	row: DatabaseRow;
-	laneId: string;
-	selected: boolean;
-	suppressClickRef: MutableRefObject<boolean>;
-	onSelectRow: (notePath: string) => void;
-	onOpenRow: (notePath: string) => void;
-	onContextMenu: (event: MouseEvent<HTMLButtonElement>) => void;
-	children: ReactNode;
-}
-
-function DatabaseBoardCardView({
-	row,
-	laneId,
-	selected,
-	suppressClickRef,
-	onSelectRow,
-	onOpenRow,
-	onContextMenu,
-	children,
-}: DatabaseBoardCardViewProps) {
-	const dragId = boardCardDragId(row.note_path, laneId);
-	const { ref: droppableRef, isDropTarget } = useDroppable({
-		id: `card:${dragId}`,
-		data: {
-			laneId,
-			notePath: row.note_path,
-		},
-		accept: "database-board-card",
-	});
-	const { ref, handleRef, isDragging } = useDraggable({
-		id: dragId,
-		type: "database-board-card",
-		sensors: DATABASE_BOARD_CARD_SENSORS,
-		data: {
-			notePath: row.note_path,
-			sourceLaneId: laneId,
-		},
-	});
-	const setCardRef = useCallback(
-		(element: HTMLButtonElement | null) => {
-			droppableRef(element);
-			ref(element);
-			handleRef(element);
-		},
-		[droppableRef, handleRef, ref],
-	);
-
-	return (
-		<button
-			ref={setCardRef}
-			type="button"
-			className="databaseBoardCard"
-			data-state={selected ? "selected" : undefined}
-			data-dragging={isDragging ? "true" : undefined}
-			data-drop-target={isDropTarget ? "true" : undefined}
-			onClick={() => {
-				if (suppressClickRef.current) return;
-				onSelectRow(row.note_path);
-			}}
-			onContextMenu={onContextMenu}
-			onDoubleClick={() => onOpenRow(row.note_path)}
-			onKeyDown={(event) => {
-				if (event.key === "Enter") {
-					event.preventDefault();
-					onOpenRow(row.note_path);
-				} else if (event.key === " ") {
-					event.preventDefault();
-					onSelectRow(row.note_path);
-				}
-			}}
-			title="Double-click to open note"
-		>
-			{children}
-		</button>
-	);
-}
 
 export function DatabaseBoard({
 	rows,
@@ -537,6 +201,9 @@ export function DatabaseBoard({
 	onLaneColorChange,
 	onStatusColorChange,
 	boardCardFields,
+	hasMoreRows = false,
+	isLoadingMoreRows = false,
+	onLoadMoreRows,
 	onSaveCell,
 }: DatabaseBoardProps) {
 	const isCardFieldVisible = useCallback(
@@ -568,6 +235,8 @@ export function DatabaseBoard({
 	});
 	const [moveError, setMoveError] = useState("");
 	const [laneEdit, setLaneEdit] = useState<LaneEditState | null>(null);
+	const boardShellRef = useRef<HTMLDivElement | null>(null);
+	const loadMoreRef = useRef<HTMLDivElement | null>(null);
 	const suppressClickRef = useRef(false);
 
 	const tagIconOverrides = useMemo(
@@ -753,8 +422,17 @@ export function DatabaseBoard({
 		[handleLaneDrop],
 	);
 
+	useSentinelLoadMore({
+		hasMore: hasMoreRows,
+		isLoading: isLoadingMoreRows,
+		onLoadMore: onLoadMoreRows,
+		rootRef: boardShellRef,
+		sentinelRef: loadMoreRef,
+		rootMargin: "480px 0px",
+	});
+
 	return (
-		<div className="databaseBoardShell">
+		<div ref={boardShellRef} className="databaseBoardShell">
 			<Dialog
 				open={laneEdit != null}
 				onOpenChange={(open) => {
@@ -1109,6 +787,13 @@ export function DatabaseBoard({
 					</div>
 				</DragDropProvider>
 			)}
+			{hasMoreRows ? (
+				<div
+					ref={loadMoreRef}
+					className="databaseBoardLoadMoreSentinel"
+					aria-hidden="true"
+				/>
+			) : null}
 		</div>
 	);
 }

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -2,12 +2,7 @@ import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
 import { Calendar03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m, useReducedMotion } from "motion/react";
-import {
-	useCallback,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
 import { useDatabaseBoard } from "../../hooks/database/useDatabaseBoard";
 import { useSentinelLoadMore } from "../../hooks/useLoadMoreTriggers";
@@ -51,11 +46,11 @@ import {
 	DialogTitle,
 } from "../ui/shadcn/dialog";
 import { Input } from "../ui/shadcn/input";
-import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import {
 	DatabaseBoardCardView,
 	DatabaseBoardLaneView,
 } from "./DatabaseBoardViews";
+import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import {
 	DatabaseNoteAppearanceIcon,
 	databaseNoteAppearanceStyle,
@@ -94,7 +89,7 @@ interface DatabaseBoardProps {
 	boardCardFields?: string[];
 	hasMoreRows?: boolean;
 	isLoadingMoreRows?: boolean;
-	onLoadMoreRows?: () => void | Promise<unknown>;
+	onLoadMoreRows?: () => undefined | Promise<unknown>;
 	onSaveCell: (
 		notePath: string,
 		column: DatabaseColumn,
@@ -179,7 +174,6 @@ function formatCompactBoardDateTime(value: string): string {
 		.replace(/\s/g, "");
 	return `${month} ${day}, ${time}`;
 }
-
 
 export function DatabaseBoard({
 	rows,

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -1,0 +1,356 @@
+import { PointerActivationConstraints } from "@dnd-kit/dom";
+import {
+	KeyboardSensor,
+	PointerSensor,
+	useDraggable,
+	useDroppable,
+} from "@dnd-kit/react";
+import { Tag01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { m } from "motion/react";
+import {
+	type MouseEvent,
+	type MutableRefObject,
+	type ReactNode,
+	useCallback,
+	useMemo,
+} from "react";
+import {
+	DATABASE_BOARD_EMPTY_LANE_ID,
+	type DatabaseBoardLane,
+} from "../../lib/database/board";
+import { databaseValueToneStyleForColor } from "../../lib/database/palette";
+import type { DatabaseRow } from "../../lib/database/types";
+import {
+	type NativeContextMenuItem,
+	showNativeContextMenu,
+	showNativePopupMenu,
+} from "../../lib/nativeContextMenu";
+import { priorityToneStyle } from "../../lib/priorityProperties";
+import { statusToneStyle } from "../../lib/statusProperties";
+import {
+	EDITOR_TEXT_COLORS,
+	type EditorTextColor,
+	isEditorTextColor,
+} from "../editor/textColors";
+import { priorityPropertyIconForValue } from "../status/PriorityPropertyPill";
+import { statusPropertyIconForValue } from "../status/StatusPropertyPill";
+import { springPresets } from "../ui/animations";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
+
+const DATABASE_BOARD_CARD_SENSORS = [
+	PointerSensor.configure({
+		activationConstraints: [
+			new PointerActivationConstraints.Distance({ value: 5 }),
+		],
+	}),
+	KeyboardSensor,
+];
+
+function getLaneColor(
+	laneColors: Record<string, string>,
+	laneId: string,
+): EditorTextColor | null {
+	const color = laneColors[laneId];
+	return color && isEditorTextColor(color) ? color : null;
+}
+
+function boardCardDragId(notePath: string, laneId: string): string {
+	return `${laneId}:${notePath}`;
+}
+
+interface DatabaseBoardLaneViewProps {
+	lane: DatabaseBoardLane;
+	laneIndex: number;
+	showColumnColor: boolean;
+	laneColors: Record<string, string>;
+	statusColors: Record<string, EditorTextColor>;
+	isStatusGroup: boolean;
+	isPriorityGroup: boolean;
+	isTagGroup: boolean;
+	shouldReduceMotion: boolean | null;
+	onLaneColorChange?:
+		| ((laneId: string, color: EditorTextColor | null) => void)
+		| null;
+	onAddLane?: () => void;
+	onRenameLane?: (lane: DatabaseBoardLane) => void;
+	reorderableLanes: DatabaseBoardLane[];
+	moveLaneToIndex: (sourceLaneId: string, targetIndex: number) => void;
+	children: ReactNode;
+}
+
+export function DatabaseBoardLaneView({
+	lane,
+	laneIndex,
+	showColumnColor,
+	laneColors,
+	statusColors,
+	isStatusGroup,
+	isPriorityGroup,
+	isTagGroup,
+	shouldReduceMotion,
+	onLaneColorChange,
+	onAddLane,
+	onRenameLane,
+	reorderableLanes,
+	moveLaneToIndex,
+	children,
+}: DatabaseBoardLaneViewProps) {
+	const { ref, isDropTarget } = useDroppable({
+		id: lane.id,
+		data: { laneId: lane.id },
+		accept: "database-board-card",
+	});
+	const laneMenuItems = useMemo<NativeContextMenuItem[]>(
+		() => [
+			...(onRenameLane
+				? [
+						{
+							label: `Rename ${lane.label}`,
+							action: () => onRenameLane(lane),
+						},
+					]
+				: []),
+			...(onAddLane
+				? [
+						{
+							label: "Add lane",
+							action: onAddLane,
+						},
+					]
+				: []),
+			...(onRenameLane || onAddLane ? [{ type: "separator" as const }] : []),
+			...reorderableLanes.map((targetLane, index) => ({
+				label: `Position ${index + 1}: ${targetLane.label}`,
+				enabled: targetLane.id !== lane.id,
+				action: () => moveLaneToIndex(lane.id, index),
+			})),
+		],
+		[lane, moveLaneToIndex, onAddLane, onRenameLane, reorderableLanes],
+	);
+	const handleLaneContextMenu = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
+
+			void showNativeContextMenu(event, laneMenuItems).catch(
+				(error: unknown) => {
+					console.error("Failed to show board lane context menu", error);
+				},
+			);
+		},
+		[lane.id, laneMenuItems],
+	);
+	const handleLaneMenuClick = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			if (lane.id === DATABASE_BOARD_EMPTY_LANE_ID) return;
+
+			void showNativePopupMenu(event, laneMenuItems).catch((error: unknown) => {
+				console.error("Failed to show board lane context menu", error);
+			});
+		},
+		[lane.id, laneMenuItems],
+	);
+	const laneTitleContent = (
+		<>
+			{isStatusGroup || isPriorityGroup || isTagGroup ? (
+				<HugeiconsIcon
+					icon={
+						isStatusGroup
+							? statusPropertyIconForValue(lane.label)
+							: isPriorityGroup
+								? priorityPropertyIconForValue(lane.label)
+								: Tag01Icon
+					}
+					className="databaseBoardLaneTitleIcon"
+					size="var(--icon-sm)"
+					strokeWidth={1.2}
+					aria-hidden="true"
+				/>
+			) : (
+				<span className="databaseBoardLaneDot" />
+			)}
+			<div className="databaseBoardLaneTitle">{lane.label}</div>
+		</>
+	);
+
+	return (
+		<m.div
+			ref={ref}
+			className="databaseBoardLane"
+			data-show-column-color={showColumnColor ? "true" : "false"}
+			data-workflow-state={lane.workflowState}
+			style={
+				isStatusGroup
+					? statusToneStyle(lane.label, statusColors)
+					: isPriorityGroup
+						? priorityToneStyle(lane.label)
+						: databaseValueToneStyleForColor(
+								lane.id,
+								getLaneColor(laneColors, lane.id),
+							)
+			}
+			data-active={isDropTarget ? "true" : "false"}
+			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={
+				shouldReduceMotion
+					? { duration: 0 }
+					: {
+							...springPresets.snappy,
+							delay: Math.min(laneIndex * 0.04, 0.18),
+						}
+			}
+		>
+			<div className="databaseBoardLaneHeader">
+				{onLaneColorChange ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<button
+								type="button"
+								className="databaseBoardLaneTitleGroup databaseBoardLaneTitleButton"
+								aria-label={`Set color for ${lane.label}`}
+								title={`Set color for ${lane.label}`}
+							>
+								{laneTitleContent}
+							</button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent
+							align="start"
+							className="databaseBoardColorMenu"
+						>
+							<div className="databaseBoardColorRibbon">
+								{EDITOR_TEXT_COLORS.map((color) => (
+									<button
+										key={color.id}
+										type="button"
+										className="databaseBoardColorRibbonSwatch"
+										style={databaseValueToneStyleForColor(color.id, color.id)}
+										onClick={() => onLaneColorChange(lane.id, color.id)}
+										title={color.label}
+										aria-label={`Set ${lane.label} color to ${color.label}`}
+									/>
+								))}
+								<button
+									type="button"
+									className="databaseBoardColorRibbonClear"
+									onClick={() => onLaneColorChange(lane.id, null)}
+									title="Clear color"
+									aria-label={`Clear color for ${lane.label}`}
+								>
+									<span />
+								</button>
+							</div>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : (
+					<div className="databaseBoardLaneTitleGroup">{laneTitleContent}</div>
+				)}
+				<div className="databaseBoardLaneHeaderActions">
+					<button
+						type="button"
+						className="databaseBoardLaneHandle"
+						disabled={lane.id === DATABASE_BOARD_EMPTY_LANE_ID}
+						aria-label={
+							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
+								? "No value stays last"
+								: `Open ${lane.label} lane options`
+						}
+						title={
+							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
+								? "No value stays last"
+								: `Open ${lane.label} lane options`
+						}
+						aria-haspopup="menu"
+						onClick={handleLaneMenuClick}
+						onContextMenu={handleLaneContextMenu}
+					>
+						<span className="databaseBoardLaneHandleDots" />
+					</button>
+				</div>
+			</div>
+			<div className="databaseBoardLaneBody">{children}</div>
+		</m.div>
+	);
+}
+
+interface DatabaseBoardCardViewProps {
+	row: DatabaseRow;
+	laneId: string;
+	selected: boolean;
+	suppressClickRef: MutableRefObject<boolean>;
+	onSelectRow: (notePath: string) => void;
+	onOpenRow: (notePath: string) => void;
+	onContextMenu: (event: MouseEvent<HTMLButtonElement>) => void;
+	children: ReactNode;
+}
+
+export function DatabaseBoardCardView({
+	row,
+	laneId,
+	selected,
+	suppressClickRef,
+	onSelectRow,
+	onOpenRow,
+	onContextMenu,
+	children,
+}: DatabaseBoardCardViewProps) {
+	const dragId = boardCardDragId(row.note_path, laneId);
+	const { ref: droppableRef, isDropTarget } = useDroppable({
+		id: `card:${dragId}`,
+		data: {
+			laneId,
+			notePath: row.note_path,
+		},
+		accept: "database-board-card",
+	});
+	const { ref, handleRef, isDragging } = useDraggable({
+		id: dragId,
+		type: "database-board-card",
+		sensors: DATABASE_BOARD_CARD_SENSORS,
+		data: {
+			notePath: row.note_path,
+			sourceLaneId: laneId,
+		},
+	});
+	const setCardRef = useCallback(
+		(element: HTMLButtonElement | null) => {
+			droppableRef(element);
+			ref(element);
+			handleRef(element);
+		},
+		[droppableRef, handleRef, ref],
+	);
+
+	return (
+		<button
+			ref={setCardRef}
+			type="button"
+			className="databaseBoardCard"
+			data-state={selected ? "selected" : undefined}
+			data-dragging={isDragging ? "true" : undefined}
+			data-drop-target={isDropTarget ? "true" : undefined}
+			onClick={() => {
+				if (suppressClickRef.current) return;
+				onSelectRow(row.note_path);
+			}}
+			onContextMenu={onContextMenu}
+			onDoubleClick={() => onOpenRow(row.note_path)}
+			onKeyDown={(event) => {
+				if (event.key === "Enter") {
+					event.preventDefault();
+					onOpenRow(row.note_path);
+				} else if (event.key === " ") {
+					event.preventDefault();
+					onSelectRow(row.note_path);
+				}
+			}}
+			title="Double-click to open note"
+		>
+			{children}
+		</button>
+	);
+}

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -58,7 +58,7 @@ interface DatabaseTableProps {
 	onResizeColumn: (columnId: string, width: number) => void;
 	hasMoreRows?: boolean;
 	isLoadingMoreRows?: boolean;
-	onLoadMoreRows?: () => void | Promise<unknown>;
+	onLoadMoreRows?: () => undefined | Promise<unknown>;
 }
 
 const EMPTY_LANE_COLORS: Record<string, string> = {};

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -1,10 +1,13 @@
 import {
 	type ColumnDef,
+	type Row,
 	flexRender,
 	getCoreRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { createDatabaseRowGroups } from "../../lib/database/board";
 import { databaseCellValueFromRow } from "../../lib/database/config";
 import type {
@@ -53,9 +56,27 @@ interface DatabaseTableProps {
 	) => Promise<void>;
 	onRenameTitle: (notePath: string, nextTitle: string) => Promise<boolean>;
 	onResizeColumn: (columnId: string, width: number) => void;
+	hasMoreRows?: boolean;
+	isLoadingMoreRows?: boolean;
+	onLoadMoreRows?: () => void | Promise<unknown>;
 }
 
 const EMPTY_LANE_COLORS: Record<string, string> = {};
+const DATABASE_TABLE_ROW_HEIGHT = 38;
+const DATABASE_TABLE_GROUP_ROW_HEIGHT = 34;
+
+type DatabaseTableGroup = ReturnType<typeof createDatabaseRowGroups>[number];
+type DatabaseDisplayItem =
+	| {
+			id: string;
+			kind: "group";
+			group: DatabaseTableGroup;
+	  }
+	| {
+			id: string;
+			kind: "row";
+			row: Row<DatabaseRow>;
+	  };
 
 function uniqueOptionValues(values: string[]): string[] {
 	const counts = new Map<string, { value: string; count: number }>();
@@ -79,6 +100,38 @@ function uniqueOptionValues(values: string[]): string[] {
 				}),
 		)
 		.map((entry) => entry.value);
+}
+
+function createDatabaseDisplayItems(
+	displayRows: Row<DatabaseRow>[],
+	rowGroups: DatabaseTableGroup[],
+	hasGroups: boolean,
+): DatabaseDisplayItem[] {
+	if (!hasGroups) {
+		return displayRows.map((row) => ({
+			id: row.id,
+			kind: "row",
+			row,
+		}));
+	}
+	const rowsByPath = new Map(
+		displayRows.map((row) => [row.original.note_path, row]),
+	);
+	return rowGroups.flatMap((group) => [
+		{
+			id: group.id,
+			kind: "group" as const,
+			group,
+		},
+		...group.rows
+			.map((row) => rowsByPath.get(row.note_path))
+			.filter((row): row is Row<DatabaseRow> => row != null)
+			.map((row) => ({
+				id: `${group.id}:${row.id}`,
+				kind: "row" as const,
+				row,
+			})),
+	]);
 }
 
 function SortIndicator({
@@ -114,8 +167,12 @@ export function DatabaseTable({
 	onSaveCell,
 	onRenameTitle,
 	onResizeColumn,
+	hasMoreRows = false,
+	isLoadingMoreRows = false,
+	onLoadMoreRows,
 }: DatabaseTableProps) {
 	const [resizingColumnId, setResizingColumnId] = useState<string | null>(null);
+	const tableContainerRef = useRef<HTMLDivElement>(null);
 	const safeLaneColors = useMemo<Record<string, EditorTextColor>>(() => {
 		const next: Record<string, EditorTextColor> = {};
 		for (const [laneId, color] of Object.entries(laneColors)) {
@@ -228,35 +285,31 @@ export function DatabaseTable({
 	);
 	const displayRows = table.getRowModel().rows;
 	const visibleColumnCount = table.getVisibleLeafColumns().length || 1;
-	const rowsByPath = useMemo(
-		() => new Map(displayRows.map((row) => [row.original.note_path, row])),
-		[displayRows],
-	);
 	const hasGroups = groupColumn != null && rowGroups.length > 0;
 	const canCreateInGroup = groupColumn != null && onCreateRow != null;
-	const renderRow = (row: (typeof displayRows)[number], keyPrefix = "") => (
-		<TableRow
-			key={`${keyPrefix}${row.id}`}
-			data-state={
-				row.original.note_path === selectedRowPath ? "selected" : undefined
-			}
-			className="databaseRow"
-			onClick={() => onSelectRow(row.original.note_path)}
-		>
-			{row.getVisibleCells().map((cell) => (
-				<TableCell
-					key={cell.id}
-					style={{
-						width: cell.column.getSize(),
-						minWidth: cell.column.getSize(),
-					}}
-					className="databaseBodyCell"
-				>
-					{flexRender(cell.column.columnDef.cell, cell.getContext())}
-				</TableCell>
-			))}
-		</TableRow>
+	const displayItems = useMemo(
+		() => createDatabaseDisplayItems(displayRows, rowGroups, hasGroups),
+		[displayRows, hasGroups, rowGroups],
 	);
+	const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
+		count: displayItems.length,
+		estimateSize: (index) =>
+			displayItems[index]?.kind === "group"
+				? DATABASE_TABLE_GROUP_ROW_HEIGHT
+				: DATABASE_TABLE_ROW_HEIGHT,
+		getScrollElement: () => tableContainerRef.current,
+		getItemKey: (index) => displayItems[index]?.id ?? index,
+		overscan: 8,
+	});
+	const virtualItems = rowVirtualizer.getVirtualItems();
+	useVirtualLoadMore({
+		hasMore: hasMoreRows,
+		isLoading: isLoadingMoreRows,
+		onLoadMore: onLoadMoreRows,
+		virtualItems,
+		totalItems: displayItems.length,
+		remainingItems: 12,
+	});
 
 	useEffect(() => {
 		if (!resizingColumnId) return;
@@ -267,9 +320,10 @@ export function DatabaseTable({
 
 	return (
 		<div
+			ref={tableContainerRef}
 			className={`databaseTableShell${activeResizingColumnId ? " is-resizing" : ""}`}
 		>
-			<Table className="databaseTable">
+			<Table className="databaseTable is-virtualized">
 				<TableHeader>
 					{table.getHeaderGroups().map((headerGroup) => (
 						<TableRow key={headerGroup.id} className="databaseHeaderRow">
@@ -315,12 +369,30 @@ export function DatabaseTable({
 						</TableRow>
 					))}
 				</TableHeader>
-				<TableBody>
-					{displayRows.length > 0 ? (
-						hasGroups ? (
-							rowGroups.map((group) => (
-								<Fragment key={group.id}>
-									<tr className="databaseGroupHeaderRow">
+				<TableBody
+					style={{
+						height:
+							displayItems.length > 0
+								? `${rowVirtualizer.getTotalSize()}px`
+								: undefined,
+					}}
+				>
+					{displayItems.length > 0 ? (
+						virtualItems.map((virtualRow) => {
+							const item = displayItems[virtualRow.index];
+							if (!item) return null;
+							const transform = `translateY(${virtualRow.start}px)`;
+							if (item.kind === "group") {
+								const { group } = item;
+								return (
+									<tr
+										key={virtualRow.key}
+										className="databaseGroupHeaderRow"
+										style={{
+											height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
+											transform,
+										}}
+									>
 										<td
 											colSpan={visibleColumnCount}
 											className="databaseGroupCell"
@@ -348,17 +420,42 @@ export function DatabaseTable({
 											) : null}
 										</td>
 									</tr>
-									{group.rows
-										.map((row) => rowsByPath.get(row.note_path))
-										.filter(
-											(row): row is (typeof displayRows)[number] => row != null,
-										)
-										.map((row) => renderRow(row, `${group.id}:`))}
-								</Fragment>
-							))
-						) : (
-							displayRows.map((row) => renderRow(row))
-						)
+								);
+							}
+							const { row } = item;
+							return (
+								<TableRow
+									key={virtualRow.key}
+									data-state={
+										row.original.note_path === selectedRowPath
+											? "selected"
+											: undefined
+									}
+									className="databaseRow"
+									style={{
+										height: `${DATABASE_TABLE_ROW_HEIGHT}px`,
+										transform,
+									}}
+									onClick={() => onSelectRow(row.original.note_path)}
+								>
+									{row.getVisibleCells().map((cell) => (
+										<TableCell
+											key={cell.id}
+											style={{
+												width: cell.column.getSize(),
+												minWidth: cell.column.getSize(),
+											}}
+											className="databaseBodyCell"
+										>
+											{flexRender(
+												cell.column.columnDef.cell,
+												cell.getContext(),
+											)}
+										</TableCell>
+									))}
+								</TableRow>
+							);
+						})
 					) : (
 						<TableRow>
 							<TableCell

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -8,10 +8,7 @@ import {
 	EMPTY_BOARD_CARD_ORDER,
 	EMPTY_BOARD_LANE_ORDER,
 } from "../../lib/database/viewConfig";
-import type {
-	WorkspaceDatabaseDocument,
-	WorkspaceDatabaseQueryResult,
-} from "../../lib/tauri";
+import type { WorkspaceDatabaseDocument } from "../../lib/tauri";
 import { Plus } from "../Icons";
 import { CanvasPaneAwait } from "../app/CanvasPaneAwait";
 import { DatabaseBoard } from "../database/DatabaseBoard";
@@ -31,7 +28,6 @@ interface DatabasesPaneProps {
 	databasesOpenRequest: DatabasesOpenRequest;
 	onConsumeOpenRequest?: () => void;
 	initialDocument?: WorkspaceDatabaseDocument | null;
-	initialRows?: WorkspaceDatabaseQueryResult | null;
 }
 
 function DatabasesPaneContent({
@@ -40,7 +36,6 @@ function DatabasesPaneContent({
 	databasesOpenRequest,
 	onConsumeOpenRequest,
 	initialDocument = null,
-	initialRows = null,
 }: DatabasesPaneProps) {
 	const reduceMotion = useReducedMotion();
 	const {
@@ -59,7 +54,6 @@ function DatabasesPaneContent({
 		databasesOpenRequest,
 		onConsumeOpenRequest,
 		initialDocument,
-		initialRows,
 	});
 
 	if (doc.loading) {
@@ -112,11 +106,6 @@ function DatabasesPaneContent({
 					{ui.error ? (
 						<div className="databaseNotice databaseNoticeError">{ui.error}</div>
 					) : null}
-					{rows.rowsTruncated ? (
-						<div className="databaseNotice">
-							Limited to the first 200 notes.
-						</div>
-					) : null}
 					{activeCollection.config.view.layout === "board" &&
 					views.boardHandlers ? (
 						<DatabaseBoard
@@ -152,6 +141,9 @@ function DatabasesPaneContent({
 							onCardOrderChange={views.boardHandlers.onCardOrderChange}
 							onLaneColorChange={views.boardHandlers.onLaneColorChange}
 							onStatusColorChange={display.setStatusColor}
+							hasMoreRows={rows.hasMoreRows}
+							isLoadingMoreRows={rows.isLoadingMoreRows}
+							onLoadMoreRows={rows.loadMoreRows}
 							onSaveCell={actions.handleUpdateCell}
 						/>
 					) : (
@@ -172,6 +164,9 @@ function DatabasesPaneContent({
 							onSaveCell={actions.handleUpdateCell}
 							onRenameTitle={actions.handleRenameRowTitle}
 							onResizeColumn={views.handleResizeColumn}
+							hasMoreRows={rows.hasMoreRows}
+							isLoadingMoreRows={rows.isLoadingMoreRows}
+							onLoadMoreRows={rows.loadMoreRows}
 						/>
 					)}
 				</>

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -2,6 +2,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import {
 	type CSSProperties,
 	type MouseEvent,
+	forwardRef,
 	memo,
 	useCallback,
 	useEffect,
@@ -46,6 +47,9 @@ interface FolioNoteListItemProps {
 	appearance?: FileTreeAppearance | null;
 	onOpenAppearancePicker: (path: string) => void;
 	iconNameForTag: (tag: string) => string;
+	className?: string;
+	style?: CSSProperties;
+	virtualIndex?: number;
 }
 
 type FolioImageRef =
@@ -388,25 +392,32 @@ function FolioRenameInput({
 	);
 }
 
-export const FolioNoteListItem = memo(function FolioNoteListItem({
-	note,
-	selected,
-	onOpen,
-	onOpenInNewTab,
-	onPrefetch,
-	isPinned = false,
-	onRename,
-	onDelete,
-	onTogglePinned,
-	onFocus,
-	taskSummary = null,
-	isRenaming = false,
-	onCommitRename,
-	onCancelRename,
-	appearance = null,
-	onOpenAppearancePicker,
-	iconNameForTag,
-}: FolioNoteListItemProps) {
+export const FolioNoteListItem = memo(
+	forwardRef<HTMLLIElement, FolioNoteListItemProps>(function FolioNoteListItem(
+		{
+			note,
+			selected,
+			onOpen,
+			onOpenInNewTab,
+			onPrefetch,
+			isPinned = false,
+			onRename,
+			onDelete,
+			onTogglePinned,
+			onFocus,
+			taskSummary = null,
+			isRenaming = false,
+			onCommitRename,
+			onCancelRename,
+			appearance = null,
+			onOpenAppearancePicker,
+			iconNameForTag,
+			className,
+			style,
+			virtualIndex,
+		},
+		ref,
+	) {
 	const title = note.title.trim() || titleFromPath(note.note_path);
 	const isMarkdown = note.is_markdown;
 	const { stem: fileStem, ext: fileExt } = splitEditableFileName(
@@ -593,7 +604,12 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 	);
 
 	return (
-		<li className="folioNoteListItem">
+		<li
+			ref={ref}
+			className={`folioNoteListItem${className ? ` ${className}` : ""}`}
+			style={style}
+			data-index={virtualIndex}
+		>
 			{isRenaming ? (
 				<div
 					className="folioNoteRow"
@@ -665,4 +681,5 @@ export const FolioNoteListItem = memo(function FolioNoteListItem({
 			)}
 		</li>
 	);
-});
+	}),
+);

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -418,268 +418,268 @@ export const FolioNoteListItem = memo(
 		},
 		ref,
 	) {
-	const title = note.title.trim() || titleFromPath(note.note_path);
-	const isMarkdown = note.is_markdown;
-	const { stem: fileStem, ext: fileExt } = splitEditableFileName(
-		basename(note.note_path),
-	);
-	const { Icon, color } = getFileTypeInfo(note.note_path, isMarkdown);
-	const customColor =
-		appearance?.color && isEditorTextColor(appearance.color)
-			? appearance.color
-			: null;
-	const rowStyle = customColor
-		? ({
-				"--folio-file-color": `var(${getEditorTextColorOption(customColor).cssVar})`,
-			} as CSSProperties)
-		: undefined;
-	const iconColor = customColor ? "var(--folio-file-color)" : color;
-	const extBadge = !isMarkdown && fileExt ? fileExt.slice(1) : "";
-	const preview = useMemo(() => {
-		return previewText(note.preview, title);
-	}, [note.preview, title]);
-	const updated = isMarkdown ? dateLabel(note.updated) : "";
-	const visibleTags = note.tags.slice(0, 2);
-	const hiddenTagCount = Math.max(0, note.tags.length - visibleTags.length);
-	const folder = parentDir(note.note_path);
-	const thumbnailSrc = useFolioThumbnail(note);
-	const firstUrl = useFolioFirstUrl(note);
-	const firstUrlLabel = firstUrl ? urlLabel(firstUrl) : "";
-	const taskProgress =
-		taskSummary && taskSummary.total_count > 0 ? (
-			<TaskProgressIndicator
-				summary={taskSummary}
-				className="folioNoteTaskProgress"
+		const title = note.title.trim() || titleFromPath(note.note_path);
+		const isMarkdown = note.is_markdown;
+		const { stem: fileStem, ext: fileExt } = splitEditableFileName(
+			basename(note.note_path),
+		);
+		const { Icon, color } = getFileTypeInfo(note.note_path, isMarkdown);
+		const customColor =
+			appearance?.color && isEditorTextColor(appearance.color)
+				? appearance.color
+				: null;
+		const rowStyle = customColor
+			? ({
+					"--folio-file-color": `var(${getEditorTextColorOption(customColor).cssVar})`,
+				} as CSSProperties)
+			: undefined;
+		const iconColor = customColor ? "var(--folio-file-color)" : color;
+		const extBadge = !isMarkdown && fileExt ? fileExt.slice(1) : "";
+		const preview = useMemo(() => {
+			return previewText(note.preview, title);
+		}, [note.preview, title]);
+		const updated = isMarkdown ? dateLabel(note.updated) : "";
+		const visibleTags = note.tags.slice(0, 2);
+		const hiddenTagCount = Math.max(0, note.tags.length - visibleTags.length);
+		const folder = parentDir(note.note_path);
+		const thumbnailSrc = useFolioThumbnail(note);
+		const firstUrl = useFolioFirstUrl(note);
+		const firstUrlLabel = firstUrl ? urlLabel(firstUrl) : "";
+		const taskProgress =
+			taskSummary && taskSummary.total_count > 0 ? (
+				<TaskProgressIndicator
+					summary={taskSummary}
+					className="folioNoteTaskProgress"
+				/>
+			) : null;
+		const handleRevealInFinder = useCallback(async () => {
+			try {
+				await invoke("space_reveal_path", { path: note.note_path });
+			} catch (error) {
+				console.error("Failed to show file in Finder", error);
+			}
+		}, [note.note_path]);
+		const handleContextMenu = useCallback(
+			(event: MouseEvent) => {
+				void showNativeContextMenu(event, [
+					{
+						label: "Open",
+						action: () => onOpen(note.note_path),
+					},
+					{
+						label: "Open in New Tab",
+						action: () => onOpenInNewTab(note.note_path),
+					},
+					{
+						label: "Show in Finder",
+						action: () => void handleRevealInFinder(),
+					},
+					{ type: "separator" },
+					...(onRename
+						? [
+								{
+									label: "Rename",
+									action: () => onRename(note.note_path),
+								},
+							]
+						: []),
+					...(onTogglePinned
+						? [
+								{
+									label: isPinned ? "Unpin file" : "Pin file",
+									action: () => void onTogglePinned(note.note_path),
+								},
+							]
+						: []),
+					fileTreeAppearanceNativeMenu(() =>
+						onOpenAppearancePicker(note.note_path),
+					),
+					{ type: "separator" },
+					{
+						label: "Delete",
+						action: () => onDelete(note.note_path),
+					},
+				]).catch((error: unknown) => {
+					console.error("Failed to show folio context menu", error);
+				});
+			},
+			[
+				handleRevealInFinder,
+				isPinned,
+				note.note_path,
+				onDelete,
+				onOpen,
+				onOpenAppearancePicker,
+				onOpenInNewTab,
+				onRename,
+				onTogglePinned,
+			],
+		);
+		const fileIcon = appearance?.icon ? (
+			<DatabaseColumnIcon
+				iconName={appearance.icon}
+				size="var(--icon-lg)"
+				className="folioNoteFileIcon"
 			/>
-		) : null;
-	const handleRevealInFinder = useCallback(async () => {
-		try {
-			await invoke("space_reveal_path", { path: note.note_path });
-		} catch (error) {
-			console.error("Failed to show file in Finder", error);
-		}
-	}, [note.note_path]);
-	const handleContextMenu = useCallback(
-		(event: MouseEvent) => {
-			void showNativeContextMenu(event, [
-				{
-					label: "Open",
-					action: () => onOpen(note.note_path),
-				},
-				{
-					label: "Open in New Tab",
-					action: () => onOpenInNewTab(note.note_path),
-				},
-				{
-					label: "Show in Finder",
-					action: () => void handleRevealInFinder(),
-				},
-				{ type: "separator" },
-				...(onRename
-					? [
-							{
-								label: "Rename",
-								action: () => onRename(note.note_path),
-							},
-						]
-					: []),
-				...(onTogglePinned
-					? [
-							{
-								label: isPinned ? "Unpin file" : "Pin file",
-								action: () => void onTogglePinned(note.note_path),
-							},
-						]
-					: []),
-				fileTreeAppearanceNativeMenu(() =>
-					onOpenAppearancePicker(note.note_path),
-				),
-				{ type: "separator" },
-				{
-					label: "Delete",
-					action: () => onDelete(note.note_path),
-				},
-			]).catch((error: unknown) => {
-				console.error("Failed to show folio context menu", error);
-			});
-		},
-		[
-			handleRevealInFinder,
-			isPinned,
-			note.note_path,
-			onDelete,
-			onOpen,
-			onOpenAppearancePicker,
-			onOpenInNewTab,
-			onRename,
-			onTogglePinned,
-		],
-	);
-	const fileIcon = appearance?.icon ? (
-		<DatabaseColumnIcon
-			iconName={appearance.icon}
-			size="var(--icon-lg)"
-			className="folioNoteFileIcon"
-		/>
-	) : (
-		<Icon
-			size="var(--icon-lg)"
-			className="folioNoteFileIcon"
-			style={{ color: iconColor }}
-			aria-hidden="true"
-		/>
-	);
-	const noteTitleIcon = (
-		<span className="folioNoteTitleIcon" aria-hidden="true">
-			{fileIcon}
-		</span>
-	);
-	const rowDetails = (
-		<div className="folioNoteBody">
-			<span className="folioNoteCopy">
-				<span className="folioNotePreview">{preview}</span>
+		) : (
+			<Icon
+				size="var(--icon-lg)"
+				className="folioNoteFileIcon"
+				style={{ color: iconColor }}
+				aria-hidden="true"
+			/>
+		);
+		const noteTitleIcon = (
+			<span className="folioNoteTitleIcon" aria-hidden="true">
+				{fileIcon}
 			</span>
-			{thumbnailSrc ? (
-				<span className="folioNoteThumbnail" aria-hidden="true">
-					<img src={thumbnailSrc} alt="" />
+		);
+		const rowDetails = (
+			<div className="folioNoteBody">
+				<span className="folioNoteCopy">
+					<span className="folioNotePreview">{preview}</span>
 				</span>
-			) : null}
-			<span className="folioNoteFooter">
-				<span className="folioNoteTags">
-					{firstUrl ? (
-						<a
-							href={firstUrl}
-							className="databaseCellPill folioNoteTag folioNoteUrl"
-							title={firstUrl}
-							onClick={(event) => {
-								event.preventDefault();
-								event.stopPropagation();
-								void openUrl(firstUrl);
-							}}
-						>
-							<DatabaseColumnIcon
-								iconName="link"
-								className="folioNoteUrlIcon"
-								size="var(--icon-xs)"
-								strokeWidth={1.2}
-							/>
-							{firstUrlLabel}
-						</a>
-					) : null}
-					{visibleTags.length > 0 ? (
-						visibleTags.map((tag) => (
-							<span
-								key={tag}
-								className="databaseCellPill folioNoteTag"
-								title={formatDatabaseTagLabel(tag)}
+				{thumbnailSrc ? (
+					<span className="folioNoteThumbnail" aria-hidden="true">
+						<img src={thumbnailSrc} alt="" />
+					</span>
+				) : null}
+				<span className="folioNoteFooter">
+					<span className="folioNoteTags">
+						{firstUrl ? (
+							<a
+								href={firstUrl}
+								className="databaseCellPill folioNoteTag folioNoteUrl"
+								title={firstUrl}
+								onClick={(event) => {
+									event.preventDefault();
+									event.stopPropagation();
+									void openUrl(firstUrl);
+								}}
 							>
 								<DatabaseColumnIcon
-									iconName={iconNameForTag(tag)}
-									className="folioNoteTagIcon"
+									iconName="link"
+									className="folioNoteUrlIcon"
 									size="var(--icon-xs)"
 									strokeWidth={1.2}
 								/>
-								{formatDatabaseTagLabel(tag)}
+								{firstUrlLabel}
+							</a>
+						) : null}
+						{visibleTags.length > 0 ? (
+							visibleTags.map((tag) => (
+								<span
+									key={tag}
+									className="databaseCellPill folioNoteTag"
+									title={formatDatabaseTagLabel(tag)}
+								>
+									<DatabaseColumnIcon
+										iconName={iconNameForTag(tag)}
+										className="folioNoteTagIcon"
+										size="var(--icon-xs)"
+										strokeWidth={1.2}
+									/>
+									{formatDatabaseTagLabel(tag)}
+								</span>
+							))
+						) : firstUrl ? null : (
+							<span className="folioNoteFolder">{folder || "No folder"}</span>
+						)}
+						{hiddenTagCount > 0 ? (
+							<span className="databaseCellPill databaseCellPillMore folioNoteTag">
+								+{hiddenTagCount}
 							</span>
-						))
-					) : firstUrl ? null : (
-						<span className="folioNoteFolder">{folder || "No folder"}</span>
-					)}
-					{hiddenTagCount > 0 ? (
-						<span className="databaseCellPill databaseCellPillMore folioNoteTag">
-							+{hiddenTagCount}
-						</span>
-					) : null}
-				</span>
-				<span className="folioNoteDates">{updated}</span>
-			</span>
-		</div>
-	);
-	const fileDetails = (
-		<span className="folioFileLine">
-			{fileIcon}
-			<span className="folioFileName">{fileStem || title}</span>
-			{extBadge ? <span className="fileTreeExtBadge">{extBadge}</span> : null}
-		</span>
-	);
-
-	return (
-		<li
-			ref={ref}
-			className={`folioNoteListItem${className ? ` ${className}` : ""}`}
-			style={style}
-			data-index={virtualIndex}
-		>
-			{isRenaming ? (
-				<div
-					className="folioNoteRow"
-					data-state={selected ? "selected" : "idle"}
-					data-kind={isMarkdown ? "markdown" : "file"}
-					data-pinned={isPinned ? "true" : undefined}
-					data-folio-note-path={note.note_path}
-					title={note.note_path}
-					style={rowStyle}
-				>
-					<span className="folioNoteRowTop">
-						<FolioRenameInput
-							key={`${note.note_path}:${fileStem}`}
-							initialName={fileStem || titleFromPath(note.note_path)}
-							relPath={note.note_path}
-							fileStem={fileStem}
-							fileExt={fileExt}
-							onCommitRename={onCommitRename}
-							onCancelRename={onCancelRename}
-						/>
-						{taskProgress}
+						) : null}
 					</span>
-					{isMarkdown ? rowDetails : fileDetails}
-				</div>
-			) : (
-				<button
-					type="button"
-					className="folioNoteRow"
-					data-state={selected ? "selected" : "idle"}
-					data-kind={isMarkdown ? "markdown" : "file"}
-					data-pinned={isPinned ? "true" : undefined}
-					data-folio-note-path={note.note_path}
-					aria-current={selected ? "page" : undefined}
-					onClick={(event) => {
-						if (event.metaKey || event.ctrlKey) {
-							onOpenInNewTab(note.note_path);
-							return;
-						}
-						onOpen(note.note_path);
-					}}
-					onContextMenu={handleContextMenu}
-					onDoubleClick={() => onOpenInNewTab(note.note_path)}
-					onAuxClick={(event) => {
-						if (event.button === 1) onOpenInNewTab(note.note_path);
-					}}
-					onMouseEnter={() => {
-						if (isMarkdown) onPrefetch(note.note_path);
-					}}
-					onFocus={() => {
-						onFocus();
-						if (isMarkdown) onPrefetch(note.note_path);
-					}}
-					title={note.note_path}
-					style={rowStyle}
-				>
-					{isMarkdown ? (
-						<>
-							<span className="folioNoteRowTop">
-								<span className="folioNoteTitle">{title}</span>
-								{taskProgress}
-								{noteTitleIcon}
-							</span>
-							{rowDetails}
-						</>
-					) : (
-						fileDetails
-					)}
-				</button>
-			)}
-		</li>
-	);
+					<span className="folioNoteDates">{updated}</span>
+				</span>
+			</div>
+		);
+		const fileDetails = (
+			<span className="folioFileLine">
+				{fileIcon}
+				<span className="folioFileName">{fileStem || title}</span>
+				{extBadge ? <span className="fileTreeExtBadge">{extBadge}</span> : null}
+			</span>
+		);
+
+		return (
+			<li
+				ref={ref}
+				className={`folioNoteListItem${className ? ` ${className}` : ""}`}
+				style={style}
+				data-index={virtualIndex}
+			>
+				{isRenaming ? (
+					<div
+						className="folioNoteRow"
+						data-state={selected ? "selected" : "idle"}
+						data-kind={isMarkdown ? "markdown" : "file"}
+						data-pinned={isPinned ? "true" : undefined}
+						data-folio-note-path={note.note_path}
+						title={note.note_path}
+						style={rowStyle}
+					>
+						<span className="folioNoteRowTop">
+							<FolioRenameInput
+								key={`${note.note_path}:${fileStem}`}
+								initialName={fileStem || titleFromPath(note.note_path)}
+								relPath={note.note_path}
+								fileStem={fileStem}
+								fileExt={fileExt}
+								onCommitRename={onCommitRename}
+								onCancelRename={onCancelRename}
+							/>
+							{taskProgress}
+						</span>
+						{isMarkdown ? rowDetails : fileDetails}
+					</div>
+				) : (
+					<button
+						type="button"
+						className="folioNoteRow"
+						data-state={selected ? "selected" : "idle"}
+						data-kind={isMarkdown ? "markdown" : "file"}
+						data-pinned={isPinned ? "true" : undefined}
+						data-folio-note-path={note.note_path}
+						aria-current={selected ? "page" : undefined}
+						onClick={(event) => {
+							if (event.metaKey || event.ctrlKey) {
+								onOpenInNewTab(note.note_path);
+								return;
+							}
+							onOpen(note.note_path);
+						}}
+						onContextMenu={handleContextMenu}
+						onDoubleClick={() => onOpenInNewTab(note.note_path)}
+						onAuxClick={(event) => {
+							if (event.button === 1) onOpenInNewTab(note.note_path);
+						}}
+						onMouseEnter={() => {
+							if (isMarkdown) onPrefetch(note.note_path);
+						}}
+						onFocus={() => {
+							onFocus();
+							if (isMarkdown) onPrefetch(note.note_path);
+						}}
+						title={note.note_path}
+						style={rowStyle}
+					>
+						{isMarkdown ? (
+							<>
+								<span className="folioNoteRowTop">
+									<span className="folioNoteTitle">{title}</span>
+									{taskProgress}
+									{noteTitleIcon}
+								</span>
+								{rowDetails}
+							</>
+						) : (
+							fileDetails
+						)}
+					</button>
+				)}
+			</li>
+		);
 	}),
 );

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -1,7 +1,16 @@
 import { PinIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+	type CSSProperties,
+	memo,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -36,6 +45,26 @@ interface FolioNotesListPaneProps {
 }
 
 const FOLIO_SORT_MODE_STORAGE_KEY = "glyph.folio.sortMode";
+const FOLIO_NOTE_ROW_ESTIMATE = 104;
+const FOLIO_FILE_ROW_ESTIMATE = 42;
+const FOLIO_PINNED_HEADING_ESTIMATE = 28;
+const FOLIO_PINNED_DIVIDER_ESTIMATE = 18;
+
+type FolioVirtualRow =
+	| {
+			id: string;
+			kind: "heading";
+	  }
+	| {
+			id: string;
+			kind: "divider";
+	  }
+	| {
+			id: string;
+			kind: "note";
+			note: FolioItem;
+			isPinned: boolean;
+	  };
 
 function isFolioNotesSortMode(value: unknown): value is FolioNotesSortMode {
 	return value === "alphabetical" || value === "edited" || value === "created";
@@ -213,6 +242,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	>(null);
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const paneRef = useRef<HTMLElement | null>(null);
+	const listRef = useRef<HTMLUListElement | null>(null);
 	const pinnedPathSet = useMemo(
 		() => new Set(normalizedPinnedFiles),
 		[normalizedPinnedFiles],
@@ -266,12 +296,47 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		() => [...visiblePinnedNotes, ...visibleRegularNotes],
 		[visiblePinnedNotes, visibleRegularNotes],
 	);
+	const virtualRows = useMemo<FolioVirtualRow[]>(() => {
+		const rows: FolioVirtualRow[] = [];
+		if (visiblePinnedNotes.length > 0) {
+			rows.push({ id: "pinned-heading", kind: "heading" });
+			for (const note of visiblePinnedNotes) {
+				rows.push({
+					id: `note:${note.note_path}`,
+					kind: "note",
+					note,
+					isPinned: true,
+				});
+			}
+		}
+		if (visiblePinnedNotes.length > 0 && visibleRegularNotes.length > 0) {
+			rows.push({ id: "pinned-divider", kind: "divider" });
+		}
+		for (const note of visibleRegularNotes) {
+			rows.push({
+				id: `note:${note.note_path}`,
+				kind: "note",
+				note,
+				isPinned: false,
+			});
+		}
+		return rows;
+	}, [visiblePinnedNotes, visibleRegularNotes]);
 	const selectedIndex = useMemo(
 		() =>
 			activeTabPath
 				? visibleNotes.findIndex((note) => note.note_path === activeTabPath)
 				: -1,
 		[activeTabPath, visibleNotes],
+	);
+	const selectedVirtualIndex = useMemo(
+		() =>
+			activeTabPath
+				? virtualRows.findIndex(
+						(row) => row.kind === "note" && row.note.note_path === activeTabPath,
+					)
+				: -1,
+		[activeTabPath, virtualRows],
 	);
 	const taskSummaryPaths = useMemo(
 		() =>
@@ -296,6 +361,21 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 				: DEFAULT_TAG_ICON_NAME,
 		[beautifulTags, tagIconOverrides],
 	);
+	const rowVirtualizer = useVirtualizer<HTMLElement, HTMLLIElement>({
+		count: virtualRows.length,
+		estimateSize: (index) => {
+			const row = virtualRows[index];
+			if (row?.kind === "heading") return FOLIO_PINNED_HEADING_ESTIMATE;
+			if (row?.kind === "divider") return FOLIO_PINNED_DIVIDER_ESTIMATE;
+			if (row?.kind === "note" && !row.note.is_markdown)
+				return FOLIO_FILE_ROW_ESTIMATE;
+			return FOLIO_NOTE_ROW_ESTIMATE;
+		},
+		getScrollElement: () => listRef.current,
+		getItemKey: (index) => virtualRows[index]?.id ?? index,
+		overscan: 8,
+	});
+	const virtualItems = rowVirtualizer.getVirtualItems();
 
 	useTauriEvent("notes:external_changed", (payload) => {
 		if (hasPinnedMarkdownFiles) {
@@ -322,19 +402,16 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		setSortMode(nextSortMode);
 		writeStoredFolioSortMode(nextSortMode);
 	}, []);
-	const scrollNoteIntoView = useCallback((path: string) => {
-		requestAnimationFrame(() => {
-			const rows =
-				paneRef.current?.querySelectorAll<HTMLElement>(
-					"[data-folio-note-path]",
-				) ?? [];
-			for (const row of rows) {
-				if (row.dataset.folioNotePath !== path) continue;
-				row.scrollIntoView?.({ block: "nearest" });
-				return;
-			}
-		});
-	}, []);
+	const scrollNoteIntoView = useCallback(
+		(path: string) => {
+			const index = virtualRows.findIndex(
+				(row) => row.kind === "note" && row.note.note_path === path,
+			);
+			if (index < 0) return;
+			rowVirtualizer.scrollToIndex(index, { align: "auto" });
+		},
+		[rowVirtualizer, virtualRows],
+	);
 	const openNote = useCallback(
 		(path: string) => {
 			void onOpenFile(path);
@@ -435,8 +512,9 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 
 	useEffect(() => {
 		if (!activeTabPath) return;
-		scrollNoteIntoView(activeTabPath);
-	}, [activeTabPath, scrollNoteIntoView]);
+		if (selectedVirtualIndex < 0) return;
+		rowVirtualizer.scrollToIndex(selectedVirtualIndex, { align: "auto" });
+	}, [activeTabPath, rowVirtualizer, selectedVirtualIndex]);
 
 	const body = (() => {
 		if (error) {
@@ -461,76 +539,84 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 						Showing the first {nonMarkdownFileLimit.toLocaleString()} files.
 					</div>
 				) : null}
-				<ul className="folioNotesList">
-					{visiblePinnedNotes.length > 0 ? (
-						<li className="folioNotesPinnedHeading">
-							<HugeiconsIcon
-								icon={PinIcon}
-								size="var(--icon-sm)"
-								strokeWidth={1}
+				<ul
+					ref={listRef}
+					className="folioNotesList is-virtualized"
+					style={
+						{
+							"--folio-virtual-height": `${rowVirtualizer.getTotalSize()}px`,
+						} as CSSProperties
+					}
+				>
+					{virtualItems.map((virtualRow) => {
+						const row = virtualRows[virtualRow.index];
+						if (!row) return null;
+						const virtualStyle = {
+							transform: `translateY(${virtualRow.start}px)`,
+						};
+						if (row.kind === "heading") {
+							return (
+								<li
+									key={virtualRow.key}
+									data-index={virtualRow.index}
+									ref={(node) => rowVirtualizer.measureElement(node)}
+									className="folioNotesPinnedHeading folioNotesVirtualRow"
+									style={virtualStyle}
+								>
+									<HugeiconsIcon
+										icon={PinIcon}
+										size="var(--icon-sm)"
+										strokeWidth={1}
+									/>
+									<span>Pinned</span>
+								</li>
+							);
+						}
+						if (row.kind === "divider") {
+							return (
+								<li
+									key={virtualRow.key}
+									data-index={virtualRow.index}
+									ref={(node) => rowVirtualizer.measureElement(node)}
+									className="folioNotesPinnedDivider folioNotesVirtualRow"
+									style={virtualStyle}
+									aria-hidden="true"
+								/>
+							);
+						}
+						return (
+							<FolioNoteListItem
+								key={virtualRow.key}
+								virtualIndex={virtualRow.index}
+								ref={(node) => rowVirtualizer.measureElement(node)}
+								className="folioNotesVirtualRow"
+								style={virtualStyle}
+								note={row.note}
+								selected={activeTabPath === row.note.note_path}
+								isPinned={row.isPinned}
+								onOpen={openNote}
+								onOpenInNewTab={openNoteInNewTab}
+								onPrefetch={prefetchNote}
+								onRename={onRenameFile ? renameNote : undefined}
+								onDelete={deleteNote}
+								onTogglePinned={togglePinnedNote}
+								onFocus={focusPane}
+								isRenaming={
+									Boolean(onRenameFile) && renamingPath === row.note.note_path
+								}
+								onCommitRename={commitRename}
+								onCancelRename={cancelRename}
+								appearance={itemAppearance[row.note.note_path] ?? null}
+								onOpenAppearancePicker={setAppearancePickerPath}
+								iconNameForTag={iconNameForTag}
+								taskSummary={
+									row.note.is_markdown
+										? (taskSummariesByPath?.[row.note.note_path] ?? null)
+										: null
+								}
 							/>
-							<span>Pinned</span>
-						</li>
-					) : null}
-					{visiblePinnedNotes.map((note) => (
-						<FolioNoteListItem
-							key={note.note_path}
-							note={note}
-							selected={activeTabPath === note.note_path}
-							isPinned
-							onOpen={openNote}
-							onOpenInNewTab={openNoteInNewTab}
-							onPrefetch={prefetchNote}
-							onRename={onRenameFile ? renameNote : undefined}
-							onDelete={deleteNote}
-							onTogglePinned={togglePinnedNote}
-							onFocus={focusPane}
-							isRenaming={
-								Boolean(onRenameFile) && renamingPath === note.note_path
-							}
-							onCommitRename={commitRename}
-							onCancelRename={cancelRename}
-							appearance={itemAppearance[note.note_path] ?? null}
-							onOpenAppearancePicker={setAppearancePickerPath}
-							iconNameForTag={iconNameForTag}
-							taskSummary={
-								note.is_markdown
-									? (taskSummariesByPath?.[note.note_path] ?? null)
-									: null
-							}
-						/>
-					))}
-					{visiblePinnedNotes.length > 0 && visibleRegularNotes.length > 0 ? (
-						<li className="folioNotesPinnedDivider" aria-hidden="true" />
-					) : null}
-					{visibleRegularNotes.map((note) => (
-						<FolioNoteListItem
-							key={note.note_path}
-							note={note}
-							selected={activeTabPath === note.note_path}
-							isPinned={false}
-							onOpen={openNote}
-							onOpenInNewTab={openNoteInNewTab}
-							onPrefetch={prefetchNote}
-							onRename={onRenameFile ? renameNote : undefined}
-							onDelete={deleteNote}
-							onTogglePinned={togglePinnedNote}
-							onFocus={focusPane}
-							isRenaming={
-								Boolean(onRenameFile) && renamingPath === note.note_path
-							}
-							onCommitRename={commitRename}
-							onCancelRename={cancelRename}
-							appearance={itemAppearance[note.note_path] ?? null}
-							onOpenAppearancePicker={setAppearancePickerPath}
-							iconNameForTag={iconNameForTag}
-							taskSummary={
-								note.is_markdown
-									? (taskSummariesByPath?.[note.note_path] ?? null)
-									: null
-							}
-						/>
-					))}
+						);
+					})}
 				</ul>
 			</>
 		);

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -333,7 +333,8 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		() =>
 			activeTabPath
 				? virtualRows.findIndex(
-						(row) => row.kind === "note" && row.note.note_path === activeTabPath,
+						(row) =>
+							row.kind === "note" && row.note.note_path === activeTabPath,
 					)
 				: -1,
 		[activeTabPath, virtualRows],

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -48,7 +48,16 @@ function filterNotesForScope(
 	notes: FolioItem[],
 	scope: FolioScope,
 ): FolioItem[] {
+	const folderPrefix =
+		scope.kind === "folder" ? normalizeFolioPath(scope.folderPrefix) : "";
 	switch (scope.kind) {
+		case "folder":
+			return notes.filter((note) => {
+				const notePath = normalizeRelPath(note.note_path);
+				return (
+					notePath === folderPrefix || notePath.startsWith(`${folderPrefix}/`)
+				);
+			});
 		case "tag":
 			return notes.filter(
 				(note) => note.is_markdown && tagMatches(note.tags, scope.tag),

--- a/src/hooks/database/useDatabaseRows.ts
+++ b/src/hooks/database/useDatabaseRows.ts
@@ -68,7 +68,7 @@ function rebuildRowsPages(
 					available_properties: availableProperties,
 					total_count: totalCount,
 					truncated: hadMore,
-					next_offset: hadMore ? pageSize : null,
+					next_offset: hadMore ? 0 : null,
 				},
 			],
 			pageParams: [0],
@@ -136,13 +136,15 @@ export function useDatabaseRows({
 	const setRows = useCallback<Dispatch<SetStateAction<DatabaseRow[]>>>(
 		(updater) => {
 			if (!selectedDatabaseId || !selectedViewId) return;
-			queryClient.setQueryData<DatabaseRowsPagesData>(rowsQueryKey, (current) => {
-				const currentRows =
-					current?.pages.flatMap((page) => page.rows) ?? [];
-				const nextRows =
-					typeof updater === "function" ? updater(currentRows) : updater;
-				return rebuildRowsPages(current, nextRows, pageSize);
-			});
+			queryClient.setQueryData<DatabaseRowsPagesData>(
+				rowsQueryKey,
+				(current) => {
+					const currentRows = current?.pages.flatMap((page) => page.rows) ?? [];
+					const nextRows =
+						typeof updater === "function" ? updater(currentRows) : updater;
+					return rebuildRowsPages(current, nextRows, pageSize);
+				},
+			);
 		},
 		[pageSize, queryClient, rowsQueryKey, selectedDatabaseId, selectedViewId],
 	);
@@ -173,12 +175,8 @@ export function useDatabaseRows({
 			setSelectedRowPath(null);
 			return;
 		}
-		try {
-			await rowsQuery.refetch();
-		} catch (cause) {
-			setError(extractErrorMessage(cause));
-		}
-	}, [canLoadRows, rowsQuery, setError]);
+		await rowsQuery.refetch();
+	}, [canLoadRows, rowsQuery]);
 
 	useEffect(() => {
 		if (rowsQuery.error) {

--- a/src/hooks/database/useDatabaseRows.ts
+++ b/src/hooks/database/useDatabaseRows.ts
@@ -1,16 +1,28 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+	type InfiniteData,
+	useInfiniteQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
-	getPrefetchedDatabaseRows,
 	invalidateDatabaseRowsPrefetch,
-	prefetchDatabaseRows,
-	setPrefetchedDatabaseRows,
+	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import type {
 	DatabaseRow,
 	WorkspaceDatabaseDocument,
 	WorkspaceDatabaseQueryResult,
 } from "../../lib/tauri";
+import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import type { PaneErrorHandlers } from "./types";
 
@@ -18,34 +30,124 @@ export interface UseDatabaseRowsOptions extends PaneErrorHandlers {
 	selectedDatabaseId: string | null;
 	selectedViewId: string | null;
 	document: WorkspaceDatabaseDocument | null;
-	initialRows?: WorkspaceDatabaseQueryResult | null;
+	pageSize?: number;
+}
+
+type DatabaseRowsPagesData = InfiniteData<WorkspaceDatabaseQueryResult, number>;
+
+function rebuildRowsPages(
+	current: DatabaseRowsPagesData | undefined,
+	rows: DatabaseRow[],
+	pageSize: number,
+): DatabaseRowsPagesData {
+	const fallbackPage = current?.pages.find(
+		(page) => page.available_properties.length > 0,
+	);
+	const availableProperties = fallbackPage?.available_properties ?? [];
+	const hadMore = current?.pages[current.pages.length - 1]?.next_offset != null;
+	const totalCount = hadMore
+		? Math.max(current?.pages[0]?.total_count ?? 0, rows.length)
+		: rows.length;
+	const pages: WorkspaceDatabaseQueryResult[] = [];
+	for (let offset = 0; offset < rows.length; offset += pageSize) {
+		const pageRows = rows.slice(offset, offset + pageSize);
+		const hasLocalNext = offset + pageSize < rows.length;
+		pages.push({
+			rows: pageRows,
+			available_properties: availableProperties,
+			total_count: totalCount,
+			truncated: hasLocalNext || hadMore,
+			next_offset: hasLocalNext || hadMore ? offset + pageRows.length : null,
+		});
+	}
+	if (pages.length === 0) {
+		return {
+			pages: [
+				{
+					rows: [],
+					available_properties: availableProperties,
+					total_count: totalCount,
+					truncated: hadMore,
+					next_offset: hadMore ? pageSize : null,
+				},
+			],
+			pageParams: [0],
+		};
+	}
+	return {
+		pages,
+		pageParams: pages.map((_, index) => index * pageSize),
+	};
 }
 
 export function useDatabaseRows({
 	selectedDatabaseId,
 	selectedViewId,
 	document,
-	initialRows = null,
+	pageSize = 200,
 	setError,
 }: UseDatabaseRowsOptions) {
-	const [rows, setRows] = useState<DatabaseRow[]>(
-		() => initialRows?.rows ?? [],
-	);
-	const [rowsTruncated, setRowsTruncated] = useState(
-		() => initialRows?.truncated ?? false,
-	);
+	const queryClient = useQueryClient();
 	const [selectedRowPath, setSelectedRowPath] = useState<string | null>(null);
-	const rowRequestTokenRef = useRef(0);
 	const fsRowsRefreshTimerRef = useRef<number | null>(null);
 	const previousSelectionRef = useRef<{
 		databaseId: string | null;
 		viewId: string | null;
+		pageSize: number;
 	} | null>(null);
 
+	const canLoadRows =
+		selectedDatabaseId != null &&
+		selectedViewId != null &&
+		document != null &&
+		document.database.id === selectedDatabaseId &&
+		document.database.views.some((view) => view.id === selectedViewId);
+	const rowsQueryKey = useMemo(
+		() =>
+			selectedDatabaseId && selectedViewId
+				? navigationQueryKeys.databaseRowsPages(
+						selectedDatabaseId,
+						selectedViewId,
+						pageSize,
+					)
+				: [...navigationQueryKeys.databases(), "rows-pages", "__inactive__"],
+		[pageSize, selectedDatabaseId, selectedViewId],
+	);
+	const rowsQuery = useInfiniteQuery<WorkspaceDatabaseQueryResult, Error>({
+		queryKey: rowsQueryKey,
+		queryFn: ({ pageParam }) => {
+			const offset = typeof pageParam === "number" ? pageParam : 0;
+			return invoke("databases_query_rows", {
+				database_id: selectedDatabaseId ?? "",
+				view_id: selectedViewId ?? "",
+				offset,
+				limit: pageSize,
+			});
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.next_offset ?? undefined,
+		enabled: canLoadRows,
+	});
+
+	const rows = useMemo(
+		() => rowsQuery.data?.pages.flatMap((page) => page.rows) ?? [],
+		[rowsQuery.data],
+	);
+	const setRows = useCallback<Dispatch<SetStateAction<DatabaseRow[]>>>(
+		(updater) => {
+			if (!selectedDatabaseId || !selectedViewId) return;
+			queryClient.setQueryData<DatabaseRowsPagesData>(rowsQueryKey, (current) => {
+				const currentRows =
+					current?.pages.flatMap((page) => page.rows) ?? [];
+				const nextRows =
+					typeof updater === "function" ? updater(currentRows) : updater;
+				return rebuildRowsPages(current, nextRows, pageSize);
+			});
+		},
+		[pageSize, queryClient, rowsQueryKey, selectedDatabaseId, selectedViewId],
+	);
+
 	const clearRows = useCallback(() => {
-		rowRequestTokenRef.current += 1;
-		setRows([]);
-		setRowsTruncated(false);
 		setSelectedRowPath(null);
 	}, []);
 
@@ -53,63 +155,36 @@ export function useDatabaseRows({
 		const previous = previousSelectionRef.current;
 		if (
 			previous?.databaseId === selectedDatabaseId &&
-			previous.viewId === selectedViewId
+			previous.viewId === selectedViewId &&
+			previous.pageSize === pageSize
 		) {
 			return;
 		}
 		previousSelectionRef.current = {
 			databaseId: selectedDatabaseId,
 			viewId: selectedViewId,
+			pageSize,
 		};
-		clearRows();
-	}, [clearRows, selectedDatabaseId, selectedViewId]);
+		setSelectedRowPath(null);
+	}, [pageSize, selectedDatabaseId, selectedViewId]);
 
 	const loadRows = useCallback(async () => {
-		const requestToken = rowRequestTokenRef.current + 1;
-		rowRequestTokenRef.current = requestToken;
-		if (
-			!selectedDatabaseId ||
-			!selectedViewId ||
-			!document ||
-			document.database.id !== selectedDatabaseId ||
-			!document.database.views.some((view) => view.id === selectedViewId)
-		) {
-			if (rowRequestTokenRef.current === requestToken) {
-				setRows([]);
-				setRowsTruncated(false);
-				setSelectedRowPath(null);
-			}
+		if (!canLoadRows) {
+			setSelectedRowPath(null);
 			return;
 		}
 		try {
-			const next = await prefetchDatabaseRows(
-				selectedDatabaseId,
-				selectedViewId,
-			);
-			if (rowRequestTokenRef.current !== requestToken) return;
-			setRows(next.rows);
-			setRowsTruncated(next.truncated);
-			setPrefetchedDatabaseRows(selectedDatabaseId, selectedViewId, next);
+			await rowsQuery.refetch();
 		} catch (cause) {
-			if (rowRequestTokenRef.current !== requestToken) return;
 			setError(extractErrorMessage(cause));
 		}
-	}, [document, selectedDatabaseId, selectedViewId, setError]);
+	}, [canLoadRows, rowsQuery, setError]);
 
 	useEffect(() => {
-		if (!selectedDatabaseId || !selectedViewId) return;
-		const cachedRows = getPrefetchedDatabaseRows(
-			selectedDatabaseId,
-			selectedViewId,
-		);
-		if (cachedRows) {
-			setRows(cachedRows.rows);
-			setRowsTruncated(cachedRows.truncated);
-			void loadRows();
-			return;
+		if (rowsQuery.error) {
+			setError(extractErrorMessage(rowsQuery.error));
 		}
-		void loadRows();
-	}, [loadRows, selectedDatabaseId, selectedViewId]);
+	}, [rowsQuery.error, setError]);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: clear pending background reloads when the row loader changes.
 	useEffect(
@@ -125,7 +200,6 @@ export function useDatabaseRows({
 	const scheduleRowsRefreshForNoteChange = useCallback(
 		(payload: { rel_path: string; removed: boolean }) => {
 			if (!payload.rel_path.toLowerCase().endsWith(".md")) return;
-			rowRequestTokenRef.current += 1;
 			if (fsRowsRefreshTimerRef.current !== null) {
 				window.clearTimeout(fsRowsRefreshTimerRef.current);
 			}
@@ -146,7 +220,9 @@ export function useDatabaseRows({
 	return {
 		rows,
 		setRows,
-		rowsTruncated,
+		hasMoreRows: rowsQuery.hasNextPage,
+		isLoadingMoreRows: rowsQuery.isFetchingNextPage,
+		loadMoreRows: rowsQuery.fetchNextPage,
 		selectedRowPath,
 		setSelectedRowPath,
 		loadRows,

--- a/src/hooks/database/useDatabasesPane.ts
+++ b/src/hooks/database/useDatabasesPane.ts
@@ -1,15 +1,15 @@
 import { useCallback, useMemo, useState } from "react";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
-import type {
-	WorkspaceDatabaseDocument,
-	WorkspaceDatabaseQueryResult,
-} from "../../lib/tauri";
+import type { WorkspaceDatabaseDocument } from "../../lib/tauri";
 import type { ActiveCollection } from "./types";
 import { useCollectionWorkspace } from "./useCollectionWorkspace";
 import { useDatabaseDisplaySettings } from "./useDatabaseDisplaySettings";
 import { useDatabaseRowActions } from "./useDatabaseRowActions";
 import { useDatabaseRows } from "./useDatabaseRows";
 import { useDatabaseViewActions } from "./useDatabaseViewActions";
+
+const DATABASE_TABLE_ROW_PAGE_SIZE = 200;
+const DATABASE_BOARD_ROW_PAGE_SIZE = 48;
 
 export interface UseDatabasesPaneOptions {
 	onOpenFile: (relPath: string) => Promise<void>;
@@ -20,7 +20,6 @@ export interface UseDatabasesPaneOptions {
 	databasesOpenRequest: DatabasesOpenRequest;
 	onConsumeOpenRequest?: () => void;
 	initialDocument?: WorkspaceDatabaseDocument | null;
-	initialRows?: WorkspaceDatabaseQueryResult | null;
 }
 
 export function useDatabasesPane({
@@ -28,7 +27,6 @@ export function useDatabasesPane({
 	databasesOpenRequest,
 	onConsumeOpenRequest,
 	initialDocument = null,
-	initialRows = null,
 }: UseDatabasesPaneOptions) {
 	const [error, setError] = useState("");
 	const clearError = useCallback(() => setError(""), []);
@@ -41,21 +39,25 @@ export function useDatabasesPane({
 		initialDocument,
 	});
 
-	const rows = useDatabaseRows({
-		selectedDatabaseId: workspace.selectedDatabaseId,
-		selectedViewId: workspace.selectedViewId,
-		document: workspace.document,
-		initialRows,
-		setError,
-		clearError,
-	});
-
 	const display = useDatabaseDisplaySettings();
 
 	const views = useDatabaseViewActions({
 		document: workspace.document,
 		selectedViewId: workspace.selectedViewId,
 		saveDatabase: workspace.saveDatabase,
+	});
+
+	const rowPageSize =
+		views.activeConfig?.view.layout === "board"
+			? DATABASE_BOARD_ROW_PAGE_SIZE
+			: DATABASE_TABLE_ROW_PAGE_SIZE;
+	const rows = useDatabaseRows({
+		selectedDatabaseId: workspace.selectedDatabaseId,
+		selectedViewId: workspace.selectedViewId,
+		document: workspace.document,
+		pageSize: rowPageSize,
+		setError,
+		clearError,
 	});
 
 	const activeCollection = useMemo((): ActiveCollection | null => {

--- a/src/hooks/useLoadMoreTriggers.ts
+++ b/src/hooks/useLoadMoreTriggers.ts
@@ -1,0 +1,68 @@
+import type { VirtualItem } from "@tanstack/react-virtual";
+import { type RefObject, useEffect } from "react";
+
+interface LoadMoreState {
+	hasMore: boolean;
+	isLoading: boolean;
+	onLoadMore?: () => void | Promise<unknown>;
+}
+
+interface VirtualLoadMoreOptions extends LoadMoreState {
+	virtualItems: VirtualItem[];
+	totalItems: number;
+	remainingItems: number;
+}
+
+export function useVirtualLoadMore({
+	hasMore,
+	isLoading,
+	onLoadMore,
+	virtualItems,
+	totalItems,
+	remainingItems,
+}: VirtualLoadMoreOptions) {
+	useEffect(() => {
+		if (!hasMore || isLoading || !onLoadMore) return;
+		const lastVirtualItem = virtualItems[virtualItems.length - 1];
+		if (!lastVirtualItem) return;
+		if (lastVirtualItem.index < totalItems - remainingItems) return;
+		void onLoadMore();
+	}, [hasMore, isLoading, onLoadMore, remainingItems, totalItems, virtualItems]);
+}
+
+interface SentinelLoadMoreOptions<
+	TRoot extends Element,
+	TSentinel extends Element,
+> extends LoadMoreState {
+	rootRef: RefObject<TRoot | null>;
+	sentinelRef: RefObject<TSentinel | null>;
+	rootMargin?: string;
+}
+
+export function useSentinelLoadMore<
+	TRoot extends Element,
+	TSentinel extends Element,
+>({
+	hasMore,
+	isLoading,
+	onLoadMore,
+	rootRef,
+	sentinelRef,
+	rootMargin = "0px",
+}: SentinelLoadMoreOptions<TRoot, TSentinel>) {
+	useEffect(() => {
+		const root = rootRef.current;
+		const sentinel = sentinelRef.current;
+		if (!root || !sentinel || !hasMore || !onLoadMore) return;
+		const observer = new IntersectionObserver(
+			(entries) => {
+				const entry = entries[0];
+				if (!entry?.isIntersecting || isLoading) return;
+				void onLoadMore();
+			},
+			{ root, rootMargin, threshold: 0 },
+		);
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	}, [hasMore, isLoading, onLoadMore, rootMargin, rootRef, sentinelRef]);
+}

--- a/src/hooks/useLoadMoreTriggers.ts
+++ b/src/hooks/useLoadMoreTriggers.ts
@@ -4,7 +4,7 @@ import { type RefObject, useEffect } from "react";
 interface LoadMoreState {
 	hasMore: boolean;
 	isLoading: boolean;
-	onLoadMore?: () => void | Promise<unknown>;
+	onLoadMore?: () => undefined | Promise<unknown>;
 }
 
 interface VirtualLoadMoreOptions extends LoadMoreState {
@@ -27,7 +27,14 @@ export function useVirtualLoadMore({
 		if (!lastVirtualItem) return;
 		if (lastVirtualItem.index < totalItems - remainingItems) return;
 		void onLoadMore();
-	}, [hasMore, isLoading, onLoadMore, remainingItems, totalItems, virtualItems]);
+	}, [
+		hasMore,
+		isLoading,
+		onLoadMore,
+		remainingItems,
+		totalItems,
+		virtualItems,
+	]);
 }
 
 interface SentinelLoadMoreOptions<

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -315,7 +315,7 @@ function rebuildAllDocsPages(
 	}
 	if (pages.length === 0) {
 		return {
-			pages: [{ items: [], nextOffset: hadMore ? ALL_DOCS_PAGE_SIZE : null }],
+			pages: [{ items: [], nextOffset: hadMore ? 0 : null }],
 			pageParams: [0],
 		};
 	}

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -6,17 +6,14 @@ import { summarizeChecklistsFromMarkdown } from "./checklistSummary";
 import {
 	readStoredSelectedDatabaseId,
 	resolveSelectedDatabaseId,
-	resolveSelectedViewId,
 } from "./database/selectedViewStorage";
 import { parseNotePreview } from "./notePreview";
 import { queryClient } from "./queryClient";
 import type {
 	AllDocsItem,
-	DatabaseRow,
 	NoteTaskSummary,
 	TextFileDoc,
 	WorkspaceDatabaseDocument,
-	WorkspaceDatabaseQueryResult,
 	WorkspaceDatabaseSummary,
 } from "./tauri";
 import { invoke } from "./tauri";
@@ -68,17 +65,24 @@ export const navigationQueryKeys = {
 			"document",
 			databaseId.trim(),
 		] as const,
-	databaseRows: (databaseId: string, viewId: string) =>
+	databaseRowsPages: (databaseId: string, viewId: string, pageSize: number) =>
 		[
 			...navigationQueryKeys.databases(),
-			"rows",
+			"rows-pages",
 			databaseId.trim(),
 			viewId.trim(),
+			pageSize,
 		] as const,
 	allDocs: () => [...navigationQueryKeys.all, "all-docs"] as const,
 	allDocsList: (folderPrefix?: string | null) =>
 		[
 			...navigationQueryKeys.allDocs(),
+			normalizeAllDocsFolder(folderPrefix),
+		] as const,
+	allDocsPages: (folderPrefix?: string | null) =>
+		[
+			...navigationQueryKeys.allDocs(),
+			"pages",
 			normalizeAllDocsFolder(folderPrefix),
 		] as const,
 	allDocsCount: (folderPrefix?: string | null) =>
@@ -172,86 +176,11 @@ export function setPrefetchedDatabaseDocument(
 	);
 }
 
-async function loadAllDatabaseRows(
-	databaseId: string,
-	viewId: string,
-): Promise<WorkspaceDatabaseQueryResult> {
-	const maxIterations = 100;
-	let offset = 0;
-	let totalCount = 0;
-	let truncated = false;
-	let iterations = 0;
-	const rows: DatabaseRow[] = [];
-	let availableProperties =
-		[] as WorkspaceDatabaseQueryResult["available_properties"];
-
-	while (true) {
-		const next = await invoke("databases_query_rows", {
-			database_id: databaseId,
-			view_id: viewId,
-			offset,
-			limit: 200,
-		});
-		rows.push(...next.rows);
-		totalCount = next.total_count;
-		truncated = next.truncated;
-		if (next.available_properties.length > 0) {
-			availableProperties = next.available_properties;
-		}
-		iterations += 1;
-		if (next.next_offset == null) {
-			return {
-				rows,
-				available_properties: availableProperties,
-				total_count: totalCount,
-				truncated,
-				next_offset: null,
-			};
-		}
-		if (iterations >= maxIterations) {
-			return {
-				rows,
-				available_properties: availableProperties,
-				total_count: totalCount,
-				truncated: true,
-				next_offset: next.next_offset,
-			};
-		}
-		offset = next.next_offset;
-	}
-}
-
-export function prefetchDatabaseRows(databaseId: string, viewId: string) {
-	return queryClient.fetchQuery({
-		queryKey: navigationQueryKeys.databaseRows(databaseId, viewId),
-		queryFn: () => loadAllDatabaseRows(databaseId, viewId),
-	});
-}
-
-export function getPrefetchedDatabaseRows(databaseId: string, viewId: string) {
-	return (
-		queryClient.getQueryData<WorkspaceDatabaseQueryResult>(
-			navigationQueryKeys.databaseRows(databaseId, viewId),
-		) ?? null
-	);
-}
-
-export function setPrefetchedDatabaseRows(
-	databaseId: string,
-	viewId: string,
-	rows: WorkspaceDatabaseQueryResult,
-) {
-	queryClient.setQueryData(
-		navigationQueryKeys.databaseRows(databaseId, viewId),
-		rows,
-	);
-}
-
 export function invalidateDatabaseRowsPrefetch(databaseId?: string | null) {
 	void queryClient.invalidateQueries({
 		queryKey: databaseId
-			? [...navigationQueryKeys.databases(), "rows", databaseId.trim()]
-			: [...navigationQueryKeys.databases(), "rows"],
+			? [...navigationQueryKeys.databases(), "rows-pages", databaseId.trim()]
+			: [...navigationQueryKeys.databases(), "rows-pages"],
 	});
 }
 
@@ -278,16 +207,11 @@ export async function prefetchDatabasesLanding(
 		storedId: readStoredSelectedDatabaseId(),
 	});
 	if (!databaseId) return;
-	const document = await prefetchDatabaseDocument(databaseId);
-	const preferredViewId = resolveSelectedViewId(
-		databaseId,
-		document.database.views,
-	);
-	if (!preferredViewId) return;
-	await prefetchDatabaseRows(databaseId, preferredViewId);
+	await prefetchDatabaseDocument(databaseId);
 }
 
 export const ALL_DOCS_LIST_LIMIT = 2000;
+export const ALL_DOCS_PAGE_SIZE = 48;
 
 export function formatAllDocsCountLabel(count: number): string | null {
 	if (count <= 0) return null;
@@ -301,33 +225,67 @@ export async function loadAllDocsCount(folderPrefix?: string | null) {
 	});
 }
 
-export async function loadAllDocs(folderPrefix?: string | null) {
-	const normalized = normalizeAllDocsFolder(folderPrefix);
+export interface AllDocsPage {
+	items: AllDocsItem[];
+	nextOffset: number | null;
+}
+
+interface AllDocsPagesData {
+	pages: AllDocsPage[];
+	pageParams: unknown[];
+}
+
+export async function loadAllDocsPage(
+	folderPrefix?: string | null,
+	offset = 0,
+	limit = ALL_DOCS_PAGE_SIZE,
+): Promise<AllDocsPage> {
 	const items = await invoke("all_docs_list", {
-		limit: ALL_DOCS_LIST_LIMIT,
+		limit: limit + 1,
+		offset,
 		folder_prefix: folderPrefix?.trim() ? folderPrefix : null,
 	});
-	if (normalized === "__all__") return items;
-	return items.filter((item) => {
-		const normalizedPath = item.note_path
-			.trim()
-			.replace(/\\/g, "/")
-			.replace(/^\/+/, "");
-		return (
-			normalizedPath === normalized ||
-			normalizedPath.startsWith(`${normalized}/`)
+	const pageItems = items.slice(0, limit);
+	return {
+		items: pageItems,
+		nextOffset: items.length > limit ? offset + pageItems.length : null,
+	};
+}
+
+export async function loadAllDocs(folderPrefix?: string | null) {
+	const pages: AllDocsItem[] = [];
+	let offset = 0;
+	while (pages.length < ALL_DOCS_LIST_LIMIT) {
+		const next = await loadAllDocsPage(
+			folderPrefix,
+			offset,
+			Math.min(ALL_DOCS_PAGE_SIZE, ALL_DOCS_LIST_LIMIT - pages.length),
 		);
-	});
+		pages.push(...next.items);
+		if (next.nextOffset == null) break;
+		offset = next.nextOffset;
+	}
+	return pages;
 }
 
 export function prefetchAllDocs(folderPrefix?: string | null) {
-	return queryClient.fetchQuery({
-		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
-		queryFn: () => loadAllDocs(folderPrefix),
+	return queryClient.prefetchInfiniteQuery({
+		queryKey: navigationQueryKeys.allDocsPages(folderPrefix),
+		queryFn: ({ pageParam }) => {
+			const offset = typeof pageParam === "number" ? pageParam : 0;
+			return loadAllDocsPage(folderPrefix, offset);
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage: AllDocsPage) =>
+			lastPage.nextOffset ?? undefined,
 	});
 }
 
 export function getPrefetchedAllDocs(folderPrefix?: string | null) {
+	const pages = queryClient.getQueryData<AllDocsPagesData>(
+		navigationQueryKeys.allDocsPages(folderPrefix),
+	);
+	if (pages) return pages.pages.flatMap((page) => page.items);
 	return (
 		queryClient.getQueryData<AllDocsItem[]>(
 			navigationQueryKeys.allDocsList(folderPrefix),
@@ -335,22 +293,71 @@ export function getPrefetchedAllDocs(folderPrefix?: string | null) {
 	);
 }
 
-function updateAllDocsListCaches(
+function rebuildAllDocsPages(
+	current: AllDocsPagesData,
+	items: AllDocsItem[],
+): AllDocsPagesData {
+	if (current.pages.length === 0 && items.length === 0) {
+		return {
+			pages: [{ items, nextOffset: null }],
+			pageParams: [0],
+		};
+	}
+	const hadMore = current.pages[current.pages.length - 1]?.nextOffset != null;
+	const pages: AllDocsPage[] = [];
+	for (let offset = 0; offset < items.length; offset += ALL_DOCS_PAGE_SIZE) {
+		const pageItems = items.slice(offset, offset + ALL_DOCS_PAGE_SIZE);
+		const hasLocalNext = offset + ALL_DOCS_PAGE_SIZE < items.length;
+		pages.push({
+			items: pageItems,
+			nextOffset: hasLocalNext || hadMore ? offset + pageItems.length : null,
+		});
+	}
+	if (pages.length === 0) {
+		return {
+			pages: [{ items: [], nextOffset: hadMore ? ALL_DOCS_PAGE_SIZE : null }],
+			pageParams: [0],
+		};
+	}
+	return {
+		pages,
+		pageParams: pages.map((_, index) => index * ALL_DOCS_PAGE_SIZE),
+	};
+}
+
+function updateAllDocsCaches(
 	updater: (current: AllDocsItem[], folderKey: string) => AllDocsItem[],
 ) {
 	const queries = queryClient
 		.getQueryCache()
 		.findAll({ queryKey: navigationQueryKeys.allDocs() });
 	for (const query of queries) {
-		if (!Array.isArray(query.queryKey) || query.queryKey.length !== 3) {
+		if (!Array.isArray(query.queryKey)) {
 			continue;
 		}
-		const folderKey = normalizeAllDocsFolder(String(query.queryKey[2] ?? ""));
-		const current = queryClient.getQueryData<AllDocsItem[]>(query.queryKey);
+		if (query.queryKey.length === 3) {
+			const folderKey = normalizeAllDocsFolder(String(query.queryKey[2] ?? ""));
+			const current = queryClient.getQueryData<AllDocsItem[]>(query.queryKey);
+			if (!current) continue;
+			queryClient.setQueryData<AllDocsItem[]>(
+				query.queryKey,
+				updater(current, folderKey),
+			);
+			continue;
+		}
+		if (query.queryKey.length !== 4 || query.queryKey[2] !== "pages") {
+			continue;
+		}
+		const folderKey = normalizeAllDocsFolder(String(query.queryKey[3] ?? ""));
+		const current = queryClient.getQueryData<AllDocsPagesData>(query.queryKey);
 		if (!current) continue;
-		queryClient.setQueryData<AllDocsItem[]>(
+		const nextItems = updater(
+			current.pages.flatMap((page) => page.items),
+			folderKey,
+		);
+		queryClient.setQueryData<AllDocsPagesData>(
 			query.queryKey,
-			updater(current, folderKey),
+			rebuildAllDocsPages(current, nextItems),
 		);
 	}
 }
@@ -361,10 +368,17 @@ function findCachedAllDocsItem(path: string): AllDocsItem | null {
 		.getQueryCache()
 		.findAll({ queryKey: navigationQueryKeys.allDocs() });
 	for (const query of queries) {
-		if (!Array.isArray(query.queryKey) || query.queryKey.length !== 3) {
+		if (!Array.isArray(query.queryKey)) {
 			continue;
 		}
-		const current = queryClient.getQueryData<AllDocsItem[]>(query.queryKey);
+		const current =
+			query.queryKey.length === 3
+				? queryClient.getQueryData<AllDocsItem[]>(query.queryKey)
+				: query.queryKey.length === 4 && query.queryKey[2] === "pages"
+					? queryClient
+							.getQueryData<AllDocsPagesData>(query.queryKey)
+							?.pages.flatMap((page) => page.items)
+					: null;
 		const item = current?.find(
 			(note) => normalizeAllDocsPath(note.note_path) === normalizedPath,
 		);
@@ -376,7 +390,7 @@ function findCachedAllDocsItem(path: string): AllDocsItem | null {
 function upsertAllDocsPrefetchItem(item: AllDocsItem) {
 	const normalizedPath = normalizeAllDocsPath(item.note_path);
 	if (!normalizedPath) return;
-	updateAllDocsListCaches((current, folderKey) => {
+	updateAllDocsCaches((current, folderKey) => {
 		const withoutItem = current.filter(
 			(note) => normalizeAllDocsPath(note.note_path) !== normalizedPath,
 		);
@@ -426,7 +440,7 @@ export function optimisticallyRenameAllDocsPath(
 	if (!from || !to) return;
 	const fromTitle = titleFromAllDocsPath(from);
 	const toTitle = titleFromAllDocsPath(to);
-	updateAllDocsListCaches((current, folderKey) => {
+	updateAllDocsCaches((current, folderKey) => {
 		const next: AllDocsItem[] = [];
 		for (const note of current) {
 			const notePath = normalizeAllDocsPath(note.note_path);
@@ -458,7 +472,7 @@ export function optimisticallyRemoveAllDocsPath(
 ) {
 	const normalizedPath = normalizeAllDocsPath(path);
 	if (!normalizedPath) return;
-	updateAllDocsListCaches((current) =>
+	updateAllDocsCaches((current) =>
 		current.filter((note) => {
 			const notePath = normalizeAllDocsPath(note.note_path);
 			return (
@@ -470,11 +484,17 @@ export function optimisticallyRemoveAllDocsPath(
 }
 
 export function invalidateAllDocsPrefetch(folderPrefix?: string | null) {
+	if (typeof folderPrefix === "string" || folderPrefix === null) {
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		});
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocsPages(folderPrefix),
+		});
+		return;
+	}
 	void queryClient.invalidateQueries({
-		queryKey:
-			typeof folderPrefix === "string" || folderPrefix === null
-				? navigationQueryKeys.allDocsList(folderPrefix)
-				: navigationQueryKeys.allDocs(),
+		queryKey: navigationQueryKeys.allDocs(),
 	});
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -967,7 +967,11 @@ interface TauriCommands {
 		void
 	>;
 	all_docs_list: CommandDef<
-		{ limit?: number | null; folder_prefix?: string | null },
+		{
+			limit?: number | null;
+			offset?: number | null;
+			folder_prefix?: string | null;
+		},
 		AllDocsItem[]
 	>;
 	all_docs_count: CommandDef<{ folder_prefix?: string | null }, number>;

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -61,6 +61,21 @@
 	gap: 22px;
 }
 
+.allDocsSections.is-virtualized {
+	position: relative;
+	display: block;
+	flex: 0 0 auto;
+	min-height: 0;
+}
+
+.allDocsVirtualRow {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	will-change: transform;
+}
+
 .allDocsSection {
 	display: flex;
 	flex-direction: column;

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -450,13 +450,24 @@ input.notePropertyValue {
 
 .databaseStatusTrigger .propertyValueText {
 	min-width: 0;
-	max-width: 100%;
+	width: 100%;
 }
 
 .databaseStatusTrigger .propertyValueText > span {
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	flex: 1 1 auto;
+}
+
+.databaseCellButton.is-pill-list .propertyValueText {
+	width: 100%;
+	min-width: 0;
+}
+
+.databaseCellButton.is-pill-list .propertyValueText > span {
+	flex: 1 1 auto;
+	min-width: 0;
 }
 
 .notePropertyStatusTrigger:hover .propertyValueText,

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -31,6 +31,13 @@
 	padding: 10px 6px 12px;
 }
 
+.databaseBoardLoadMoreSentinel {
+	width: 100%;
+	height: 1px;
+	flex: 0 0 auto;
+	pointer-events: none;
+}
+
 .databaseBoardError,
 .databaseBoardEmptyText {
 	font-size: calc(var(--text-base) * 0.9);
@@ -491,4 +498,47 @@
 	min-width: 100%;
 	table-layout: fixed;
 	background: var(--bg-primary);
+}
+
+.databaseTable.is-virtualized {
+	display: grid;
+}
+
+.databaseTable.is-virtualized [data-slot="table-header"] {
+	position: sticky;
+	top: 0;
+	z-index: 8;
+	display: grid;
+	background: var(--bg-primary);
+}
+
+.databaseTable.is-virtualized [data-slot="table-body"] {
+	position: relative;
+	display: grid;
+}
+
+.databaseTable.is-virtualized [data-slot="table-body"] [data-slot="table-row"],
+.databaseTable.is-virtualized .databaseGroupHeaderRow {
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: flex;
+	width: max-content;
+	min-width: 100%;
+	background: var(--bg-primary);
+}
+
+.databaseTable.is-virtualized .databaseHeaderRow {
+	display: flex;
+	width: max-content;
+	min-width: 100%;
+}
+
+.databaseTable.is-virtualized .databaseGroupCell {
+	width: 100%;
+}
+
+.databaseTable.is-virtualized .databaseBodyCell {
+	display: flex;
+	align-items: center;
 }

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -152,6 +152,27 @@
 	padding: 2px 6px 8px;
 }
 
+.folioNotesList.is-virtualized {
+	position: relative;
+	display: block;
+}
+
+.folioNotesList.is-virtualized::before {
+	content: "";
+	display: block;
+	height: var(--folio-virtual-height, 0px);
+	pointer-events: none;
+}
+
+.folioNotesVirtualRow {
+	position: absolute;
+	top: 0;
+	left: 6px;
+	right: 6px;
+	width: auto;
+	will-change: transform;
+}
+
 .folioNoteListItem {
 	margin: 1px 0;
 	padding: 0;


### PR DESCRIPTION
## Description

Replaces eager-loading list rendering with virtualized scrolling and paginated data fetching across three major panes (All Docs, Database Table, Database Board, Folio Notes List), resolving UI jank and memory pressure when working with large collections.

### Summary of changes

**Virtual Scrolling (TanStack Virtual)**
- **All Docs pane** — Card grid is now virtualized with variable-height rows (section headers + card rows). Pane width is tracked via ResizeObserver for responsive column count.
- **Database Table** — Rows and group headers are rendered via `useVirtualizer` with fixed row estimates, eliminating DOM nodes for off-screen items.
- **Database Board** — Uses a sentinel IntersectionObserver (`useSentinelLoadMore`) to trigger page fetches when the user nears the bottom.
- **Folio Notes List** — Pinned heading, divider, and note items are all virtualized with per-item size estimates.

**Pagination / Infinite Queries (TanStack Query)**
- `useDatabaseRows` migrated from manual token-based fetch + useState to `useInfiniteQuery` with cursor-based page fetching.
- Database rows use different page sizes: 200 for table views, 48 for board views.
- All Docs migrated from a single `useQuery` loading all items (up to 2000) to `useInfiniteQuery` with 48-item pages.
- Rust `all_docs_list` command now accepts an `offset` parameter for pagination.
- New shared hooks `useVirtualLoadMore` and `useSentinelLoadMore` for triggering page fetches.

**Architecture cleanups**
- Removed `initialRows` prop threading through `DatabasesPane` → `useDatabasesPane` → `useDatabaseRows` (no longer needed with React Query cache).
- Removed manual prefetch/cache helpers (`prefetchDatabaseRows`, `getPrefetchedDatabaseRows`, `setPrefetchedDatabaseRows`).
- Extracted `DatabaseBoardLaneView` and `DatabaseBoardCardView` into `DatabaseBoardViews.tsx`.
- Removed stale "Limited to the first 200 notes" truncation notice.
- Navigation prefetch no longer eagerly loads all database rows on startup.

**Folio mode folder scoping**
- Added missing `"folder"` case to `filterNotesForScope` in `useFolioNotes` so the folder scope actually filters notes.

**Rust backend**
- `all_docs_list` now supports SQL `OFFSET` for cursor-based pagination.

### Reasoning

The app had three related performance issues:
1. Large note collections (1000s of notes / database rows) rendered all DOM nodes at once, causing janky scrolling and high memory usage.
2. Database views eagerly loaded all rows upfront, creating long wait times and a "Limited to first 200" truncation that lost the rest of the data.
3. All Docs pane loaded up to 2000 notes immediately, slowing initial render.

Virtual scrolling + paginated infinite queries address all three — only visible rows render, and data streams in on demand.

### Additional context

- Board view uses a smaller page size (48) because each row renders an entire card with drag-and-drop handles.
- The sentinel-based load-more (board) vs. virtualizer-based load-more (table, all docs) distinction exists because the board is not a single-scroll-container list — each lane scrolls independently within the board shell.
- `useSentinelLoadMore` is also suitable for other non-homogeneous scroll containers in the future.

How to contribute: https://kelpui.com/docs/getting-started/contributing/


## Screenshots

(No visual changes — this is a behind-the-scenes performance and data-fetching refactor. Scrolling UX is preserved.)


## Docs

N/A — internal architecture change, no new public API surface.


## Ready?

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * All Docs pane now features virtualized infinite-scroll rendering for seamless navigation through large document lists
  * Database board and table views now support paginated loading for handling large datasets
  * Folio notes list now uses virtualized rendering for improved responsiveness

* **Chores**
  * Version updated to 0.8.0-alpha.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->