### PR TITLE
alpha-7: YAML/properties panel & info sidebar (#186) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.0-alpha.6",
+	"version": "0.8.0-alpha.7",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/noteProperties/NotePropertiesToolbar.tsx
+++ b/src/components/editor/noteProperties/NotePropertiesToolbar.tsx
@@ -62,7 +62,7 @@ export function NotePropertiesToolbar({
 
 	return (
 		<div className="notePropertiesToolbar">
-			<div className="notePropertiesToolbarLabel">Frontmatter</div>
+			<div className="notePropertiesToolbarLabel">Properties</div>
 			<div
 				className="notePropertiesModeSwitch"
 				role="tablist"

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -6,6 +6,7 @@ import { Input } from "../../ui/shadcn/input";
 import type { EditorTextColor } from "../textColors";
 import { NotePropertyValueField } from "./NotePropertyValueField";
 import { PropertyKindBadge } from "./PropertyKindBadge";
+import { humanizePropertyKey } from "./utils";
 
 interface NotePropertyRowProps {
 	rowId: string;
@@ -43,55 +44,32 @@ export function NotePropertyRow({
 	tagInputRef,
 }: NotePropertyRowProps) {
 	const [keyDraft, setKeyDraft] = useState(property.key);
+	const [editingKey, setEditingKey] = useState(false);
 
 	useEffect(() => {
 		setKeyDraft(property.key);
 	}, [property.key]);
 
 	const commitKeyDraft = () => {
+		setEditingKey(false);
 		if (keyDraft === property.key) return;
 		onUpdate(index, { key: keyDraft });
 	};
 
 	return (
 		<div className="notePropertyRow">
-			{readOnly ? (
-				<>
-					<div className="notePropertyIdentity">
-						<PropertyKindBadge kind={property.kind} />
-						<div className="notePropertyKeyStatic">{property.key}</div>
-					</div>
-					<div className="notePropertyValueStatic">
-						<NotePropertyValueField
-							rowId={rowId}
-							index={index}
-							property={property}
-							readOnly
-							availableTags={availableTags}
-							tagDraft={tagDraft}
-							statusColors={statusColors}
-							onSetTagDraft={onSetTagDraft}
-							onAddTag={onAddTag}
-							onRemoveTag={onRemoveTag}
-							onUpdate={onUpdate}
-							onStatusColorChange={onStatusColorChange}
-							onSetTagInputRef={onSetTagInputRef}
-							tagInputRef={tagInputRef}
-						/>
-					</div>
-				</>
-			) : (
-				<>
-					<div className="notePropertyIdentity">
-						<PropertyKindBadge
-							kind={property.kind}
-							interactive
-							onSelect={(kind) => onUpdate(index, { kind })}
-						/>
+			<div className="notePropertyIdentity">
+				<PropertyKindBadge
+					kind={property.kind}
+					interactive={!readOnly}
+					onSelect={(kind) => onUpdate(index, { kind })}
+				/>
+				<div className="notePropertyKeyWrap">
+					{editingKey && !readOnly ? (
 						<Input
 							value={keyDraft}
 							className="plainTextInput notePropertyKeyInput"
-							placeholder="Property"
+							placeholder="Key"
 							aria-label="Property name"
 							onChange={(event) => setKeyDraft(event.target.value)}
 							onBlur={commitKeyDraft}
@@ -100,38 +78,54 @@ export function NotePropertyRow({
 								event.preventDefault();
 								event.currentTarget.blur();
 							}}
+							autoFocus
 						/>
-					</div>
-					<div className="notePropertyValue">
-						<NotePropertyValueField
-							rowId={rowId}
-							index={index}
-							property={property}
-							readOnly={false}
-							availableTags={availableTags}
-							tagDraft={tagDraft}
-							statusColors={statusColors}
-							onSetTagDraft={onSetTagDraft}
-							onAddTag={onAddTag}
-							onRemoveTag={onRemoveTag}
-							onUpdate={onUpdate}
-							onStatusColorChange={onStatusColorChange}
-							onSetTagInputRef={onSetTagInputRef}
-							tagInputRef={tagInputRef}
-						/>
-					</div>
-					<Button
-						type="button"
-						size="icon-sm"
-						variant="ghost"
-						className="notePropertyRemoveButton"
-						onClick={() => onRemove(index)}
-						aria-label={`Remove ${property.key || "property"}`}
-					>
-						<X size="var(--icon-xs)" />
-					</Button>
-				</>
-			)}
+					) : (
+						<button
+							type="button"
+							className="notePropertyKeyLabel"
+							onClick={() => {
+								if (!readOnly) setEditingKey(true);
+							}}
+							disabled={readOnly}
+						>
+							{humanizePropertyKey(property.key) || (
+								<span className="notePropertyKeyPlaceholder">Property</span>
+							)}
+						</button>
+					)}
+				</div>
+			</div>
+			<div className="notePropertyValueWrap">
+				<NotePropertyValueField
+					rowId={rowId}
+					index={index}
+					property={property}
+					readOnly={readOnly}
+					availableTags={availableTags}
+					tagDraft={tagDraft}
+					statusColors={statusColors}
+					onSetTagDraft={onSetTagDraft}
+					onAddTag={onAddTag}
+					onRemoveTag={onRemoveTag}
+					onUpdate={onUpdate}
+					onStatusColorChange={onStatusColorChange}
+					onSetTagInputRef={onSetTagInputRef}
+					tagInputRef={tagInputRef}
+				/>
+			</div>
+			{!readOnly ? (
+				<Button
+					type="button"
+					size="icon-sm"
+					variant="ghost"
+					className="notePropertyRemoveButton"
+					onClick={() => onRemove(index)}
+					aria-label={`Remove ${property.key || "property"}`}
+				>
+					<X size="var(--icon-xs)" />
+				</Button>
+			) : null}
 		</div>
 	);
 }

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -24,7 +24,12 @@ import { Input } from "../../ui/shadcn/input";
 import { useWikiLinkAutocomplete } from "../hooks/useWikiLinkAutocomplete";
 import { EDITOR_TEXT_COLORS, type EditorTextColor } from "../textColors";
 import { WikiLinkedText } from "./WikiLinkedText";
-import { buildTagSuggestions, formatTagLabel } from "./utils";
+import {
+	buildTagSuggestions,
+	formatPropertyDate,
+	formatTagLabel,
+	tagHueFromName,
+} from "./utils";
 
 interface NotePropertyValueFieldProps {
 	rowId: string;
@@ -97,25 +102,68 @@ export function NotePropertyValueField({
 			);
 		}
 		if (property.kind === "tags") {
+			if (property.value_list.length === 0) {
+				return <span className="notePropertyEmptyValue">—</span>;
+			}
 			return (
 				<div className="notePropertyPills">
-					{property.value_list.map((value, valueIndex) => (
-						<span
-							key={`${property.key || rowId}-${valueIndex}-${value}`}
-							className="notePropertyPill"
-						>
-							{formatTagLabel(value)}
-						</span>
-					))}
+					{property.value_list.map((value, valueIndex) => {
+						const hue = tagHueFromName(value);
+						return (
+							<span
+								key={`${property.key || rowId}-${valueIndex}-${value}`}
+								className="notePropertyPill"
+								style={
+									{
+										"--tag-pill-hue": `${hue}`,
+									} as CSSProperties
+								}
+							>
+								{value.startsWith("#") ? value.slice(1) : value}
+							</span>
+						);
+					})}
 				</div>
 			);
 		}
 		if (property.kind === "checkbox") {
-			return property.value_bool ? "True" : "False";
+			return (
+				<span className="notePropertyEmptyValue">
+					{property.value_bool ? "Yes" : "No"}
+				</span>
+			);
+		}
+		if (property.kind === "date") {
+			const formatted = formatPropertyDate(property.value_text ?? "");
+			if (!formatted) {
+				return <span className="notePropertyEmptyValue">—</span>;
+			}
+			return <span className="notePropertyDateValue">{formatted}</span>;
+		}
+		if (property.kind === "url") {
+			const url = property.value_text ?? "";
+			if (!url) {
+				return <span className="notePropertyEmptyValue">—</span>;
+			}
+			return (
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="notePropertyLinkValue"
+					onClick={(event) => event.stopPropagation()}
+				>
+					{url}
+				</a>
+			);
+		}
+		const text = property.value_text ?? "";
+		if (!text) {
+			return <span className="notePropertyEmptyValue">—</span>;
 		}
 		return (
-			<span style={{ color: "var(--text-primary)" }}>
-				<WikiLinkedText value={property.value_text ?? ""} />
+			<span className="notePropertyTextValue">
+				<WikiLinkedText value={text} />
 			</span>
 		);
 	}
@@ -269,19 +317,28 @@ export function NotePropertyValueField({
 						tagInputRef?.focus();
 					}}
 				>
-					{property.value_list.map((value, valueIndex) => (
-						<button
-							key={`${property.key || rowId}-${valueIndex}-${value}`}
-							type="button"
-							className="notePropertyToken"
-							onClick={() => onRemoveTag(index, value)}
-							title={`Remove ${formatTagLabel(value)}`}
-							aria-label={`Remove ${formatTagLabel(value)}`}
-						>
-							<span>{formatTagLabel(value)}</span>
-							<X size="var(--icon-xs)" />
-						</button>
-					))}
+					{property.value_list.map((value, valueIndex) => {
+						const hue = tagHueFromName(value);
+						const label = value.startsWith("#") ? value.slice(1) : value;
+						return (
+							<button
+								key={`${property.key || rowId}-${valueIndex}-${value}`}
+								type="button"
+								className="notePropertyToken"
+								style={
+									{
+										"--tag-pill-hue": `${hue}`,
+									} as CSSProperties
+								}
+								onClick={() => onRemoveTag(index, value)}
+								title={`Remove ${label}`}
+								aria-label={`Remove ${label}`}
+							>
+								<span>{label}</span>
+								<X size="var(--icon-xs)" />
+							</button>
+						);
+					})}
 					<input
 						ref={(node) => onSetTagInputRef(rowId, node)}
 						type="text"
@@ -349,7 +406,7 @@ export function NotePropertyValueField({
 							: "text"
 				}
 				value={textDraft}
-				placeholder="Value"
+				placeholder={textDraft ? "" : "—"}
 				aria-label={`${property.key || "Property"} value`}
 				onChange={(event) => {
 					const nextValue = event.target.value;

--- a/src/components/editor/noteProperties/utils.ts
+++ b/src/components/editor/noteProperties/utils.ts
@@ -1,5 +1,29 @@
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 
+export function humanizePropertyKey(key: string): string {
+	if (!key) return "";
+	return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function tagHueFromName(name: string): number {
+	let hash = 0;
+	for (let i = 0; i < name.length; i++) {
+		hash = name.charCodeAt(i) + ((hash << 5) - hash);
+	}
+	return Math.abs(hash) % 360;
+}
+
+export function formatPropertyDate(value: string): string {
+	if (!value) return "";
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return value;
+	return parsed.toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
 export function emptyProperty(): NoteProperty {
 	return {
 		key: "",

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -1,4 +1,8 @@
-import { BadgeInfoIcon, GitBranchIcon } from "@hugeicons/core-free-icons";
+import {
+	BadgeInfoIcon,
+	GitBranchIcon,
+	InformationCircleIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
@@ -388,40 +392,51 @@ export function NotesInfoSidebar({
 							)}
 						</section>
 
-						<section className="markdownEditorInfoSection">
-							<h3 className="markdownEditorInfoSectionLabel">File info</h3>
+						<section className="markdownEditorInfoSection markdownEditorInfoSectionFile">
+							<h3 className="markdownEditorInfoSectionLabel markdownEditorInfoSectionLabelSubtle">
+								<HugeiconsIcon
+									icon={InformationCircleIcon}
+									size="var(--icon-sm)"
+									strokeWidth={1}
+								/>
+								Info
+							</h3>
 							<div className="markdownEditorInfoRows">
 								<div className="markdownEditorInfoRow">
-									<span>Path</span>
-									<span className="markdownEditorInfoPathValue">{relPath}</span>
-								</div>
-								<div className="markdownEditorInfoRow">
 									<span>Modified</span>
-									<strong>
+									<span className="markdownEditorInfoValue">
 										{formatMetadataDate(
 											lastSavedMtimeMs
 												? new Date(lastSavedMtimeMs).toISOString()
 												: (previewContext?.updated ?? null),
 										)}
-									</strong>
+									</span>
 								</div>
 								<div className="markdownEditorInfoRow">
 									<span>Created</span>
-									<strong>{formatMetadataDate(previewContext?.created)}</strong>
+									<span className="markdownEditorInfoValue">
+										{formatMetadataDate(previewContext?.created)}
+									</span>
+								</div>
+								<div className="markdownEditorInfoRow">
+									<span>Path</span>
+									<span className="markdownEditorInfoPathValue">{relPath}</span>
 								</div>
 								<div className="markdownEditorInfoRow">
 									<span>Lines</span>
-									<strong>
+									<span className="markdownEditorInfoValue">
 										{(previewContext?.line_count ?? lineCount).toLocaleString()}
-									</strong>
+									</span>
 								</div>
 								<div className="markdownEditorInfoRow">
 									<span>Size</span>
-									<strong>{formatFileSize(utf8SizeBytes)}</strong>
+									<span className="markdownEditorInfoValue">
+										{formatFileSize(utf8SizeBytes)}
+									</span>
 								</div>
 								<div className="markdownEditorInfoRow">
 									<span>Save status</span>
-									<strong>{saveLabel}</strong>
+									<span className="markdownEditorInfoValue">{saveLabel}</span>
 								</div>
 							</div>
 						</section>

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -132,7 +132,7 @@
 .notesInfoSidebarHost[data-open="true"] {
 	flex-basis: var(--markdown-info-sidebar-width, 340px);
 	width: var(--markdown-info-sidebar-width, 340px);
-	padding: 0;
+	padding: 8px 0 0 0;
 	background: transparent;
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;
@@ -141,7 +141,7 @@
 
 :root[data-translucent-sidebar="false"]
 	.notesInfoSidebarHost[data-open="true"] {
-	padding: 0;
+	padding: 8px 0 0 0;
 	background: var(--bg-sidebar);
 	backdrop-filter: none;
 	-webkit-backdrop-filter: none;

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -305,7 +305,7 @@
 	margin: 0 auto 6px;
 	border: none;
 	border-radius: 8px;
-	padding: 7px 10px;
+	padding: 5px 10px;
 	background: color-mix(in srgb, var(--bg-secondary) 54%, transparent);
 	color: var(--text-secondary);
 	font-size: calc(var(--text-base) * 0.9);

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -39,7 +39,7 @@
 .notePropertiesPanel {
 	display: flex;
 	flex-direction: column;
-	gap: 6px;
+	gap: 4px;
 	font-family: var(--font-sans);
 }
 
@@ -53,11 +53,11 @@
 }
 
 .notePropertiesToolbarLabel {
-	font-size: calc(var(--text-base) * 0.8);
+	font-size: calc(var(--text-base) * 0.92);
 	font-weight: var(--font-semibold);
-	letter-spacing: 0.035em;
-	text-transform: uppercase;
-	color: var(--text-tertiary);
+	letter-spacing: -0.01em;
+	text-transform: none;
+	color: var(--text-primary);
 	font-family: var(--font-sans);
 	line-height: 1.15;
 }
@@ -132,6 +132,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0;
+	padding-top: 0;
 }
 
 .notePropertyAddWrap {
@@ -141,12 +142,29 @@
 }
 
 .notePropertyRow {
+	position: relative;
 	display: grid;
-	grid-template-columns: minmax(100px, 0.4fr) minmax(0, 1.45fr) auto;
-	align-items: start;
-	gap: 6px;
-	padding: 3px 0;
+	grid-template-columns: minmax(90px, 0.44fr) minmax(0, 1fr);
+	align-items: center;
+	gap: 12px;
+	padding: 4px 24px 4px 0;
 	transition: background var(--transition-fast);
+}
+
+.notePropertyRow .notePropertyIdentity {
+	gap: 8px;
+}
+
+.notePropertyRow .notePropertyKindBadge {
+	padding: 0;
+	width: 18px;
+	justify-content: center;
+}
+
+.notePropertyRow .notePropertyKindBadge svg {
+	color: var(--text-tertiary);
+	width: var(--icon-sm);
+	height: var(--icon-sm);
 }
 
 .notePropertyIdentity {
@@ -171,10 +189,46 @@
 	line-height: 1.35;
 }
 
+.notePropertyKeyWrap {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.notePropertyKeyLabel {
+	display: block;
+	padding: 0;
+	border: none;
+	background: transparent;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.9);
+	font-weight: var(--font-normal);
+	font-family: var(--font-sans);
+	line-height: 1.35;
+	text-align: left;
+	cursor: default;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.notePropertyKeyLabel:not(:disabled):hover {
+	color: var(--text-primary);
+	cursor: text;
+}
+
+.notePropertyKeyPlaceholder {
+	color: var(--text-tertiary);
+}
+
 .notePropertyKeyInput {
 	flex: 1 1 auto;
-	font-weight: var(--font-medium);
-	color: var(--text-secondary);
+	font-weight: var(--font-normal);
+	color: var(--text-primary);
+	padding: 0;
+	height: 22px;
+	font-size: calc(var(--text-base) * 0.85);
 }
 
 .notePropertyFieldInput,
@@ -211,15 +265,19 @@ input.notePropertyValue {
 	outline: none;
 }
 
-.notePropertyKeyStatic {
-	font-weight: var(--font-medium);
-	color: var(--text-secondary);
+.notePropertyFieldInput.notePropertyFieldInput:focus-visible,
+.notePropertyKeyInput.notePropertyKeyInput:focus-visible {
+	box-shadow: none;
+	outline: none;
+	border: 0;
+}
+
+.notePropertyValueWrap {
+	color: var(--text-primary);
 	min-width: 0;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	overflow-wrap: break-word;
 	font-size: calc(var(--text-base) * 0.9);
-	letter-spacing: 0;
+	line-height: 1.35;
 }
 
 .notePropertyValue {
@@ -242,14 +300,6 @@ input.notePropertyValue {
 	width: 280px;
 	max-width: min(280px, calc(100vw - 40px));
 	z-index: 40;
-}
-
-.notePropertyValueStatic {
-	color: var(--text-primary);
-	min-width: 0;
-	overflow-wrap: break-word;
-	font-size: calc(var(--text-base) * 0.9);
-	line-height: 1.35;
 }
 
 .notePropertyWikiText {
@@ -375,19 +425,25 @@ input.notePropertyValue {
 }
 
 .notePropertyPill {
+	--tag-pill-hue: 0;
+
 	display: inline-flex;
 	align-items: center;
 	height: 22px;
 	max-width: 100%;
-	padding: 0 7px;
+	padding: 0 8px;
 	border: 0;
-	border-radius: 4px;
+	border-radius: var(--radius-sm);
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 8%,
+		hsl(var(--tag-pill-hue) 70% 45%) 10%,
 		var(--bg-secondary)
 	);
-	color: color-mix(in srgb, var(--interactive-accent) 62%, var(--text-primary));
+	color: color-mix(
+		in srgb,
+		hsl(var(--tag-pill-hue) 70% 40%) 70%,
+		var(--text-primary)
+	);
 	font-family: var(--font-sans);
 	font-size: var(--text-xs);
 	font-weight: var(--font-semibold);
@@ -546,18 +602,26 @@ input.notePropertyValue {
 }
 
 .notePropertyToken {
-	--pill-tone: var(--interactive-accent);
+	--tag-pill-hue: 0;
 
 	display: inline-flex;
 	align-items: center;
 	gap: 3px;
 	max-width: 100%;
 	height: 22px;
-	padding: 0 7px;
+	padding: 0 8px;
 	border: 0;
-	border-radius: 4px;
-	background: color-mix(in srgb, var(--pill-tone) 10%, var(--bg-secondary));
-	color: color-mix(in srgb, var(--pill-tone) 68%, var(--text-primary));
+	border-radius: var(--radius-sm);
+	background: color-mix(
+		in srgb,
+		hsl(var(--tag-pill-hue) 70% 45%) 10%,
+		var(--bg-secondary)
+	);
+	color: color-mix(
+		in srgb,
+		hsl(var(--tag-pill-hue) 70% 40%) 70%,
+		var(--text-primary)
+	);
 	font-family: var(--font-sans);
 	font-size: var(--text-xs);
 	font-weight: var(--font-semibold);
@@ -569,8 +633,16 @@ input.notePropertyValue {
 
 .notePropertyToken:hover,
 .notePropertyToken:focus-visible {
-	background: color-mix(in srgb, var(--pill-tone) 16%, var(--bg-secondary));
-	color: color-mix(in srgb, var(--pill-tone) 78%, var(--text-primary));
+	background: color-mix(
+		in srgb,
+		hsl(var(--tag-pill-hue) 70% 45%) 16%,
+		var(--bg-secondary)
+	);
+	color: color-mix(
+		in srgb,
+		hsl(var(--tag-pill-hue) 70% 40%) 78%,
+		var(--text-primary)
+	);
 }
 
 .notePropertyToken > span {
@@ -583,6 +655,15 @@ input.notePropertyValue {
 .notePropertyToken svg {
 	color: currentcolor;
 	flex-shrink: 0;
+	opacity: 0;
+	width: 10px;
+	height: 10px;
+	transition: opacity 120ms ease;
+}
+
+.notePropertyToken:hover svg,
+.notePropertyToken:focus-visible svg {
+	opacity: 1;
 }
 
 .notePropertyTagField {
@@ -706,9 +787,11 @@ input.notePropertyValue {
 }
 
 .notePropertyRemoveButton {
+	position: absolute;
+	right: 0;
+	top: 50%;
+	transform: translateY(-50%);
 	opacity: 0;
-	align-self: center;
-	margin-top: 0;
 	width: 18px;
 	height: 18px;
 	min-width: 18px;
@@ -733,18 +816,22 @@ input.notePropertyValue {
 
 @media (max-width: 720px) {
 	.notePropertyRow {
-		grid-template-columns: 1fr auto;
-		align-items: start;
+		grid-template-columns: 1fr;
+		gap: 3px;
+		padding-right: 24px;
 	}
 
 	.notePropertyIdentity,
-	.notePropertyValue {
+	.notePropertyValueWrap {
 		grid-column: 1 / 2;
 	}
 
 	.notePropertyRemoveButton {
 		grid-column: 2 / 3;
 		grid-row: 1 / 3;
+		position: static;
+		transform: none;
+		align-self: center;
 	}
 
 	.notePropertyIdentity {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -658,7 +658,12 @@
 
 .markdownEditorInfoSectionFrontmatter {
 	padding-top: 2px;
-	padding-bottom: 14px;
+	padding-bottom: 8px;
+}
+
+.markdownEditorInfoSectionFile {
+	padding-top: 6px;
+	border-top: 1px solid color-mix(in srgb, var(--border-light) 50%, transparent);
 }
 
 .markdownEditorInfoSectionLabel {
@@ -669,6 +674,22 @@
 	text-transform: uppercase;
 	color: var(--text-tertiary);
 	line-height: 1.15;
+}
+
+.markdownEditorInfoSectionLabelSubtle {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: var(--font-normal);
+	font-size: calc(var(--text-base) * 0.85);
+	color: var(--text-secondary);
+}
+
+.markdownEditorInfoValue {
+	font-weight: var(--font-normal);
+	color: var(--text-primary);
 }
 
 .markdownEditorInfoRows {
@@ -690,6 +711,10 @@
 .markdownEditorInfoRow strong {
 	font-weight: var(--font-medium);
 	color: var(--text-primary);
+}
+
+.markdownEditorInfoSectionFile .markdownEditorInfoRow {
+	font-size: calc(var(--text-base) * 0.88);
 }
 
 .markdownEditorInfoRow code {


### PR DESCRIPTION
## Description

Cleans up the properties panel (formerly "Frontmatter") and the note info sidebar ahead of the alpha.7 release. The properties editing experience is now more polished with a unified read/edit view, click-to-edit key labels, deterministic tag pill colors, and proper rendering for date/URL/checkbox property kinds.

### Summary of changes

- **Version bump**: `0.8.0-alpha.6` → `0.8.0-alpha.7`
- **Properties panel**:
  - Renamed "Frontmatter" label → "Properties"
  - Unified read-only and edit modes in `NotePropertyRow` — removed the branching layout, now uses click-to-edit key labels with `humanizePropertyKey` (snake_case/kebab-case → Title Case)
  - Tag pills now get a deterministic HSL hue from `tagHueFromName` (hash of tag name → 0–360°) instead of being monochrome
  - Empty values show `—` placeholder across all property kinds
  - Date kind renders as a locale-formatted date string
  - URL kind renders as a clickable link (`target="_blank", rel="noopener noreferrer"`)
  - Checkbox kind shows "Yes"/"No" instead of "True"/"False"
  - Remove button is now absolutely positioned within each row, appears on row hover
  - Tag token remove (X) button hidden by default, revealed on hover/focus
  - Cleaner focus-visible styles (no browser outline on property inputs)
  - Responsive layout improved for narrow widths (single column)
- **Info sidebar**:
  - "File info" renamed to "Info" with an info icon
  - Fields reordered: Modified, Created, Path, Lines, Size, Save status
  - Removed `<strong>` tags — consistent styling via `.markdownEditorInfoValue`
  - Added visual separator (top border) between sections
- **CSS refinements**: spacing, typography sizing, reduced visual noise throughout

### Reasoning

These changes make the properties panel feel more cohesive and production-ready. The old read/edit branching produced duplicated JSX and a disjointed experience. Deterministic tag hues add visual scanning utility without requiring user configuration. The info sidebar was inconsistent with the rest of the UI (used `<strong>` in some spots, mismatched label styling).

## Screenshots

(No visual changes.)

## Docs

No documentation changes needed — these are internal UI refinements with no API surface changes.

## Ready?

- [x] Ran the linter to ensure style guidelines were followed
- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Created a demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced note property value rendering: colored tag pills (with better empty states), Yes/No checkboxes, localized date formatting, and improved URL display with external links.
  * Refined property key editing so keys toggle more smoothly into edit mode and commit cleanly.
* **UI/UX**
  * Updated the editor toolbar label from “Frontmatter” to “Properties”.
  * Refreshed note properties and file-info sidebar styling (spacing, focus visuals, responsive layout).
* **Version**
  * Updated to **0.8.0-alpha.7**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->