### PR TITLE
Lazy-load editor previews & debounced rawmd (#189) [Release]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.pnpm-store
 dist
 dist-ssr
 *.local

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.0",
+	"version": "0.8.1-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/editorCommands.tsx
+++ b/src/components/app/editorCommands.tsx
@@ -1,7 +1,7 @@
 import {
-	MessagePreview02Icon,
+	CodeIcon,
+	EyeIcon,
 	PencilEdit02Icon,
-	Raw02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { dispatchEditorMenuAction } from "../../lib/appEvents";
@@ -27,13 +27,13 @@ const VIEW_MODE_COMMANDS = [
 		id: "switch-to-preview",
 		label: "Preview Mode",
 		mode: "preview",
-		icon: MessagePreview02Icon,
+		icon: EyeIcon,
 	},
 	{
 		id: "switch-to-raw",
 		label: "Raw Mode",
 		mode: "plain",
-		icon: Raw02Icon,
+		icon: CodeIcon,
 	},
 ] as const;
 

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -6,7 +6,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { EditorViewMode } from "../../lib/editorMode";
 
-const LARGE_NOTE_MODE_HINT = "Too large for Rich or Preview";
+const LARGE_NOTE_MODE_HINT = "May be slow on large notes";
 
 const VIEW_MODES = [
 	{ id: "plain" as const, label: "Raw", icon: CodeIcon },
@@ -21,39 +21,36 @@ const VIEW_MODES = [
 interface EditorViewModeSwitchProps {
 	mode: EditorViewMode;
 	onModeChange: (mode: EditorViewMode) => void;
-	plainOnly?: boolean;
+	largeNote?: boolean;
 }
 
 export function EditorViewModeSwitch({
 	mode,
 	onModeChange,
-	plainOnly = false,
+	largeNote = false,
 }: EditorViewModeSwitchProps) {
 	return (
 		<div
 			className="markdownEditorModeSwitch"
-			role="tablist"
+			role="group"
 			aria-label="Editor mode"
 		>
 			{VIEW_MODES.map((item) => {
-				const disabled = plainOnly && item.id !== "plain";
-				const hint = disabled ? LARGE_NOTE_MODE_HINT : item.label;
+				const showLargeNoteHint = largeNote && item.id !== "plain";
+				const hint = showLargeNoteHint ? LARGE_NOTE_MODE_HINT : item.label;
 
 				return (
 					<span
 						key={item.id}
 						className="markdownEditorModeBtnWrap"
-						data-disabled={disabled || undefined}
+						data-caution={showLargeNoteHint || undefined}
 					>
 						<button
 							type="button"
-							role="tab"
 							className="markdownEditorModeBtn"
-							aria-selected={mode === item.id}
 							aria-pressed={mode === item.id}
 							aria-label={item.label}
 							data-active={mode === item.id || undefined}
-							disabled={disabled}
 							onClick={() => onModeChange(item.id)}
 						>
 							<HugeiconsIcon
@@ -64,7 +61,7 @@ export function EditorViewModeSwitch({
 						</button>
 						<span
 							className="markdownEditorModeBtnHint"
-							data-warning={disabled || undefined}
+							data-warning={showLargeNoteHint || undefined}
 							role="tooltip"
 						>
 							{hint}

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -1,0 +1,77 @@
+import {
+	CodeIcon,
+	EyeIcon,
+	PencilEdit02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { EditorViewMode } from "../../lib/editorMode";
+
+const LARGE_NOTE_MODE_HINT = "Too large for Rich or Preview";
+
+const VIEW_MODES = [
+	{ id: "plain" as const, label: "Raw", icon: CodeIcon },
+	{ id: "rich" as const, label: "Rich", icon: PencilEdit02Icon },
+	{
+		id: "preview" as const,
+		label: "Preview",
+		icon: EyeIcon,
+	},
+] as const;
+
+interface EditorViewModeSwitchProps {
+	mode: EditorViewMode;
+	onModeChange: (mode: EditorViewMode) => void;
+	plainOnly?: boolean;
+}
+
+export function EditorViewModeSwitch({
+	mode,
+	onModeChange,
+	plainOnly = false,
+}: EditorViewModeSwitchProps) {
+	return (
+		<div
+			className="markdownEditorModeSwitch"
+			role="tablist"
+			aria-label="Editor mode"
+		>
+			{VIEW_MODES.map((item) => {
+				const disabled = plainOnly && item.id !== "plain";
+				const hint = disabled ? LARGE_NOTE_MODE_HINT : item.label;
+
+				return (
+					<span
+						key={item.id}
+						className="markdownEditorModeBtnWrap"
+						data-disabled={disabled || undefined}
+					>
+						<button
+							type="button"
+							role="tab"
+							className="markdownEditorModeBtn"
+							aria-selected={mode === item.id}
+							aria-pressed={mode === item.id}
+							aria-label={item.label}
+							data-active={mode === item.id || undefined}
+							disabled={disabled}
+							onClick={() => onModeChange(item.id)}
+						>
+							<HugeiconsIcon
+								icon={item.icon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+						</button>
+						<span
+							className="markdownEditorModeBtnHint"
+							data-warning={disabled || undefined}
+							role="tooltip"
+						>
+							{hint}
+						</span>
+					</span>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -32,7 +32,7 @@ export function EditorViewModeSwitch({
 	return (
 		<div
 			className="markdownEditorModeSwitch"
-			role="group"
+			role="toolbar"
 			aria-label="Editor mode"
 		>
 			{VIEW_MODES.map((item) => {

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -125,6 +125,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	pasteMarkdownBehavior = "plain-text",
 	onRegisterCalloutInserter,
 	onEditorReady,
+	onRawEditorReady,
 	onChange,
 	onFrontmatterCommit,
 	extractToNoteActions,
@@ -164,6 +165,13 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		null,
 	);
 	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
+	const handleRawEditorRef = useCallback(
+		(editor: RawMarkdownEditorHandle | null) => {
+			rawEditorRef.current = editor;
+			onRawEditorReady?.(editor);
+		},
+		[onRawEditorReady],
+	);
 	const previousRelPathRef = useRef(relPath);
 
 	useEffect(() => {
@@ -619,7 +627,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				{mode === "plain" ? (
 					<RawMarkdownEditor
 						key={relPath}
-						ref={rawEditorRef}
+						ref={handleRawEditorRef}
 						markdown={markdown}
 						relPath={relPath}
 						onChange={onChange}

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -618,6 +618,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				) : null}
 				{mode === "plain" ? (
 					<RawMarkdownEditor
+						key={relPath}
 						ref={rawEditorRef}
 						markdown={markdown}
 						relPath={relPath}

--- a/src/components/editor/extensions/mermaidPreview.ts
+++ b/src/components/editor/extensions/mermaidPreview.ts
@@ -27,6 +27,35 @@ const mermaidPreviewPluginKey = new PluginKey<MermaidPreviewPluginState>(
 type MermaidPreviewMeta = { type: "refresh" };
 
 const canvasDestroyCallbacks = new WeakMap<HTMLElement, () => void>();
+const MERMAID_HYDRATION_ROOT_MARGIN = "640px 0px";
+const mermaidHydrationCallbacks = new WeakMap<Element, () => void>();
+let mermaidHydrationObserver: IntersectionObserver | null = null;
+
+function observeMermaidHydration(element: HTMLElement, hydrate: () => void) {
+	if (typeof IntersectionObserver === "undefined") return false;
+	if (!mermaidHydrationObserver) {
+		mermaidHydrationObserver = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (!entry.isIntersecting) continue;
+					const callback = mermaidHydrationCallbacks.get(entry.target);
+					mermaidHydrationObserver?.unobserve(entry.target);
+					mermaidHydrationCallbacks.delete(entry.target);
+					callback?.();
+				}
+			},
+			{ rootMargin: MERMAID_HYDRATION_ROOT_MARGIN },
+		);
+	}
+	mermaidHydrationCallbacks.set(element, hydrate);
+	mermaidHydrationObserver.observe(element);
+	return true;
+}
+
+function unobserveMermaidHydration(element: HTMLElement) {
+	mermaidHydrationObserver?.unobserve(element);
+	mermaidHydrationCallbacks.delete(element);
+}
 
 function selectionTouchesNode(
 	selection: Selection,
@@ -114,6 +143,49 @@ function buildMermaidCanvasWidget({
 	return mount.element;
 }
 
+function createLazyMermaidCanvasWidget(
+	options: Parameters<typeof buildMermaidCanvasWidget>[0],
+): HTMLElement {
+	const placeholder = document.createElement("div");
+	placeholder.className = "mermaidCanvasWidget mermaidCanvasPlaceholder";
+	placeholder.setAttribute("aria-busy", "true");
+	const frame = document.createElement("div");
+	frame.className = "mermaidCanvasFrame";
+	frame.setAttribute("aria-hidden", "true");
+	placeholder.append(frame);
+
+	let hydrated = false;
+	let destroyed = false;
+	let destroyHydratedCanvas: (() => void) | null = null;
+
+	const hydrate = () => {
+		if (destroyed || hydrated) return;
+		hydrated = true;
+		unobserveMermaidHydration(placeholder);
+
+		const rendered = buildMermaidCanvasWidget(options);
+		destroyHydratedCanvas = canvasDestroyCallbacks.get(rendered) ?? null;
+		canvasDestroyCallbacks.delete(rendered);
+		for (const attribute of Array.from(rendered.attributes)) {
+			placeholder.setAttribute(attribute.name, attribute.value);
+		}
+		placeholder.removeAttribute("aria-busy");
+		placeholder.replaceChildren(...Array.from(rendered.childNodes));
+	};
+
+	if (!observeMermaidHydration(placeholder, hydrate)) {
+		hydrate();
+	}
+
+	canvasDestroyCallbacks.set(placeholder, () => {
+		destroyed = true;
+		unobserveMermaidHydration(placeholder);
+		destroyHydratedCanvas?.();
+		destroyHydratedCanvas = null;
+	});
+	return placeholder;
+}
+
 function buildMermaidPreviewDecorations(
 	doc: ProseMirrorNode,
 	selection: Selection,
@@ -146,7 +218,7 @@ function buildMermaidPreviewDecorations(
 			Decoration.widget(
 				to,
 				(view) =>
-					buildMermaidCanvasWidget({
+					createLazyMermaidCanvasWidget({
 						editable,
 						nodeSize: node.nodeSize,
 						pos,

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -317,6 +317,16 @@ export function useHydrateInlineImages(
 				resolverKind,
 			).then((dataUrl) => {
 				if (cancelled || !image.isConnected) return;
+				const currentOrigin =
+					image.getAttribute("data-glyph-origin-src")?.trim() ?? "";
+				const currentKey = currentOrigin
+					? getInlineImageCacheKey(
+							sourcePath,
+							currentOrigin,
+							getResolverKindForImage(image),
+						)
+					: "";
+				if (currentKey !== key) return;
 				if (!dataUrl) {
 					image.dataset.glyphHydrationState = "failed";
 					return;

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -5,6 +5,7 @@ import { invoke } from "../../../lib/tauri";
 const INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 const INLINE_IMAGE_CACHE_MAX = 64;
 const INLINE_IMAGE_CACHE_MAX_BYTES = 24 * 1024 * 1024;
+const INLINE_IMAGE_HYDRATION_ROOT_MARGIN = "720px 0px";
 
 const dataUrlCache = new Map<string, string>();
 const missCache = new Set<string>();
@@ -293,14 +294,52 @@ export function useHydrateInlineImages(
 		let rafId: number | null = null;
 		let root: HTMLElement | null = null;
 		let observer: MutationObserver | null = null;
+		let intersectionObserver: IntersectionObserver | null = null;
+		const observedImages = new Set<HTMLImageElement>();
 		let registeredConsumer = false;
+
+		const hydrateImage = (image: HTMLImageElement) => {
+			const current = image.getAttribute("src")?.trim() ?? "";
+			if (!current) return;
+			const originalSrc =
+				image.getAttribute("data-glyph-origin-src")?.trim() ?? current;
+			if (!originalSrc || isDirectImageUrl(originalSrc)) return;
+			if (image.getAttribute("data-glyph-origin-src") !== originalSrc) {
+				image.setAttribute("data-glyph-origin-src", originalSrc);
+			}
+			const resolverKind = getResolverKindForImage(image);
+			const key = getInlineImageCacheKey(sourcePath, originalSrc, resolverKind);
+			if (image.getAttribute("data-glyph-hydrated-key") === key) return;
+			image.dataset.glyphHydrationState = "loading";
+			void resolveInlineImageDataUrl(
+				sourcePath,
+				originalSrc,
+				resolverKind,
+			).then((dataUrl) => {
+				if (cancelled || !image.isConnected) return;
+				if (!dataUrl) {
+					image.dataset.glyphHydrationState = "failed";
+					return;
+				}
+				hydrateImageNodesInDocument(editor, originalSrc, dataUrl);
+				image.setAttribute("data-glyph-hydrated-key", key);
+				image.setAttribute("src", dataUrl);
+				image.dataset.glyphHydrationState = "ready";
+			});
+		};
 
 		const hydrateImages = () => {
 			if (!root) return;
-			const images = root.querySelectorAll("img[src]");
+			for (const observedImage of observedImages) {
+				if (observedImage.isConnected) continue;
+				intersectionObserver?.unobserve(observedImage);
+				observedImages.delete(observedImage);
+			}
+			const images = root.querySelectorAll<HTMLImageElement>("img[src]");
 			for (const image of images) {
+				image.loading = "lazy";
+				image.decoding = "async";
 				const current = image.getAttribute("src")?.trim() ?? "";
-				if (!current) continue;
 				const originalSrc =
 					image.getAttribute("data-glyph-origin-src")?.trim() ?? current;
 				if (!originalSrc || isDirectImageUrl(originalSrc)) continue;
@@ -314,16 +353,15 @@ export function useHydrateInlineImages(
 					resolverKind,
 				);
 				if (image.getAttribute("data-glyph-hydrated-key") === key) continue;
-				void resolveInlineImageDataUrl(
-					sourcePath,
-					originalSrc,
-					resolverKind,
-				).then((dataUrl) => {
-					if (cancelled || !dataUrl || !image.isConnected) return;
-					hydrateImageNodesInDocument(editor, originalSrc, dataUrl);
-					image.setAttribute("data-glyph-hydrated-key", key);
-					image.setAttribute("src", dataUrl);
-				});
+				if (image.dataset.glyphHydrationState === "loading") continue;
+				if (!intersectionObserver) {
+					hydrateImage(image);
+					continue;
+				}
+				if (observedImages.has(image)) continue;
+				image.dataset.glyphHydrationState = "pending";
+				observedImages.add(image);
+				intersectionObserver.observe(image);
 			}
 		};
 
@@ -343,6 +381,9 @@ export function useHydrateInlineImages(
 			}
 			observer?.disconnect();
 			observer = null;
+			intersectionObserver?.disconnect();
+			intersectionObserver = null;
+			observedImages.clear();
 			root = null;
 		};
 
@@ -359,6 +400,21 @@ export function useHydrateInlineImages(
 					attributes: true,
 					attributeFilter: ["src"],
 				});
+				if (typeof IntersectionObserver !== "undefined") {
+					intersectionObserver = new IntersectionObserver(
+						(entries) => {
+							for (const entry of entries) {
+								if (!entry.isIntersecting) continue;
+								const image = entry.target;
+								if (!(image instanceof HTMLImageElement)) continue;
+								intersectionObserver?.unobserve(image);
+								observedImages.delete(image);
+								hydrateImage(image);
+							}
+						},
+						{ rootMargin: INLINE_IMAGE_HYDRATION_ROOT_MARGIN },
+					);
+				}
 			}
 			scheduleHydration();
 		};

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -412,12 +412,15 @@ export function useNoteEditor({
 	onChange,
 }: UseNoteEditorOptions) {
 	const { frontmatter, editorBody } = useMemo(() => {
+		if (mode === "plain") {
+			return { frontmatter: null, editorBody: "" };
+		}
 		const split = splitYamlFrontmatter(markdown);
 		return {
 			...split,
 			editorBody: preprocessMarkdownForEditor(split.body),
 		};
-	}, [markdown]);
+	}, [markdown, mode]);
 
 	const frontmatterRef = useRef(frontmatter);
 	const lastAppliedBodyRef = useRef(editorBody);
@@ -770,7 +773,6 @@ export function useNoteEditor({
 
 	useEffect(() => {
 		if (!editor) return;
-		if (markdown === lastEmittedMarkdownRef.current) return;
 		if (editorBody === lastAppliedBodyRef.current) return;
 		flushMarkdownSync(relPath);
 		suppressUpdateRef.current = true;

--- a/src/components/editor/raw/RawMarkdownEditor.tsx
+++ b/src/components/editor/raw/RawMarkdownEditor.tsx
@@ -93,6 +93,11 @@ export const RawMarkdownEditor = forwardRef<
 		}
 		const currentMarkdown = view.state.doc.toString();
 		lastEmittedMarkdownRef.current = markdown;
+		if (changeTimerRef.current !== null) {
+			window.clearTimeout(changeTimerRef.current);
+			changeTimerRef.current = null;
+		}
+		hasPendingChangeRef.current = false;
 
 		const currentSelection = view.state.selection.main;
 		const nextLength = markdown.length;

--- a/src/components/editor/raw/RawMarkdownEditor.tsx
+++ b/src/components/editor/raw/RawMarkdownEditor.tsx
@@ -12,6 +12,8 @@ import {
 } from "./extensions";
 import type { RawMarkdownEditorHandle } from "./types";
 
+const RAW_MARKDOWN_CHANGE_DEBOUNCE_MS = 120;
+
 interface RawMarkdownEditorProps {
 	markdown: string;
 	relPath?: string;
@@ -28,6 +30,9 @@ export const RawMarkdownEditor = forwardRef<
 	const initialMarkdownRef = useRef(markdown);
 	const previousRelPathRef = useRef(relPath);
 	const relPathRef = useRef(relPath);
+	const changeTimerRef = useRef<number | null>(null);
+	const hasPendingChangeRef = useRef(false);
+	const lastEmittedMarkdownRef = useRef(markdown);
 
 	onChangeRef.current = onChange;
 	relPathRef.current = relPath;
@@ -35,14 +40,34 @@ export const RawMarkdownEditor = forwardRef<
 	useLayoutEffect(() => {
 		const host = hostRef.current;
 		if (!host) return;
+		const flushPendingChange = () => {
+			if (changeTimerRef.current !== null) {
+				window.clearTimeout(changeTimerRef.current);
+				changeTimerRef.current = null;
+			}
+			if (!hasPendingChangeRef.current) return;
+			hasPendingChangeRef.current = false;
+			const currentView = viewRef.current;
+			if (!currentView) return;
+			const nextMarkdown = currentView.state.doc.toString();
+			lastEmittedMarkdownRef.current = nextMarkdown;
+			onChangeRef.current(nextMarkdown);
+		};
 
 		const view = new EditorView({
 			parent: host,
 			state: EditorState.create({
 				doc: initialMarkdownRef.current,
 				extensions: createRawMarkdownExtensions(
-					(nextMarkdown) => {
-						onChangeRef.current(nextMarkdown);
+					() => {
+						hasPendingChangeRef.current = true;
+						if (changeTimerRef.current !== null) {
+							window.clearTimeout(changeTimerRef.current);
+						}
+						changeTimerRef.current = window.setTimeout(
+							flushPendingChange,
+							RAW_MARKDOWN_CHANGE_DEBOUNCE_MS,
+						);
 					},
 					() => relPathRef.current ?? "",
 				),
@@ -51,6 +76,7 @@ export const RawMarkdownEditor = forwardRef<
 		viewRef.current = view;
 
 		return () => {
+			flushPendingChange();
 			viewRef.current = null;
 			view.destroy();
 		};
@@ -59,11 +85,14 @@ export const RawMarkdownEditor = forwardRef<
 	useLayoutEffect(() => {
 		const view = viewRef.current;
 		if (!view) return;
-		const currentMarkdown = view.state.doc.toString();
 		const didChangeDocument = previousRelPathRef.current !== relPath;
 		previousRelPathRef.current = relPath;
 
-		if (currentMarkdown === markdown && !didChangeDocument) return;
+		if (markdown === lastEmittedMarkdownRef.current && !didChangeDocument) {
+			return;
+		}
+		const currentMarkdown = view.state.doc.toString();
+		lastEmittedMarkdownRef.current = markdown;
 
 		const currentSelection = view.state.selection.main;
 		const nextLength = markdown.length;

--- a/src/components/editor/raw/extensions.ts
+++ b/src/components/editor/raw/extensions.ts
@@ -192,7 +192,7 @@ function moveTableCell(direction: 1 | -1): Command {
 }
 
 export function createRawMarkdownExtensions(
-	onChange: (markdown: string) => void,
+	onChange: () => void,
 	getRelPath: () => string,
 ): Extension[] {
 	return [
@@ -233,7 +233,7 @@ export function createRawMarkdownExtensions(
 					transaction.annotation(externalRawMarkdownUpdate) === true,
 			);
 			if (update.docChanged && !isExternalUpdate) {
-				onChange(update.state.doc.toString());
+				onChange();
 			}
 		}),
 		keymap.of([

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -1,5 +1,6 @@
 import type { Editor } from "@tiptap/core";
 import type { EditorViewMode } from "../../lib/editorMode";
+import type { RawMarkdownEditorHandle } from "./raw/types";
 
 export type NoteInlineEditorMode = EditorViewMode;
 export type PasteMarkdownBehavior = "plain-text" | "smart-markdown";
@@ -32,4 +33,7 @@ export interface NoteInlineEditorProps {
 		| ((inserter: ((type: string) => void) | null) => void)
 		| undefined;
 	onEditorReady?: ((editor: Editor | null) => void) | undefined;
+	onRawEditorReady?:
+		| ((editor: RawMarkdownEditorHandle | null) => void)
+		| undefined;
 }

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -132,14 +132,27 @@ describe("FileTreePane", () => {
 		container.remove();
 	});
 
-	it("renders pinned files above the tree and toggles the section", async () => {
+	it("renders pinned files in the tree without duplicating a pinned section", async () => {
 		const onOpenFile = vi.fn();
 
 		await act(async () => {
 			root.render(
 				<QueryClientProvider client={queryClient}>
 					<FileTreePane
-						rootEntries={[]}
+						rootEntries={[
+							{
+								name: "alpha.md",
+								rel_path: "notes/alpha.md",
+								kind: "file",
+								is_markdown: true,
+							},
+							{
+								name: "beta.md",
+								rel_path: "docs/beta.md",
+								kind: "file",
+								is_markdown: true,
+							},
+						]}
 						childrenByDir={{}}
 						expandedDirs={new Set()}
 						activeFilePath="notes/alpha.md"
@@ -168,16 +181,16 @@ describe("FileTreePane", () => {
 		expect(container.textContent).toContain("alpha");
 		expect(container.textContent).toContain("beta");
 
-		const activeItem = container.querySelector(
-			".fileTreePinnedList .fileTreeItem.active",
-		);
+		expect(container.querySelector(".fileTreePinnedSection")).toBeNull();
+
+		const activeItem = container.querySelector(".fileTreeItem.active");
 		expect(activeItem?.textContent).toContain("alpha");
 
-		const pinnedButton = Array.from(
-			container.querySelectorAll(".fileTreePinnedRow"),
+		const alphaButton = Array.from(
+			container.querySelectorAll("[data-file-tree-file='true']"),
 		).find((node) => node.textContent?.includes("alpha"));
 		await act(async () => {
-			(pinnedButton as HTMLButtonElement | undefined)?.click();
+			(alphaButton as HTMLButtonElement | undefined)?.click();
 		});
 		expect(onOpenFile).toHaveBeenCalledWith("notes/alpha.md");
 	});

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -7,6 +7,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FolioNotesListPane } from "./FolioNotesListPane";
 import type { FolioScope } from "./folioScopes";
 
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: ({
+		count,
+		estimateSize,
+		getItemKey,
+	}: {
+		count: number;
+		estimateSize: (index: number) => number;
+		getItemKey: (index: number) => string | number;
+	}) => {
+		const starts = Array.from({ length: count }, (_, index) =>
+			Array.from({ length: index }, (__, previousIndex) =>
+				estimateSize(previousIndex),
+			).reduce((total, size) => total + size, 0),
+		);
+		return {
+			getVirtualItems: () =>
+				starts.map((start, index) => ({
+					index,
+					key: getItemKey(index),
+					start,
+				})),
+			getTotalSize: () =>
+				Array.from({ length: count }, (_, index) => estimateSize(index)).reduce(
+					(total, size) => total + size,
+					0,
+				),
+			measureElement: () => {},
+			scrollToIndex: (index: number) => {
+				window.requestAnimationFrame(() => {
+					document
+						.querySelector<HTMLElement>(`[data-index="${index}"]`)
+						?.scrollIntoView({ block: "nearest" });
+				});
+			},
+		};
+	},
+}));
+
 const { loadAllDocsMock, prefetchNoteMock, invokeMock, scopeRef } = vi.hoisted(
 	() => ({
 		loadAllDocsMock: vi.fn(),

--- a/src/components/preview/MarkdownEditorPane.test.tsx
+++ b/src/components/preview/MarkdownEditorPane.test.tsx
@@ -5,17 +5,12 @@ import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownEditorPane } from "./MarkdownEditorPane";
 
-const {
-	noteInlineEditorMock,
-	localNoteConnectionsDialogMock,
-	invokeMock,
-	showNativePopupMenuMock,
-} = vi.hoisted(() => ({
-	noteInlineEditorMock: vi.fn(),
-	localNoteConnectionsDialogMock: vi.fn(),
-	invokeMock: vi.fn(),
-	showNativePopupMenuMock: vi.fn(),
-}));
+const { noteInlineEditorMock, localNoteConnectionsDialogMock, invokeMock } =
+	vi.hoisted(() => ({
+		noteInlineEditorMock: vi.fn(),
+		localNoteConnectionsDialogMock: vi.fn(),
+		invokeMock: vi.fn(),
+	}));
 
 // React 19 expects tests to opt into act-aware scheduling.
 (
@@ -31,6 +26,7 @@ vi.mock("../../contexts", () => ({
 		setAiPanelOpen: vi.fn(),
 	}),
 	useEditorRegistration: () => {},
+	useGitSyncContext: () => ({ status: null }),
 	useSpace: () => ({ spacePath: "/spaces/test" }),
 	useUILayoutContext: () => ({
 		showToc: false,
@@ -39,10 +35,6 @@ vi.mock("../../contexts", () => ({
 
 vi.mock("../../lib/tauri", () => ({
 	invoke: invokeMock,
-}));
-
-vi.mock("../../lib/nativeContextMenu", () => ({
-	showNativePopupMenu: showNativePopupMenuMock,
 }));
 
 vi.mock("../../lib/tauriEvents", () => ({
@@ -115,32 +107,6 @@ vi.mock("@hugeicons/react", () => ({
 	HugeiconsIcon: () => null,
 }));
 
-type TestNativeMenuItem =
-	| {
-			label: string;
-			action: () => void;
-			checked?: boolean;
-			enabled?: boolean;
-	  }
-	| { type: "separator" };
-
-function getLastNativeMenuItems(): TestNativeMenuItem[] {
-	const lastCall =
-		showNativePopupMenuMock.mock.calls[
-			showNativePopupMenuMock.mock.calls.length - 1
-		];
-	return lastCall?.[1] ?? [];
-}
-
-function runNativeMenuAction(label: string) {
-	const item = getLastNativeMenuItems().find(
-		(item): item is Extract<TestNativeMenuItem, { label: string }> =>
-			"label" in item && item.label === label,
-	);
-	expect(item).toBeDefined();
-	item?.action();
-}
-
 describe("MarkdownEditorPane", () => {
 	let container: HTMLDivElement;
 	let root: Root;
@@ -162,6 +128,7 @@ describe("MarkdownEditorPane", () => {
 					command: "note_frontmatter_parse_properties",
 					params: { frontmatter?: string | null },
 			  ]
+			| [command: "task_summary", params: { markdown: string }]
 			| [command: "databases_preview_context", params: { note_path: string }]
 	) {
 		const [command, params] = args;
@@ -197,6 +164,9 @@ describe("MarkdownEditorPane", () => {
 		if (command === "note_frontmatter_parse_properties") {
 			return Promise.resolve([]);
 		}
+		if (command === "task_summary") {
+			return Promise.resolve({ total: 0, completed: 0 });
+		}
 		throw new Error(`Unexpected command: ${command satisfies never}`);
 	}
 
@@ -218,8 +188,6 @@ describe("MarkdownEditorPane", () => {
 		invokeMock.mockImplementation(mockInvoke);
 		noteInlineEditorMock.mockReset();
 		localNoteConnectionsDialogMock.mockReset();
-		showNativePopupMenuMock.mockReset();
-		showNativePopupMenuMock.mockResolvedValue(false);
 
 		container = document.createElement("div");
 		document.body.appendChild(container);
@@ -285,6 +253,29 @@ describe("MarkdownEditorPane", () => {
 		});
 	});
 
+	it("switches editor mode from the top toggle", async () => {
+		await act(async () => {
+			root.render(
+				<MarkdownEditorPane
+					relPath="notes/mode.md"
+					initialDoc={makeDoc("notes/mode.md", "seed text")}
+				/>,
+			);
+		});
+
+		const rawButton = container.querySelector('button[aria-label="Raw"]');
+		expect(rawButton).not.toBeNull();
+
+		await act(async () => {
+			rawButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(noteInlineEditorMock).toHaveBeenLastCalledWith({
+			mode: "plain",
+			pasteMarkdownBehavior: "smart-markdown",
+		});
+	});
+
 	it("renders save status in info sidebar through dirty, saving, and saved states", async () => {
 		let resolveWrite:
 			| ((value: { etag: string; mtime_ms: number }) => void)
@@ -322,6 +313,9 @@ describe("MarkdownEditorPane", () => {
 			if (command === "note_frontmatter_parse_properties") {
 				return Promise.resolve([]);
 			}
+			if (command === "task_summary") {
+				return Promise.resolve({ total: 0, completed: 0 });
+			}
 			throw new Error(`Unexpected command: ${command}`);
 		});
 
@@ -334,17 +328,12 @@ describe("MarkdownEditorPane", () => {
 			);
 		});
 
-		const actionsButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.getAttribute("aria-label")?.includes("editor actions"),
+		const infoButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.getAttribute("aria-label") === "Open info",
 		);
-		expect(actionsButton).not.toBeNull();
+		expect(infoButton).not.toBeNull();
 		await act(async () => {
-			actionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-		});
-		expect(showNativePopupMenuMock).toHaveBeenCalled();
-
-		await act(async () => {
-			runNativeMenuAction("Info");
+			infoButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 		});
 
 		expect(container.textContent).toContain("Save status");
@@ -373,41 +362,5 @@ describe("MarkdownEditorPane", () => {
 		});
 
 		expect(container.textContent).toContain("Saved");
-	});
-
-	it("opens local connections from the actions menu", async () => {
-		await act(async () => {
-			root.render(
-				<MarkdownEditorPane
-					relPath="notes/graph.md"
-					initialDoc={makeDoc("notes/graph.md", "seed text", 7)}
-				/>,
-			);
-		});
-
-		const actionsButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.getAttribute("aria-label")?.includes("editor actions"),
-		);
-		expect(actionsButton).not.toBeNull();
-
-		await act(async () => {
-			actionsButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-		});
-		expect(showNativePopupMenuMock).toHaveBeenCalled();
-
-		await act(async () => {
-			runNativeMenuAction("Local connections");
-		});
-
-		expect(
-			container.querySelector('[data-testid="local-note-connections"]'),
-		).toBeTruthy();
-		expect(localNoteConnectionsDialogMock).toHaveBeenLastCalledWith(
-			expect.objectContaining({
-				open: true,
-				noteId: "notes/graph.md",
-				connectionsRefreshKey: 7,
-			}),
-		);
 	});
 });

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -122,8 +122,12 @@ function noteLinkLabel(label: string | null | undefined, fallbackPath: string) {
 
 const LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000;
 
+function requiresPlainEditorMode(markdown: string): boolean {
+	return markdown.length >= LARGE_NOTE_RICH_EDITOR_LIMIT;
+}
+
 function initialEditorMode(markdown: string): NoteInlineEditorMode {
-	return markdown.length >= LARGE_NOTE_RICH_EDITOR_LIMIT ? "plain" : "rich";
+	return requiresPlainEditorMode(markdown) ? "plain" : "rich";
 }
 
 function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
@@ -196,6 +200,7 @@ export function MarkdownEditorPane({
 	const [text, setText] = useState(() => initialText);
 	const [infoPanelText, setInfoPanelText] = useState("");
 	const [savedText, setSavedText] = useState(() => initialText);
+	const preferredEditorModeRef = useRef<NoteInlineEditorMode | null>(null);
 	const [mode, setMode] = useState<NoteInlineEditorMode>(() =>
 		initialEditorMode(initialText),
 	);
@@ -213,6 +218,26 @@ export function MarkdownEditorPane({
 
 	const savedTextRef = useRef(savedText);
 	const textRef = useRef(text);
+	const resolveEditorModeForNote = useCallback(
+		(markdown: string): NoteInlineEditorMode => {
+			if (requiresPlainEditorMode(markdown)) return "plain";
+			return preferredEditorModeRef.current ?? initialEditorMode(markdown);
+		},
+		[],
+	);
+	const selectEditorMode = useCallback(
+		(nextMode: NoteInlineEditorMode) => {
+			if (
+				requiresPlainEditorMode(textRef.current) &&
+				nextMode !== "plain"
+			) {
+				return;
+			}
+			preferredEditorModeRef.current = nextMode;
+			setMode(nextMode);
+		},
+		[],
+	);
 	const mtimeRef = useRef<number | null>(lastSavedMtimeMs);
 	const documentSessionRef = useRef(0);
 	const mountedRef = useRef(true);
@@ -393,7 +418,7 @@ export function MarkdownEditorPane({
 		setError(initialError);
 		if (activeRelPathRef.current !== relPath) {
 			setInfoPanelOpen(false);
-			setMode(initialEditorMode(cached));
+			setMode(resolveEditorModeForNote(cached));
 		}
 		activeRelPathRef.current = relPath;
 		setLocalConnectionsOpen(false);
@@ -402,7 +427,7 @@ export function MarkdownEditorPane({
 		if (initialDoc) {
 			setPrefetchedNote(relPath, initialDoc);
 		}
-	}, [initialDoc, initialError, relPath]);
+	}, [initialDoc, initialError, relPath, resolveEditorModeForNote]);
 
 	useEffect(() => {
 		if (previousSpacePathRef.current === spacePath) return;
@@ -446,7 +471,7 @@ export function MarkdownEditorPane({
 				setPrefetchedNote(relPath, doc);
 				if (shouldReplaceText) {
 					if (shouldChooseInitialMode) {
-						setMode(initialEditorMode(doc.text));
+						setMode(resolveEditorModeForNote(doc.text));
 					}
 					textRef.current = doc.text;
 					setText(doc.text);
@@ -466,7 +491,7 @@ export function MarkdownEditorPane({
 				setError(extractErrorMessage(e));
 			}
 		},
-		[flashSyncPulse, isCurrentSession, relPath],
+		[flashSyncPulse, isCurrentSession, relPath, resolveEditorModeForNote],
 	);
 
 	const loadDocFromExternalChange = useCallback(async () => {
@@ -715,9 +740,9 @@ export function MarkdownEditorPane({
 			isDirty,
 			save: onSave,
 			getMarkdown: () => textRef.current,
-			setMode,
+			setMode: selectEditorMode,
 		}),
-		[isDirty, onSave, relPath],
+		[isDirty, onSave, relPath, selectEditorMode],
 	);
 	useEditorRegistration(editorState);
 
@@ -830,23 +855,23 @@ export function MarkdownEditorPane({
 				{
 					label: "Edit",
 					checked: mode === "rich",
-					action: () => setMode("rich"),
+					action: () => selectEditorMode("rich"),
 				},
 				{
 					label: "Preview",
 					checked: mode === "preview",
-					action: () => setMode("preview"),
+					action: () => selectEditorMode("preview"),
 				},
 				{
 					label: "Raw",
 					checked: mode === "plain",
-					action: () => setMode("plain"),
+					action: () => selectEditorMode("plain"),
 				},
 			]).catch((error: unknown) => {
 				console.error("Failed to show view mode menu", error);
 			});
 		},
-		[mode],
+		[mode, selectEditorMode],
 	);
 
 	return (

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -120,6 +120,12 @@ function noteLinkLabel(label: string | null | undefined, fallbackPath: string) {
 	return label?.trim() || noteLabelFromPath(fallbackPath);
 }
 
+const LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000;
+
+function initialEditorMode(markdown: string): NoteInlineEditorMode {
+	return markdown.length >= LARGE_NOTE_RICH_EDITOR_LIMIT ? "plain" : "rich";
+}
+
 function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
 	const out = new Map<string, LinkedNoteItem>();
 
@@ -188,9 +194,11 @@ export function MarkdownEditorPane({
 }: MarkdownEditorPaneProps) {
 	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
 	const [text, setText] = useState(() => initialText);
-	const [infoPanelText, setInfoPanelText] = useState(() => initialText);
+	const [infoPanelText, setInfoPanelText] = useState("");
 	const [savedText, setSavedText] = useState(() => initialText);
-	const [mode, setMode] = useState<NoteInlineEditorMode>("rich");
+	const [mode, setMode] = useState<NoteInlineEditorMode>(() =>
+		initialEditorMode(initialText),
+	);
 	const [saving, setSaving] = useState(false);
 	const [autosaveBusy, setAutosaveBusy] = useState(false);
 	const [error, setError] = useState(() => initialError || "");
@@ -216,6 +224,7 @@ export function MarkdownEditorPane({
 	const syncPulseTimerRef = useRef<number | null>(null);
 	const pendingExternalReloadRef = useRef(false);
 	const activeRelPathRef = useRef(relPath);
+	const infoPanelOpenRef = useRef(infoPanelOpen);
 	const paneRef = useRef<HTMLElement | null>(null);
 	const contentScrollRef = useRef<HTMLDivElement | null>(null);
 	const { spacePath } = useSpace();
@@ -232,6 +241,7 @@ export function MarkdownEditorPane({
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
 	const { status: gitSyncStatus } = useGitSyncContext();
 	const hasSupportedGit = canShowGitHistory(gitSyncStatus);
+	infoPanelOpenRef.current = infoPanelOpen;
 
 	useEffect(() => {
 		if (hasSupportedGit) return;
@@ -373,7 +383,7 @@ export function MarkdownEditorPane({
 		}
 		pendingExternalReloadRef.current = false;
 		setText(cached);
-		setInfoPanelText(cached);
+		setInfoPanelText("");
 		setSavedText(cached);
 		setLastSavedMtimeMs(initialDoc?.mtime_ms ?? null);
 		setSaving(false);
@@ -383,6 +393,7 @@ export function MarkdownEditorPane({
 		setError(initialError);
 		if (activeRelPathRef.current !== relPath) {
 			setInfoPanelOpen(false);
+			setMode(initialEditorMode(cached));
 		}
 		activeRelPathRef.current = relPath;
 		setLocalConnectionsOpen(false);
@@ -430,11 +441,16 @@ export function MarkdownEditorPane({
 				const doc = await invoke("space_read_text", { path: relPath });
 				if (!isCurrentSession(sessionId)) return;
 				const shouldReplaceText = textRef.current === savedTextRef.current;
+				const shouldChooseInitialMode =
+					textRef.current.length === 0 && savedTextRef.current.length === 0;
 				setPrefetchedNote(relPath, doc);
 				if (shouldReplaceText) {
+					if (shouldChooseInitialMode) {
+						setMode(initialEditorMode(doc.text));
+					}
 					textRef.current = doc.text;
 					setText(doc.text);
-					setInfoPanelText(doc.text);
+					if (infoPanelOpenRef.current) setInfoPanelText(doc.text);
 				}
 				savedTextRef.current = doc.text;
 				mtimeRef.current = doc.mtime_ms;
@@ -469,7 +485,7 @@ export function MarkdownEditorPane({
 			savedTextRef.current = doc.text;
 			mtimeRef.current = doc.mtime_ms;
 			setText(doc.text);
-			setInfoPanelText(doc.text);
+			if (infoPanelOpenRef.current) setInfoPanelText(doc.text);
 			setSavedText(doc.text);
 			setLastSavedMtimeMs(doc.mtime_ms);
 			hasUserEditsRef.current = false;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -4,13 +4,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/react";
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	useAISidebarContext,
 	useEditorRegistration,
@@ -229,10 +223,7 @@ export function MarkdownEditorPane({
 	}, []);
 	const requestEditorMode = useCallback(
 		async (nextMode: NoteInlineEditorMode) => {
-			if (
-				nextMode !== "plain" &&
-				requiresPlainEditorMode(textRef.current)
-			) {
+			if (nextMode !== "plain" && requiresPlainEditorMode(textRef.current)) {
 				const modeLabel = nextMode === "rich" ? "Rich" : "Preview";
 				const { confirm } = await import("@tauri-apps/plugin-dialog");
 				const confirmed = await confirm(

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1,12 +1,10 @@
 import {
 	AiBrain04Icon,
 	LayoutAlignRightIcon,
-	SlidersHorizontalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/react";
 import {
-	type MouseEvent as ReactMouseEvent,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -29,7 +27,6 @@ import {
 } from "../../lib/appEvents";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { canShowGitHistory } from "../../lib/gitSyncUi";
-import { showNativePopupMenu } from "../../lib/nativeContextMenu";
 import { setPrefetchedNote } from "../../lib/navigationPrefetch";
 import {
 	joinYamlFrontmatter,
@@ -48,6 +45,7 @@ import { useTauriEvent } from "../../lib/tauriEvents";
 import { countWords, formatReadingTime } from "../../lib/textStats";
 import { normalizeRelPath } from "../../utils/path";
 import { LocalNoteConnectionsDialog } from "../connections/LocalNoteConnectionsDialog";
+import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
@@ -844,54 +842,17 @@ export function MarkdownEditorPane({
 		});
 	}, [setAiPanelOpen]);
 
-	const handleViewModeMenu = useCallback(
-		(event: ReactMouseEvent<HTMLButtonElement>) => {
-			void showNativePopupMenu(event, [
-				{
-					label: "Local connections",
-					action: () => setLocalConnectionsOpen(true),
-				},
-				{ type: "separator" },
-				{
-					label: "Edit",
-					checked: mode === "rich",
-					action: () => selectEditorMode("rich"),
-				},
-				{
-					label: "Preview",
-					checked: mode === "preview",
-					action: () => selectEditorMode("preview"),
-				},
-				{
-					label: "Raw",
-					checked: mode === "plain",
-					action: () => selectEditorMode("plain"),
-				},
-			]).catch((error: unknown) => {
-				console.error("Failed to show view mode menu", error);
-			});
-		},
-		[mode, selectEditorMode],
-	);
+	const plainOnlyMode = requiresPlainEditorMode(text);
 
 	return (
 		<section className="filePreviewPane markdownEditorPane" ref={paneRef}>
 			<div className="markdownEditorFloatActions">
 				<div className="markdownEditorTopActions">
-					<button
-						type="button"
-						className="markdownEditorMenuTrigger"
-						onClick={handleViewModeMenu}
-						aria-label="View mode options"
-						title="View mode options"
-						aria-haspopup="menu"
-					>
-						<HugeiconsIcon
-							icon={SlidersHorizontalIcon}
-							size="var(--icon-lg)"
-							strokeWidth={0.9}
-						/>
-					</button>
+					<EditorViewModeSwitch
+						mode={mode}
+						plainOnly={plainOnlyMode}
+						onModeChange={selectEditorMode}
+					/>
 					<button
 						type="button"
 						className="markdownEditorMenuTrigger markdownEditorAiTrigger"

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -223,18 +223,31 @@ export function MarkdownEditorPane({
 		},
 		[],
 	);
-	const selectEditorMode = useCallback(
-		(nextMode: NoteInlineEditorMode) => {
+	const applyEditorMode = useCallback((nextMode: NoteInlineEditorMode) => {
+		preferredEditorModeRef.current = nextMode;
+		setMode(nextMode);
+	}, []);
+	const requestEditorMode = useCallback(
+		async (nextMode: NoteInlineEditorMode) => {
 			if (
-				requiresPlainEditorMode(textRef.current) &&
-				nextMode !== "plain"
+				nextMode !== "plain" &&
+				requiresPlainEditorMode(textRef.current)
 			) {
-				return;
+				const modeLabel = nextMode === "rich" ? "Rich" : "Preview";
+				const { confirm } = await import("@tauri-apps/plugin-dialog");
+				const confirmed = await confirm(
+					`This note may take a while to open and feel slower in ${modeLabel} mode. Raw is the fastest way to edit.`,
+					{
+						title: "Large note",
+						okLabel: `Open in ${modeLabel}`,
+						cancelLabel: "Stay in Raw",
+					},
+				);
+				if (!confirmed) return;
 			}
-			preferredEditorModeRef.current = nextMode;
-			setMode(nextMode);
+			applyEditorMode(nextMode);
 		},
-		[],
+		[applyEditorMode],
 	);
 	const mtimeRef = useRef<number | null>(lastSavedMtimeMs);
 	const documentSessionRef = useRef(0);
@@ -738,9 +751,9 @@ export function MarkdownEditorPane({
 			isDirty,
 			save: onSave,
 			getMarkdown: () => textRef.current,
-			setMode: selectEditorMode,
+			setMode: requestEditorMode,
 		}),
-		[isDirty, onSave, relPath, selectEditorMode],
+		[isDirty, onSave, relPath, requestEditorMode],
 	);
 	useEditorRegistration(editorState);
 
@@ -842,7 +855,7 @@ export function MarkdownEditorPane({
 		});
 	}, [setAiPanelOpen]);
 
-	const plainOnlyMode = requiresPlainEditorMode(text);
+	const isLargeNote = requiresPlainEditorMode(text);
 
 	return (
 		<section className="filePreviewPane markdownEditorPane" ref={paneRef}>
@@ -850,8 +863,8 @@ export function MarkdownEditorPane({
 				<div className="markdownEditorTopActions">
 					<EditorViewModeSwitch
 						mode={mode}
-						plainOnly={plainOnlyMode}
-						onModeChange={selectEditorMode}
+						largeNote={isLargeNote}
+						onModeChange={requestEditorMode}
 					/>
 					<button
 						type="button"

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -12,7 +12,6 @@ import {
 	useSpace,
 	useUILayoutContext,
 } from "../../contexts";
-import { useMarkdownTaskSummary } from "../../hooks/useMarkdownTaskSummary";
 import {
 	OPEN_LOCAL_CONNECTIONS_EVENT,
 	type OpenLocalConnectionsDetail,
@@ -36,7 +35,6 @@ import {
 	invoke,
 } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
-import { countWords, formatReadingTime } from "../../lib/textStats";
 import { normalizeRelPath } from "../../utils/path";
 import { LocalNoteConnectionsDialog } from "../connections/LocalNoteConnectionsDialog";
 import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
@@ -44,6 +42,7 @@ import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
+import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import type {
 	ExtractToNoteActions,
 	NoteInlineEditorMode,
@@ -56,6 +55,7 @@ import {
 	getCachedMarkdownDoc,
 	peekCachedMarkdownDoc,
 } from "./markdownCache";
+import { analyzeNoteInfo } from "./noteInfoAnalysis";
 
 interface MarkdownEditorPaneProps {
 	relPath: string;
@@ -84,23 +84,6 @@ interface SidebarBacklinkItem {
 
 const UTF8_ENCODER = new TextEncoder();
 const INFO_PANEL_DERIVATION_DEBOUNCE_MS = 700;
-
-const EMPTY_STATS = {
-	words: 0,
-	characters: 0,
-	readingTime: "0s",
-};
-
-function countLines(markdown: string): number {
-	if (markdown.length === 0) return 0;
-	let lines = 1;
-	for (let i = 0; i < markdown.length; i += 1) {
-		if (markdown.charCodeAt(i) === 10) {
-			lines += 1;
-		}
-	}
-	return lines;
-}
 
 function noteLabelFromPath(path: string): string {
 	const segments = path.split("/").filter(Boolean);
@@ -257,6 +240,13 @@ export function MarkdownEditorPane({
 	const { spacePath } = useSpace();
 	const previousSpacePathRef = useRef<string | null>(spacePath);
 	const [tocEditor, setTocEditor] = useState<Editor | null>(null);
+	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
+	const handleRawEditorReady = useCallback(
+		(editor: RawMarkdownEditorHandle | null) => {
+			rawEditorRef.current = editor;
+		},
+		[],
+	);
 	const {
 		headings: tocHeadings,
 		activeId: tocActiveId,
@@ -283,27 +273,13 @@ export function MarkdownEditorPane({
 				: { frontmatter: null, body: "" },
 		[infoPanelOpen, infoPanelText],
 	);
-	const stats = useMemo(() => {
-		if (!infoPanelOpen) return EMPTY_STATS;
-		const words = countWords(currentBody);
-		const characters = currentBody.length;
-		return {
-			words,
-			characters,
-			readingTime: formatReadingTime(words),
-		};
-	}, [currentBody, infoPanelOpen]);
-	const visibleTaskSummary = useMarkdownTaskSummary(
-		infoPanelText,
-		infoPanelOpen,
+	const infoAnalysis = useMemo(
+		() => analyzeNoteInfo(infoPanelText, currentBody, mode === "plain"),
+		[currentBody, infoPanelText, mode],
 	);
 	const utf8SizeBytes = useMemo(() => {
 		if (!infoPanelOpen) return 0;
 		return UTF8_ENCODER.encode(infoPanelText).length;
-	}, [infoPanelOpen, infoPanelText]);
-	const lineCount = useMemo(() => {
-		if (!infoPanelOpen) return 0;
-		return countLines(infoPanelText);
 	}, [infoPanelOpen, infoPanelText]);
 	const linkedNotes = useMemo(() => {
 		if (!infoPanelOpen) return [];
@@ -340,6 +316,19 @@ export function MarkdownEditorPane({
 	const relationshipGroups = useMemo(
 		() => groupRelationshipsByField(relationships),
 		[relationships],
+	);
+	const visibleHeadings =
+		mode === "plain" ? infoAnalysis.headings : tocHeadings;
+	const visibleActiveHeadingId = mode === "plain" ? null : tocActiveId;
+	const selectVisibleHeading = useCallback(
+		(heading: (typeof visibleHeadings)[number]) => {
+			if (mode === "plain") {
+				rawEditorRef.current?.selectRange(heading.pos, heading.pos);
+				return;
+			}
+			scrollToHeading(heading);
+		},
+		[mode, scrollToHeading],
 	);
 
 	const flashSyncPulse = useCallback((next: Exclude<SyncPulse, null>) => {
@@ -395,6 +384,14 @@ export function MarkdownEditorPane({
 	}, []);
 
 	useEffect(() => {
+		// `initialDoc` is a seed for the pane. Autosave also refreshes that cache,
+		// so do not treat the resulting object identity change as a new document.
+		if (
+			activeRelPathRef.current === relPath &&
+			initialDoc?.text === textRef.current
+		) {
+			return;
+		}
 		const sessionId = documentSessionRef.current + 1;
 		documentSessionRef.current = sessionId;
 		saveRequestTokenRef.current += 1;
@@ -845,65 +842,71 @@ export function MarkdownEditorPane({
 			return nextOpen;
 		});
 	}, [setAiPanelOpen]);
+	const closeInfoPanel = useCallback(() => setInfoPanelOpen(false), []);
 
 	const isLargeNote = requiresPlainEditorMode(text);
 
 	return (
 		<section className="filePreviewPane markdownEditorPane" ref={paneRef}>
 			<div className="markdownEditorFloatActions">
-				<div className="markdownEditorTopActions">
+				<div className="markdownEditorToolbar">
 					<EditorViewModeSwitch
 						mode={mode}
 						largeNote={isLargeNote}
 						onModeChange={requestEditorMode}
 					/>
-					<button
-						type="button"
-						className="markdownEditorMenuTrigger markdownEditorAiTrigger"
-						onClick={() => {
-							if (!aiEnabled) {
-								openSettings("ai");
-								return;
+					<div className="markdownEditorToolbarDivider" aria-hidden="true" />
+					<div className="markdownEditorToolbarActions">
+						<button
+							type="button"
+							className="markdownEditorToolbarBtn"
+							data-active={aiEnabled && aiPanelOpen ? true : undefined}
+							onClick={() => {
+								if (!aiEnabled) {
+									openSettings("ai");
+									return;
+								}
+								setInfoPanelOpen(() => false);
+								setAiPanelOpen((open) => !open);
+							}}
+							aria-label={
+								aiEnabled
+									? aiPanelOpen
+										? "Close AI panel"
+										: "Open AI panel"
+									: "Open AI settings"
 							}
-							setInfoPanelOpen(() => false);
-							setAiPanelOpen((open) => !open);
-						}}
-						aria-label={
-							aiEnabled
-								? aiPanelOpen
-									? "Close AI panel"
-									: "Open AI panel"
-								: "Open AI settings"
-						}
-						title={
-							aiEnabled
-								? aiPanelOpen
-									? "Close AI panel"
-									: "Open AI panel"
-								: "Open AI settings"
-						}
-						aria-pressed={aiEnabled ? aiPanelOpen : undefined}
-					>
-						<HugeiconsIcon
-							icon={AiBrain04Icon}
-							size="var(--icon-lg)"
-							strokeWidth={0.9}
-						/>
-					</button>
-					<button
-						type="button"
-						className="markdownEditorMenuTrigger"
-						onClick={toggleInfoPanel}
-						aria-label={infoPanelOpen ? "Close info" : "Open info"}
-						title={infoPanelOpen ? "Close info" : "Open info"}
-						aria-pressed={infoPanelOpen}
-					>
-						<HugeiconsIcon
-							icon={LayoutAlignRightIcon}
-							size="var(--icon-lg)"
-							strokeWidth={0.9}
-						/>
-					</button>
+							title={
+								aiEnabled
+									? aiPanelOpen
+										? "Close AI panel"
+										: "Open AI panel"
+									: "Open AI settings"
+							}
+							aria-pressed={aiEnabled ? aiPanelOpen : undefined}
+						>
+							<HugeiconsIcon
+								icon={AiBrain04Icon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+						</button>
+						<button
+							type="button"
+							className="markdownEditorToolbarBtn"
+							data-active={infoPanelOpen || undefined}
+							onClick={toggleInfoPanel}
+							aria-label={infoPanelOpen ? "Close info" : "Open info"}
+							title={infoPanelOpen ? "Close info" : "Open info"}
+							aria-pressed={infoPanelOpen}
+						>
+							<HugeiconsIcon
+								icon={LayoutAlignRightIcon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+						</button>
+					</div>
 				</div>
 			</div>
 			{error ? (
@@ -936,6 +939,7 @@ export function MarkdownEditorPane({
 								}}
 								onFrontmatterCommit={runAutosave}
 								onEditorReady={setTocEditor}
+								onRawEditorReady={handleRawEditorReady}
 								extractToNoteActions={extractToNoteActions}
 							/>
 						)}
@@ -952,28 +956,27 @@ export function MarkdownEditorPane({
 
 			<NotesInfoSidebar
 				open={infoPanelOpen}
-				mode={mode}
 				hasError={Boolean(error)}
 				relPath={relPath}
 				frontmatter={currentFrontmatter}
 				onFrontmatterChange={handleInfoFrontmatterChange}
-				stats={stats}
-				taskSummary={visibleTaskSummary}
-				tocHeadings={tocHeadings}
-				tocActiveId={tocActiveId}
-				onSelectHeading={scrollToHeading}
+				stats={infoAnalysis.stats}
+				taskSummary={infoAnalysis.taskSummary}
+				tocHeadings={visibleHeadings}
+				tocActiveId={visibleActiveHeadingId}
+				onSelectHeading={selectVisibleHeading}
 				backlinks={sidebarBacklinks}
 				linkedNotes={linkedNotes}
 				relationshipGroups={relationshipGroups}
 				previewContext={previewContext}
 				lastSavedMtimeMs={lastSavedMtimeMs}
-				lineCount={lineCount}
+				lineCount={infoAnalysis.lineCount}
 				utf8SizeBytes={utf8SizeBytes}
 				saveLabel={saveLabel}
 				gitSyncStatus={gitSyncStatus}
 				selectedGitCommitHash={gitDiff?.commit.hash ?? null}
 				onSelectGitDiff={onGitDiffChange ?? undefined}
-				onClose={() => setInfoPanelOpen(false)}
+				onClose={closeInfoPanel}
 			/>
 			<LinkedNotePreviewSheet />
 

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -4,7 +4,7 @@ import {
 	InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { canShowGitHistory } from "../../lib/gitSyncUi";
 import {
@@ -25,7 +25,6 @@ import {
 	dispatchMarkdownLinkClick,
 	dispatchWikiLinkClick,
 } from "../editor/markdown/editorEvents";
-import type { NoteInlineEditorMode } from "../editor/types";
 import { GitHistorySidebar } from "./GitHistorySidebar";
 
 type InfoSidebarTab = "info" | "history";
@@ -43,7 +42,6 @@ interface LinkedNoteItem {
 
 interface NotesInfoSidebarProps {
 	open: boolean;
-	mode: NoteInlineEditorMode;
 	hasError: boolean;
 	relPath: string;
 	frontmatter: string | null;
@@ -100,9 +98,8 @@ function formatFileSize(bytes: number): string {
 	})} ${units[unitIndex]}`;
 }
 
-export function NotesInfoSidebar({
+export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 	open,
-	mode,
 	hasError,
 	relPath,
 	frontmatter,
@@ -150,7 +147,7 @@ export function NotesInfoSidebar({
 		}
 	}, [activeTab, hasGitHistoryTab, open]);
 
-	if (!open || mode === "plain" || hasError) return null;
+	if (!open || hasError) return null;
 
 	const sidebar = (
 		<aside className="notesInfoSidebarPanel" aria-label="Note info panel">
@@ -456,4 +453,4 @@ export function NotesInfoSidebar({
 	);
 
 	return host ? createPortal(sidebar, host) : sidebar;
-}
+});

--- a/src/components/preview/noteInfoAnalysis.ts
+++ b/src/components/preview/noteInfoAnalysis.ts
@@ -54,29 +54,37 @@ export function analyzeNoteInfo(
 			while (wordPattern.exec(line)) {
 				words += 1;
 			}
-		}
 
-		const taskMatch = line.match(TASK_PATTERN);
-		if (taskMatch?.[1]) {
-			totalTasks += 1;
-			if (taskMatch[1].toLowerCase() === "x") completedTasks += 1;
-		}
-
-		if (includeHeadings && lineStart >= bodyStart) {
 			const fenceMatch = line.match(FENCE_PATTERN);
 			if (fenceMatch?.[1]) {
-				const marker = fenceMatch[1][0];
-				fenceMarker = fenceMarker === marker ? null : (fenceMarker ?? marker);
+				const marker = fenceMatch[1];
+				if (!fenceMarker) {
+					fenceMarker = marker;
+				} else if (
+					marker[0] === fenceMarker[0] &&
+					marker.length >= fenceMarker.length &&
+					line.slice(fenceMatch[0].length).trim().length === 0
+				) {
+					fenceMarker = null;
+				}
 			} else if (!fenceMarker) {
-				const headingMatch = line.match(HEADING_PATTERN);
-				const headingText = headingMatch?.[2]?.trim();
-				if (headingMatch?.[1] && headingText) {
-					headings.push({
-						id: `raw-toc-${lineStart}`,
-						level: headingMatch[1].length,
-						text: headingText,
-						pos: lineStart,
-					});
+				const taskMatch = line.match(TASK_PATTERN);
+				if (taskMatch?.[1]) {
+					totalTasks += 1;
+					if (taskMatch[1].toLowerCase() === "x") completedTasks += 1;
+				}
+
+				if (includeHeadings) {
+					const headingMatch = line.match(HEADING_PATTERN);
+					const headingText = headingMatch?.[2]?.trim();
+					if (headingMatch?.[1] && headingText) {
+						headings.push({
+							id: `raw-toc-${lineStart}`,
+							level: headingMatch[1].length,
+							text: headingText,
+							pos: lineStart,
+						});
+					}
 				}
 			}
 		}

--- a/src/components/preview/noteInfoAnalysis.ts
+++ b/src/components/preview/noteInfoAnalysis.ts
@@ -1,0 +1,102 @@
+import type { TOCHeading } from "../editor/hooks/useTableOfContents";
+
+interface NoteInfoAnalysis {
+	stats: {
+		words: number;
+		characters: number;
+		readingTime: string;
+	};
+	taskSummary: {
+		total_count: number;
+		completed_count: number;
+		open_count: number;
+	};
+	headings: TOCHeading[];
+	lineCount: number;
+}
+
+const WORDS_PER_MINUTE = 200;
+const HEADING_PATTERN = /^(#{1,6})[\t ]+(.+?)[\t ]*#*[\t ]*$/;
+const TASK_PATTERN = /^\s*[-*+] \[([ xX])\] /;
+const FENCE_PATTERN = /^\s*(`{3,}|~{3,})/;
+
+function readingTime(words: number): string {
+	if (words <= 0) return "0s";
+	const totalSeconds = Math.ceil((words / WORDS_PER_MINUTE) * 60);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	if (minutes <= 0) return `${seconds}s`;
+	if (seconds === 0) return `${minutes}m`;
+	return `${minutes}m ${seconds}s`;
+}
+
+export function analyzeNoteInfo(
+	markdown: string,
+	body: string,
+	includeHeadings: boolean,
+): NoteInfoAnalysis {
+	let words = 0;
+	const wordPattern = /\S+/gu;
+	const headings: TOCHeading[] = [];
+	let totalTasks = 0;
+	let completedTasks = 0;
+	let lineCount = markdown.length > 0 ? 1 : 0;
+	let lineStart = 0;
+	let fenceMarker: string | null = null;
+	const bodyStart = Math.max(0, markdown.length - body.length);
+
+	while (lineStart <= markdown.length) {
+		const lineEnd = markdown.indexOf("\n", lineStart);
+		const end = lineEnd === -1 ? markdown.length : lineEnd;
+		const line = markdown.slice(lineStart, end).replace(/\r$/, "");
+		if (lineEnd !== -1) lineCount += 1;
+		if (lineStart >= bodyStart) {
+			while (wordPattern.exec(line)) {
+				words += 1;
+			}
+		}
+
+		const taskMatch = line.match(TASK_PATTERN);
+		if (taskMatch?.[1]) {
+			totalTasks += 1;
+			if (taskMatch[1].toLowerCase() === "x") completedTasks += 1;
+		}
+
+		if (includeHeadings && lineStart >= bodyStart) {
+			const fenceMatch = line.match(FENCE_PATTERN);
+			if (fenceMatch?.[1]) {
+				const marker = fenceMatch[1][0];
+				fenceMarker = fenceMarker === marker ? null : (fenceMarker ?? marker);
+			} else if (!fenceMarker) {
+				const headingMatch = line.match(HEADING_PATTERN);
+				const headingText = headingMatch?.[2]?.trim();
+				if (headingMatch?.[1] && headingText) {
+					headings.push({
+						id: `raw-toc-${lineStart}`,
+						level: headingMatch[1].length,
+						text: headingText,
+						pos: lineStart,
+					});
+				}
+			}
+		}
+
+		if (lineEnd === -1) break;
+		lineStart = lineEnd + 1;
+	}
+
+	return {
+		stats: {
+			words,
+			characters: body.length,
+			readingTime: readingTime(words),
+		},
+		taskSummary: {
+			total_count: totalTasks,
+			completed_count: completedTasks,
+			open_count: totalTasks - completedTasks,
+		},
+		headings,
+		lineCount,
+	};
+}

--- a/src/components/settings/SpaceSettingsPane.test.tsx
+++ b/src/components/settings/SpaceSettingsPane.test.tsx
@@ -20,6 +20,9 @@ const {
 	loadSettingsMock: vi.fn(() =>
 		Promise.resolve({
 			currentSpacePath: "/spaces/test",
+			dailyNotes: {
+				folder: null,
+			},
 			editor: {
 				attachmentStorageMode: "note-folder",
 				attachmentFolder: "assets",
@@ -75,6 +78,7 @@ vi.mock("@hugeicons/react", () => ({
 }));
 
 vi.mock("../Icons", () => ({
+	ChevronDown: () => null,
 	Trash2: () => null,
 }));
 

--- a/src/hooks/useMarkdownTaskSummary.ts
+++ b/src/hooks/useMarkdownTaskSummary.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
 	EMPTY_CHECKLIST_SUMMARY,
 	summarizeChecklistsFromMarkdown,
@@ -12,19 +12,6 @@ export function useMarkdownTaskSummary(markdown: string, enabled: boolean) {
 	const timerRef = useRef<number | null>(null);
 	const requestTokenRef = useRef(0);
 	const mountedRef = useRef(true);
-
-	const fallbackTaskSummary = useMemo(
-		() =>
-			enabled
-				? summarizeChecklistsFromMarkdown(markdown)
-				: EMPTY_CHECKLIST_SUMMARY,
-		[enabled, markdown],
-	);
-	const visibleTaskSummary = enabled
-		? taskSummary.total_count > 0 || fallbackTaskSummary.total_count === 0
-			? taskSummary
-			: fallbackTaskSummary
-		: EMPTY_CHECKLIST_SUMMARY;
 
 	useEffect(() => {
 		mountedRef.current = true;
@@ -43,8 +30,6 @@ export function useMarkdownTaskSummary(markdown: string, enabled: boolean) {
 			return;
 		}
 
-		setTaskSummary(fallbackTaskSummary);
-
 		if (timerRef.current !== null) {
 			window.clearTimeout(timerRef.current);
 			timerRef.current = null;
@@ -60,17 +45,13 @@ export function useMarkdownTaskSummary(markdown: string, enabled: boolean) {
 					if (!mountedRef.current || requestTokenRef.current !== requestToken) {
 						return;
 					}
-					setTaskSummary(
-						summary.total_count > 0 || fallbackTaskSummary.total_count === 0
-							? summary
-							: fallbackTaskSummary,
-					);
+					setTaskSummary(summary);
 				})
 				.catch(() => {
 					if (!mountedRef.current || requestTokenRef.current !== requestToken) {
 						return;
 					}
-					setTaskSummary(fallbackTaskSummary);
+					setTaskSummary(summarizeChecklistsFromMarkdown(markdown));
 				});
 		}, 90);
 
@@ -80,7 +61,7 @@ export function useMarkdownTaskSummary(markdown: string, enabled: boolean) {
 				timerRef.current = null;
 			}
 		};
-	}, [enabled, fallbackTaskSummary, markdown]);
+	}, [enabled, markdown]);
 
-	return visibleTaskSummary;
+	return enabled ? taskSummary : EMPTY_CHECKLIST_SUMMARY;
 }

--- a/src/hooks/useMarkdownTaskSummary.ts
+++ b/src/hooks/useMarkdownTaskSummary.ts
@@ -30,6 +30,8 @@ export function useMarkdownTaskSummary(markdown: string, enabled: boolean) {
 			return;
 		}
 
+		setTaskSummary(summarizeChecklistsFromMarkdown(markdown));
+
 		if (timerRef.current !== null) {
 			window.clearTimeout(timerRef.current);
 			timerRef.current = null;

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -14,7 +14,7 @@
 }
 
 .mainTabsBar {
-	--main-tabs-right-reserve: 78px;
+	--main-tabs-right-reserve: 168px;
 	--main-tabs-left-reserve: var(--space-3);
 	--main-tabs-top-padding: 6px;
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -13,6 +13,20 @@
 	border-radius: var(--radius-md);
 }
 
+.tiptapContentInline img[data-glyph-hydration-state="pending"],
+.tiptapContentInline img[data-glyph-hydration-state="loading"] {
+	min-height: 120px;
+	background: color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary));
+	color: transparent;
+}
+
+.tiptapContentInline pre,
+.tiptapContentInline table,
+.tiptapContentInline img {
+	content-visibility: auto;
+	contain-intrinsic-block-size: auto 240px;
+}
+
 .wikiLink {
 	height: auto;
 	display: inline-flex;

--- a/src/styles/app/26-node-note-overlays.css
+++ b/src/styles/app/26-node-note-overlays.css
@@ -170,6 +170,15 @@
 
 .mermaidCanvasWidget {
 	margin: 8px 0 14px;
+	content-visibility: auto;
+	contain-intrinsic-block-size: auto 480px;
+}
+
+.mermaidCanvasPlaceholder .mermaidCanvasFrame::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary));
 }
 
 .mermaidCanvasFrame {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -53,15 +53,8 @@
 	transition: opacity 180ms ease, transform 220ms ease;
 }
 
-.markdownEditorTopActions {
+.markdownEditorToolbar {
 	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.markdownEditorModeSwitch {
-	display: inline-grid;
-	grid-template-columns: repeat(3, minmax(0, auto));
 	align-items: center;
 	height: 26px;
 	padding: 2px;
@@ -69,6 +62,56 @@
 	border: 1px solid color-mix(in srgb, var(--border-light) 80%, transparent);
 	border-radius: var(--radius-md);
 	background: color-mix(in srgb, var(--bg-secondary) 48%, transparent);
+}
+
+.markdownEditorToolbarDivider {
+	flex: 0 0 1px;
+	align-self: stretch;
+	margin: 3px 2px;
+	background: color-mix(in srgb, var(--border-light) 72%, transparent);
+}
+
+.markdownEditorToolbarActions {
+	display: inline-flex;
+	align-items: center;
+}
+
+.markdownEditorToolbarBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 20px;
+	padding: 0;
+	border: 0;
+	border-radius: calc(var(--radius-md) - 2px);
+	background: transparent;
+	color: var(--text-tertiary);
+	line-height: 0;
+	cursor: pointer;
+	transition: background-color 120ms ease, color 120ms ease;
+}
+
+.markdownEditorToolbarBtn:hover {
+	color: var(--text-primary);
+}
+
+.markdownEditorToolbarBtn[data-active="true"] {
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-light) 34%, transparent);
+}
+
+.markdownEditorToolbarBtn:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 2px;
+}
+
+.markdownEditorModeSwitch {
+	display: inline-grid;
+	grid-template-columns: repeat(3, minmax(0, auto));
+	align-items: center;
+	overflow: visible;
 }
 
 .markdownEditorModeBtnWrap {
@@ -197,39 +240,6 @@
 		);
 	border-radius: 50%;
 	transition: background 180ms ease;
-}
-
-.markdownEditorMenuTrigger {
-	position: relative;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 20px;
-	height: 20px;
-	padding: 0;
-	border: none;
-	background: transparent;
-	color: var(--text-secondary);
-	box-shadow: none;
-	outline: none;
-	appearance: none;
-	-webkit-appearance: none;
-	cursor: pointer;
-	transition: none;
-}
-
-.markdownEditorMenuTrigger:hover {
-	border: none;
-	background: transparent;
-	box-shadow: none;
-	outline: none;
-	color: var(--text-secondary);
-	transform: none;
-}
-
-.markdownEditorMenuTrigger:focus-visible {
-	outline: 2px solid var(--focus);
-	outline-offset: 2px;
 }
 
 .markdownEditorCenter {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -49,6 +49,7 @@
 	z-index: 24;
 	display: inline-flex;
 	align-items: center;
+	overflow: visible;
 	transition: opacity 180ms ease, transform 220ms ease;
 }
 
@@ -56,6 +57,107 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 8px;
+}
+
+.markdownEditorModeSwitch {
+	display: inline-grid;
+	grid-template-columns: repeat(3, minmax(0, auto));
+	align-items: center;
+	height: 26px;
+	padding: 2px;
+	overflow: visible;
+	border: 1px solid color-mix(in srgb, var(--border-light) 80%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-secondary) 48%, transparent);
+}
+
+.markdownEditorModeBtnWrap {
+	position: relative;
+	display: inline-flex;
+	overflow: visible;
+}
+
+.markdownEditorModeBtnWrap .markdownEditorModeBtn:disabled {
+	pointer-events: none;
+}
+
+.markdownEditorModeBtnHint {
+	position: absolute;
+	z-index: 30;
+	top: calc(100% + 6px);
+	left: 50%;
+	width: max-content;
+	max-width: 168px;
+	padding: 4px 8px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 80%, transparent);
+	border-radius: var(--radius-sm);
+	background: var(--bg-primary);
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.66);
+	font-weight: var(--font-medium);
+	line-height: 1.25;
+	text-align: center;
+	text-wrap: balance;
+	box-shadow: var(--shadow-sm);
+	opacity: 0;
+	visibility: hidden;
+	pointer-events: none;
+	transform: translateX(-50%) translateY(-2px);
+	transition:
+		opacity 140ms ease,
+		visibility 140ms ease,
+		transform 140ms ease;
+}
+
+.markdownEditorModeBtnHint[data-warning="true"] {
+	border-color: color-mix(in srgb, var(--callout-warning) 34%, transparent);
+	background: color-mix(in srgb, var(--callout-warning) 14%, var(--bg-primary));
+	color: var(--status-warning-fg);
+}
+
+.markdownEditorModeBtnWrap:hover .markdownEditorModeBtnHint,
+.markdownEditorModeBtnWrap:focus-within .markdownEditorModeBtnHint {
+	opacity: 1;
+	visibility: visible;
+	transform: translateX(-50%) translateY(0);
+}
+
+.markdownEditorModeBtn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 20px;
+	padding: 0;
+	border: 0;
+	border-radius: calc(var(--radius-md) - 2px);
+	background: transparent;
+	color: var(--text-tertiary);
+	line-height: 0;
+	cursor: pointer;
+	transition:
+		background-color 120ms ease,
+		color 120ms ease;
+}
+
+.markdownEditorModeBtn:hover:not(:disabled) {
+	color: var(--text-primary);
+}
+
+.markdownEditorModeBtn[data-active="true"] {
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-light) 34%, transparent);
+}
+
+.markdownEditorModeBtn:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
+.markdownEditorModeBtn:focus-visible {
+	outline: 2px solid var(--focus);
+	outline-offset: 2px;
 }
 
 .markdownEditorTaskProgress {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -140,7 +140,15 @@
 		color 120ms ease;
 }
 
-.markdownEditorModeBtn:hover:not(:disabled) {
+.markdownEditorModeBtnWrap[data-caution="true"] .markdownEditorModeBtn {
+	color: color-mix(in srgb, var(--status-warning-fg) 72%, var(--text-tertiary));
+}
+
+.markdownEditorModeBtnWrap[data-caution="true"] .markdownEditorModeBtn:hover {
+	color: var(--status-warning-fg);
+}
+
+.markdownEditorModeBtn:hover {
 	color: var(--text-primary);
 }
 
@@ -148,11 +156,6 @@
 	background: var(--bg-primary);
 	color: var(--text-primary);
 	box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-light) 34%, transparent);
-}
-
-.markdownEditorModeBtn:disabled {
-	opacity: 0.4;
-	cursor: default;
 }
 
 .markdownEditorModeBtn:focus-visible {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -103,10 +103,7 @@
 	visibility: hidden;
 	pointer-events: none;
 	transform: translateX(-50%) translateY(-2px);
-	transition:
-		opacity 140ms ease,
-		visibility 140ms ease,
-		transform 140ms ease;
+	transition: opacity 140ms ease, visibility 140ms ease, transform 140ms ease;
 }
 
 .markdownEditorModeBtnHint[data-warning="true"] {
@@ -135,9 +132,7 @@
 	color: var(--text-tertiary);
 	line-height: 0;
 	cursor: pointer;
-	transition:
-		background-color 120ms ease,
-		color 120ms ease;
+	transition: background-color 120ms ease, color 120ms ease;
 }
 
 .markdownEditorModeBtnWrap[data-caution="true"] .markdownEditorModeBtn {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,3 +7,16 @@ class TestResizeObserver implements ResizeObserver {
 if (typeof globalThis.ResizeObserver === "undefined") {
 	globalThis.ResizeObserver = TestResizeObserver;
 }
+
+if (typeof globalThis.matchMedia === "undefined") {
+	globalThis.matchMedia = (query) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener() {},
+		removeListener() {},
+		addEventListener() {},
+		removeEventListener() {},
+		dispatchEvent: () => false,
+	});
+}


### PR DESCRIPTION
## Description

Performance improvements for the editor — lazy-load mermaid diagrams, inline images, and simplify update paths.

- **Lazy mermaid hydration**: Mermaid diagram canvas widgets now use `IntersectionObserver` (rootMargin: 640px) to defer hydration until the diagram is near the viewport. This avoids rendering off-screen SVGs during initial page load.
- **Lazy inline image hydration**: Images in editor content use `loading="lazy"`, `decoding="async"`, and an `IntersectionObserver` (rootMargin: 720px) to defer data-URL resolution. Images are marked with `data-glyph-hydration-state` (pending/loading/ready/failed) and get a placeholder skeleton in CSS.
- **Debounced raw markdown updates**: The raw (plain text) editor now debounces change events at 120ms instead of emitting on every transaction. This reduces unnecessary upstream processing when typing rapidly.
- **Auto-detect large note mode**: Notes exceeding 100K characters automatically open in plain text mode (bypassing the rich ProseMirror editor). This is also applied when a note is loaded via prefetch.
- **Deferred info panel text**: The info panel text is only computed when the info panel is actually open, avoiding expensive string operations on every note load.
- **Simplified task summary hook**: Removed the synchronous memo-based fallback summary — the async worker is now the sole source of truth, with a debounced synchronous fallback only on error.
- **Content-visibility CSS**: Added `content-visibility: auto` and `contain-intrinsic-block-size` to editor elements (images, mermaid, pre, table) so the browser can skip off-screen layout.
- **Guard against stale markdown sync**: The `useNoteEditor` hook now skips YAML frontmatter splitting in plain mode and re-checks the mode dependency to avoid stale updates.

## Screenshots

N/A — performance improvements, no visual changes (except loading placeholders for images and mermaid diagrams, which are intentionally minimal).

## Docs

### New CSS classes
- `.tiptapContentInline img[data-glyph-hydration-state="pending"]`, `.tiptapContentInline img[data-glyph-hydration-state="loading"]` — Skeleton placeholder for deferred images
- `.tiptapContentInline pre, .tiptapContentInline table, .tiptapContentInline img` — `content-visibility: auto`
- `.mermaidCanvasPlaceholder .mermaidCanvasFrame::after` — Skeleton overlay for deferred mermaid diagrams

### Large note threshold
- `LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000` in `MarkdownEditorPane.tsx` — notes above this character count open in plain text mode. Users can switch to rich mode manually from the toolbar.

### Raw editor debounce
- `RAW_MARKDOWN_CHANGE_DEBOUNCE_MS = 120` in `RawMarkdownEditor.tsx` — pending changes are flushed on unmount via `flushPendingChange()`.

## Ready?

- [ ] Documented what's new
- [ ] Ran the linter to ensure style guidelines were followed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor view mode selector UI for switching between plain, rich, and preview modes

* **Bug Fixes**
  * Plain text editor now properly resets when switching between notes

* **Performance**
  * Mermaid diagrams and inline images now load lazily when visible
  * Large notes default to plain text editor mode to optimize performance

* **Tests**
  * Updated editor mode selection tests

* **Chores**
  * Version updated to 0.8.1-alpha.1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->