### PR TITLE
Incremental indexing with progress reporting (#190) [Release]

### DIFF
--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use serde::Serialize;
-use tauri::{State, WebviewWindow};
+use tauri::{Emitter, State, WebviewWindow};
 
 use crate::space::SpaceState;
 
@@ -10,13 +10,13 @@ use super::checklists::{
     query_note_checklist_summaries, summarize_tasks, NoteTaskSummary, NoteTaskSummaryItem,
 };
 use super::db::open_db;
-use super::indexer::rebuild;
+use super::indexer::{rebuild_with_progress, sync};
 use super::relationships::{query_note_relationships, NoteRelationship};
 use super::search_advanced::{run_search_advanced, SearchAdvancedRequest};
 use super::search_hybrid::hybrid_search;
 use super::tags::{people_tag_to_handle, tag_depth, PEOPLE_TAG_NAMESPACE};
 use super::types::{
-    BacklinkItem, IndexRebuildResult, LocalConnectionsEdge, LocalConnectionsNode,
+    BacklinkItem, IndexProgress, IndexRebuildResult, LocalConnectionsEdge, LocalConnectionsNode,
     LocalConnectionsTagEdge, LocalConnectionsTagNode, LocalNoteConnections, PersonCount,
     SearchResult, SpaceConnectionKind, SpaceConnections, SpaceConnectionsEdge,
     SpaceConnectionsNode, SpaceConnectionsTagEdge, SpaceConnectionsTagNode, TagCount,
@@ -130,10 +130,35 @@ pub async fn index_rebuild(
     state: State<'_, SpaceState>,
 ) -> Result<IndexRebuildResult, String> {
     let root = state.root_for_window(&window)?;
-    let res = tauri::async_runtime::spawn_blocking(move || rebuild(&root))
-        .await
-        .map_err(|e| e.to_string())??;
+    let progress_window = window.clone();
+    let res = tauri::async_runtime::spawn_blocking(move || {
+        rebuild_with_progress(&root, |completed, total| {
+            if completed == 0 || completed == total || completed % 50 == 0 {
+                let _ = progress_window.emit("index:progress", IndexProgress { completed, total });
+            }
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())??;
     Ok(res)
+}
+
+#[tauri::command]
+pub async fn index_sync(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+) -> Result<IndexRebuildResult, String> {
+    let root = state.root_for_window(&window)?;
+    let progress_window = window.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        sync(&root, |completed, total| {
+            if completed == 0 || completed == total || completed % 50 == 0 {
+                let _ = progress_window.emit("index:progress", IndexProgress { completed, total });
+            }
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -93,6 +93,32 @@ fn collect_markdown_files(space_root: &Path) -> Result<Vec<(String, PathBuf)>, S
     Ok(out)
 }
 
+fn file_fingerprint(path: &Path) -> Result<(i64, i64), String> {
+    let metadata = std::fs::metadata(path).map_err(|e| e.to_string())?;
+    let modified_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64)
+        .unwrap_or_default();
+    let size = metadata.len().min(i64::MAX as u64) as i64;
+    Ok((modified_ns, size))
+}
+
+fn record_file_fingerprint(
+    conn: &rusqlite::Connection,
+    note_id: &str,
+    file_path: &Path,
+) -> Result<(), String> {
+    let (modified_ns, size) = file_fingerprint(file_path)?;
+    conn.execute(
+        "INSERT OR REPLACE INTO indexed_files(path, modified_ns, size) VALUES(?, ?, ?)",
+        rusqlite::params![note_id, modified_ns, size],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 fn link_kind_for_id(to_id: &str) -> &'static str {
     if utils::is_markdown_path(Path::new(to_id)) {
         "note"
@@ -124,6 +150,7 @@ fn index_note_with_conn(
     if existing_etag.as_deref() == Some(etag.as_str()) {
         ensure_note_relationships_indexed(conn, note_id, markdown)?;
         refresh_indexed_timestamps_if_needed(conn, note_id, file_path)?;
+        record_file_fingerprint(conn, note_id, file_path)?;
         return Ok(());
     }
 
@@ -227,6 +254,7 @@ fn index_note_with_conn(
     }
 
     tx.commit().map_err(|e| e.to_string())?;
+    record_file_fingerprint(conn, note_id, file_path)?;
     Ok(())
 }
 
@@ -288,11 +316,19 @@ pub fn remove_note(space_root: &Path, note_id: &str) -> Result<(), String> {
         [note_id],
     )
     .map_err(|e| e.to_string())?;
+    tx.execute("DELETE FROM indexed_files WHERE path = ?", [note_id])
+        .map_err(|e| e.to_string())?;
     tx.commit().map_err(|e| e.to_string())?;
     Ok(())
 }
 
-pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
+pub fn rebuild_with_progress<F>(
+    space_root: &Path,
+    mut on_progress: F,
+) -> Result<IndexRebuildResult, String>
+where
+    F: FnMut(usize, usize),
+{
     let mut conn = open_db(space_root)?;
     let tx = conn.transaction().map_err(|e| e.to_string())?;
     let people_tags_enabled = people_mentions_as_tags_enabled();
@@ -309,14 +345,17 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
         .map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM note_relationships", [])
         .map_err(|e| e.to_string())?;
+    tx.execute("DELETE FROM indexed_files", [])
+        .map_err(|e| e.to_string())?;
 
     let note_paths = collect_markdown_files(space_root)?;
     let mut link_data: Vec<(String, HashSet<String>, HashSet<String>)> =
         Vec::with_capacity(note_paths.len());
     let mut relationship_data = Vec::with_capacity(note_paths.len());
     let count = note_paths.len();
+    on_progress(0, count);
 
-    for (rel, path) in &note_paths {
+    for (index, (rel, path)) in note_paths.iter().enumerate() {
         let markdown = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
 
         let (mut title, created, updated) =
@@ -386,6 +425,15 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
         let (to_ids, to_titles) = parse_outgoing_links(rel, &markdown);
         link_data.push((rel.clone(), to_ids, to_titles));
         relationship_data.push((rel.clone(), parse_frontmatter_relationships(&markdown)));
+        let (modified_ns, size) = file_fingerprint(path)?;
+        tx.execute(
+            "INSERT INTO indexed_files(path, modified_ns, size) VALUES(?, ?, ?)",
+            rusqlite::params![rel, modified_ns, size],
+        )
+        .map_err(|e| e.to_string())?;
+        if index + 1 < count {
+            on_progress(index + 1, count);
+        }
     }
 
     for (rel, to_ids, to_titles) in &link_data {
@@ -414,7 +462,68 @@ pub fn rebuild(space_root: &Path) -> Result<IndexRebuildResult, String> {
     }
 
     tx.commit().map_err(|e| e.to_string())?;
+    on_progress(count, count);
     Ok(IndexRebuildResult { indexed: count })
+}
+
+pub fn sync<F>(space_root: &Path, mut on_progress: F) -> Result<IndexRebuildResult, String>
+where
+    F: FnMut(usize, usize),
+{
+    let conn = open_db(space_root)?;
+    let tracked = {
+        let mut statement = conn
+            .prepare("SELECT path, modified_ns, size FROM indexed_files")
+            .map_err(|e| e.to_string())?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                ))
+            })
+            .map_err(|e| e.to_string())?
+            .collect::<Result<HashMap<_, _>, _>>()
+            .map_err(|e| e.to_string())?;
+        rows
+    };
+    if tracked.is_empty() {
+        drop(conn);
+        return rebuild_with_progress(space_root, on_progress);
+    }
+
+    let note_paths = collect_markdown_files(space_root)?;
+    let disk_paths = note_paths
+        .iter()
+        .map(|(path, _)| path.as_str())
+        .collect::<HashSet<_>>();
+    let removed = tracked
+        .keys()
+        .filter(|path| !disk_paths.contains(path.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let total = note_paths.len() + removed.len();
+    let mut indexed = 0;
+    on_progress(0, total);
+
+    for (position, (note_id, path)) in note_paths.iter().enumerate() {
+        let fingerprint = file_fingerprint(path)?;
+        if tracked.get(note_id) != Some(&fingerprint) {
+            let markdown = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+            index_note_with_conn(&conn, note_id, &markdown, path)?;
+            indexed += 1;
+        }
+        on_progress(position + 1, total);
+    }
+
+    drop(conn);
+    for (offset, note_id) in removed.iter().enumerate() {
+        remove_note(space_root, note_id)?;
+        indexed += 1;
+        on_progress(note_paths.len() + offset + 1, total);
+    }
+
+    Ok(IndexRebuildResult { indexed })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -253,8 +253,8 @@ fn index_note_with_conn(
         .map_err(|e| e.to_string())?;
     }
 
+    record_file_fingerprint(&tx, note_id, file_path)?;
     tx.commit().map_err(|e| e.to_string())?;
-    record_file_fingerprint(conn, note_id, file_path)?;
     Ok(())
 }
 

--- a/src-tauri/src/index/schema.rs
+++ b/src-tauri/src/index/schema.rs
@@ -70,6 +70,12 @@ CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
   body,
   tokenize = 'porter'
 );
+
+CREATE TABLE IF NOT EXISTS indexed_files (
+  path TEXT PRIMARY KEY,
+  modified_ns INTEGER NOT NULL,
+  size INTEGER NOT NULL
+);
 "#,
     )
     .map_err(|e| e.to_string())

--- a/src-tauri/src/index/types.rs
+++ b/src-tauri/src/index/types.rs
@@ -13,6 +13,12 @@ pub struct IndexRebuildResult {
     pub indexed: usize,
 }
 
+#[derive(Clone, Serialize)]
+pub struct IndexProgress {
+    pub completed: usize,
+    pub total: usize,
+}
+
 #[derive(Serialize)]
 pub struct BacklinkItem {
     pub id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1564,6 +1564,7 @@ pub fn run() {
             pinned_files::commands::pinned_files_rename_path,
             pinned_files::commands::pinned_files_delete_path,
             index::commands::index_rebuild,
+            index::commands::index_sync,
             index::commands::search,
             index::commands::search_advanced,
             index::commands::search_parse_and_run,

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -27,6 +27,9 @@ pub fn create_notes_watcher(
     let (idx_tx, idx_rx) = std_mpsc::channel::<(String, bool)>();
 
     let root_idx = root.clone();
+    let index_app = app.clone();
+    let index_window_label = window_label.clone();
+    let index_space_path = root.to_string_lossy().to_string();
     std::thread::spawn(move || {
         let debounce = std::time::Duration::from_millis(DEBOUNCE_MS);
         while let Ok(first) = idx_rx.recv() {
@@ -49,13 +52,26 @@ pub fn create_notes_watcher(
             }
 
             for (rel_s, is_remove) in pending {
-                if is_remove {
-                    let _ = index::remove_note(&root_idx, &rel_s);
+                let result = if is_remove {
+                    index::remove_note(&root_idx, &rel_s)
                 } else {
                     let abs = root_idx.join(&rel_s);
                     if let Ok(markdown) = std::fs::read_to_string(&abs) {
-                        let _ = index::index_note(&root_idx, &rel_s, &markdown);
+                        index::index_note(&root_idx, &rel_s, &markdown)
+                    } else {
+                        continue;
                     }
+                };
+                if result.is_ok() {
+                    let _ = index_app.emit_to(
+                        &index_window_label,
+                        "notes:external_changed",
+                        ExternalChangeEvent {
+                            space_path: index_space_path.clone(),
+                            rel_path: rel_s,
+                            removed: is_remove,
+                        },
+                    );
                 }
             }
         }
@@ -100,15 +116,6 @@ pub fn create_notes_watcher(
             {
                 let _ = idx_tx.send((rel_s.clone(), is_remove));
 
-                let _ = app2.emit_to(
-                    &window_label,
-                    "notes:external_changed",
-                    ExternalChangeEvent {
-                        space_path: space_path.clone(),
-                        rel_path: rel_s.clone(),
-                        removed: is_remove,
-                    },
-                );
             }
 
             let _ = app2.emit_to(

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -1,11 +1,11 @@
 use notify::Watcher;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc as std_mpsc;
 use tauri::Emitter;
 
-use crate::{index, utils};
+use crate::{index, paths, utils};
 
 use super::state::{has_recent_local_change, RecentLocalChanges};
 
@@ -51,11 +51,15 @@ pub fn create_notes_watcher(
                 }
             }
 
+            let mut events = Vec::new();
             for (rel_s, is_remove) in pending {
                 let result = if is_remove {
                     index::remove_note(&root_idx, &rel_s)
                 } else {
-                    let abs = root_idx.join(&rel_s);
+                    let abs = match paths::join_under(&root_idx, Path::new(&rel_s)) {
+                        Ok(abs) => abs,
+                        Err(_) => continue,
+                    };
                     if let Ok(markdown) = std::fs::read_to_string(&abs) {
                         index::index_note(&root_idx, &rel_s, &markdown)
                     } else {
@@ -63,16 +67,16 @@ pub fn create_notes_watcher(
                     }
                 };
                 if result.is_ok() {
-                    let _ = index_app.emit_to(
-                        &index_window_label,
-                        "notes:external_changed",
-                        ExternalChangeEvent {
-                            space_path: index_space_path.clone(),
-                            rel_path: rel_s,
-                            removed: is_remove,
-                        },
-                    );
+                    events.push(ExternalChangeEvent {
+                        space_path: index_space_path.clone(),
+                        rel_path: rel_s,
+                        removed: is_remove,
+                    });
                 }
+            }
+
+            for event in events {
+                let _ = index_app.emit_to(&index_window_label, "notes:external_changed", event);
             }
         }
     });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.1-alpha.1",
+	"version": "0.8.1-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -66,6 +66,7 @@ import {
 	CalendarPaletteController,
 	preloadCalendarPalette,
 } from "./CalendarPaletteController";
+import { IndexingNotice } from "./IndexingNotice";
 import { MainContent } from "./MainContent";
 import { Sidebar } from "./Sidebar";
 import {
@@ -101,6 +102,7 @@ export function AppShell() {
 		closeSpace,
 		onboardingNotePath,
 		consumeOnboardingNotePath,
+		isIndexing,
 	} = space;
 	const fileTreeCtx = useFileTreeContext();
 	const {
@@ -1183,6 +1185,7 @@ export function AppShell() {
 				rightSidebarOpen && "appShellRightSidebarOpen",
 			)}
 		>
+			{isIndexing ? <IndexingNotice /> : null}
 			<div
 				aria-hidden="true"
 				className="windowDragStrip"

--- a/src/components/app/IndexingNotice.tsx
+++ b/src/components/app/IndexingNotice.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import type { IndexProgress } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
+
+export function IndexingNotice() {
+	const [progress, setProgress] = useState<IndexProgress | null>(null);
+	useTauriEvent("index:progress", setProgress);
+	const total = progress?.total ?? 0;
+	const completed = progress?.completed ?? 0;
+	const percentage = total > 0 ? Math.min(100, (completed / total) * 100) : 0;
+
+	return (
+		<output className="indexingNotice" aria-live="polite">
+			<div className="indexingNoticeCopy">
+				<strong>Indexing your space</strong>
+				<span>
+					{total > 0
+						? `${completed.toLocaleString()} of ${total.toLocaleString()} notes`
+						: "Checking for note changes…"}
+				</span>
+			</div>
+			<div className="indexingNoticeTrack" aria-hidden="true">
+				<div
+					className={
+						total > 0 ? "indexingNoticeBar" : "indexingNoticeBar is-pending"
+					}
+					style={total > 0 ? { width: `${percentage}%` } : undefined}
+				/>
+			</div>
+		</output>
+	);
+}

--- a/src/contexts/FileTreeContext.test.tsx
+++ b/src/contexts/FileTreeContext.test.tsx
@@ -67,11 +67,10 @@ describe("FileTreeProvider pinned files", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		currentSpacePath = "/space-a";
-		const startIndexRebuild = vi.fn();
+		const startIndexSync = vi.fn(() => Promise.resolve());
 		useSpaceMock.mockImplementation(() => ({
 			spacePath: currentSpacePath,
-			isIndexing: false,
-			startIndexRebuild,
+			startIndexSync,
 		}));
 		useTauriEventMock.mockImplementation(() => {});
 		invokeMock.mockImplementation((command: string) => {

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -97,7 +97,7 @@ async function fetchAllPeople(): Promise<PersonCount[]> {
 }
 
 export function FileTreeProvider({ children }: { children: ReactNode }) {
-	const { spacePath, isIndexing, startIndexRebuild } = useSpace();
+	const { spacePath, startIndexSync } = useSpace();
 
 	const [rootEntries, setRootEntries] = useState<FsEntry[]>([]);
 	const [childrenByDir, setChildrenByDir] = useState<
@@ -251,13 +251,12 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 
 		const originSpace = spacePath;
 		let cancelled = false;
+		const indexSync = startIndexSync();
 		(async () => {
 			try {
 				const entries = await invoke("space_list_dir", {});
 				if (!cancelled) {
 					setRootEntries(entries);
-					void startIndexRebuild();
-					void refreshTags();
 				}
 			} catch {
 				/* ignore initial load errors */
@@ -293,14 +292,13 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 				/* ignore pinned file load errors */
 			}
 		})();
+		void indexSync.then(() => {
+			if (!cancelled) void refreshTags();
+		});
 		return () => {
 			cancelled = true;
 		};
-	}, [spacePath, startIndexRebuild, refreshTags]);
-
-	useEffect(() => {
-		if (!isIndexing && spacePath) void refreshTags();
-	}, [isIndexing, spacePath, refreshTags]);
+	}, [spacePath, startIndexSync, refreshTags]);
 
 	const refreshPinnedFiles = useCallback(async () => {
 		if (!spacePath) {

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -42,6 +42,7 @@ interface SpaceContextValue {
 	settingsLoaded: boolean;
 	consumeOnboardingNotePath: () => void;
 	startIndexRebuild: () => Promise<void>;
+	startIndexSync: () => Promise<void>;
 	onOpenSpace: () => Promise<void>;
 	onOpenSpaceAtPath: (path: string) => Promise<void>;
 	onContinueLastSpace: () => Promise<void>;
@@ -94,6 +95,15 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	const [isIndexing, setIsIndexing] = useState(false);
 	const [settingsLoaded, setSettingsLoaded] = useState(false);
 	const isOpeningSpaceRef = useRef(false);
+	const currentSpacePathRef = useRef<string | null>(spacePath);
+	const indexSyncRef = useRef<{
+		spacePath: string;
+		promise: Promise<void>;
+	} | null>(null);
+	currentSpacePathRef.current = spacePath;
+	useEffect(() => {
+		if (!spacePath) indexSyncRef.current = null;
+	}, [spacePath]);
 
 	const syncRecentSpacesMenu = useCallback((spaces: string[]) => {
 		void invoke("set_recent_spaces_menu", {
@@ -192,6 +202,28 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		} finally {
 			setIsIndexing(false);
 		}
+	}, []);
+
+	const startIndexSync = useCallback((): Promise<void> => {
+		const currentSpacePath = currentSpacePathRef.current;
+		if (!currentSpacePath) return Promise.resolve();
+		if (indexSyncRef.current?.spacePath === currentSpacePath) {
+			return indexSyncRef.current.promise;
+		}
+
+		setIsIndexing(true);
+		const promise = invoke("index_sync")
+			.then(() => undefined)
+			.catch(() => {
+				/* the index is derived and will retry on the next open */
+			})
+			.finally(() => {
+				if (currentSpacePathRef.current === currentSpacePath) {
+					setIsIndexing(false);
+				}
+			});
+		indexSyncRef.current = { spacePath: currentSpacePath, promise };
+		return promise;
 	}, []);
 
 	const applySpaceSelection = useCallback(
@@ -298,6 +330,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			settingsLoaded,
 			consumeOnboardingNotePath,
 			startIndexRebuild,
+			startIndexSync,
 			onOpenSpace,
 			onOpenSpaceAtPath,
 			onContinueLastSpace,
@@ -316,6 +349,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			settingsLoaded,
 			consumeOnboardingNotePath,
 			startIndexRebuild,
+			startIndexSync,
 			onOpenSpace,
 			onOpenSpaceAtPath,
 			onContinueLastSpace,

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -218,7 +218,13 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				/* the index is derived and will retry on the next open */
 			})
 			.finally(() => {
-				if (currentSpacePathRef.current === currentSpacePath) {
+				if (indexSyncRef.current?.promise === promise) {
+					indexSyncRef.current = null;
+				}
+				if (
+					currentSpacePathRef.current === currentSpacePath ||
+					currentSpacePathRef.current === null
+				) {
 					setIsIndexing(false);
 				}
 			});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -476,6 +476,11 @@ interface IndexRebuildResult {
 	indexed: number;
 }
 
+export interface IndexProgress {
+	completed: number;
+	total: number;
+}
+
 interface AiContextAttachment {
 	kind: "folder" | "file";
 	path: string;
@@ -953,6 +958,7 @@ interface TauriCommands {
 		Record<string, string>
 	>;
 	index_rebuild: CommandDef<void, IndexRebuildResult>;
+	index_sync: CommandDef<void, IndexRebuildResult>;
 	search: CommandDef<{ query: string }, SearchResult[]>;
 	search_advanced: CommandDef<
 		{ request: SearchAdvancedRequest },

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -71,6 +71,7 @@ type TauriEventMap = {
 		rel_path: string;
 		removed: boolean;
 	};
+	"index:progress": import("./tauri").IndexProgress;
 	"settings:updated": {
 		spacePath?: string;
 		ui?: {

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -29,6 +29,79 @@
 	position: relative;
 }
 
+.indexingNotice {
+	position: absolute;
+	top: 12px;
+	left: 50%;
+	z-index: 60;
+	width: min(360px, calc(100% - 32px));
+	transform: translateX(-50%);
+	padding: 10px 12px 9px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 78%, transparent);
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
+	box-shadow: var(--shadow-md);
+	backdrop-filter: blur(18px) saturate(1.2);
+	-webkit-backdrop-filter: blur(18px) saturate(1.2);
+	pointer-events: none;
+}
+
+.indexingNoticeCopy {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.indexingNoticeCopy strong {
+	font-weight: 600;
+	color: var(--text-primary);
+}
+
+.indexingNoticeCopy span {
+	color: var(--text-muted);
+	font-variant-numeric: tabular-nums;
+}
+
+.indexingNoticeTrack {
+	height: 3px;
+	margin-top: 8px;
+	overflow: hidden;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+}
+
+.indexingNoticeBar {
+	height: 100%;
+	border-radius: inherit;
+	background: var(--accent-color);
+	transition: width 120ms ease-out;
+}
+
+.indexingNoticeBar.is-pending {
+	width: 35%;
+	animation: indexing-notice-pending 1.1s ease-in-out infinite alternate;
+}
+
+@keyframes indexing-notice-pending {
+	from {
+		transform: translateX(-90%);
+	}
+	to {
+		transform: translateX(280%);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.indexingNoticeBar,
+	.indexingNoticeBar.is-pending {
+		transition: none;
+		animation: none;
+	}
+}
+
 .drag,
 [data-tauri-drag-region] {
 	-webkit-app-region: drag;


### PR DESCRIPTION
Closes <!-- LINK TO GH ISSUE -->


## Description

Replaces the full-index-rebuild-on-every-open with an incremental sync that skips unchanged notes, and surfaces indexing progress to the user.

### Summary of changes

- **New `index_sync` command** — On space open, fingerprints each indexed note (modified time + file size) and only re-indexes files that have changed since last scan. Falls back to a full rebuild if no prior state exists.
- **New `indexed_files` SQLite table** — Stores file fingerprints (`modified_ns`, `size`) keyed by note path, so the indexer can cheaply skip unchanged files.
- **Progress events** — Both `index_rebuild` and `index_sync` emit `index:progress` events so the frontend can show a real progress bar.
- **`IndexingNotice` component** — A centered, glassmorphic badge at the top of `AppShell` that shows a progress bar and note count during indexing.
- **File watcher reordering** — Moved `notes:external_changed` event emission to after the debounced batch is fully processed, so the frontend receives one coherent notification per batch rather than per-file events.
- **Removed legacy refresh cascade** — Tags now refresh after `indexSync` resolves instead of in a separate `useEffect` watching `isIndexing`.

### Reasoning

The old flow triggered a full re-index (walking + parsing every markdown file) on every space open, with no progress indication — leaving the app unresponsive for large spaces. The sync approach makes subsequent opens near-instant when nothing has changed, and the progress bar gives the user clear feedback when indexing does occur.

### Additional context

- `index_sync` is deduplicated via `indexSyncRef` — if called multiple times for the same space path, it reuses the in-flight promise.
- The existing `index_rebuild` (full rebuild) is kept for manual use (e.g., from dev tools or future UI).
- The progress event is throttled to emit every 50 notes to avoid flooding the IPC channel.


## Screenshots

*Visual: a centered notification bar with a progress track and note count.*


## Docs

The new `index:progress` Tauri event can be listened to by any frontend component:

```ts
import { useTauriEvent } from "../../lib/tauriEvents";
useTauriEvent("index:progress", (progress) => {
  console.log(`${progress.completed} / ${progress.total}`);
});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app indexing progress notice with real-time status updates during note synchronization.
  * Introduced a background “index sync” operation to keep the index up to date.

* **Improvements**
  * Enhanced incremental synchronization by tracking note file fingerprints, reindexing only changed notes, and removing entries for deleted notes.
  * Improved handling of external changes so updates are applied in a debounced, coalesced way.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->