### PR TITLE
Internal heading anchors & footnote navigation (#192) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.3-alpha.1",
+	"version": "0.8.3-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/navigationPrefetch";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
+import { cssEscape } from "../../utils/dom";
 import { ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
@@ -229,10 +230,7 @@ export const SidebarContent = memo(function SidebarContent({
 		const tryCenterRenameTarget = () => {
 			if (cancelled) return;
 			attempts += 1;
-			const escapedPath =
-				typeof CSS !== "undefined" && typeof CSS.escape === "function"
-					? CSS.escape(renamingPath)
-					: renamingPath;
+			const escapedPath = cssEscape(renamingPath);
 			const target = document.querySelector<HTMLElement>(
 				`[data-file-tree-path="${escapedPath}"]`,
 			);

--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -144,6 +144,7 @@ vi.mock("./hooks/useResetScrollOnChange", () => ({
 }));
 
 vi.mock("./markdown/editorEvents", () => ({
+	dispatchInternalAnchorClick: vi.fn(),
 	dispatchMarkdownLinkClick: vi.fn(),
 	dispatchWikiLinkClick: vi.fn(),
 }));

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -33,6 +33,7 @@ import { useResetScrollOnChange } from "./hooks/useResetScrollOnChange";
 import { useRibbonCommands } from "./hooks/useRibbonCommands";
 import { useTableInlineControls } from "./hooks/useTableInlineControls";
 import {
+	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,
 	dispatchWikiLinkClick,
 } from "./markdown/editorEvents";
@@ -112,7 +113,10 @@ async function openFrontmatterHref(
 		await openUrl(href);
 		return;
 	}
-	if (href.startsWith("#")) return;
+	if (href.startsWith("#")) {
+		dispatchInternalAnchorClick({ anchor: href, sourcePath });
+		return;
+	}
 	dispatchMarkdownLinkClick({ href, sourcePath });
 }
 

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -1,7 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
-import { cssEscape } from "../../../utils/dom";
+import { cssEscape } from "../../utils/dom";
 import {
 	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -1,0 +1,173 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+import { cssEscape } from "../../../utils/dom";
+import {
+	dispatchInternalAnchorClick,
+	dispatchMarkdownLinkClick,
+	dispatchPersonClick,
+	dispatchTagClick,
+	dispatchWikiLinkClick,
+} from "./markdown/editorEvents";
+
+function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
+	const href = link.getAttribute("href")?.trim() ?? "";
+	const text = link.textContent?.trim() ?? "";
+	if (!href || text !== href) return false;
+	const previousText = link.previousSibling?.textContent ?? "";
+	const nextText = link.nextSibling?.textContent ?? "";
+	return previousText.endsWith("](") && nextText.startsWith(")");
+}
+
+function expandMarkdownLinkForEditing(
+	view: EditorView,
+	link: HTMLAnchorElement,
+): boolean {
+	const href = link.getAttribute("href")?.trim() ?? "";
+	if (!href || href.startsWith("#")) return false;
+
+	const linkText = (link.textContent ?? "").trim() || href;
+	const markdown = `[${linkText}](${href})`;
+	try {
+		const from = view.posAtDOM(link, 0);
+		const to = view.posAtDOM(link, link.childNodes.length);
+		if (from >= to) return false;
+
+		const hrefStart = from + markdown.lastIndexOf(href);
+		const hrefEnd = hrefStart + href.length;
+		let tr = view.state.tr.insertText(markdown, from, to);
+		try {
+			tr = tr.setSelection(TextSelection.create(tr.doc, hrefStart, hrefEnd));
+		} catch {
+			// Fallback for malformed/mocked docs; the inserted markdown still edits correctly.
+		}
+		view.dispatch(tr.scrollIntoView());
+		view.focus();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function scrollToFootnoteCounterpart(
+	view: EditorView,
+	source: HTMLElement,
+	id: string,
+): void {
+	const isDefinition = source.classList.contains("footnoteDef");
+	const targetClass = isDefinition ? "footnoteRef" : "footnoteDef";
+	const selector = `.${targetClass}[data-footnote-id="${cssEscape(id)}"]`;
+	const destination = view.dom.querySelector<HTMLElement>(selector);
+	if (!destination) return;
+	destination.scrollIntoView({ behavior: "smooth", block: "center" });
+}
+
+export function handleEditorClick(
+	event: MouseEvent,
+	view: EditorView,
+	relPath: string,
+	interactive: boolean,
+	editable: boolean,
+): boolean {
+	const target = event.target instanceof Element ? event.target : null;
+	const tagToken = target?.closest(".tagToken") as HTMLElement | null;
+	if (tagToken) {
+		if (!interactive) {
+			event.preventDefault();
+			return true;
+		}
+		event.preventDefault();
+		const rawTag =
+			tagToken.getAttribute("data-tag") ?? tagToken.textContent ?? "";
+		const normalized = rawTag.trim().replace(/^#+/, "");
+		if (!normalized) return true;
+		dispatchTagClick({ tag: `#${normalized}` });
+		return true;
+	}
+
+	const personToken = target?.closest(".personToken") as HTMLElement | null;
+	if (personToken) {
+		if (!interactive) {
+			event.preventDefault();
+			return true;
+		}
+		event.preventDefault();
+		const rawHandle =
+			personToken.getAttribute("data-handle") ?? personToken.textContent ?? "";
+		const normalized = rawHandle.trim().replace(/^@+/, "");
+		if (!normalized) return true;
+		dispatchPersonClick({ handle: `@${normalized}` });
+		return true;
+	}
+
+	const footnote = target?.closest(
+		".footnoteRef, .footnoteDef",
+	) as HTMLElement | null;
+	if (footnote) {
+		event.preventDefault();
+		if (!interactive) return true;
+		const id = footnote.getAttribute("data-footnote-id");
+		if (id) scrollToFootnoteCounterpart(view, footnote, id);
+		return true;
+	}
+
+	const wikiLink = target?.closest(
+		'[data-wikilink="true"]',
+	) as HTMLElement | null;
+	if (wikiLink) {
+		if (!interactive) {
+			event.preventDefault();
+			return true;
+		}
+		event.preventDefault();
+		dispatchWikiLinkClick({
+			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
+			target: wikiLink.getAttribute("data-target") ?? "",
+			alias: wikiLink.getAttribute("data-alias") || null,
+			anchorKind:
+				(wikiLink.getAttribute("data-anchor-kind") as
+					| "none"
+					| "heading"
+					| "block") ?? "none",
+			anchor: wikiLink.getAttribute("data-anchor") || null,
+			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
+			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
+		});
+		return true;
+	}
+
+	const link = target?.closest("a") as HTMLAnchorElement | null;
+	if (!link) return false;
+	const href = link.getAttribute("href") ?? "";
+	if (!href) return false;
+	if (!interactive) {
+		event.preventDefault();
+		return true;
+	}
+	if (href.startsWith("#")) {
+		event.preventDefault();
+		dispatchInternalAnchorClick({ anchor: href, sourcePath: relPath });
+		return true;
+	}
+	event.preventDefault();
+	if (
+		editable &&
+		isExpandedMarkdownUrlLink(link) &&
+		(href.startsWith("http://") || href.startsWith("https://"))
+	) {
+		void openUrl(href);
+		return true;
+	}
+	if (editable && expandMarkdownLinkForEditing(view, link)) {
+		return true;
+	}
+	if (href.startsWith("http://") || href.startsWith("https://")) {
+		void openUrl(href);
+		return true;
+	}
+	dispatchMarkdownLinkClick({
+		href,
+		sourcePath: relPath,
+	});
+	return true;
+}

--- a/src/components/editor/extensions/footnoteDecorations.ts
+++ b/src/components/editor/extensions/footnoteDecorations.ts
@@ -1,0 +1,132 @@
+import { Extension } from "@tiptap/core";
+import type { Node } from "@tiptap/pm/model";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import {
+	type ChangedRange,
+	changedRangesFromTransactions,
+	mergeChangedRanges,
+} from "./changedRanges";
+
+// Matches a footnote token such as `[^1]` or `[^note]`. The id may not contain
+// whitespace or closing brackets, mirroring the raw-mode footnote highlighter.
+const FOOTNOTE_PATTERN = /\[\^([^\]\s]+)\]/g;
+
+const pluginKey = new PluginKey("footnote-decorations");
+
+function footnoteDecorationsForTextNode(
+	node: Node,
+	pos: number,
+	parent: Node | null,
+): Decoration[] {
+	const decorations: Decoration[] = [];
+	const text = node.text;
+	if (!node.isText || !text) return decorations;
+	if (parent?.type.name === "codeBlock") return decorations;
+	if (node.marks.some((mark) => mark.type.name === "code")) return decorations;
+
+	const isFirstChild = parent?.firstChild === node;
+
+	FOOTNOTE_PATTERN.lastIndex = 0;
+	for (const match of text.matchAll(FOOTNOTE_PATTERN)) {
+		const id = match[1];
+		if (!id) continue;
+		const start = match.index ?? 0;
+		const end = start + match[0].length;
+		const from = pos + start;
+		const to = pos + end;
+		// A definition is the leading `[^id]:` marker of a block.
+		const isDefinition = isFirstChild && start === 0 && text[end] === ":";
+		decorations.push(
+			Decoration.inline(from, to, {
+				class: isDefinition ? "footnoteDef" : "footnoteRef",
+				"data-footnote-id": id,
+			}),
+		);
+	}
+
+	return decorations;
+}
+
+function buildDecorations(doc: Node): DecorationSet {
+	const decorations: Decoration[] = [];
+	doc.descendants((node, pos, parent) => {
+		decorations.push(...footnoteDecorationsForTextNode(node, pos, parent));
+	});
+	return DecorationSet.create(doc, decorations);
+}
+
+function expandRangesToTextblocks(
+	doc: Node,
+	ranges: readonly ChangedRange[],
+): ChangedRange[] {
+	const expanded: ChangedRange[] = [];
+	for (const range of ranges) {
+		doc.nodesBetween(range.from, range.to, (node, pos) => {
+			if (!node.isTextblock) return;
+			expanded.push({ from: pos, to: pos + node.nodeSize });
+			return false;
+		});
+	}
+	return mergeChangedRanges(expanded.length ? expanded : ranges);
+}
+
+function buildDecorationsInRanges(
+	doc: Node,
+	ranges: readonly ChangedRange[],
+): Decoration[] {
+	const decorations: Decoration[] = [];
+	const seen = new Set<number>();
+	for (const range of ranges) {
+		doc.nodesBetween(range.from, range.to, (node, pos, parent) => {
+			if (seen.has(pos)) return false;
+			seen.add(pos);
+			decorations.push(...footnoteDecorationsForTextNode(node, pos, parent));
+		});
+	}
+	return decorations;
+}
+
+function updateDecorations(
+	tr: Transaction,
+	decorations: DecorationSet,
+): DecorationSet {
+	const changedRanges = changedRangesFromTransactions(
+		[tr],
+		tr.doc.content.size,
+	);
+	if (!changedRanges.length) return decorations.map(tr.mapping, tr.doc);
+	const scanRanges = expandRangesToTextblocks(tr.doc, changedRanges);
+	const mapped = decorations.map(tr.mapping, tr.doc);
+	const staleDecorations = scanRanges.flatMap((range) =>
+		mapped.find(range.from, range.to),
+	);
+	const nextDecorations = buildDecorationsInRanges(tr.doc, scanRanges);
+	return mapped.remove(staleDecorations).add(tr.doc, nextDecorations);
+}
+
+export const FootnoteDecorations = Extension.create({
+	name: "footnote-decorations",
+	addProseMirrorPlugins() {
+		return [
+			new Plugin({
+				key: pluginKey,
+				state: {
+					init(_: unknown, state: EditorState) {
+						return buildDecorations(state.doc);
+					},
+					apply(tr: Transaction, old: DecorationSet) {
+						if (!tr.docChanged) return old.map(tr.mapping, tr.doc);
+						return updateDecorations(tr, old);
+					},
+				},
+				props: {
+					decorations(state) {
+						return pluginKey.getState(state);
+					},
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/extensions/footnoteDecorations.ts
+++ b/src/components/editor/extensions/footnoteDecorations.ts
@@ -5,12 +5,10 @@ import { createIncrementalTextDecorationExtension } from "./incrementalTextDecor
 export const FootnoteDecorations = createIncrementalTextDecorationExtension({
 	name: "footnote-decorations",
 	pluginKey: "footnote-decorations",
-	collectDecorations({ node, pos, parent }) {
+	collectDecorations({ node, pos }) {
 		const decorations: Decoration[] = [];
 		const text = node.text;
 		if (!text) return decorations;
-
-		const isFirstChild = parent?.firstChild === node;
 
 		FOOTNOTE_PATTERN.lastIndex = 0;
 		for (const match of text.matchAll(FOOTNOTE_PATTERN)) {
@@ -20,8 +18,8 @@ export const FootnoteDecorations = createIncrementalTextDecorationExtension({
 			const end = start + match[0].length;
 			const from = pos + start;
 			const to = pos + end;
-			const kind = footnoteKindAt(text, start, match[0].length);
-			const isDefinition = isFirstChild && start === 0 && kind === "def";
+			const isDefinition =
+				footnoteKindAt(text, start, match[0].length) === "def";
 			decorations.push(
 				Decoration.inline(from, to, {
 					class: isDefinition ? "footnoteDef" : "footnoteRef",

--- a/src/components/editor/extensions/footnoteDecorations.ts
+++ b/src/components/editor/extensions/footnoteDecorations.ts
@@ -1,132 +1,35 @@
-import { Extension } from "@tiptap/core";
-import type { Node } from "@tiptap/pm/model";
-import type { EditorState, Transaction } from "@tiptap/pm/state";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { Decoration, DecorationSet } from "@tiptap/pm/view";
-import {
-	type ChangedRange,
-	changedRangesFromTransactions,
-	mergeChangedRanges,
-} from "./changedRanges";
+import { Decoration } from "@tiptap/pm/view";
+import { FOOTNOTE_PATTERN, footnoteKindAt } from "../markdown/footnote";
+import { createIncrementalTextDecorationExtension } from "./incrementalTextDecorations";
 
-// Matches a footnote token such as `[^1]` or `[^note]`. The id may not contain
-// whitespace or closing brackets, mirroring the raw-mode footnote highlighter.
-const FOOTNOTE_PATTERN = /\[\^([^\]\s]+)\]/g;
-
-const pluginKey = new PluginKey("footnote-decorations");
-
-function footnoteDecorationsForTextNode(
-	node: Node,
-	pos: number,
-	parent: Node | null,
-): Decoration[] {
-	const decorations: Decoration[] = [];
-	const text = node.text;
-	if (!node.isText || !text) return decorations;
-	if (parent?.type.name === "codeBlock") return decorations;
-	if (node.marks.some((mark) => mark.type.name === "code")) return decorations;
-
-	const isFirstChild = parent?.firstChild === node;
-
-	FOOTNOTE_PATTERN.lastIndex = 0;
-	for (const match of text.matchAll(FOOTNOTE_PATTERN)) {
-		const id = match[1];
-		if (!id) continue;
-		const start = match.index ?? 0;
-		const end = start + match[0].length;
-		const from = pos + start;
-		const to = pos + end;
-		// A definition is the leading `[^id]:` marker of a block.
-		const isDefinition = isFirstChild && start === 0 && text[end] === ":";
-		decorations.push(
-			Decoration.inline(from, to, {
-				class: isDefinition ? "footnoteDef" : "footnoteRef",
-				"data-footnote-id": id,
-			}),
-		);
-	}
-
-	return decorations;
-}
-
-function buildDecorations(doc: Node): DecorationSet {
-	const decorations: Decoration[] = [];
-	doc.descendants((node, pos, parent) => {
-		decorations.push(...footnoteDecorationsForTextNode(node, pos, parent));
-	});
-	return DecorationSet.create(doc, decorations);
-}
-
-function expandRangesToTextblocks(
-	doc: Node,
-	ranges: readonly ChangedRange[],
-): ChangedRange[] {
-	const expanded: ChangedRange[] = [];
-	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos) => {
-			if (!node.isTextblock) return;
-			expanded.push({ from: pos, to: pos + node.nodeSize });
-			return false;
-		});
-	}
-	return mergeChangedRanges(expanded.length ? expanded : ranges);
-}
-
-function buildDecorationsInRanges(
-	doc: Node,
-	ranges: readonly ChangedRange[],
-): Decoration[] {
-	const decorations: Decoration[] = [];
-	const seen = new Set<number>();
-	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos, parent) => {
-			if (seen.has(pos)) return false;
-			seen.add(pos);
-			decorations.push(...footnoteDecorationsForTextNode(node, pos, parent));
-		});
-	}
-	return decorations;
-}
-
-function updateDecorations(
-	tr: Transaction,
-	decorations: DecorationSet,
-): DecorationSet {
-	const changedRanges = changedRangesFromTransactions(
-		[tr],
-		tr.doc.content.size,
-	);
-	if (!changedRanges.length) return decorations.map(tr.mapping, tr.doc);
-	const scanRanges = expandRangesToTextblocks(tr.doc, changedRanges);
-	const mapped = decorations.map(tr.mapping, tr.doc);
-	const staleDecorations = scanRanges.flatMap((range) =>
-		mapped.find(range.from, range.to),
-	);
-	const nextDecorations = buildDecorationsInRanges(tr.doc, scanRanges);
-	return mapped.remove(staleDecorations).add(tr.doc, nextDecorations);
-}
-
-export const FootnoteDecorations = Extension.create({
+export const FootnoteDecorations = createIncrementalTextDecorationExtension({
 	name: "footnote-decorations",
-	addProseMirrorPlugins() {
-		return [
-			new Plugin({
-				key: pluginKey,
-				state: {
-					init(_: unknown, state: EditorState) {
-						return buildDecorations(state.doc);
-					},
-					apply(tr: Transaction, old: DecorationSet) {
-						if (!tr.docChanged) return old.map(tr.mapping, tr.doc);
-						return updateDecorations(tr, old);
-					},
-				},
-				props: {
-					decorations(state) {
-						return pluginKey.getState(state);
-					},
-				},
-			}),
-		];
+	pluginKey: "footnote-decorations",
+	collectDecorations({ node, pos, parent }) {
+		const decorations: Decoration[] = [];
+		const text = node.text;
+		if (!text) return decorations;
+
+		const isFirstChild = parent?.firstChild === node;
+
+		FOOTNOTE_PATTERN.lastIndex = 0;
+		for (const match of text.matchAll(FOOTNOTE_PATTERN)) {
+			const id = match[1];
+			if (!id) continue;
+			const start = match.index ?? 0;
+			const end = start + match[0].length;
+			const from = pos + start;
+			const to = pos + end;
+			const kind = footnoteKindAt(text, start, match[0].length);
+			const isDefinition = isFirstChild && start === 0 && kind === "def";
+			decorations.push(
+				Decoration.inline(from, to, {
+					class: isDefinition ? "footnoteDef" : "footnoteRef",
+					"data-footnote-id": id,
+				}),
+			);
+		}
+
+		return decorations;
 	},
 });

--- a/src/components/editor/extensions/incrementalTextDecorations.ts
+++ b/src/components/editor/extensions/incrementalTextDecorations.ts
@@ -1,0 +1,136 @@
+import { Extension } from "@tiptap/core";
+import type { Node } from "@tiptap/pm/model";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { type Decoration, DecorationSet } from "@tiptap/pm/view";
+import {
+	type ChangedRange,
+	changedRangesFromTransactions,
+	mergeChangedRanges,
+} from "./changedRanges";
+
+export interface TextNodeDecorationContext {
+	node: Node;
+	pos: number;
+	parent: Node | null;
+}
+
+function shouldSkipTextNode(node: Node, parent: Node | null): boolean {
+	if (!node.isText || !node.text) return true;
+	if (parent?.type.name === "codeBlock") return true;
+	if (node.marks.some((mark) => mark.type.name === "code")) return true;
+	return false;
+}
+
+function collectDecorationsForNode(
+	doc: Node,
+	pos: number,
+	parent: Node | null,
+	collect: (context: TextNodeDecorationContext) => Decoration[],
+): Decoration[] {
+	if (shouldSkipTextNode(doc, parent)) return [];
+	return collect({ node: doc, pos, parent });
+}
+
+function buildDecorations(
+	doc: Node,
+	collect: (context: TextNodeDecorationContext) => Decoration[],
+): DecorationSet {
+	const decorations: Decoration[] = [];
+	doc.descendants((node, pos, parent) => {
+		decorations.push(...collectDecorationsForNode(node, pos, parent, collect));
+	});
+	return DecorationSet.create(doc, decorations);
+}
+
+function expandRangesToTextblocks(
+	doc: Node,
+	ranges: readonly ChangedRange[],
+): ChangedRange[] {
+	const expanded: ChangedRange[] = [];
+	for (const range of ranges) {
+		doc.nodesBetween(range.from, range.to, (node, pos) => {
+			if (!node.isTextblock) return;
+			expanded.push({ from: pos, to: pos + node.nodeSize });
+			return false;
+		});
+	}
+	return mergeChangedRanges(expanded.length ? expanded : ranges);
+}
+
+function buildDecorationsInRanges(
+	doc: Node,
+	ranges: readonly ChangedRange[],
+	collect: (context: TextNodeDecorationContext) => Decoration[],
+): Decoration[] {
+	const decorations: Decoration[] = [];
+	const seen = new Set<number>();
+	for (const range of ranges) {
+		doc.nodesBetween(range.from, range.to, (node, pos, parent) => {
+			if (seen.has(pos)) return false;
+			seen.add(pos);
+			decorations.push(
+				...collectDecorationsForNode(node, pos, parent, collect),
+			);
+		});
+	}
+	return decorations;
+}
+
+function updateDecorations(
+	tr: Transaction,
+	decorations: DecorationSet,
+	collect: (context: TextNodeDecorationContext) => Decoration[],
+): DecorationSet {
+	const changedRanges = changedRangesFromTransactions(
+		[tr],
+		tr.doc.content.size,
+	);
+	if (!changedRanges.length) return decorations.map(tr.mapping, tr.doc);
+	const scanRanges = expandRangesToTextblocks(tr.doc, changedRanges);
+	const mapped = decorations.map(tr.mapping, tr.doc);
+	const staleDecorations = scanRanges.flatMap((range) =>
+		mapped.find(range.from, range.to),
+	);
+	const nextDecorations = buildDecorationsInRanges(tr.doc, scanRanges, collect);
+	return mapped.remove(staleDecorations).add(tr.doc, nextDecorations);
+}
+
+export function createIncrementalTextDecorationPlugin(options: {
+	pluginKey: string;
+	collectDecorations: (context: TextNodeDecorationContext) => Decoration[];
+}): Plugin {
+	const pluginKey = new PluginKey(options.pluginKey);
+	const collect = options.collectDecorations;
+
+	return new Plugin({
+		key: pluginKey,
+		state: {
+			init(_: unknown, state: EditorState) {
+				return buildDecorations(state.doc, collect);
+			},
+			apply(tr: Transaction, old: DecorationSet) {
+				if (!tr.docChanged) return old.map(tr.mapping, tr.doc);
+				return updateDecorations(tr, old, collect);
+			},
+		},
+		props: {
+			decorations(state) {
+				return pluginKey.getState(state);
+			},
+		},
+	});
+}
+
+export function createIncrementalTextDecorationExtension(options: {
+	name: string;
+	pluginKey: string;
+	collectDecorations: (context: TextNodeDecorationContext) => Decoration[];
+}) {
+	return Extension.create({
+		name: options.name,
+		addProseMirrorPlugins() {
+			return [createIncrementalTextDecorationPlugin(options)];
+		},
+	});
+}

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./changedRanges";
 import { SyntaxHighlightedCodeBlock } from "./codeBlockHighlighting";
 import { ColoredText } from "./coloredText";
+import { FootnoteDecorations } from "./footnoteDecorations";
 import { HeadingCollapse } from "./headingCollapse";
 import { HighlightedText } from "./highlightedText";
 import { MarkdownImage } from "./markdownImage";
@@ -736,6 +737,7 @@ export function createEditorExtensions(
 			enableShortcutTransform: enableEditingExtensions,
 		}),
 		TagDecorations.configure({ enablePeopleMentions }),
+		FootnoteDecorations,
 		...(enableEditingExtensions && enableVimKeybindings ? [VimMode] : []),
 	];
 }

--- a/src/components/editor/extensions/tagDecorations.ts
+++ b/src/components/editor/extensions/tagDecorations.ts
@@ -1,32 +1,23 @@
 import { Extension } from "@tiptap/core";
-import type { Node } from "@tiptap/pm/model";
-import type { EditorState, Transaction } from "@tiptap/pm/state";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { Decoration } from "@tiptap/pm/view";
 import {
-	type ChangedRange,
-	changedRangesFromTransactions,
-	mergeChangedRanges,
-} from "./changedRanges";
+	type TextNodeDecorationContext,
+	createIncrementalTextDecorationPlugin,
+} from "./incrementalTextDecorations";
 
 const TAG_PATTERN = /(^|[^\w/])#([A-Za-z0-9_][\w/-]*)/g;
 const PERSON_PATTERN = /(^|[^A-Za-z0-9_.-])@([A-Za-z0-9_][A-Za-z0-9_-]*)/g;
 
-const pluginKey = new PluginKey("tag-decorations");
-
-function tagDecorationsForTextNode(
-	node: Node,
-	pos: number,
-	parent: Node | null,
+function collectTagDecorations(
+	{ node, pos }: TextNodeDecorationContext,
 	enablePeopleMentions: boolean,
 ): Decoration[] {
 	const decorations: Decoration[] = [];
-	if (!node.isText || !node.text) return decorations;
-	if (parent?.type.name === "codeBlock") return decorations;
-	if (node.marks.some((mark) => mark.type.name === "code")) return decorations;
+	const text = node.text;
+	if (!text) return decorations;
 
 	TAG_PATTERN.lastIndex = 0;
-	for (const match of node.text.matchAll(TAG_PATTERN)) {
+	for (const match of text.matchAll(TAG_PATTERN)) {
 		const leading = match[1] ?? "";
 		const tag = match[2] ?? "";
 		if (!tag) continue;
@@ -44,7 +35,7 @@ function tagDecorationsForTextNode(
 	if (!enablePeopleMentions) return decorations;
 
 	PERSON_PATTERN.lastIndex = 0;
-	for (const match of node.text.matchAll(PERSON_PATTERN)) {
+	for (const match of text.matchAll(PERSON_PATTERN)) {
 		const leading = match[1] ?? "";
 		const handle = match[2] ?? "";
 		if (!handle) continue;
@@ -62,76 +53,6 @@ function tagDecorationsForTextNode(
 	return decorations;
 }
 
-function buildDecorationsWithPeople(
-	doc: Node,
-	enablePeopleMentions: boolean,
-): DecorationSet {
-	const decorations: Decoration[] = [];
-	doc.descendants((node, pos, parent) => {
-		decorations.push(
-			...tagDecorationsForTextNode(node, pos, parent, enablePeopleMentions),
-		);
-	});
-	return DecorationSet.create(doc, decorations);
-}
-
-function expandRangesToTextblocks(
-	doc: Node,
-	ranges: readonly ChangedRange[],
-): ChangedRange[] {
-	const expanded: ChangedRange[] = [];
-	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos) => {
-			if (!node.isTextblock) return;
-			expanded.push({ from: pos, to: pos + node.nodeSize });
-			return false;
-		});
-	}
-	return mergeChangedRanges(expanded.length ? expanded : ranges);
-}
-
-function buildDecorationsInRanges(
-	doc: Node,
-	ranges: readonly ChangedRange[],
-	enablePeopleMentions: boolean,
-): Decoration[] {
-	const decorations: Decoration[] = [];
-	const seen = new Set<number>();
-	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos, parent) => {
-			if (seen.has(pos)) return false;
-			seen.add(pos);
-			decorations.push(
-				...tagDecorationsForTextNode(node, pos, parent, enablePeopleMentions),
-			);
-		});
-	}
-	return decorations;
-}
-
-function updateDecorationsWithPeople(
-	tr: Transaction,
-	decorations: DecorationSet,
-	enablePeopleMentions: boolean,
-): DecorationSet {
-	const changedRanges = changedRangesFromTransactions(
-		[tr],
-		tr.doc.content.size,
-	);
-	if (!changedRanges.length) return decorations.map(tr.mapping, tr.doc);
-	const scanRanges = expandRangesToTextblocks(tr.doc, changedRanges);
-	const mapped = decorations.map(tr.mapping, tr.doc);
-	const staleDecorations = scanRanges.flatMap((range) =>
-		mapped.find(range.from, range.to),
-	);
-	const nextDecorations = buildDecorationsInRanges(
-		tr.doc,
-		scanRanges,
-		enablePeopleMentions,
-	);
-	return mapped.remove(staleDecorations).add(tr.doc, nextDecorations);
-}
-
 export const TagDecorations = Extension.create({
 	name: "tag-decorations",
 	addOptions() {
@@ -142,22 +63,10 @@ export const TagDecorations = Extension.create({
 	addProseMirrorPlugins() {
 		const enablePeopleMentions = Boolean(this.options.enablePeopleMentions);
 		return [
-			new Plugin({
-				key: pluginKey,
-				state: {
-					init(_: unknown, state: EditorState) {
-						return buildDecorationsWithPeople(state.doc, enablePeopleMentions);
-					},
-					apply(tr: Transaction, old: DecorationSet) {
-						if (!tr.docChanged) return old.map(tr.mapping, tr.doc);
-						return updateDecorationsWithPeople(tr, old, enablePeopleMentions);
-					},
-				},
-				props: {
-					decorations(state) {
-						return pluginKey.getState(state);
-					},
-				},
+			createIncrementalTextDecorationPlugin({
+				pluginKey: "tag-decorations",
+				collectDecorations: (context) =>
+					collectTagDecorations(context, enablePeopleMentions),
 			}),
 		];
 	},

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -1,7 +1,5 @@
-import { openUrl } from "@tauri-apps/plugin-opener";
 import type { JSONContent } from "@tiptap/core";
 import { MarkdownManager } from "@tiptap/markdown";
-import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { useEditor } from "@tiptap/react";
 import {
@@ -23,14 +21,8 @@ import {
 import { invoke } from "../../../lib/tauri";
 import { useTauriEvent } from "../../../lib/tauriEvents";
 import { parentDir } from "../../../utils/path";
+import { handleEditorClick } from "../editorClickHandlers";
 import { createEditorExtensions } from "../extensions";
-import {
-	dispatchInternalAnchorClick,
-	dispatchMarkdownLinkClick,
-	dispatchPersonClick,
-	dispatchTagClick,
-	dispatchWikiLinkClick,
-} from "../markdown/editorEvents";
 import { looksLikeMarkdownPaste } from "../markdown/markdownPaste";
 import {
 	postprocessMarkdownFromEditor,
@@ -264,179 +256,6 @@ interface PendingMarkdownSync {
 	lastEmittedMarkdown: string;
 	onChange: (nextMarkdown: string) => void;
 	relPath: string;
-}
-
-function expandMarkdownLinkForEditing(
-	view: EditorView,
-	link: HTMLAnchorElement,
-): boolean {
-	const href = link.getAttribute("href")?.trim() ?? "";
-	if (!href) return false;
-	if (href.startsWith("#")) return false;
-
-	const linkText = (link.textContent ?? "").trim() || href;
-	const markdown = `[${linkText}](${href})`;
-
-	try {
-		const from = view.posAtDOM(link, 0);
-		const to = view.posAtDOM(link, link.childNodes.length);
-		if (from >= to) return false;
-
-		const hrefStart = from + markdown.lastIndexOf(href);
-		const hrefEnd = hrefStart + href.length;
-		let tr = view.state.tr.insertText(markdown, from, to);
-		try {
-			tr = tr.setSelection(TextSelection.create(tr.doc, hrefStart, hrefEnd));
-		} catch {
-			// Fallback for malformed/mocked docs; the inserted markdown still edits correctly.
-		}
-		view.dispatch(tr.scrollIntoView());
-		view.focus();
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
-	const href = link.getAttribute("href")?.trim() ?? "";
-	const text = link.textContent?.trim() ?? "";
-	if (!href || text !== href) return false;
-	const previousText = link.previousSibling?.textContent ?? "";
-	const nextText = link.nextSibling?.textContent ?? "";
-	return previousText.endsWith("](") && nextText.startsWith(")");
-}
-
-function cssEscape(value: string): string {
-	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
-		return CSS.escape(value);
-	}
-	return value.replace(/["\\]/g, "\\$&");
-}
-
-// Clicking a footnote reference jumps to its definition, and clicking a
-// definition jumps back to the first reference that points at it.
-function scrollToFootnoteCounterpart(
-	view: EditorView,
-	source: HTMLElement,
-	id: string,
-): void {
-	const isDefinition = source.classList.contains("footnoteDef");
-	const targetClass = isDefinition ? "footnoteRef" : "footnoteDef";
-	const selector = `.${targetClass}[data-footnote-id="${cssEscape(id)}"]`;
-	const destination = view.dom.querySelector<HTMLElement>(selector);
-	if (!destination) return;
-	destination.scrollIntoView({ behavior: "smooth", block: "center" });
-}
-
-function handleEditorClick(
-	event: MouseEvent,
-	view: EditorView,
-	relPath: string,
-	interactive: boolean,
-	editable: boolean,
-): boolean {
-	const target = event.target instanceof Element ? event.target : null;
-	const tagToken = target?.closest(".tagToken") as HTMLElement | null;
-	if (tagToken) {
-		if (!interactive) {
-			event.preventDefault();
-			return true;
-		}
-		event.preventDefault();
-		const rawTag =
-			tagToken.getAttribute("data-tag") ?? tagToken.textContent ?? "";
-		const normalized = rawTag.trim().replace(/^#+/, "");
-		if (!normalized) return true;
-		dispatchTagClick({ tag: `#${normalized}` });
-		return true;
-	}
-
-	const personToken = target?.closest(".personToken") as HTMLElement | null;
-	if (personToken) {
-		if (!interactive) {
-			event.preventDefault();
-			return true;
-		}
-		event.preventDefault();
-		const rawHandle =
-			personToken.getAttribute("data-handle") ?? personToken.textContent ?? "";
-		const normalized = rawHandle.trim().replace(/^@+/, "");
-		if (!normalized) return true;
-		dispatchPersonClick({ handle: `@${normalized}` });
-		return true;
-	}
-
-	const footnote = target?.closest(
-		".footnoteRef, .footnoteDef",
-	) as HTMLElement | null;
-	if (footnote) {
-		event.preventDefault();
-		if (!interactive) return true;
-		const id = footnote.getAttribute("data-footnote-id");
-		if (id) scrollToFootnoteCounterpart(view, footnote, id);
-		return true;
-	}
-
-	const wikiLink = target?.closest(
-		'[data-wikilink="true"]',
-	) as HTMLElement | null;
-	if (wikiLink) {
-		if (!interactive) {
-			event.preventDefault();
-			return true;
-		}
-		event.preventDefault();
-		dispatchWikiLinkClick({
-			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
-			target: wikiLink.getAttribute("data-target") ?? "",
-			alias: wikiLink.getAttribute("data-alias") || null,
-			anchorKind:
-				(wikiLink.getAttribute("data-anchor-kind") as
-					| "none"
-					| "heading"
-					| "block") ?? "none",
-			anchor: wikiLink.getAttribute("data-anchor") || null,
-			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
-			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
-		});
-		return true;
-	}
-
-	const link = target?.closest("a") as HTMLAnchorElement | null;
-	if (!link) return false;
-	const href = link?.getAttribute("href") ?? "";
-	if (!href) return false;
-	if (!interactive) {
-		event.preventDefault();
-		return true;
-	}
-	if (href.startsWith("#")) {
-		event.preventDefault();
-		dispatchInternalAnchorClick({ anchor: href, sourcePath: relPath });
-		return true;
-	}
-	event.preventDefault();
-	if (
-		editable &&
-		isExpandedMarkdownUrlLink(link) &&
-		(href.startsWith("http://") || href.startsWith("https://"))
-	) {
-		void openUrl(href);
-		return true;
-	}
-	if (editable && expandMarkdownLinkForEditing(view, link)) {
-		return true;
-	}
-	if (href.startsWith("http://") || href.startsWith("https://")) {
-		void openUrl(href);
-		return true;
-	}
-	dispatchMarkdownLinkClick({
-		href,
-		sourcePath: relPath,
-	});
-	return true;
 }
 
 export function useNoteEditor({

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -25,6 +25,7 @@ import { useTauriEvent } from "../../../lib/tauriEvents";
 import { parentDir } from "../../../utils/path";
 import { createEditorExtensions } from "../extensions";
 import {
+	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,
 	dispatchPersonClick,
 	dispatchTagClick,
@@ -377,7 +378,11 @@ function handleEditorClick(
 		event.preventDefault();
 		return true;
 	}
-	if (href.startsWith("#")) return false;
+	if (href.startsWith("#")) {
+		event.preventDefault();
+		dispatchInternalAnchorClick({ anchor: href, sourcePath: relPath });
+		return true;
+	}
 	event.preventDefault();
 	if (
 		editable &&

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -307,6 +307,28 @@ function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
 	return previousText.endsWith("](") && nextText.startsWith(")");
 }
 
+function cssEscape(value: string): string {
+	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+		return CSS.escape(value);
+	}
+	return value.replace(/["\\]/g, "\\$&");
+}
+
+// Clicking a footnote reference jumps to its definition, and clicking a
+// definition jumps back to the first reference that points at it.
+function scrollToFootnoteCounterpart(
+	view: EditorView,
+	source: HTMLElement,
+	id: string,
+): void {
+	const isDefinition = source.classList.contains("footnoteDef");
+	const targetClass = isDefinition ? "footnoteRef" : "footnoteDef";
+	const selector = `.${targetClass}[data-footnote-id="${cssEscape(id)}"]`;
+	const destination = view.dom.querySelector<HTMLElement>(selector);
+	if (!destination) return;
+	destination.scrollIntoView({ behavior: "smooth", block: "center" });
+}
+
 function handleEditorClick(
 	event: MouseEvent,
 	view: EditorView,
@@ -342,6 +364,17 @@ function handleEditorClick(
 		const normalized = rawHandle.trim().replace(/^@+/, "");
 		if (!normalized) return true;
 		dispatchPersonClick({ handle: `@${normalized}` });
+		return true;
+	}
+
+	const footnote = target?.closest(
+		".footnoteRef, .footnoteDef",
+	) as HTMLElement | null;
+	if (footnote) {
+		event.preventDefault();
+		if (!interactive) return true;
+		const id = footnote.getAttribute("data-footnote-id");
+		if (id) scrollToFootnoteCounterpart(view, footnote, id);
 		return true;
 	}
 

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -7,12 +7,14 @@ import {
 	changedRangesFromTransactions,
 	mergeChangedRanges,
 } from "../extensions/changedRanges";
+import { withHeadingSlugs } from "../markdown/headingAnchor";
 
 export interface TOCHeading {
 	id: string;
 	level: number;
 	text: string;
 	pos: number;
+	slug?: string;
 }
 
 function getHeadingElement(
@@ -81,7 +83,7 @@ function extractHeadingsFromDoc(doc: ProseMirrorNode): TOCHeading[] {
 		const heading = headingFromNode(node, pos);
 		if (heading) headings.push(heading);
 	});
-	return headings;
+	return withHeadingSlugs(headings);
 }
 
 function expandRangesToTextblocks(
@@ -158,7 +160,7 @@ function updateHeadingsFromTransaction(
 
 	next.push(...extractHeadingsInRanges(transaction.doc, scanRanges));
 	next.sort((a, b) => a.pos - b.pos);
-	return next;
+	return withHeadingSlugs(next);
 }
 
 export function useTableOfContents(editor: Editor | null) {

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -2,6 +2,7 @@ export const WIKI_LINK_CLICK_EVENT = "glyph:wikilink-click";
 export const MARKDOWN_LINK_CLICK_EVENT = "glyph:markdown-link-click";
 export const TAG_CLICK_EVENT = "glyph:tag-click";
 export const PERSON_CLICK_EVENT = "glyph:person-click";
+export const INTERNAL_ANCHOR_CLICK_EVENT = "glyph:internal-anchor-click";
 
 export interface WikiLinkClickDetail {
 	raw: string;
@@ -23,6 +24,11 @@ export interface PersonClickDetail {
 
 export interface MarkdownLinkClickDetail {
 	href: string;
+	sourcePath: string;
+}
+
+export interface InternalAnchorClickDetail {
+	anchor: string;
 	sourcePath: string;
 }
 
@@ -49,6 +55,16 @@ export function dispatchMarkdownLinkClick(
 ): void {
 	window.dispatchEvent(
 		new CustomEvent<MarkdownLinkClickDetail>(MARKDOWN_LINK_CLICK_EVENT, {
+			detail,
+		}),
+	);
+}
+
+export function dispatchInternalAnchorClick(
+	detail: InternalAnchorClickDetail,
+): void {
+	window.dispatchEvent(
+		new CustomEvent<InternalAnchorClickDetail>(INTERNAL_ANCHOR_CLICK_EVENT, {
 			detail,
 		}),
 	);

--- a/src/components/editor/markdown/footnote.ts
+++ b/src/components/editor/markdown/footnote.ts
@@ -1,0 +1,51 @@
+// Matches a footnote token such as `[^1]` or `[^note]`. The id may not contain
+// whitespace or closing brackets.
+export const FOOTNOTE_PATTERN = /\[\^([^\]\s]+)\]/g;
+
+export type FootnoteKind = "ref" | "def";
+
+export function isFootnoteDefinition(
+	text: string,
+	matchIndex: number,
+	matchLength: number,
+): boolean {
+	return matchIndex === 0 && text[matchIndex + matchLength] === ":";
+}
+
+export function footnoteKindAt(
+	text: string,
+	matchIndex: number,
+	matchLength: number,
+): FootnoteKind {
+	return isFootnoteDefinition(text, matchIndex, matchLength) ? "def" : "ref";
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Find the document offset of a footnote ref/def counterpart. Returns the
+ * start offset of the matching token, or null when none exists.
+ */
+export function findFootnoteCounterpartOffset(
+	markdown: string,
+	id: string,
+	fromKind: FootnoteKind,
+): number | null {
+	const escapedId = escapeRegExp(id);
+	if (fromKind === "ref") {
+		const definitionPattern = new RegExp(`^\\[\\^${escapedId}\\]:`, "m");
+		const match = definitionPattern.exec(markdown);
+		return match?.index ?? null;
+	}
+
+	const referencePattern = new RegExp(`\\[\\^${escapedId}\\]`, "g");
+	for (const match of markdown.matchAll(referencePattern)) {
+		const start = match.index ?? 0;
+		if (!isFootnoteDefinition(markdown, start, match[0].length)) {
+			return start;
+		}
+	}
+	return null;
+}

--- a/src/components/editor/markdown/footnote.ts
+++ b/src/components/editor/markdown/footnote.ts
@@ -9,7 +9,8 @@ export function isFootnoteDefinition(
 	matchIndex: number,
 	matchLength: number,
 ): boolean {
-	return matchIndex === 0 && text[matchIndex + matchLength] === ":";
+	const atLineStart = matchIndex === 0 || text[matchIndex - 1] === "\n";
+	return atLineStart && text[matchIndex + matchLength] === ":";
 }
 
 export function footnoteKindAt(

--- a/src/components/editor/markdown/headingAnchor.ts
+++ b/src/components/editor/markdown/headingAnchor.ts
@@ -26,6 +26,20 @@ function normalizeAnchor(anchor: string): string {
 	return value.trim().toLowerCase();
 }
 
+/** Attach GitHub-style disambiguated anchor slugs to a heading list. */
+export function withHeadingSlugs(
+	headings: readonly TOCHeading[],
+): TOCHeading[] {
+	const counts = new Map<string, number>();
+	return headings.map((heading) => {
+		const base = slugifyHeading(heading.text);
+		const seen = counts.get(base) ?? 0;
+		counts.set(base, seen + 1);
+		const slug = seen === 0 ? base : `${base}-${seen}`;
+		return { ...heading, slug };
+	});
+}
+
 /**
  * Resolve an in-document anchor (e.g. "#heading-1") to the heading it targets.
  * Duplicate heading texts are disambiguated the same way GitHub does, by
@@ -39,19 +53,18 @@ export function resolveAnchorHeading(
 	const normalized = normalizeAnchor(anchor);
 	if (!normalized) return null;
 
-	const counts = new Map<string, number>();
-	let textMatch: TOCHeading | null = null;
+	const indexed =
+		headings.length > 0 && headings[0]?.slug !== undefined
+			? headings
+			: withHeadingSlugs(headings);
 
-	for (const heading of headings) {
-		const base = slugifyHeading(heading.text);
-		const seen = counts.get(base) ?? 0;
-		counts.set(base, seen + 1);
-		const slug = seen === 0 ? base : `${base}-${seen}`;
-		if (slug === normalized) return heading;
-		if (!textMatch && heading.text.trim().toLowerCase() === normalized) {
-			textMatch = heading;
-		}
+	for (const heading of indexed) {
+		if (heading.slug === normalized) return heading;
 	}
 
-	return textMatch;
+	return (
+		indexed.find(
+			(heading) => heading.text.trim().toLowerCase() === normalized,
+		) ?? null
+	);
 }

--- a/src/components/editor/markdown/headingAnchor.ts
+++ b/src/components/editor/markdown/headingAnchor.ts
@@ -9,7 +9,7 @@ export function slugifyHeading(text: string): string {
 	return text
 		.trim()
 		.toLowerCase()
-		.replace(/[^\w\s-]/g, "")
+		.replace(/[^\p{L}\p{N}_\s-]/gu, "")
 		.replace(/\s+/g, "-")
 		.replace(/-+/g, "-")
 		.replace(/^-+|-+$/g, "");

--- a/src/components/editor/markdown/headingAnchor.ts
+++ b/src/components/editor/markdown/headingAnchor.ts
@@ -1,0 +1,57 @@
+import type { TOCHeading } from "../hooks/useTableOfContents";
+
+/**
+ * Convert a heading's text into a GitHub-style anchor slug, e.g.
+ * "Heading 1" -> "heading-1". This mirrors what markdown table-of-contents
+ * generators emit so in-document links like `[Heading 1](#heading-1)` resolve.
+ */
+export function slugifyHeading(text: string): string {
+	return text
+		.trim()
+		.toLowerCase()
+		.replace(/[^\w\s-]/g, "")
+		.replace(/\s+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}
+
+function normalizeAnchor(anchor: string): string {
+	let value = anchor.trim();
+	if (value.startsWith("#")) value = value.slice(1);
+	try {
+		value = decodeURIComponent(value);
+	} catch {
+		// Keep the raw value when it isn't valid percent-encoding.
+	}
+	return value.trim().toLowerCase();
+}
+
+/**
+ * Resolve an in-document anchor (e.g. "#heading-1") to the heading it targets.
+ * Duplicate heading texts are disambiguated the same way GitHub does, by
+ * appending "-1", "-2", ... to repeated slugs. Falls back to a case-insensitive
+ * exact text match when no slug matches.
+ */
+export function resolveAnchorHeading(
+	headings: readonly TOCHeading[],
+	anchor: string,
+): TOCHeading | null {
+	const normalized = normalizeAnchor(anchor);
+	if (!normalized) return null;
+
+	const counts = new Map<string, number>();
+	let textMatch: TOCHeading | null = null;
+
+	for (const heading of headings) {
+		const base = slugifyHeading(heading.text);
+		const seen = counts.get(base) ?? 0;
+		counts.set(base, seen + 1);
+		const slug = seen === 0 ? base : `${base}-${seen}`;
+		if (slug === normalized) return heading;
+		if (!textMatch && heading.text.trim().toLowerCase() === normalized) {
+			textMatch = heading;
+		}
+	}
+
+	return textMatch;
+}

--- a/src/components/editor/raw/contentDecorations.ts
+++ b/src/components/editor/raw/contentDecorations.ts
@@ -1,13 +1,13 @@
 import { syntaxTree } from "@codemirror/language";
 import type { Range, Text } from "@codemirror/state";
 import { Decoration, type EditorView } from "@codemirror/view";
+import { FOOTNOTE_PATTERN, footnoteKindAt } from "../markdown/footnote";
 import { parseWikiLink } from "../markdown/wikiLinkCodec";
 
 const WIKI_LINK_PATTERN = /!?\[\[[^\]\n]+\]\]/g;
 const TAG_PATTERN = /(^|[^\w/#])#([A-Za-z0-9_][\w/-]*)/g;
 const HIGHLIGHT_PATTERN = /==([^=\n]+)==/g;
 const COMMENT_PATTERN = /%%(?:[^%]|%(?!%))*%%/g;
-const FOOTNOTE_PATTERN = /\[\^[^\]\n]+\]/g;
 const BLOCK_ID_PATTERN = /(?:^|\s)(\^[A-Za-z0-9-]+)(?=\s*$)/;
 const FRONTMATTER_SCAN_LIMIT = 500;
 
@@ -110,14 +110,22 @@ export function addGlyphInlineDecorations(
 		COMMENT_PATTERN,
 		"cm-raw-comment",
 	);
-	addPatternDecorations(
-		ranges,
-		view,
-		lineFrom,
-		text,
-		FOOTNOTE_PATTERN,
-		"cm-raw-footnote",
-	);
+	FOOTNOTE_PATTERN.lastIndex = 0;
+	for (const match of text.matchAll(FOOTNOTE_PATTERN)) {
+		if (match.index === undefined || !match[1]) continue;
+		const from = lineFrom + match.index;
+		if (isCodePosition(view, from)) continue;
+		const kind = footnoteKindAt(text, match.index, match[0].length);
+		ranges.push(
+			Decoration.mark({
+				class: "cm-raw-footnote",
+				attributes: {
+					"data-footnote-id": match[1],
+					"data-footnote-kind": kind,
+				},
+			}).range(from, from + match[0].length),
+		);
+	}
 
 	const blockIdMatch = text.match(BLOCK_ID_PATTERN);
 	if (blockIdMatch?.[1]) {

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -49,6 +49,14 @@ function scrollToRawFootnoteCounterpart(
 	return true;
 }
 
+function placeCaretAtEvent(view: EditorView, event: MouseEvent): boolean {
+	const offset = view.posAtCoords({ x: event.clientX, y: event.clientY });
+	if (offset === null) return false;
+	view.dispatch({ selection: { anchor: offset } });
+	view.focus();
+	return true;
+}
+
 export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 	return {
 		mousedown: (event: MouseEvent) => {
@@ -70,10 +78,12 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 			const footnote = target?.closest<HTMLElement>(".cm-raw-footnote");
 			if (footnote?.dataset.footnoteId) {
 				const kind = footnote.dataset.footnoteKind === "def" ? "def" : "ref";
-				return scrollToRawFootnoteCounterpart(
-					view,
-					footnote.dataset.footnoteId,
-					kind,
+				return (
+					scrollToRawFootnoteCounterpart(
+						view,
+						footnote.dataset.footnoteId,
+						kind,
+					) || placeCaretAtEvent(view, event)
 				);
 			}
 

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -6,6 +6,10 @@ import {
 	dispatchTagClick,
 	dispatchWikiLinkClick,
 } from "../markdown/editorEvents";
+import {
+	type FootnoteKind,
+	findFootnoteCounterpartOffset,
+} from "../markdown/footnote";
 import { parseWikiLink } from "../markdown/wikiLinkCodec";
 
 function toggleTask(view: EditorView, target: HTMLElement): boolean {
@@ -26,13 +30,32 @@ function toggleTask(view: EditorView, target: HTMLElement): boolean {
 	return true;
 }
 
+function scrollToRawFootnoteCounterpart(
+	view: EditorView,
+	id: string,
+	fromKind: FootnoteKind,
+): boolean {
+	const offset = findFootnoteCounterpartOffset(
+		view.state.doc.toString(),
+		id,
+		fromKind,
+	);
+	if (offset === null) return false;
+	view.dispatch({
+		selection: { anchor: offset },
+		effects: EditorView.scrollIntoView(offset, { y: "center" }),
+	});
+	view.focus();
+	return true;
+}
+
 export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 	return {
 		mousedown: (event: MouseEvent) => {
 			const target = event.target as Element | null;
 			if (
 				target?.closest(
-					".cm-raw-task-checkbox, .cm-raw-wiki-link, .cm-raw-markdown-link, .cm-raw-tag",
+					".cm-raw-task-checkbox, .cm-raw-wiki-link, .cm-raw-markdown-link, .cm-raw-tag, .cm-raw-footnote",
 				)
 			) {
 				event.preventDefault();
@@ -43,6 +66,16 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 			const target = event.target as Element | null;
 			const task = target?.closest<HTMLElement>(".cm-raw-task-checkbox");
 			if (task) return toggleTask(view, task);
+
+			const footnote = target?.closest<HTMLElement>(".cm-raw-footnote");
+			if (footnote?.dataset.footnoteId) {
+				const kind = footnote.dataset.footnoteKind === "def" ? "def" : "ref";
+				return scrollToRawFootnoteCounterpart(
+					view,
+					footnote.dataset.footnoteId,
+					kind,
+				);
+			}
 
 			const wikiLink = target?.closest<HTMLElement>(".cm-raw-wiki-link");
 			if (wikiLink) {

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -1,6 +1,7 @@
 import { EditorView } from "@codemirror/view";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,
 	dispatchTagClick,
 	dispatchWikiLinkClick,
@@ -64,6 +65,13 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 			if (!href) return false;
 			if (href.startsWith("http://") || href.startsWith("https://")) {
 				void openUrl(href);
+				return true;
+			}
+			if (href.startsWith("#")) {
+				dispatchInternalAnchorClick({
+					anchor: href,
+					sourcePath: getRelPath(),
+				});
 				return true;
 			}
 			dispatchMarkdownLinkClick({ href, sourcePath: getRelPath() });

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -41,6 +41,11 @@ import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
+import {
+	INTERNAL_ANCHOR_CLICK_EVENT,
+	type InternalAnchorClickDetail,
+} from "../editor/markdown/editorEvents";
+import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
 import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import type {
@@ -330,6 +335,30 @@ export function MarkdownEditorPane({
 		},
 		[mode, scrollToHeading],
 	);
+
+	const tocHeadingsRef = useRef(tocHeadings);
+	tocHeadingsRef.current = tocHeadings;
+	useEffect(() => {
+		const onInternalAnchorClick = (event: Event) => {
+			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
+			if (!detail || detail.sourcePath !== relPath) return;
+			// In plain (raw) mode the live document lives in CodeMirror, so parse
+			// headings from the current text rather than the info-panel snapshot.
+			const headings =
+				mode === "plain"
+					? analyzeNoteInfo(textRef.current, textRef.current, true).headings
+					: tocHeadingsRef.current;
+			const heading = resolveAnchorHeading(headings, detail.anchor);
+			if (heading) selectVisibleHeading(heading);
+		};
+		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
+		return () => {
+			window.removeEventListener(
+				INTERNAL_ANCHOR_CLICK_EVENT,
+				onInternalAnchorClick,
+			);
+		};
+	}, [mode, relPath, selectVisibleHeading]);
 
 	const flashSyncPulse = useCallback((next: Exclude<SyncPulse, null>) => {
 		if (syncPulseTimerRef.current !== null) {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -41,11 +41,6 @@ import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
-import {
-	INTERNAL_ANCHOR_CLICK_EVENT,
-	type InternalAnchorClickDetail,
-} from "../editor/markdown/editorEvents";
-import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
 import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import type {
@@ -61,6 +56,7 @@ import {
 	peekCachedMarkdownDoc,
 } from "./markdownCache";
 import { analyzeNoteInfo } from "./noteInfoAnalysis";
+import { useInternalAnchorNavigation } from "./useInternalAnchorNavigation";
 
 interface MarkdownEditorPaneProps {
 	relPath: string;
@@ -336,29 +332,14 @@ export function MarkdownEditorPane({
 		[mode, scrollToHeading],
 	);
 
-	const tocHeadingsRef = useRef(tocHeadings);
-	tocHeadingsRef.current = tocHeadings;
-	useEffect(() => {
-		const onInternalAnchorClick = (event: Event) => {
-			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
-			if (!detail || detail.sourcePath !== relPath) return;
-			// In plain (raw) mode the live document lives in CodeMirror, so parse
-			// headings from the current text rather than the info-panel snapshot.
-			const headings =
-				mode === "plain"
-					? analyzeNoteInfo(textRef.current, textRef.current, true).headings
-					: tocHeadingsRef.current;
-			const heading = resolveAnchorHeading(headings, detail.anchor);
-			if (heading) selectVisibleHeading(heading);
-		};
-		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
-		return () => {
-			window.removeEventListener(
-				INTERNAL_ANCHOR_CLICK_EVENT,
-				onInternalAnchorClick,
-			);
-		};
-	}, [mode, relPath, selectVisibleHeading]);
+	const getPlainText = useCallback(() => textRef.current, []);
+	useInternalAnchorNavigation({
+		relPath,
+		mode,
+		getPlainText,
+		tocHeadings,
+		selectVisibleHeading,
+	});
 
 	const flashSyncPulse = useCallback((next: Exclude<SyncPulse, null>) => {
 		if (syncPulseTimerRef.current !== null) {

--- a/src/components/preview/noteInfoAnalysis.ts
+++ b/src/components/preview/noteInfoAnalysis.ts
@@ -1,4 +1,5 @@
 import type { TOCHeading } from "../editor/hooks/useTableOfContents";
+import { withHeadingSlugs } from "../editor/markdown/headingAnchor";
 
 interface NoteInfoAnalysis {
 	stats: {
@@ -104,7 +105,7 @@ export function analyzeNoteInfo(
 			completed_count: completedTasks,
 			open_count: totalTasks - completedTasks,
 		},
-		headings,
+		headings: includeHeadings ? withHeadingSlugs(headings) : headings,
 		lineCount,
 	};
 }

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import type { EditorViewMode } from "../../lib/editorMode";
+import type { TOCHeading } from "../editor/hooks/useTableOfContents";
+import {
+	INTERNAL_ANCHOR_CLICK_EVENT,
+	type InternalAnchorClickDetail,
+} from "../editor/markdown/editorEvents";
+import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
+import { analyzeNoteInfo } from "./noteInfoAnalysis";
+
+interface UseInternalAnchorNavigationArgs {
+	relPath: string;
+	mode: EditorViewMode;
+	getPlainText: () => string;
+	tocHeadings: readonly TOCHeading[];
+	selectVisibleHeading: (heading: TOCHeading) => void;
+}
+
+export function useInternalAnchorNavigation({
+	relPath,
+	mode,
+	getPlainText,
+	tocHeadings,
+	selectVisibleHeading,
+}: UseInternalAnchorNavigationArgs) {
+	const tocHeadingsRef = useRef(tocHeadings);
+	tocHeadingsRef.current = tocHeadings;
+
+	useEffect(() => {
+		const onInternalAnchorClick = (event: Event) => {
+			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
+			if (!detail || detail.sourcePath !== relPath) return;
+
+			const headings =
+				mode === "plain"
+					? analyzeNoteInfo(getPlainText(), getPlainText(), true).headings
+					: tocHeadingsRef.current;
+			const heading = resolveAnchorHeading(headings, detail.anchor);
+			if (heading) selectVisibleHeading(heading);
+		};
+
+		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
+		return () => {
+			window.removeEventListener(
+				INTERNAL_ANCHOR_CLICK_EVENT,
+				onInternalAnchorClick,
+			);
+		};
+	}, [getPlainText, mode, relPath, selectVisibleHeading]);
+}

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -108,6 +108,34 @@
 	color: color-mix(in srgb, var(--interactive-accent) 80%, var(--text-primary));
 }
 
+.tiptapContentInline .footnoteRef {
+	color: var(--interactive-accent);
+	font-size: 0.75em;
+	font-weight: var(--font-semibold);
+	vertical-align: super;
+	line-height: 0;
+	cursor: pointer;
+	border-radius: 3px;
+	padding: 0 1px;
+	transition: background 120ms ease;
+}
+.tiptapContentInline .footnoteRef:hover {
+	background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+}
+
+.tiptapContentInline .footnoteDef {
+	color: color-mix(in srgb, var(--interactive-accent) 70%, var(--text-tertiary));
+	font-family: var(--font-mono);
+	font-size: 0.85em;
+	font-weight: var(--font-semibold);
+	cursor: pointer;
+	border-radius: 3px;
+	transition: background 120ms ease;
+}
+.tiptapContentInline .footnoteDef:hover {
+	background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+}
+
 .tiptapContentInline .personToken {
 	display: inline-block;
 	color: var(--pill-contrast-fg);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,6 @@
+export function cssEscape(value: string): string {
+	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+		return CSS.escape(value);
+	}
+	return value.replace(/["\\]/g, "\\$&");
+}


### PR DESCRIPTION
Closes _(no linked issue — internal feature work)_


## Description

Adds two navigation enhancements to the editor and preview panes:

### Internal heading anchors
- `[text](#heading-name)` links now scroll the editor/preview to the targeted heading instead of being a no-op.
- New `headingAnchor.ts` with GitHub-style slug generation and disambiguation of duplicate heading texts.
- New `INTERNAL_ANCHOR_CLICK_EVENT` custom event dispatched from both TipTap (wysiwyg) and CodeMirror (raw) mode click handlers.
- `MarkdownEditorPane.tsx` listens for the event and resolves the anchor against the current TOC, scrolling the heading into view.
- Works in both rich-text and plain (raw) editor modes.

### Footnote navigation
- New ProseMirror plugin (`footnoteDecorations.ts`) applies inline decorations to `[^id]` tokens, distinguishing between reference tokens and definition markers (`[^id]:`).
- Clicking a footnote reference scrolls the view to its definition, and vice versa — implemented via `handleEditorClick` in `useNoteEditor.ts`.
- Styled with accent-colored superscript references and monospace definition markers (`25-node-note-content.css`).
- Plugin uses incremental decoration updates (`changedRangesFromTransactions`) to avoid rebuilding the full decoration set on every keystroke.

### Also
- Bumped version to `0.8.3-alpha.2`.


## Screenshots

_(Non-visual changes — affects in-editor interaction and scrolling behaviour.)_


## Docs

- Internal anchor links use GitHub-style slugification: `Heading 1` → `#heading-1`
- Duplicate headings are disambiguated with `-1`, `-2` suffixes (matching GitHub's approach).
- Footnote references (`[^1]`) are clickable in the editor — click to jump between reference and definition.
- The `INTERNAL_ANCHOR_CLICK_EVENT` (`glyph:internal-anchor-click`) carries `{ anchor, sourcePath }` and can be used by other panes (e.g. preview) to respond to in-document links.


## Ready?

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for navigating between footnote references and their definitions within documents.
  * Enabled internal anchor link navigation to headings and document sections.
  * Enhanced heading navigation with slug-based anchor resolution for improved linking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->