### PR TITLE
0.8.3-alpha.4: editor cleanups from review comments (#197) [Release]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,12 +20,3 @@
 
 - Completed and cancelled AI requests write per-run audit JSON under `.glyph/cache/ai/` and chat history under `.glyph/Glyph/ai_history/`.
 - Audit JSON includes request messages, context manifest, truncated context, truncated response, tool events, and an `outcome` field currently initialized as `null`.
-
-## AI API Key Management
-
-- AI API keys are stored per space in `.glyph/Glyph/ai_secrets.json` by `src-tauri/src/ai_rig/local_secrets.rs`.
-- Normal workspace file APIs block hidden `.glyph/` paths, so the file tree, previews, and AI tools cannot read that file through standard space-relative access.
-- Secrets are not written to `ai.json`, SQLite index rows, or AI history logs.
-
-
-

--- a/security.md
+++ b/security.md
@@ -20,3 +20,12 @@
 
 - Completed and cancelled AI requests write per-run audit JSON under `.glyph/cache/ai/` and chat history under `.glyph/Glyph/ai_history/`.
 - Audit JSON includes request messages, context manifest, truncated context, truncated response, tool events, and an `outcome` field currently initialized as `null`.
+
+## AI API Key Management
+
+- AI API keys are stored per space in `.glyph/Glyph/ai_secrets.json` by `src-tauri/src/ai_rig/local_secrets.rs`.
+- Normal workspace file APIs block hidden `.glyph/` paths, so the file tree, previews, and AI tools cannot read that file through standard space-relative access.
+- Secrets are not written to `ai.json`, SQLite index rows, or AI history logs.
+
+
+

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.3-alpha.3",
+	"version": "0.8.3-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -27,6 +27,7 @@ interface UseNoteFindOptions {
 	tiptapHostRef: RefObject<HTMLDivElement | null>;
 }
 
+// This function is used to check if the primary find shortcut is pressed
 function isPrimaryFindShortcut(event: ReactKeyboardEvent | KeyboardEvent) {
 	return (
 		event.metaKey &&
@@ -37,6 +38,7 @@ function isPrimaryFindShortcut(event: ReactKeyboardEvent | KeyboardEvent) {
 	);
 }
 
+// This function is used to get the selected text for the query
 function selectedTextForQuery(text: string): string {
 	const normalized = text.replace(/\s+/g, " ").trim();
 	if (!normalized || normalized.length > MAX_SELECTION_QUERY_LENGTH) return "";

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -29,7 +29,8 @@ interface UseNoteFindOptions {
 
 function isPrimaryFindShortcut(event: ReactKeyboardEvent | KeyboardEvent) {
 	return (
-		(event.metaKey || event.ctrlKey) &&
+		event.metaKey &&
+		!event.ctrlKey &&
 		!event.altKey &&
 		!event.shiftKey &&
 		event.key.toLowerCase() === "f"

--- a/src/components/editor/textColors.ts
+++ b/src/components/editor/textColors.ts
@@ -26,25 +26,25 @@ export const EDITOR_TEXT_COLORS = [
 		id: "brown",
 		label: "Brown",
 		cssVar: "--glyph-inline-color-brown",
-		fallbackHex: "#9a6c3f",
+		fallbackHex: "#9f6b53",
 	},
 	{
 		id: "orange",
 		label: "Orange",
 		cssVar: "--glyph-inline-color-orange",
-		fallbackHex: "#c25100",
+		fallbackHex: "#d9730d",
 	},
 	{
 		id: "yellow",
 		label: "Yellow",
 		cssVar: "--glyph-inline-color-yellow",
-		fallbackHex: "#8f6b00",
+		fallbackHex: "#cb912f",
 	},
 	{
 		id: "green",
 		label: "Green",
 		cssVar: "--glyph-inline-color-green",
-		fallbackHex: "#216e4e",
+		fallbackHex: "#448361",
 	},
 	{
 		id: "blue",
@@ -62,7 +62,7 @@ export const EDITOR_TEXT_COLORS = [
 		id: "red",
 		label: "Red",
 		cssVar: "--glyph-inline-color-red",
-		fallbackHex: "#c9372c",
+		fallbackHex: "#e03e3e",
 	},
 ] as const satisfies readonly EditorTextColorOption[];
 

--- a/src/lib/database/palette.ts
+++ b/src/lib/database/palette.ts
@@ -1,5 +1,8 @@
 import type { CSSProperties } from "react";
-import type { EditorTextColor } from "../../components/editor/textColors";
+import {
+	type EditorTextColor,
+	getEditorTextColorOption,
+} from "../../components/editor/textColors";
 
 const DATABASE_TONES = [
 	"var(--color-blue-500)",
@@ -9,17 +12,6 @@ const DATABASE_TONES = [
 	"var(--color-yellow-500)",
 	"var(--color-red-500)",
 ] as const;
-
-const DATABASE_TONE_BY_COLOR: Record<EditorTextColor, string> = {
-	gray: "var(--glyph-inline-color-gray, #626f86)",
-	brown: "var(--glyph-inline-color-brown, #9f6b53)",
-	orange: "var(--glyph-inline-color-orange, #d9730d)",
-	yellow: "var(--glyph-inline-color-yellow, #cb912f)",
-	green: "var(--glyph-inline-color-green, #448361)",
-	blue: "var(--glyph-inline-color-blue, #0c66e4)",
-	purple: "var(--glyph-inline-color-purple, #7e5bef)",
-	red: "var(--glyph-inline-color-red, #e03e3e)",
-};
 
 function hashSeed(seed: string): number {
 	let hash = 0;
@@ -46,8 +38,9 @@ function databaseToneStyleForColor(
 	seed: string,
 ): CSSProperties {
 	if (color) {
+		const { cssVar, fallbackHex } = getEditorTextColorOption(color);
 		return {
-			"--database-tone": DATABASE_TONE_BY_COLOR[color],
+			"--database-tone": `var(${cssVar}, ${fallbackHex})`,
 		} as CSSProperties;
 	}
 	return databaseToneStyle(seed);

--- a/src/lib/database/palette.ts
+++ b/src/lib/database/palette.ts
@@ -12,13 +12,13 @@ const DATABASE_TONES = [
 
 const DATABASE_TONE_BY_COLOR: Record<EditorTextColor, string> = {
 	gray: "var(--glyph-inline-color-gray, #626f86)",
-	brown: "var(--glyph-inline-color-brown, #9a6c3f)",
-	orange: "var(--glyph-inline-color-orange, #c25100)",
-	yellow: "var(--glyph-inline-color-yellow, #8f6b00)",
-	green: "var(--glyph-inline-color-green, #216e4e)",
+	brown: "var(--glyph-inline-color-brown, #9f6b53)",
+	orange: "var(--glyph-inline-color-orange, #d9730d)",
+	yellow: "var(--glyph-inline-color-yellow, #cb912f)",
+	green: "var(--glyph-inline-color-green, #448361)",
 	blue: "var(--glyph-inline-color-blue, #0c66e4)",
 	purple: "var(--glyph-inline-color-purple, #7e5bef)",
-	red: "var(--glyph-inline-color-red, #c9372c)",
+	red: "var(--glyph-inline-color-red, #e03e3e)",
 };
 
 function hashSeed(seed: string): number {

--- a/src/styles/app/12-editor-shell.css
+++ b/src/styles/app/12-editor-shell.css
@@ -19,24 +19,20 @@ button.ribbonBtn {
 	height: 32px;
 	padding: 0;
 	border-radius: var(--radius-md);
-	color: var(--text-secondary);
+	color: var(--editor-body-color);
 	transition: background-color var(--transition-base), color
 		var(--transition-base), box-shadow var(--transition-base);
 }
 
 button.ribbonBtn:hover {
 	transform: none;
-	background: color-mix(in srgb, var(--bg-hover) 84%, var(--bg-secondary));
-	color: var(--text-primary);
+	background: color-mix(in srgb, var(--editor-body-color) 6%, transparent);
+	color: var(--editor-body-color);
 }
 
 button.ribbonBtn.active {
-	background: color-mix(
-		in srgb,
-		var(--interactive-accent) 10%,
-		var(--selection-bg-muted)
-	);
-	color: var(--interactive-accent);
+	background: color-mix(in srgb, var(--editor-body-color) 10%, var(--bg-hover));
+	color: var(--editor-body-color);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+		color-mix(in srgb, var(--editor-body-color) 14%, transparent);
 }

--- a/src/styles/app/12-editor-shell.css
+++ b/src/styles/app/12-editor-shell.css
@@ -32,7 +32,7 @@ button.ribbonBtn:hover {
 
 button.ribbonBtn.active {
 	background: color-mix(in srgb, var(--editor-body-color) 10%, var(--bg-hover));
-	color: var(--editor-body-color);
+	color: var(--interactive-accent);
 	box-shadow: inset 0 0 0 1px
 		color-mix(in srgb, var(--editor-body-color) 14%, transparent);
 }

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -123,10 +123,10 @@
 
 .rfNodeNoteEditorRibbon .ribbonBtn.active {
 	background: color-mix(in srgb, var(--editor-body-color) 10%, var(--bg-hover));
-	color: var(--editor-body-color);
+	color: var(--interactive-accent);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--editor-body-color) 14%, transparent), inset 0 -1px 0
-		color-mix(in srgb, var(--bg-primary) 54%, transparent);
+		color-mix(in srgb, var(--editor-body-color) 14%, transparent), inset 0 -1px
+		0 color-mix(in srgb, var(--bg-primary) 54%, transparent);
 }
 
 .rfNodeNoteEditorRibbon .ribbonBtn:disabled {

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -55,7 +55,7 @@
 		var(--bg-primary) 94%,
 		var(--bg-secondary)
 	);
-	color: var(--text-secondary);
+	color: var(--editor-body-color);
 	flex-shrink: 0;
 	overflow-x: auto;
 	overflow-y: hidden;
@@ -107,7 +107,7 @@
 	height: 26px;
 	padding: 0;
 	border-radius: var(--radius-sm);
-	color: var(--text-secondary);
+	color: var(--editor-body-color);
 	flex: 0 0 auto;
 	transition: background-color var(--transition-base), color
 		var(--transition-base), box-shadow var(--transition-base), transform
@@ -115,17 +115,17 @@
 }
 
 .rfNodeNoteEditorRibbon .ribbonBtn:hover {
-	background: color-mix(in srgb, var(--text-primary) 6%, transparent);
-	color: var(--text-primary);
+	background: color-mix(in srgb, var(--editor-body-color) 6%, transparent);
+	color: var(--editor-body-color);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--text-primary) 8%, transparent);
+		color-mix(in srgb, var(--editor-body-color) 10%, transparent);
 }
 
 .rfNodeNoteEditorRibbon .ribbonBtn.active {
-	background: color-mix(in srgb, var(--text-primary) 10%, transparent);
-	color: var(--text-primary);
+	background: color-mix(in srgb, var(--editor-body-color) 10%, var(--bg-hover));
+	color: var(--editor-body-color);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--text-primary) 12%, transparent), inset 0 -1px 0
+		color-mix(in srgb, var(--editor-body-color) 14%, transparent), inset 0 -1px 0
 		color-mix(in srgb, var(--bg-primary) 54%, transparent);
 }
 
@@ -236,7 +236,7 @@
 	padding: 12px var(--editor-readable-content-gutter-compact);
 	font-size: var(--editor-inline-font-size);
 	line-height: 1.5;
-	color: var(--text-primary);
+	color: var(--editor-body-color);
 }
 
 .tiptapHostInline {

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -182,7 +182,7 @@
 .tiptapContentInline {
 	letter-spacing: 0;
 	line-height: 1.68;
-	color: color-mix(in srgb, var(--text-primary) 96%, var(--text-secondary));
+	color: var(--editor-body-color);
 	text-rendering: optimizeLegibility;
 }
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -640,8 +640,10 @@
 }
 
 .tiptapContentInline table {
-	width: max-content;
-	min-width: 100%;
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 100%;
+	table-layout: fixed;
 	border-collapse: separate;
 	border-spacing: 0;
 	margin: 12px 0;
@@ -656,7 +658,8 @@
 	border: 1px solid var(--border-light);
 	padding: 8px 10px;
 	vertical-align: top;
-	min-width: 132px;
+	min-width: 0;
+	overflow-wrap: anywhere;
 	background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
 	transition: background-color var(--transition-fast), box-shadow
 		var(--transition-fast), border-color var(--transition-fast);
@@ -672,6 +675,7 @@
 .tiptapContentInline td > p {
 	margin: 0;
 	min-height: 1.2em;
+	overflow-wrap: anywhere;
 }
 
 .tiptapContentInline td:focus-within,

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -558,35 +558,35 @@
 }
 
 .tiptapContentInline span[data-glyph-color="gray"] {
-	color: var(--glyph-inline-color-gray, #5f5e5b);
+	color: var(--glyph-inline-color-gray);
 }
 
 .tiptapContentInline span[data-glyph-color="brown"] {
-	color: var(--glyph-inline-color-brown, #8b5e3c);
+	color: var(--glyph-inline-color-brown);
 }
 
 .tiptapContentInline span[data-glyph-color="orange"] {
-	color: var(--glyph-inline-color-orange, #c76b1a);
+	color: var(--glyph-inline-color-orange);
 }
 
 .tiptapContentInline span[data-glyph-color="yellow"] {
-	color: var(--glyph-inline-color-yellow, #a26a00);
+	color: var(--glyph-inline-color-yellow);
 }
 
 .tiptapContentInline span[data-glyph-color="green"] {
-	color: var(--glyph-inline-color-green, #0f7b0f);
+	color: var(--glyph-inline-color-green);
 }
 
 .tiptapContentInline span[data-glyph-color="blue"] {
-	color: var(--glyph-inline-color-blue, #1a6ba4);
+	color: var(--glyph-inline-color-blue);
 }
 
 .tiptapContentInline span[data-glyph-color="purple"] {
-	color: var(--glyph-inline-color-purple, #7a4bc2);
+	color: var(--glyph-inline-color-purple);
 }
 
 .tiptapContentInline span[data-glyph-color="red"] {
-	color: var(--glyph-inline-color-red, #c73838);
+	color: var(--glyph-inline-color-red);
 }
 
 .tiptapContentInline pre {

--- a/src/styles/themes/dark-themes.css
+++ b/src/styles/themes/dark-themes.css
@@ -1,12 +1,12 @@
 :root.dark {
 	--glyph-inline-color-gray: #b6c2cf;
-	--glyph-inline-color-brown: #c6a27e;
-	--glyph-inline-color-orange: #fca700;
-	--glyph-inline-color-yellow: #d3b000;
+	--glyph-inline-color-brown: #d4a574;
+	--glyph-inline-color-orange: #fba034;
+	--glyph-inline-color-yellow: #e8c547;
 	--glyph-inline-color-green: #4bce97;
 	--glyph-inline-color-blue: #85b8ff;
 	--glyph-inline-color-purple: #b8acf6;
-	--glyph-inline-color-red: #ff9c8f;
+	--glyph-inline-color-red: #ff6b6b;
 	--pill-contrast-fg: color-mix(
 		in srgb,
 		var(--text-primary, #f3f5f8) 94%,

--- a/src/styles/themes/semantic-base.css
+++ b/src/styles/themes/semantic-base.css
@@ -10,6 +10,11 @@
 
 	--text-primary: var(--color-gray-800);
 	--text-secondary: rgba(55, 53, 47, 0.65);
+	--editor-body-color: color-mix(
+		in srgb,
+		var(--text-primary) 96%,
+		var(--text-secondary)
+	);
 	--text-tertiary: rgba(55, 53, 47, 0.45);
 	--text-placeholder: rgba(55, 53, 47, 0.35);
 	--text-inverse: var(--color-white);

--- a/src/styles/themes/semantic-base.css
+++ b/src/styles/themes/semantic-base.css
@@ -66,13 +66,13 @@
 	--callout-warning: #f0b429;
 	--callout-error: #f97066;
 	--glyph-inline-color-gray: #626f86;
-	--glyph-inline-color-brown: #9a6c3f;
-	--glyph-inline-color-orange: #c25100;
-	--glyph-inline-color-yellow: #8f6b00;
-	--glyph-inline-color-green: #216e4e;
+	--glyph-inline-color-brown: #9f6b53;
+	--glyph-inline-color-orange: #d9730d;
+	--glyph-inline-color-yellow: #cb912f;
+	--glyph-inline-color-green: #448361;
 	--glyph-inline-color-blue: #0c66e4;
 	--glyph-inline-color-purple: #7e5bef;
-	--glyph-inline-color-red: #c9372c;
+	--glyph-inline-color-red: #e03e3e;
 	--glyph-inline-highlight-yellow: color-mix(
 		in srgb,
 		var(--status-warning-fg) 24%,


### PR DESCRIPTION
Closes #196
Closes #194


## Description

Follow-up cleanups from review and user feedback for the 0.8.3 alpha line. Focuses on editor UX polish, color consistency, and small security/docs housekeeping.

- **Find shortcut (#196):** `Cmd+F` only for in-note find — `Ctrl+F` is no longer intercepted so Emacs-style forward-char navigation works again on macOS.
- **Table layout (#194):** Tables use full editor width with fixed layout and word wrap in cells instead of overflowing horizontally.
- **Editor ribbon theming:** Ribbon buttons/icons use a shared `--editor-body-color` token so toolbar chrome matches note body text in light and dark themes.
- **Inline text colors:** Updated brown/orange/yellow/green/red palette for better contrast and distinction; removed duplicate fallback hex values in CSS (single source in theme tokens + `textColors.ts`).
- **Database palette:** Reuses `getEditorTextColorOption()` instead of a parallel color map.
- **Security docs:** Renamed `security.md` → `SECURITY.md` and documented AI API key storage location.
- **Version bump:** `0.8.3-alpha.4` in `tauri.conf.json`.

### Reasoning

These are targeted fixes rather than a broad refactor — each change addresses a specific report or review comment without altering unrelated editor behavior.

### Additional context

- Find shortcut change is macOS-only by design (`metaKey` without `ctrlKey`).
- Table wrapping uses `table-layout: fixed`, `overflow-wrap: anywhere`, and `width: 100%` on the table element.


## Screenshots

Visual changes: editor ribbon icon color alignment, updated inline text color swatches, and full-width wrapping tables. Screenshots can be added during review if needed.


## Docs

- `SECURITY.md` now notes that AI API keys live in `.glyph/Glyph/ai_secrets.json` and are excluded from workspace file APIs.
- Inline color tokens are defined once in `src/styles/themes/semantic-base.css` / `dark-themes.css` and referenced from `src/components/editor/textColors.ts`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Find keyboard shortcut to trigger only with the Cmd key (and not Ctrl).
  * Improved inline note table layout with fixed column behavior and better in-cell text wrapping.

* **Style**
  * Refreshed editor text palette and inline glyph color values (including theme updates for dark and semantic modes).
  * Standardized note/editor text and button ribbon colors on the shared editor body color styling.
  * Updated database tone coloring to derive from the selected editor text color (with proper fallbacks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->