### PR TITLE
Fix TOC crash when editor view is not yet mounted (#198) [Release]

### DIFF
--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -236,11 +236,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	}, [mathNodeEditor.close, mode, relPath]);
 
 	useEffect(() => {
-		onEditorReady?.(editor ?? null);
-		return () => onEditorReady?.(null);
-	}, [editor, onEditorReady]);
-
-	useEffect(() => {
 		const host = tiptapHostRef.current;
 		const blurHostSelection = (host: HTMLDivElement | null) => {
 			if (!host) return;
@@ -592,6 +587,13 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		tiptapHostRef.current = node;
 		setTiptapHostNode(node);
 	}, []);
+	useEffect(() => {
+		const contentRoot = getMountedEditorContentRoot(tiptapHostNode);
+		const mountedEditor =
+			editor && !editor.isDestroyed && contentRoot ? editor : null;
+		onEditorReady?.(mountedEditor, mountedEditor ? contentRoot : null);
+		return () => onEditorReady?.(null, null);
+	}, [editor, onEditorReady, tiptapHostNode]);
 
 	const copySelectedCodeBlock = useCallback(() => {
 		if (!selectedCodeBlock) return;

--- a/src/components/editor/hooks/editorDomUtils.ts
+++ b/src/components/editor/hooks/editorDomUtils.ts
@@ -1,8 +1,9 @@
 export function getMountedEditorContentRoot(
 	host: HTMLElement | null,
 ): HTMLElement | null {
-	if (!host) return null;
-	return host.querySelector<HTMLElement>(".ProseMirror");
+	if (!host?.isConnected) return null;
+	const contentRoot = host.querySelector<HTMLElement>(".ProseMirror");
+	return contentRoot?.isConnected ? contentRoot : null;
 }
 
 export function getOffsetWithinAncestor(

--- a/src/components/editor/hooks/useTableOfContents.test.tsx
+++ b/src/components/editor/hooks/useTableOfContents.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import type { Editor } from "@tiptap/react";
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTableOfContents } from "./useTableOfContents";
+
+(
+	globalThis as typeof globalThis & {
+		IS_REACT_ACT_ENVIRONMENT?: boolean;
+	}
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface HarnessProps {
+	contentRoot: HTMLElement | null;
+	editor: Editor;
+}
+
+function Harness({ contentRoot, editor }: HarnessProps) {
+	const { activeId, headings } = useTableOfContents(editor, contentRoot);
+	return (
+		<output
+			data-active-id={activeId ?? ""}
+			data-heading-count={headings.length}
+		/>
+	);
+}
+
+describe("useTableOfContents editor mounting", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+	let viewAccessCount: number;
+	let viewMounted: boolean;
+	let editor: Editor;
+	let editorContentRoot: HTMLDivElement;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+			window.setTimeout(() => callback(performance.now()), 16),
+		);
+		vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+			window.clearTimeout(id),
+		);
+		viewAccessCount = 0;
+		viewMounted = false;
+
+		const headingElement = document.createElement("h1");
+		headingElement.textContent = "Heading";
+		editorContentRoot = document.createElement("div");
+		editorContentRoot.appendChild(headingElement);
+
+		const headingNode = {
+			attrs: { level: 1 },
+			textContent: "Heading",
+			type: { name: "heading" },
+		};
+		const listeners = new Map<string, Set<(event: unknown) => void>>();
+		editor = {
+			get view() {
+				viewAccessCount += 1;
+				if (!viewMounted) {
+					throw new Error("The editor view is not mounted");
+				}
+				return {
+					nodeDOM: () => headingElement,
+				};
+			},
+			state: {
+				doc: {
+					descendants: (
+						callback: (node: typeof headingNode, pos: number) => void,
+					) => callback(headingNode, 0),
+				},
+			},
+			on: (event: string, callback: (event: unknown) => void) => {
+				if (!listeners.has(event)) listeners.set(event, new Set());
+				listeners.get(event)?.add(callback);
+			},
+			off: (event: string, callback: (event: unknown) => void) => {
+				listeners.get(event)?.delete(callback);
+			},
+			commands: {
+				expandHeadingAncestors: vi.fn(),
+			},
+		} as unknown as Editor;
+
+		container = document.createElement("div");
+		document.body.appendChild(container);
+		root = createRoot(container);
+	});
+
+	afterEach(() => {
+		act(() => root.unmount());
+		container.remove();
+		vi.clearAllTimers();
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	async function flushAnimationFrame() {
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(16);
+		});
+	}
+
+	it("does not ask TipTap for its view before the content root is mounted", async () => {
+		act(() => root.render(<Harness contentRoot={null} editor={editor} />));
+		await flushAnimationFrame();
+
+		expect(container.querySelector("output")?.dataset.headingCount).toBe("1");
+		expect(viewAccessCount).toBe(0);
+	});
+
+	it("starts DOM tracking when the mounted content root becomes available", async () => {
+		act(() => root.render(<Harness contentRoot={null} editor={editor} />));
+		await flushAnimationFrame();
+		expect(viewAccessCount).toBe(0);
+
+		viewMounted = true;
+		const scrollContainer = document.createElement("div");
+		scrollContainer.style.overflowY = "auto";
+		scrollContainer.appendChild(editorContentRoot);
+		document.body.appendChild(scrollContainer);
+
+		act(() =>
+			root.render(<Harness contentRoot={editorContentRoot} editor={editor} />),
+		);
+		await flushAnimationFrame();
+
+		expect(viewAccessCount).toBeGreaterThan(0);
+		scrollContainer.remove();
+	});
+});

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -163,7 +163,10 @@ function updateHeadingsFromTransaction(
 	return withHeadingSlugs(next);
 }
 
-export function useTableOfContents(editor: Editor | null) {
+export function useTableOfContents(
+	editor: Editor | null,
+	contentRoot: HTMLElement | null,
+) {
 	const [headings, setHeadings] = useState<TOCHeading[]>([]);
 	const [activeId, setActiveId] = useState<string | null>(null);
 	const activeFrameRef = useRef<number | null>(null);
@@ -210,12 +213,12 @@ export function useTableOfContents(editor: Editor | null) {
 	}, [editor, publishHeadings]);
 
 	useEffect(() => {
-		if (!editor || headings.length === 0) {
+		if (!editor || !contentRoot || headings.length === 0) {
 			setActiveId(null);
 			return;
 		}
 
-		const scrollContainer = findScrollParent(editor.view.dom as HTMLElement);
+		const scrollContainer = findScrollParent(contentRoot);
 		if (!scrollContainer) {
 			setActiveId(headings[0]?.id ?? null);
 			return;
@@ -262,7 +265,7 @@ export function useTableOfContents(editor: Editor | null) {
 				activeFrameRef.current = null;
 			}
 		};
-	}, [editor, headings]);
+	}, [contentRoot, editor, headings]);
 
 	const scrollToHeading = useCallback(
 		(heading: TOCHeading) => {

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -32,7 +32,9 @@ export interface NoteInlineEditorProps {
 	onRegisterCalloutInserter?:
 		| ((inserter: ((type: string) => void) | null) => void)
 		| undefined;
-	onEditorReady?: ((editor: Editor | null) => void) | undefined;
+	onEditorReady?:
+		| ((editor: Editor | null, contentRoot: HTMLElement | null) => void)
+		| undefined;
 	onRawEditorReady?:
 		| ((editor: RawMarkdownEditorHandle | null) => void)
 		| undefined;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -240,7 +240,16 @@ export function MarkdownEditorPane({
 	const contentScrollRef = useRef<HTMLDivElement | null>(null);
 	const { spacePath } = useSpace();
 	const previousSpacePathRef = useRef<string | null>(spacePath);
-	const [tocEditor, setTocEditor] = useState<Editor | null>(null);
+	const [tocSource, setTocSource] = useState<{
+		editor: Editor;
+		contentRoot: HTMLElement;
+	} | null>(null);
+	const handleEditorReady = useCallback(
+		(editor: Editor | null, contentRoot: HTMLElement | null) => {
+			setTocSource(editor && contentRoot ? { editor, contentRoot } : null);
+		},
+		[],
+	);
 	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
 	const handleRawEditorReady = useCallback(
 		(editor: RawMarkdownEditorHandle | null) => {
@@ -252,7 +261,10 @@ export function MarkdownEditorPane({
 		headings: tocHeadings,
 		activeId: tocActiveId,
 		scrollToHeading,
-	} = useTableOfContents(tocEditor);
+	} = useTableOfContents(
+		tocSource?.editor ?? null,
+		tocSource?.contentRoot ?? null,
+	);
 	const [previewContext, setPreviewContext] =
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const { openSettings, showToc } = useUILayoutContext();
@@ -948,7 +960,7 @@ export function MarkdownEditorPane({
 									setText(nextText);
 								}}
 								onFrontmatterCommit={runAutosave}
-								onEditorReady={setTocEditor}
+								onEditorReady={handleEditorReady}
 								onRawEditorReady={handleRawEditorReady}
 								extractToNoteActions={extractToNoteActions}
 							/>


### PR DESCRIPTION
Closes {LINK TO GH ISSUE}


## Description

Fixes a crash in the table of contents when TipTap's editor view was accessed before the ProseMirror DOM was mounted.

- **Summary of changes**
  - Defer TOC wiring until both the editor instance and its mounted `.ProseMirror` content root are available.
  - Extend `onEditorReady` to pass `(editor, contentRoot)` instead of only `editor`.
  - Harden `getMountedEditorContentRoot` to return `null` when the host or content root is not connected to the document.
  - Update `useTableOfContents` to scroll/track headings via the mounted `contentRoot` rather than `editor.view.dom`.
  - Add `useTableOfContents` tests covering the pre-mount and post-mount lifecycle.

- **Reasoning**
  - Accessing `editor.view` before TipTap mounts throws (`The editor view is not mounted`), which could crash the note editor pane when TOC was enabled.
  - Waiting for a connected DOM node avoids touching the view until it is safe and keeps scroll-parent detection accurate.

- **Additional context**
  - No linked GitHub issue yet — replace the `Closes` line above if one exists.


## Screenshots

N/A — crash fix with no visible UI changes.


## Docs

`onEditorReady` callback signature:

```ts
onEditorReady?: (editor: Editor | null, contentRoot: HTMLElement | null) => void
```

`useTableOfContents` now requires the mounted content root:

```ts
useTableOfContents(editor, contentRoot)
```


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor readiness detection to ensure proper DOM mounting before signaling availability.
  * Enhanced table of contents integration to correctly track content once the editor is fully mounted.

* **Tests**
  * Added integration tests for table of contents hook behavior with dynamically mounted editor content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->