### PR TITLE
Editor improvements: inline table of contents, reorganized slash commands, hardened callouts

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.4-alpha.1",
+	"version": "0.8.4-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -191,7 +191,6 @@ function calloutScanRanges(tr: Transaction): ChangedRange[] {
 			if (node.type.name !== "blockquote") continue;
 			const from = resolvedPos.before(depth);
 			expanded.push({ from, to: from + node.nodeSize });
-			return;
 		}
 	};
 

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -181,7 +181,23 @@ function calloutScanRanges(tr: Transaction): ChangedRange[] {
 	const ranges = changedRangesFromTransactions([tr], tr.doc.content.size);
 	if (!ranges.length) return [];
 	const expanded: ChangedRange[] = [];
+
+	const addContainingBlockquote = (pos: number) => {
+		const resolvedPos = tr.doc.resolve(
+			Math.max(0, Math.min(pos, tr.doc.content.size)),
+		);
+		for (let depth = resolvedPos.depth; depth > 0; depth -= 1) {
+			const node = resolvedPos.node(depth);
+			if (node.type.name !== "blockquote") continue;
+			const from = resolvedPos.before(depth);
+			expanded.push({ from, to: from + node.nodeSize });
+			return;
+		}
+	};
+
 	for (const range of ranges) {
+		addContainingBlockquote(range.from);
+		addContainingBlockquote(Math.max(range.from, range.to - 1));
 		tr.doc.nodesBetween(range.from, range.to, (node, pos) => {
 			if (node.type.name !== "blockquote") return;
 			expanded.push({ from: pos, to: pos + node.nodeSize });

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -27,6 +27,7 @@ import { ColoredText } from "./coloredText";
 import { FootnoteDecorations } from "./footnoteDecorations";
 import { HeadingCollapse } from "./headingCollapse";
 import { HighlightedText } from "./highlightedText";
+import { InlineTableOfContents } from "./inlineTableOfContents";
 import { MarkdownImage } from "./markdownImage";
 import { MarkdownImageLivePreview } from "./markdownImageLivePreview";
 import { MarkdownLinkAutocomplete } from "./markdownLinkAutocomplete";
@@ -712,6 +713,7 @@ export function createEditorExtensions(
 		}),
 		...additionalExtensions,
 		MermaidPreview,
+		InlineTableOfContents,
 		...(enableEditingExtensions ? [HeadingCollapse] : []),
 		Markdown.configure({
 			markedOptions: {

--- a/src/components/editor/extensions/inlineTableOfContents.ts
+++ b/src/components/editor/extensions/inlineTableOfContents.ts
@@ -67,11 +67,23 @@ function scrollToHeading(editor: Editor, heading: TOCHeading) {
 	});
 }
 
+function findInlineTocMarkerRange(doc: ProseMirrorNode, preferredPos: number) {
+	let closestRange: { from: number; to: number } | null = null;
+	let closestDistance = Number.POSITIVE_INFINITY;
+	doc.descendants((node, pos) => {
+		if (!isInlineTocNode(node)) return;
+		const distance = Math.abs(pos - preferredPos);
+		if (distance >= closestDistance) return;
+		closestDistance = distance;
+		closestRange = { from: pos, to: pos + node.nodeSize };
+	});
+	return closestRange;
+}
+
 function createInlineTocWidget(
 	editor: Editor,
 	headings: readonly TOCHeading[],
 	markerPos: number,
-	markerSize: number,
 ) {
 	const root = document.createElement("nav");
 	root.className = "inlineTocWidget";
@@ -120,11 +132,18 @@ function createInlineTocWidget(
 			removeButton.disabled = false;
 		}
 		if (!confirmed) return;
-		editor
-			.chain()
-			.focus()
-			.deleteRange({ from: markerPos, to: markerPos + markerSize })
-			.run();
+		let currentWidgetPos = markerPos;
+		try {
+			currentWidgetPos = editor.view.posAtDOM(root, 0);
+		} catch {
+			currentWidgetPos = markerPos;
+		}
+		const markerRange = findInlineTocMarkerRange(
+			editor.state.doc,
+			currentWidgetPos,
+		);
+		if (!markerRange) return;
+		editor.chain().focus().deleteRange(markerRange).run();
 	});
 
 	header.append(title, removeButton);
@@ -177,12 +196,12 @@ function buildInlineTocDecorations(
 			}),
 			Decoration.widget(
 				pos + node.nodeSize,
-				() => createInlineTocWidget(editor, headings, pos, node.nodeSize),
+				() => createInlineTocWidget(editor, headings, pos),
 				{
 					side: 1,
 					ignoreSelection: true,
 					key: `inline-toc-${pos}-${headings
-						.map((h) => `${h.pos}:${h.text}`)
+						.map((h) => `${h.pos}:${h.level}:${h.text}`)
 						.join("|")}`,
 					stopEvent: (event) =>
 						event.target instanceof Element &&

--- a/src/components/editor/extensions/inlineTableOfContents.ts
+++ b/src/components/editor/extensions/inlineTableOfContents.ts
@@ -1,0 +1,290 @@
+import { type Editor, Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import {
+	type TOCHeading,
+	extractHeadingsFromDoc,
+	findScrollParent,
+	getHeadingElement,
+	isSameHeadingList,
+	updateHeadingsFromTransaction,
+} from "../hooks/useTableOfContents";
+import { INLINE_TOC_EDITOR_MARKER } from "../markdown/inlineTocMarkdown";
+
+const INLINE_TOC_MARKER = INLINE_TOC_EDITOR_MARKER;
+
+interface InlineTableOfContentsPluginState {
+	decorations: DecorationSet;
+	headings: TOCHeading[];
+	markerSignature: string;
+	signature: string;
+}
+
+function isInlineTocNode(node: ProseMirrorNode) {
+	return (
+		node.type.name === "paragraph" &&
+		node.textContent.trim().toLowerCase() === INLINE_TOC_MARKER
+	);
+}
+
+function getInlineTocMarkerSignature(doc: ProseMirrorNode) {
+	const parts: string[] = [];
+	doc.descendants((node, pos) => {
+		if (isInlineTocNode(node)) parts.push(`toc:${pos}:${node.nodeSize}`);
+	});
+	return parts.join("|");
+}
+
+function getInlineTocSignature(
+	markerSignature: string,
+	headings: readonly TOCHeading[],
+) {
+	if (!markerSignature) return "";
+	return [
+		markerSignature,
+		...headings.map(
+			(heading) => `${heading.pos}:${heading.level}:${heading.text}`,
+		),
+	].join("|");
+}
+
+function scrollToHeading(editor: Editor, heading: TOCHeading) {
+	editor.commands.expandHeadingAncestors(heading.pos);
+	window.requestAnimationFrame(() => {
+		const dom = getHeadingElement(editor, heading);
+		if (!dom) return;
+		const scrollContainer = findScrollParent(dom);
+		if (scrollContainer) {
+			const containerRect = scrollContainer.getBoundingClientRect();
+			const headingRect = dom.getBoundingClientRect();
+			const offset =
+				headingRect.top - containerRect.top + scrollContainer.scrollTop - 20;
+			scrollContainer.scrollTo({ top: offset, behavior: "smooth" });
+			return;
+		}
+		dom.scrollIntoView({ behavior: "smooth", block: "start" });
+	});
+}
+
+function createInlineTocWidget(
+	editor: Editor,
+	headings: readonly TOCHeading[],
+	markerPos: number,
+	markerSize: number,
+) {
+	const root = document.createElement("nav");
+	root.className = "inlineTocWidget";
+	root.contentEditable = "false";
+	root.setAttribute("aria-label", "Table of contents");
+
+	const header = document.createElement("div");
+	header.className = "inlineTocHeader";
+
+	const title = document.createElement("div");
+	title.className = "inlineTocTitle";
+	title.textContent = "Table of contents";
+
+	const removeButton = document.createElement("button");
+	removeButton.type = "button";
+	removeButton.className = "inlineTocRemoveBtn";
+	removeButton.textContent = "×";
+	removeButton.title = "Remove table of contents";
+	removeButton.setAttribute("aria-label", "Remove table of contents");
+	const stopButtonEvent = (event: Event) => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
+	removeButton.addEventListener("pointerdown", stopButtonEvent);
+	removeButton.addEventListener("mousedown", stopButtonEvent);
+
+	let removePending = false;
+	removeButton.addEventListener("click", async (event) => {
+		stopButtonEvent(event);
+		if (removePending) return;
+		removePending = true;
+		removeButton.disabled = true;
+		let confirmed = false;
+		try {
+			const { confirm } = await import("@tauri-apps/plugin-dialog");
+			confirmed = await confirm(
+				"Remove this table of contents from the note?",
+				{
+					title: "Remove table of contents",
+					okLabel: "Remove",
+					cancelLabel: "Cancel",
+				},
+			);
+		} finally {
+			removePending = false;
+			removeButton.disabled = false;
+		}
+		if (!confirmed) return;
+		editor
+			.chain()
+			.focus()
+			.deleteRange({ from: markerPos, to: markerPos + markerSize })
+			.run();
+	});
+
+	header.append(title, removeButton);
+	root.append(header);
+
+	if (!headings.length) {
+		const empty = document.createElement("div");
+		empty.className = "inlineTocEmpty";
+		empty.textContent = "No headings";
+		root.append(empty);
+		return root;
+	}
+
+	const list = document.createElement("div");
+	list.className = "inlineTocItems";
+	for (const heading of headings) {
+		const button = document.createElement("button");
+		button.type = "button";
+		button.className = "inlineTocItem";
+		button.dataset.level = String(heading.level);
+		button.textContent = heading.text;
+		button.title = heading.text;
+		button.addEventListener("mousedown", (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+		});
+		button.addEventListener("click", (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			scrollToHeading(editor, heading);
+		});
+		list.append(button);
+	}
+	root.append(list);
+	return root;
+}
+
+function buildInlineTocDecorations(
+	doc: ProseMirrorNode,
+	editor: Editor,
+	headings: readonly TOCHeading[],
+): DecorationSet {
+	const decorations: Decoration[] = [];
+
+	doc.descendants((node, pos) => {
+		if (!isInlineTocNode(node)) return;
+		decorations.push(
+			Decoration.node(pos, pos + node.nodeSize, {
+				class: "inlineTocMarker",
+			}),
+			Decoration.widget(
+				pos + node.nodeSize,
+				() => createInlineTocWidget(editor, headings, pos, node.nodeSize),
+				{
+					side: 1,
+					ignoreSelection: true,
+					key: `inline-toc-${pos}-${headings
+						.map((h) => `${h.pos}:${h.text}`)
+						.join("|")}`,
+					stopEvent: (event) =>
+						event.target instanceof Element &&
+						event.target.closest(".inlineTocWidget") !== null,
+				},
+			),
+		);
+	});
+
+	return decorations.length
+		? DecorationSet.create(doc, decorations)
+		: DecorationSet.empty;
+}
+
+const inlineTableOfContentsPluginKey =
+	new PluginKey<InlineTableOfContentsPluginState>("inline-table-of-contents");
+
+export const InlineTableOfContents = Extension.create({
+	name: "inline-table-of-contents",
+	addProseMirrorPlugins() {
+		const editor = this.editor;
+		return [
+			new Plugin<InlineTableOfContentsPluginState>({
+				key: inlineTableOfContentsPluginKey,
+				state: {
+					init: (_config, state) => {
+						const markerSignature = getInlineTocMarkerSignature(state.doc);
+						const headings = markerSignature
+							? extractHeadingsFromDoc(state.doc)
+							: [];
+						return {
+							headings,
+							markerSignature,
+							signature: getInlineTocSignature(markerSignature, headings),
+							decorations: markerSignature
+								? buildInlineTocDecorations(state.doc, editor, headings)
+								: DecorationSet.empty,
+						};
+					},
+					apply: (transaction, value) => {
+						if (!transaction.docChanged) {
+							return {
+								...value,
+								decorations: value.decorations.map(
+									transaction.mapping,
+									transaction.doc,
+								),
+							};
+						}
+
+						const markerSignature = getInlineTocMarkerSignature(
+							transaction.doc,
+						);
+						if (!markerSignature) {
+							return {
+								headings: [],
+								markerSignature,
+								signature: "",
+								decorations: DecorationSet.empty,
+							};
+						}
+
+						const headings = value.markerSignature
+							? updateHeadingsFromTransaction(value.headings, transaction)
+							: extractHeadingsFromDoc(transaction.doc);
+						const signature = getInlineTocSignature(markerSignature, headings);
+						if (
+							signature === value.signature &&
+							isSameHeadingList(value.headings, headings)
+						) {
+							return {
+								...value,
+								headings,
+								markerSignature,
+								decorations: value.decorations.map(
+									transaction.mapping,
+									transaction.doc,
+								),
+							};
+						}
+
+						return {
+							headings,
+							markerSignature,
+							signature,
+							decorations: buildInlineTocDecorations(
+								transaction.doc,
+								editor,
+								headings,
+							),
+						};
+					},
+				},
+				props: {
+					decorations(state) {
+						return (
+							inlineTableOfContentsPluginKey.getState(state)?.decorations ??
+							DecorationSet.empty
+						);
+					},
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -17,7 +17,7 @@ export interface TOCHeading {
 	slug?: string;
 }
 
-function getHeadingElement(
+export function getHeadingElement(
 	editor: Editor,
 	heading: TOCHeading,
 ): HTMLElement | null {
@@ -29,7 +29,7 @@ function getHeadingElement(
 	}
 }
 
-function findScrollParent(el: HTMLElement): HTMLElement | null {
+export function findScrollParent(el: HTMLElement): HTMLElement | null {
 	let current = el.parentElement;
 	while (current) {
 		const style = getComputedStyle(current);
@@ -46,7 +46,7 @@ function findScrollParent(el: HTMLElement): HTMLElement | null {
 	return null;
 }
 
-function isSameHeadingList(
+export function isSameHeadingList(
 	prev: readonly TOCHeading[],
 	next: readonly TOCHeading[],
 ) {
@@ -77,7 +77,7 @@ function headingFromNode(
 	};
 }
 
-function extractHeadingsFromDoc(doc: ProseMirrorNode): TOCHeading[] {
+export function extractHeadingsFromDoc(doc: ProseMirrorNode): TOCHeading[] {
 	const headings: TOCHeading[] = [];
 	doc.descendants((node, pos) => {
 		const heading = headingFromNode(node, pos);
@@ -125,7 +125,7 @@ function rangeTouchesHeading(
 	return heading.pos >= range.from && heading.pos <= range.to;
 }
 
-function updateHeadingsFromTransaction(
+export function updateHeadingsFromTransaction(
 	current: readonly TOCHeading[],
 	transaction: Transaction,
 ): TOCHeading[] {

--- a/src/components/editor/markdown/inlineTocMarkdown.ts
+++ b/src/components/editor/markdown/inlineTocMarkdown.ts
@@ -6,10 +6,11 @@ function replaceMarkerLines(
 	fromMarker: string,
 	toMarker: string,
 ) {
+	const normalizedFromMarker = fromMarker.toLowerCase();
 	return input
 		.split("\n")
 		.map((line) => {
-			if (line.trim().toLowerCase() !== fromMarker) return line;
+			if (line.trim().toLowerCase() !== normalizedFromMarker) return line;
 			const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
 			return `${leadingWhitespace}${toMarker}`;
 		})

--- a/src/components/editor/markdown/inlineTocMarkdown.ts
+++ b/src/components/editor/markdown/inlineTocMarkdown.ts
@@ -1,0 +1,33 @@
+export const INLINE_TOC_MARKDOWN_MARKER = "<!-- glyph:toc -->";
+export const INLINE_TOC_EDITOR_MARKER = "{{glyph:toc}}";
+
+function replaceMarkerLines(
+	input: string,
+	fromMarker: string,
+	toMarker: string,
+) {
+	return input
+		.split("\n")
+		.map((line) => {
+			if (line.trim().toLowerCase() !== fromMarker) return line;
+			const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
+			return `${leadingWhitespace}${toMarker}`;
+		})
+		.join("\n");
+}
+
+export function preprocessInlineTocMarkers(markdown: string) {
+	return replaceMarkerLines(
+		markdown,
+		INLINE_TOC_MARKDOWN_MARKER,
+		INLINE_TOC_EDITOR_MARKER,
+	);
+}
+
+export function postprocessInlineTocMarkers(markdown: string) {
+	return replaceMarkerLines(
+		markdown,
+		INLINE_TOC_EDITOR_MARKER,
+		INLINE_TOC_MARKDOWN_MARKER,
+	);
+}

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
@@ -11,6 +11,10 @@ import {
 	isEditorTextHighlight,
 } from "../textHighlights";
 import {
+	postprocessInlineTocMarkers,
+	preprocessInlineTocMarkers,
+} from "./inlineTocMarkdown";
+import {
 	findWikiLinkSpans,
 	parseWikiLink,
 	wikiLinkAttrsToMarkdown,
@@ -153,15 +157,19 @@ function postprocessWhitespaceLines(input: string): string {
 export function preprocessMarkdownForEditor(markdown: string): string {
 	return preprocessColoredText(
 		preprocessHighlightedText(
-			encodeMarkdownImageDestinations(canonicalizeWikiLinks(markdown)),
+			encodeMarkdownImageDestinations(
+				canonicalizeWikiLinks(preprocessInlineTocMarkers(markdown)),
+			),
 		),
 	);
 }
 
 export function postprocessMarkdownFromEditor(markdown: string): string {
-	return postprocessWhitespaceLines(
-		postprocessHighlightedText(
-			postprocessColoredText(canonicalizeWikiLinks(markdown)),
+	return postprocessInlineTocMarkers(
+		postprocessWhitespaceLines(
+			postprocessHighlightedText(
+				postprocessColoredText(canonicalizeWikiLinks(markdown)),
+			),
 		),
 	);
 }

--- a/src/components/editor/slashCommands.ts
+++ b/src/components/editor/slashCommands.ts
@@ -10,6 +10,7 @@ import {
 	INLINE_MATH_STARTER,
 	type MathEditRequest,
 } from "./extensions/math/mathOptions";
+import { INLINE_TOC_EDITOR_MARKER } from "./markdown/inlineTocMarkdown";
 import { lockEditorScrollDuringSuggestion } from "./suggestionScroll";
 import { EDITOR_TEXT_COLORS } from "./textColors";
 import { EDITOR_TEXT_HIGHLIGHTS } from "./textHighlights";
@@ -31,6 +32,19 @@ function clampSlashCommandIndex(index: number, itemCount: number) {
 	if (index < 0) return itemCount - 1;
 	if (index >= itemCount) return 0;
 	return index;
+}
+
+function slashCommandSearchText(item: SlashCommandItem) {
+	return [item.title, item.description, ...item.keywords]
+		.join(" ")
+		.toLowerCase();
+}
+
+function slashCommandMatchesQuery(item: SlashCommandItem, query: string) {
+	const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+	if (!terms.length) return true;
+	const searchText = slashCommandSearchText(item);
+	return terms.every((term) => searchText.includes(term));
 }
 
 function insertMathAndOpen(
@@ -192,6 +206,25 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
 				.focus()
 				.deleteRange(range)
 				.insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+				.run(),
+	},
+	{
+		icon: "☰",
+		title: "Table of contents",
+		description: "Insert a live outline for this note",
+		keywords: ["toc", "outline", "contents", "headings", "navigation"],
+		command: ({ editor, range }) =>
+			editor
+				.chain()
+				.focus()
+				.deleteRange(range)
+				.insertContent([
+					{
+						type: "paragraph",
+						content: [{ type: "text", text: INLINE_TOC_EDITOR_MARKER }],
+					},
+					{ type: "paragraph" },
+				])
 				.run(),
 	},
 	{
@@ -364,17 +397,15 @@ export const SlashCommand = Extension.create({
 			suggestion: {
 				char: "/",
 				startOfLine: false,
+				allowSpaces: true,
 				allow: ({ state }: { state: EditorState }) => {
 					const { $from } = state.selection;
 					return $from.parent.type.name === "paragraph";
 				},
 				items: ({ query }: { query: string }) => {
-					const normalized = query.toLowerCase();
-					return SLASH_COMMANDS.filter((item) => {
-						if (!normalized) return true;
-						if (item.title.toLowerCase().includes(normalized)) return true;
-						return item.keywords.some((k) => k.includes(normalized));
-					}).slice(0, 20);
+					return SLASH_COMMANDS.filter((item) =>
+						slashCommandMatchesQuery(item, query),
+					).slice(0, 20);
 				},
 				render: () => {
 					let menu: HTMLDivElement | null = null;

--- a/src/components/editor/slashCommands.ts
+++ b/src/components/editor/slashCommands.ts
@@ -35,9 +35,7 @@ function clampSlashCommandIndex(index: number, itemCount: number) {
 }
 
 function slashCommandSearchText(item: SlashCommandItem) {
-	return [item.title, item.description, ...item.keywords]
-		.join(" ")
-		.toLowerCase();
+	return [item.title, ...item.keywords].join(" ").toLowerCase();
 }
 
 function slashCommandMatchesQuery(item: SlashCommandItem, query: string) {

--- a/src/components/editor/slashCommands.ts
+++ b/src/components/editor/slashCommands.ts
@@ -79,22 +79,6 @@ function insertMathAndOpen(
 
 const SLASH_COMMANDS: SlashCommandItem[] = [
 	{
-		icon: "ƒx",
-		title: "Inline equation",
-		description: "Insert LaTeX within a line",
-		keywords: ["latex", "math", "formula", "equation", "inline"],
-		command: ({ editor, range, onMathEditRequest }) =>
-			insertMathAndOpen(editor, range, "inline", onMathEditRequest),
-	},
-	{
-		icon: "∑",
-		title: "Display equation",
-		description: "Insert a centered LaTeX block",
-		keywords: ["latex", "math", "formula", "equation", "block", "display"],
-		command: ({ editor, range, onMathEditRequest }) =>
-			insertMathAndOpen(editor, range, "block", onMathEditRequest),
-	},
-	{
 		icon: "H1",
 		title: "Heading 1",
 		description: "Big section heading",
@@ -174,26 +158,12 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
 			editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
 	},
 	{
-		icon: "M",
-		title: "Mermaid chart",
-		description: "Insert a Mermaid diagram block",
-		keywords: ["mermaid", "diagram", "flowchart", "graph"],
+		icon: "—",
+		title: "Divider",
+		description: "Insert a horizontal rule",
+		keywords: ["hr", "divider", "rule"],
 		command: ({ editor, range }) =>
-			editor
-				.chain()
-				.focus()
-				.deleteRange(range)
-				.insertContent({
-					type: "codeBlock",
-					attrs: { language: "mermaid" },
-					content: [
-						{
-							type: "text",
-							text: "flowchart TD\n  A[Start] --> B[End]",
-						},
-					],
-				})
-				.run(),
+			editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
 	},
 	{
 		icon: "▦",
@@ -228,12 +198,26 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
 				.run(),
 	},
 	{
-		icon: "—",
-		title: "Divider",
-		description: "Insert a horizontal rule",
-		keywords: ["hr", "divider", "rule"],
+		icon: "M",
+		title: "Mermaid chart",
+		description: "Insert a Mermaid diagram block",
+		keywords: ["mermaid", "diagram", "flowchart", "graph"],
 		command: ({ editor, range }) =>
-			editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+			editor
+				.chain()
+				.focus()
+				.deleteRange(range)
+				.insertContent({
+					type: "codeBlock",
+					attrs: { language: "mermaid" },
+					content: [
+						{
+							type: "text",
+							text: "flowchart TD\n  A[Start] --> B[End]",
+						},
+					],
+				})
+				.run(),
 	},
 	{
 		icon: "i",
@@ -251,6 +235,50 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
 						{
 							type: "paragraph",
 							content: [{ type: "text", text: "[!info]" }],
+						},
+						{ type: "paragraph" },
+					],
+				})
+				.run(),
+	},
+	{
+		icon: "?",
+		title: "Tip callout",
+		description: "Insert a tip callout",
+		keywords: ["callout", "tip", "hint", "admonition"],
+		command: ({ editor, range }) =>
+			editor
+				.chain()
+				.focus()
+				.deleteRange(range)
+				.insertContent({
+					type: "blockquote",
+					content: [
+						{
+							type: "paragraph",
+							content: [{ type: "text", text: "[!tip]" }],
+						},
+						{ type: "paragraph" },
+					],
+				})
+				.run(),
+	},
+	{
+		icon: "+",
+		title: "Success callout",
+		description: "Insert a success callout",
+		keywords: ["callout", "success", "done", "admonition"],
+		command: ({ editor, range }) =>
+			editor
+				.chain()
+				.focus()
+				.deleteRange(range)
+				.insertContent({
+					type: "blockquote",
+					content: [
+						{
+							type: "paragraph",
+							content: [{ type: "text", text: "[!success]" }],
 						},
 						{ type: "paragraph" },
 					],
@@ -302,48 +330,20 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
 				.run(),
 	},
 	{
-		icon: "+",
-		title: "Success callout",
-		description: "Insert a success callout",
-		keywords: ["callout", "success", "done", "admonition"],
-		command: ({ editor, range }) =>
-			editor
-				.chain()
-				.focus()
-				.deleteRange(range)
-				.insertContent({
-					type: "blockquote",
-					content: [
-						{
-							type: "paragraph",
-							content: [{ type: "text", text: "[!success]" }],
-						},
-						{ type: "paragraph" },
-					],
-				})
-				.run(),
+		icon: "ƒx",
+		title: "Inline equation",
+		description: "Insert LaTeX within a line",
+		keywords: ["latex", "math", "formula", "equation", "inline"],
+		command: ({ editor, range, onMathEditRequest }) =>
+			insertMathAndOpen(editor, range, "inline", onMathEditRequest),
 	},
 	{
-		icon: "?",
-		title: "Tip callout",
-		description: "Insert a tip callout",
-		keywords: ["callout", "tip", "hint", "admonition"],
-		command: ({ editor, range }) =>
-			editor
-				.chain()
-				.focus()
-				.deleteRange(range)
-				.insertContent({
-					type: "blockquote",
-					content: [
-						{
-							type: "paragraph",
-							content: [{ type: "text", text: "[!tip]" }],
-						},
-						{ type: "paragraph" },
-					],
-				})
-				.run(),
+		icon: "∑",
+		title: "Display equation",
+		description: "Insert a centered LaTeX block",
+		keywords: ["latex", "math", "formula", "equation", "block", "display"],
+		command: ({ editor, range, onMathEditRequest }) =>
+			insertMathAndOpen(editor, range, "block", onMathEditRequest),
 	},
 	...EDITOR_TEXT_COLORS.map<SlashCommandItem>((color) => ({
 		icon: "A",
@@ -405,7 +405,7 @@ export const SlashCommand = Extension.create({
 				items: ({ query }: { query: string }) => {
 					return SLASH_COMMANDS.filter((item) =>
 						slashCommandMatchesQuery(item, query),
-					).slice(0, 20);
+					);
 				},
 				render: () => {
 					let menu: HTMLDivElement | null = null;

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -410,6 +410,116 @@
 	color: var(--editor-heading-h6-color);
 }
 
+.tiptapContentInline .inlineTocMarker {
+	display: none;
+}
+
+.inlineTocWidget {
+	margin: var(--space-3) 0 var(--space-4);
+	padding: var(--space-3);
+	border: 1px solid color-mix(in srgb, var(--border-default) 78%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-secondary) 64%, var(--bg-primary));
+}
+
+.inlineTocHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: var(--space-2);
+	gap: var(--space-2);
+}
+
+.inlineTocTitle {
+	color: var(--text-secondary);
+	font-size: calc(var(--editor-font-size) * 0.78);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+}
+
+.inlineTocRemoveBtn {
+	appearance: none;
+	-webkit-appearance: none;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-tertiary);
+	font: inherit;
+	font-size: calc(var(--editor-font-size) * 0.95);
+	line-height: 1;
+	cursor: pointer;
+	transition: background-color var(--transition-fast), color
+		var(--transition-fast);
+}
+
+.inlineTocRemoveBtn:hover,
+.inlineTocRemoveBtn:focus-visible {
+	background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.inlineTocItems {
+	display: grid;
+	gap: 2px;
+}
+
+.inlineTocItem {
+	appearance: none;
+	-webkit-appearance: none;
+	display: block;
+	width: 100%;
+	min-width: 0;
+	padding: 4px 6px;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: calc(var(--editor-font-size) * 0.9);
+	line-height: 1.35;
+	text-align: left;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: background-color var(--transition-fast), color
+		var(--transition-fast);
+}
+
+.inlineTocItem:hover,
+.inlineTocItem:focus-visible {
+	background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.inlineTocItem[data-level="2"] {
+	padding-left: calc(var(--space-3) + 6px);
+}
+
+.inlineTocItem[data-level="3"] {
+	padding-left: calc(var(--space-5) + 2px);
+}
+
+.inlineTocItem[data-level="4"],
+.inlineTocItem[data-level="5"],
+.inlineTocItem[data-level="6"] {
+	padding-left: calc(var(--space-6) + 6px);
+}
+
+.inlineTocEmpty {
+	color: var(--text-tertiary);
+	font-size: calc(var(--editor-font-size) * 0.9);
+}
+
 .tiptapContentInline .headingCollapseHeading {
 	position: relative;
 }


### PR DESCRIPTION
Closes <!-- LINK TO GH ISSUE -->


## Description

Editor quality-of-life improvements for the alpha-2 release.

- **Inline Table of Contents**: Adds a TipTap extension (`InlineTableOfContents`) that renders a live-updating table of contents node in the editor, with a corresponding markdown serialization/parsing bridge. The TOC tracks headings as the user types.
- **Slash commands reorganized**: Slash commands are now keyword-searchable (multi‑term matching), commands are reordered for quicker access to frequently used items, and new commands added for divider (horizontal rule), table, and inline table of contents.
- **Callouts hardened**: Improved callout extension reliability and rendering.

Also includes new CSS in `25-node-note-content.css` for the table of contents styling and a refactored `slashCommandMatchesQuery` utility for search.

### Reasoning

The inline TOC makes longer notes easier to navigate. The slash command reorganization addresses feedback that the menu was cluttered — reordering put headings first, grouping block-level inserts, and added keyword search so the menu is usable even as more commands are added.


## Screenshots

<!-- N/A — editor internal changes, no UI screenshots needed. Delete if not applicable. -->


## Docs

- New inline TOC extension: `src/components/editor/extensions/inlineTableOfContents.ts`
- Inline TOC markdown bridge: `src/components/editor/markdown/inlineTocMarkdown.ts`
- Slash command search: uses `slashCommandMatchesQuery(item, query)` — multi‑term, case‑insensitive matching against title + description + keywords


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline table of contents widget that reads document headings and lets you scroll directly to selected entries.
  * Enabled inline TOC markers end-to-end, including wiki-link markdown conversion support and a “Table of contents” slash command that inserts the live outline marker.
* **Improvements**
  * Refined slash command search so queries match across titles and keywords using multi-term filtering.
* **Style**
  * Added dedicated styling for the inline TOC widget (header, items, empty state, and remove button).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->