### PR TITLE
Add PR CI checks and fix escaped dollar markdown round-trip

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,79 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting and lint
+        run: pnpm check
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  rust:
+    name: Rust
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Check
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: Test
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -19,15 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 10.28.2
 
@@ -36,7 +38,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.pnpm-store.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
@@ -60,13 +62,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: src-tauri -> target
 

--- a/src/components/editor/extensions/math/mathOptions.ts
+++ b/src/components/editor/extensions/math/mathOptions.ts
@@ -13,6 +13,16 @@ export const BLOCK_MATH_STARTER = String.raw`\begin{aligned}
   a &= b + c
 \end{aligned}`;
 
+const ESCAPED_DOLLAR_PLACEHOLDER = "\uE000";
+
+export function preprocessEscapedDollars(markdown: string): string {
+	return markdown.replace(/\\\$/g, ESCAPED_DOLLAR_PLACEHOLDER);
+}
+
+export function postprocessEscapedDollars(markdown: string): string {
+	return markdown.replaceAll(ESCAPED_DOLLAR_PLACEHOLDER, String.raw`\$`);
+}
+
 export const GLYPH_KATEX_OPTIONS = {
 	maxExpand: 1000,
 	maxSize: 20,

--- a/src/components/editor/extensions/math/mathOptions.ts
+++ b/src/components/editor/extensions/math/mathOptions.ts
@@ -14,13 +14,23 @@ export const BLOCK_MATH_STARTER = String.raw`\begin{aligned}
 \end{aligned}`;
 
 const ESCAPED_DOLLAR_PLACEHOLDER = "\uE000";
+const LITERAL_PLACEHOLDER_ESCAPE = "\uE001";
+const LITERAL_ESCAPE_ESCAPE = "\uE002";
 
+/** Swap escaped dollar signs for a placeholder before math parsing. */
 export function preprocessEscapedDollars(markdown: string): string {
-	return markdown.replace(/\\\$/g, ESCAPED_DOLLAR_PLACEHOLDER);
+	return markdown
+		.replace(/\uE001/g, LITERAL_ESCAPE_ESCAPE)
+		.replace(/\uE000/g, LITERAL_PLACEHOLDER_ESCAPE)
+		.replace(/\\\$/g, ESCAPED_DOLLAR_PLACEHOLDER);
 }
 
+/** Restore escaped dollar signs after math parsing. */
 export function postprocessEscapedDollars(markdown: string): string {
-	return markdown.replaceAll(ESCAPED_DOLLAR_PLACEHOLDER, String.raw`\$`);
+	return markdown
+		.replace(new RegExp(ESCAPED_DOLLAR_PLACEHOLDER, "g"), String.raw`\$`)
+		.replace(/\uE001/g, "\uE000")
+		.replace(/\uE002/g, "\uE001");
 }
 
 export const GLYPH_KATEX_OPTIONS = {

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.test.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.test.ts
@@ -71,4 +71,18 @@ describe("wikiLinkMarkdownBridge", () => {
 			"alpha\n \nbeta",
 		);
 	});
+
+	it("preserves escaped dollar signs through editor bridge round-trip", () => {
+		const md = String.raw`Price is \$5 and math is $x^2$.`;
+		expect(postprocessMarkdownFromEditor(preprocessMarkdownForEditor(md))).toBe(
+			md,
+		);
+	});
+
+	it("preserves literal placeholder sentinels through editor bridge round-trip", () => {
+		const md = "Marker \uE000 and escape \uE001 here";
+		expect(postprocessMarkdownFromEditor(preprocessMarkdownForEditor(md))).toBe(
+			md,
+		);
+	});
 });

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
@@ -1,4 +1,8 @@
 import {
+	postprocessEscapedDollars,
+	preprocessEscapedDollars,
+} from "../extensions/math/mathOptions";
+import {
 	EDITOR_TEXT_COLOR_BRIDGE_CLOSE_TOKEN,
 	getEditorTextColorBridgeOpenToken,
 	getEditorTextColorMarkdownOpenTag,
@@ -155,20 +159,24 @@ function postprocessWhitespaceLines(input: string): string {
 }
 
 export function preprocessMarkdownForEditor(markdown: string): string {
-	return preprocessColoredText(
-		preprocessHighlightedText(
-			encodeMarkdownImageDestinations(
-				canonicalizeWikiLinks(preprocessInlineTocMarkers(markdown)),
+	return preprocessEscapedDollars(
+		preprocessColoredText(
+			preprocessHighlightedText(
+				encodeMarkdownImageDestinations(
+					canonicalizeWikiLinks(preprocessInlineTocMarkers(markdown)),
+				),
 			),
 		),
 	);
 }
 
 export function postprocessMarkdownFromEditor(markdown: string): string {
-	return postprocessInlineTocMarkers(
-		postprocessWhitespaceLines(
-			postprocessHighlightedText(
-				postprocessColoredText(canonicalizeWikiLinks(markdown)),
+	return postprocessEscapedDollars(
+		postprocessInlineTocMarkers(
+			postprocessWhitespaceLines(
+				postprocessHighlightedText(
+					postprocessColoredText(canonicalizeWikiLinks(markdown)),
+				),
 			),
 		),
 	);


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that runs frontend (`pnpm check`, `pnpm test`, `pnpm build`) and Rust (`cargo check`, `cargo test`) validation on pull requests to `main`. Also fixes a LaTeX markdown round-trip bug where escaped `\$` sequences were stripped during editor parse/serialize, which was failing the smart paste integration test.

## Related Issues

Closes #

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

N/A — CI and markdown parsing fix only.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request checks that run frontend and Rust build/test validation with limited permissions and concurrency control.
  * Improved markdown processing in the editor to preserve literal dollar signs during math editing round-trips.

* **Bug Fixes**
  * Fixed edge cases where escaped dollar signs and special placeholder characters could be modified during markdown conversion.

* **Tests**
  * Added new round-trip coverage to ensure escaped dollar signs and placeholder characters remain unchanged after preprocess/postprocess.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->