### PR TITLE
Upgrade Quick Note with TipTap editor, add overlay/shortcut utilities

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,8 +14,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f390cd30d1d6d # v3.0.2
+        with:
+          filters: |
+            frontend:
+              - 'src/**'
+              - 'public/**'
+              - 'index.html'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'biome.json'
+              - 'components.json'
+              - 'tsconfig.json'
+              - 'tsconfig.node.json'
+              - 'vite.config.ts'
+            rust:
+              - 'src-tauri/**'
+
   frontend:
     name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,6 +94,8 @@ jobs:
 
   rust:
     name: Rust
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
     steps:
       - name: Checkout

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -969,8 +969,8 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
         WebviewUrl::App(format!("index.html?window={QUICK_NOTE_WINDOW_LABEL}").into()),
     )
     .title("Quick Note")
-    .inner_size(640.0, 360.0)
-    .resizable(false)
+    .inner_size(680.0, 440.0)
+    .resizable(true)
     .decorations(true)
     .title_bar_style(TitleBarStyle::Overlay)
     .hidden_title(true)

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -1,5 +1,5 @@
-import type { AnyExtension } from "@tiptap/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import type { AnyExtension } from "@tiptap/core";
 import { AnimatePresence } from "motion/react";
 import {
 	type MouseEvent as ReactMouseEvent,

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -1,3 +1,4 @@
+import type { AnyExtension } from "@tiptap/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { AnimatePresence } from "motion/react";
 import {
@@ -46,6 +47,8 @@ import { loadMathExtensionFactory } from "./math/loadMathExtensions";
 import type { SelectedCodeBlockState } from "./noteEditorOverlayTypes";
 import type { RawMarkdownEditorHandle } from "./raw/types";
 import type { NoteInlineEditorProps } from "./types";
+
+const EMPTY_ADDITIONAL_EXTENSIONS: AnyExtension[] = [];
 
 const RawMarkdownEditor = lazy(() =>
 	import("./raw/RawMarkdownEditor").then((module) => ({
@@ -142,6 +145,9 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	mode,
 	interactive = true,
 	deferHeavyFeatures = false,
+	chrome = "full",
+	additionalExtensions: additionalExtensionsProp = EMPTY_ADDITIONAL_EXTENSIONS,
+	placeholder,
 	pasteMarkdownBehavior = "plain-text",
 	onRegisterCalloutInserter,
 	onEditorReady,
@@ -150,6 +156,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	onFrontmatterCommit,
 	extractToNoteActions,
 }: NoteInlineEditorProps) {
+	const chromeMinimal = chrome === "minimal";
 	const mathNodeEditor = useMathNodeEditor();
 	const [mathExtensions, setMathExtensions] = useState<
 		import("@tiptap/core").AnyExtension[]
@@ -158,7 +165,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		mode === "plain",
 	);
 	useEffect(() => {
-		if (mode === "plain" || mathExtensions.length > 0) {
+		if (chromeMinimal || mode === "plain" || mathExtensions.length > 0) {
 			setMathExtensionsReady(true);
 			return;
 		}
@@ -180,7 +187,12 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		return () => {
 			cancelled = true;
 		};
-	}, [mathExtensions.length, mathNodeEditor.open, mode]);
+	}, [chromeMinimal, mathExtensions.length, mathNodeEditor.open, mode]);
+
+	const mergedAdditionalExtensions = useMemo(
+		() => [...mathExtensions, ...additionalExtensionsProp],
+		[additionalExtensionsProp, mathExtensions],
+	);
 
 	const {
 		editor,
@@ -191,7 +203,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		colorfulHeadings,
 		showFrontmatterInEditor,
 	} = useNoteEditor({
-		additionalExtensions: mathExtensions,
+		additionalExtensions: mergedAdditionalExtensions,
 		markdown,
 		mode,
 		relPath,
@@ -199,11 +211,14 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		enableHydrateInlineImages: !deferHeavyFeatures,
 		enableMarkdownLinkAutocomplete: !deferHeavyFeatures,
 		pasteMarkdownBehavior,
+		placeholder,
 		onChange,
 		onMathEditRequest: mathNodeEditor.open,
 	});
-	mathNodeEditor.connect(editor, mode === "rich");
+	mathNodeEditor.connect(editor, mode === "rich" && !chromeMinimal);
 
+	const canEdit = mode === "rich" && Boolean(editor?.isEditable);
+	const showEditorChrome = canEdit && !chromeMinimal;
 	const [frontmatterDraft, setFrontmatterDraft] = useState(frontmatter ?? "");
 	const lastFrontmatterRef = useRef(frontmatter);
 	const tiptapHostRef = useRef<HTMLDivElement | null>(null);
@@ -273,16 +288,15 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		relPath,
 	]);
 
-	const canEdit = mode === "rich" && Boolean(editor?.isEditable);
 	const selectedTable = useTableInlineControls({
-		canEdit,
+		canEdit: showEditorChrome,
 		editor,
 		hostRef: tiptapHostRef,
 		mode,
 	});
 	const extractToNote = useExtractSelectionToNote({
 		actions: extractToNoteActions,
-		canEdit,
+		canEdit: showEditorChrome,
 		editor,
 		hostRef: tiptapHostRef,
 		relPath,
@@ -298,7 +312,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 
 	useRibbonCommands({
 		editor,
-		canEdit,
+		canEdit: showEditorChrome,
 		mode,
 		tiptapHostRef,
 		tiptapHostNode,
@@ -389,7 +403,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	};
 
 	useEffect(() => {
-		if (!editor || mode !== "rich") {
+		if (!editor || mode !== "rich" || chromeMinimal) {
 			selectedCodeBlockRef.current = null;
 			if (codeBlockCopyResetTimerRef.current !== null) {
 				window.clearTimeout(codeBlockCopyResetTimerRef.current);
@@ -512,7 +526,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			editor.off("selectionUpdate", scheduleSelectedCodeBlockSync);
 			editor.off("transaction", scheduleSelectedCodeBlockSync);
 		};
-	}, [editor, mode]);
+	}, [chromeMinimal, editor, mode]);
 
 	const selectedCodeBlockLanguage = useMemo(
 		() => normalizeCodeBlockLanguage(selectedCodeBlock?.language),
@@ -665,16 +679,18 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			className={[
 				"rfNodeNoteEditor",
 				"rfNodeNoteEditorFlatEdges",
-				canEdit ? "rfNodeNoteEditorHasRibbon" : "",
+				showEditorChrome ? "rfNodeNoteEditorHasRibbon" : "",
 				"nodrag",
 				"nopan",
 			]
 				.filter(Boolean)
 				.join(" ")}
-			onKeyDownCapture={noteFind.handleEditorKeyDownCapture}
+			onKeyDownCapture={
+				showEditorChrome ? noteFind.handleEditorKeyDownCapture : undefined
+			}
 		>
 			<div className="rfNodeNoteEditorBody nodrag nopan nowheel">
-				{noteFind.findOpen ? (
+				{showEditorChrome && noteFind.findOpen ? (
 					<NoteFindBar
 						countLabel={noteFind.findCountLabel}
 						inputRef={noteFind.findInputRef}
@@ -724,7 +740,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				) : null}
 			</div>
 			<AnimatePresence>
-				{canEdit && editor ? (
+				{showEditorChrome && editor ? (
 					<EditorRibbon
 						editor={editor}
 						canEdit={canEdit}
@@ -737,20 +753,24 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					/>
 				) : null}
 			</AnimatePresence>
-			<ExtractToNoteDialog
-				state={extractToNote.dialogState}
-				onClose={extractToNote.closeExtractDialog}
-				onSubmit={extractToNote.submitExtractDialog}
-				onTitleChange={extractToNote.setExtractTitle}
-				onDestinationDirChange={extractToNote.setExtractDestinationDir}
-			/>
-			<NoteLinkDialog
-				editor={editor}
-				canEdit={canEdit}
-				state={linkDialog}
-				onStateChange={setLinkDialog}
-			/>
-			{mathNodeEditor.request ? (
+			{showEditorChrome ? (
+				<ExtractToNoteDialog
+					state={extractToNote.dialogState}
+					onClose={extractToNote.closeExtractDialog}
+					onSubmit={extractToNote.submitExtractDialog}
+					onTitleChange={extractToNote.setExtractTitle}
+					onDestinationDirChange={extractToNote.setExtractDestinationDir}
+				/>
+			) : null}
+			{showEditorChrome ? (
+				<NoteLinkDialog
+					editor={editor}
+					canEdit={canEdit}
+					state={linkDialog}
+					onStateChange={setLinkDialog}
+				/>
+			) : null}
+			{showEditorChrome && mathNodeEditor.request ? (
 				<Suspense fallback={null}>
 					<MathNodeEditor
 						key={`${mathNodeEditor.request.kind}:${mathNodeEditor.request.pos}`}

--- a/src/components/editor/editorOverlays.test.ts
+++ b/src/components/editor/editorOverlays.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { isEditorOverlayOpen } from "./editorOverlays";
+
+describe("isEditorOverlayOpen", () => {
+	it("returns false when no editor overlays are mounted", () => {
+		expect(isEditorOverlayOpen()).toBe(false);
+	});
+
+	it("detects an open slash command menu", () => {
+		const menu = document.createElement("div");
+		menu.className = "slashCommandMenu";
+		document.body.append(menu);
+		expect(isEditorOverlayOpen()).toBe(true);
+		menu.remove();
+	});
+
+	it("detects an open radix menu", () => {
+		const menu = document.createElement("div");
+		menu.setAttribute("role", "menu");
+		menu.setAttribute("data-state", "open");
+		document.body.append(menu);
+		expect(isEditorOverlayOpen()).toBe(true);
+		menu.remove();
+	});
+
+	it("detects an open wiki link suggestion menu", () => {
+		const menu = document.createElement("div");
+		menu.className = "wikiLinkSuggestionMenu";
+		document.body.append(menu);
+		expect(isEditorOverlayOpen()).toBe(true);
+		menu.remove();
+	});
+});

--- a/src/components/editor/editorOverlays.test.ts
+++ b/src/components/editor/editorOverlays.test.ts
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { isEditorOverlayOpen } from "./editorOverlays";
 
 describe("isEditorOverlayOpen", () => {
+	afterEach(() => {
+		document.body.innerHTML = "";
+	});
+
 	it("returns false when no editor overlays are mounted", () => {
 		expect(isEditorOverlayOpen()).toBe(false);
 	});
@@ -13,16 +17,22 @@ describe("isEditorOverlayOpen", () => {
 		menu.className = "slashCommandMenu";
 		document.body.append(menu);
 		expect(isEditorOverlayOpen()).toBe(true);
-		menu.remove();
 	});
 
-	it("detects an open radix menu", () => {
+	it("detects an open editor color dropdown", () => {
+		const menu = document.createElement("div");
+		menu.className = "editorColorDropdown";
+		menu.setAttribute("data-state", "open");
+		document.body.append(menu);
+		expect(isEditorOverlayOpen()).toBe(true);
+	});
+
+	it("ignores unrelated open radix menus", () => {
 		const menu = document.createElement("div");
 		menu.setAttribute("role", "menu");
 		menu.setAttribute("data-state", "open");
 		document.body.append(menu);
-		expect(isEditorOverlayOpen()).toBe(true);
-		menu.remove();
+		expect(isEditorOverlayOpen()).toBe(false);
 	});
 
 	it("detects an open wiki link suggestion menu", () => {
@@ -30,6 +40,5 @@ describe("isEditorOverlayOpen", () => {
 		menu.className = "wikiLinkSuggestionMenu";
 		document.body.append(menu);
 		expect(isEditorOverlayOpen()).toBe(true);
-		menu.remove();
 	});
 });

--- a/src/components/editor/editorOverlays.ts
+++ b/src/components/editor/editorOverlays.ts
@@ -1,0 +1,6 @@
+const EDITOR_OVERLAY_SELECTOR =
+	'.slashCommandMenu, .wikiLinkSuggestionMenu, [role="menu"][data-state="open"], [data-radix-menu-content][data-state="open"]';
+
+export function isEditorOverlayOpen(root: ParentNode = document): boolean {
+	return Boolean(root.querySelector(EDITOR_OVERLAY_SELECTOR));
+}

--- a/src/components/editor/editorOverlays.ts
+++ b/src/components/editor/editorOverlays.ts
@@ -1,5 +1,5 @@
 const EDITOR_OVERLAY_SELECTOR =
-	'.slashCommandMenu, .wikiLinkSuggestionMenu, [role="menu"][data-state="open"], [data-radix-menu-content][data-state="open"]';
+	".slashCommandMenu, .wikiLinkSuggestionMenu, .editorColorDropdown[data-state=\"open\"]";
 
 export function isEditorOverlayOpen(root: ParentNode = document): boolean {
 	return Boolean(root.querySelector(EDITOR_OVERLAY_SELECTOR));

--- a/src/components/editor/extensions/editorShortcuts.integration.test.ts
+++ b/src/components/editor/extensions/editorShortcuts.integration.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { describe, expect, it, vi } from "vitest";
+import { createEditorShortcutsExtension } from "./editorShortcuts";
+
+function createEditor(handlers: { onEscape?: () => void; onSave?: () => void }) {
+	const element = document.createElement("div");
+	document.body.append(element);
+	const handlersRef = { current: handlers };
+	const editor = new Editor({
+		extensions: [
+			StarterKit,
+			createEditorShortcutsExtension(() => handlersRef.current),
+		],
+		content: "<p>hello</p>",
+		element,
+	});
+
+	return {
+		editor,
+		destroy() {
+			editor.destroy();
+			element.remove();
+		},
+	};
+}
+
+function isMacPlatform() {
+	return /Mac/.test(navigator.platform);
+}
+
+function press(editor: Editor, key: string, modifiers: Partial<KeyboardEventInit> = {}) {
+	const event = new KeyboardEvent("keydown", {
+		bubbles: true,
+		cancelable: true,
+		key,
+		code: key,
+		...modifiers,
+	});
+	editor.commands.focus();
+	editor.view.dom.dispatchEvent(event);
+	return event.defaultPrevented;
+}
+
+function pressModEnter(editor: Editor) {
+	return press(editor, "Enter", {
+		metaKey: isMacPlatform(),
+		ctrlKey: !isMacPlatform(),
+	});
+}
+
+describe("createEditorShortcutsExtension", () => {
+	it("calls onSave for Mod+Enter when no overlay is open", () => {
+		const onSave = vi.fn();
+		const harness = createEditor({ onSave });
+
+		try {
+			expect(pressModEnter(harness.editor)).toBe(true);
+			expect(onSave).toHaveBeenCalledTimes(1);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("calls onEscape when no overlay is open", () => {
+		const onEscape = vi.fn();
+		const harness = createEditor({ onEscape });
+
+		try {
+			expect(press(harness.editor, "Escape")).toBe(true);
+			expect(onEscape).toHaveBeenCalledTimes(1);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("does not call onEscape when a slash menu is open", () => {
+		const onEscape = vi.fn();
+		const harness = createEditor({ onEscape });
+		const menu = document.createElement("div");
+		menu.className = "slashCommandMenu";
+		document.body.append(menu);
+
+		try {
+			expect(press(harness.editor, "Escape")).toBe(false);
+			expect(onEscape).not.toHaveBeenCalled();
+		} finally {
+			menu.remove();
+			harness.destroy();
+		}
+	});
+
+	it("does not call onEscape when a wiki link menu is open", () => {
+		const onEscape = vi.fn();
+		const harness = createEditor({ onEscape });
+		const menu = document.createElement("div");
+		menu.className = "wikiLinkSuggestionMenu";
+		document.body.append(menu);
+
+		try {
+			expect(press(harness.editor, "Escape")).toBe(false);
+			expect(onEscape).not.toHaveBeenCalled();
+		} finally {
+			menu.remove();
+			harness.destroy();
+		}
+	});
+
+	it("does not call onSave for Mod+Enter when an overlay is open", () => {
+		const onSave = vi.fn();
+		const harness = createEditor({ onSave });
+		const menu = document.createElement("div");
+		menu.className = "slashCommandMenu";
+		document.body.append(menu);
+
+		try {
+			pressModEnter(harness.editor);
+			expect(onSave).not.toHaveBeenCalled();
+		} finally {
+			menu.remove();
+			harness.destroy();
+		}
+	});
+});

--- a/src/components/editor/extensions/editorShortcuts.integration.test.ts
+++ b/src/components/editor/extensions/editorShortcuts.integration.test.ts
@@ -5,7 +5,10 @@ import StarterKit from "@tiptap/starter-kit";
 import { describe, expect, it, vi } from "vitest";
 import { createEditorShortcutsExtension } from "./editorShortcuts";
 
-function createEditor(handlers: { onEscape?: () => void; onSave?: () => void }) {
+function createEditor(handlers: {
+	onEscape?: () => void;
+	onSave?: () => void;
+}) {
 	const element = document.createElement("div");
 	document.body.append(element);
 	const handlersRef = { current: handlers };
@@ -31,7 +34,11 @@ function isMacPlatform() {
 	return /Mac/.test(navigator.platform);
 }
 
-function press(editor: Editor, key: string, modifiers: Partial<KeyboardEventInit> = {}) {
+function press(
+	editor: Editor,
+	key: string,
+	modifiers: Partial<KeyboardEventInit> = {},
+) {
 	const event = new KeyboardEvent("keydown", {
 		bubbles: true,
 		cancelable: true,

--- a/src/components/editor/extensions/editorShortcuts.ts
+++ b/src/components/editor/extensions/editorShortcuts.ts
@@ -1,0 +1,32 @@
+import { Extension } from "@tiptap/core";
+import { isEditorOverlayOpen } from "../editorOverlays";
+
+export interface EditorShortcutsHandlers {
+	onEscape?: () => void;
+	onSave?: () => void;
+}
+
+export function createEditorShortcutsExtension(
+	getHandlers: () => EditorShortcutsHandlers,
+) {
+	return Extension.create({
+		name: "editorShortcuts",
+		priority: 1000,
+		addKeyboardShortcuts() {
+			return {
+				Escape: () => {
+					const { onEscape } = getHandlers();
+					if (!onEscape || isEditorOverlayOpen()) return false;
+					onEscape();
+					return true;
+				},
+				"Mod-Enter": () => {
+					const { onSave } = getHandlers();
+					if (!onSave || isEditorOverlayOpen()) return false;
+					onSave();
+					return true;
+				},
+			};
+		},
+	});
+}

--- a/src/components/editor/extensions/vimMode.ts
+++ b/src/components/editor/extensions/vimMode.ts
@@ -1,6 +1,7 @@
 import { type Editor, Extension } from "@tiptap/core";
 import type { EditorState } from "@tiptap/pm/state";
 import { Plugin, Selection } from "@tiptap/pm/state";
+import { isEditorOverlayOpen } from "../editorOverlays";
 
 type VimInputMode = "insert" | "normal";
 
@@ -33,12 +34,6 @@ declare module "@tiptap/core" {
 			enterVimNormalMode: () => ReturnType;
 		};
 	}
-}
-
-function hasOpenSuggestionMenu() {
-	return Boolean(
-		document.querySelector(".slashCommandMenu, .wikiLinkSuggestionMenu"),
-	);
 }
 
 function syncVimModeAttribute(editor: Editor, mode: VimInputMode | null) {
@@ -305,7 +300,7 @@ export const VimMode = Extension.create<object, VimModeStorage>({
 		const swallow = () => swallowNormalModeKey(this.storage, this.editor);
 		const shortcuts: Record<string, () => boolean> = {
 			Escape: () => {
-				if (!this.editor.isEditable || hasOpenSuggestionMenu()) return false;
+				if (!this.editor.isEditable || isEditorOverlayOpen()) return false;
 				return this.editor.commands.enterVimNormalMode();
 			},
 			"Control-r": normal(() => this.editor.commands.redo()),

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -470,6 +470,7 @@ export function useNoteEditor({
 		void additionalExtensions;
 		void peopleMentionsEnabled;
 		void enableMarkdownLinkAutocomplete;
+		void placeholder;
 		void vimKeybindingsEnabled;
 		return () => {
 			flushMarkdownSync(relPath);
@@ -480,6 +481,7 @@ export function useNoteEditor({
 		additionalExtensions,
 		peopleMentionsEnabled,
 		enableMarkdownLinkAutocomplete,
+		placeholder,
 		vimKeybindingsEnabled,
 	]);
 
@@ -646,6 +648,7 @@ export function useNoteEditor({
 			additionalExtensions,
 			peopleMentionsEnabled,
 			enableMarkdownLinkAutocomplete,
+			placeholder,
 			vimKeybindingsEnabled,
 		],
 	);

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -249,6 +249,7 @@ interface UseNoteEditorOptions {
 	enableHydrateInlineImages?: boolean;
 	enableMarkdownLinkAutocomplete?: boolean;
 	pasteMarkdownBehavior?: PasteMarkdownBehavior;
+	placeholder?: string;
 	onChange: (nextMarkdown: string) => void;
 	onMathEditRequest?: (request: MathEditRequest) => void;
 }
@@ -270,6 +271,7 @@ export function useNoteEditor({
 	enableHydrateInlineImages = true,
 	enableMarkdownLinkAutocomplete = true,
 	pasteMarkdownBehavior = "plain-text",
+	placeholder = "Start writing or press / for commands",
 	onChange,
 	onMathEditRequest,
 }: UseNoteEditorOptions) {
@@ -314,13 +316,14 @@ export function useNoteEditor({
 				enablePeopleMentions: peopleMentionsEnabled,
 				enableVimKeybindings: vimKeybindingsEnabled,
 				onMathEditRequest,
-				placeholder: "Start writing or press / for commands",
+				placeholder,
 			}),
 		[
 			additionalExtensions,
 			enableMarkdownLinkAutocomplete,
-			peopleMentionsEnabled,
 			onMathEditRequest,
+			peopleMentionsEnabled,
+			placeholder,
 			vimKeybindingsEnabled,
 		],
 	);

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -1,8 +1,9 @@
-import type { Editor } from "@tiptap/core";
+import type { AnyExtension, Editor } from "@tiptap/core";
 import type { EditorViewMode } from "../../lib/editorMode";
 import type { RawMarkdownEditorHandle } from "./raw/types";
 
 export type NoteInlineEditorMode = EditorViewMode;
+export type NoteInlineEditorChrome = "full" | "minimal";
 export type PasteMarkdownBehavior = "plain-text" | "smart-markdown";
 
 export interface CreateMarkdownFileOptions {
@@ -28,6 +29,9 @@ export interface NoteInlineEditorProps {
 	extractToNoteActions?: ExtractToNoteActions;
 	interactive?: boolean;
 	deferHeavyFeatures?: boolean;
+	chrome?: NoteInlineEditorChrome;
+	additionalExtensions?: AnyExtension[];
+	placeholder?: string;
 	pasteMarkdownBehavior?: PasteMarkdownBehavior;
 	onRegisterCalloutInserter?:
 		| ((inserter: ((type: string) => void) | null) => void)

--- a/src/components/quick-note/QuickNoteWindow.test.tsx
+++ b/src/components/quick-note/QuickNoteWindow.test.tsx
@@ -51,7 +51,10 @@ const {
 		),
 		editorReadyCallbackRef: {
 			current: null as
-				| ((editor: typeof mockEditor | null, contentRoot: HTMLElement | null) => void)
+				| ((
+						editor: typeof mockEditor | null,
+						contentRoot: HTMLElement | null,
+				  ) => void)
 				| null,
 		},
 		additionalExtensionsRef: {

--- a/src/components/quick-note/QuickNoteWindow.test.tsx
+++ b/src/components/quick-note/QuickNoteWindow.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QuickNoteWindow } from "./QuickNoteWindow";
+
+const {
+	emitMock,
+	invokeMock,
+	loadSettingsMock,
+	editorReadyCallbackRef,
+	mockEditor,
+	setEditorText,
+	additionalExtensionsRef,
+} = vi.hoisted(() => {
+	const listeners = new Map<string, Set<() => void>>();
+	let text = "";
+	const mockEditor = {
+		getText: () => text,
+		getMarkdown: () => text,
+		commands: {
+			focus: vi.fn(),
+			setContent: vi.fn((content: string) => {
+				text = content;
+				for (const callback of listeners.get("update") ?? []) {
+					callback();
+				}
+			}),
+		},
+		on: vi.fn((event: string, callback: () => void) => {
+			if (!listeners.has(event)) {
+				listeners.set(event, new Set());
+			}
+			listeners.get(event)?.add(callback);
+		}),
+		off: vi.fn((event: string, callback: () => void) => {
+			listeners.get(event)?.delete(callback);
+		}),
+	};
+
+	return {
+		emitMock: vi.fn(() => Promise.resolve()),
+		invokeMock: vi.fn(),
+		loadSettingsMock: vi.fn(() =>
+			Promise.resolve({
+				quickNotes: {
+					folder: "Quick Notes",
+				},
+			}),
+		),
+		editorReadyCallbackRef: {
+			current: null as
+				| ((editor: typeof mockEditor | null, contentRoot: HTMLElement | null) => void)
+				| null,
+		},
+		additionalExtensionsRef: {
+			current: null as unknown[] | null,
+		},
+		mockEditor,
+		setEditorText(next: string) {
+			text = next;
+			for (const callback of listeners.get("update") ?? []) {
+				callback();
+			}
+		},
+	};
+});
+
+(
+	globalThis as typeof globalThis & {
+		IS_REACT_ACT_ENVIRONMENT?: boolean;
+	}
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@tauri-apps/api/event", () => ({
+	emit: emitMock,
+}));
+
+vi.mock("../../lib/settings", () => ({
+	loadSettings: loadSettingsMock,
+	reloadFromDisk: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../lib/tauri", () => ({
+	invoke: invokeMock,
+}));
+
+vi.mock("../../lib/tauriEvents", () => ({
+	useTauriEvent: () => {},
+}));
+
+vi.mock("../editor/NoteInlineEditor", () => ({
+	NoteInlineEditor: ({
+		onChange,
+		onEditorReady,
+		deferHeavyFeatures,
+		chrome,
+		placeholder,
+		additionalExtensions,
+	}: {
+		onChange: (nextMarkdown: string) => void;
+		onEditorReady?: (
+			editor: typeof mockEditor | null,
+			contentRoot: HTMLElement | null,
+		) => void;
+		deferHeavyFeatures?: boolean;
+		chrome?: string;
+		placeholder?: string;
+		additionalExtensions?: unknown[];
+	}) => {
+		editorReadyCallbackRef.current = onEditorReady ?? null;
+		if (additionalExtensions) {
+			if (
+				additionalExtensionsRef.current &&
+				additionalExtensionsRef.current !== additionalExtensions
+			) {
+				(
+					globalThis as typeof globalThis & {
+						__quickNoteAdditionalExtensionsChanged?: boolean;
+					}
+				).__quickNoteAdditionalExtensionsChanged = true;
+			}
+			additionalExtensionsRef.current = additionalExtensions;
+		}
+		return (
+			<div
+				data-testid="quick-note-editor"
+				data-defer-heavy-features={deferHeavyFeatures ? "true" : "false"}
+				data-chrome={chrome}
+				data-placeholder={placeholder}
+				data-additional-extensions={String(additionalExtensions?.length ?? 0)}
+			>
+				<textarea
+					aria-label="Quick note editor"
+					onChange={(event) => {
+						setEditorText(event.target.value);
+						onChange(event.target.value);
+					}}
+				/>
+			</div>
+		);
+	},
+}));
+
+vi.mock("./QuickNoteTargetBreadcrumbs", () => ({
+	QUICK_NOTE_TARGET_VALUE: "__quick-note-today__",
+	QuickNoteTargetBreadcrumbs: () => null,
+}));
+
+vi.mock("../Icons", () => ({
+	FileText: () => null,
+	Save: () => null,
+}));
+
+describe("QuickNoteWindow", () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach(() => {
+		container = document.createElement("div");
+		document.body.append(container);
+		root = createRoot(container);
+		setEditorText("");
+		additionalExtensionsRef.current = null;
+		(
+			globalThis as typeof globalThis & {
+				__quickNoteAdditionalExtensionsChanged?: boolean;
+			}
+		).__quickNoteAdditionalExtensionsChanged = false;
+		emitMock.mockClear();
+		invokeMock.mockReset();
+		loadSettingsMock.mockClear();
+		invokeMock.mockImplementation((command: string) => {
+			if (command === "space_read_text") {
+				return Promise.resolve({ text: "", mtime_ms: 0 });
+			}
+			if (command === "space_write_text") {
+				return Promise.resolve();
+			}
+			return Promise.resolve();
+		});
+	});
+
+	afterEach(() => {
+		act(() => {
+			root.unmount();
+		});
+		container.remove();
+	});
+
+	async function renderWindow() {
+		await act(async () => {
+			root.render(<QuickNoteWindow />);
+		});
+		await act(async () => {
+			editorReadyCallbackRef.current?.(mockEditor, null);
+		});
+	}
+
+	function getSaveButton() {
+		return container.querySelector(
+			".quickNoteSaveButton",
+		) as HTMLButtonElement | null;
+	}
+
+	function typeInEditor(value: string) {
+		act(() => {
+			setEditorText(value);
+		});
+	}
+
+	it("passes quick note editor options to NoteInlineEditor", async () => {
+		await renderWindow();
+		const editor = container.querySelector('[data-testid="quick-note-editor"]');
+		expect(editor?.getAttribute("data-defer-heavy-features")).toBe("true");
+		expect(editor?.getAttribute("data-chrome")).toBe("minimal");
+		expect(editor?.getAttribute("data-additional-extensions")).toBe("1");
+		expect(editor?.getAttribute("data-placeholder")).toBe(
+			"Write a quick note or press / for commands",
+		);
+	});
+
+	it("keeps editor extensions stable while typing", async () => {
+		await renderWindow();
+		const initialExtensions = additionalExtensionsRef.current;
+		expect(initialExtensions).not.toBeNull();
+		act(() => {
+			setEditorText("first");
+		});
+		act(() => {
+			setEditorText("first second");
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(additionalExtensionsRef.current).toBe(initialExtensions);
+		expect(
+			(
+				globalThis as typeof globalThis & {
+					__quickNoteAdditionalExtensionsChanged?: boolean;
+				}
+			).__quickNoteAdditionalExtensionsChanged,
+		).not.toBe(true);
+	});
+
+	it("enables save from live editor text before draft state syncs", async () => {
+		await renderWindow();
+		const saveButton = getSaveButton();
+		expect(saveButton?.disabled).toBe(true);
+		act(() => {
+			setEditorText("instant note");
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+		expect(getSaveButton()?.disabled).toBe(false);
+	});
+
+	it("saves from the save button and clears the editor", async () => {
+		await renderWindow();
+		typeInEditor("capture this");
+		const saveButton = getSaveButton();
+		expect(saveButton?.disabled).toBe(false);
+		await act(async () => {
+			saveButton?.click();
+		});
+		await vi.waitFor(() => {
+			expect(invokeMock).toHaveBeenCalledWith(
+				"space_write_text",
+				expect.objectContaining({
+					text: "capture this\n",
+				}),
+			);
+		});
+		expect(invokeMock).toHaveBeenCalledWith("space_read_text", {
+			path: expect.stringContaining("Quick Note"),
+		});
+		expect(mockEditor.commands.setContent).toHaveBeenCalledWith("", {
+			contentType: "markdown",
+		});
+		expect(emitMock).toHaveBeenCalledWith(
+			"quick-note:open_note",
+			expect.objectContaining({ path: expect.stringContaining("Quick Note") }),
+		);
+	});
+});

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -1,14 +1,14 @@
-import type { Editor } from "@tiptap/core";
 import { emit } from "@tauri-apps/api/event";
+import type { Editor } from "@tiptap/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isMissingFileError } from "../../lib/fsErrors";
 import { loadSettings, reloadFromDisk } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename, parentDir } from "../../utils/path";
-import { createEditorShortcutsExtension } from "../editor/extensions/editorShortcuts";
-import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { FileText, Save } from "../Icons";
+import { NoteInlineEditor } from "../editor/NoteInlineEditor";
+import { createEditorShortcutsExtension } from "../editor/extensions/editorShortcuts";
 import {
 	QUICK_NOTE_TARGET_VALUE,
 	type QuickNoteTarget,

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -88,7 +88,7 @@ function focusEditor(editor: Editor | null) {
 }
 
 function editorHasText(editor: Editor | null): boolean {
-	return Boolean(editor?.getText().trim());
+	return Boolean(editor?.getMarkdown().trim());
 }
 
 function clearDraft(editor: Editor | null) {

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -1,23 +1,21 @@
+import type { Editor } from "@tiptap/core";
 import { emit } from "@tauri-apps/api/event";
-import {
-	type KeyboardEvent,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isMissingFileError } from "../../lib/fsErrors";
 import { loadSettings, reloadFromDisk } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { basename, parentDir } from "../../utils/path";
+import { createEditorShortcutsExtension } from "../editor/extensions/editorShortcuts";
+import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { FileText, Save } from "../Icons";
 import {
 	QUICK_NOTE_TARGET_VALUE,
 	type QuickNoteTarget,
 	QuickNoteTargetBreadcrumbs,
 } from "./QuickNoteTargetBreadcrumbs";
+
+const QUICK_NOTE_PLACEHOLDER = "Write a quick note or press / for commands";
 
 function pad(value: number): string {
 	return value.toString().padStart(2, "0");
@@ -85,17 +83,36 @@ function quickNoteTarget(folder: string): QuickNoteTarget {
 	};
 }
 
+function focusEditor(editor: Editor | null) {
+	editor?.commands.focus(undefined, { scrollIntoView: false });
+}
+
+function editorHasText(editor: Editor | null): boolean {
+	return Boolean(editor?.getText().trim());
+}
+
+function clearDraft(editor: Editor | null) {
+	editor?.commands.setContent("", { contentType: "markdown" });
+}
+
 export function QuickNoteWindow() {
 	const [folder, setFolder] = useState("Quick Notes");
 	const [draft, setDraft] = useState("");
+	const [hasText, setHasText] = useState(false);
 	const [status, setStatus] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [targetValue, setTargetValue] = useState(QUICK_NOTE_TARGET_VALUE);
-	const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const editorRef = useRef<Editor | null>(null);
+	const unsubscribeRef = useRef<(() => void) | null>(null);
+	const shortcutsRef = useRef({
+		onEscape: () => {
+			void invoke("hide_quick_note_window");
+		},
+		onSave: () => {},
+	});
 	const statusTimerRef = useRef<number | null>(null);
 	const focusTimerRef = useRef<number | null>(null);
 
-	const hasText = draft.trim().length > 0;
 	const todayQuickNotePath = useMemo(() => quickNotePath(folder), [folder]);
 	const selectedTarget = useMemo((): QuickNoteTarget => {
 		if (targetValue === QUICK_NOTE_TARGET_VALUE) {
@@ -114,9 +131,14 @@ export function QuickNoteWindow() {
 	const shortcutLabel = isMac ? "⌘+Enter" : "Ctrl+Enter";
 	const shortcutModifierLabel = isMac ? "⌘" : "Ctrl";
 
+	const readDraft = useCallback(
+		() => editorRef.current?.getMarkdown().trim() ?? "",
+		[],
+	);
+
 	const chooseTarget = useCallback((target: QuickNoteTarget) => {
 		setTargetValue(target.value);
-		window.setTimeout(() => textareaRef.current?.focus(), 20);
+		window.setTimeout(() => focusEditor(editorRef.current), 20);
 	}, []);
 
 	const refreshSettings = useCallback(async (withReload = false) => {
@@ -131,15 +153,11 @@ export function QuickNoteWindow() {
 		void refreshSettings().catch((cause) => {
 			console.error("Failed to load quick note settings", cause);
 		});
-		const focusTimer = window.setTimeout(
-			() => textareaRef.current?.focus(),
-			80,
-		);
-		return () => window.clearTimeout(focusTimer);
 	}, [refreshSettings]);
 
 	useEffect(() => {
 		return () => {
+			unsubscribeRef.current?.();
 			if (statusTimerRef.current !== null) {
 				window.clearTimeout(statusTimerRef.current);
 			}
@@ -156,7 +174,7 @@ export function QuickNoteWindow() {
 	});
 
 	const save = useCallback(async () => {
-		const text = draft.trim();
+		const text = readDraft();
 		if (!text || saving) return;
 		setSaving(true);
 		setStatus("");
@@ -165,7 +183,9 @@ export function QuickNoteWindow() {
 				selectedTarget.value === QUICK_NOTE_TARGET_VALUE
 					? await appendQuickNote(folder, text)
 					: await appendQuickNoteToPath(selectedTarget.path, text);
+			clearDraft(editorRef.current);
 			setDraft("");
+			setHasText(false);
 			setStatus(`Saved ${savedLabel(path)}`);
 			void emit("quick-note:open_note", { path }).catch(() => {});
 			if (statusTimerRef.current !== null) {
@@ -176,7 +196,7 @@ export function QuickNoteWindow() {
 			}
 			statusTimerRef.current = window.setTimeout(() => setStatus(""), 1600);
 			focusTimerRef.current = window.setTimeout(
-				() => textareaRef.current?.focus(),
+				() => focusEditor(editorRef.current),
 				20,
 			);
 		} catch (cause) {
@@ -184,33 +204,69 @@ export function QuickNoteWindow() {
 		} finally {
 			setSaving(false);
 		}
-	}, [draft, folder, saving, selectedTarget.path, selectedTarget.value]);
+	}, [folder, readDraft, saving, selectedTarget.path, selectedTarget.value]);
 
-	const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		const primary = event.metaKey || event.ctrlKey;
-		if (event.key === "Escape") {
-			event.preventDefault();
+	shortcutsRef.current = {
+		onEscape: () => {
 			void invoke("hide_quick_note_window");
+		},
+		onSave: () => {
+			void save();
+		},
+	};
+
+	const shortcutExtension = useMemo(
+		() => createEditorShortcutsExtension(() => shortcutsRef.current),
+		[],
+	);
+	const editorAdditionalExtensions = useMemo(
+		() => [shortcutExtension],
+		[shortcutExtension],
+	);
+
+	const handleEditorReady = useCallback((editor: Editor | null) => {
+		unsubscribeRef.current?.();
+		unsubscribeRef.current = null;
+		editorRef.current = editor;
+		if (!editor) {
+			setHasText(false);
 			return;
 		}
-		if (primary && event.key === "Enter") {
-			event.preventDefault();
-			void save();
-		}
-	};
+		focusEditor(editor);
+		const syncHasText = () => {
+			const nextHasText = editorHasText(editor);
+			setHasText((current) =>
+				current === nextHasText ? current : nextHasText,
+			);
+		};
+		syncHasText();
+		editor.on("update", syncHasText);
+		unsubscribeRef.current = () => {
+			editor.off("update", syncHasText);
+		};
+	}, []);
+
+	const handleDraftChange = useCallback((nextMarkdown: string) => {
+		setDraft(nextMarkdown);
+	}, []);
 
 	return (
 		<div className="quickNoteRoot">
 			<div className="quickNoteDragHandle" data-tauri-drag-region />
-			<textarea
-				ref={textareaRef}
-				className="quickNoteTextarea"
-				value={draft}
-				placeholder="Write a quick note"
-				onChange={(event) => setDraft(event.target.value)}
-				onKeyDown={handleKeyDown}
-				spellCheck
-			/>
+			<div className="quickNoteEditorArea">
+				<NoteInlineEditor
+					markdown={draft}
+					relPath={selectedTarget.path}
+					mode="rich"
+					chrome="minimal"
+					deferHeavyFeatures
+					additionalExtensions={editorAdditionalExtensions}
+					placeholder={QUICK_NOTE_PLACEHOLDER}
+					pasteMarkdownBehavior="smart-markdown"
+					onChange={handleDraftChange}
+					onEditorReady={handleEditorReady}
+				/>
+			</div>
 			<div className="quickNoteEditorChrome">
 				<div className="quickNoteTargetGroup">
 					<button

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -1,5 +1,7 @@
 .quickNoteRoot {
 	position: relative;
+	display: flex;
+	flex-direction: column;
 	height: 100%;
 	color: var(--text-primary);
 	background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
@@ -15,28 +17,42 @@
 	left: 0;
 	right: 0;
 	height: 18px;
-	z-index: 1;
+	z-index: 3;
 }
 
-.quickNoteTextarea {
-	width: 100%;
-	min-width: 0;
+.quickNoteEditorArea {
+	flex: 1;
+	min-height: 0;
+	padding-top: 18px;
+	overflow: hidden;
+	-webkit-app-region: no-drag;
+}
+
+.quickNoteEditorArea .rfNodeNoteEditor {
 	height: 100%;
-	resize: none;
 	border: 0;
-	outline: none;
+	border-radius: 0;
 	background: transparent;
-	color: color-mix(in srgb, var(--text-primary) 96%, var(--text-secondary));
-	padding: 30px 28px 72px;
-	font: inherit;
-	font-size: var(--editor-inline-font-size);
-	line-height: 1.68;
-	letter-spacing: 0;
-	caret-color: var(--interactive-accent);
+	overflow: hidden;
 }
 
-.quickNoteTextarea::placeholder {
-	color: var(--text-placeholder);
+.quickNoteEditorArea .rfNodeNoteEditor:focus-within {
+	border-color: transparent;
+	box-shadow: none;
+}
+
+.quickNoteEditorArea .rfNodeNoteEditorBody {
+	padding: 10px 24px 72px;
+	background: transparent;
+}
+
+.quickNoteEditorArea .tiptapHostInline,
+.quickNoteEditorArea .tiptapContentInline {
+	min-height: 100%;
+}
+
+.quickNoteEditorArea .tiptapContentInline {
+	padding-bottom: 8px;
 }
 
 .quickNoteEditorChrome {
@@ -49,6 +65,7 @@
 	justify-content: space-between;
 	gap: 16px;
 	pointer-events: none;
+	z-index: 4;
 }
 
 .quickNoteTargetGroup,


### PR DESCRIPTION
## Summary

Upgrades the Quick Note window from a plain textarea to a TipTap-based rich editor with minimal chrome, extracts a shared `isEditorOverlayOpen()` utility from vim mode, and introduces a reusable `editorShortcuts` Tiptap extension for overlay-aware keyboard shortcuts (Escape to close, Mod+Enter to save).

## Testing

- [ ] pnpm check
- [ ] pnpm build
- [ ] cd src-tauri && cargo check
- [ ] Relevant manual testing completed on macOS

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used src/lib/tauri.ts for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Note now opens in a larger, resizable window.
  * The note editor now supports minimal editor chrome, custom placeholders, and additional extensions.
* **Bug Fixes**
  * Keyboard shortcuts (Escape/Save) now correctly defer while editor overlays/menus are open.
  * Vim mode Escape behavior is updated to respect overlay state.
  * Quick Note editing and saving stay more reliably synchronized.
* **Tests**
  * Added/expanded tests for editor overlays, keyboard shortcuts, and Quick Note behavior.
* **Chores**
  * Improved CI to run frontend vs. Rust checks only when relevant files change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->