### PR TITLE
Extract table inline controls context menus delete support (#205) [Release]

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f390cd30d1d6d # v3.0.2
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         with:
           filters: |
             frontend:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.4",
+	"version": "0.8.5-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -1,6 +1,5 @@
 import {
 	Copy01Icon,
-	LocationAdd01Icon,
 	SourceCodeIcon,
 	Tick02Icon,
 } from "@hugeicons/core-free-icons";
@@ -10,13 +9,14 @@ import { EditorContent } from "@tiptap/react";
 import { memo } from "react";
 import { Button } from "../ui/shadcn/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
+import { TableInlineControls } from "./TableInlineControls";
 import {
 	CODE_BLOCK_LANGUAGE_OPTIONS,
 	type SupportedCodeBlockLanguage,
 } from "./extensions/codeBlockHighlighting";
 import type {
 	SelectedCodeBlockState,
-	SelectedTableState,
+	TableInlineControlsProps,
 } from "./noteEditorOverlayTypes";
 
 interface NoteEditorSurfaceProps {
@@ -26,12 +26,7 @@ interface NoteEditorSurfaceProps {
 	canEdit: boolean;
 	hostRef: (node: HTMLDivElement | null) => void;
 
-	table: {
-		selected: SelectedTableState | null;
-		onControlMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
-		onAddRow: () => void;
-		onAddColumn: () => void;
-	};
+	tableControls: TableInlineControlsProps | null;
 
 	codeBlock: {
 		selected: SelectedCodeBlockState | null;
@@ -52,7 +47,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 	colorfulHeadings,
 	canEdit,
 	hostRef,
-	table,
+	tableControls,
 	codeBlock,
 }: NoteEditorSurfaceProps) {
 	const hostClassName = [
@@ -74,47 +69,8 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 			}
 		>
 			<EditorContent editor={editor} />
-			{canEdit && table.selected ? (
-				<>
-					<button
-						type="button"
-						className="tableInlineAddBtn is-row"
-						data-axis="row"
-						aria-label="Add row"
-						title="Add row"
-						style={{
-							left: `${table.selected.rowControlLeft}px`,
-							top: `${table.selected.rowControlTop}px`,
-						}}
-						onMouseDown={table.onControlMouseDown}
-						onClick={table.onAddRow}
-					>
-						<HugeiconsIcon
-							icon={LocationAdd01Icon}
-							size="var(--icon-md)"
-							strokeWidth={0.9}
-						/>
-					</button>
-					<button
-						type="button"
-						className="tableInlineAddBtn is-column"
-						data-axis="column"
-						aria-label="Add column"
-						title="Add column"
-						style={{
-							left: `${table.selected.columnControlLeft}px`,
-							top: `${table.selected.columnControlTop}px`,
-						}}
-						onMouseDown={table.onControlMouseDown}
-						onClick={table.onAddColumn}
-					>
-						<HugeiconsIcon
-							icon={LocationAdd01Icon}
-							size="var(--icon-md)"
-							strokeWidth={0.9}
-						/>
-					</button>
-				</>
+			{canEdit && tableControls ? (
+				<TableInlineControls {...tableControls} />
 			) : null}
 			{canEdit && codeBlock.selected ? (
 				<div

--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -23,7 +23,11 @@ const {
 	let frontmatter: string | null = null;
 	const chainCommands = {
 		addColumnAfter: vi.fn(() => chainCommands),
+		addColumnBefore: vi.fn(() => chainCommands),
 		addRowAfter: vi.fn(() => chainCommands),
+		addRowBefore: vi.fn(() => chainCommands),
+		deleteColumn: vi.fn(() => chainCommands),
+		deleteRow: vi.fn(() => chainCommands),
 		focus: vi.fn(() => chainCommands),
 		run: vi.fn(() => true),
 		updateAttributes: vi.fn(() => chainCommands),
@@ -31,6 +35,10 @@ const {
 	const mockEditor = {
 		isEditable: true,
 		chain: vi.fn(() => chainCommands),
+		can: vi.fn(() => ({
+			deleteRow: () => true,
+			deleteColumn: () => true,
+		})),
 		commands: {
 			refreshMermaidPreviews: vi.fn(),
 			setNoteSearch: vi.fn(),
@@ -210,6 +218,42 @@ vi.mock("../ui/shadcn/popover", () => ({
 	),
 }));
 
+vi.mock("../ui/shadcn/dropdown-menu", () => ({
+	DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="dropdown-menu">{children}</div>
+	),
+	DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+		<>{children}</>
+	),
+	DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+		<div role="menu" data-slot="dropdown-menu-content">
+			{children}
+		</div>
+	),
+	DropdownMenuItem: ({
+		children,
+		onSelect,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onSelect?: () => void;
+		disabled?: boolean;
+	}) => (
+		<button
+			type="button"
+			role="menuitem"
+			data-slot="dropdown-menu-item"
+			disabled={disabled}
+			onClick={() => {
+				if (!disabled) onSelect?.();
+			}}
+		>
+			{children}
+		</button>
+	),
+	DropdownMenuSeparator: () => <hr />,
+}));
+
 describe("NoteInlineEditor table controls", () => {
 	let container: HTMLDivElement;
 	let root: Root;
@@ -361,23 +405,23 @@ describe("NoteInlineEditor table controls", () => {
 		expect(host?.getAttribute("data-colorful-headings")).toBeNull();
 	});
 
-	it("runs the correct TipTap commands when the inline icons are clicked", async () => {
+	it("runs the correct TipTap commands when the inline menu items are selected", async () => {
 		render("rich");
 
 		await syncSelection("Ada");
 
-		const rowButton = container.querySelector(
-			'[data-axis="row"]',
-		) as HTMLButtonElement | null;
-		const columnButton = container.querySelector(
-			'[data-axis="column"]',
-		) as HTMLButtonElement | null;
-		expect(rowButton).toBeTruthy();
-		expect(columnButton).toBeTruthy();
+		const rowMenu = container
+			.querySelector('[data-axis="row"]')
+			?.closest('[data-testid="dropdown-menu"]');
+		const addRowBelow = Array.from(
+			rowMenu?.querySelectorAll('[data-slot="dropdown-menu-item"]') ?? [],
+		).find((element) => element.textContent === "Add row below") as
+			| HTMLButtonElement
+			| undefined;
+		expect(addRowBelow).toBeTruthy();
 
 		await act(async () => {
-			rowButton?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
-			rowButton?.click();
+			addRowBelow?.click();
 		});
 		expect(chainCommands.focus).toHaveBeenCalledWith(null, {
 			scrollIntoView: false,
@@ -388,11 +432,18 @@ describe("NoteInlineEditor table controls", () => {
 		chainCommands.focus.mockClear();
 		chainCommands.run.mockClear();
 
+		const columnMenu = container
+			.querySelector('[data-axis="column"]')
+			?.closest('[data-testid="dropdown-menu"]');
+		const addColumnRight = Array.from(
+			columnMenu?.querySelectorAll('[data-slot="dropdown-menu-item"]') ?? [],
+		).find((element) => element.textContent === "Add column right") as
+			| HTMLButtonElement
+			| undefined;
+		expect(addColumnRight).toBeTruthy();
+
 		await act(async () => {
-			columnButton?.dispatchEvent(
-				new MouseEvent("mousedown", { bubbles: true }),
-			);
-			columnButton?.click();
+			addColumnRight?.click();
 		});
 		expect(chainCommands.focus).toHaveBeenCalledWith(null, {
 			scrollIntoView: false,

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -288,7 +288,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		relPath,
 	]);
 
-	const selectedTable = useTableInlineControls({
+	const tableControls = useTableInlineControls({
 		canEdit: showEditorChrome,
 		editor,
 		hostRef: tiptapHostRef,
@@ -550,30 +550,12 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		},
 		[editor],
 	);
-	const preventCodeBlockPickerMouseDown = useCallback(
+	const preventOverlayMouseDown = useCallback(
 		(event: ReactMouseEvent<HTMLElement>) => {
 			event.preventDefault();
 		},
 		[],
 	);
-	const preventTableControlMouseDown = useCallback(
-		(event: ReactMouseEvent<HTMLButtonElement>) => {
-			event.preventDefault();
-		},
-		[],
-	);
-	const addRowToSelectedTable = useCallback(() => {
-		if (!editor) return;
-		editor.chain().focus(null, { scrollIntoView: false }).addRowAfter().run();
-	}, [editor]);
-	const addColumnToSelectedTable = useCallback(() => {
-		if (!editor) return;
-		editor
-			.chain()
-			.focus(null, { scrollIntoView: false })
-			.addColumnAfter()
-			.run();
-	}, [editor]);
 	useEffect(() => {
 		if (!editor) return;
 		if (mode === "rich" || mode === "preview") {
@@ -635,21 +617,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			});
 	}, [selectedCodeBlock]);
 
-	const tableControls = useMemo(
-		() => ({
-			selected: selectedTable,
-			onControlMouseDown: preventTableControlMouseDown,
-			onAddRow: addRowToSelectedTable,
-			onAddColumn: addColumnToSelectedTable,
-		}),
-		[
-			addColumnToSelectedTable,
-			addRowToSelectedTable,
-			preventTableControlMouseDown,
-			selectedTable,
-		],
-	);
-
 	const codeBlockControls = useMemo(
 		() => ({
 			selected: selectedCodeBlock,
@@ -658,7 +625,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			language: selectedCodeBlockLanguage,
 			languageLabel: selectedCodeBlockLanguageLabel,
 			copied: codeBlockCopied,
-			onPickerMouseDown: preventCodeBlockPickerMouseDown,
+			onPickerMouseDown: preventOverlayMouseDown,
 			onApplyLanguage: applyCodeBlockLanguage,
 			onCopy: copySelectedCodeBlock,
 		}),
@@ -667,7 +634,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			codeBlockCopied,
 			codeBlockPickerOpen,
 			copySelectedCodeBlock,
-			preventCodeBlockPickerMouseDown,
+			preventOverlayMouseDown,
 			selectedCodeBlock,
 			selectedCodeBlockLanguage,
 			selectedCodeBlockLanguageLabel,
@@ -734,7 +701,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 						colorfulHeadings={colorfulHeadings}
 						canEdit={canEdit}
 						hostRef={handleTiptapHostRef}
-						table={tableControls}
+						tableControls={tableControls}
 						codeBlock={codeBlockControls}
 					/>
 				) : null}

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -1,0 +1,215 @@
+import { LocationAdd01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { type MouseEvent, memo, useCallback, useMemo } from "react";
+import {
+	type NativeContextMenuItem,
+	isNativeContextMenuAvailable,
+	showNativePopupMenu,
+} from "../../lib/nativeContextMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
+import type {
+	TableEditorCommand,
+	TableInlineControlsProps,
+} from "./noteEditorOverlayTypes";
+
+type TableAxisMenuItem =
+	| {
+			type: "action";
+			label: string;
+			command: TableEditorCommand;
+			enabled?: boolean;
+			destructive?: boolean;
+	  }
+	| { type: "separator" };
+
+function buildAxisMenuItems(
+	beforeLabel: string,
+	afterLabel: string,
+	deleteLabel: string,
+	beforeCommand: TableEditorCommand,
+	afterCommand: TableEditorCommand,
+	deleteCommand: TableEditorCommand,
+	canDelete: boolean,
+): TableAxisMenuItem[] {
+	return [
+		{ type: "action", label: beforeLabel, command: beforeCommand },
+		{ type: "action", label: afterLabel, command: afterCommand },
+		{ type: "separator" },
+		{
+			type: "action",
+			label: deleteLabel,
+			command: deleteCommand,
+			enabled: canDelete,
+			destructive: true,
+		},
+	];
+}
+
+function toNativeMenuItems(
+	items: TableAxisMenuItem[],
+	onCommand: (command: TableEditorCommand) => void,
+): NativeContextMenuItem[] {
+	return items.map((item) => {
+		if (item.type === "separator") {
+			return { type: "separator" };
+		}
+		return {
+			label: item.label,
+			enabled: item.enabled,
+			action: () => onCommand(item.command),
+		};
+	});
+}
+
+interface TableAxisControlProps {
+	axis: "row" | "column";
+	left: number;
+	top: number;
+	ariaLabel: string;
+	menuItems: TableAxisMenuItem[];
+	onControlMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
+	onCommand: (command: TableEditorCommand) => void;
+	nativeMenusEnabled: boolean;
+}
+
+const TableAxisControl = memo(function TableAxisControl({
+	axis,
+	left,
+	top,
+	ariaLabel,
+	menuItems,
+	onControlMouseDown,
+	onCommand,
+	nativeMenusEnabled,
+}: TableAxisControlProps) {
+	const nativeMenuItems = useMemo(
+		() => toNativeMenuItems(menuItems, onCommand),
+		[menuItems, onCommand],
+	);
+	const handleNativeMenuClick = useCallback(
+		(event: MouseEvent<HTMLButtonElement>) => {
+			void showNativePopupMenu(event, nativeMenuItems).catch(
+				(error: unknown) => {
+					console.error(`Failed to show table ${axis} menu`, error);
+				},
+			);
+		},
+		[axis, nativeMenuItems],
+	);
+
+	const triggerButton = (
+		<button
+			type="button"
+			className={`tableInlineAddBtn is-${axis}`}
+			data-axis={axis}
+			aria-label={ariaLabel}
+			title={ariaLabel}
+			style={{
+				left: `${left}px`,
+				top: `${top}px`,
+			}}
+			onMouseDown={onControlMouseDown}
+			onClick={nativeMenusEnabled ? handleNativeMenuClick : undefined}
+		>
+			<HugeiconsIcon
+				icon={LocationAdd01Icon}
+				size="var(--icon-md)"
+				strokeWidth={0.9}
+			/>
+		</button>
+	);
+
+	if (nativeMenusEnabled) {
+		return triggerButton;
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
+			<DropdownMenuContent align="start">
+				{menuItems.map((item) => {
+					if (item.type === "separator") {
+						return <DropdownMenuSeparator key="separator" />;
+					}
+					return (
+						<DropdownMenuItem
+							key={item.command}
+							disabled={item.enabled === false}
+							variant={item.destructive ? "destructive" : "default"}
+							onSelect={() => onCommand(item.command)}
+						>
+							{item.label}
+						</DropdownMenuItem>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+});
+
+export const TableInlineControls = memo(function TableInlineControls({
+	selected,
+	onControlMouseDown,
+	onCommand,
+	canDeleteRow,
+	canDeleteColumn,
+}: TableInlineControlsProps) {
+	const nativeMenusEnabled = isNativeContextMenuAvailable();
+	const rowMenuItems = useMemo(
+		() =>
+			buildAxisMenuItems(
+				"Add row above",
+				"Add row below",
+				"Delete row",
+				"addRowBefore",
+				"addRowAfter",
+				"deleteRow",
+				canDeleteRow,
+			),
+		[canDeleteRow],
+	);
+	const columnMenuItems = useMemo(
+		() =>
+			buildAxisMenuItems(
+				"Add column left",
+				"Add column right",
+				"Delete column",
+				"addColumnBefore",
+				"addColumnAfter",
+				"deleteColumn",
+				canDeleteColumn,
+			),
+		[canDeleteColumn],
+	);
+
+	return (
+		<>
+			<TableAxisControl
+				axis="row"
+				left={selected.rowControlLeft}
+				top={selected.rowControlTop}
+				ariaLabel="Row options"
+				menuItems={rowMenuItems}
+				onControlMouseDown={onControlMouseDown}
+				onCommand={onCommand}
+				nativeMenusEnabled={nativeMenusEnabled}
+			/>
+			<TableAxisControl
+				axis="column"
+				left={selected.columnControlLeft}
+				top={selected.columnControlTop}
+				ariaLabel="Column options"
+				menuItems={columnMenuItems}
+				onControlMouseDown={onControlMouseDown}
+				onCommand={onCommand}
+				nativeMenusEnabled={nativeMenusEnabled}
+			/>
+		</>
+	);
+});

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -132,7 +132,7 @@ const TableAxisControl = memo(function TableAxisControl({
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
-			<DropdownMenuContent align="start">
+			<DropdownMenuContent className="tableInlineControlsMenu" align="start">
 				{menuItems.map((item) => {
 					if (item.type === "separator") {
 						return <DropdownMenuSeparator key="separator" />;

--- a/src/components/editor/editorOverlays.test.ts
+++ b/src/components/editor/editorOverlays.test.ts
@@ -27,6 +27,14 @@ describe("isEditorOverlayOpen", () => {
 		expect(isEditorOverlayOpen()).toBe(true);
 	});
 
+	it("detects an open table inline controls menu", () => {
+		const menu = document.createElement("div");
+		menu.className = "tableInlineControlsMenu";
+		menu.setAttribute("data-state", "open");
+		document.body.append(menu);
+		expect(isEditorOverlayOpen()).toBe(true);
+	});
+
 	it("ignores unrelated open radix menus", () => {
 		const menu = document.createElement("div");
 		menu.setAttribute("role", "menu");

--- a/src/components/editor/editorOverlays.ts
+++ b/src/components/editor/editorOverlays.ts
@@ -1,5 +1,5 @@
 const EDITOR_OVERLAY_SELECTOR =
-	".slashCommandMenu, .wikiLinkSuggestionMenu, .editorColorDropdown[data-state=\"open\"]";
+	'.slashCommandMenu, .wikiLinkSuggestionMenu, .editorColorDropdown[data-state="open"]';
 
 export function isEditorOverlayOpen(root: ParentNode = document): boolean {
 	return Boolean(root.querySelector(EDITOR_OVERLAY_SELECTOR));

--- a/src/components/editor/editorOverlays.ts
+++ b/src/components/editor/editorOverlays.ts
@@ -1,5 +1,5 @@
 const EDITOR_OVERLAY_SELECTOR =
-	'.slashCommandMenu, .wikiLinkSuggestionMenu, .editorColorDropdown[data-state="open"]';
+	'.slashCommandMenu, .wikiLinkSuggestionMenu, .editorColorDropdown[data-state="open"], .tableInlineControlsMenu[data-state="open"]';
 
 export function isEditorOverlayOpen(root: ParentNode = document): boolean {
 	return Boolean(root.querySelector(EDITOR_OVERLAY_SELECTOR));

--- a/src/components/editor/hooks/tableEditorCommands.ts
+++ b/src/components/editor/hooks/tableEditorCommands.ts
@@ -1,0 +1,9 @@
+import type { Editor } from "@tiptap/core";
+import type { TableEditorCommand } from "../noteEditorOverlayTypes";
+
+export function runTableEditorCommand(
+	editor: Editor,
+	command: TableEditorCommand,
+): void {
+	editor.chain().focus(null, { scrollIntoView: false })[command]().run();
+}

--- a/src/components/editor/hooks/useTableInlineControls.ts
+++ b/src/components/editor/hooks/useTableInlineControls.ts
@@ -1,11 +1,24 @@
 import type { Editor } from "@tiptap/core";
-import { type RefObject, useEffect, useRef, useState } from "react";
-import type { SelectedTableState } from "../noteEditorOverlayTypes";
+import {
+	type MouseEvent as ReactMouseEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import type {
+	SelectedTableState,
+	TableEditorCommand,
+	TableInlineControlsProps,
+} from "../noteEditorOverlayTypes";
 import type { NoteInlineEditorMode } from "../types";
 import {
 	getMountedEditorContentRoot,
 	getOffsetWithinAncestor,
 } from "./editorDomUtils";
+import { runTableEditorCommand } from "./tableEditorCommands";
 
 const TABLE_INLINE_CONTROL_OFFSET_PX = 20;
 const TABLE_INLINE_CONTROL_EDGE_PADDING_PX = 10;
@@ -22,11 +35,48 @@ export function useTableInlineControls({
 	editor,
 	hostRef,
 	mode,
-}: UseTableInlineControlsArgs): SelectedTableState | null {
+}: UseTableInlineControlsArgs): TableInlineControlsProps | null {
 	const syncRafRef = useRef<number | null>(null);
 	const [selectedTable, setSelectedTable] = useState<SelectedTableState | null>(
 		null,
 	);
+	const [canDeleteRow, setCanDeleteRow] = useState(false);
+	const [canDeleteColumn, setCanDeleteColumn] = useState(false);
+
+	const onControlMouseDown = useCallback(
+		(event: ReactMouseEvent<HTMLElement>) => {
+			event.preventDefault();
+		},
+		[],
+	);
+	const onCommand = useCallback(
+		(command: TableEditorCommand) => {
+			if (!editor) return;
+			runTableEditorCommand(editor, command);
+		},
+		[editor],
+	);
+
+	useEffect(() => {
+		if (!editor || mode !== "rich" || !canEdit) {
+			setCanDeleteRow(false);
+			setCanDeleteColumn(false);
+			return;
+		}
+
+		const syncDeleteCapabilities = () => {
+			setCanDeleteRow(editor.can().deleteRow());
+			setCanDeleteColumn(editor.can().deleteColumn());
+		};
+
+		syncDeleteCapabilities();
+		editor.on("transaction", syncDeleteCapabilities);
+		editor.on("selectionUpdate", syncDeleteCapabilities);
+		return () => {
+			editor.off("transaction", syncDeleteCapabilities);
+			editor.off("selectionUpdate", syncDeleteCapabilities);
+		};
+	}, [canEdit, editor, mode]);
 
 	useEffect(() => {
 		if (!editor || mode !== "rich" || !canEdit) {
@@ -125,5 +175,20 @@ export function useTableInlineControls({
 		};
 	}, [canEdit, editor, hostRef, mode]);
 
-	return selectedTable;
+	return useMemo(() => {
+		if (!selectedTable) return null;
+		return {
+			selected: selectedTable,
+			onControlMouseDown,
+			onCommand,
+			canDeleteRow,
+			canDeleteColumn,
+		};
+	}, [
+		canDeleteColumn,
+		canDeleteRow,
+		onCommand,
+		onControlMouseDown,
+		selectedTable,
+	]);
 }

--- a/src/components/editor/noteEditorOverlayTypes.ts
+++ b/src/components/editor/noteEditorOverlayTypes.ts
@@ -13,3 +13,19 @@ export interface SelectedTableState {
 	columnControlLeft: number;
 	columnControlTop: number;
 }
+
+export type TableEditorCommand =
+	| "addRowBefore"
+	| "addRowAfter"
+	| "deleteRow"
+	| "addColumnBefore"
+	| "addColumnAfter"
+	| "deleteColumn";
+
+export interface TableInlineControlsProps {
+	selected: SelectedTableState;
+	onControlMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
+	onCommand: (command: TableEditorCommand) => void;
+	canDeleteRow: boolean;
+	canDeleteColumn: boolean;
+}


### PR DESCRIPTION
## Summary

Extracts the table row/column inline add buttons from `NoteEditorSurface.tsx` into a new `TableInlineControls.tsx` component. Adds context menus (native macOS menu with shadcn DropdownMenu fallback) with insert before/after and delete row/column actions.

## Related Issues

Closes #

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table editing controls now appear as a dedicated inline menu for row and column actions.
  * Row/column delete options are shown when permitted by the current editor state.
* **Bug Fixes**
  * Inline table action availability updates more reliably as the selection changes.
  * Improved overlay mouse interaction handling for inline editors.
* **Refactor**
  * Reworked the table inline control flow to use a cleaner, shared props/command interface across the editor surface and inline editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->