### PR TITLE
Enhance Help menu with links, commands, and unified event handling

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -890,16 +890,67 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         ],
     )?;
 
-    let help_menu = Submenu::with_id_and_items(
+    let help_getting_started = menu_item_with_shortcut(
         app,
-        HELP_SUBMENU_ID,
-        "Help",
-        true,
-        &[
-            #[cfg(not(target_os = "macos"))]
-            &PredefinedMenuItem::about(app, None, None)?,
-        ],
+        menu_shortcuts,
+        "help.getting_started",
+        "Getting Started",
+        space_open,
+        None,
     )?;
+    let help_welcome_note = menu_item_with_shortcut(
+        app,
+        menu_shortcuts,
+        "help.welcome_note",
+        "Welcome Note",
+        space_open,
+        None,
+    )?;
+    let help_shortcuts = menu_item_with_shortcut(
+        app,
+        menu_shortcuts,
+        "help.shortcuts",
+        "Keyboard Shortcuts…",
+        true,
+        None,
+    )?;
+    const HELP_LINK_GROUPS: &[&[(&str, &str)]] = &[
+        &[
+            ("help.website", "Glyph Website"),
+            ("help.changelog", "Changelog"),
+            ("help.privacy", "Privacy Policy"),
+            ("help.terms", "Terms of Service"),
+        ],
+        &[
+            ("help.discord", "Discord"),
+            ("help.github", "GitHub"),
+            ("help.x", "Follow on X"),
+        ],
+    ];
+    let help_menu = {
+        let builder = SubmenuBuilder::with_id(app, HELP_SUBMENU_ID, "Help");
+        #[cfg(not(target_os = "macos"))]
+        let builder = builder
+            .item(&PredefinedMenuItem::about(app, None, None)?)
+            .separator();
+        let builder = builder
+            .item(&help_getting_started)
+            .item(&help_welcome_note)
+            .separator()
+            .item(&help_shortcuts)
+            .separator();
+        let mut builder = builder;
+        for (group_index, group) in HELP_LINK_GROUPS.iter().enumerate() {
+            if group_index > 0 {
+                builder = builder.separator();
+            }
+            for (id, label) in *group {
+                let item = menu_item_with_shortcut(app, menu_shortcuts, id, label, true, None)?;
+                builder = builder.item(&item);
+            }
+        }
+        builder.build()?
+    };
 
     if show_markdown_menu {
         Menu::with_items(

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1021,6 +1021,8 @@ export function AppShell() {
 		onEditorAction: (action) => {
 			dispatchEditorMenuAction({ action });
 		},
+		openGettingStarted,
+		showWelcomeNote,
 	});
 
 	const commands = useAppCommands({

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -7,6 +7,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { memo, useMemo, useState } from "react";
 import { useUILayoutContext } from "../../contexts";
+import { GLYPH_LINKS } from "../../lib/helpMenu";
 import { useLicenseStatus } from "../../lib/license";
 import { cn } from "../../lib/utils";
 import { Search, X } from "../Icons";
@@ -208,7 +209,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 						<Button
 							type="button"
 							className="settingsFeedbackButton"
-							onClick={() => void openUrl("https://discord.gg/cNqrBfFx7D")}
+							onClick={() => void openUrl(GLYPH_LINKS.discord)}
 						>
 							<HugeiconsIcon
 								icon={BubbleChatQuestionIcon}

--- a/src/components/app/commandPaletteHelpers.ts
+++ b/src/components/app/commandPaletteHelpers.ts
@@ -4,7 +4,7 @@ import type { SearchAdvancedRequest } from "../../lib/tauri";
 
 export interface Command {
 	id: string;
-	label: string;
+	label?: string;
 	icon?: ReactNode;
 	category?: string;
 	searchTerms?: readonly string[];

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -193,7 +193,7 @@ function resolveCommandShortcuts(
 		const commandWithManifest = definition
 			? {
 					...command,
-					label: command.label ?? definition.label,
+					label: definition.label ?? command.label ?? command.id,
 					category: SHORTCUT_CATEGORY_LABELS[definition.category],
 					allowInEditable: definition.allowInEditable,
 					shortcut: definition.defaultBinding ?? command.shortcut,
@@ -861,7 +861,6 @@ export function useAppCommands({
 			},
 			{
 				id: "show-getting-started",
-				label: "Show getting started",
 				icon: (
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
@@ -869,13 +868,11 @@ export function useAppCommands({
 						strokeWidth={0.9}
 					/>
 				),
-				category: "Help",
 				enabled: Boolean(spacePath),
 				action: openGettingStarted,
 			},
 			{
 				id: "show-welcome-note",
-				label: "Show welcome note",
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
@@ -883,9 +880,8 @@ export function useAppCommands({
 						strokeWidth={0.9}
 					/>
 				),
-				category: "Help",
 				enabled: Boolean(spacePath),
-				action: () => void showWelcomeNote(),
+				action: showWelcomeNote,
 			},
 		];
 		return resolveCommandShortcuts(

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -193,7 +193,7 @@ function resolveCommandShortcuts(
 		const commandWithManifest = definition
 			? {
 					...command,
-					label: definition.label ?? command.label ?? command.id,
+					label: command.label ?? definition.label ?? command.id,
 					category: SHORTCUT_CATEGORY_LABELS[definition.category],
 					allowInEditable: definition.allowInEditable,
 					shortcut: definition.defaultBinding ?? command.shortcut,

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -9,6 +9,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
+import { GLYPH_LINKS } from "../../lib/helpMenu";
 import { useLicenseStatus } from "../../lib/license";
 import {
 	type ReleaseChannel,
@@ -119,7 +120,7 @@ export function AboutSettingsPane() {
 						<button
 							type="button"
 							className="settingsInlineLink"
-							onClick={() => void openUrl("https://x.com/karat_sidhu")}
+							onClick={() => void openUrl(GLYPH_LINKS.x)}
 						>
 							Karat Sidhu
 						</button>
@@ -130,7 +131,7 @@ export function AboutSettingsPane() {
 							size="sm"
 							variant="outline"
 							className="aboutLinkButton"
-							onClick={() => void openUrl("https://glyphformac.com")}
+							onClick={() => void openUrl(GLYPH_LINKS.website)}
 						>
 							<HugeiconsIcon
 								icon={GlobeIcon}
@@ -144,7 +145,7 @@ export function AboutSettingsPane() {
 							size="sm"
 							variant="outline"
 							className="aboutLinkButton"
-							onClick={() => void openUrl("https://discord.gg/cNqrBfFx7D")}
+							onClick={() => void openUrl(GLYPH_LINKS.discord)}
 						>
 							<HugeiconsIcon
 								icon={DiscordIcon}
@@ -158,7 +159,7 @@ export function AboutSettingsPane() {
 							size="sm"
 							variant="outline"
 							className="aboutLinkButton"
-							onClick={() => void openUrl("https://glyphformac.com/terms")}
+							onClick={() => void openUrl(GLYPH_LINKS.terms)}
 						>
 							<HugeiconsIcon
 								icon={File01Icon}
@@ -172,7 +173,7 @@ export function AboutSettingsPane() {
 							size="sm"
 							variant="outline"
 							className="aboutLinkButton"
-							onClick={() => void openUrl("https://glyphformac.com/privacy")}
+							onClick={() => void openUrl(GLYPH_LINKS.privacy)}
 						>
 							<HugeiconsIcon
 								icon={Shield01Icon}
@@ -305,9 +306,7 @@ export function AboutSettingsPane() {
 								type="button"
 								size="sm"
 								variant="outline"
-								onClick={() =>
-									void openUrl("https://glyphformac.com/changelog")
-								}
+								onClick={() => void openUrl(GLYPH_LINKS.changelog)}
 							>
 								<HugeiconsIcon
 									icon={ListViewIcon}

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
+import { buildHelpMenuCommandHandlers } from "../lib/helpMenu";
 import { useTauriEvent } from "../lib/tauriEvents";
 
 interface UseMenuListenersProps {
@@ -22,6 +23,8 @@ interface UseMenuListenersProps {
 	onAttachAllOpenNotesToAi: () => void;
 	onOpenAiSettings: () => void;
 	onEditorAction: (action: string) => void;
+	openGettingStarted: () => void;
+	showWelcomeNote: () => void | Promise<void>;
 }
 
 export function useMenuListeners({
@@ -43,73 +46,24 @@ export function useMenuListeners({
 	onAttachAllOpenNotesToAi,
 	onOpenAiSettings,
 	onEditorAction,
+	openGettingStarted,
+	showWelcomeNote,
 }: UseMenuListenersProps): void {
 	const { openSettings } = useUILayoutContext();
-	const handleNewNote = useCallback(() => {
-		onNewNote();
-	}, [onNewNote]);
-	const handleCreateFromTemplate = useCallback(() => {
-		onCreateFromTemplate();
-	}, [onCreateFromTemplate]);
-	const handleOpenDailyNote = useCallback(() => {
-		onOpenDailyNote();
-	}, [onOpenDailyNote]);
-	const handleSaveNote = useCallback(() => {
-		onSaveNote();
-	}, [onSaveNote]);
-	const handleCloseTab = useCallback(() => {
-		onCloseTab();
-	}, [onCloseTab]);
-	const handleOpenSpace = useCallback(() => {
-		void onOpenSpace();
-	}, [onOpenSpace]);
+	const helpMenuCommandHandlers = useMemo(
+		() =>
+			buildHelpMenuCommandHandlers(
+				openGettingStarted,
+				showWelcomeNote,
+				openSettings,
+			),
+		[openGettingStarted, openSettings, showWelcomeNote],
+	);
 	const handleOpenRecentSpace = useCallback(
 		(payload: { path: string }) => {
 			void onOpenRecentSpaceAtPath(payload.path);
 		},
 		[onOpenRecentSpaceAtPath],
-	);
-	const handleCreateSpace = useCallback(() => {
-		void onCreateSpace();
-	}, [onCreateSpace]);
-	const handleCloseSpace = useCallback(() => {
-		void closeSpace();
-	}, [closeSpace]);
-	const handleRevealSpace = useCallback(() => {
-		onRevealSpace();
-	}, [onRevealSpace]);
-	const handleOpenSpaceSettings = useCallback(() => {
-		onOpenSpaceSettings();
-	}, [onOpenSpaceSettings]);
-	const handleGitSyncNow = useCallback(() => {
-		onGitSyncNow();
-	}, [onGitSyncNow]);
-	const handleOpenGitSettings = useCallback(() => {
-		onOpenGitSettings();
-	}, [onOpenGitSettings]);
-	const handleOpenAbout = useCallback(() => {
-		openSettings("about");
-	}, [openSettings]);
-	const handleOpenSettings = useCallback(() => {
-		openSettings();
-	}, [openSettings]);
-	const handleToggleAi = useCallback(() => {
-		onToggleAiPane();
-	}, [onToggleAiPane]);
-	const handleAttachCurrentNote = useCallback(() => {
-		onAttachCurrentNoteToAi();
-	}, [onAttachCurrentNoteToAi]);
-	const handleAttachAllOpenNotes = useCallback(() => {
-		onAttachAllOpenNotesToAi();
-	}, [onAttachAllOpenNotesToAi]);
-	const handleOpenAiSettings = useCallback(() => {
-		onOpenAiSettings();
-	}, [onOpenAiSettings]);
-	const handleEditorAction = useCallback(
-		(payload: { action: string }) => {
-			onEditorAction(payload.action);
-		},
-		[onEditorAction],
 	);
 	const handleAppCommand = useCallback(
 		(payload: { command_id: string }) => {
@@ -128,6 +82,7 @@ export function useMenuListeners({
 				"open-git-sync-settings": onOpenGitSettings,
 				"open-about": () => openSettings("about"),
 				"open-settings": () => openSettings(),
+				...helpMenuCommandHandlers,
 				"toggle-ai": onToggleAiPane,
 				"ai-attach-current-note": onAttachCurrentNoteToAi,
 				"ai-attach-all-open-notes": onAttachAllOpenNotesToAi,
@@ -187,6 +142,7 @@ export function useMenuListeners({
 		},
 		[
 			closeSpace,
+			helpMenuCommandHandlers,
 			onAttachAllOpenNotesToAi,
 			onAttachCurrentNoteToAi,
 			onCloseTab,
@@ -208,24 +164,5 @@ export function useMenuListeners({
 	);
 
 	useTauriEvent("menu:app_command", handleAppCommand);
-	useTauriEvent("menu:new_note", handleNewNote);
-	useTauriEvent("menu:create_from_template", handleCreateFromTemplate);
-	useTauriEvent("menu:open_daily_note", handleOpenDailyNote);
-	useTauriEvent("menu:save_note", handleSaveNote);
-	useTauriEvent("menu:close_tab", handleCloseTab);
-	useTauriEvent("menu:open_space", handleOpenSpace);
 	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);
-	useTauriEvent("menu:create_space", handleCreateSpace);
-	useTauriEvent("menu:close_space", handleCloseSpace);
-	useTauriEvent("menu:reveal_space", handleRevealSpace);
-	useTauriEvent("menu:open_space_settings", handleOpenSpaceSettings);
-	useTauriEvent("menu:git_sync_now", handleGitSyncNow);
-	useTauriEvent("menu:open_git_settings", handleOpenGitSettings);
-	useTauriEvent("menu:open_about", handleOpenAbout);
-	useTauriEvent("menu:open_settings", handleOpenSettings);
-	useTauriEvent("menu:toggle_ai", handleToggleAi);
-	useTauriEvent("menu:ai_attach_current_note", handleAttachCurrentNote);
-	useTauriEvent("menu:ai_attach_all_open_notes", handleAttachAllOpenNotes);
-	useTauriEvent("menu:open_ai_settings", handleOpenAiSettings);
-	useTauriEvent("menu:editor_action", handleEditorAction);
 }

--- a/src/lib/commands/commandManifest.test.ts
+++ b/src/lib/commands/commandManifest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { APP_COMMANDS, listCommandDefinitions } from "./commandManifest";
+import {
+	APP_COMMANDS,
+	listCommandDefinitions,
+	listShortcutConfigurableCommands,
+} from "./commandManifest";
 
 const FRONTEND_MENU_COMMAND_IDS = [
 	"new-note",
@@ -19,6 +23,16 @@ const FRONTEND_MENU_COMMAND_IDS = [
 	"ai-attach-current-note",
 	"ai-attach-all-open-notes",
 	"open-ai-settings",
+	"show-getting-started",
+	"show-welcome-note",
+	"open-shortcuts-settings",
+	"open-glyph-website",
+	"open-glyph-changelog",
+	"open-glyph-privacy",
+	"open-glyph-terms",
+	"open-glyph-discord",
+	"open-glyph-github",
+	"open-glyph-x",
 ];
 
 describe("app command manifest", () => {
@@ -50,5 +64,13 @@ describe("app command manifest", () => {
 		for (const commandId of FRONTEND_MENU_COMMAND_IDS) {
 			expect(commandIds.has(commandId)).toBe(true);
 		}
+	});
+
+	it("only exposes open-settings from settings commands in shortcut settings", () => {
+		const settingsShortcutIds = listShortcutConfigurableCommands()
+			.filter((command) => command.category === "settings")
+			.map((command) => command.id);
+
+		expect(settingsShortcutIds).toEqual(["open-settings"]);
 	});
 });

--- a/src/lib/commands/commandManifest.ts
+++ b/src/lib/commands/commandManifest.ts
@@ -37,3 +37,11 @@ export function getCommandDefinition(id: string): AppCommandDefinition | null {
 export function listCommandDefinitions(): AppCommandDefinition[] {
 	return Object.values(APP_COMMANDS);
 }
+
+export function isShortcutConfigurable(command: AppCommandDefinition): boolean {
+	return command.category !== "settings" || command.id === "open-settings";
+}
+
+export function listShortcutConfigurableCommands(): AppCommandDefinition[] {
+	return listCommandDefinitions().filter(isShortcutConfigurable);
+}

--- a/src/lib/helpMenu.ts
+++ b/src/lib/helpMenu.ts
@@ -1,0 +1,40 @@
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { SettingsTab } from "../components/settings/settingsConfig";
+
+export const GLYPH_LINKS = {
+	website: "https://glyphformac.com",
+	changelog: "https://glyphformac.com/changelog",
+	privacy: "https://glyphformac.com/privacy",
+	terms: "https://glyphformac.com/terms",
+	discord: "https://discord.gg/cNqrBfFx7D",
+	github: "https://github.com/SidhuK/Glyph",
+	x: "https://x.com/karat_sidhu",
+} as const;
+
+const GLYPH_LINK_COMMAND_HANDLERS = {
+	"open-glyph-website": GLYPH_LINKS.website,
+	"open-glyph-changelog": GLYPH_LINKS.changelog,
+	"open-glyph-privacy": GLYPH_LINKS.privacy,
+	"open-glyph-terms": GLYPH_LINKS.terms,
+	"open-glyph-discord": GLYPH_LINKS.discord,
+	"open-glyph-github": GLYPH_LINKS.github,
+	"open-glyph-x": GLYPH_LINKS.x,
+} as const;
+
+export function buildHelpMenuCommandHandlers(
+	openGettingStarted: () => void,
+	showWelcomeNote: () => void | Promise<void>,
+	openSettings: (tab?: SettingsTab) => void,
+): Record<string, () => void | Promise<void>> {
+	return {
+		"show-getting-started": openGettingStarted,
+		"show-welcome-note": showWelcomeNote,
+		"open-shortcuts-settings": () => openSettings("shortcuts"),
+		...Object.fromEntries(
+			Object.entries(GLYPH_LINK_COMMAND_HANDLERS).map(([commandId, url]) => [
+				commandId,
+				() => void openUrl(url),
+			]),
+		),
+	};
+}

--- a/src/lib/shortcuts/registry.ts
+++ b/src/lib/shortcuts/registry.ts
@@ -1,7 +1,7 @@
 import {
 	type AppCommandDefinition,
 	type CommandCategory,
-	listCommandDefinitions,
+	listShortcutConfigurableCommands,
 } from "../commands/commandManifest";
 
 export type ShortcutActionId = string;
@@ -12,7 +12,7 @@ export interface ShortcutActionDefinition extends AppCommandDefinition {
 }
 
 export const SHORTCUT_ACTIONS: ShortcutActionDefinition[] =
-	listCommandDefinitions();
+	listShortcutConfigurableCommands();
 
 if (import.meta.env.DEV) {
 	const seen = new Set<string>();

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -11,26 +11,7 @@ import type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 
 type TauriEventMap = {
 	"menu:app_command": { command_id: string };
-	"menu:new_note": undefined;
-	"menu:create_from_template": undefined;
-	"menu:open_daily_note": undefined;
-	"menu:save_note": undefined;
-	"menu:close_tab": undefined;
-	"menu:open_space": undefined;
 	"menu:open_recent_space": { path: string };
-	"menu:create_space": undefined;
-	"menu:close_space": undefined;
-	"menu:reveal_space": undefined;
-	"menu:open_space_settings": undefined;
-	"menu:git_sync_now": undefined;
-	"menu:open_git_settings": undefined;
-	"menu:open_about": undefined;
-	"menu:open_settings": undefined;
-	"menu:toggle_ai": undefined;
-	"menu:ai_attach_current_note": undefined;
-	"menu:ai_attach_all_open_notes": undefined;
-	"menu:open_ai_settings": undefined;
-	"menu:editor_action": { action: string };
 	"quick-note:open_note": { path: string };
 	"external-markdown:close_requested": undefined;
 	"git_sync:status": import("./tauri").GitSyncStatus;

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -976,23 +976,113 @@
 		},
 		"show-getting-started": {
 			"id": "show-getting-started",
-			"label": "Show Getting Started",
+			"label": "Getting Started",
 			"description": "Open the getting started flow.",
 			"category": "settings",
 			"context": "space",
 			"defaultBinding": null,
 			"allowInEditable": false,
-			"commandPalette": true
+			"commandPalette": true,
+			"menuId": "help.getting_started"
 		},
 		"show-welcome-note": {
 			"id": "show-welcome-note",
-			"label": "Show Welcome Note",
+			"label": "Welcome Note",
 			"description": "Create or open the welcome note in the root of the current space.",
 			"category": "settings",
 			"context": "space",
 			"defaultBinding": null,
 			"allowInEditable": false,
-			"commandPalette": true
+			"commandPalette": true,
+			"menuId": "help.welcome_note"
+		},
+		"open-shortcuts-settings": {
+			"id": "open-shortcuts-settings",
+			"label": "Keyboard Shortcuts\u2026",
+			"description": "Open the keyboard shortcuts section in settings.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": true,
+			"menuId": "help.shortcuts"
+		},
+		"open-glyph-website": {
+			"id": "open-glyph-website",
+			"label": "Glyph Website",
+			"description": "Open the Glyph website.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.website"
+		},
+		"open-glyph-changelog": {
+			"id": "open-glyph-changelog",
+			"label": "Changelog",
+			"description": "Open the published Glyph changelog.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.changelog"
+		},
+		"open-glyph-privacy": {
+			"id": "open-glyph-privacy",
+			"label": "Privacy Policy",
+			"description": "Open the Glyph privacy policy.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.privacy"
+		},
+		"open-glyph-terms": {
+			"id": "open-glyph-terms",
+			"label": "Terms of Service",
+			"description": "Open the Glyph terms of service.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.terms"
+		},
+		"open-glyph-discord": {
+			"id": "open-glyph-discord",
+			"label": "Discord",
+			"description": "Open the Glyph community Discord.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.discord"
+		},
+		"open-glyph-github": {
+			"id": "open-glyph-github",
+			"label": "GitHub",
+			"description": "Open the Glyph repository on GitHub.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.github"
+		},
+		"open-glyph-x": {
+			"id": "open-glyph-x",
+			"label": "Follow on X",
+			"description": "Open Karat Sidhu on X.",
+			"category": "settings",
+			"context": "global",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": false,
+			"menuId": "help.x"
 		},
 		"strikethrough": {
 			"id": "strikethrough",


### PR DESCRIPTION
## Summary

Replaces the bare static Help submenu with a richer menu including Getting Started, Welcome Note, Keyboard Shortcuts, and external link groups (Website, Changelog, Privacy, Terms, Discord, GitHub, X). Consolidates individual menu event listeners into a unified `menu:app_command` dispatcher, centralizes Glyph URLs in `helpMenu.ts`, and adds filtering so settings-scoped commands don't clutter the shortcut configuration UI.

## Related Issues

Closes #

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] Relevant manual testing completed on macOS

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Help menu with “Getting Started,” “Welcome Note,” and “Keyboard Shortcuts…” options.
  * Added Help/Glyph quick links (website, changelog, privacy, terms, Discord, GitHub, and X).
  * Updated command/palette coverage so Help actions appear consistently.
* **Bug Fixes**
  * Centralized external link destinations to prevent inconsistent or outdated URLs in About/Help.
  * Improved shortcut command labeling (falls back to command IDs when needed) and refined which settings commands can be configured for shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->