### PR TITLE
Wikilink improvements and hardening: dot-in-filename support, extension detection refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.amp/plugins/emdash-hook.ts

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.amp/plugins/emdash-hook.ts
+.amp/
+.pi/

--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,9 @@
 	"files": {
 		"ignore": [
 			".agents",
+			".amp",
 			".claude",
+			".pi",
 			".pnpm-store",
 			"dist",
 			"src-tauri/gen",

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -456,8 +456,8 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::index::schema::ensure_schema;
-    use crate::index::set_people_mentions_as_tags_enabled;
     use crate::index::tags::{expand_indexed_people, expand_indexed_tags};
+    use crate::index::{people_mentions_as_tags_test_lock, set_people_mentions_as_tags_enabled};
 
     use super::{list_people, list_tags};
 
@@ -507,6 +507,7 @@ mod tests {
 
     #[test]
     fn list_tags_excludes_people_namespace_and_people_list_strips_prefix() {
+        let _lock = people_mentions_as_tags_test_lock();
         set_people_mentions_as_tags_enabled(true);
         let conn = Connection::open_in_memory().unwrap();
         ensure_schema(&conn).unwrap();

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
@@ -24,6 +26,12 @@ use super::tags::{
 use super::types::IndexRebuildResult;
 
 static PEOPLE_MENTIONS_AS_TAGS_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+pub(crate) fn people_mentions_as_tags_test_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
 
 pub fn set_people_mentions_as_tags_enabled(enabled: bool) {
     PEOPLE_MENTIONS_AS_TAGS_ENABLED.store(enabled, Ordering::Relaxed);

--- a/src-tauri/src/index/links.rs
+++ b/src-tauri/src/index/links.rs
@@ -125,9 +125,7 @@ fn is_file_wikilink_target(target: &str) -> bool {
 }
 
 fn should_append_markdown_extension(target: &str) -> bool {
-    target.contains('/')
-        && !utils::has_wikilink_file_extension(target)
-        && !utils::has_explicit_file_extension(target)
+    target.contains('/') && !utils::has_explicit_file_extension(target)
 }
 
 fn is_linkable_file_target(target: &str) -> bool {

--- a/src-tauri/src/index/links.rs
+++ b/src-tauri/src/index/links.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashSet, path::Path};
 
+use crate::utils;
+
 pub fn normalize_rel_path(raw: &str) -> Option<String> {
     let raw = raw.replace('\\', "/");
     let raw = raw.trim().trim_matches('/');
@@ -118,39 +120,18 @@ pub fn parse_outgoing_links(
 }
 
 fn is_file_wikilink_target(target: &str) -> bool {
-    target.contains('/') || is_linkable_file_target(target)
+    is_linkable_file_target(target)
+        || (target.contains('/') && !utils::has_explicit_file_extension(target))
 }
 
 fn should_append_markdown_extension(target: &str) -> bool {
-    target.contains('/') && !has_extension(target)
-}
-
-fn has_extension(target: &str) -> bool {
-    Path::new(target).extension().is_some()
+    target.contains('/')
+        && !utils::has_wikilink_file_extension(target)
+        && !utils::has_explicit_file_extension(target)
 }
 
 fn is_linkable_file_target(target: &str) -> bool {
-    let Some(ext) = Path::new(target)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
-    else {
-        return false;
-    };
-    matches!(
-        ext.as_str(),
-        "md" | "pdf"
-            | "png"
-            | "jpg"
-            | "jpeg"
-            | "webp"
-            | "gif"
-            | "svg"
-            | "bmp"
-            | "avif"
-            | "tif"
-            | "tiff"
-    )
+    utils::has_wikilink_file_extension(target)
 }
 
 #[cfg(test)]
@@ -180,5 +161,26 @@ mod tests {
         assert!(paths.contains("assets/logo.png"));
         assert!(paths.contains("notes/peer.md"));
         assert!(titles.is_empty());
+    }
+
+    #[test]
+    fn parses_nested_dotted_wikilink_as_markdown_path() {
+        let (paths, titles) =
+            parse_outgoing_links("notes/source.md", "[[projects/0.5.6 project hail mary]]");
+
+        assert!(paths.contains("projects/0.5.6 project hail mary.md"));
+        assert!(titles.is_empty());
+    }
+
+    #[test]
+    fn does_not_rewrite_unsupported_explicit_wikilink_extensions_as_markdown() {
+        let (paths, titles) =
+            parse_outgoing_links("notes/source.md", "[[assets/archive.zip]] [[data.csv]]");
+
+        assert!(!paths.contains("assets/archive.zip"));
+        assert!(!paths.contains("assets/archive.zip.md"));
+        assert!(!paths.contains("data.csv.md"));
+        assert!(titles.contains("assets/archive.zip"));
+        assert!(titles.contains("data.csv"));
     }
 }

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod tags;
 mod types;
 
 pub use db::open_db;
+#[cfg(test)]
+pub(crate) use indexer::people_mentions_as_tags_test_lock;
 pub use indexer::{
     index_note, people_mentions_as_tags_enabled, remove_note, set_people_mentions_as_tags_enabled,
 };

--- a/src-tauri/src/index/search_advanced.rs
+++ b/src-tauri/src/index/search_advanced.rs
@@ -170,19 +170,29 @@ mod tests {
     use rusqlite::Connection;
 
     use crate::index::schema::ensure_schema;
-    use crate::index::{people_mentions_as_tags_enabled, set_people_mentions_as_tags_enabled};
+    use std::sync::MutexGuard;
+
+    use crate::index::{
+        people_mentions_as_tags_enabled, people_mentions_as_tags_test_lock,
+        set_people_mentions_as_tags_enabled,
+    };
 
     use super::{run_search_advanced, SearchAdvancedRequest};
 
     struct PeopleMentionsFlagGuard {
         previous: bool,
+        _lock: MutexGuard<'static, ()>,
     }
 
     impl PeopleMentionsFlagGuard {
         fn set(enabled: bool) -> Self {
+            let lock = people_mentions_as_tags_test_lock();
             let previous = people_mentions_as_tags_enabled();
             set_people_mentions_as_tags_enabled(enabled);
-            Self { previous }
+            Self {
+                previous,
+                _lock: lock,
+            }
         }
     }
 

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -149,21 +149,11 @@ fn list_files(root: &Path, markdown_only: bool, limit: usize) -> Result<Vec<File
 }
 
 fn is_image_rel_path(path: &str) -> bool {
-    let lower = path.to_ascii_lowercase();
-    lower.ends_with(".png")
-        || lower.ends_with(".jpg")
-        || lower.ends_with(".jpeg")
-        || lower.ends_with(".webp")
-        || lower.ends_with(".gif")
-        || lower.ends_with(".svg")
-        || lower.ends_with(".bmp")
-        || lower.ends_with(".avif")
-        || lower.ends_with(".tif")
-        || lower.ends_with(".tiff")
+    utils::is_image_path(path)
 }
 
 fn is_pdf_rel_path(path: &str) -> bool {
-    path.to_ascii_lowercase().ends_with(".pdf")
+    utils::is_pdf_path(path)
 }
 
 fn is_standard_wikilink_rel_path(entry: &FileEntry) -> bool {
@@ -175,13 +165,6 @@ fn choose_unambiguous_match(matches: Vec<String>) -> Option<String> {
         1 => matches.into_iter().next(),
         _ => None,
     }
-}
-
-fn has_explicit_extension(path: &str) -> bool {
-    Path::new(path)
-        .file_name()
-        .and_then(|name| Path::new(name).extension())
-        .is_some()
 }
 
 fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<String> {
@@ -236,7 +219,7 @@ fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<
         return choose_unambiguous_match(exact_name_matches);
     }
 
-    if has_explicit_extension(file_name_query) {
+    if utils::has_explicit_file_extension(file_name_query) {
         return None;
     }
 
@@ -284,7 +267,7 @@ fn resolve_standard_wikilink_target(entries: &[FileEntry], target: &str) -> Opti
         {
             return Some(hit.rel_path.clone());
         }
-        if !has_explicit_extension(&path_query) {
+        if !utils::has_explicit_file_extension(&path_query) {
             let markdown_query = format!("{path_query}.md");
             return link_entries
                 .iter()
@@ -295,7 +278,7 @@ fn resolve_standard_wikilink_target(entries: &[FileEntry], target: &str) -> Opti
     }
 
     let file_name_query = normalized.trim_start_matches('/');
-    if has_explicit_extension(file_name_query) {
+    if utils::has_explicit_file_extension(file_name_query) {
         let matches = link_entries
             .iter()
             .filter(|entry| basename(&entry.rel_path).eq_ignore_ascii_case(file_name_query))
@@ -497,6 +480,42 @@ mod tests {
             Some("docs/spec.pdf".to_string())
         );
         assert_eq!(resolve_standard_wikilink_target(&entries, "logo.png"), None);
+    }
+
+    #[test]
+    fn standard_wikilink_resolves_dotted_markdown_title_without_extension() {
+        let entries = vec![entry("0.5.6 project hail mary.md"), entry("docs/note.md")];
+
+        let resolved = resolve_standard_wikilink_target(&entries, "0.5.6 project hail mary");
+
+        assert_eq!(resolved, Some("0.5.6 project hail mary.md".to_string()));
+    }
+
+    #[test]
+    fn standard_wikilink_resolves_dotted_nested_markdown_path_without_extension() {
+        let entries = vec![
+            entry("projects/0.5.6 project hail mary.md"),
+            entry("docs/note.md"),
+        ];
+
+        let resolved =
+            resolve_standard_wikilink_target(&entries, "projects/0.5.6 project hail mary");
+
+        assert_eq!(
+            resolved,
+            Some("projects/0.5.6 project hail mary.md".to_string())
+        );
+    }
+
+    #[test]
+    fn standard_wikilink_does_not_resolve_unsupported_extension_as_markdown_stem() {
+        let entries = vec![entry("assets/archive.zip.md"), entry("data.csv.md")];
+
+        assert_eq!(
+            resolve_standard_wikilink_target(&entries, "assets/archive.zip"),
+            None
+        );
+        assert_eq!(resolve_standard_wikilink_target(&entries, "data.csv"), None);
     }
 
     #[test]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -58,13 +58,8 @@ pub fn path_extension_lower(path: &str) -> Option<String> {
 }
 
 pub fn has_explicit_file_extension(path: &str) -> bool {
-    path_extension_lower(path).is_some_and(|ext| {
-        !ext.is_empty()
-            && ext.len() <= 10
-            && ext
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
-    })
+    path_extension_lower(path)
+        .is_some_and(|ext| !ext.is_empty() && !ext.chars().any(char::is_whitespace))
 }
 
 pub fn is_markdown_extension(ext: &str) -> bool {

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -49,6 +49,55 @@ pub fn is_markdown_path(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+pub fn path_extension_lower(path: &str) -> Option<String> {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| Path::new(name).extension())
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+}
+
+pub fn has_explicit_file_extension(path: &str) -> bool {
+    path_extension_lower(path).is_some_and(|ext| {
+        !ext.is_empty()
+            && ext.len() <= 10
+            && ext
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+    })
+}
+
+pub fn is_markdown_extension(ext: &str) -> bool {
+    ext.eq_ignore_ascii_case("md")
+}
+
+pub fn is_pdf_extension(ext: &str) -> bool {
+    ext.eq_ignore_ascii_case("pdf")
+}
+
+pub fn is_image_extension(ext: &str) -> bool {
+    matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "png" | "jpg" | "jpeg" | "webp" | "gif" | "svg" | "bmp" | "avif" | "tif" | "tiff"
+    )
+}
+
+pub fn is_wikilink_file_extension(ext: &str) -> bool {
+    is_markdown_extension(ext) || is_pdf_extension(ext) || is_image_extension(ext)
+}
+
+pub fn has_wikilink_file_extension(path: &str) -> bool {
+    path_extension_lower(path).is_some_and(|ext| is_wikilink_file_extension(&ext))
+}
+
+pub fn is_image_path(path: &str) -> bool {
+    path_extension_lower(path).is_some_and(|ext| is_image_extension(&ext))
+}
+
+pub fn is_pdf_path(path: &str) -> bool {
+    path_extension_lower(path).is_some_and(|ext| is_pdf_extension(&ext))
+}
+
 pub fn should_hide(name: &str) -> bool {
     name.starts_with('.')
 }

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -68,7 +68,7 @@ pub fn has_explicit_file_extension(path: &str) -> bool {
 }
 
 pub fn is_markdown_extension(ext: &str) -> bool {
-    ext.eq_ignore_ascii_case("md")
+    ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown")
 }
 
 pub fn is_pdf_extension(ext: &str) -> bool {

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -80,12 +80,15 @@ export function useTabManager(spacePath: string | null) {
 			const nextMarkdownTabs = nextTabs
 				.filter(
 					(tab) =>
-						tab.kind === "file" && tab.target?.toLowerCase().endsWith(".md"),
+						tab.kind === "file" &&
+						tab.target !== null &&
+						isMarkdownPath(tab.target),
 				)
 				.map((tab) => tab.target as string);
 			const nextActiveMarkdownPath =
 				nextActiveTab?.kind === "file" &&
-				nextActiveTab.target?.toLowerCase().endsWith(".md")
+				nextActiveTab.target !== null &&
+				isMarkdownPath(nextActiveTab.target)
 					? nextActiveTab.target
 					: null;
 

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -1,8 +1,14 @@
 import { useCallback, useEffect } from "react";
 import type { UseFileTreeResult } from "../../hooks/useFileTree";
-import { isPdfTarget } from "../../lib/linkSuggestions";
 import { invoke } from "../../lib/tauri";
-import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
+import {
+	isImagePath,
+	isMarkdownCreatablePath,
+	isMarkdownPath,
+	isPdfPath,
+	normalizeRelPath,
+	parentDir,
+} from "../../utils/path";
 import {
 	MARKDOWN_LINK_CLICK_EVENT,
 	type MarkdownLinkClickDetail,
@@ -13,35 +19,6 @@ import {
 	WIKI_LINK_CLICK_EVENT,
 	type WikiLinkClickDetail,
 } from "../editor/markdown/editorEvents";
-
-const IMAGE_EXTENSIONS = new Set([
-	"png",
-	"jpg",
-	"jpeg",
-	"webp",
-	"gif",
-	"svg",
-	"bmp",
-	"avif",
-	"tif",
-	"tiff",
-]);
-
-function fileExtension(path: string): string {
-	const name = path.split("/").pop() ?? path;
-	const dot = name.lastIndexOf(".");
-	if (dot <= 0 || dot === name.length - 1) return "";
-	return name.slice(dot + 1).toLowerCase();
-}
-
-function isImageWikiTarget(target: string): boolean {
-	return IMAGE_EXTENSIONS.has(fileExtension(target));
-}
-
-function isMarkdownWikiTarget(target: string): boolean {
-	const ext = fileExtension(target);
-	return !ext || ext === "md";
-}
 
 interface UseWorkspaceLinkEventsArgs {
 	activeMarkdownTabPath: string | null;
@@ -63,7 +40,7 @@ export function useWorkspaceLinkEvents({
 			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 			if (!normalizedTarget) return;
-			if (isPdfTarget(normalizedTarget)) {
+			if (isPdfPath(normalizedTarget)) {
 				const resolved = await invoke("space_resolve_wikilink", {
 					target: normalizedTarget,
 				});
@@ -74,7 +51,7 @@ export function useWorkspaceLinkEvents({
 				setError(`Could not resolve PDF wikilink: ${rawTarget}`);
 				return;
 			}
-			if (!isMarkdownWikiTarget(normalizedTarget)) {
+			if (!isMarkdownCreatablePath(normalizedTarget)) {
 				setError(`Only markdown notes are creatable via [[...]]: ${rawTarget}`);
 				return;
 			}
@@ -133,7 +110,7 @@ export function useWorkspaceLinkEvents({
 					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 					if (!normalizedTarget) return;
 
-					if (detail.embed || isImageWikiTarget(normalizedTarget)) {
+					if (detail.embed || isImagePath(normalizedTarget)) {
 						const resolvedImage = await invoke("space_resolve_image_wikilink", {
 							target: normalizedTarget,
 						});
@@ -145,12 +122,12 @@ export function useWorkspaceLinkEvents({
 						return;
 					}
 
-					if (isPdfTarget(normalizedTarget)) {
+					if (isPdfPath(normalizedTarget)) {
 						await openOrCreateWikiLinkTarget(detail.target);
 						return;
 					}
 
-					if (!isMarkdownWikiTarget(normalizedTarget)) {
+					if (!isMarkdownCreatablePath(normalizedTarget)) {
 						setError(
 							`Unsupported non-markdown wikilink target: ${detail.target}`,
 						);

--- a/src/lib/linkSuggestions.ts
+++ b/src/lib/linkSuggestions.ts
@@ -1,3 +1,4 @@
+import { isImagePath, isPdfPath } from "../utils/path";
 import { invoke } from "./tauri";
 
 export interface EditorLinkSuggestion {
@@ -20,11 +21,11 @@ interface SuggestMarkdownLinksOptions {
 }
 
 export function isImageTarget(path: string): boolean {
-	return /\.(?:avif|bmp|gif|jpe?g|png|svg|tiff?|webp)$/i.test(path);
+	return isImagePath(path);
 }
 
 export function isPdfTarget(path: string): boolean {
-	return /\.pdf$/i.test(path);
+	return isPdfPath(path);
 }
 
 function titleFromPath(path: string): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -24,7 +24,8 @@ export function splitEditableFileName(name: string): {
 }
 
 export function isMarkdownPath(relPath: string): boolean {
-	return relPath.toLowerCase().endsWith(".md");
+	const ext = fileExtension(relPath);
+	return ext === "md" || ext === "markdown";
 }
 
 const IMAGE_EXTENSIONS = new Set([
@@ -49,7 +50,7 @@ export function fileExtension(path: string): string {
 
 export function hasExplicitFileExtension(path: string): boolean {
 	const ext = fileExtension(path);
-	return /^[a-z0-9_-]{1,10}$/.test(ext);
+	return ext.length > 0 && !/\s/.test(ext);
 }
 
 export function isImagePath(path: string): boolean {
@@ -62,7 +63,7 @@ export function isPdfPath(path: string): boolean {
 
 export function isMarkdownCreatablePath(path: string): boolean {
 	const ext = fileExtension(path);
-	return ext === "md" || !hasExplicitFileExtension(path);
+	return ext === "md" || ext === "markdown" || !hasExplicitFileExtension(path);
 }
 
 export function isPreviewableNotePath(path: string): boolean {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -27,14 +27,49 @@ export function isMarkdownPath(relPath: string): boolean {
 	return relPath.toLowerCase().endsWith(".md");
 }
 
+const IMAGE_EXTENSIONS = new Set([
+	"avif",
+	"bmp",
+	"gif",
+	"jpeg",
+	"jpg",
+	"png",
+	"svg",
+	"tif",
+	"tiff",
+	"webp",
+]);
+
+export function fileExtension(path: string): string {
+	const name = basename(path);
+	const dotIndex = name.lastIndexOf(".");
+	if (dotIndex <= 0 || dotIndex === name.length - 1) return "";
+	return name.slice(dotIndex + 1).toLowerCase();
+}
+
+export function hasExplicitFileExtension(path: string): boolean {
+	const ext = fileExtension(path);
+	return /^[a-z0-9_-]{1,10}$/.test(ext);
+}
+
+export function isImagePath(path: string): boolean {
+	return IMAGE_EXTENSIONS.has(fileExtension(path));
+}
+
+export function isPdfPath(path: string): boolean {
+	return fileExtension(path) === "pdf";
+}
+
+export function isMarkdownCreatablePath(path: string): boolean {
+	const ext = fileExtension(path);
+	return ext === "md" || !hasExplicitFileExtension(path);
+}
+
 export function isPreviewableNotePath(path: string): boolean {
 	const normalized = normalizeRelPath(path.split("#", 1)[0] ?? path);
 	const filename = basename(normalized);
 	if (!filename) return false;
-	if (filename.includes(".") && !filename.toLowerCase().endsWith(".md")) {
-		return false;
-	}
-	return true;
+	return isMarkdownCreatablePath(filename);
 }
 
 export function displayNameFromPath(relPath: string): string {


### PR DESCRIPTION
## Description

Fixes wikilink resolution when wiki link targets contain dots in the filename (e.g., `[[projects/0.5.6 project hail mary]]`). Previously, any path with an extension-like suffix was treated as an explicit file target, causing dotted markdown titles to fail resolution. Now, only known wikilink extensions (`.md`, `.pdf`, image formats) or explicit unsupported extensions trigger non-markdown behavior — everything else gets the `.md` extension appended.

This was accomplished by:

- **Consolidated extension detection** — Moved ad-hoc extension helpers (`has_extension`, inline regex, `is_image_rel_path`, `is_pdf_rel_path`, etc.) from `links.rs`, `link_ops.rs`, and `useWorkspaceLinkEvents.ts` into shared utility modules (`src-tauri/src/utils.rs` and `src/utils/path.ts`). Eliminates duplicated and inconsistent logic across the codebase.
- **`has_explicit_file_extension`** — A new shared function (Rust + TypeScript) that validates an extension is a real file extension (letters/digits/underscores/hyphens, 1–10 chars) rather than a coincidental dot in the name.
- **`isMarkdownCreatablePath` (TS)** / **`is_wikilink_file_extension` (Rust)** — New predicates that correctly identify targets as markdown (creatable), known non-markdown (images/PDFs), or explicitly unsupported extensions (`.zip`, `.csv`, etc.).
- **Dual `has_explicit_file_extension` + `has_wikilink_file_extension` check** in `should_append_markdown_extension` and `is_file_wikilink_target`, so paths like `projects/0.5.6 project hail mary` get `.md` appended while `assets/archive.zip` does not.
- **Edge case: nested dotted markdown paths** — The path-level check (`target.contains(/)`) now correctly defers to the explicit-extension check, so `projects/0.5.6 something` resolves as a markdown path even though it has a dot and a slash.
- **Tests added** in both `links.rs` (parsing) and `link_ops.rs` (resolution) to cover dotted filenames, nested dotted paths, and unsupported explicit extensions.

### Additional changes
- Updated `.gitignore` to exclude `.amp/` and `.pi/` extension hooks.

## Screenshots

N/A — backend logic changes, no visual changes.

## Docs

The new utility predicates in `src/utils/path.ts` and `src-tauri/src/utils.rs` serve as the single source of truth for file-type classification across both TypeScript frontend and Rust backend. Key functions:

- `hasExplicitFileExtension(path)` / `has_explicit_file_extension()` — true if the file has a real extension (not a coincidental dot)
- `isMarkdownCreatablePath(path)` — true if extension is `.md` or no explicit extension (i.e., it could be a markdown note)
- `isImagePath(path)` / `isPdfPath(path)` — convenience wrappers for known non-markdown wikilink types

## Ready?

- [x] Ran the linter to ensure style guidelines were followed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of links and file paths across the app, including better support for images, PDFs, and markdown-style notes.
  * Links with nested or dotted names are now recognized more reliably.

* **Bug Fixes**
  * Fixed cases where valid note links were treated as unsupported.
  * Prevented unsupported file types from being rewritten or opened as markdown notes.
  * Improved click behavior for workspace links so the right target opens more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->