### PR TITLE
Improve file tree drag-and-drop into expanded folders

### DIFF
--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -1,4 +1,4 @@
-import { useDraggable, useDroppable } from "@dnd-kit/react";
+import { useDraggable } from "@dnd-kit/react";
 import {
 	ArrowRight02Icon,
 	Folder01Icon,
@@ -22,6 +22,7 @@ import {
 	FILE_TREE_ENTRY_SENSORS,
 	FILE_TREE_ENTRY_TYPE,
 	fileTreeEntryDragId,
+	useFileTreeDirDropTargets,
 } from "./fileTreeDnd";
 import {
 	buildRowStyle,
@@ -152,18 +153,22 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			kind: "dir",
 		},
 	});
-	const { ref: droppableRef, isDropTarget } = useDroppable({
-		id: `file-tree-dir:${entry.rel_path}`,
-		data: { targetDirPath: entry.rel_path },
-		accept: FILE_TREE_ENTRY_TYPE,
+	const {
+		rowDroppableRef,
+		isRowDropTarget,
+		childrenDroppableRef,
+		isChildrenDropTarget,
+	} = useFileTreeDirDropTargets({
+		relPath: entry.rel_path,
+		isExpanded,
 	});
-	const setRowRef = useCallback(
+	const setDragHandleRef = useCallback(
 		(element: HTMLButtonElement | null) => {
 			draggableRef(element);
-			droppableRef(element);
 			handleRef(element);
+			rowDroppableRef(element);
 		},
-		[draggableRef, droppableRef, handleRef],
+		[draggableRef, handleRef, rowDroppableRef],
 	);
 	const handleContextMenu = useCallback(
 		(event: MouseEvent) => {
@@ -222,7 +227,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 				) : (
 					<>
 						<m.button
-							ref={setRowRef}
+							ref={setDragHandleRef}
 							type="button"
 							className="fileTreeRow"
 							onClick={() => {
@@ -240,7 +245,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 							title={entry.rel_path || entry.name || "Folder"}
 							data-draggable="true"
 							data-dragging={isDragging ? "true" : undefined}
-							data-drop-target={isDropTarget ? "true" : undefined}
+							data-drop-target={isRowDropTarget ? "true" : undefined}
 							data-has-custom-color={customColor ? "true" : "false"}
 							data-file-tree-kind="dir"
 							data-file-tree-path={entry.rel_path}
@@ -320,13 +325,16 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 				)}
 			</div>
 			<AnimatePresence>
-				{isExpanded && children ? (
+				{isExpanded ? (
 					<m.div
+						ref={childrenDroppableRef}
+						className="fileTreeChildren"
 						initial={{ height: 0, opacity: 0 }}
 						animate={{ height: "auto", opacity: 1 }}
 						exit={{ height: 0, opacity: 0 }}
 						transition={springTransition}
 						style={{ overflow: "hidden" }}
+						data-drop-target={isChildrenDropTarget ? "true" : undefined}
 					>
 						{children}
 					</m.div>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -39,7 +39,10 @@ import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { springPresets } from "../ui/animations";
 import { FileTreeDirItem } from "./FileTreeDirItem";
 import { FileTreeFileItem } from "./FileTreeFileItem";
-import { FILE_TREE_ENTRY_TYPE } from "./fileTreeDnd";
+import {
+	FILE_TREE_ENTRY_TYPE,
+	FILE_TREE_ROOT_DROP_COLLISION_PRIORITY,
+} from "./fileTreeDnd";
 
 interface FileTreePaneProps {
 	rootEntries: FsEntry[];
@@ -149,6 +152,7 @@ function FileTreeRootDrop({
 		id: targetDirPath ? `file-tree-focused:${targetDirPath}` : "file-tree-root",
 		data: { targetDirPath },
 		accept: FILE_TREE_ENTRY_TYPE,
+		collisionPriority: FILE_TREE_ROOT_DROP_COLLISION_PRIORITY,
 	});
 
 	return (
@@ -330,7 +334,8 @@ function TreeEntries({
 
 				if (isDir) {
 					const isExpanded = expandedDirs.has(e.rel_path);
-					const children = childrenByDir[e.rel_path];
+					const childEntries = childrenByDir[e.rel_path];
+					const childEntriesLoaded = childEntries !== undefined;
 
 					return (
 						<FileTreeDirItem
@@ -359,9 +364,9 @@ function TreeEntries({
 							onCancelRename={onCancelRename}
 							onMoveClickSuppressRef={onMoveClickSuppressRef}
 						>
-							{children && (
+							{childEntriesLoaded ? (
 								<TreeEntries
-									entries={children}
+									entries={childEntries ?? []}
 									parentDepth={depth}
 									childrenByDir={childrenByDir}
 									expandedDirs={expandedDirs}
@@ -395,7 +400,7 @@ function TreeEntries({
 									showFilePreviews={showFilePreviews}
 									filePreviewsByPath={filePreviewsByPath}
 								/>
-							)}
+							) : null}
 						</FileTreeDirItem>
 					);
 				}

--- a/src/components/filetree/fileTreeDnd.ts
+++ b/src/components/filetree/fileTreeDnd.ts
@@ -40,6 +40,11 @@ export function fileTreeDirDropData(relPath: string): {
 	return { targetDirPath: relPath };
 }
 
+function fileTreeDirChildrenCollisionPriority(relPath: string): number {
+	const depth = relPath.split("/").filter(Boolean).length;
+	return FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY + depth / (depth + 1);
+}
+
 export function useFileTreeDirDropTargets({
 	relPath,
 	isExpanded,
@@ -58,7 +63,7 @@ export function useFileTreeDirDropTargets({
 			id: fileTreeDirChildrenDropId(relPath),
 			data: fileTreeDirDropData(relPath),
 			accept: FILE_TREE_ENTRY_TYPE,
-			collisionPriority: FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY,
+			collisionPriority: fileTreeDirChildrenCollisionPriority(relPath),
 			disabled: !isExpanded,
 		});
 

--- a/src/components/filetree/fileTreeDnd.ts
+++ b/src/components/filetree/fileTreeDnd.ts
@@ -1,7 +1,14 @@
 import { PointerActivationConstraints } from "@dnd-kit/dom";
-import { KeyboardSensor, PointerSensor } from "@dnd-kit/react";
+import { KeyboardSensor, PointerSensor, useDroppable } from "@dnd-kit/react";
 
 export const FILE_TREE_ENTRY_TYPE = "file-tree-entry";
+
+/** Matches `CollisionPriority.Highest` in @dnd-kit/abstract. */
+const FILE_TREE_DIR_ROW_COLLISION_PRIORITY = 4;
+/** Matches `CollisionPriority.Normal` in @dnd-kit/abstract. */
+const FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY = 2;
+/** Matches `CollisionPriority.Low` in @dnd-kit/abstract. */
+export const FILE_TREE_ROOT_DROP_COLLISION_PRIORITY = 1;
 
 export const FILE_TREE_ENTRY_SENSORS = [
 	PointerSensor.configure({
@@ -17,4 +24,48 @@ export function fileTreeEntryDragId(
 	path: string,
 ): string {
 	return `${kind}:${path}`;
+}
+
+export function fileTreeDirRowDropId(relPath: string): string {
+	return `file-tree-dir-row:${relPath}`;
+}
+
+export function fileTreeDirChildrenDropId(relPath: string): string {
+	return `file-tree-dir-children:${relPath}`;
+}
+
+export function fileTreeDirDropData(relPath: string): {
+	targetDirPath: string;
+} {
+	return { targetDirPath: relPath };
+}
+
+export function useFileTreeDirDropTargets({
+	relPath,
+	isExpanded,
+}: {
+	relPath: string;
+	isExpanded: boolean;
+}) {
+	const { ref: rowDroppableRef, isDropTarget: isRowDropTarget } = useDroppable({
+		id: fileTreeDirRowDropId(relPath),
+		data: fileTreeDirDropData(relPath),
+		accept: FILE_TREE_ENTRY_TYPE,
+		collisionPriority: FILE_TREE_DIR_ROW_COLLISION_PRIORITY,
+	});
+	const { ref: childrenDroppableRef, isDropTarget: isChildrenDropTarget } =
+		useDroppable({
+			id: fileTreeDirChildrenDropId(relPath),
+			data: fileTreeDirDropData(relPath),
+			accept: FILE_TREE_ENTRY_TYPE,
+			collisionPriority: FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY,
+			disabled: !isExpanded,
+		});
+
+	return {
+		rowDroppableRef,
+		isRowDropTarget,
+		childrenDroppableRef,
+		isChildrenDropTarget,
+	};
 }

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -239,6 +239,17 @@
 	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	box-shadow: inset 0 0 0 1px
 		color-mix(in srgb, var(--interactive-accent) 34%, transparent);
+	border-radius: 6px;
+}
+
+.fileTreeChildren {
+	min-height: 28px;
+}
+
+.fileTreeChildren[data-drop-target="true"] {
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 22%, transparent);
+	border-radius: 6px;
 }
 
 .fileTreeRow[data-draggable="true"]:not([data-dragging="true"]) {


### PR DESCRIPTION
## Summary

Adds separate row and children drop targets for folder items so notes can be dragged into an open folder’s contents, not just its title row. Centralizes folder DnD setup in `fileTreeDnd.ts` with explicit collision priorities (row > children > root scroll) so nested folders and the root drop zone resolve correctly. Includes drop-target styling for the expanded children area and a minimum height so empty folders remain droppable.

## Related Issues

Closes #27

## Testing

- [x] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [x] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


Made with [Cursor](https://cursor.com)