### PR TITLE
[codex] unify editor suggestion engine

### DIFF
--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -519,7 +519,7 @@ mod tests {
             .unwrap();
         }
 
-        let tags = list_tags(&conn, 50, 0).unwrap();
+        let tags = list_tags(&conn, 50, 0, None).unwrap();
         assert_eq!(tags.len(), 3);
 
         let root = tags.iter().find(|tag| tag.tag == "work").unwrap();
@@ -565,7 +565,7 @@ mod tests {
             .unwrap();
         }
 
-        let tags = list_tags(&conn, 50, 0).unwrap();
+        let tags = list_tags(&conn, 50, 0, None).unwrap();
         assert_eq!(
             tags.iter().map(|tag| tag.tag.as_str()).collect::<Vec<_>>(),
             vec!["work"]

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -347,13 +347,17 @@ pub async fn tags_list(
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
+    query: Option<String>,
 ) -> Result<Vec<TagCount>, String> {
     let root = state.root_for_window(&window)?;
     let limit = limit.unwrap_or(200).min(2000) as i64;
     let offset = offset.unwrap_or(0) as i64;
+    let query = query
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<TagCount>, String> {
         let conn = open_db(&root)?;
-        list_tags(&conn, limit, offset)
+        list_tags(&conn, limit, offset, query.as_deref())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -363,22 +367,48 @@ fn list_tags(
     conn: &rusqlite::Connection,
     limit: i64,
     offset: i64,
+    query: Option<&str>,
 ) -> Result<Vec<TagCount>, String> {
-    let mut stmt = conn
-        .prepare(
-            "SELECT tag,
-                    SUM(CASE WHEN is_explicit = 1 THEN 1 ELSE 0 END) AS direct_count,
-                    COUNT(*) AS total_count,
-                    MAX(is_explicit) AS is_explicit
-             FROM tags
-             WHERE tag NOT LIKE 'people/%'
-             GROUP BY tag
-             ORDER BY tag ASC
-             LIMIT ? OFFSET ?",
-        )
-        .map_err(|e| e.to_string())?;
+    let mut sql = String::from(
+        "SELECT tag,
+                SUM(CASE WHEN is_explicit = 1 THEN 1 ELSE 0 END) AS direct_count,
+                COUNT(*) AS total_count,
+                MAX(is_explicit) AS is_explicit
+         FROM tags
+         WHERE tag NOT LIKE 'people/%'",
+    );
+    let mut params: Vec<rusqlite::types::Value> = Vec::new();
+    let mut order_by = String::from("tag ASC");
+    if let Some(query) = query {
+        let escaped = escape_like(query);
+        let prefix = format!("{escaped}%");
+        let contains = format!("%{escaped}%");
+        sql.push_str(" AND (tag LIKE ? ESCAPE '\\' OR tag LIKE ? ESCAPE '\\')");
+        params.push(rusqlite::types::Value::from(prefix.clone()));
+        params.push(rusqlite::types::Value::from(contains));
+        sql.push_str(" GROUP BY tag HAVING MAX(is_explicit) = 1");
+        order_by = String::from(
+            "CASE
+                WHEN tag = ? THEN 0
+                WHEN tag LIKE ? ESCAPE '\\' THEN 1
+                ELSE 2
+             END,
+             tag ASC",
+        );
+        params.push(rusqlite::types::Value::from(query.to_string()));
+        params.push(rusqlite::types::Value::from(prefix));
+    } else {
+        sql.push_str(" GROUP BY tag");
+    }
+    sql.push_str(" ORDER BY ");
+    sql.push_str(&order_by);
+    sql.push_str(" LIMIT ? OFFSET ?");
+    params.push(rusqlite::types::Value::from(limit));
+    params.push(rusqlite::types::Value::from(offset));
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
     let mut rows = stmt
-        .query(rusqlite::params![limit, offset])
+        .query(rusqlite::params_from_iter(params.iter()))
         .map_err(|e| e.to_string())?;
     let mut out = Vec::new();
     while let Some(row) = rows.next().map_err(|e| e.to_string())? {

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -35,6 +35,7 @@ import type { MathEditRequest } from "./math/mathOptions";
 import { MermaidPreview } from "./mermaidPreview";
 import { NoteSearch } from "./noteSearch";
 import { PersonAutocomplete } from "./personAutocomplete";
+import { TagAutocomplete } from "./tagAutocomplete";
 import { TagDecorations } from "./tagDecorations";
 import { VimMode } from "./vimMode";
 import { WikiLink } from "./wikiLink";
@@ -755,6 +756,7 @@ export function createEditorExtensions(
 		...(enableEditingExtensions && enablePeopleMentions
 			? [PersonAutocomplete]
 			: []),
+		...(enableEditingExtensions ? [TagAutocomplete] : []),
 		...(enableEditingExtensions && enableSlashCommand
 			? [SlashCommand.configure({ onMathEditRequest })]
 			: []),

--- a/src/components/editor/extensions/markdownLinkAutocomplete.ts
+++ b/src/components/editor/extensions/markdownLinkAutocomplete.ts
@@ -1,10 +1,11 @@
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
-import Suggestion, { type SuggestionProps } from "@tiptap/suggestion";
+import Suggestion from "@tiptap/suggestion";
 import {
 	type EditorLinkSuggestion,
 	suggestMarkdownLinks,
 } from "../../../lib/linkSuggestions";
+import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const MD_LINK_SUGGESTION_KEY = new PluginKey("markdown-link-suggestion");
 
@@ -19,13 +20,16 @@ export const MarkdownLinkAutocomplete = Extension.create({
 	},
 	addProseMirrorPlugins() {
 		const getItems = async (query: string): Promise<EditorLinkSuggestion[]> => {
-			const currentPath =
-				typeof this.options.getCurrentPath === "function"
-					? this.options.getCurrentPath()
-					: this.options.currentPath;
+			const getSourcePath = () => {
+				const currentPath =
+					typeof this.options.getCurrentPath === "function"
+						? this.options.getCurrentPath()
+						: this.options.currentPath;
+				return currentPath || null;
+			};
 			return suggestMarkdownLinks({
 				query,
-				sourcePath: currentPath || null,
+				sourcePath: getSourcePath(),
 				limit: this.options.suggestionLimit,
 			});
 		};
@@ -67,18 +71,15 @@ export const MarkdownLinkAutocomplete = Extension.create({
 						.insertContent(`](${props.insertText})`)
 						.run();
 				},
-				render: () => {
-					let menu: HTMLDivElement | null = null;
-					let selectedIndex = 0;
-					let activeProps: SuggestionProps<EditorLinkSuggestion> | null = null;
-
-					const updateMenu = (props: SuggestionProps<EditorLinkSuggestion>) => {
-						if (!menu) return;
-						menu.replaceChildren();
-						for (const [index, item] of props.items.entries()) {
+				render: () =>
+					createTipTapSuggestionMenu<EditorLinkSuggestion>({
+						menuClassName: "wikiLinkSuggestionMenu",
+						lockEditorScroll: false,
+						renderItem: ({ item, isActive, select }) => {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "wikiLinkSuggestionItem";
+							button.classList.toggle("active", isActive);
 
 							const title = document.createElement("span");
 							title.className = "wikiLinkSuggestionTitle";
@@ -91,60 +92,11 @@ export const MarkdownLinkAutocomplete = Extension.create({
 							button.append(title, path);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
-								props.command(item);
+								select(item);
 							});
-							if (index === selectedIndex) button.classList.add("active");
-							menu.append(button);
-						}
-						const rect = props.clientRect?.();
-						if (rect) {
-							menu.style.left = `${rect.left}px`;
-							menu.style.top = `${rect.bottom + 6}px`;
-						}
-					};
-
-					return {
-						onStart: (props: SuggestionProps<EditorLinkSuggestion>) => {
-							activeProps = props;
-							selectedIndex = 0;
-							menu = document.createElement("div");
-							menu.className = "wikiLinkSuggestionMenu";
-							document.body.append(menu);
-							updateMenu(props);
+							return button;
 						},
-						onUpdate: (props: SuggestionProps<EditorLinkSuggestion>) => {
-							activeProps = props;
-							updateMenu(props);
-						},
-						onKeyDown: ({ event }) => {
-							const current = activeProps;
-							if (!current?.items.length) return false;
-							if (event.key === "ArrowDown") {
-								selectedIndex = (selectedIndex + 1) % current.items.length;
-								updateMenu(current);
-								return true;
-							}
-							if (event.key === "ArrowUp") {
-								selectedIndex =
-									(selectedIndex - 1 + current.items.length) %
-									current.items.length;
-								updateMenu(current);
-								return true;
-							}
-							if (event.key === "Enter" || event.key === "Tab") {
-								event.preventDefault();
-								current.command(current.items[selectedIndex]);
-								return true;
-							}
-							return false;
-						},
-						onExit: () => {
-							menu?.remove();
-							menu = null;
-							activeProps = null;
-						},
-					};
-				},
+					}),
 			}),
 		];
 	},

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -1,7 +1,8 @@
 import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
-import Suggestion, { type SuggestionProps } from "@tiptap/suggestion";
+import Suggestion from "@tiptap/suggestion";
 import { type PersonCount, invoke } from "../../../lib/tauri";
+import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const PERSON_SUGGESTION_KEY = new PluginKey("person-suggestion");
 
@@ -35,14 +36,14 @@ export const PersonAutocomplete = Extension.create({
 			const normalized = normalizeHandle(query);
 			let people: PersonCount[] = [];
 			try {
-				people = (await invoke("people_list", {
+				people = await invoke("people_list", {
 					limit: this.options.suggestionLimit * 5,
-				})) as PersonCount[];
+				});
 			} catch (error) {
 				console.warn("Failed to load people suggestions", error);
 				return [];
 			}
-			const matches: PersonSuggestionItem[] = (people as PersonCount[])
+			const matches: PersonSuggestionItem[] = people
 				.filter((person) =>
 					normalized.length === 0 ? true : person.handle.includes(normalized),
 				)
@@ -94,18 +95,16 @@ export const PersonAutocomplete = Extension.create({
 						.insertContent(`@${props.handle}`)
 						.run();
 				},
-				render: () => {
-					let menu: HTMLDivElement | null = null;
-					let selectedIndex = 0;
-					let activeProps: SuggestionProps<PersonSuggestionItem> | null = null;
-
-					const updateMenu = (props: SuggestionProps<PersonSuggestionItem>) => {
-						if (!menu) return;
-						menu.replaceChildren();
-						for (const [index, item] of props.items.entries()) {
+				render: () =>
+					createTipTapSuggestionMenu<PersonSuggestionItem>({
+						menuClassName: "wikiLinkSuggestionMenu",
+						lockEditorScroll: false,
+						resetSelectionOnUpdate: true,
+						renderItem: ({ item, isActive, select }) => {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "wikiLinkSuggestionItem";
+							button.classList.toggle("active", isActive);
 							const meta = item.isNew
 								? "Create mention"
 								: `${item.count ?? 0} note${item.count === 1 ? "" : "s"}`;
@@ -118,61 +117,11 @@ export const PersonAutocomplete = Extension.create({
 							button.append(title, path);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
-								props.command(item);
+								select(item);
 							});
-							if (index === selectedIndex) button.classList.add("active");
-							menu.append(button);
-						}
-						const rect = props.clientRect?.();
-						if (rect) {
-							menu.style.left = `${rect.left}px`;
-							menu.style.top = `${rect.bottom + 6}px`;
-						}
-					};
-
-					return {
-						onStart: (props: SuggestionProps<PersonSuggestionItem>) => {
-							activeProps = props;
-							selectedIndex = 0;
-							menu = document.createElement("div");
-							menu.className = "wikiLinkSuggestionMenu";
-							document.body.append(menu);
-							updateMenu(props);
+							return button;
 						},
-						onUpdate: (props: SuggestionProps<PersonSuggestionItem>) => {
-							activeProps = props;
-							selectedIndex = 0;
-							updateMenu(props);
-						},
-						onKeyDown: ({ event }) => {
-							const current = activeProps;
-							if (!current?.items.length) return false;
-							if (event.key === "ArrowDown") {
-								selectedIndex = (selectedIndex + 1) % current.items.length;
-								updateMenu(current);
-								return true;
-							}
-							if (event.key === "ArrowUp") {
-								selectedIndex =
-									(selectedIndex - 1 + current.items.length) %
-									current.items.length;
-								updateMenu(current);
-								return true;
-							}
-							if (event.key === "Enter" || event.key === "Tab") {
-								event.preventDefault();
-								current.command(current.items[selectedIndex]);
-								return true;
-							}
-							return false;
-						},
-						onExit: () => {
-							menu?.remove();
-							menu = null;
-							activeProps = null;
-						},
-					};
-				},
+					}),
 			}),
 		];
 	},

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -1,0 +1,157 @@
+import { Extension } from "@tiptap/core";
+import { PluginKey } from "@tiptap/pm/state";
+import Suggestion from "@tiptap/suggestion";
+import type { TagCount } from "../../../lib/tauri";
+import { invoke } from "../../../lib/tauri";
+import {
+	normalizeTagDraftPrefix,
+	normalizeTagToken,
+} from "../noteProperties/utils";
+import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+
+const TAG_SUGGESTION_KEY = new PluginKey("tag-suggestion");
+const TAG_METADATA_PAGE_SIZE = 500;
+
+interface TagSuggestionItem {
+	tag: string;
+	count: number;
+	isNew?: boolean;
+}
+
+async function fetchAllTags(): Promise<TagCount[]> {
+	const tags: TagCount[] = [];
+	for (let offset = 0; ; offset += TAG_METADATA_PAGE_SIZE) {
+		const page = await invoke("tags_list", {
+			limit: TAG_METADATA_PAGE_SIZE,
+			offset,
+		});
+		tags.push(...page);
+		if (page.length < TAG_METADATA_PAGE_SIZE) return tags;
+	}
+}
+
+function rankInlineTag(
+	tag: string,
+	normalizedQuery: string,
+	descendantPrefix: string,
+): number {
+	if (tag === normalizedQuery) return 0;
+	if (tag.startsWith(descendantPrefix)) return 1;
+	if (tag.startsWith(normalizedQuery)) return 2;
+	return 3;
+}
+
+export const TagAutocomplete = Extension.create({
+	name: "tag-autocomplete",
+	addOptions() {
+		return {
+			suggestionLimit: 8,
+		};
+	},
+	addProseMirrorPlugins() {
+		const getItems = async (query: string): Promise<TagSuggestionItem[]> => {
+			const normalizedQuery = normalizeTagDraftPrefix(query);
+			if (!normalizedQuery) return [];
+			let tags: TagCount[] = [];
+			try {
+				tags = await fetchAllTags();
+			} catch (error) {
+				console.warn("Failed to load tag suggestions", error);
+				return [];
+			}
+			const descendantPrefix = normalizedQuery.endsWith("/")
+				? normalizedQuery
+				: `${normalizedQuery}/`;
+			const matches = tags
+				.filter(
+					({ tag, is_explicit }) =>
+						is_explicit &&
+						(tag.startsWith(normalizedQuery) || tag.includes(normalizedQuery)),
+				)
+				.sort((left, right) => {
+					const leftRank = rankInlineTag(
+						left.tag,
+						normalizedQuery,
+						descendantPrefix,
+					);
+					const rightRank = rankInlineTag(
+						right.tag,
+						normalizedQuery,
+						descendantPrefix,
+					);
+					if (leftRank !== rightRank) return leftRank - rightRank;
+					return left.tag.localeCompare(right.tag);
+				})
+				.map(({ tag, direct_count }) => ({
+					tag,
+					count: direct_count,
+					isNew: false,
+				}));
+			const normalizedTag = normalizeTagToken(normalizedQuery);
+			if (normalizedTag && !matches.some(({ tag }) => tag === normalizedTag)) {
+				matches.unshift({
+					tag: normalizedTag,
+					count: 0,
+					isNew: true,
+				});
+			}
+			return matches.slice(0, this.options.suggestionLimit);
+		};
+
+		return [
+			Suggestion<TagSuggestionItem>({
+				editor: this.editor,
+				pluginKey: TAG_SUGGESTION_KEY,
+				char: "#",
+				startOfLine: false,
+				allowSpaces: false,
+				allowedPrefixes: [" ", "\t", "\n", "(", "[", "{", '"', "'"],
+				allow: ({ state, range }) => {
+					const previousChar = state.doc.textBetween(
+						Math.max(0, range.from - 1),
+						range.from,
+						"\n",
+						"\n",
+					);
+					return !previousChar || /[\s([{"']/.test(previousChar);
+				},
+				items: ({ query }) => getItems(query),
+				command: ({ editor, range, props }) => {
+					editor
+						.chain()
+						.focus()
+						.deleteRange(range)
+						.insertContent(`#${props.tag} `)
+						.run();
+				},
+				render: () =>
+					createTipTapSuggestionMenu<TagSuggestionItem>({
+						menuClassName: "wikiLinkSuggestionMenu",
+						renderItem: ({ item, isActive, select }) => {
+							const button = document.createElement("button");
+							button.type = "button";
+							button.className = "wikiLinkSuggestionItem";
+							button.classList.toggle("active", isActive);
+
+							const title = document.createElement("span");
+							title.className = "wikiLinkSuggestionTitle";
+							title.textContent = `#${item.tag}`;
+
+							const path = document.createElement("span");
+							path.className = "wikiLinkSuggestionPath";
+							path.textContent = item.isNew
+								? "Create tag"
+								: `${item.count} note${item.count === 1 ? "" : "s"}`;
+
+							button.append(title, path);
+							button.addEventListener("mousedown", (event) => {
+								event.preventDefault();
+								select(item);
+							});
+							return button;
+						},
+					}),
+			}),
+		];
+	},
+});

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -10,24 +10,11 @@ import {
 import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const TAG_SUGGESTION_KEY = new PluginKey("tag-suggestion");
-const TAG_METADATA_PAGE_SIZE = 500;
 
 interface TagSuggestionItem {
 	tag: string;
 	count: number;
 	isNew?: boolean;
-}
-
-async function fetchAllTags(): Promise<TagCount[]> {
-	const tags: TagCount[] = [];
-	for (let offset = 0; ; offset += TAG_METADATA_PAGE_SIZE) {
-		const page = await invoke("tags_list", {
-			limit: TAG_METADATA_PAGE_SIZE,
-			offset,
-		});
-		tags.push(...page);
-		if (page.length < TAG_METADATA_PAGE_SIZE) return tags;
-	}
 }
 
 function rankInlineTag(
@@ -54,7 +41,10 @@ export const TagAutocomplete = Extension.create({
 			if (!normalizedQuery) return [];
 			let tags: TagCount[] = [];
 			try {
-				tags = await fetchAllTags();
+				tags = await invoke("tags_list", {
+					limit: this.options.suggestionLimit,
+					query: normalizedQuery,
+				});
 			} catch (error) {
 				console.warn("Failed to load tag suggestions", error);
 				return [];

--- a/src/components/editor/extensions/tagDecorations.ts
+++ b/src/components/editor/extensions/tagDecorations.ts
@@ -7,6 +7,14 @@ import {
 
 const TAG_PATTERN = /(^|[^\w/])#([A-Za-z0-9_][\w/-]*)/g;
 const PERSON_PATTERN = /(^|[^A-Za-z0-9_.-])@([A-Za-z0-9_][A-Za-z0-9_-]*)/g;
+const TOKEN_SELECTOR = ".tagToken, .personToken";
+
+export function handleTagDecorationMouseDown(event: MouseEvent): boolean {
+	const target = event.target instanceof Element ? event.target : null;
+	if (!target?.closest(TOKEN_SELECTOR)) return false;
+	event.preventDefault();
+	return true;
+}
 
 function collectTagDecorations(
 	{ node, pos }: TextNodeDecorationContext,

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -17,7 +17,7 @@ import {
 	wikiLinkAttrsToMarkdown,
 } from "../markdown/wikiLinkCodec";
 import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
-import { lockEditorScrollDuringSuggestion } from "../suggestionScroll";
+import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const WIKI_LINK_INPUT_REGEX = /(!?\[\[[^\]\n]+\]\])$/;
 const WIKI_LINK_PASTE_REGEX = /(!?\[\[[^\]\n]+\]\])/g;
@@ -309,29 +309,14 @@ export const WikiLink = Node.create({
 						.insertContent(" ")
 						.run();
 				},
-				render: () => {
-					let menu: HTMLDivElement | null = null;
-					let selectedIndex = 0;
-					let activeProps: SuggestionProps<EditorLinkSuggestion> | null = null;
-					let unlockEditorScroll: (() => void) | null = null;
-
-					const updateSelection = (items: EditorLinkSuggestion[]) => {
-						if (!menu) return;
-						const children = Array.from(menu.children);
-						children.forEach((child, index) => {
-							child.classList.toggle("active", index === selectedIndex);
-						});
-						if (!items.length) selectedIndex = 0;
-					};
-
-					const updateMenu = (props: SuggestionProps<EditorLinkSuggestion>) => {
-						if (!menu) return;
-						menu.replaceChildren();
-						if (!props.items.length) return;
-						for (const [index, item] of props.items.entries()) {
+				render: () =>
+					createTipTapSuggestionMenu<EditorLinkSuggestion>({
+						menuClassName: "wikiLinkSuggestionMenu",
+						renderItem: ({ item, isActive, select }) => {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "wikiLinkSuggestionItem";
+							button.classList.toggle("active", isActive);
 
 							const title = document.createElement("span");
 							title.className = "wikiLinkSuggestionTitle";
@@ -344,86 +329,11 @@ export const WikiLink = Node.create({
 							button.append(title, path);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
-								props.command(item);
+								select(item);
 							});
-							if (index === selectedIndex) button.classList.add("active");
-							menu.append(button);
-						}
-						const rect = props.clientRect?.();
-						if (rect && menu) {
-							const pad = 8;
-							const gap = 6;
-							const menuRect = menu.getBoundingClientRect();
-							const placeBelowTop = rect.bottom + gap;
-							const placeAboveTop = rect.top - menuRect.height - gap;
-							const maxLeft = window.innerWidth - menuRect.width - pad;
-							const maxTop = window.innerHeight - menuRect.height - pad;
-							const nextLeft = Math.max(pad, Math.min(rect.left, maxLeft));
-							const nextTop =
-								placeBelowTop <= maxTop
-									? placeBelowTop
-									: Math.max(pad, Math.min(placeAboveTop, maxTop));
-							menu.style.left = `${nextLeft}px`;
-							menu.style.top = `${nextTop}px`;
-						}
-					};
-
-					const createMenu = (props: SuggestionProps<EditorLinkSuggestion>) => {
-						if (menu) menu.remove();
-						menu = document.createElement("div");
-						menu.className = "wikiLinkSuggestionMenu";
-						document.body.append(menu);
-						updateMenu(props);
-					};
-
-					return {
-						onStart: (props: SuggestionProps<EditorLinkSuggestion>) => {
-							activeProps = props;
-							selectedIndex = 0;
-							unlockEditorScroll?.();
-							unlockEditorScroll = lockEditorScrollDuringSuggestion(
-								props.editor,
-								() => menu,
-							);
-							createMenu(props);
+							return button;
 						},
-						onUpdate: (props: SuggestionProps<EditorLinkSuggestion>) => {
-							activeProps = props;
-							if (!menu) createMenu(props);
-							updateMenu(props);
-						},
-						onKeyDown: ({ event }) => {
-							const current = activeProps;
-							if (!current?.items.length) return false;
-							if (event.key === "ArrowDown") {
-								selectedIndex = (selectedIndex + 1) % current.items.length;
-								updateSelection(current.items);
-								return true;
-							}
-							if (event.key === "ArrowUp") {
-								selectedIndex =
-									(selectedIndex - 1 + current.items.length) %
-									current.items.length;
-								updateSelection(current.items);
-								return true;
-							}
-							if (event.key === "Enter" || event.key === "Tab") {
-								event.preventDefault();
-								current.command(current.items[selectedIndex]);
-								return true;
-							}
-							if (event.key === "Escape") return true;
-							return false;
-						},
-						onExit: () => {
-							unlockEditorScroll?.();
-							unlockEditorScroll = null;
-							if (menu) menu.remove();
-							menu = null;
-							activeProps = null;
-						},
-					};
-				},
+					}),
 			}),
 		];
 	},

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -23,6 +23,7 @@ import { parentDir } from "../../../utils/path";
 import { handleEditorClick } from "../editorClickHandlers";
 import { createEditorExtensions } from "../extensions";
 import type { MathEditRequest } from "../extensions/math/mathOptions";
+import { handleTagDecorationMouseDown } from "../extensions/tagDecorations";
 import { looksLikeMarkdownPaste } from "../markdown/markdownPaste";
 import {
 	postprocessMarkdownFromEditor,
@@ -502,6 +503,10 @@ export function useNoteEditor({
 					spellcheck: "true",
 				},
 				handleDOMEvents: {
+					mousedown: (_view, event): boolean => {
+						if (!(event instanceof MouseEvent)) return false;
+						return handleTagDecorationMouseDown(event);
+					},
 					click: (view, event): boolean => {
 						if (!(event instanceof MouseEvent)) return false;
 						return handleEditorClick(

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -1,17 +1,15 @@
-import type { KeyboardEvent, RefObject } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useCallback, useMemo } from "react";
 import {
 	type EditorLinkSuggestion,
 	suggestWikiLinks,
 } from "../../../lib/linkSuggestions";
+import {
+	type SuggestionRange,
+	useInputSuggestionEngine,
+} from "../suggestions/suggestionEngine";
 
 const WIKI_LINK_SUGGESTION_LIMIT = 8;
-
-interface WikiLinkRange {
-	from: number;
-	to: number;
-	query: string;
-}
 
 interface UseWikiLinkAutocompleteOptions {
 	enabled: boolean;
@@ -24,7 +22,7 @@ interface UseWikiLinkAutocompleteOptions {
 function findActiveWikiLinkRange(
 	value: string,
 	selectionStart: number | null,
-): WikiLinkRange | null {
+): SuggestionRange | null {
 	if (selectionStart == null) return null;
 	const beforeCursor = value.slice(0, selectionStart);
 	const openIndex = beforeCursor.lastIndexOf("[[");
@@ -48,76 +46,31 @@ export function useWikiLinkAutocomplete({
 	onChange,
 	onSelectItem,
 }: UseWikiLinkAutocompleteOptions) {
-	const requestIdRef = useRef(0);
-	const [range, setRange] = useState<WikiLinkRange | null>(null);
-	const [items, setItems] = useState<EditorLinkSuggestion[]>([]);
-	const [activeIndex, setActiveIndex] = useState(0);
-
-	const close = useCallback(() => {
-		requestIdRef.current += 1;
-		setRange(null);
-		setItems([]);
-		setActiveIndex(0);
-	}, []);
-
-	const refresh = useCallback(
-		(nextValue: string, selectionStart: number | null) => {
-			if (!enabled) {
-				close();
-				return;
-			}
-
-			const nextRange = findActiveWikiLinkRange(nextValue, selectionStart);
-			if (!nextRange) {
-				close();
-				return;
-			}
-
-			const requestId = requestIdRef.current + 1;
-			requestIdRef.current = requestId;
-			setRange(nextRange);
-			setActiveIndex(0);
-			setItems([]);
-
-			void suggestWikiLinks({
-				query: nextRange.query,
-				includeAttachments: false,
-				limit: WIKI_LINK_SUGGESTION_LIMIT,
-			})
-				.then((results) => {
-					if (requestIdRef.current !== requestId) return;
-					setItems(results);
-				})
-				.catch((error) => {
-					if (requestIdRef.current !== requestId) return;
-					console.warn("Failed to load wikilink suggestions", error);
-					setItems([]);
-				});
-		},
-		[close, enabled],
+	const provider = useMemo(
+		() => ({
+			id: "wiki-link",
+			limit: WIKI_LINK_SUGGESTION_LIMIT,
+			getItems: (query: string) =>
+				suggestWikiLinks({
+					query,
+					includeAttachments: false,
+					limit: WIKI_LINK_SUGGESTION_LIMIT,
+				}),
+		}),
+		[],
 	);
-
-	useEffect(() => {
-		const input = inputRef.current;
-		if (!input || document.activeElement !== input) return;
-		refresh(value, input.selectionStart);
-	}, [inputRef, refresh, value]);
-
-	const select = useCallback(
-		(item: EditorLinkSuggestion) => {
+	const handleSelect = useCallback(
+		(item: EditorLinkSuggestion, range: SuggestionRange) => {
 			if (onSelectItem) {
 				onSelectItem(item);
-				close();
 				return;
 			}
-			if (!range) return;
 			const markdown = `[[${item.insertText}]]`;
 			const nextValue = `${value.slice(0, range.from)}${markdown}${value.slice(
 				range.to,
 			)}`;
 			const nextCursor = range.from + markdown.length;
 			onChange(nextValue);
-			close();
 			requestAnimationFrame(() => {
 				const input = inputRef.current;
 				if (!input) return;
@@ -125,45 +78,14 @@ export function useWikiLinkAutocomplete({
 				input.setSelectionRange(nextCursor, nextCursor);
 			});
 		},
-		[close, inputRef, onChange, onSelectItem, range, value],
+		[inputRef, onChange, onSelectItem, value],
 	);
-
-	const handleKeyDown = useCallback(
-		(event: KeyboardEvent<HTMLInputElement>) => {
-			if (!items.length) return false;
-			if (event.key === "ArrowDown") {
-				event.preventDefault();
-				setActiveIndex((current) => (current + 1) % items.length);
-				return true;
-			}
-			if (event.key === "ArrowUp") {
-				event.preventDefault();
-				setActiveIndex(
-					(current) => (current - 1 + items.length) % items.length,
-				);
-				return true;
-			}
-			if (event.key === "Enter" || event.key === "Tab") {
-				event.preventDefault();
-				select(items[activeIndex] ?? items[0]);
-				return true;
-			}
-			if (event.key === "Escape") {
-				event.preventDefault();
-				close();
-				return true;
-			}
-			return false;
-		},
-		[activeIndex, close, items, select],
-	);
-
-	return {
-		activeIndex,
-		close,
-		handleKeyDown,
-		items,
-		refresh,
-		select,
-	};
+	return useInputSuggestionEngine({
+		enabled,
+		inputRef,
+		value,
+		provider,
+		findRange: findActiveWikiLinkRange,
+		onSelect: handleSelect,
+	});
 }

--- a/src/components/editor/slashCommands.ts
+++ b/src/components/editor/slashCommands.ts
@@ -1,17 +1,16 @@
 import { type Editor, Extension } from "@tiptap/core";
 import type { EditorState } from "@tiptap/pm/state";
-import Suggestion, {
-	exitSuggestion,
-	type SuggestionKeyDownProps,
-	type SuggestionProps,
-} from "@tiptap/suggestion";
+import Suggestion from "@tiptap/suggestion";
 import {
 	BLOCK_MATH_STARTER,
 	INLINE_MATH_STARTER,
 	type MathEditRequest,
 } from "./extensions/math/mathOptions";
 import { INLINE_TOC_EDITOR_MARKER } from "./markdown/inlineTocMarkdown";
-import { lockEditorScrollDuringSuggestion } from "./suggestionScroll";
+import {
+	createTipTapSuggestionMenu,
+	exitTipTapSuggestion,
+} from "./suggestions/tiptapSuggestionMenu";
 import { EDITOR_TEXT_COLORS } from "./textColors";
 import { EDITOR_TEXT_HIGHLIGHTS } from "./textHighlights";
 
@@ -27,21 +26,10 @@ interface SlashCommandItem {
 	}) => void;
 }
 
-function clampSlashCommandIndex(index: number, itemCount: number) {
-	if (itemCount <= 0) return 0;
-	if (index < 0) return itemCount - 1;
-	if (index >= itemCount) return 0;
-	return index;
-}
-
-function slashCommandSearchText(item: SlashCommandItem) {
-	return [item.title, ...item.keywords].join(" ").toLowerCase();
-}
-
 function slashCommandMatchesQuery(item: SlashCommandItem, query: string) {
 	const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
 	if (!terms.length) return true;
-	const searchText = slashCommandSearchText(item);
+	const searchText = [item.title, ...item.keywords].join(" ").toLowerCase();
 	return terms.every((term) => searchText.includes(term));
 }
 
@@ -405,46 +393,15 @@ export const SlashCommand = Extension.create({
 						slashCommandMatchesQuery(item, query),
 					);
 				},
-				render: () => {
-					let menu: HTMLDivElement | null = null;
-					let selectedIndex = 0;
-					let currentProps: SuggestionProps<SlashCommandItem> | null = null;
-					let unlockEditorScroll: (() => void) | null = null;
-
-					const updateSelection = (items: SlashCommandItem[]) => {
-						if (!menu) return;
-						selectedIndex = clampSlashCommandIndex(selectedIndex, items.length);
-						const children = Array.from(menu.children);
-						children.forEach((child, index) => {
-							child.classList.toggle("active", index === selectedIndex);
-						});
-						const activeItem = children[selectedIndex];
-						if (activeItem instanceof HTMLElement) {
-							activeItem.scrollIntoView({ block: "nearest" });
-						}
-					};
-
-					const createMenu = (props: SuggestionProps<SlashCommandItem>) => {
-						if (menu) menu.remove();
-						menu = document.createElement("div");
-						menu.className = "slashCommandMenu";
-						document.body.append(menu);
-						updateMenu(props);
-					};
-
-					const updateMenu = (props: SuggestionProps<SlashCommandItem>) => {
-						if (!menu) return;
-						currentProps = props;
-						selectedIndex = clampSlashCommandIndex(
-							selectedIndex,
-							props.items.length,
-						);
-						menu.replaceChildren();
-						if (!props.items.length) return;
-						for (const [index, item] of props.items.entries()) {
+				render: () =>
+					createTipTapSuggestionMenu<SlashCommandItem>({
+						menuClassName: "slashCommandMenu",
+						onEscape: exitTipTapSuggestion,
+						renderItem: ({ item, isActive, select }) => {
 							const button = document.createElement("button");
 							button.type = "button";
 							button.className = "slashCommandItem";
+							button.classList.toggle("active", isActive);
 							const icon = document.createElement("span");
 							icon.className = "slashCommandIcon";
 							icon.textContent = item.icon;
@@ -454,85 +411,11 @@ export const SlashCommand = Extension.create({
 							button.append(icon, title);
 							button.addEventListener("mousedown", (event) => {
 								event.preventDefault();
-								props.command(item);
+								select(item);
 							});
-							if (index === selectedIndex) {
-								button.classList.add("active");
-							}
-							menu?.append(button);
-						}
-						const rect = props.clientRect?.();
-						if (rect && menu) {
-							const pad = 8;
-							const gap = 6;
-							const menuRect = menu.getBoundingClientRect();
-							const placeBelowTop = rect.bottom + gap;
-							const placeAboveTop = rect.top - menuRect.height - gap;
-							const maxLeft = window.innerWidth - menuRect.width - pad;
-							const maxTop = window.innerHeight - menuRect.height - pad;
-							const nextLeft = Math.max(pad, Math.min(rect.left, maxLeft));
-							const nextTop =
-								placeBelowTop <= maxTop
-									? placeBelowTop
-									: Math.max(pad, Math.min(placeAboveTop, maxTop));
-							menu.style.left = `${nextLeft}px`;
-							menu.style.top = `${nextTop}px`;
-						}
-					};
-
-					return {
-						onStart: (props: SuggestionProps<SlashCommandItem>) => {
-							selectedIndex = 0;
-							currentProps = props;
-							unlockEditorScroll?.();
-							unlockEditorScroll = lockEditorScrollDuringSuggestion(
-								props.editor,
-								() => menu,
-							);
-							createMenu(props);
+							return button;
 						},
-						onUpdate: (props: SuggestionProps<SlashCommandItem>) => {
-							if (!menu) createMenu(props);
-							updateMenu(props);
-						},
-						onKeyDown: (props: SuggestionKeyDownProps) => {
-							const items = currentProps?.items ?? [];
-							if (!items.length) return false;
-							if (props.event.key === "ArrowDown") {
-								selectedIndex = clampSlashCommandIndex(
-									selectedIndex + 1,
-									items.length,
-								);
-								updateSelection(items);
-								return true;
-							}
-							if (props.event.key === "ArrowUp") {
-								selectedIndex = clampSlashCommandIndex(
-									selectedIndex - 1,
-									items.length,
-								);
-								updateSelection(items);
-								return true;
-							}
-							if (props.event.key === "Enter" || props.event.key === "Tab") {
-								currentProps?.command(items[selectedIndex]);
-								return true;
-							}
-							if (props.event.key === "Escape") {
-								exitSuggestion(props.view);
-								return true;
-							}
-							return false;
-						},
-						onExit: () => {
-							unlockEditorScroll?.();
-							unlockEditorScroll = null;
-							if (menu) menu.remove();
-							menu = null;
-							currentProps = null;
-						},
-					};
-				},
+					}),
 			},
 		};
 	},

--- a/src/components/editor/suggestionScroll.ts
+++ b/src/components/editor/suggestionScroll.ts
@@ -16,7 +16,6 @@ export function lockEditorScrollDuringSuggestion(
 
 	const scrollTop = host.scrollTop;
 	const scrollLeft = host.scrollLeft;
-	const overflow = host.style.overflow;
 
 	const restoreScroll = () => {
 		host.scrollTop = scrollTop;
@@ -29,7 +28,6 @@ export function lockEditorScrollDuringSuggestion(
 		event.preventDefault();
 	};
 
-	host.style.overflow = "hidden";
 	host.addEventListener("scroll", restoreScroll);
 	document.addEventListener("wheel", preventDocumentScroll, {
 		capture: true,
@@ -42,7 +40,6 @@ export function lockEditorScrollDuringSuggestion(
 	restoreScroll();
 
 	return () => {
-		host.style.overflow = overflow;
 		host.removeEventListener("scroll", restoreScroll);
 		document.removeEventListener("wheel", preventDocumentScroll, {
 			capture: true,

--- a/src/components/editor/suggestions/suggestionEngine.ts
+++ b/src/components/editor/suggestions/suggestionEngine.ts
@@ -145,6 +145,11 @@ export function useInputSuggestionEngine<T>({
 
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === "Escape" && range) {
+				event.preventDefault();
+				close();
+				return true;
+			}
 			if (!items.length) return false;
 			if (event.key === "ArrowDown") {
 				event.preventDefault();
@@ -165,14 +170,9 @@ export function useInputSuggestionEngine<T>({
 				select(items[activeIndex] ?? items[0]);
 				return true;
 			}
-			if (event.key === "Escape") {
-				event.preventDefault();
-				close();
-				return true;
-			}
 			return false;
 		},
-		[activeIndex, close, items, select],
+		[activeIndex, close, items, range, select],
 	);
 
 	return {

--- a/src/components/editor/suggestions/suggestionEngine.ts
+++ b/src/components/editor/suggestions/suggestionEngine.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { KeyboardEvent, RefObject } from "react";
+
+export type SuggestionResult<T> = T[] | Promise<T[]>;
+
+export interface SuggestionProvider<T> {
+	id: string;
+	limit?: number;
+	getItems: (query: string) => SuggestionResult<T>;
+	filter?: (item: T, query: string) => boolean;
+	sort?: (left: T, right: T, query: string) => number;
+}
+
+export interface SuggestionRange {
+	from: number;
+	to: number;
+	query: string;
+}
+
+export interface UseInputSuggestionEngineOptions<T> {
+	enabled: boolean;
+	inputRef: RefObject<HTMLInputElement | null>;
+	value: string;
+	provider: SuggestionProvider<T>;
+	findRange: (
+		value: string,
+		selectionStart: number | null,
+	) => SuggestionRange | null;
+	onSelect: (item: T, range: SuggestionRange) => void;
+}
+
+export function clampSuggestionIndex(index: number, itemCount: number): number {
+	if (itemCount <= 0) return 0;
+	if (index < 0) return itemCount - 1;
+	if (index >= itemCount) return 0;
+	return index;
+}
+
+export function nextSuggestionIndex(
+	currentIndex: number,
+	itemCount: number,
+	direction: 1 | -1,
+): number {
+	return clampSuggestionIndex(currentIndex + direction, itemCount);
+}
+
+export function queryMatchesText(query: string, searchText: string): boolean {
+	const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+	if (!terms.length) return true;
+	const haystack = searchText.toLowerCase();
+	return terms.every((term) => haystack.includes(term));
+}
+
+export async function resolveSuggestionItems<T>(
+	provider: SuggestionProvider<T>,
+	query: string,
+): Promise<T[]> {
+	const items = await provider.getItems(query);
+	return applySuggestionTransforms(provider, query, items);
+}
+
+function applySuggestionTransforms<T>(
+	provider: SuggestionProvider<T>,
+	query: string,
+	items: T[],
+): T[] {
+	const filtered = provider.filter
+		? items.filter((item) => provider.filter?.(item, query) ?? true)
+		: items;
+	const sorted = provider.sort
+		? [...filtered].sort(
+				(left, right) => provider.sort?.(left, right, query) ?? 0,
+			)
+		: filtered;
+	return sorted.slice(0, provider.limit ?? sorted.length);
+}
+
+export function useInputSuggestionEngine<T>({
+	enabled,
+	inputRef,
+	value,
+	provider,
+	findRange,
+	onSelect,
+}: UseInputSuggestionEngineOptions<T>) {
+	const requestIdRef = useRef(0);
+	const [range, setRange] = useState<SuggestionRange | null>(null);
+	const [items, setItems] = useState<T[]>([]);
+	const [activeIndex, setActiveIndex] = useState(0);
+
+	const close = useCallback(() => {
+		requestIdRef.current += 1;
+		setRange(null);
+		setItems([]);
+		setActiveIndex(0);
+	}, []);
+
+	const refresh = useCallback(
+		(nextValue: string, selectionStart: number | null) => {
+			if (!enabled) {
+				close();
+				return;
+			}
+
+			const nextRange = findRange(nextValue, selectionStart);
+			if (!nextRange) {
+				close();
+				return;
+			}
+
+			const requestId = requestIdRef.current + 1;
+			requestIdRef.current = requestId;
+			setRange(nextRange);
+			setActiveIndex(0);
+			setItems([]);
+
+			void resolveSuggestionItems(provider, nextRange.query)
+				.then((results) => {
+					if (requestIdRef.current !== requestId) return;
+					setItems(results);
+				})
+				.catch((error) => {
+					if (requestIdRef.current !== requestId) return;
+					console.warn(`Failed to load ${provider.id} suggestions`, error);
+					setItems([]);
+				});
+		},
+		[close, enabled, findRange, provider],
+	);
+
+	useEffect(() => {
+		const input = inputRef.current;
+		if (!input || document.activeElement !== input) return;
+		refresh(value, input.selectionStart);
+	}, [inputRef, refresh, value]);
+
+	const select = useCallback(
+		(item: T) => {
+			if (!range) return;
+			onSelect(item, range);
+			close();
+		},
+		[close, onSelect, range],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent<HTMLInputElement>) => {
+			if (!items.length) return false;
+			if (event.key === "ArrowDown") {
+				event.preventDefault();
+				setActiveIndex((current) =>
+					nextSuggestionIndex(current, items.length, 1),
+				);
+				return true;
+			}
+			if (event.key === "ArrowUp") {
+				event.preventDefault();
+				setActiveIndex((current) =>
+					nextSuggestionIndex(current, items.length, -1),
+				);
+				return true;
+			}
+			if (event.key === "Enter" || event.key === "Tab") {
+				event.preventDefault();
+				select(items[activeIndex] ?? items[0]);
+				return true;
+			}
+			if (event.key === "Escape") {
+				event.preventDefault();
+				close();
+				return true;
+			}
+			return false;
+		},
+		[activeIndex, close, items, select],
+	);
+
+	return {
+		activeIndex,
+		close,
+		handleKeyDown,
+		items,
+		range,
+		refresh,
+		select,
+	};
+}

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -63,7 +63,13 @@ export function createTipTapSuggestionMenu<T>({
 		});
 		const activeItem = children[selectedIndex];
 		if (activeItem instanceof HTMLElement) {
-			activeItem.scrollIntoView({ block: "nearest" });
+			const menuRect = menu.getBoundingClientRect();
+			const itemRect = activeItem.getBoundingClientRect();
+			if (itemRect.top < menuRect.top) {
+				menu.scrollTop -= menuRect.top - itemRect.top;
+			} else if (itemRect.bottom > menuRect.bottom) {
+				menu.scrollTop += itemRect.bottom - menuRect.bottom;
+			}
 		}
 	};
 
@@ -118,8 +124,12 @@ export function createTipTapSuggestionMenu<T>({
 			const current = activeProps;
 			const items = current?.items ?? [];
 			if (event.key === "Escape") {
-				if (!onEscape) return false;
-				onEscape(view);
+				event.preventDefault();
+				if (onEscape) {
+					onEscape(view);
+				} else {
+					exitSuggestion(view);
+				}
 				return true;
 			}
 			if (!items.length) return false;

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -1,0 +1,155 @@
+import type { Editor } from "@tiptap/core";
+import type { EditorView } from "@tiptap/pm/view";
+import {
+	type SuggestionKeyDownProps,
+	type SuggestionProps,
+	exitSuggestion,
+} from "@tiptap/suggestion";
+import { lockEditorScrollDuringSuggestion } from "../suggestionScroll";
+import { clampSuggestionIndex, nextSuggestionIndex } from "./suggestionEngine";
+
+interface RenderTipTapSuggestionItemOptions<T> {
+	item: T;
+	index: number;
+	isActive: boolean;
+	select: (item: T) => void;
+}
+
+interface TipTapSuggestionMenuOptions<T> {
+	menuClassName: string;
+	itemActiveClassName?: string;
+	renderItem: (options: RenderTipTapSuggestionItemOptions<T>) => HTMLElement;
+	lockEditorScroll?: boolean;
+	resetSelectionOnUpdate?: boolean;
+	onEscape?: (view: EditorView) => void;
+}
+
+function placeMenu(menu: HTMLElement, rect: DOMRect): void {
+	const pad = 8;
+	const gap = 6;
+	const menuRect = menu.getBoundingClientRect();
+	const placeBelowTop = rect.bottom + gap;
+	const placeAboveTop = rect.top - menuRect.height - gap;
+	const maxLeft = window.innerWidth - menuRect.width - pad;
+	const maxTop = window.innerHeight - menuRect.height - pad;
+	const nextLeft = Math.max(pad, Math.min(rect.left, maxLeft));
+	const nextTop =
+		placeBelowTop <= maxTop
+			? placeBelowTop
+			: Math.max(pad, Math.min(placeAboveTop, maxTop));
+	menu.style.left = `${nextLeft}px`;
+	menu.style.top = `${nextTop}px`;
+}
+
+export function createTipTapSuggestionMenu<T>({
+	menuClassName,
+	itemActiveClassName = "active",
+	renderItem,
+	lockEditorScroll = true,
+	resetSelectionOnUpdate = false,
+	onEscape,
+}: TipTapSuggestionMenuOptions<T>) {
+	let menu: HTMLDivElement | null = null;
+	let selectedIndex = 0;
+	let activeProps: SuggestionProps<T> | null = null;
+	let unlockEditorScroll: (() => void) | null = null;
+
+	const updateSelection = (items: T[]) => {
+		if (!menu) return;
+		selectedIndex = clampSuggestionIndex(selectedIndex, items.length);
+		const children = Array.from(menu.children);
+		children.forEach((child, index) => {
+			child.classList.toggle(itemActiveClassName, index === selectedIndex);
+		});
+		const activeItem = children[selectedIndex];
+		if (activeItem instanceof HTMLElement) {
+			activeItem.scrollIntoView({ block: "nearest" });
+		}
+	};
+
+	const updateMenu = (props: SuggestionProps<T>) => {
+		if (!menu) return;
+		activeProps = props;
+		selectedIndex = clampSuggestionIndex(selectedIndex, props.items.length);
+		menu.replaceChildren();
+		menu.style.display = props.items.length ? "" : "none";
+		for (const [index, item] of props.items.entries()) {
+			menu.append(
+				renderItem({
+					item,
+					index,
+					isActive: index === selectedIndex,
+					select: (nextItem) => props.command(nextItem),
+				}),
+			);
+		}
+		const rect = props.clientRect?.();
+		if (rect && props.items.length) placeMenu(menu, rect);
+	};
+
+	const createMenu = (props: SuggestionProps<T>) => {
+		menu?.remove();
+		menu = document.createElement("div");
+		menu.className = menuClassName;
+		document.body.append(menu);
+		updateMenu(props);
+	};
+
+	return {
+		onStart: (props: SuggestionProps<T>) => {
+			activeProps = props;
+			selectedIndex = 0;
+			unlockEditorScroll?.();
+			if (lockEditorScroll) {
+				unlockEditorScroll = lockEditorScrollDuringSuggestion(
+					props.editor as Editor,
+					() => menu,
+				);
+			}
+			createMenu(props);
+		},
+		onUpdate: (props: SuggestionProps<T>) => {
+			activeProps = props;
+			if (resetSelectionOnUpdate) selectedIndex = 0;
+			if (!menu) createMenu(props);
+			updateMenu(props);
+		},
+		onKeyDown: ({ event, view }: SuggestionKeyDownProps) => {
+			const current = activeProps;
+			const items = current?.items ?? [];
+			if (event.key === "Escape") {
+				if (!onEscape) return false;
+				onEscape(view);
+				return true;
+			}
+			if (!items.length) return false;
+			if (event.key === "ArrowDown") {
+				selectedIndex = nextSuggestionIndex(selectedIndex, items.length, 1);
+				updateSelection(items);
+				return true;
+			}
+			if (event.key === "ArrowUp") {
+				selectedIndex = nextSuggestionIndex(selectedIndex, items.length, -1);
+				updateSelection(items);
+				return true;
+			}
+			if (event.key === "Enter" || event.key === "Tab") {
+				event.preventDefault();
+				current?.command(items[selectedIndex] ?? items[0]);
+				return true;
+			}
+			return false;
+		},
+		onExit: () => {
+			unlockEditorScroll?.();
+			unlockEditorScroll = null;
+			menu?.remove();
+			menu = null;
+			activeProps = null;
+		},
+	};
+}
+
+export function exitTipTapSuggestion(view: EditorView): void {
+	exitSuggestion(view);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -988,7 +988,7 @@ interface TauriCommands {
 		CalendarDateNote[]
 	>;
 	tags_list: CommandDef<
-		{ limit?: number | null; offset?: number | null },
+		{ limit?: number | null; offset?: number | null; query?: string | null },
 		TagCount[]
 	>;
 	people_list: CommandDef<


### PR DESCRIPTION
## Summary

This PR creates a shared editor suggestion system and uses it across the main autocomplete surfaces in the note editor.

What changed:

- Added a reusable input suggestion engine for text inputs, including request cancellation, active item tracking, keyboard navigation, and item selection.
- Added a reusable TipTap suggestion menu renderer that handles popup placement, active item updates, keyboard behavior, scroll locking, and cleanup.
- Refactored wiki link, markdown link, person mention, and slash command suggestions to use the shared menu instead of each owning duplicate menu state.
- Added inline `#tag` autocomplete in the TipTap editor, backed by indexed explicit tags and a create-new-tag fallback.
- Updated tag/person decoration mouse handling so clicking decorated tokens does not interfere with editor selection.
- Kept editor scroll locking behavior, but removed the direct overflow mutation that caused heavier layout side effects.

## Why

The editor had several suggestion implementations that all solved the same problems independently: popup creation, viewport placement, selected-index wrapping, keyboard handling, scroll locking, and teardown.

That duplication made small behavior fixes easy to miss in one autocomplete surface. Moving the shared behavior into one implementation makes wiki links, markdown links, people, tags, and slash commands easier to maintain and keeps their interaction model consistent.

## Impact

For users:

- Slash commands and link/person suggestions should feel the same as before, but now share more consistent keyboard and popup behavior.
- Inline `#tag` autocomplete is now available while editing notes.
- Existing explicit tags are suggested and ranked, and users can still create a new tag from the typed token.

For developers:

- New TipTap suggestion menus can be added with `createTipTapSuggestionMenu` instead of copying popup lifecycle code.
- Input-based autocomplete can use `useInputSuggestionEngine` for cancellation, keyboard navigation, and selection state.
- The old duplicated menu bookkeeping was removed from several editor extensions.

## Root Cause

This was not a bug fix for one failing path. The root issue was that suggestion UI behavior had grown independently in multiple files, which made the editor harder to extend and made interaction fixes more expensive than they needed to be.

## Validation

I validated the change with:

- `git diff --cached --check`
- `./node_modules/.bin/biome check .`
- `./node_modules/.bin/tsc && ./node_modules/.bin/vite build`
- `cargo check` from `src-tauri/`

Note: the documented `pnpm check && pnpm build && cd src-tauri && cargo check` pre-push command could not run directly in this noninteractive environment because pnpm stopped before project scripts while checking dependency install/build-script approvals. I reran the equivalent project checks through the local installed binaries instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag autocomplete in the editor, including suggestions for existing tags and an option to create a new tag.
  * Improved mention, wiki link, markdown link, and slash-command suggestion menus with more consistent navigation and selection.

* **Bug Fixes**
  * Updated editor interactions so clicking suggestion tokens behaves more reliably.
  * Improved scrolling behavior while suggestion menus are open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->