### PR TITLE
Support multiline table cell content

### DIFF
--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -1,11 +1,6 @@
 import { type AnyExtension, Extension } from "@tiptap/core";
 import Link from "@tiptap/extension-link";
-import {
-	Table,
-	TableCell,
-	TableHeader,
-	TableRow,
-} from "@tiptap/extension-table";
+import { TableCell, TableHeader, TableRow } from "@tiptap/extension-table";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Markdown } from "@tiptap/markdown";
@@ -36,6 +31,7 @@ import type { MathEditRequest } from "./math/mathOptions";
 import { MermaidPreview } from "./mermaidPreview";
 import { NoteSearch } from "./noteSearch";
 import { PersonAutocomplete } from "./personAutocomplete";
+import { GlyphTable } from "./tableMarkdown";
 import { TagAutocomplete } from "./tagAutocomplete";
 import { TagDecorations } from "./tagDecorations";
 import { VimMode } from "./vimMode";
@@ -562,56 +558,6 @@ const TaskDetailShortcut = Extension.create({
 	},
 });
 
-const TableEnterNavigation = Extension.create({
-	name: "table-enter-navigation",
-	addKeyboardShortcuts() {
-		return {
-			Enter: () => {
-				const { editor } = this;
-				if (!editor.isEditable || !editor.isActive("table")) return false;
-
-				const { $from } = editor.state.selection;
-				let cellDepth = -1;
-				let rowDepth = -1;
-				let tableDepth = -1;
-
-				for (let depth = $from.depth; depth > 0; depth -= 1) {
-					const node = $from.node(depth);
-					if (
-						cellDepth === -1 &&
-						(node.type.name === "tableCell" || node.type.name === "tableHeader")
-					) {
-						cellDepth = depth;
-					}
-					if (rowDepth === -1 && node.type.name === "tableRow") {
-						rowDepth = depth;
-					}
-					if (node.type.name === "table") {
-						tableDepth = depth;
-						break;
-					}
-				}
-
-				if (cellDepth === -1 || rowDepth === -1 || tableDepth === -1)
-					return false;
-
-				const rowNode = $from.node(rowDepth);
-				const tableNode = $from.node(tableDepth);
-				const isLastCellInRow =
-					$from.index(rowDepth) === rowNode.childCount - 1;
-				const isLastRowInTable =
-					$from.index(tableDepth) === tableNode.childCount - 1;
-
-				if (isLastCellInRow && isLastRowInTable) {
-					return editor.chain().focus().addRowAfter().goToNextCell().run();
-				}
-
-				return editor.commands.goToNextCell();
-			},
-		};
-	},
-});
-
 interface EditorPlaceholderOptions {
 	placeholder: string;
 }
@@ -718,10 +664,9 @@ export function createEditorExtensions(
 					MarkdownLinkSyntaxCollapse,
 					MarkdownImageLivePreview,
 					NoteSearch,
-					TableEnterNavigation,
 				]
 			: []),
-		Table.configure({ resizable: enableEditingExtensions }),
+		GlyphTable.configure({ resizable: enableEditingExtensions }),
 		TableRow,
 		TableHeader,
 		TableCell,

--- a/src/components/editor/extensions/table.integration.test.ts
+++ b/src/components/editor/extensions/table.integration.test.ts
@@ -55,6 +55,32 @@ function findFirstTableCellPos(editor: Editor) {
 	return match;
 }
 
+function press(editor: Editor, key: string) {
+	const event = new KeyboardEvent("keydown", {
+		bubbles: true,
+		cancelable: true,
+		key,
+		code: key,
+	});
+	editor.commands.focus();
+	editor.view.dom.dispatchEvent(event);
+	return event.defaultPrevented;
+}
+
+function firstCellContent(editor: Editor) {
+	const cellPos = findFirstTableCellPos(editor);
+	expect(cellPos).toBeGreaterThan(-1);
+	return editor.state.doc.nodeAt(cellPos)?.content.toJSON();
+}
+
+function firstTableCellContent(markdown: string) {
+	const manager = createMarkdownManager();
+	const json = manager.parse(markdown);
+	const table = json.content?.find((node) => node.type === "table");
+	const firstCell = table?.content?.[0]?.content?.[0];
+	return firstCell?.content;
+}
+
 function tableShape(markdown: string) {
 	const manager = createMarkdownManager();
 	const json = manager.parse(markdown);
@@ -85,6 +111,107 @@ describe("Table markdown integration", () => {
 		expect(output).toContain("| Name");
 		expect(output).toContain("| Ada");
 		expect(output).toContain("| Lin");
+	});
+
+	it("lets Enter create a new paragraph inside a table cell", () => {
+		const input = [
+			"| Name | Role |",
+			"| --- | --- |",
+			"| Ada | Engineer |",
+		].join("\n");
+		const harness = createEditor(input);
+
+		try {
+			const cellPos = findFirstTableCellPos(harness.editor);
+			expect(cellPos).toBeGreaterThan(-1);
+
+			harness.editor.commands.setTextSelection(cellPos + 5);
+			expect(press(harness.editor, "Enter")).toBe(true);
+
+			expect(firstCellContent(harness.editor)).toEqual([
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "Nam" }],
+				},
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "e" }],
+				},
+			]);
+			expect(firstTableCellContent(harness.editor.getMarkdown())).toEqual([
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "Nam" }],
+				},
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "e" }],
+				},
+			]);
+		} finally {
+			harness.destroy();
+		}
+	});
+
+	it("lets Enter create another bullet item inside a table cell", () => {
+		const input = [
+			"| Name | Role |",
+			"| --- | --- |",
+			"| Ada | Engineer |",
+		].join("\n");
+		const harness = createEditor(input);
+
+		try {
+			const cellPos = findFirstTableCellPos(harness.editor);
+			expect(cellPos).toBeGreaterThan(-1);
+
+			harness.editor.commands.setTextSelection(cellPos + 6);
+			expect(harness.editor.commands.toggleBulletList()).toBe(true);
+			expect(press(harness.editor, "Enter")).toBe(true);
+
+			expect(firstCellContent(harness.editor)).toEqual([
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "Name" }],
+								},
+							],
+						},
+						{
+							type: "listItem",
+							content: [{ type: "paragraph" }],
+						},
+					],
+				},
+			]);
+			expect(firstTableCellContent(harness.editor.getMarkdown())).toEqual([
+				{
+					type: "bulletList",
+					content: [
+						{
+							type: "listItem",
+							content: [
+								{
+									type: "paragraph",
+									content: [{ type: "text", text: "Name" }],
+								},
+							],
+						},
+						{
+							type: "listItem",
+							content: [{ type: "paragraph" }],
+						},
+					],
+				},
+			]);
+		} finally {
+			harness.destroy();
+		}
 	});
 
 	it("round-trips markdown after inserting a row", () => {

--- a/src/components/editor/extensions/tableMarkdown.ts
+++ b/src/components/editor/extensions/tableMarkdown.ts
@@ -1,0 +1,245 @@
+import type { JSONContent, MarkdownToken } from "@tiptap/core";
+import { Table } from "@tiptap/extension-table";
+
+type TableTokenCell = {
+	tokens?: MarkdownToken[];
+};
+
+type TableToken = MarkdownToken & {
+	header?: TableTokenCell[];
+	rows?: TableTokenCell[][];
+};
+
+interface MarkdownParseHelpers {
+	parseInline: (tokens: MarkdownToken[]) => JSONContent[];
+	createNode: (
+		type: string,
+		attrs?: Record<string, unknown>,
+		content?: JSONContent[],
+	) => JSONContent;
+}
+
+interface MarkdownRenderHelpers {
+	renderChildren: (
+		nodes: JSONContent | JSONContent[],
+		separator?: string,
+	) => string;
+}
+
+const TABLE_CELL_BREAK = "<br>";
+const EMPTY_PARAGRAPH_MARKDOWN = "&nbsp;";
+const NBSP_CHAR = "\u00A0";
+const LIST_ITEM_MARKER = /^(\s*)([-+*]|\d+\.)\s+/;
+const ORDERED_LIST_MARKER = /^\s*\d+\.\s+/;
+
+function isTableCell(node: JSONContent) {
+	return node.type === "tableCell" || node.type === "tableHeader";
+}
+
+function textFromTokens(tokens: MarkdownToken[]) {
+	return tokens
+		.map((token) => {
+			const raw = token.raw ?? token.text;
+			return typeof raw === "string" ? raw : "";
+		})
+		.join("");
+}
+
+function splitCellTokens(tokens: MarkdownToken[]) {
+	const lines: MarkdownToken[][] = [[]];
+
+	for (const token of tokens) {
+		const raw = token.raw ?? token.text;
+		if (
+			token.type === "html" &&
+			typeof raw === "string" &&
+			/^<br\s*\/?>$/i.test(raw.trim())
+		) {
+			lines.push([]);
+			continue;
+		}
+
+		lines[lines.length - 1]?.push(token);
+	}
+
+	return lines;
+}
+
+function tokensWithoutListMarker(tokens: MarkdownToken[]) {
+	const nextTokens = tokens.map((token) => ({ ...token }));
+
+	for (const token of nextTokens) {
+		const raw = token.raw ?? token.text;
+		if (typeof raw !== "string") continue;
+
+		const match = raw.match(LIST_ITEM_MARKER);
+		if (!match) return tokens;
+
+		const marker = match[0];
+		if (typeof token.raw === "string")
+			token.raw = token.raw.slice(marker.length);
+		if (typeof token.text === "string")
+			token.text = token.text.slice(marker.length);
+		return nextTokens;
+	}
+
+	return tokens;
+}
+
+function parseTableCellInline(
+	tokens: MarkdownToken[],
+	h: MarkdownParseHelpers,
+) {
+	const content = h.parseInline(tokens);
+	if (
+		content.length === 1 &&
+		content[0]?.type === "text" &&
+		(content[0].text === EMPTY_PARAGRAPH_MARKDOWN ||
+			content[0].text === NBSP_CHAR)
+	) {
+		return [];
+	}
+	return content;
+}
+
+function paragraph(content: JSONContent[]) {
+	return content.length > 0
+		? { type: "paragraph", content }
+		: { type: "paragraph" };
+}
+
+function parseTableCellContent(
+	tokens: MarkdownToken[],
+	h: MarkdownParseHelpers,
+) {
+	const lines = splitCellTokens(tokens).filter(
+		(line) => textFromTokens(line).trim().length > 0,
+	);
+	if (lines.length === 0) return [{ type: "paragraph" }];
+
+	const allListItems = lines.every((line) =>
+		LIST_ITEM_MARKER.test(textFromTokens(line)),
+	);
+	if (allListItems) {
+		const listType = ORDERED_LIST_MARKER.test(textFromTokens(lines[0] ?? []))
+			? "orderedList"
+			: "bulletList";
+		return [
+			{
+				type: listType,
+				content: lines.map((line) => ({
+					type: "listItem",
+					content: [
+						paragraph(parseTableCellInline(tokensWithoutListMarker(line), h)),
+					],
+				})),
+			},
+		];
+	}
+
+	return lines.map((line) => paragraph(parseTableCellInline(line, h)));
+}
+
+function escapeTableCell(text: string) {
+	return text.replace(/\n+/g, TABLE_CELL_BREAK).replace(/\|/g, "\\|").trim();
+}
+
+function renderTableCellContent(cell: JSONContent, h: MarkdownRenderHelpers) {
+	const children = cell.content ?? [];
+	if (children.length === 0) return "";
+
+	if (children.length === 1 && children[0]?.type === "paragraph") {
+		return escapeTableCell(h.renderChildren(children[0].content ?? []));
+	}
+
+	return children
+		.map((child) => {
+			if (child.type === "paragraph") {
+				return h.renderChildren(child.content ?? []);
+			}
+			return h.renderChildren([child]);
+		})
+		.map(escapeTableCell)
+		.join(TABLE_CELL_BREAK);
+}
+
+function renderGlyphTableToMarkdown(
+	node: JSONContent,
+	h: MarkdownRenderHelpers,
+) {
+	const rows =
+		node.content?.map((row) =>
+			(row.content ?? []).filter(isTableCell).map((cell) => ({
+				text: renderTableCellContent(cell, h),
+				isHeader: cell.type === "tableHeader",
+			})),
+		) ?? [];
+	const columnCount = rows.reduce((max, row) => Math.max(max, row.length), 0);
+	if (columnCount === 0) return "";
+
+	const widths = Array.from({ length: columnCount }, (_, index) =>
+		Math.max(3, ...rows.map((row) => row[index]?.text.length ?? 0)),
+	);
+	const pad = (text: string, index: number) =>
+		text + " ".repeat(Math.max(0, (widths[index] ?? 3) - text.length));
+	const firstRow = rows[0] ?? [];
+	const hasHeader = firstRow.some((cell) => cell.isHeader);
+	const header = Array.from({ length: columnCount }, (_, index) =>
+		pad(hasHeader ? (firstRow[index]?.text ?? "") : "", index),
+	);
+	const body = hasHeader ? rows.slice(1) : rows;
+	const lines = [
+		`| ${header.join(" | ")} |`,
+		`| ${widths.map((width) => "-".repeat(width)).join(" | ")} |`,
+		...body.map(
+			(row) =>
+				`| ${Array.from({ length: columnCount }, (_, index) =>
+					pad(row[index]?.text ?? "", index),
+				).join(" | ")} |`,
+		),
+	];
+
+	return `\n${lines.join("\n")}\n`;
+}
+
+export const GlyphTable = Table.extend({
+	parseMarkdown: (token: TableToken, h: MarkdownParseHelpers) => {
+		const rows: JSONContent[] = [];
+
+		if (token.header) {
+			rows.push(
+				h.createNode(
+					"tableRow",
+					{},
+					token.header.map((cell) =>
+						h.createNode(
+							"tableHeader",
+							{},
+							parseTableCellContent(cell.tokens ?? [], h),
+						),
+					),
+				),
+			);
+		}
+
+		for (const row of token.rows ?? []) {
+			rows.push(
+				h.createNode(
+					"tableRow",
+					{},
+					row.map((cell) =>
+						h.createNode(
+							"tableCell",
+							{},
+							parseTableCellContent(cell.tokens ?? [], h),
+						),
+					),
+				),
+			);
+		}
+
+		return h.createNode("table", undefined, rows);
+	},
+	renderMarkdown: (node: JSONContent, h: MarkdownRenderHelpers) =>
+		renderGlyphTableToMarkdown(node, h),
+});


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/230


## Description

Adds durable support for multiline paragraphs and list content inside table cells.

- Removes the custom Enter-to-next-cell shortcut so Enter can create normal rich content inside table cells.
- Adds a focused Glyph table Markdown bridge that preserves multiline paragraphs and list items across save/load round trips.
- Adds integration coverage for both editor behavior and Markdown persistence.

## Docs

Rich table cells are serialized through the Glyph table Markdown extension. Simple table cells remain normal Markdown table cells; multiline and list content is encoded with table-safe line breaks so parsing restores the table cell block structure.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

