### PR TITLE
Add "Copy File Path" to file context menus and command palette

### DIFF
--- a/src/components/app/MainTabsBreadcrumbs.tsx
+++ b/src/components/app/MainTabsBreadcrumbs.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useState } from "react";
 import type { MouseEvent } from "react";
 import { toast } from "sonner";
+import { useSpace } from "../../contexts";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
 import { type FsEntry, invoke } from "../../lib/tauri";
@@ -206,22 +208,9 @@ export function MainTabsBreadcrumbs({
 	const [openBreadcrumbMenuKey, setOpenBreadcrumbMenuKey] = useState<
 		string | null
 	>(null);
+	const { spacePath } = useSpace();
 	const breadcrumbParts = breadcrumbPartsForPath(activeTabPath);
 	const breadcrumbDisplay = breadcrumbDisplayItems(breadcrumbParts);
-	const handleCopyBreadcrumbPath = useCallback(async (part: BreadcrumbPart) => {
-		try {
-			const clipboard = navigator.clipboard;
-			if (!clipboard?.writeText) {
-				throw new Error("Clipboard is not available.");
-			}
-			await clipboard.writeText(part.path || "/");
-			toast.success("Copied path.");
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : "Could not copy path.";
-			toast.error("Could not copy path", { description: message });
-		}
-	}, []);
 	const handleRevealBreadcrumbPart = useCallback(
 		async (part: BreadcrumbPart) => {
 			if (part.kind === "folder") {
@@ -256,10 +245,7 @@ export function MainTabsBreadcrumbs({
 	const handleBreadcrumbContextMenu = useCallback(
 		(event: MouseEvent<HTMLButtonElement>, part: BreadcrumbPart) => {
 			void showNativeContextMenu(event, [
-				{
-					label: "Copy Path",
-					action: () => void handleCopyBreadcrumbPath(part),
-				},
+				...buildPathCopyMenuItems(spacePath, part.path),
 				{
 					label: "Reveal in File Tree",
 					action: () => void handleRevealBreadcrumbPart(part),
@@ -283,10 +269,10 @@ export function MainTabsBreadcrumbs({
 			});
 		},
 		[
-			handleCopyBreadcrumbPath,
 			handleOpenBreadcrumbContainer,
 			handleRevealBreadcrumbPart,
 			handleRevealInFinder,
+			spacePath,
 		],
 	);
 

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -37,6 +37,7 @@ import {
 import { getCommandDefinition } from "../../lib/commands/commandManifest";
 import type { EditorViewMode } from "../../lib/editorMode";
 import { getLicenseStatus } from "../../lib/license";
+import { copyAbsolutePath, copyRelativePath } from "../../lib/pathClipboard";
 import type { EffectiveShortcutBindings } from "../../lib/settings";
 import {
 	SHORTCUT_CATEGORY_LABELS,
@@ -538,6 +539,44 @@ export function useAppCommands({
 				enabled: Boolean(activeMarkdownTabPath),
 				allowInEditable: true,
 				action: () => void handleCopyOpenNoteAsMarkdown(),
+			},
+			{
+				id: "copy-active-file-relative-path",
+				label: "Copy current file relative path",
+				icon: (
+					<HugeiconsIcon
+						icon={Link01Icon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				category: "File Operations",
+				enabled: Boolean(activeFilePath),
+				allowInEditable: true,
+				searchTerms: ["copy file path", "relative path"],
+				action: () => {
+					if (!activeFilePath) return;
+					void copyRelativePath(activeFilePath);
+				},
+			},
+			{
+				id: "copy-active-file-absolute-path",
+				label: "Copy current file absolute path",
+				icon: (
+					<HugeiconsIcon
+						icon={Link01Icon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				category: "File Operations",
+				enabled: Boolean(spacePath) && Boolean(activeFilePath),
+				allowInEditable: true,
+				searchTerms: ["copy file path", "absolute path", "full path"],
+				action: () => {
+					if (!activeFilePath) return;
+					void copyAbsolutePath(spacePath, activeFilePath);
+				},
 			},
 			{
 				id: "move-active-file",

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -13,7 +13,9 @@ import type {
 	ReactNode,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { useSpace } from "../../contexts";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import type { FileTreeAppearance, FsEntry } from "../../lib/tauri";
 import { Plus } from "../Icons";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
@@ -134,6 +136,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	fileCount,
 	onMoveClickSuppressRef,
 }: FileTreeDirItemProps) {
+	const { spacePath } = useSpace();
 	const customColor =
 		appearance?.color && isEditorTextColor(appearance.color)
 			? appearance.color
@@ -186,6 +189,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					action: () => void onRequestCreateFolder(entry.rel_path),
 				},
 				{ type: "separator" },
+				...buildPathCopyMenuItems(spacePath, entry.rel_path),
+				{ type: "separator" },
 				{
 					label: "Rename",
 					action: onStartRename,
@@ -208,6 +213,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			onNewFileInDir,
 			onRequestCreateFolder,
 			onStartRename,
+			spacePath,
 		],
 	);
 

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -12,6 +12,10 @@ vi.mock("../../lib/nativeContextMenu", () => ({
 	showNativeContextMenu: showNativeContextMenuMock,
 }));
 
+vi.mock("../../contexts", () => ({
+	useSpace: () => ({ spacePath: "/space" }),
+}));
+
 vi.mock("motion/react", async () => {
 	const React = await vi.importActual<typeof import("react")>("react");
 	const stripMotionProps = (

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -4,7 +4,9 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import type { KeyboardEvent, MouseEvent, MutableRefObject } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { useSpace } from "../../contexts";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import { invoke } from "../../lib/tauri";
 import type {
 	FileTreeAppearance,
@@ -152,6 +154,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	taskSummary = null,
 	previewText = null,
 }: FileTreeFileItemProps) {
+	const { spacePath } = useSpace();
 	const customColor =
 		appearance?.color && isEditorTextColor(appearance.color)
 			? appearance.color
@@ -221,6 +224,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					label: "Show in Finder",
 					action: () => void handleRevealInFinder(),
 				},
+				...buildPathCopyMenuItems(spacePath, entry.rel_path),
 				{ type: "separator" },
 				{
 					label: "Rename",
@@ -273,6 +277,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			onStartRename,
 			onTogglePinned,
 			parentDirPath,
+			spacePath,
 		],
 	);
 

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -10,8 +10,10 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useSpace } from "../../contexts";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
+import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import type { FileTreeAppearance, NoteTaskSummary } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { basename, parentDir, splitEditableFileName } from "../../utils/path";
@@ -416,6 +418,7 @@ export const FolioNoteListItem = memo(
 	) {
 		const title = note.title.trim() || titleFromPath(note.note_path);
 		const isMarkdown = note.is_markdown;
+		const { spacePath } = useSpace();
 		const { stem: fileStem, ext: fileExt } = splitEditableFileName(
 			basename(note.note_path),
 		);
@@ -470,6 +473,7 @@ export const FolioNoteListItem = memo(
 						label: "Show in Finder",
 						action: () => void handleRevealInFinder(),
 					},
+					...buildPathCopyMenuItems(spacePath, note.note_path),
 					{ type: "separator" },
 					...(onRename
 						? [
@@ -499,6 +503,7 @@ export const FolioNoteListItem = memo(
 				onOpenAppearancePicker,
 				onOpenInNewTab,
 				onRename,
+				spacePath,
 			],
 		);
 		const fileIcon = appearance?.icon ? (

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -56,6 +56,7 @@ const { loadAllDocsMock, prefetchNoteMock, invokeMock, scopeRef } = vi.hoisted(
 );
 
 vi.mock("../../contexts", () => ({
+	useSpace: () => ({ spacePath: "/space" }),
 	useUILayoutContext: () => ({
 		folioScope: scopeRef.current,
 	}),

--- a/src/lib/pathClipboard.ts
+++ b/src/lib/pathClipboard.ts
@@ -35,7 +35,10 @@ export async function copyPathToClipboard(
 }
 
 export async function copyRelativePath(relPath: string): Promise<void> {
-	await copyPathToClipboard(relativePathLabel(relPath));
+	await copyPathToClipboard(
+		relativePathLabel(relPath),
+		"Copied relative path.",
+	);
 }
 
 export async function copyAbsolutePath(
@@ -43,7 +46,10 @@ export async function copyAbsolutePath(
 	relPath: string,
 ): Promise<void> {
 	try {
-		await copyPathToClipboard(await absoluteSpacePath(spacePath, relPath));
+		await copyPathToClipboard(
+			await absoluteSpacePath(spacePath, relPath),
+			"Copied absolute path.",
+		);
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : "Could not copy path.";

--- a/src/lib/pathClipboard.ts
+++ b/src/lib/pathClipboard.ts
@@ -1,0 +1,68 @@
+import { join } from "@tauri-apps/api/path";
+import { toast } from "sonner";
+import type { NativeContextMenuItem } from "./nativeContextMenu";
+
+function relativePathLabel(relPath: string): string {
+	return relPath || "/";
+}
+
+async function absoluteSpacePath(
+	spacePath: string | null,
+	relPath: string,
+): Promise<string> {
+	if (!spacePath) {
+		throw new Error("No space is open.");
+	}
+	return relPath ? await join(spacePath, relPath) : spacePath;
+}
+
+export async function copyPathToClipboard(
+	path: string,
+	successMessage = "Copied path.",
+): Promise<void> {
+	try {
+		const clipboard = navigator.clipboard;
+		if (!clipboard?.writeText) {
+			throw new Error("Clipboard is not available.");
+		}
+		await clipboard.writeText(path);
+		toast.success(successMessage);
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Could not copy path.";
+		toast.error("Could not copy path", { description: message });
+	}
+}
+
+export async function copyRelativePath(relPath: string): Promise<void> {
+	await copyPathToClipboard(relativePathLabel(relPath));
+}
+
+export async function copyAbsolutePath(
+	spacePath: string | null,
+	relPath: string,
+): Promise<void> {
+	try {
+		await copyPathToClipboard(await absoluteSpacePath(spacePath, relPath));
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Could not copy path.";
+		toast.error("Could not copy path", { description: message });
+	}
+}
+
+export function buildPathCopyMenuItems(
+	spacePath: string | null,
+	relPath: string,
+): NativeContextMenuItem[] {
+	return [
+		{
+			label: "Copy Relative Path",
+			action: () => void copyRelativePath(relPath),
+		},
+		{
+			label: "Copy Absolute Path",
+			action: () => void copyAbsolutePath(spacePath, relPath),
+		},
+	];
+}


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/229


## Description

Adds **Copy Relative Path** and **Copy Absolute Path** actions across Glyph’s file-navigation surfaces so users can paste space-relative or on-disk paths into terminals, scripts, and external tools without opening Finder.

### Summary of changes

**New shared module — `src/lib/pathClipboard.ts`**

Centralizes clipboard writes, toast feedback, and native context-menu item construction:

- `copyPathToClipboard(path, successMessage?)` — writes to `navigator.clipboard` with success/error toasts
- `copyRelativePath(relPath)` — copies the space-relative path (`rel_path`, or `/` for the space root)
- `copyAbsolutePath(spacePath, relPath)` — joins `spacePath` + `relPath` via Tauri’s `join()` for a platform-native absolute path
- `buildPathCopyMenuItems(spacePath, relPath)` — returns the two standard context-menu entries used everywhere

**Context menus — relative + absolute path copy**

| Surface | File | Change |
|---|---|---|
| File tree — files | `FileTreeFileItem.tsx` | Adds copy-path items after “Show in Finder” |
| File tree — folders | `FileTreeDirItem.tsx` | Adds copy-path items after “New folder” separator |
| Folio note list | `FolioNoteListItem.tsx` | Adds copy-path items after “Show in Finder” |
| Tab breadcrumbs | `MainTabsBreadcrumbs.tsx` | Replaces single “Copy Path” with the shared relative/absolute pair |

All four surfaces now call `buildPathCopyMenuItems(spacePath, relPath)` and read `spacePath` from `useSpace()`.

**Command palette — active file path copy**

`useAppCommands.tsx` registers two new **File Operations** commands:

- **Copy current file relative path** (`copy-active-file-relative-path`) — enabled when `activeFilePath` is set
- **Copy current file absolute path** (`copy-active-file-absolute-path`) — enabled when both `spacePath` and `activeFilePath` are set

Both commands include search terms (`copy file path`, `relative path`, `absolute path`, `full path`) and are allowed in editable contexts (`allowInEditable: true`).

**Tests**

- `FileTreeFileItem.test.tsx` — mocks `useSpace` so context-menu tests have a stable `spacePath`
- `FolioNotesListPane.test.tsx` — same `useSpace` mock addition for folio list rendering

### Reasoning

- **Discord request (SambalGoreng, 6/23/26):** users wanted a quick way to copy file paths for shell and external-tool workflows. Glyph already had “Show in Finder” and a breadcrumb-only relative “Copy Path”, but coverage was inconsistent.
- **Shared helper over duplication:** the issue called out four surfaces that would otherwise repeat clipboard/toast/menu logic. `pathClipboard.ts` keeps labels, error handling, and join behavior in one place.
- **Frontend `join()` for absolute paths:** absolute paths are resolved with `@tauri-apps/api/path` `join(spacePath, relPath)` rather than the backend `space_resolve_abs_path` command. This works for both files and folders without extending the Rust API, and matches the existing `useFileTree` fallback pattern for non-markdown files.
- **Breadcrumb alignment:** breadcrumbs previously copied only the relative path inline. They now use the same menu items and behavior as the file tree and folio.

### Additional context / review hints

- **Toast copy:** success toasts currently use the generic message `"Copied path."` for both variants. Issue #229 suggested distinguishing messages (`"Copied relative path."` / `"Copied absolute path."`) — happy to adjust in a follow-up if preferred.
- **No keyboard shortcuts** were added; palette discovery relies on search terms only.
- **`appCommandManifest.json`** was not updated — these commands are registered inline in `useAppCommands.tsx` like other dynamic File Operations entries.
- **Non-goals respected:** no wikilink/URI copy, no note-content copy (that remains “Copy note as Markdown”), no changes to Show in Finder / rename / move flows.
- **Parent epic:** part of the file-tree workflow group ([#240](https://github.com/SidhuK/Glyph/issues/240)).

### Files changed (8)

```
src/lib/pathClipboard.ts                          (new)
src/components/app/MainTabsBreadcrumbs.tsx
src/components/app/useAppCommands.tsx
src/components/filetree/FileTreeFileItem.tsx
src/components/filetree/FileTreeDirItem.tsx
src/components/filetree/FileTreeFileItem.test.tsx
src/components/folio/FolioNoteListItem.tsx
src/components/folio/FolioNotesListPane.test.tsx
```


## Screenshots

_Context-menu and command-palette additions — no visual styling changes beyond two new menu items / palette entries._

**File tree file context menu** — “Copy Relative Path” and “Copy Absolute Path” appear after “Show in Finder”:

```
Open
Show in Finder
Copy Relative Path    ← new
Copy Absolute Path    ← new
─────────────────
Rename
Duplicate
…
```

**Command palette** — search “copy file path” with an active tab open:

```
Copy current file relative path
Copy current file absolute path
```


## Docs

### API surface (`pathClipboard.ts`)

```ts
// Copy helpers
copyRelativePath(relPath: string): Promise<void>
copyAbsolutePath(spacePath: string | null, relPath: string): Promise<void>

// Context menu builder — spread into showNativeContextMenu items array
buildPathCopyMenuItems(spacePath: string | null, relPath: string): NativeContextMenuItem[]
```

### Path formats

| Variant | Example input | Clipboard output |
|---|---|---|
| Relative | `notes/projects/roadmap.md` | `notes/projects/roadmap.md` |
| Relative (root) | `""` | `/` |
| Absolute | space `/Users/me/MySpace`, rel `notes/a.md` | `/Users/me/MySpace/notes/a.md` (native separators) |

### Command palette IDs

- `copy-active-file-relative-path`
- `copy-active-file-absolute-path`

### Manual QA checklist (macOS)

- [ ] Right-click a root-level markdown note → copy relative + absolute
- [ ] Right-click a nested file → copy relative + absolute
- [ ] Right-click a folder → copy relative + absolute
- [ ] Right-click a folio note list item → copy relative + absolute
- [ ] Right-click a breadcrumb segment → copy relative + absolute
- [ ] Command palette commands with active tab vs no active file (disabled state)
- [ ] Paste paths into Terminal / VS Code
- [ ] Space path with spaces or unicode characters
- [ ] No regression: Show in Finder, Open, Rename, Move, Pin


## Ready?

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed) — self-documenting module; no extra comments required
- [x] Wrote tests for new components/features — updated existing context-menu test mocks; no dedicated `pathClipboard` unit tests
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-copy actions for file, folder, note, and breadcrumb paths in context menus.
  * Added command palette actions to copy the current file’s relative or absolute path.
  * Path copy options now work consistently across the app using the current workspace location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->