### PR TITLE
Preserve rich editor caret across resets

### DIFF
--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -11,12 +11,14 @@ const {
 	canCommands,
 	chainCommands,
 	emitSettingsUpdated,
+	getActiveEditor,
 	getEditorOptions,
 	invokeMock,
 	loadSettingsMock,
 	mockEditor,
 	openUrlMock,
 	parseMock,
+	setActiveEditor,
 	setEditorOptions,
 	setSettingsUpdatedHandler,
 } = vi.hoisted(() => {
@@ -51,6 +53,7 @@ const {
 		commands: {
 			setContent: vi.fn(),
 			setHeadingCollapseEnabled: vi.fn(),
+			setTextSelection: vi.fn(() => true),
 		},
 		state: {
 			selection: {
@@ -72,6 +75,9 @@ const {
 				setNodeMarkup: vi.fn(),
 			},
 			doc: {
+				content: {
+					size: 42,
+				},
 				descendants: vi.fn(),
 				resolve: vi.fn((pos: number) => ({ pos })),
 			},
@@ -87,11 +93,13 @@ const {
 		view: {
 			dispatch: vi.fn(),
 			focus: vi.fn(),
+			hasFocus: vi.fn(() => false),
 			posAtDOM: vi.fn(),
 			state: undefined as unknown,
 		},
 	};
 	mockEditor.view.state = mockEditor.state;
+	let activeEditor = mockEditor;
 	const parseMock = vi.fn(() => ({
 		content: [
 			{
@@ -137,9 +145,13 @@ const {
 		mockEditor,
 		openUrlMock: vi.fn(),
 		parseMock,
+		setActiveEditor: (editor: typeof mockEditor) => {
+			activeEditor = editor;
+		},
 		setEditorOptions: (options: Record<string, unknown>) => {
 			editorOptions = options;
 		},
+		getActiveEditor: () => activeEditor,
 		setSettingsUpdatedHandler: (handler: typeof settingsUpdatedHandler) => {
 			settingsUpdatedHandler = handler;
 		},
@@ -168,7 +180,7 @@ vi.mock("@tiptap/markdown", () => ({
 vi.mock("@tiptap/react", () => ({
 	useEditor: (options: Record<string, unknown>) => {
 		setEditorOptions(options);
-		return mockEditor;
+		return getActiveEditor();
 	},
 }));
 
@@ -304,6 +316,7 @@ describe("useNoteEditor", () => {
 
 	beforeEach(() => {
 		setSettingsUpdatedHandler(null);
+		setActiveEditor(mockEditor);
 		mockEditor.isEditable = true;
 		mockEditor.isActive.mockReset();
 		mockEditor.isActive.mockReturnValue(false);
@@ -313,6 +326,11 @@ describe("useNoteEditor", () => {
 		mockEditor.can.mockClear();
 		mockEditor.commands.setContent.mockReset();
 		mockEditor.commands.setHeadingCollapseEnabled.mockReset();
+		mockEditor.commands.setTextSelection.mockReset();
+		mockEditor.commands.setTextSelection.mockReturnValue(true);
+		mockEditor.state.doc.content.size = 42;
+		mockEditor.state.selection.from = 2;
+		mockEditor.state.selection.to = 4;
 		mockEditor.state.doc.descendants.mockReset();
 		mockEditor.state.doc.descendants.mockImplementation(() => {});
 		mockEditor.state.doc.resolve.mockReset();
@@ -335,6 +353,8 @@ describe("useNoteEditor", () => {
 		);
 		mockEditor.view.dispatch.mockReset();
 		mockEditor.view.focus.mockReset();
+		mockEditor.view.hasFocus.mockReset();
+		mockEditor.view.hasFocus.mockReturnValue(false);
 		mockEditor.view.posAtDOM.mockReset();
 		mockEditor.view.posAtDOM.mockImplementation(
 			(_node: Node, offset: number) => (offset === 0 ? 5 : 14),
@@ -542,6 +562,87 @@ describe("useNoteEditor", () => {
 		const recreatedOptions = getEditorOptions() as { content?: string } | null;
 		expect(recreatedOptions?.content).toBe("latest pending body");
 		expect(onChange).toHaveBeenCalledWith("latest pending body");
+	});
+
+	it("restores the focused selection after recreating the editor", async () => {
+		const onChange = vi.fn();
+		const firstExtension = Extension.create({ name: "first-extension" });
+		const secondExtension = Extension.create({ name: "second-extension" });
+		const nextEditor = {
+			...mockEditor,
+			commands: {
+				...mockEditor.commands,
+				setTextSelection: vi.fn(() => true),
+			},
+			state: {
+				...mockEditor.state,
+				doc: {
+					...mockEditor.state.doc,
+					content: { size: 5 },
+				},
+			},
+			view: {
+				...mockEditor.view,
+				focus: vi.fn(),
+				hasFocus: vi.fn(() => false),
+			},
+		};
+		nextEditor.view.state = nextEditor.state;
+
+		await act(async () => {
+			root.render(
+				<Harness additionalExtensions={[firstExtension]} onChange={onChange} />,
+			);
+		});
+
+		mockEditor.state.selection.from = 12;
+		mockEditor.state.selection.to = 12;
+		mockEditor.view.hasFocus.mockReturnValue(true);
+		setActiveEditor(nextEditor as typeof mockEditor);
+
+		await act(async () => {
+			root.render(
+				<Harness
+					additionalExtensions={[secondExtension]}
+					onChange={onChange}
+				/>,
+			);
+		});
+
+		expect(nextEditor.commands.setTextSelection).toHaveBeenCalledWith({
+			from: 5,
+			to: 5,
+		});
+		expect(nextEditor.view.focus).toHaveBeenCalled();
+	});
+
+	it("restores the focused selection after replacing editor content", async () => {
+		const onChange = vi.fn();
+
+		await act(async () => {
+			root.render(<Harness markdown="first body" onChange={onChange} />);
+		});
+
+		mockEditor.state.doc.content.size = 8;
+		mockEditor.state.selection.from = 3;
+		mockEditor.state.selection.to = 3;
+		mockEditor.view.hasFocus.mockReturnValue(true);
+
+		await act(async () => {
+			root.render(<Harness markdown="changed body" onChange={onChange} />);
+		});
+
+		expect(mockEditor.commands.setContent).toHaveBeenCalledWith(
+			"changed body",
+			{
+				contentType: "markdown",
+			},
+		);
+		expect(mockEditor.commands.setTextSelection).toHaveBeenCalledWith({
+			from: 3,
+			to: 3,
+		});
+		expect(mockEditor.view.focus).toHaveBeenCalled();
 	});
 
 	it("tracks colorful headings from settings and live updates", async () => {

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -353,6 +353,7 @@ export function useNoteEditor({
 	const committedEditorRef = useRef<ReturnType<typeof useEditor>>(null);
 	const pendingMarkdownSyncRef = useRef<PendingMarkdownSync | null>(null);
 	const pendingSelectionRestoreRef = useRef<SelectionSnapshot | null>(null);
+	const editorContentRelPathRef = useRef(relPath);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
 	const markdownSyncFrameRef = useRef<number | null>(null);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
@@ -754,9 +755,13 @@ export function useNoteEditor({
 		if (editorBody === lastAppliedBodyRef.current) return;
 		flushMarkdownSync(relPath);
 		suppressUpdateRef.current = true;
-		const snapshot = snapshotFocusedSelection(editor, relPath);
+		const snapshot = snapshotFocusedSelection(
+			editor,
+			editorContentRelPathRef.current,
+		);
 		editor.commands.setContent(editorBody, { contentType: "markdown" });
 		if (snapshot) restoreSelectionSnapshot(editor, snapshot, relPath);
+		editorContentRelPathRef.current = relPath;
 		lastAppliedBodyRef.current = editorBody;
 		lastEmittedMarkdownRef.current = markdown;
 	}, [editor, editorBody, flushMarkdownSync, markdown, mode, relPath]);

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -265,6 +265,55 @@ interface PendingMarkdownSync {
 	relPath: string;
 }
 
+interface SelectionSnapshot {
+	from: number;
+	relPath: string;
+	to: number;
+}
+
+function clampSelectionPosition(pos: number, docSize: number): number {
+	return Math.min(Math.max(pos, 0), docSize);
+}
+
+function snapshotFocusedSelection(
+	editor: NonNullable<ReturnType<typeof useEditor>> | null,
+	relPath: string,
+): SelectionSnapshot | null {
+	if (!editor?.view.hasFocus()) return null;
+	const { from, to } = editor.state.selection;
+	return { from, relPath, to };
+}
+
+function restoreSelectionSnapshot(
+	editor: NonNullable<ReturnType<typeof useEditor>>,
+	snapshot: SelectionSnapshot,
+	relPath: string,
+): boolean {
+	if (snapshot.relPath !== relPath) return false;
+	const docSize = editor.state.doc.content.size;
+	const from = clampSelectionPosition(snapshot.from, docSize);
+	const to = clampSelectionPosition(snapshot.to, docSize);
+	const range = from <= to ? { from, to } : { from: to, to: from };
+	try {
+		if (editor.commands.setTextSelection(range)) {
+			editor.view.focus();
+			return true;
+		}
+	} catch {
+		// Fall back to a collapsed selection below.
+	}
+	try {
+		if (editor.commands.setTextSelection(range.from)) {
+			editor.view.focus();
+			return true;
+		}
+	} catch {
+		// If neither selection can be represented in the new document, leave the
+		// editor unfocused instead of letting the browser choose an end position.
+	}
+	return false;
+}
+
 export function useNoteEditor({
 	additionalExtensions = EMPTY_ADDITIONAL_EXTENSIONS,
 	markdown,
@@ -301,7 +350,9 @@ export function useNoteEditor({
 	const attachmentStorageModeRef = useRef<AttachmentStorageMode>("note-folder");
 	const attachmentFolderRef = useRef<string | null>(DEFAULT_ATTACHMENT_FOLDER);
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null);
+	const committedEditorRef = useRef<ReturnType<typeof useEditor>>(null);
 	const pendingMarkdownSyncRef = useRef<PendingMarkdownSync | null>(null);
+	const pendingSelectionRestoreRef = useRef<SelectionSnapshot | null>(null);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
 	const markdownSyncFrameRef = useRef<number | null>(null);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
@@ -476,6 +527,11 @@ export function useNoteEditor({
 		void placeholder;
 		void vimKeybindingsEnabled;
 		return () => {
+			const snapshot = snapshotFocusedSelection(
+				committedEditorRef.current,
+				relPath,
+			);
+			if (snapshot) pendingSelectionRestoreRef.current = snapshot;
 			flushMarkdownSync(relPath);
 		};
 	}, [
@@ -661,6 +717,18 @@ export function useNoteEditor({
 	);
 	editorRef.current = editor;
 
+	useLayoutEffect(() => {
+		if (!editor) return;
+		const snapshot = pendingSelectionRestoreRef.current;
+		if (!snapshot) return;
+		pendingSelectionRestoreRef.current = null;
+		restoreSelectionSnapshot(editor, snapshot, relPath);
+	}, [editor, relPath]);
+
+	useLayoutEffect(() => {
+		committedEditorRef.current = editor;
+	}, [editor]);
+
 	useEffect(() => {
 		if (!editor) return;
 		editor.setEditable(mode === "rich");
@@ -686,7 +754,9 @@ export function useNoteEditor({
 		if (editorBody === lastAppliedBodyRef.current) return;
 		flushMarkdownSync(relPath);
 		suppressUpdateRef.current = true;
+		const snapshot = snapshotFocusedSelection(editor, relPath);
 		editor.commands.setContent(editorBody, { contentType: "markdown" });
+		if (snapshot) restoreSelectionSnapshot(editor, snapshot, relPath);
 		lastAppliedBodyRef.current = editorBody;
 		lastEmittedMarkdownRef.current = markdown;
 	}, [editor, editorBody, flushMarkdownSync, markdown, mode, relPath]);


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/232


## Description

Fixes a rare rich-text editing issue where the caret could jump to the end of the note when TipTap rebuilt or reset the editor while focused.

- Summary of changes
  - Snapshot the focused rich-editor selection before dependency-driven editor recreation.
  - Restore the selection after the new editor instance is available.
  - Preserve selection around full-document `setContent()` resets.
  - Clamp restored positions to the current document size.
  - Add tests for editor recreation and content replacement selection restoration.
- Reasoning
  - Rich editor extension changes can recreate the TipTap editor after async features/settings load.
  - The previous code preserved pending markdown but not the user’s caret position.
  - Restoring selection centrally in `useNoteEditor` covers math loading, settings-driven extension changes, and content resets.
- Additional context
  - This is not a visual change; it preserves editing state during internal editor lifecycle changes.


## Screenshots

N/A — non-visual editing-state fix.


## Docs

No external docs needed. The behavior is covered by tests in `useNoteEditor.test.tsx`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the text cursor and selection when the editor is refreshed or content is updated.
  * Restores focus after changes so editing can continue without losing place.
  * Improves behavior when the editor instance is replaced, keeping selection consistent across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->