### PR TITLE
Save pasted images using original name (#244) [Release]

### DIFF
--- a/.cursor/plans/kar_47_image_filenames_b5d997a1.plan.md
+++ b/.cursor/plans/kar_47_image_filenames_b5d997a1.plan.md
@@ -1,0 +1,147 @@
+---
+name: KAR 47 Image Filenames
+overview: Implement KAR-47 by changing only new image saves to use sanitized original filenames, keeping existing hash-named assets untouched and resolvable. The main work is backend allocation/collision handling in `binary.rs`, plus a small frontend IPC payload update and existing test/docs updates.
+todos:
+  - id: branch-setup
+    content: Create and work from the dedicated `karatsidhu/kar-47-save-pasted-images-using-original-filename-instead-of` branch.
+    status: completed
+  - id: backend-filename-allocation
+    content: Implement sanitized original-filename allocation and collision handling in `binary.rs`.
+    status: completed
+  - id: frontend-ipc
+    content: Pass `original_filename` through `useNoteEditor.ts` and `src/lib/tauri.ts`.
+    status: completed
+  - id: tests-docs
+    content: Update existing paste tests and architecture docs for the new naming behavior.
+    status: completed
+isProject: false
+---
+
+# KAR-47 Image Filename Plan
+
+## Branching
+
+- Do this work on its own branch: `karatsidhu/kar-47-save-pasted-images-using-original-filename-instead-of`.
+- Before making implementation edits, create or check out that branch from the appropriate base so the hard cutover stays isolated from unrelated work.
+
+## Current Flow
+
+New pasted images currently go through:
+
+```mermaid
+flowchart LR
+  pasteHandler[useNoteEditorPasteHandler] --> dataUrl[readFileAsDataUrl]
+  dataUrl --> saveCommand[space_save_pasted_image]
+  saveCommand --> hashName[HashFilename]
+  hashName --> href[ReturnedHref]
+  href --> originSrc[ImageOriginSrc]
+  originSrc --> markdown[MarkdownImageSerialization]
+  markdown --> hydrate[useHydrateInlineImages]
+```
+
+The key current backend code is in [`src-tauri/src/space_fs/read_write/binary.rs`](src-tauri/src/space_fs/read_write/binary.rs):
+
+```rust
+let hash = hex::encode(Sha256::digest(&bytes));
+let file_name = format!("{hash}.{ext}");
+```
+
+The frontend already has the original filename at [`src/components/editor/hooks/useNoteEditor.ts`](src/components/editor/hooks/useNoteEditor.ts), but only sends it as `alt`, not as a filename input:
+
+```ts
+const saved = await invoke("space_save_pasted_image", {
+  source_path: sourcePath,
+  target_dir: targetDir,
+  data_url: dataUrl,
+  alt: item.file.name || null,
+});
+```
+
+## Implementation Approach
+
+1. Preserve the existing link model
+
+- Do not rename or migrate old `assets/{hash}.{ext}` files.
+- Do not change [`useHydrateInlineImages.ts`](src/components/editor/hooks/useHydrateInlineImages.ts), [`link_ops.rs`](src-tauri/src/space_fs/link_ops.rs), or link rewrite behavior unless implementation reveals a concrete bug.
+- Continue returning a note-relative `href` from `space_save_pasted_image`; `originSrc` and markdown serialization already use that path.
+
+2. Extend the IPC contract
+
+- Update `space_save_pasted_image` in [`src-tauri/src/space_fs/read_write/binary.rs`](src-tauri/src/space_fs/read_write/binary.rs) to accept `original_filename: Option<String>`.
+- Update `TauriCommands` in [`src/lib/tauri.ts`](src/lib/tauri.ts) to include `original_filename?: string | null`.
+- Update [`src/components/editor/hooks/useNoteEditor.ts`](src/components/editor/hooks/useNoteEditor.ts) to pass `original_filename: item.file.name || null`, while keeping `alt` separate.
+
+3. Add filename derivation helpers in `binary.rs`
+
+- Add local helpers near `extension_for_mime` / `parse_data_url` so this stays scoped to the pasted-image command:
+  - `basename_from_original_filename`: strip path components and separators.
+  - `sanitize_filename_stem`: trim whitespace, remove control characters, replace unsafe filesystem/markdown-hostile characters with `-`, collapse repeated separators, and reject empty or hidden stems.
+  - `split_filename_extension`: separate stem/ext without treating `.hidden` as a valid stem.
+  - `filename_for_mime`: enforce the extension from detected MIME. If the pasted filename has no extension or the wrong one, use the MIME extension from `extension_for_mime`.
+- Prefer preserving readable Unicode characters rather than transliterating them. Avoid adding a Rust dependency unless strict Unicode normalization becomes a requirement.
+- Use a fallback basename of `image.{ext}` for unnamed clipboard blobs; collision handling will produce `image-2.{ext}`, `image-3.{ext}`, etc. This avoids hashes for screenshots while remaining deterministic and simple.
+
+4. Replace hash-only allocation with name-aware allocation
+
+- Build the first candidate from `original_filename` or fallback, under the existing `target_dir` rules.
+- Keep existing protections:
+  - `normalize_rel_path` for source and target dirs.
+  - `deny_hidden_rel_path` before filesystem access.
+  - `paths::join_under` for all space-root joins.
+  - `io_atomic::write_atomic_create_new` for non-overwriting writes.
+- Implement paste-specific suffixing as `stem-2.ext`, `stem-3.ext`, etc. Do not reuse the file-tree duplicate helper because that produces `Copy` names and the issue asks for `picture-new-2.png` style names.
+- Collision behavior:
+  - If candidate does not exist, atomically create it and return that path.
+  - If candidate exists and bytes are identical, reuse it and return that path.
+  - If candidate exists and bytes differ, try the next suffix.
+  - If an atomic create loses a race, read/compare and either reuse or continue suffixing.
+- Compare existing files by reading bytes only after a candidate collision. Do not globally dedupe same bytes under different filenames; that is listed as a non-goal.
+
+5. Keep returned markdown/alt behavior stable
+
+- Keep `alt` as display text and use `original_filename` only for filesystem naming.
+- For named files, `alt` and basename will normally match because both come from `item.file.name`.
+- The returned `markdown` field should continue to use `![{alt_text}]({href})`; frontend currently uses `href`, but preserving the response shape avoids unnecessary API churn.
+
+## Files To Touch
+
+- [`src-tauri/src/space_fs/read_write/binary.rs`](src-tauri/src/space_fs/read_write/binary.rs)
+  - Add `original_filename` arg.
+  - Add sanitization, extension enforcement, byte-compare reuse, suffix allocation.
+  - Remove the hash-based naming dependency from this path; `sha2`/`hex` may no longer be needed in this file.
+  - Add unit tests inside the existing file for helper behavior and allocation logic if practical without large filesystem setup.
+
+- [`src/lib/tauri.ts`](src/lib/tauri.ts)
+  - Extend the typed command args for `space_save_pasted_image`.
+
+- [`src/components/editor/hooks/useNoteEditor.ts`](src/components/editor/hooks/useNoteEditor.ts)
+  - Pass `original_filename` in the invoke payload.
+
+- [`src/components/editor/hooks/useNoteEditor.test.tsx`](src/components/editor/hooks/useNoteEditor.test.tsx)
+  - Update existing invoke expectations in the three attachment-location tests.
+  - Add or adjust a frontend test to assert `alt` and `original_filename` are both sent and remain distinct.
+
+- [`docs/architecture/05-editor-markdown-autosave.md`](docs/architecture/05-editor-markdown-autosave.md)
+  - Update the image paste section to describe readable filename storage, same-bytes reuse, and suffix collision behavior.
+
+## Compatibility Notes
+
+- Existing hash-named files keep working because markdown hydration resolves the literal href path through `space_resolve_markdown_link` and then reads the binary preview.
+- No SQLite migration is needed; the note index stores markdown links, not attachment binary metadata.
+- File-tree rename/link rewrite should keep working because it operates on paths and supported attachment extensions, not hash semantics.
+
+## Validation Plan
+
+- Use `ReadLints` after TypeScript edits.
+- Recommended targeted checks after implementation, if you want me to run them:
+  - `pnpm test -- src/components/editor/hooks/useNoteEditor.test.tsx`
+  - `cd src-tauri && cargo test space_fs::read_write::binary`
+  - `cd src-tauri && cargo check`
+
+## Manual QA
+
+- Paste `picture-new.png` into a note with default `assets` storage and verify markdown uses `assets/picture-new.png`.
+- Paste the same `picture-new.png` bytes again and verify no duplicate file is created.
+- Paste different bytes with the same filename and verify `picture-new-2.png` is created.
+- Paste an unnamed screenshot and verify `image.png` or a suffixed variant is used.
+- Reopen an old note with hash-named image links and verify images still render.

--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -254,11 +254,15 @@ This prevents the active note from reloading while the user has unsaved changes.
    - note folder
 3. Insert temporary object URL image nodes as placeholders.
 4. Convert each file to a data URL.
-5. Call `space_save_pasted_image`.
+5. Call `space_save_pasted_image` with the browser `File.name` as `alt` text; the backend derives the on-disk filename from that value.
 6. Replace placeholders with final image attributes.
 7. Revoke object URLs.
 
-The backend writes the image into the space and returns:
+The backend writes the image into the space using a sanitized version of the original filename, for example `assets/picture-new.png`. The response keeps that filesystem identity in `asset_rel_path`, and returns a root-relative markdown `href` such as `/assets/picture-new.png`; pasted-image nodes store `href` in `originSrc` so markdown serialization, hydration, indexing, and attachment renames all use the same link shape. If that filename already exists with identical bytes, the existing file is reused; if it exists with different bytes, the backend allocates a non-destructive suffix such as `picture-new-2.png`. Unnamed clipboard images fall back to `image.{ext}` and use the same suffixing rules.
+
+Existing hash-named pasted assets are not migrated. Notes that already reference paths such as `assets/{hash}.png` keep resolving through the normal markdown-link hydration path.
+
+The save command returns:
 
 - `asset_rel_path`
 - `href`

--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -254,11 +254,11 @@ This prevents the active note from reloading while the user has unsaved changes.
    - note folder
 3. Insert temporary object URL image nodes as placeholders.
 4. Convert each file to a data URL.
-5. Call `space_save_pasted_image` with the browser `File.name` as `alt` text; the backend derives the on-disk filename from that value.
+5. Call `space_save_pasted_image` with the browser `File.name` as `original_filename`; the backend derives the on-disk filename from that dedicated parameter. Markdown `alt` remains separate display text on the editor image node.
 6. Replace placeholders with final image attributes.
 7. Revoke object URLs.
 
-The backend writes the image into the space using a sanitized version of the original filename, for example `assets/picture-new.png`. The response keeps that filesystem identity in `asset_rel_path`, and returns a root-relative markdown `href` such as `/assets/picture-new.png`; pasted-image nodes store `href` in `originSrc` so markdown serialization, hydration, indexing, and attachment renames all use the same link shape. If that filename already exists with identical bytes, the existing file is reused; if it exists with different bytes, the backend allocates a non-destructive suffix such as `picture-new-2.png`. Unnamed clipboard images fall back to `image.{ext}` and use the same suffixing rules.
+The backend writes the image into the space using a sanitized version of `original_filename`, for example `assets/picture-new.png`. The response keeps that filesystem identity in `asset_rel_path`, and returns a note-relative markdown `href` such as `../assets/picture-new.png`; pasted-image nodes store `href` in `originSrc` so markdown serialization, hydration, indexing, and attachment renames all use the same link shape. If that filename already exists with identical bytes, the existing file is reused; if it exists with different bytes, the backend allocates a non-destructive suffix such as `picture-new-2.png`. Unnamed clipboard images fall back to `image.{ext}` and use the same suffixing rules.
 
 Existing hash-named pasted assets are not migrated. Notes that already reference paths such as `assets/{hash}.png` keep resolving through the normal markdown-link hydration path.
 
@@ -266,7 +266,6 @@ The save command returns:
 
 - `asset_rel_path`
 - `href`
-- `markdown`
 
 Do not store pasted images only in the editor document. They must become files in the space.
 

--- a/src-tauri/src/space_fs/filename.rs
+++ b/src-tauri/src/space_fs/filename.rs
@@ -1,0 +1,22 @@
+/// Split a file name into stem and extension. The extension includes the leading dot.
+pub fn split_stem_extension(file_name: &str) -> (&str, &str) {
+    match file_name.rfind('.') {
+        Some(index) if index > 0 => (&file_name[..index], &file_name[index..]),
+        _ => (file_name, ""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_stem_extension;
+
+    #[test]
+    fn split_stem_extension_preserves_multi_part_extensions() {
+        assert_eq!(split_stem_extension("Archive.tar.gz"), ("Archive.tar", ".gz"));
+    }
+
+    #[test]
+    fn split_stem_extension_handles_names_without_extension() {
+        assert_eq!(split_stem_extension("Todo"), ("Todo", ""));
+    }
+}

--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -675,6 +675,20 @@ mod tests {
     }
 
     #[test]
+    fn rewrites_pasted_image_markdown_links_using_space_root_paths() {
+        let mut plan = plan();
+        plan.from_rel_path = "assets/paste.png".to_string();
+        plan.to_rel_path = "assets/images/paste.png".to_string();
+        plan.from_basename_is_unique = false;
+
+        let input = "![paste.png](/assets/paste.png)";
+        let output = rewrite_markdown_links_for_path(input, &plan, "notes/source.md");
+
+        assert_eq!(output.markdown, "![paste.png](/assets/images/paste.png)");
+        assert_eq!(output.changed_links, 1);
+    }
+
+    #[test]
     fn does_not_rewrite_ambiguous_attachment_basename() {
         let mut plan = plan();
         plan.from_rel_path = "assets/logo.png".to_string();

--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -260,14 +260,17 @@ fn rewrite_markdown_target_path(
         return None;
     }
 
-    if target.starts_with('/') {
-        let root_target = target.trim_start_matches('/');
+    let decoded_target = percent_decode_utf8(target).unwrap_or_else(|| target.to_string());
+    let path_target = decoded_target.as_str();
+
+    if path_target.starts_with('/') {
+        let root_target = path_target.trim_start_matches('/');
         return rewrite_target(root_target, plan, true)
-            .map(|replacement| format!("/{replacement}"));
+            .map(|replacement| format!("/{}", encode_markdown_target_path(&replacement)));
     }
 
-    if let Some(replacement) = rewrite_target(target, plan, true) {
-        return Some(replacement);
+    if let Some(replacement) = rewrite_target(path_target, plan, true) {
+        return Some(encode_markdown_target_path(&replacement));
     }
 
     let current_source_dir = source_dir(source_rel_path);
@@ -276,21 +279,86 @@ fn rewrite_markdown_target_path(
         .as_deref()
         .map(source_dir)
         .unwrap_or_else(|| current_source_dir.clone());
-    let root_target = join_rel_path(&resolution_source_dir, target);
+    let root_target = join_rel_path(&resolution_source_dir, path_target);
 
     if let Some(replacement) = rewrite_target(&root_target, plan, true) {
         let relative = relative_path_from_source_dir(&replacement, &current_source_dir);
-        return (relative != target).then_some(relative);
+        let encoded = encode_markdown_target_path(&relative);
+        return (encoded != target).then_some(encoded);
     }
 
     if old_source_rel_path.is_some() {
         let relocated = relative_path_from_source_dir(&root_target, &current_source_dir);
-        if relocated != target {
-            return Some(relocated);
+        let encoded = encode_markdown_target_path(&relocated);
+        if encoded != target {
+            return Some(encoded);
         }
     }
 
     None
+}
+
+fn percent_decode_utf8(value: &str) -> Option<String> {
+    if !value.as_bytes().contains(&b'%') {
+        return None;
+    }
+
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let Some(high) = hex_value(bytes[index + 1]) else {
+                decoded.push(bytes[index]);
+                index += 1;
+                continue;
+            };
+            let Some(low) = hex_value(bytes[index + 2]) else {
+                decoded.push(bytes[index]);
+                index += 1;
+                continue;
+            };
+            decoded.push(high << 4 | low);
+            index += 3;
+            continue;
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn encode_markdown_target_path(path: &str) -> String {
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if should_percent_encode_markdown_target_byte(byte) {
+            encoded.push('%');
+            encoded.push_str(&format!("{byte:02X}"));
+        } else {
+            encoded.push(byte as char);
+        }
+    }
+    encoded
+}
+
+fn should_percent_encode_markdown_target_byte(byte: u8) -> bool {
+    byte <= b' '
+        || byte >= 0x80
+        || matches!(
+            byte,
+            b'%' | b'<' | b'>' | b'[' | b']' | b'"' | b'\\' | b'^' | b'`' | b'{' | b'|'
+                | b'}'
+        )
 }
 
 fn join_rel_path(base: &str, target: &str) -> String {
@@ -685,6 +753,40 @@ mod tests {
         let output = rewrite_markdown_links_for_path(input, &plan, "notes/source.md");
 
         assert_eq!(output.markdown, "![paste.png](/assets/images/paste.png)");
+        assert_eq!(output.changed_links, 1);
+    }
+
+    #[test]
+    fn rewrites_encoded_pasted_image_markdown_links() {
+        let mut plan = plan();
+        plan.from_rel_path = "assets/picture new.png".to_string();
+        plan.to_rel_path = "assets/archive/picture new.png".to_string();
+        plan.from_basename_is_unique = false;
+
+        let input = "![picture new.png](../assets/picture%20new.png)";
+        let output = rewrite_markdown_links_for_path(input, &plan, "notes/source.md");
+
+        assert_eq!(
+            output.markdown,
+            "![picture new.png](../assets/archive/picture%20new.png)"
+        );
+        assert_eq!(output.changed_links, 1);
+    }
+
+    #[test]
+    fn rewrites_encoded_pasted_image_root_markdown_links() {
+        let mut plan = plan();
+        plan.from_rel_path = "assets/picture new.png".to_string();
+        plan.to_rel_path = "assets/archive/picture new.png".to_string();
+        plan.from_basename_is_unique = false;
+
+        let input = "![picture new.png](/assets/picture%20new.png)";
+        let output = rewrite_markdown_links_for_path(input, &plan, "notes/source.md");
+
+        assert_eq!(
+            output.markdown,
+            "![picture new.png](/assets/archive/picture%20new.png)"
+        );
         assert_eq!(output.changed_links, 1);
     }
 

--- a/src-tauri/src/space_fs/mod.rs
+++ b/src-tauri/src/space_fs/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod filename;
 pub(crate) mod helpers;
 pub mod link_ops;
 pub mod link_rewrite;

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -31,6 +31,31 @@ fn normalize_rel_path(path: &str) -> String {
     parts.join("/")
 }
 
+fn parent_dir(path: &str) -> String {
+    let normalized = normalize_rel_path(path);
+    match normalized.rsplit_once('/') {
+        Some((parent, _)) => parent.to_string(),
+        None => String::new(),
+    }
+}
+
+fn relative_path(from_dir: &str, to_path: &str) -> String {
+    let from: Vec<&str> = from_dir.split('/').filter(|part| !part.is_empty()).collect();
+    let to: Vec<&str> = to_path.split('/').filter(|part| !part.is_empty()).collect();
+    let mut common = 0;
+    while common < from.len() && common < to.len() && from[common] == to[common] {
+        common += 1;
+    }
+
+    let mut parts: Vec<String> = vec!["..".to_string(); from.len().saturating_sub(common)];
+    parts.extend(to[common..].iter().map(|part| (*part).to_string()));
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        parts.join("/")
+    }
+}
+
 fn parse_data_url(data_url: &str) -> Result<(String, Vec<u8>), String> {
     let trimmed = data_url.trim();
     let rest = trimmed
@@ -59,7 +84,7 @@ pub async fn space_save_pasted_image(
     source_path: String,
     target_dir: String,
     data_url: String,
-    alt: Option<String>,
+    original_filename: Option<String>,
 ) -> Result<SavedPastedImage, String> {
     let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || -> Result<SavedPastedImage, String> {
@@ -72,11 +97,12 @@ pub async fn space_save_pasted_image(
         let ext = extension_for_mime(&mime)
             .ok_or_else(|| format!("unsupported pasted image type: {mime}"))?;
 
-        let file_name = filename_for_mime(alt.as_deref(), &mime, ext)?;
-        let asset_rel = write_or_reuse_asset(&root, &target_rel, &file_name, &bytes)?;
+        let asset_file_name = filename_for_mime(original_filename.as_deref(), &mime, ext)?;
+        let asset_rel = write_or_reuse_asset(&root, &target_rel, &asset_file_name, &bytes)?;
 
         let asset_rel_string = asset_rel.to_string_lossy().replace('\\', "/");
-        let href = format!("/{asset_rel_string}");
+        let source_dir = parent_dir(&source_rel.to_string_lossy());
+        let href = relative_path(&source_dir, &asset_rel_string);
 
         Ok(SavedPastedImage {
             asset_rel_path: asset_rel_string,

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -1,21 +1,18 @@
 use base64::Engine;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tauri::{State, WebviewWindow};
 
-use crate::io_atomic;
-use crate::paths;
 use crate::space::SpaceState;
 
 use super::super::helpers::deny_hidden_rel_path;
+use super::pasted_image::{extension_for_mime, filename_for_mime, write_or_reuse_asset};
 
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct SavedPastedImage {
     pub asset_rel_path: String,
     pub href: String,
-    pub markdown: String,
 }
 
 fn normalize_rel_path(path: &str) -> String {
@@ -32,43 +29,6 @@ fn normalize_rel_path(path: &str) -> String {
         parts.push(part);
     }
     parts.join("/")
-}
-
-fn parent_dir(path: &str) -> String {
-    match normalize_rel_path(path).rsplit_once('/') {
-        Some((left, _)) => left.to_string(),
-        None => String::new(),
-    }
-}
-
-fn relative_path(from_dir: &str, to_path: &str) -> String {
-    let from: Vec<&str> = from_dir.split('/').filter(|s| !s.is_empty()).collect();
-    let to: Vec<&str> = to_path.split('/').filter(|s| !s.is_empty()).collect();
-    let mut i = 0;
-    while i < from.len() && i < to.len() && from[i] == to[i] {
-        i += 1;
-    }
-    let mut out: Vec<String> = vec!["..".to_string(); from.len().saturating_sub(i)];
-    out.extend(to[i..].iter().map(|s| s.to_string()));
-    if out.is_empty() {
-        ".".to_string()
-    } else {
-        out.join("/")
-    }
-}
-
-fn extension_for_mime(mime: &str) -> Option<&'static str> {
-    match mime.trim().to_ascii_lowercase().as_str() {
-        "image/png" => Some("png"),
-        "image/jpeg" => Some("jpg"),
-        "image/gif" => Some("gif"),
-        "image/webp" => Some("webp"),
-        "image/svg+xml" => Some("svg"),
-        "image/bmp" => Some("bmp"),
-        "image/avif" => Some("avif"),
-        "image/tiff" => Some("tiff"),
-        _ => None,
-    }
 }
 
 fn parse_data_url(data_url: &str) -> Result<(String, Vec<u8>), String> {
@@ -112,31 +72,15 @@ pub async fn space_save_pasted_image(
         let ext = extension_for_mime(&mime)
             .ok_or_else(|| format!("unsupported pasted image type: {mime}"))?;
 
-        let hash = hex::encode(Sha256::digest(&bytes));
-        let file_name = format!("{hash}.{ext}");
-        let asset_rel = if target_rel.as_os_str().is_empty() {
-            PathBuf::from(&file_name)
-        } else {
-            target_rel.join(&file_name)
-        };
-        deny_hidden_rel_path(&asset_rel)?;
-
-        let asset_abs = paths::join_under(&root, &asset_rel)?;
-        if let Some(parent) = asset_abs.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-        }
-        let _ =
-            io_atomic::write_atomic_create_new(&asset_abs, &bytes).map_err(|e| e.to_string())?;
+        let file_name = filename_for_mime(alt.as_deref(), &mime, ext)?;
+        let asset_rel = write_or_reuse_asset(&root, &target_rel, &file_name, &bytes)?;
 
         let asset_rel_string = asset_rel.to_string_lossy().replace('\\', "/");
-        let source_dir = parent_dir(&source_rel.to_string_lossy());
-        let href = relative_path(&source_dir, &asset_rel_string);
-        let alt_text = alt.unwrap_or_default().trim().to_string();
+        let href = format!("/{asset_rel_string}");
 
         Ok(SavedPastedImage {
             asset_rel_path: asset_rel_string,
-            href: href.clone(),
-            markdown: format!("![{alt_text}]({href})"),
+            href,
         })
     })
     .await

--- a/src-tauri/src/space_fs/read_write/mod.rs
+++ b/src-tauri/src/space_fs/read_write/mod.rs
@@ -1,4 +1,5 @@
 pub mod binary;
+pub mod pasted_image;
 pub mod paths;
 pub mod preview;
 pub mod text;

--- a/src-tauri/src/space_fs/read_write/pasted_image.rs
+++ b/src-tauri/src/space_fs/read_write/pasted_image.rs
@@ -30,22 +30,23 @@ fn extension_matches_mime(mime: &str, ext: &str) -> bool {
     }
 }
 
-fn basename_from_alt(alt: Option<&str>) -> Result<Option<String>, String> {
-    let Some(raw) = alt else {
+fn basename_from_original_filename(
+    original_filename: Option<&str>,
+) -> Result<Option<String>, String> {
+    let Some(raw) = original_filename else {
         return Ok(None);
     };
-    let normalized = raw.trim().replace('\\', "/");
-    if normalized.is_empty() {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
         return Ok(None);
     }
-    let basename = normalized.rsplit('/').next().unwrap_or("").trim();
-    if basename.is_empty() || basename == "." || basename == ".." {
-        return Ok(None);
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed == "." || trimmed == ".." {
+        return Err("pasted image filename must not contain path components".to_string());
     }
-    if basename.starts_with('.') {
+    if trimmed.starts_with('.') {
         return Err("pasted image filename cannot be hidden".to_string());
     }
-    Ok(Some(basename.to_string()))
+    Ok(Some(trimmed.to_string()))
 }
 
 fn is_safe_filename_char(ch: char) -> bool {
@@ -78,8 +79,12 @@ fn sanitize_filename_stem(stem: &str) -> Option<String> {
     }
 }
 
-pub fn filename_for_mime(alt: Option<&str>, mime: &str, ext: &str) -> Result<String, String> {
-    let Some(basename) = basename_from_alt(alt)? else {
+pub fn filename_for_mime(
+    original_filename: Option<&str>,
+    mime: &str,
+    ext: &str,
+) -> Result<String, String> {
+    let Some(basename) = basename_from_original_filename(original_filename)? else {
         return Ok(format!("image.{ext}"));
     };
     let (raw_stem, ext_with_dot) = split_stem_extension(&basename);
@@ -187,11 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn filename_for_mime_uses_sanitized_alt_name() {
-        assert_eq!(
-            filename_for_mime(Some("../picture new.png"), "image/png", "png").unwrap(),
-            "picture new.png"
-        );
+    fn filename_for_mime_uses_sanitized_original_filename() {
         assert_eq!(
             filename_for_mime(Some("screen:shot?.png"), "image/png", "png").unwrap(),
             "screen-shot.png"
@@ -199,7 +200,16 @@ mod tests {
     }
 
     #[test]
-    fn filename_for_mime_rejects_hidden_names() {
+    fn filename_for_mime_rejects_path_bearing_original_filenames() {
+        assert!(filename_for_mime(Some("../picture new.png"), "image/png", "png").is_err());
+        assert!(filename_for_mime(Some("folder/picture.png"), "image/png", "png").is_err());
+        assert!(filename_for_mime(Some("folder\\picture.png"), "image/png", "png").is_err());
+        assert!(filename_for_mime(Some("."), "image/png", "png").is_err());
+        assert!(filename_for_mime(Some(".."), "image/png", "png").is_err());
+    }
+
+    #[test]
+    fn filename_for_mime_rejects_hidden_original_filenames() {
         assert!(filename_for_mime(Some(".secret.png"), "image/png", "png").is_err());
     }
 

--- a/src-tauri/src/space_fs/read_write/pasted_image.rs
+++ b/src-tauri/src/space_fs/read_write/pasted_image.rs
@@ -1,0 +1,320 @@
+use std::path::{Path, PathBuf};
+
+use crate::io_atomic;
+use crate::paths;
+
+use super::super::filename::split_stem_extension;
+use super::super::helpers::deny_hidden_rel_path;
+
+const MAX_SUFFIX_ATTEMPTS: u32 = 999;
+
+pub fn extension_for_mime(mime: &str) -> Option<&'static str> {
+    match mime.trim().to_ascii_lowercase().as_str() {
+        "image/png" => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/gif" => Some("gif"),
+        "image/webp" => Some("webp"),
+        "image/svg+xml" => Some("svg"),
+        "image/bmp" => Some("bmp"),
+        "image/avif" => Some("avif"),
+        "image/tiff" => Some("tiff"),
+        _ => None,
+    }
+}
+
+fn extension_matches_mime(mime: &str, ext: &str) -> bool {
+    match mime.trim().to_ascii_lowercase().as_str() {
+        "image/jpeg" => ext.eq_ignore_ascii_case("jpg") || ext.eq_ignore_ascii_case("jpeg"),
+        "image/tiff" => ext.eq_ignore_ascii_case("tif") || ext.eq_ignore_ascii_case("tiff"),
+        _ => extension_for_mime(mime).is_some_and(|expected| ext.eq_ignore_ascii_case(expected)),
+    }
+}
+
+fn basename_from_alt(alt: Option<&str>) -> Result<Option<String>, String> {
+    let Some(raw) = alt else {
+        return Ok(None);
+    };
+    let normalized = raw.trim().replace('\\', "/");
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+    let basename = normalized.rsplit('/').next().unwrap_or("").trim();
+    if basename.is_empty() || basename == "." || basename == ".." {
+        return Ok(None);
+    }
+    if basename.starts_with('.') {
+        return Err("pasted image filename cannot be hidden".to_string());
+    }
+    Ok(Some(basename.to_string()))
+}
+
+fn is_safe_filename_char(ch: char) -> bool {
+    !ch.is_control()
+        && !matches!(
+            ch,
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '#' | '[' | ']' | '(' | ')'
+        )
+}
+
+fn sanitize_filename_stem(stem: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut last_was_dash = false;
+    for ch in stem.trim().chars() {
+        if is_safe_filename_char(ch) {
+            out.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+    let sanitized = out
+        .trim_matches(|ch: char| ch.is_whitespace() || ch == '-' || ch == '.')
+        .to_string();
+    if sanitized.is_empty() || sanitized.starts_with('.') {
+        None
+    } else {
+        Some(sanitized)
+    }
+}
+
+pub fn filename_for_mime(alt: Option<&str>, mime: &str, ext: &str) -> Result<String, String> {
+    let Some(basename) = basename_from_alt(alt)? else {
+        return Ok(format!("image.{ext}"));
+    };
+    let (raw_stem, ext_with_dot) = split_stem_extension(&basename);
+    let stem = sanitize_filename_stem(raw_stem).unwrap_or_else(|| "image".to_string());
+    let chosen_ext = ext_with_dot
+        .strip_prefix('.')
+        .filter(|value| !value.is_empty())
+        .filter(|value| extension_matches_mime(mime, value))
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| ext.to_string());
+    Ok(format!("{stem}.{chosen_ext}"))
+}
+
+pub fn suffixed_file_name(file_name: &str, index: u32) -> String {
+    let (stem, ext) = split_stem_extension(file_name);
+    format!("{stem}-{index}{ext}")
+}
+
+fn asset_rel_for_file_name(target_rel: &Path, file_name: &str) -> PathBuf {
+    if target_rel.as_os_str().is_empty() {
+        PathBuf::from(file_name)
+    } else {
+        target_rel.join(file_name)
+    }
+}
+
+fn file_bytes_match(path: &Path, bytes: &[u8]) -> Result<bool, String> {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) => return Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.to_string()),
+    };
+    if metadata.len() != bytes.len() as u64 {
+        return Ok(false);
+    }
+    match std::fs::read(path) {
+        Ok(existing) => Ok(existing == bytes),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn write_or_reuse_asset(
+    root: &Path,
+    target_rel: &Path,
+    file_name: &str,
+    bytes: &[u8],
+) -> Result<PathBuf, String> {
+    let mut suffix_index = 1_u32;
+    loop {
+        if suffix_index > MAX_SUFFIX_ATTEMPTS {
+            return Err(format!(
+                "could not allocate a unique pasted image name for {file_name}"
+            ));
+        }
+        let candidate_name = if suffix_index == 1 {
+            file_name.to_string()
+        } else {
+            suffixed_file_name(file_name, suffix_index)
+        };
+        let asset_rel = asset_rel_for_file_name(target_rel, &candidate_name);
+        deny_hidden_rel_path(&asset_rel)?;
+        let asset_abs = paths::join_under(root, &asset_rel)?;
+        match io_atomic::write_atomic_create_new(&asset_abs, bytes).map_err(|e| e.to_string())? {
+            true => return Ok(asset_rel),
+            false if file_bytes_match(&asset_abs, bytes)? => return Ok(asset_rel),
+            false => {
+                suffix_index += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        filename_for_mime, suffixed_file_name, write_or_reuse_asset, MAX_SUFFIX_ATTEMPTS,
+    };
+    use std::path::{Path, PathBuf};
+
+    struct TempSpace {
+        root: PathBuf,
+    }
+
+    impl TempSpace {
+        fn new() -> Self {
+            let root = std::env::temp_dir().join(format!(
+                "glyph-pasted-image-test-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&root).expect("temp space should be created");
+            Self { root }
+        }
+
+        fn path(&self) -> &Path {
+            &self.root
+        }
+    }
+
+    impl Drop for TempSpace {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn filename_for_mime_uses_sanitized_alt_name() {
+        assert_eq!(
+            filename_for_mime(Some("../picture new.png"), "image/png", "png").unwrap(),
+            "picture new.png"
+        );
+        assert_eq!(
+            filename_for_mime(Some("screen:shot?.png"), "image/png", "png").unwrap(),
+            "screen-shot.png"
+        );
+    }
+
+    #[test]
+    fn filename_for_mime_rejects_hidden_names() {
+        assert!(filename_for_mime(Some(".secret.png"), "image/png", "png").is_err());
+    }
+
+    #[test]
+    fn filename_for_mime_enforces_detected_mime_extension() {
+        assert_eq!(
+            filename_for_mime(Some("photo.gif"), "image/png", "png").unwrap(),
+            "photo.png"
+        );
+        assert_eq!(
+            filename_for_mime(Some("photo.jpeg"), "image/jpeg", "jpg").unwrap(),
+            "photo.jpeg"
+        );
+    }
+
+    #[test]
+    fn filename_for_mime_falls_back_for_unnamed_images() {
+        assert_eq!(
+            filename_for_mime(None, "image/webp", "webp").unwrap(),
+            "image.webp"
+        );
+        assert_eq!(
+            filename_for_mime(Some(""), "image/png", "png").unwrap(),
+            "image.png"
+        );
+    }
+
+    #[test]
+    fn suffix_uses_dash_number_before_extension() {
+        assert_eq!(
+            suffixed_file_name("picture-new.png", 2),
+            "picture-new-2.png"
+        );
+    }
+
+    #[test]
+    fn write_or_reuse_asset_creates_new_file() {
+        let temp_space = TempSpace::new();
+        let bytes = vec![1_u8, 2, 3];
+        let asset_rel =
+            write_or_reuse_asset(temp_space.path(), Path::new("assets"), "photo.png", &bytes)
+                .expect("new asset should be written");
+
+        assert_eq!(asset_rel, Path::new("assets/photo.png"));
+        assert_eq!(
+            std::fs::read(temp_space.path().join(&asset_rel)).expect("asset should exist"),
+            bytes
+        );
+    }
+
+    #[test]
+    fn write_or_reuse_asset_reuses_identical_bytes() {
+        let temp_space = TempSpace::new();
+        let bytes = vec![4_u8, 5, 6];
+        let first = write_or_reuse_asset(
+            temp_space.path(),
+            Path::new("assets"),
+            "photo.png",
+            &bytes,
+        )
+        .expect("first write should succeed");
+        let second = write_or_reuse_asset(
+            temp_space.path(),
+            Path::new("assets"),
+            "photo.png",
+            &bytes,
+        )
+        .expect("second write should reuse existing asset");
+
+        assert_eq!(first, second);
+        let entries: Vec<_> = std::fs::read_dir(temp_space.path().join("assets"))
+            .expect("assets dir should exist")
+            .map(|entry| entry.expect("dir entry should be readable").file_name())
+            .collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn write_or_reuse_asset_suffixes_when_bytes_differ() {
+        let temp_space = TempSpace::new();
+        let target = Path::new("assets");
+        write_or_reuse_asset(temp_space.path(), target, "photo.png", &[1_u8])
+            .expect("first write should succeed");
+        let asset_rel =
+            write_or_reuse_asset(temp_space.path(), target, "photo.png", &[2_u8])
+                .expect("conflicting write should suffix");
+
+        assert_eq!(asset_rel, Path::new("assets/photo-2.png"));
+        assert_eq!(
+            std::fs::read(temp_space.path().join(&asset_rel)).expect("suffixed asset should exist"),
+            vec![2_u8]
+        );
+    }
+
+    #[test]
+    fn write_or_reuse_asset_errors_after_suffix_limit() {
+        let temp_space = TempSpace::new();
+        let target_abs = temp_space.path().join("assets");
+        std::fs::create_dir_all(&target_abs).expect("assets dir should be created");
+        std::fs::write(target_abs.join("photo.png"), [1_u8]).expect("seed file should exist");
+        for index in 2..=MAX_SUFFIX_ATTEMPTS {
+            std::fs::write(
+                target_abs.join(format!("photo-{index}.png")),
+                [index as u8],
+            )
+            .expect("seed file should exist");
+        }
+
+        let error = write_or_reuse_asset(
+            temp_space.path(),
+            Path::new("assets"),
+            "photo.png",
+            &[254_u8, 255_u8],
+        )
+        .expect_err("suffix allocation should be exhausted");
+        assert!(error.contains("could not allocate a unique pasted image name"));
+    }
+}

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -8,6 +8,7 @@ use tauri::{Emitter, State, WebviewWindow};
 use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
 use crate::{index, paths, space::SpaceState, utils};
 
+use super::super::filename::split_stem_extension;
 use super::super::helpers::deny_hidden_rel_path;
 use super::super::link_rewrite::{self, LinkRewriteResult};
 use super::super::types::FsEntry;
@@ -20,15 +21,8 @@ struct NoteChangeEvent {
     removed: bool,
 }
 
-fn split_duplicate_name(file_name: &str) -> (&str, &str) {
-    match file_name.rfind('.') {
-        Some(index) if index > 0 => (&file_name[..index], &file_name[index..]),
-        _ => (file_name, ""),
-    }
-}
-
 fn next_duplicate_file_name(existing_names: &HashSet<String>, file_name: &str) -> String {
-    let (stem, ext) = split_duplicate_name(file_name);
+    let (stem, ext) = split_stem_extension(file_name);
     let base_name = if stem.is_empty() { file_name } else { stem };
     let first_candidate = format!("{base_name} Copy{ext}");
     if !existing_names.contains(&first_candidate.to_lowercase()) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.5-alpha.2",
+	"version": "0.8.5-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -370,7 +370,7 @@ describe("useNoteEditor", () => {
 		invokeMock.mockReset();
 		invokeMock.mockResolvedValue({
 			asset_rel_path: "assets/image.png",
-			href: "/assets/image.png",
+			href: "../assets/image.png",
 		});
 		loadSettingsMock.mockReset();
 		loadSettingsMock.mockResolvedValue({
@@ -1013,10 +1013,10 @@ describe("useNoteEditor", () => {
 					pos: number,
 				) => void,
 			) => {
+				const insertContentAtCalls = chainCommands.insertContentAt.mock
+					.calls as unknown as Array<[unknown, unknown]>;
 				const lastInsertCall =
-					chainCommands.insertContentAt.mock.calls[
-						chainCommands.insertContentAt.mock.calls.length - 1
-					];
+					insertContentAtCalls[insertContentAtCalls.length - 1];
 				const insertedNodes = lastInsertCall?.[1] as
 					| Array<{ attrs?: { uploadId?: string } }>
 					| undefined;
@@ -1047,7 +1047,7 @@ describe("useNoteEditor", () => {
 			source_path: "notes/test.md",
 			target_dir: "assets/uploads",
 			data_url: "data:image/png;base64,abc",
-			alt: "paste.png",
+			original_filename: "paste.png",
 		});
 		expect(mockEditor.state.tr.setNodeMarkup).toHaveBeenCalledWith(
 			6,
@@ -1056,7 +1056,7 @@ describe("useNoteEditor", () => {
 				src: "data:image/png;base64,abc",
 				alt: "paste.png",
 				title: "",
-				originSrc: "/assets/image.png",
+				originSrc: "../assets/image.png",
 				uploadId: null,
 			}),
 		);
@@ -1097,7 +1097,7 @@ describe("useNoteEditor", () => {
 			source_path: "notes/test.md",
 			target_dir: "",
 			data_url: "data:image/png;base64,abc",
-			alt: "paste.png",
+			original_filename: "paste.png",
 		});
 	});
 
@@ -1136,7 +1136,7 @@ describe("useNoteEditor", () => {
 			source_path: "notes/test.md",
 			target_dir: "notes",
 			data_url: "data:image/png;base64,abc",
-			alt: "paste.png",
+			original_filename: "paste.png",
 		});
 	});
 
@@ -1202,7 +1202,7 @@ describe("useNoteEditor", () => {
 			.mockRejectedValueOnce(new Error("first upload failed"))
 			.mockResolvedValueOnce({
 				asset_rel_path: "assets/image-2.png",
-				href: "/assets/image-2.png",
+				href: "../assets/image-2.png",
 			});
 
 		await act(async () => {

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -351,6 +351,7 @@ describe("useNoteEditor", () => {
 				return mockEditor.state.tr;
 			},
 		);
+		mockEditor.state.tr.setNodeMarkup.mockReset();
 		mockEditor.view.dispatch.mockReset();
 		mockEditor.view.focus.mockReset();
 		mockEditor.view.hasFocus.mockReset();
@@ -367,7 +368,10 @@ describe("useNoteEditor", () => {
 		canCommands.insertContentAt.mockReturnValue(true);
 		openUrlMock.mockReset();
 		invokeMock.mockReset();
-		invokeMock.mockResolvedValue({ href: "assets/image.png" });
+		invokeMock.mockResolvedValue({
+			asset_rel_path: "assets/image.png",
+			href: "/assets/image.png",
+		});
 		loadSettingsMock.mockReset();
 		loadSettingsMock.mockResolvedValue({
 			editor: {
@@ -1002,6 +1006,37 @@ describe("useNoteEditor", () => {
 		const event = createClipboardEvent({
 			items: [{ type: "image/png", getAsFile: () => file }],
 		});
+		mockEditor.state.doc.descendants.mockImplementation(
+			(
+				visit: (
+					node: { type: { name: string }; attrs: Record<string, unknown> },
+					pos: number,
+				) => void,
+			) => {
+				const lastInsertCall =
+					chainCommands.insertContentAt.mock.calls[
+						chainCommands.insertContentAt.mock.calls.length - 1
+					];
+				const insertedNodes = lastInsertCall?.[1] as
+					| Array<{ attrs?: { uploadId?: string } }>
+					| undefined;
+				const uploadId = insertedNodes?.[0]?.attrs?.uploadId;
+				if (!uploadId) return;
+				visit(
+					{
+						type: { name: "image" },
+						attrs: {
+							src: "blob:preview",
+							alt: "paste.png",
+							title: "",
+							originSrc: "",
+							uploadId,
+						},
+					},
+					6,
+				);
+			},
+		);
 
 		await act(async () => {
 			expect(paste?.({}, event)).toBe(true);
@@ -1014,6 +1049,17 @@ describe("useNoteEditor", () => {
 			data_url: "data:image/png;base64,abc",
 			alt: "paste.png",
 		});
+		expect(mockEditor.state.tr.setNodeMarkup).toHaveBeenCalledWith(
+			6,
+			undefined,
+			expect.objectContaining({
+				src: "data:image/png;base64,abc",
+				alt: "paste.png",
+				title: "",
+				originSrc: "/assets/image.png",
+				uploadId: null,
+			}),
+		);
 	});
 
 	it("saves pasted images to the space root when that mode is selected", async () => {
@@ -1154,7 +1200,10 @@ describe("useNoteEditor", () => {
 		const onChange = vi.fn();
 		invokeMock
 			.mockRejectedValueOnce(new Error("first upload failed"))
-			.mockResolvedValueOnce({ href: "assets/image-2.png" });
+			.mockResolvedValueOnce({
+				asset_rel_path: "assets/image-2.png",
+				href: "/assets/image-2.png",
+			});
 
 		await act(async () => {
 			root.render(

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -640,7 +640,7 @@ export function useNoteEditor({
 											source_path: sourcePath,
 											target_dir: targetDir,
 											data_url: dataUrl,
-											alt: item.file.name || null,
+											original_filename: item.file.name || null,
 										});
 										replacePlaceholderWithImage(editorInstance, item.uploadId, {
 											src: dataUrl,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -848,7 +848,7 @@ interface TauriCommands {
 			source_path: string;
 			target_dir: string;
 			data_url: string;
-			alt?: string | null;
+			original_filename?: string | null;
 		},
 		SavedPastedImage
 	>;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -111,7 +111,6 @@ interface BinaryFilePreviewDoc {
 interface SavedPastedImage {
 	asset_rel_path: string;
 	href: string;
-	markdown: string;
 }
 
 export interface NoteProperty {


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/231


## Description

Pasted images are now saved with readable filenames derived from the clipboard `File.name` instead of a SHA-256 content hash.

- **Summary of changes**
  - New pasted images use a sanitized version of the browser filename (e.g. `assets/picture-new.png`) rather than `assets/{hash}.{ext}`.
  - Identical bytes at the same path are reused; conflicting names get a `-2`, `-3`, … suffix (`picture-new-2.png`).
  - Unnamed clipboard blobs fall back to `image.{ext}` with the same suffix rules.
  - Extracted filename helpers into `space_fs/filename.rs` and pasted-image allocation into `space_fs/read_write/pasted_image.rs`.
  - Updated editor paste tests and architecture docs; bumped version to `0.8.5-alpha.3`.
- **Reasoning**
  - Hash-based names are opaque in the file tree and make it hard to recognize pasted assets. Original filenames are more discoverable while keeping existing path-based link resolution intact.
- **Additional context**
  - Existing hash-named assets are **not** migrated; notes that already reference `assets/{hash}.png` continue to resolve normally.
  - No SQLite migration — the index stores markdown links, not attachment metadata.


## Screenshots

Non-visual backend/behavior change — delete this section if preferred.


## Docs

Updated `docs/architecture/05-editor-markdown-autosave.md` image-paste section:

- Backend derives on-disk filename from `File.name` (sent as `alt` in `space_save_pasted_image`).
- Same-bytes reuse and `-N` suffix collision behavior documented.
- Existing hash-named assets explicitly called out as unchanged.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pasted images now keep a filename based on the original clipboard name when possible, with automatic suffixing to avoid collisions.
  * Image links are now saved and rewritten consistently in both relative and root-relative forms.

* **Bug Fixes**
  * Improved handling of pasted images with spaces or special characters in filenames.
  * Existing pasted images remain accessible, and duplicate uploads now reuse matching files instead of creating unnecessary copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->