### PR TITLE
Collections filtering, grouping, and board UX improvements

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+allowBuilds:
+  '@biomejs/biome': true
+  esbuild: true
+
 onlyBuiltDependencies:
   - "@biomejs/biome"
   - esbuild

--- a/src-tauri/src/databases/filter.rs
+++ b/src-tauri/src/databases/filter.rs
@@ -1,0 +1,465 @@
+use chrono::Datelike;
+
+use crate::index::tags::{normalize_tag, tag_matches_hierarchy};
+
+use super::query::{cell_text_values, cell_value_from_row, normalize_text};
+use super::types::{DatabaseColumn, DatabaseFilter, DatabaseRow};
+
+fn normalize_tag_text(value: &str) -> Option<String> {
+    normalize_tag(value)
+}
+
+fn date_matches_shortcut(value: &str, shortcut: &str) -> bool {
+    let date = match chrono::DateTime::parse_from_rfc3339(value) {
+        Ok(parsed) => parsed.with_timezone(&chrono::Local).date_naive(),
+        Err(_) => match chrono::NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d") {
+            Ok(parsed) => parsed,
+            Err(_) => return false,
+        },
+    };
+    let today = chrono::Local::now().date_naive();
+    match normalize_text(shortcut).as_str() {
+        "today" => date == today,
+        "yesterday" => date == today - chrono::Days::new(1),
+        "overdue" => date < today,
+        "this week" => {
+            let days_until_sunday = 6 - today.weekday().num_days_from_monday();
+            let week_end = today + chrono::Days::new(days_until_sunday as u64);
+            date >= today && date <= week_end
+        }
+        "last 7 days" => date >= today - chrono::Days::new(6) && date <= today,
+        "last 30 days" => date >= today - chrono::Days::new(29) && date <= today,
+        _ => false,
+    }
+}
+
+fn parse_filter_number(value: &str) -> Option<f64> {
+    let normalized = value.trim().replace(['$', ',', '%'], "");
+    let parsed = normalized.parse::<f64>().ok()?;
+    parsed.is_finite().then_some(parsed)
+}
+
+pub(super) fn row_matches_filters(
+    row: &DatabaseRow,
+    columns: &[DatabaseColumn],
+    filters: &[DatabaseFilter],
+) -> bool {
+    filters.iter().all(|filter| {
+        if filter.operator == "within_last_7_days" {
+            let Some(column) = columns.iter().find(|entry| entry.id == filter.column_id) else {
+                return false;
+            };
+            let cell = cell_value_from_row(row, column);
+            let Some(value) = cell.value_text.as_deref() else {
+                return false;
+            };
+            return date_matches_shortcut(
+                value,
+                filter.value_text.as_deref().unwrap_or("Last 7 Days"),
+            );
+        }
+        let Some(column) = columns.iter().find(|entry| entry.id == filter.column_id) else {
+            return false;
+        };
+        let cell = cell_value_from_row(row, column);
+        let is_tags_column =
+            column.column_type == "tags" || column.property_kind.as_deref() == Some("tags");
+        let raw_filter_text = filter.value_text.as_deref().unwrap_or_default();
+        let filter_text = if is_tags_column {
+            String::new()
+        } else {
+            normalize_text(raw_filter_text)
+        };
+        let normalized_filter_tag = if is_tags_column {
+            normalize_tag_text(raw_filter_text)
+        } else {
+            None
+        };
+        let text_values: Vec<String> = if is_tags_column {
+            cell.value_list
+                .iter()
+                .filter_map(|v| normalize_tag_text(v))
+                .collect()
+        } else {
+            cell_text_values(&cell)
+        };
+        match filter.operator.as_str() {
+            "equals" => {
+                if is_tags_column {
+                    normalized_filter_tag
+                        .as_ref()
+                        .is_some_and(|tag| text_values.iter().any(|value| value == tag))
+                } else {
+                    !filter_text.is_empty() && text_values.iter().any(|value| value == &filter_text)
+                }
+            }
+            "not_equals" => {
+                if is_tags_column {
+                    normalized_filter_tag
+                        .as_ref()
+                        .is_some_and(|tag| text_values.iter().all(|value| value != tag))
+                } else {
+                    filter_text.is_empty() || text_values.iter().all(|value| value != &filter_text)
+                }
+            }
+            "contains" => {
+                if is_tags_column {
+                    false
+                } else {
+                    filter_text.is_empty()
+                        || text_values.iter().any(|value| value.contains(&filter_text))
+                }
+            }
+            "not_contains" => {
+                if is_tags_column {
+                    false
+                } else {
+                    filter_text.is_empty()
+                        || text_values
+                            .iter()
+                            .all(|value| !value.contains(&filter_text))
+                }
+            }
+            "starts_with" => {
+                if is_tags_column {
+                    false
+                } else {
+                    filter_text.is_empty()
+                        || text_values
+                            .iter()
+                            .any(|value| value.starts_with(&filter_text))
+                }
+            }
+            "ends_with" => {
+                if is_tags_column {
+                    false
+                } else {
+                    filter_text.is_empty()
+                        || text_values
+                            .iter()
+                            .any(|value| value.ends_with(&filter_text))
+                }
+            }
+            "greater_than" | "less_than" => {
+                if is_tags_column {
+                    false
+                } else {
+                    let Some(filter_number) = parse_filter_number(raw_filter_text) else {
+                        return false;
+                    };
+                    text_values
+                        .iter()
+                        .filter_map(|value| parse_filter_number(value))
+                        .any(|value| {
+                            if filter.operator == "greater_than" {
+                                value > filter_number
+                            } else {
+                                value < filter_number
+                            }
+                        })
+                }
+            }
+            "tags_contains" => normalized_filter_tag.as_ref().is_some_and(|filter_tag| {
+                text_values
+                    .iter()
+                    .any(|tag| tag_matches_hierarchy(filter_tag, tag))
+            }),
+            "is_empty" => text_values.is_empty() && cell.value_bool.is_none(),
+            "is_not_empty" => !text_values.is_empty() || cell.value_bool.is_some(),
+            "is_true" => cell.value_bool == Some(true),
+            "is_false" => cell.value_bool == Some(false),
+            "any_of" => {
+                let filter_values = if filter.value_list.is_empty() {
+                    filter
+                        .value_text
+                        .clone()
+                        .map(|value| vec![value])
+                        .unwrap_or_default()
+                } else {
+                    filter.value_list.clone()
+                };
+                if filter_values.is_empty() {
+                    return true;
+                }
+                let normalized_tag_filters = if is_tags_column {
+                    let filters = filter_values
+                        .iter()
+                        .map(|value| normalize_tag_text(value))
+                        .collect::<Option<Vec<_>>>();
+                    let Some(filters) = filters else {
+                        return false;
+                    };
+                    Some(filters)
+                } else {
+                    None
+                };
+                if let Some(filters) = normalized_tag_filters {
+                    filters.iter().any(|normalized| {
+                        text_values
+                            .iter()
+                            .any(|cell_value| tag_matches_hierarchy(normalized, cell_value))
+                    })
+                } else {
+                    filter_values.iter().any(|value| {
+                        let normalized = normalize_text(value);
+                        text_values
+                            .iter()
+                            .any(|cell_value| cell_value == &normalized)
+                    })
+                }
+            }
+            "none_of" => {
+                let filter_values = if filter.value_list.is_empty() {
+                    filter
+                        .value_text
+                        .clone()
+                        .map(|value| vec![value])
+                        .unwrap_or_default()
+                } else {
+                    filter.value_list.clone()
+                };
+                let normalized_tag_filters = if is_tags_column {
+                    let filters = filter_values
+                        .iter()
+                        .map(|value| normalize_tag_text(value))
+                        .collect::<Option<Vec<_>>>();
+                    let Some(filters) = filters else {
+                        return false;
+                    };
+                    Some(filters)
+                } else {
+                    None
+                };
+                if let Some(filters) = normalized_tag_filters {
+                    filters.iter().all(|normalized| {
+                        text_values
+                            .iter()
+                            .all(|cell_value| !tag_matches_hierarchy(normalized, cell_value))
+                    })
+                } else {
+                    filter_values.iter().all(|value| {
+                        let normalized = normalize_text(value);
+                        text_values
+                            .iter()
+                            .all(|cell_value| cell_value != &normalized)
+                    })
+                }
+            }
+            _ => false,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::super::types::DatabaseCellValue;
+    use super::*;
+
+    fn tags_column() -> DatabaseColumn {
+        DatabaseColumn {
+            id: "tags".to_string(),
+            column_type: "tags".to_string(),
+            label: "Tags".to_string(),
+            icon: None,
+            width: None,
+            visible: true,
+            property_key: None,
+            property_kind: None,
+        }
+    }
+
+    fn title_column() -> DatabaseColumn {
+        DatabaseColumn {
+            id: "title".to_string(),
+            column_type: "title".to_string(),
+            label: "Title".to_string(),
+            icon: None,
+            width: None,
+            visible: true,
+            property_key: None,
+            property_kind: None,
+        }
+    }
+
+    fn folder_column() -> DatabaseColumn {
+        DatabaseColumn {
+            id: "folder".to_string(),
+            column_type: "folder".to_string(),
+            label: "Folder".to_string(),
+            icon: None,
+            width: None,
+            visible: true,
+            property_key: None,
+            property_kind: None,
+        }
+    }
+
+    fn number_property_column(key: &str) -> DatabaseColumn {
+        DatabaseColumn {
+            id: format!("property:{key}"),
+            column_type: "property".to_string(),
+            label: key.to_string(),
+            icon: None,
+            width: None,
+            visible: true,
+            property_key: Some(key.to_string()),
+            property_kind: Some("number".to_string()),
+        }
+    }
+
+    fn sample_row(tags: Vec<&str>) -> DatabaseRow {
+        DatabaseRow {
+            note_path: "notes/child.md".to_string(),
+            title: "Child".to_string(),
+            folder: "notes".to_string(),
+            created: "2026-03-24T10:00:00Z".to_string(),
+            updated: "2026-03-24T10:00:00Z".to_string(),
+            preview: String::new(),
+            tags: tags.into_iter().map(str::to_string).collect(),
+            linked_notes: Vec::new(),
+            properties: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn tag_filters_match_descendant_explicit_tags() {
+        let columns = vec![tags_column()];
+        let row = sample_row(vec!["work/today/further"]);
+        let filters = vec![DatabaseFilter {
+            column_id: "tags".to_string(),
+            operator: "tags_contains".to_string(),
+            value_text: Some("#work".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(row_matches_filters(&row, &columns, &filters));
+
+        let non_matching_filters = vec![DatabaseFilter {
+            column_id: "tags".to_string(),
+            operator: "tags_contains".to_string(),
+            value_text: Some("#personal".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+        assert!(!row_matches_filters(&row, &columns, &non_matching_filters));
+    }
+
+    #[test]
+    fn malformed_tag_filters_fail_closed() {
+        let columns = vec![tags_column()];
+        let row = sample_row(vec!["work/today/further"]);
+        let filters = vec![DatabaseFilter {
+            column_id: "tags".to_string(),
+            operator: "tags_contains".to_string(),
+            value_text: Some("#work//today".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(!row_matches_filters(&row, &columns, &filters));
+    }
+
+    #[test]
+    fn unsupported_string_operators_fail_closed_for_tag_columns() {
+        let columns = vec![tags_column()];
+        let row = sample_row(vec!["work/today/further"]);
+        let filters = vec![DatabaseFilter {
+            column_id: "tags".to_string(),
+            operator: "contains".to_string(),
+            value_text: Some("work".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(!row_matches_filters(&row, &columns, &filters));
+    }
+
+    #[test]
+    fn unknown_filter_columns_fail_closed() {
+        let columns = vec![title_column()];
+        let row = sample_row(Vec::new());
+        let filters = vec![DatabaseFilter {
+            column_id: "missing".to_string(),
+            operator: "contains".to_string(),
+            value_text: Some("Child".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(!row_matches_filters(&row, &columns, &filters));
+    }
+
+    #[test]
+    fn multiple_filters_must_all_match() {
+        let columns = vec![title_column(), tags_column()];
+        let row = sample_row(vec!["work"]);
+        let filters = vec![
+            DatabaseFilter {
+                column_id: "title".to_string(),
+                operator: "contains".to_string(),
+                value_text: Some("Child".to_string()),
+                value_bool: None,
+                value_list: Vec::new(),
+            },
+            DatabaseFilter {
+                column_id: "tags".to_string(),
+                operator: "tags_contains".to_string(),
+                value_text: Some("#personal".to_string()),
+                value_bool: None,
+                value_list: Vec::new(),
+            },
+        ];
+
+        assert!(!row_matches_filters(&row, &columns, &filters));
+    }
+
+    #[test]
+    fn folder_filters_match_exact_folder_values() {
+        let columns = vec![folder_column()];
+        let row = sample_row(Vec::new());
+        let matching_filters = vec![DatabaseFilter {
+            column_id: "folder".to_string(),
+            operator: "equals".to_string(),
+            value_text: Some("notes".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+        let unrelated_filters = vec![DatabaseFilter {
+            column_id: "folder".to_string(),
+            operator: "equals".to_string(),
+            value_text: Some("archive".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(row_matches_filters(&row, &columns, &matching_filters));
+        assert!(!row_matches_filters(&row, &columns, &unrelated_filters));
+    }
+
+    #[test]
+    fn invalid_number_filters_fail_closed() {
+        let columns = vec![number_property_column("score")];
+        let mut row = sample_row(Vec::new());
+        row.properties.insert(
+            "score".to_string(),
+            DatabaseCellValue {
+                kind: "number".to_string(),
+                value_text: Some("10".to_string()),
+                value_bool: None,
+                value_list: Vec::new(),
+            },
+        );
+        let filters = vec![DatabaseFilter {
+            column_id: "property:score".to_string(),
+            operator: "greater_than".to_string(),
+            value_text: Some("not a number".to_string()),
+            value_bool: None,
+            value_list: Vec::new(),
+        }];
+
+        assert!(!row_matches_filters(&row, &columns, &filters));
+    }
+}

--- a/src-tauri/src/databases/filter.rs
+++ b/src-tauri/src/databases/filter.rs
@@ -23,9 +23,11 @@ fn date_matches_shortcut(value: &str, shortcut: &str) -> bool {
         "yesterday" => date == today - chrono::Days::new(1),
         "overdue" => date < today,
         "this week" => {
+            let days_since_monday = today.weekday().num_days_from_monday();
+            let week_start = today - chrono::Days::new(days_since_monday as u64);
             let days_until_sunday = 6 - today.weekday().num_days_from_monday();
             let week_end = today + chrono::Days::new(days_until_sunday as u64);
-            date >= today && date <= week_end
+            date >= week_start && date <= week_end
         }
         "last 7 days" => date >= today - chrono::Days::new(6) && date <= today,
         "last 30 days" => date >= today - chrono::Days::new(29) && date <= today,

--- a/src-tauri/src/databases/mod.rs
+++ b/src-tauri/src/databases/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+mod filter;
 mod query;
 mod store;
 mod types;

--- a/src-tauri/src/databases/query.rs
+++ b/src-tauri/src/databases/query.rs
@@ -1,16 +1,15 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
-use chrono::Datelike;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::index::commands::parse_raw_search_query;
 use crate::index::open_db;
 use crate::index::search_advanced::run_search_advanced;
-use crate::index::tags::{normalize_tag, tag_matches_hierarchy};
 use crate::paths;
 use crate::space_fs::helpers::deny_hidden_rel_path;
 
+use super::filter::row_matches_filters;
 use super::types::{
     DatabaseCellValue, DatabaseColumn, DatabaseDefinition, DatabaseDocument,
     DatabasePropertyOption, DatabaseQueryResult, DatabaseRow, DatabaseViewDefinition,
@@ -123,12 +122,8 @@ fn field_catalog(
     out
 }
 
-fn normalize_text(value: &str) -> String {
+pub(super) fn normalize_text(value: &str) -> String {
     value.trim().to_lowercase()
-}
-
-fn normalize_tag_text(value: &str) -> Option<String> {
-    normalize_tag(value)
 }
 
 fn parent_dir(path: &str) -> String {
@@ -139,7 +134,7 @@ fn parent_dir(path: &str) -> String {
         .unwrap_or_else(|| "/".to_string())
 }
 
-fn cell_value_from_row(row: &DatabaseRow, column: &DatabaseColumn) -> DatabaseCellValue {
+pub(super) fn cell_value_from_row(row: &DatabaseRow, column: &DatabaseColumn) -> DatabaseCellValue {
     match column.column_type.as_str() {
         "title" => DatabaseCellValue {
             kind: "text".to_string(),
@@ -205,7 +200,7 @@ fn cell_value_from_row(row: &DatabaseRow, column: &DatabaseColumn) -> DatabaseCe
     }
 }
 
-fn cell_text_values(cell: &DatabaseCellValue) -> Vec<String> {
+pub(super) fn cell_text_values(cell: &DatabaseCellValue) -> Vec<String> {
     let mut values = Vec::new();
     if let Some(value) = &cell.value_text {
         let normalized = normalize_text(value);
@@ -223,247 +218,6 @@ fn cell_text_values(cell: &DatabaseCellValue) -> Vec<String> {
         values.push(if value { "true" } else { "false" }.to_string());
     }
     values
-}
-
-fn date_matches_shortcut(value: &str, shortcut: &str) -> bool {
-    let date = match chrono::DateTime::parse_from_rfc3339(value) {
-        Ok(parsed) => parsed.with_timezone(&chrono::Local).date_naive(),
-        Err(_) => match chrono::NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d") {
-            Ok(parsed) => parsed,
-            Err(_) => return false,
-        },
-    };
-    let today = chrono::Local::now().date_naive();
-    match normalize_text(shortcut).as_str() {
-        "today" => date == today,
-        "yesterday" => date == today - chrono::Days::new(1),
-        "overdue" => date < today,
-        "this week" => {
-            let days_until_sunday = 6 - today.weekday().num_days_from_monday();
-            let week_end = today + chrono::Days::new(days_until_sunday as u64);
-            date >= today && date <= week_end
-        }
-        "last 7 days" => date >= today - chrono::Days::new(6) && date <= today,
-        "last 30 days" => date >= today - chrono::Days::new(29) && date <= today,
-        _ => false,
-    }
-}
-
-fn parse_filter_number(value: &str) -> Option<f64> {
-    let normalized = value.trim().replace(['$', ',', '%'], "");
-    let parsed = normalized.parse::<f64>().ok()?;
-    parsed.is_finite().then_some(parsed)
-}
-
-fn row_matches_filters(
-    row: &DatabaseRow,
-    columns: &[DatabaseColumn],
-    filters: &[super::types::DatabaseFilter],
-) -> bool {
-    filters.iter().all(|filter| {
-        if filter.operator == "within_last_7_days" {
-            let Some(column) = columns.iter().find(|entry| entry.id == filter.column_id) else {
-                return true;
-            };
-            let cell = cell_value_from_row(row, column);
-            let Some(value) = cell.value_text.as_deref() else {
-                return false;
-            };
-            return date_matches_shortcut(
-                value,
-                filter.value_text.as_deref().unwrap_or("Last 7 Days"),
-            );
-        }
-        let Some(column) = columns.iter().find(|entry| entry.id == filter.column_id) else {
-            return true;
-        };
-        let cell = cell_value_from_row(row, column);
-        let is_tags_column =
-            column.column_type == "tags" || column.property_kind.as_deref() == Some("tags");
-        let raw_filter_text = filter.value_text.as_deref().unwrap_or_default();
-        let filter_text = if is_tags_column {
-            String::new()
-        } else {
-            normalize_text(raw_filter_text)
-        };
-        let normalized_filter_tag = if is_tags_column {
-            normalize_tag_text(raw_filter_text)
-        } else {
-            None
-        };
-        let text_values: Vec<String> = if is_tags_column {
-            cell.value_list
-                .iter()
-                .filter_map(|v| normalize_tag_text(v))
-                .collect()
-        } else {
-            cell_text_values(&cell)
-        };
-        match filter.operator.as_str() {
-            "equals" => {
-                if is_tags_column {
-                    normalized_filter_tag
-                        .as_ref()
-                        .is_some_and(|tag| text_values.iter().any(|value| value == tag))
-                } else {
-                    !filter_text.is_empty() && text_values.iter().any(|value| value == &filter_text)
-                }
-            }
-            "not_equals" => {
-                if is_tags_column {
-                    normalized_filter_tag
-                        .as_ref()
-                        .is_some_and(|tag| text_values.iter().all(|value| value != tag))
-                } else {
-                    filter_text.is_empty() || text_values.iter().all(|value| value != &filter_text)
-                }
-            }
-            "contains" => {
-                if is_tags_column {
-                    false
-                } else {
-                    filter_text.is_empty()
-                        || text_values.iter().any(|value| value.contains(&filter_text))
-                }
-            }
-            "not_contains" => {
-                if is_tags_column {
-                    false
-                } else {
-                    filter_text.is_empty()
-                        || text_values
-                            .iter()
-                            .all(|value| !value.contains(&filter_text))
-                }
-            }
-            "starts_with" => {
-                if is_tags_column {
-                    false
-                } else {
-                    filter_text.is_empty()
-                        || text_values
-                            .iter()
-                            .any(|value| value.starts_with(&filter_text))
-                }
-            }
-            "ends_with" => {
-                if is_tags_column {
-                    false
-                } else {
-                    filter_text.is_empty()
-                        || text_values
-                            .iter()
-                            .any(|value| value.ends_with(&filter_text))
-                }
-            }
-            "greater_than" | "less_than" => {
-                if is_tags_column {
-                    false
-                } else {
-                    let Some(filter_number) = parse_filter_number(raw_filter_text) else {
-                        return true;
-                    };
-                    text_values
-                        .iter()
-                        .filter_map(|value| parse_filter_number(value))
-                        .any(|value| {
-                            if filter.operator == "greater_than" {
-                                value > filter_number
-                            } else {
-                                value < filter_number
-                            }
-                        })
-                }
-            }
-            "tags_contains" => normalized_filter_tag.as_ref().is_some_and(|filter_tag| {
-                text_values
-                    .iter()
-                    .any(|tag| tag_matches_hierarchy(filter_tag, tag))
-            }),
-            "is_empty" => text_values.is_empty() && cell.value_bool.is_none(),
-            "is_not_empty" => !text_values.is_empty() || cell.value_bool.is_some(),
-            "is_true" => cell.value_bool == Some(true),
-            "is_false" => cell.value_bool == Some(false),
-            "any_of" => {
-                let filter_values = if filter.value_list.is_empty() {
-                    filter
-                        .value_text
-                        .clone()
-                        .map(|value| vec![value])
-                        .unwrap_or_default()
-                } else {
-                    filter.value_list.clone()
-                };
-                if filter_values.is_empty() {
-                    return true;
-                }
-                let normalized_tag_filters = if is_tags_column {
-                    let filters = filter_values
-                        .iter()
-                        .map(|value| normalize_tag_text(value))
-                        .collect::<Option<Vec<_>>>();
-                    let Some(filters) = filters else {
-                        return false;
-                    };
-                    Some(filters)
-                } else {
-                    None
-                };
-                if let Some(filters) = normalized_tag_filters {
-                    filters.iter().any(|normalized| {
-                        text_values
-                            .iter()
-                            .any(|cell_value| tag_matches_hierarchy(normalized, cell_value))
-                    })
-                } else {
-                    filter_values.iter().any(|value| {
-                        let normalized = normalize_text(value);
-                        text_values
-                            .iter()
-                            .any(|cell_value| cell_value == &normalized)
-                    })
-                }
-            }
-            "none_of" => {
-                let filter_values = if filter.value_list.is_empty() {
-                    filter
-                        .value_text
-                        .clone()
-                        .map(|value| vec![value])
-                        .unwrap_or_default()
-                } else {
-                    filter.value_list.clone()
-                };
-                let normalized_tag_filters = if is_tags_column {
-                    let filters = filter_values
-                        .iter()
-                        .map(|value| normalize_tag_text(value))
-                        .collect::<Option<Vec<_>>>();
-                    let Some(filters) = filters else {
-                        return false;
-                    };
-                    Some(filters)
-                } else {
-                    None
-                };
-                if let Some(filters) = normalized_tag_filters {
-                    filters.iter().all(|normalized| {
-                        text_values
-                            .iter()
-                            .all(|cell_value| !tag_matches_hierarchy(normalized, cell_value))
-                    })
-                } else {
-                    filter_values.iter().all(|value| {
-                        let normalized = normalize_text(value);
-                        text_values
-                            .iter()
-                            .all(|cell_value| cell_value != &normalized)
-                    })
-                }
-            }
-            _ => true,
-        }
-    })
 }
 
 fn string_cell(cell: &DatabaseCellValue) -> String {
@@ -967,21 +721,8 @@ mod tests {
 
     use crate::index::schema::ensure_schema;
 
-    use super::super::types::{DatabaseCellValue, DatabaseColumn, DatabaseFilter, DatabaseRow};
-    use super::{row_matches_filters, row_matches_search, tag_source_ids};
-
-    fn tags_column() -> DatabaseColumn {
-        DatabaseColumn {
-            id: "tags".to_string(),
-            column_type: "tags".to_string(),
-            label: "Tags".to_string(),
-            icon: None,
-            width: None,
-            visible: true,
-            property_key: None,
-            property_kind: None,
-        }
-    }
+    use super::super::types::{DatabaseCellValue, DatabaseRow};
+    use super::{row_matches_search, tag_source_ids};
 
     fn sample_row(tags: Vec<&str>) -> DatabaseRow {
         DatabaseRow {
@@ -1035,60 +776,6 @@ mod tests {
         );
 
         assert!(row_matches_search(&row, "review product"));
-    }
-
-    #[test]
-    fn tag_filters_match_descendant_explicit_tags() {
-        let columns = vec![tags_column()];
-        let row = sample_row(vec!["work/today/further"]);
-        let filters = vec![DatabaseFilter {
-            column_id: "tags".to_string(),
-            operator: "tags_contains".to_string(),
-            value_text: Some("#work".to_string()),
-            value_bool: None,
-            value_list: Vec::new(),
-        }];
-
-        assert!(row_matches_filters(&row, &columns, &filters));
-
-        let non_matching_filters = vec![DatabaseFilter {
-            column_id: "tags".to_string(),
-            operator: "tags_contains".to_string(),
-            value_text: Some("#personal".to_string()),
-            value_bool: None,
-            value_list: Vec::new(),
-        }];
-        assert!(!row_matches_filters(&row, &columns, &non_matching_filters));
-    }
-
-    #[test]
-    fn malformed_tag_filters_fail_closed() {
-        let columns = vec![tags_column()];
-        let row = sample_row(vec!["work/today/further"]);
-        let filters = vec![DatabaseFilter {
-            column_id: "tags".to_string(),
-            operator: "tags_contains".to_string(),
-            value_text: Some("#work//today".to_string()),
-            value_bool: None,
-            value_list: Vec::new(),
-        }];
-
-        assert!(!row_matches_filters(&row, &columns, &filters));
-    }
-
-    #[test]
-    fn unsupported_string_operators_fail_closed_for_tag_columns() {
-        let columns = vec![tags_column()];
-        let row = sample_row(vec!["work/today/further"]);
-        let filters = vec![DatabaseFilter {
-            column_id: "tags".to_string(),
-            operator: "contains".to_string(),
-            value_text: Some("work".to_string()),
-            value_bool: None,
-            value_list: Vec::new(),
-        }];
-
-        assert!(!row_matches_filters(&row, &columns, &filters));
     }
 
     #[test]

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -40,7 +40,10 @@ fn parent_dir(path: &str) -> String {
 }
 
 fn relative_path(from_dir: &str, to_path: &str) -> String {
-    let from: Vec<&str> = from_dir.split('/').filter(|part| !part.is_empty()).collect();
+    let from: Vec<&str> = from_dir
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect();
     let to: Vec<&str> = to_path.split('/').filter(|part| !part.is_empty()).collect();
     let mut common = 0;
     while common < from.len() && common < to.len() && from[common] == to[common] {

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -440,8 +440,10 @@ export function DatabaseBoard({
 						</DialogTitle>
 						<DialogDescription>
 							{groupColumn
-								? `Set the ${groupColumn.label} value for this board lane.`
-								: "Set the board lane value."}
+								? laneEdit?.mode === "rename"
+									? `Rename this ${groupColumn.label.toLowerCase()} lane. Cards here keep that value.`
+									: `Cards you add or move here will get this ${groupColumn.label.toLowerCase()}.`
+								: "Set the value for this board lane."}
 						</DialogDescription>
 					</DialogHeader>
 					<form
@@ -498,11 +500,12 @@ export function DatabaseBoard({
 					}
 				>
 					<div className="databaseBoardEmptyTitle">
-						Board view needs a grouping field
+						Add a field to create board lanes
 					</div>
 					<div className="databaseBoardEmptyText">
-						Choose how the board should group cards by adding a single-value
-						property like status, stage, or done.
+						Board view groups notes into lanes. Add a status, priority,
+						checkbox, tag, or similar field to your notes, then pick it in the
+						toolbar above.
 					</div>
 					<div className="databaseBoardEmptyActions">
 						<Button
@@ -511,7 +514,7 @@ export function DatabaseBoard({
 							size="sm"
 							onClick={onOpenColumns}
 						>
-							Open columns
+							Open view settings
 						</Button>
 					</div>
 				</m.div>
@@ -746,10 +749,12 @@ export function DatabaseBoard({
 									) : (
 										<div className="databaseBoardLaneEmptyCard">
 											{lane.workflowState === "archived"
-												? "Archive notes here"
+												? "Archived notes go here"
 												: lane.workflowState === "done"
-													? "Completed notes land here"
-													: "Drop notes here"}
+													? "Done notes land here"
+													: lane.id === DATABASE_BOARD_EMPTY_LANE_ID
+														? "Notes without a value appear here"
+														: "Drop notes here or add one below"}
 										</div>
 									)}
 									{onCreateRow ? (

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -256,12 +256,12 @@ export function DatabaseBoardLaneView({
 						disabled={lane.id === DATABASE_BOARD_EMPTY_LANE_ID}
 						aria-label={
 							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
-								? "No value stays last"
+								? "Unassigned lane stays last"
 								: `Open ${lane.label} lane options`
 						}
 						title={
 							lane.id === DATABASE_BOARD_EMPTY_LANE_ID
-								? "No value stays last"
+								? "Unassigned lane stays last"
 								: `Open ${lane.label} lane options`
 						}
 						aria-haspopup="menu"

--- a/src/components/database/DatabaseToolbar.tsx
+++ b/src/components/database/DatabaseToolbar.tsx
@@ -22,6 +22,16 @@ interface DatabaseToolbarProps {
 	className?: string;
 }
 
+function groupColumnOptionLabel(column: DatabaseColumn): string {
+	if (column.type === "tags" || column.property_kind === "tags") {
+		return `${column.label} (multi-lane)`;
+	}
+	if (column.property_kind === "multi_select") {
+		return `${column.label} (multi-lane)`;
+	}
+	return column.label;
+}
+
 export function DatabaseToolbar({
 	databaseView,
 	groupColumns,
@@ -45,10 +55,17 @@ export function DatabaseToolbar({
 	const hasSelectedGroupColumn =
 		groupColumnId != null &&
 		groupColumns.some((column) => column.id === groupColumnId);
+	const selectedGroupColumn =
+		(hasSelectedGroupColumn
+			? groupColumns.find((column) => column.id === groupColumnId)
+			: null) ??
+		(databaseView === "board" ? groupColumns[0] : null) ??
+		null;
 	const selectedGroupColumnId =
-		(hasSelectedGroupColumn ? groupColumnId : null) ??
+		selectedGroupColumn?.id ??
 		(databaseView === "board" ? groupColumns[0]?.id : "") ??
 		"";
+	const groupByLabel = "Grouped by";
 
 	useEffect(() => {
 		setSearchDraft(searchValue);
@@ -87,7 +104,7 @@ export function DatabaseToolbar({
 							id={searchInputId}
 							className="databaseToolbarSearchInput"
 							value={searchDraft}
-							placeholder="Search view"
+							placeholder="Search this view"
 							aria-label="Search this view"
 							onBlur={() => {
 								if (!searchDraft) setSearchExpanded(false);
@@ -134,22 +151,34 @@ export function DatabaseToolbar({
 				)}
 				{groupColumns.length > 0 ? (
 					<label className="databaseToolbarGroupBy">
-						<span className="databaseToolbarGroupByLabel">Group by</span>
+						<span className="databaseToolbarGroupByLabel">{groupByLabel}</span>
 						<select
 							className="databaseToolbarGroupBySelect"
 							value={selectedGroupColumnId}
+							title={
+								selectedGroupColumn
+									? `Grouping by ${selectedGroupColumn.label}`
+									: "Choose a field to group by"
+							}
+							aria-label={groupByLabel}
 							onChange={(event) =>
 								onGroupColumnIdChange(event.target.value || null)
 							}
 						>
-							{databaseView === "board" ? null : <option value="">None</option>}
+							{databaseView === "board" ? null : (
+								<option value="">No grouping</option>
+							)}
 							{groupColumns.map((column) => (
 								<option key={column.id} value={column.id}>
-									{column.label}
+									{groupColumnOptionLabel(column)}
 								</option>
 							))}
 						</select>
 					</label>
+				) : databaseView === "board" ? (
+					<span className="databaseToolbarGroupByHint">
+						Add a status, tag, or checkbox field to create lanes
+					</span>
 				) : null}
 				<DatabaseViewOptionsPopover
 					open={viewOptionsOpen}

--- a/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
@@ -38,6 +38,33 @@ const DATE_SHORTCUT_OPTIONS = [
 	"Last 30 Days",
 ];
 
+const SUPPORTED_FILTER_OPERATORS = [
+	"equals",
+	"not_equals",
+	"contains",
+	"not_contains",
+	"starts_with",
+	"ends_with",
+	"greater_than",
+	"less_than",
+	"is_empty",
+	"is_not_empty",
+	"is_true",
+	"is_false",
+	"tags_contains",
+	"any_of",
+	"none_of",
+	"within_last_7_days",
+] as const satisfies readonly DatabaseFilter["operator"][];
+
+function isSupportedFilterOperator(
+	operator: string,
+): operator is DatabaseFilter["operator"] {
+	return SUPPORTED_FILTER_OPERATORS.includes(
+		operator as DatabaseFilter["operator"],
+	);
+}
+
 function isTagFilterColumn(column?: DatabaseColumn | null): boolean {
 	return column?.type === "tags" || column?.property_kind === "tags";
 }
@@ -77,7 +104,8 @@ function emptyFilter(column?: DatabaseColumn | null): DatabaseFilter {
 	};
 }
 
-function operatorNeedsValue(operator: DatabaseFilter["operator"]): boolean {
+function operatorNeedsValue(operator: string): boolean {
+	if (!isSupportedFilterOperator(operator)) return false;
 	return ![
 		"is_empty",
 		"is_not_empty",
@@ -87,7 +115,7 @@ function operatorNeedsValue(operator: DatabaseFilter["operator"]): boolean {
 	].includes(operator);
 }
 
-function operatorLabel(operator: DatabaseFilter["operator"]): string {
+function operatorLabel(operator: string): string {
 	switch (operator) {
 		case "equals":
 			return "is";
@@ -120,13 +148,15 @@ function operatorLabel(operator: DatabaseFilter["operator"]): string {
 			return "is none of";
 		case "within_last_7_days":
 			return "is";
+		default:
+			return `Unsupported: ${operator}`;
 	}
 }
 
 function operatorOptions(
 	column: DatabaseColumn | null,
-	currentOperator: DatabaseFilter["operator"],
-): Array<{ value: DatabaseFilter["operator"]; label: string }> {
+	currentOperator: string,
+): Array<{ value: string; label: string; disabled?: boolean }> {
 	const options: DatabaseFilter["operator"][] = isBooleanColumn(column)
 		? ["is_true", "is_false", "is_empty", "is_not_empty"]
 		: isDateColumn(column)
@@ -152,10 +182,22 @@ function operatorOptions(
 							"is_empty",
 							"is_not_empty",
 						];
-	const normalized = options.includes(currentOperator)
-		? options
-		: [...options, currentOperator];
-	return normalized.map((value) => ({ value, label: operatorLabel(value) }));
+	const normalized = options.map((operator) => ({
+		value: operator,
+		label: operatorLabel(operator),
+		disabled: false,
+	}));
+	if (options.some((operator) => operator === currentOperator))
+		return normalized;
+
+	const currentOption = {
+		value: currentOperator,
+		label: operatorLabel(currentOperator),
+		disabled: !isSupportedFilterOperator(currentOperator),
+	};
+	return currentOption.disabled
+		? [currentOption, ...normalized]
+		: [...normalized, currentOption];
 }
 
 export function nextFilterForColumn(
@@ -222,6 +264,13 @@ export function FiltersPanel({
 	updateFilters,
 }: FiltersPanelProps) {
 	const presets = databaseFilterPresets(config, availableProperties);
+	const invalidOperatorIndex = config.filters.findIndex(
+		(filter) => !isSupportedFilterOperator(filter.operator),
+	);
+	const invalidOperatorError =
+		invalidOperatorIndex >= 0
+			? `Filter ${invalidOperatorIndex + 1} uses an unsupported operator. Choose a supported operator to restore results.`
+			: "";
 	return (
 		<section
 			className="databaseViewOptionsPanel is-wide"
@@ -269,8 +318,10 @@ export function FiltersPanel({
 					})}
 				</div>
 			</div>
-			{filterError ? (
-				<div className="databaseViewPanelError">{filterError}</div>
+			{filterError || invalidOperatorError ? (
+				<div className="databaseViewPanelError">
+					{filterError || invalidOperatorError}
+				</div>
 			) : null}
 			{config.filters.length === 0 ? (
 				<button
@@ -353,7 +404,11 @@ export function FiltersPanel({
 									}
 								>
 									{availableOperators.map((option) => (
-										<option key={option.value} value={option.value}>
+										<option
+											key={option.value}
+											value={option.value}
+											disabled={option.disabled}
+										>
 											{option.label}
 										</option>
 									))}

--- a/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
@@ -16,12 +16,14 @@ import {
 
 interface FiltersPanelProps {
 	config: DatabaseConfig;
+	columns: DatabaseColumn[];
 	availableProperties: DatabasePropertyOption[];
 	filterError: string;
 	filterUiKeys: string[];
 	filterKeyCounterRef: MutableRefObject<number>;
 	defaultFilterColumn: DatabaseColumn | null;
 	onApplyFilterPreset: (preset: DatabaseFilterPreset) => void;
+	onChangeFilterColumn: (index: number, column: DatabaseColumn | null) => void;
 	updateFilters: (
 		updater: (filters: DatabaseFilter[]) => DatabaseFilter[],
 		keyUpdater?: (keys: string[]) => string[],
@@ -156,7 +158,7 @@ function operatorOptions(
 	return normalized.map((value) => ({ value, label: operatorLabel(value) }));
 }
 
-function nextFilterForColumn(
+export function nextFilterForColumn(
 	filter: DatabaseFilter,
 	column: DatabaseColumn | null,
 ): DatabaseFilter {
@@ -209,12 +211,14 @@ function filterValueListsEqual(
 
 export function FiltersPanel({
 	config,
+	columns,
 	availableProperties,
 	filterError,
 	filterUiKeys,
 	filterKeyCounterRef,
 	defaultFilterColumn,
 	onApplyFilterPreset,
+	onChangeFilterColumn,
 	updateFilters,
 }: FiltersPanelProps) {
 	const presets = databaseFilterPresets(config, availableProperties);
@@ -241,8 +245,8 @@ export function FiltersPanel({
 				) : null}
 			</div>
 			<p className="databaseViewPanelHint">
-				Filters use database columns, tags, and note properties. To find words
-				in note text, use Search or this view's search box.
+				Narrow this view by column values. To search note text, use the search
+				box in the toolbar.
 			</p>
 			<div className="databaseViewPresetGroup" aria-label="Filter presets">
 				<span className="databaseViewPresetLabel">Presets</span>
@@ -286,8 +290,7 @@ export function FiltersPanel({
 				<div className="databaseViewFilterList">
 					{config.filters.map((filter, index) => {
 						const selectedColumn =
-							config.columns.find((column) => column.id === filter.column_id) ??
-							null;
+							columns.find((column) => column.id === filter.column_id) ?? null;
 						const availableOperators = operatorOptions(
 							selectedColumn,
 							filter.operator,
@@ -312,20 +315,15 @@ export function FiltersPanel({
 										className="databaseViewInlineSelect"
 										value={filter.column_id}
 										aria-label={`Filter ${index + 1} field`}
-										onChange={(event) =>
-											void updateFilters((filters) =>
-												filters.map((entry, i) => {
-													if (i !== index) return entry;
-													const nextColumn =
-														config.columns.find(
-															(column) => column.id === event.target.value,
-														) ?? null;
-													return nextFilterForColumn(entry, nextColumn);
-												}),
-											)
-										}
+										onChange={(event) => {
+											const nextColumn =
+												columns.find(
+													(column) => column.id === event.target.value,
+												) ?? null;
+											onChangeFilterColumn(index, nextColumn);
+										}}
 									>
-										{config.columns.map((column) => (
+										{columns.map((column) => (
 											<option key={column.id} value={column.id}>
 												{column.label}
 											</option>

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -16,7 +16,12 @@ import {
 	useState,
 } from "react";
 import { defaultDatabaseColumnIconName } from "../../lib/database/columnIcons";
-import { createPropertyColumn } from "../../lib/database/config";
+import {
+	ensureDatabaseColumn,
+	isReservedDatabasePropertyKey,
+	normalizeDatabasePropertyKey,
+	resolveDatabaseColumns,
+} from "../../lib/database/columns";
 import type {
 	DatabaseColumn,
 	DatabaseConfig,
@@ -36,7 +41,10 @@ import {
 	type ColumnMenuEntry,
 	ColumnsPanel,
 } from "./DatabaseViewOptionsColumnsPanel";
-import { FiltersPanel } from "./DatabaseViewOptionsFiltersPanel";
+import {
+	FiltersPanel,
+	nextFilterForColumn,
+} from "./DatabaseViewOptionsFiltersPanel";
 import { SortPanel } from "./DatabaseViewOptionsSortPanel";
 import { SourcePanel } from "./DatabaseViewOptionsSourcePanel";
 import {
@@ -103,17 +111,6 @@ const RESTORE_DEFAULT_COLUMNS: DatabaseColumn[] = [
 	},
 ];
 
-const RESERVED_PROPERTY_KEYS = new Set([
-	"created",
-	"folder",
-	"glyph",
-	"linked_notes",
-	"path",
-	"tags",
-	"title",
-	"updated",
-]);
-
 const builtInColumns: DatabaseColumn[] = [
 	...RESTORE_DEFAULT_COLUMNS,
 	{
@@ -159,10 +156,6 @@ const builtInColumns: DatabaseColumn[] = [
 		visible: false,
 	},
 ];
-
-function isReservedPropertyKey(key: string): boolean {
-	return RESERVED_PROPERTY_KEYS.has(key.trim().toLowerCase());
-}
 
 function filterSignature(filter: DatabaseFilter): string {
 	return JSON.stringify({
@@ -244,20 +237,17 @@ export function DatabaseViewOptionsPopover({
 	const previousFilterKeyEntriesRef = useRef<FilterKeyEntry[]>([]);
 	const filtersRef = useRef(config.filters);
 	const visibleCount = config.columns.filter((column) => column.visible).length;
+	const isTableView = config.view.layout === "table";
 	filtersRef.current = config.filters;
+	const resolvedColumns = useMemo(
+		() => resolveDatabaseColumns(config.columns, availableProperties),
+		[availableProperties, config.columns],
+	);
 
 	const columnsById = useMemo(
 		() => new Map(config.columns.map((column) => [column.id, column])),
 		[config.columns],
 	);
-	const propertyColumnsByKey = useMemo(() => {
-		const entries = new Map<string, DatabaseColumn>();
-		for (const column of config.columns) {
-			if (column.type !== "property" || !column.property_key) continue;
-			entries.set(column.property_key.trim().toLowerCase(), column);
-		}
-		return entries;
-	}, [config.columns]);
 
 	const columnMenuEntries = useMemo<ColumnMenuEntry[]>(() => {
 		const entries = new Map<string, ColumnMenuEntry>();
@@ -269,31 +259,15 @@ export function DatabaseViewOptionsPopover({
 				enabled: existing?.visible ?? column.visible,
 			});
 		}
-		for (const property of availableProperties) {
-			if (isReservedPropertyKey(property.key)) continue;
-			const trimmedKey = property.key.trim();
-			const propertyKey = trimmedKey.toLowerCase();
+		for (const column of resolvedColumns) {
+			const propertyKey = column.property_key
+				? normalizeDatabasePropertyKey(column.property_key)
+				: "";
 			const normalizedId = `property:${propertyKey}`;
-			if (entries.has(normalizedId)) continue;
-			const id = `property:${trimmedKey}`;
-			const existing =
-				columnsById.get(normalizedId) ??
-				columnsById.get(id) ??
-				propertyColumnsByKey.get(propertyKey);
-			entries.set(normalizedId, {
-				key: normalizedId,
-				column:
-					existing ?? createPropertyColumn({ ...property, key: trimmedKey }),
-				enabled: existing?.visible ?? false,
-			});
-		}
-		for (const column of config.columns) {
-			const normalized = column.property_key?.trim().toLowerCase() ?? "";
-			const normalizedId = `property:${normalized}`;
 			if (
 				column.type !== "property" ||
 				!column.property_key ||
-				isReservedPropertyKey(column.property_key) ||
+				isReservedDatabasePropertyKey(column.property_key) ||
 				entries.has(normalizedId)
 			) {
 				continue;
@@ -301,7 +275,7 @@ export function DatabaseViewOptionsPopover({
 			entries.set(normalizedId, {
 				key: normalizedId,
 				column,
-				enabled: column.visible,
+				enabled: columnsById.get(column.id)?.visible ?? false,
 			});
 		}
 		const orderById = new Map(
@@ -317,7 +291,7 @@ export function DatabaseViewOptionsPopover({
 			if (rightOrder != null) return 1;
 			return left.column.label.localeCompare(right.column.label);
 		});
-	}, [availableProperties, columnsById, config.columns, propertyColumnsByKey]);
+	}, [columnsById, config.columns, resolvedColumns]);
 
 	const deriveFilterUiKeys = useCallback(
 		(filters: DatabaseFilter[], preferredKeys?: string[]) => {
@@ -400,12 +374,17 @@ export function DatabaseViewOptionsPopover({
 	const updateFilters = async (
 		updater: (filters: DatabaseFilter[]) => DatabaseFilter[],
 		keyUpdater?: (keys: string[]) => string[],
+		columns: DatabaseColumn[] = config.columns,
 	) => {
 		const nextFilters = updater(config.filters);
 		const nextKeys = keyUpdater?.(filterUiKeys);
 		try {
 			setFilterError("");
-			const saved = await updateConfig({ ...config, filters: nextFilters });
+			const saved = await updateConfig({
+				...config,
+				columns,
+				filters: nextFilters,
+			});
 			if (!saved) return;
 			setFilterUiKeys(deriveFilterUiKeys(nextFilters, nextKeys));
 		} catch (cause) {
@@ -413,6 +392,17 @@ export function DatabaseViewOptionsPopover({
 			console.error("Failed to update database filters", cause);
 			setFilterError(message);
 		}
+	};
+
+	const changeFilterColumn = (index: number, column: DatabaseColumn | null) => {
+		void updateFilters(
+			(filters) =>
+				filters.map((entry, i) =>
+					i === index ? nextFilterForColumn(entry, column) : entry,
+				),
+			undefined,
+			column ? ensureDatabaseColumn(config.columns, column) : config.columns,
+		);
 	};
 
 	const applyFilterPreset = async (preset: DatabaseFilterPreset) => {
@@ -429,21 +419,28 @@ export function DatabaseViewOptionsPopover({
 	};
 
 	const defaultFilterColumn =
-		config.columns.find((column) => column.visible) ??
-		config.columns[0] ??
+		resolvedColumns.find((column) => column.visible) ??
+		resolvedColumns[0] ??
 		null;
 	const activeSort = config.sorts[0] ?? null;
 	const sortColumn =
-		config.columns.find((column) => column.id === activeSort?.column_id) ??
-		config.columns.find((column) => column.visible) ??
-		config.columns[0] ??
+		resolvedColumns.find((column) => column.id === activeSort?.column_id) ??
+		resolvedColumns.find((column) => column.visible) ??
+		resolvedColumns[0] ??
 		null;
 	const sortDirection = activeSort?.direction ?? "asc";
 
 	const setSort = (patch: Partial<DatabaseSort>) => {
 		if (!sortColumn && !patch.column_id) return;
+		const nextColumn = patch.column_id
+			? (resolvedColumns.find((column) => column.id === patch.column_id) ??
+				null)
+			: sortColumn;
 		void updateConfig({
 			...config,
+			columns: nextColumn
+				? ensureDatabaseColumn(config.columns, nextColumn)
+				: config.columns,
 			sorts: [
 				{
 					column_id:
@@ -489,7 +486,7 @@ export function DatabaseViewOptionsPopover({
 		<Popover
 			open={open}
 			onOpenChange={(nextOpen) => {
-				if (nextOpen) setActivePanel(null);
+				setActivePanel(null);
 				onOpenChange?.(nextOpen);
 			}}
 		>
@@ -519,7 +516,7 @@ export function DatabaseViewOptionsPopover({
 				{activePanel === "source" ? (
 					<SourcePanel config={config} updateConfig={updateConfig} />
 				) : null}
-				{activePanel === "columns" ? (
+				{isTableView && activePanel === "columns" ? (
 					<ColumnsPanel
 						columnMenuEntries={columnMenuEntries}
 						setColumnEnabled={setColumnEnabled}
@@ -535,18 +532,21 @@ export function DatabaseViewOptionsPopover({
 				{activePanel === "filters" ? (
 					<FiltersPanel
 						config={config}
+						columns={resolvedColumns}
 						availableProperties={availableProperties}
 						filterError={filterError}
 						filterUiKeys={filterUiKeys}
 						filterKeyCounterRef={filterKeyCounterRef}
 						defaultFilterColumn={defaultFilterColumn}
 						onApplyFilterPreset={applyFilterPreset}
+						onChangeFilterColumn={changeFilterColumn}
 						updateFilters={updateFilters}
 					/>
 				) : null}
 				{activePanel === "sort" ? (
 					<SortPanel
 						config={config}
+						columns={resolvedColumns}
 						availableProperties={availableProperties}
 						activeSort={activeSort}
 						sortColumn={sortColumn}
@@ -581,19 +581,21 @@ export function DatabaseViewOptionsPopover({
 						active={activePanel === "source"}
 						onClick={() => togglePanel("source")}
 					/>
-					<OptionMenuRow
-						icon={
-							<HugeiconsIcon
-								icon={GridViewIcon}
-								size="var(--icon-lg)"
-								strokeWidth={0.9}
-							/>
-						}
-						label="Columns"
-						value={`${visibleCount} selected`}
-						active={activePanel === "columns"}
-						onClick={() => togglePanel("columns")}
-					/>
+					{isTableView ? (
+						<OptionMenuRow
+							icon={
+								<HugeiconsIcon
+									icon={GridViewIcon}
+									size="var(--icon-lg)"
+									strokeWidth={0.9}
+								/>
+							}
+							label="Columns"
+							value={`${visibleCount} selected`}
+							active={activePanel === "columns"}
+							onClick={() => togglePanel("columns")}
+						/>
+					) : null}
 					<OptionMenuRow
 						icon={
 							<HugeiconsIcon
@@ -620,7 +622,7 @@ export function DatabaseViewOptionsPopover({
 							/>
 						}
 						label="Sort by"
-						value={sortLabel(activeSort ?? undefined, config.columns)}
+						value={sortLabel(activeSort ?? undefined, resolvedColumns)}
 						active={activePanel === "sort"}
 						onClick={() => togglePanel("sort")}
 					/>

--- a/src/components/database/DatabaseViewOptionsSortPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsSortPanel.tsx
@@ -13,6 +13,7 @@ import {
 
 interface SortPanelProps {
 	config: DatabaseConfig;
+	columns: DatabaseColumn[];
 	availableProperties: DatabasePropertyOption[];
 	activeSort: DatabaseSort | null;
 	sortColumn: DatabaseColumn | null;
@@ -57,6 +58,7 @@ function directionLabel(
 
 export function SortPanel({
 	config,
+	columns,
 	availableProperties,
 	activeSort,
 	sortColumn,
@@ -124,7 +126,7 @@ export function SortPanel({
 							aria-label="Sort field"
 							onChange={(event) => setSort({ column_id: event.target.value })}
 						>
-							{config.columns.map((column) => (
+							{columns.map((column) => (
 								<option key={column.id} value={column.id}>
 									{column.label}
 								</option>

--- a/src/components/database/DatabaseViewOptionsSourcePanel.tsx
+++ b/src/components/database/DatabaseViewOptionsSourcePanel.tsx
@@ -36,7 +36,7 @@ export function SourcePanel({ config, updateConfig }: SourcePanelProps) {
 						<option value="all_notes">All notes</option>
 						<option value="folder">A folder</option>
 						<option value="tag">A tag</option>
-						<option value="search">A saved search</option>
+						<option value="search">A search query</option>
 					</select>
 				</label>
 				{config.source.kind === "folder" ? (

--- a/src/components/database/DatabaseViewOptionsSourcePanel.tsx
+++ b/src/components/database/DatabaseViewOptionsSourcePanel.tsx
@@ -14,9 +14,12 @@ export function SourcePanel({ config, updateConfig }: SourcePanelProps) {
 			<div className="databaseViewPanelHeader">
 				<span>Source</span>
 			</div>
+			<p className="databaseViewPanelHint">
+				Choose which notes appear in this view. Changes save automatically.
+			</p>
 			<div className="databaseViewPanelStack">
 				<label className="databaseViewField">
-					<span>Source</span>
+					<span>Show notes from</span>
 					<select
 						className="databaseNativeSelect"
 						value={config.source.kind}
@@ -31,9 +34,9 @@ export function SourcePanel({ config, updateConfig }: SourcePanelProps) {
 						}
 					>
 						<option value="all_notes">All notes</option>
-						<option value="folder">Folder</option>
-						<option value="tag">Tag</option>
-						<option value="search">Search</option>
+						<option value="folder">A folder</option>
+						<option value="tag">A tag</option>
+						<option value="search">A saved search</option>
 					</select>
 				</label>
 				{config.source.kind === "folder" ? (
@@ -73,8 +76,8 @@ export function SourcePanel({ config, updateConfig }: SourcePanelProps) {
 				{config.source.kind === "tag" ? (
 					<DatabaseTagPicker
 						value={config.source.value}
-						label="Database Tag"
-						description="Choose a tag for this database."
+						label="Tag"
+						description="Only notes with this tag will appear."
 						placeholder="Choose a tag"
 						onChange={(value) =>
 							void updateConfig({
@@ -89,7 +92,7 @@ export function SourcePanel({ config, updateConfig }: SourcePanelProps) {
 						className="databaseViewField"
 						htmlFor="databaseViewSourceQuery"
 					>
-						<span>Query</span>
+						<span>Search query</span>
 						<Input
 							id="databaseViewSourceQuery"
 							value={config.source.value}

--- a/src/components/databases/CreateCollectionDialog.tsx
+++ b/src/components/databases/CreateCollectionDialog.tsx
@@ -49,6 +49,10 @@ const COLLECTION_TIPS = [
 		),
 	},
 	{
+		id: "grouping",
+		text: "Group the board by status, tags, or other fields on your notes.",
+	},
+	{
 		id: "notes",
 		text: "Notes you create here stay in the same folder.",
 	},

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -95,9 +95,7 @@ function DatabasesPaneContent({
 							availableProperties={
 								activeCollection.document.available_properties
 							}
-							onGroupColumnIdChange={(groupColumnId) =>
-								views.patchActiveView({ board_group_by: groupColumnId })
-							}
+							onGroupColumnIdChange={views.handleGroupColumnIdChange}
 							onChangeConfig={views.handleSaveConfig}
 							viewOptionsOpen={views.viewOptionsOpen}
 							onViewOptionsOpenChange={views.setViewOptionsOpen}
@@ -110,7 +108,7 @@ function DatabasesPaneContent({
 					views.boardHandlers ? (
 						<DatabaseBoard
 							rows={rows.rows}
-							columns={activeCollection.config.columns}
+							columns={views.resolvedColumns ?? activeCollection.config.columns}
 							groupColumnId={
 								activeCollection.config.view.board_group_by ?? null
 							}
@@ -134,9 +132,7 @@ function DatabasesPaneContent({
 								activeCollection.config.view.board_card_fields ??
 								EMPTY_BOARD_CARD_FIELDS
 							}
-							onGroupColumnIdChange={(groupColumnId) =>
-								views.patchActiveView({ board_group_by: groupColumnId })
-							}
+							onGroupColumnIdChange={views.handleGroupColumnIdChange}
 							onLaneOrderChange={views.boardHandlers.onLaneOrderChange}
 							onCardOrderChange={views.boardHandlers.onCardOrderChange}
 							onLaneColorChange={views.boardHandlers.onLaneColorChange}
@@ -187,19 +183,34 @@ function DatabasesPaneContent({
 					</div>
 					<div className="databasesEmptyText">
 						{selection.summaries.length === 0
-							? "A collection is just a group of notes in a folder. Create your first one to get started."
+							? "Collections help you see notes from a folder as a table or Kanban board."
 							: "Use Switch collection above to get started."}
 					</div>
 					{selection.summaries.length === 0 ? (
-						<Button
-							type="button"
-							size="sm"
-							className="createCollectionCta"
-							onClick={selection.openCreateCollectionDialog}
-						>
-							<Plus size="var(--icon-sm)" />
-							Create Collection
-						</Button>
+						<>
+							<ol className="databasesOnboardingSteps">
+								<li>
+									<strong>Choose notes</strong> — pick a folder, tag, or search.
+								</li>
+								<li>
+									<strong>Shape the view</strong> — show columns, filters, and
+									sorting.
+								</li>
+								<li>
+									<strong>Track work</strong> — switch to board view and group
+									by status, tags, or another field.
+								</li>
+							</ol>
+							<Button
+								type="button"
+								size="sm"
+								className="createCollectionCta"
+								onClick={selection.openCreateCollectionDialog}
+							>
+								<Plus size="var(--icon-sm)" />
+								Create Collection
+							</Button>
+						</>
 					) : null}
 				</div>
 			)}

--- a/src/contexts/FileTreeContext.test.tsx
+++ b/src/contexts/FileTreeContext.test.tsx
@@ -5,11 +5,13 @@ import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileTreeProvider, useFileTreeContext } from "./FileTreeContext";
 
-const { invokeMock, useSpaceMock, useTauriEventMock } = vi.hoisted(() => ({
-	invokeMock: vi.fn(),
-	useSpaceMock: vi.fn(),
-	useTauriEventMock: vi.fn(),
-}));
+const { invokeMock, listenTauriEventMock, useSpaceMock, useTauriEventMock } =
+	vi.hoisted(() => ({
+		invokeMock: vi.fn(),
+		listenTauriEventMock: vi.fn(),
+		useSpaceMock: vi.fn(),
+		useTauriEventMock: vi.fn(),
+	}));
 
 vi.mock("../lib/tauri", () => ({
 	invoke: invokeMock,
@@ -20,6 +22,7 @@ vi.mock("./SpaceContext", () => ({
 }));
 
 vi.mock("../lib/tauriEvents", () => ({
+	listenTauriEvent: listenTauriEventMock,
 	useTauriEvent: useTauriEventMock,
 }));
 
@@ -72,6 +75,7 @@ describe("FileTreeProvider pinned files", () => {
 			spacePath: currentSpacePath,
 			startIndexSync,
 		}));
+		listenTauriEventMock.mockResolvedValue(() => {});
 		useTauriEventMock.mockImplementation(() => {});
 		invokeMock.mockImplementation((command: string) => {
 			if (command === "space_list_dir") return Promise.resolve([]);

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useDebouncedNoteChange } from "../hooks/useDebouncedNoteChange";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { loadSettings } from "../lib/settings";
 import { normalizeTagIconKey } from "../lib/tagIcons";
@@ -316,6 +317,12 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			}
 		}
 	}, [spacePath]);
+
+	useDebouncedNoteChange({
+		delayMs: 200,
+		enabled: Boolean(spacePath),
+		onChange: () => void refreshTags(),
+	});
 
 	useTauriEvent("space:fs_changed", (payload) => {
 		if (!spacePath) return;

--- a/src/hooks/database/useActiveViewConfig.ts
+++ b/src/hooks/database/useActiveViewConfig.ts
@@ -1,4 +1,9 @@
 import { useMemo } from "react";
+import {
+	getBoardGroupColumns,
+	getDatabaseGroupColumns,
+} from "../../lib/database/board";
+import { resolveDatabaseColumns } from "../../lib/database/columns";
 import { viewToConfig } from "../../lib/database/viewConfig";
 import type {
 	DatabaseColumn,
@@ -13,6 +18,7 @@ export interface ActiveViewConfig {
 	groupColumns: DatabaseColumn[];
 	activeGroupColumn: DatabaseColumn | null;
 	visibleColumns: DatabaseColumn[];
+	resolvedColumns: DatabaseColumn[];
 }
 
 export interface UseActiveViewConfigOptions {
@@ -31,10 +37,17 @@ export function deriveActiveViewConfig(
 
 	const activeView =
 		document?.database.views.find((view) => view.id === selectedViewId) ?? null;
+	const resolvedColumns = activeConfig
+		? resolveDatabaseColumns(
+				activeConfig.columns,
+				document?.available_properties ?? [],
+			)
+		: [];
 
-	const groupColumns = (activeConfig?.columns ?? []).filter(
-		(column) => column.type === "tags" || column.type === "property",
-	);
+	const groupColumns =
+		activeConfig?.view.layout === "board"
+			? getBoardGroupColumns(resolvedColumns)
+			: getDatabaseGroupColumns(resolvedColumns);
 
 	const activeGroupColumn =
 		groupColumns.find(
@@ -50,6 +63,7 @@ export function deriveActiveViewConfig(
 		groupColumns,
 		activeGroupColumn,
 		visibleColumns,
+		resolvedColumns,
 	};
 }
 

--- a/src/hooks/database/useCollectionWorkspace.ts
+++ b/src/hooks/database/useCollectionWorkspace.ts
@@ -24,6 +24,7 @@ import type {
 	WorkspaceDatabaseSummary,
 } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
+import { useDebouncedNoteChange } from "../useDebouncedNoteChange";
 import type { PaneErrorHandlers, SaveDatabaseInput } from "./types";
 
 export interface UseCollectionWorkspaceOptions extends PaneErrorHandlers {
@@ -200,6 +201,27 @@ export function useCollectionWorkspace({
 		}
 		writeStoredSelectedViewId(selectedDatabaseId, selectedViewId);
 	}, [document, selectedDatabaseId, selectedViewId]);
+
+	useDebouncedNoteChange({
+		delayMs: 200,
+		enabled: documentIdRef.current != null,
+		onChange: () => {
+			const activeDatabaseId = documentIdRef.current;
+			if (!activeDatabaseId) return;
+			invalidateDatabasePrefetch(activeDatabaseId);
+			void prefetchDatabaseDocument(activeDatabaseId)
+				.then((next) => {
+					if (documentIdRef.current !== activeDatabaseId) return;
+					documentRef.current = next;
+					setDocument(next);
+					clearError();
+				})
+				.catch((cause) => {
+					if (documentIdRef.current !== activeDatabaseId) return;
+					setError(extractErrorMessage(cause));
+				});
+		},
+	});
 
 	const setSelectedDatabaseId = useCallback((databaseId: string) => {
 		setSelectedDatabaseIdState(databaseId);

--- a/src/hooks/database/useDatabaseRows.ts
+++ b/src/hooks/database/useDatabaseRows.ts
@@ -14,7 +14,7 @@ import {
 } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
-	invalidateDatabaseRowsPrefetch,
+	invalidateDatabasePrefetch,
 	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import type {
@@ -23,7 +23,7 @@ import type {
 	WorkspaceDatabaseQueryResult,
 } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
-import { useTauriEvent } from "../../lib/tauriEvents";
+import { useDebouncedNoteChange } from "../useDebouncedNoteChange";
 import type { PaneErrorHandlers } from "./types";
 
 export interface UseDatabaseRowsOptions extends PaneErrorHandlers {
@@ -89,7 +89,6 @@ export function useDatabaseRows({
 }: UseDatabaseRowsOptions) {
 	const queryClient = useQueryClient();
 	const [selectedRowPath, setSelectedRowPath] = useState<string | null>(null);
-	const fsRowsRefreshTimerRef = useRef<number | null>(null);
 	const previousSelectionRef = useRef<{
 		databaseId: string | null;
 		viewId: string | null;
@@ -184,36 +183,15 @@ export function useDatabaseRows({
 		}
 	}, [rowsQuery.error, setError]);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: clear pending background reloads when the row loader changes.
-	useEffect(
-		() => () => {
-			if (fsRowsRefreshTimerRef.current !== null) {
-				window.clearTimeout(fsRowsRefreshTimerRef.current);
-				fsRowsRefreshTimerRef.current = null;
+	useDebouncedNoteChange({
+		delayMs: 150,
+		onChange: () => {
+			if (selectedDatabaseId) {
+				invalidateDatabasePrefetch(selectedDatabaseId);
 			}
+			void loadRows();
 		},
-		[loadRows],
-	);
-
-	const scheduleRowsRefreshForNoteChange = useCallback(
-		(payload: { rel_path: string; removed: boolean }) => {
-			if (!payload.rel_path.toLowerCase().endsWith(".md")) return;
-			if (fsRowsRefreshTimerRef.current !== null) {
-				window.clearTimeout(fsRowsRefreshTimerRef.current);
-			}
-			fsRowsRefreshTimerRef.current = window.setTimeout(() => {
-				fsRowsRefreshTimerRef.current = null;
-				if (selectedDatabaseId) {
-					invalidateDatabaseRowsPrefetch(selectedDatabaseId);
-				}
-				void loadRows();
-			}, 150);
-		},
-		[loadRows, selectedDatabaseId],
-	);
-
-	useTauriEvent("space:fs_changed", scheduleRowsRefreshForNoteChange);
-	useTauriEvent("notes:external_changed", scheduleRowsRefreshForNoteChange);
+	});
 
 	return {
 		rows,

--- a/src/hooks/database/useDatabaseViewActions.ts
+++ b/src/hooks/database/useDatabaseViewActions.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { WorkspaceDatabaseDocument } from "../../lib/tauri";
 import type { SaveDatabase } from "./types";
 import { useActiveViewConfig } from "./useActiveViewConfig";
@@ -20,6 +21,7 @@ export function useDatabaseViewActions({
 		groupColumns,
 		activeGroupColumn,
 		visibleColumns,
+		resolvedColumns,
 	} = useActiveViewConfig({ document, selectedViewId });
 
 	const mutations = useViewConfigMutations({
@@ -29,12 +31,25 @@ export function useDatabaseViewActions({
 		saveDatabase,
 	});
 
+	const handleGroupColumnIdChange = useCallback(
+		(groupColumnId: string | null) => {
+			const groupColumn =
+				groupColumnId != null
+					? (groupColumns.find((column) => column.id === groupColumnId) ?? null)
+					: null;
+			mutations.handleGroupColumnIdChange(groupColumnId, groupColumn);
+		},
+		[groupColumns, mutations.handleGroupColumnIdChange],
+	);
+
 	return {
 		activeConfig,
 		activeView,
 		groupColumns,
 		activeGroupColumn,
 		visibleColumns,
+		resolvedColumns,
 		...mutations,
+		handleGroupColumnIdChange,
 	};
 }

--- a/src/hooks/database/useViewConfigMutations.ts
+++ b/src/hooks/database/useViewConfigMutations.ts
@@ -182,6 +182,24 @@ export function useViewConfigMutations({
 		[handleSaveConfig],
 	);
 
+	const handleGroupColumnIdChange = useCallback(
+		(groupColumnId: string | null, groupColumn: DatabaseColumn | null) => {
+			void handleSaveConfig((config) => {
+				const nextColumns =
+					groupColumnId && groupColumn
+						? config.columns.some((column) => column.id === groupColumn.id)
+							? config.columns
+							: [...config.columns, { ...groupColumn, visible: false }]
+						: config.columns;
+				return patchViewState(
+					{ ...config, columns: nextColumns },
+					{ board_group_by: groupColumnId },
+				);
+			});
+		},
+		[handleSaveConfig],
+	);
+
 	return {
 		viewOptionsOpen,
 		setViewOptionsOpen,
@@ -191,5 +209,6 @@ export function useViewConfigMutations({
 		handleResizeColumn,
 		handleChangeColumnIcon,
 		handleToggleSort,
+		handleGroupColumnIdChange,
 	};
 }

--- a/src/hooks/useDebouncedNoteChange.ts
+++ b/src/hooks/useDebouncedNoteChange.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from "react";
+import { listenTauriEvent } from "../lib/tauriEvents";
+
+interface NoteChangePayload {
+	rel_path: string;
+	removed: boolean;
+}
+
+interface UseDebouncedNoteChangeOptions {
+	delayMs: number;
+	enabled?: boolean;
+	onChange: (payload: NoteChangePayload) => void;
+}
+
+function isMarkdownNote(path: string): boolean {
+	return path.toLowerCase().endsWith(".md");
+}
+
+function runUnlisten(unlisten: () => void): void {
+	try {
+		const result = unlisten() as unknown;
+		void Promise.resolve(result).catch(() => {
+			// Tauri may already have cleaned up the listener during window teardown.
+		});
+	} catch {
+		// Ignore teardown races from Tauri listener cleanup.
+	}
+}
+
+export function useDebouncedNoteChange({
+	delayMs,
+	enabled = true,
+	onChange,
+}: UseDebouncedNoteChangeOptions): void {
+	const onChangeRef = useRef(onChange);
+	const timerRef = useRef<number | null>(null);
+	onChangeRef.current = onChange;
+
+	const schedule = useCallback(
+		(payload: NoteChangePayload) => {
+			if (!enabled || !isMarkdownNote(payload.rel_path)) return;
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+			}
+			timerRef.current = window.setTimeout(() => {
+				timerRef.current = null;
+				onChangeRef.current(payload);
+			}, delayMs);
+		},
+		[delayMs, enabled],
+	);
+
+	useEffect(() => {
+		if (!enabled) return;
+
+		let cancelled = false;
+		let unlisteners: (() => void)[] = [];
+		void Promise.all([
+			listenTauriEvent("space:fs_changed", schedule),
+			listenTauriEvent("notes:external_changed", schedule),
+		])
+			.then((stops) => {
+				if (cancelled) {
+					for (const stop of stops) runUnlisten(stop);
+					return;
+				}
+				unlisteners = stops;
+			})
+			.catch(() => {
+				// Listener setup can race with window teardown.
+			});
+
+		return () => {
+			cancelled = true;
+			if (timerRef.current !== null) {
+				window.clearTimeout(timerRef.current);
+				timerRef.current = null;
+			}
+			for (const stop of unlisteners) runUnlisten(stop);
+			unlisteners = [];
+		};
+	}, [enabled, schedule]);
+}

--- a/src/lib/database/board.test.ts
+++ b/src/lib/database/board.test.ts
@@ -13,8 +13,14 @@ import {
 	moveBoardCardToLane,
 	moveBoardLaneToIndex,
 	orderBoardLanes,
+	resolveBoardGroupColumns,
+	resolveDatabaseGroupColumns,
 } from "./board";
-import type { DatabaseColumn, DatabaseRow } from "./types";
+import type {
+	DatabaseColumn,
+	DatabasePropertyOption,
+	DatabaseRow,
+} from "./types";
 
 const statusColumn: DatabaseColumn = {
 	id: "property:status",
@@ -40,6 +46,12 @@ const tagsColumn: DatabaseColumn = {
 	label: "Tags",
 	visible: true,
 };
+
+const availableProperties: DatabasePropertyOption[] = [
+	{ key: "status", kind: "status", count: 2 },
+	{ key: "published", kind: "date", count: 1 },
+	{ key: "source", kind: "url", count: 1 },
+];
 
 const rows: DatabaseRow[] = [
 	{
@@ -114,12 +126,33 @@ describe("database board helpers", () => {
 		).toBe("property:status");
 	});
 
+	it("includes YAML properties as table grouping columns without visible columns", () => {
+		expect(
+			resolveDatabaseGroupColumns([tagsColumn], availableProperties).map(
+				(column) => [column.id, column.visible],
+			),
+		).toEqual([
+			["tags", true],
+			["property:status", false],
+			["property:published", false],
+			["property:source", false],
+		]);
+	});
+
+	it("includes only lane-friendly YAML properties as board grouping columns", () => {
+		expect(
+			resolveBoardGroupColumns([tagsColumn], availableProperties).map(
+				(column) => column.id,
+			),
+		).toEqual(["tags", "property:status"]);
+	});
+
 	it("creates lanes from the current property values", () => {
 		const lanes = createBoardLanes(rows, statusColumn);
 		expect(lanes.map((lane) => lane.label)).toEqual([
 			"Backlog",
 			"In progress",
-			"No value",
+			"No status yet",
 		]);
 		expect(lanes[0]?.rows[0]?.title).toBe("One");
 		expect(lanes[2]?.id).toBe(DATABASE_BOARD_EMPTY_LANE_ID);
@@ -153,7 +186,7 @@ describe("database board helpers", () => {
 		expect(tagLanes.map((lane) => lane.label)).toEqual([
 			"swift",
 			"ios",
-			"No value",
+			"No tags yet",
 		]);
 		expect(boardLaneIdsForRow(secondRow, tagsColumn)).toEqual(["swift", "ios"]);
 		expect(boardLaneIdForRow(secondRow, tagsColumn)).toBe("swift");
@@ -168,7 +201,7 @@ describe("database board helpers", () => {
 		expect(groups.map((group) => group.label)).toEqual([
 			"Backlog",
 			"In progress",
-			"No value",
+			"No status yet",
 		]);
 		expect(groups[0]?.rows.map((row) => row.title)).toEqual(["One"]);
 		expect(groups[2]?.rows.map((row) => row.title)).toEqual(["Three"]);
@@ -186,7 +219,7 @@ describe("database board helpers", () => {
 		expect(lanes.map((lane) => lane.label)).toEqual([
 			"Unchecked",
 			"Checked",
-			"No value",
+			"Not set yet",
 		]);
 		expect(lanes[1]?.rows[0]?.title).toBe("Two");
 	});

--- a/src/lib/database/board.ts
+++ b/src/lib/database/board.ts
@@ -4,8 +4,14 @@ import {
 	statusLabel,
 	statusOptionFromValue,
 } from "../statusProperties";
+import { resolveDatabaseColumns } from "./columns";
 import { databaseCellValueFromRow } from "./config";
-import type { DatabaseCellValue, DatabaseColumn, DatabaseRow } from "./types";
+import type {
+	DatabaseCellValue,
+	DatabaseColumn,
+	DatabasePropertyOption,
+	DatabaseRow,
+} from "./types";
 
 export const DATABASE_BOARD_EMPTY_LANE_ID = "__empty__";
 
@@ -44,10 +50,51 @@ function isBoardGroupColumn(column: DatabaseColumn): boolean {
 	);
 }
 
+function isDatabaseGroupColumn(column: DatabaseColumn): boolean {
+	return column.type === "tags" || column.type === "property";
+}
+
 export function getBoardGroupColumns(
 	columns: DatabaseColumn[],
 ): DatabaseColumn[] {
 	return columns.filter(isBoardGroupColumn);
+}
+
+export function getDatabaseGroupColumns(
+	columns: DatabaseColumn[],
+): DatabaseColumn[] {
+	return columns.filter(isDatabaseGroupColumn);
+}
+
+export function resolveDatabaseGroupColumns(
+	columns: DatabaseColumn[],
+	availableProperties: DatabasePropertyOption[] = [],
+): DatabaseColumn[] {
+	return getDatabaseGroupColumns(
+		resolveDatabaseColumns(columns, availableProperties),
+	);
+}
+
+export function resolveBoardGroupColumns(
+	columns: DatabaseColumn[],
+	availableProperties: DatabasePropertyOption[] = [],
+): DatabaseColumn[] {
+	return getBoardGroupColumns(
+		resolveDatabaseColumns(columns, availableProperties),
+	);
+}
+
+export function emptyBoardLaneLabel(column: DatabaseColumn | null): string {
+	if (!column) return "No value yet";
+	if (column.type === "tags" || column.property_kind === "tags") {
+		return "No tags yet";
+	}
+	if (column.property_kind === "status") return "No status yet";
+	if (column.property_kind === "priority") return "No priority yet";
+	if (column.property_kind === "checkbox") return "Not set yet";
+	const label = column.label.trim();
+	if (label) return `No ${label.toLowerCase()} yet`;
+	return "No value yet";
 }
 
 export function defaultBoardGroupColumnId(
@@ -57,7 +104,7 @@ export function defaultBoardGroupColumnId(
 }
 
 function checkboxLaneLabel(value: boolean | null): string {
-	if (value == null) return "No value";
+	if (value == null) return "Not set yet";
 	return value ? "Checked" : "Unchecked";
 }
 
@@ -78,7 +125,8 @@ function laneWorkflowState(
 }
 
 function boardLaneLabel(column: DatabaseColumn, laneId: string): string {
-	if (laneId === DATABASE_BOARD_EMPTY_LANE_ID) return "No value";
+	if (laneId === DATABASE_BOARD_EMPTY_LANE_ID)
+		return emptyBoardLaneLabel(column);
 	if (column.property_kind === "checkbox") {
 		return checkboxLaneLabel(laneId === "true");
 	}
@@ -287,13 +335,10 @@ export function createBoardLanes(
 	}
 
 	if (!lanes.has(DATABASE_BOARD_EMPTY_LANE_ID)) {
-		lanes.set(DATABASE_BOARD_EMPTY_LANE_ID, {
-			id: DATABASE_BOARD_EMPTY_LANE_ID,
-			label: "No value",
-			cardCount: 0,
-			rows: [],
-			workflowState: "open",
-		});
+		lanes.set(
+			DATABASE_BOARD_EMPTY_LANE_ID,
+			createEmptyLane(column, DATABASE_BOARD_EMPTY_LANE_ID),
+		);
 	}
 
 	const orderedLanes = [...lanes.values()].map((lane) => ({

--- a/src/lib/database/columns.ts
+++ b/src/lib/database/columns.ts
@@ -1,0 +1,74 @@
+import { createPropertyColumn } from "./config";
+import type { DatabaseColumn, DatabasePropertyOption } from "./types";
+
+const RESERVED_PROPERTY_KEYS = new Set([
+	"created",
+	"folder",
+	"glyph",
+	"linked_notes",
+	"path",
+	"tags",
+	"title",
+	"updated",
+]);
+
+export function normalizeDatabasePropertyKey(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+export function isReservedDatabasePropertyKey(key: string): boolean {
+	return RESERVED_PROPERTY_KEYS.has(normalizeDatabasePropertyKey(key));
+}
+
+export function resolveDatabaseColumns(
+	columns: DatabaseColumn[],
+	availableProperties: DatabasePropertyOption[] = [],
+): DatabaseColumn[] {
+	if (availableProperties.length === 0) return columns;
+
+	const byId = new Map(columns.map((column) => [column.id, column]));
+	const byPropertyKey = new Map<string, DatabaseColumn>();
+	for (const column of columns) {
+		if (column.type !== "property" || !column.property_key) continue;
+		byPropertyKey.set(
+			normalizeDatabasePropertyKey(column.property_key),
+			column,
+		);
+	}
+
+	let merged: DatabaseColumn[] | null = null;
+	for (const property of availableProperties) {
+		if (isReservedDatabasePropertyKey(property.key)) continue;
+		const key = property.key.trim();
+		if (!key) continue;
+		const normalizedKey = normalizeDatabasePropertyKey(key);
+		const exactId = `property:${key}`;
+		const normalizedId = `property:${normalizedKey}`;
+		if (
+			byId.has(exactId) ||
+			byId.has(normalizedId) ||
+			byPropertyKey.has(normalizedKey)
+		) {
+			continue;
+		}
+
+		const column = {
+			...createPropertyColumn({ ...property, key }),
+			visible: false,
+		};
+		merged ??= [...columns];
+		merged.push(column);
+		byId.set(column.id, column);
+		byPropertyKey.set(normalizedKey, column);
+	}
+
+	return merged ?? columns;
+}
+
+export function ensureDatabaseColumn(
+	columns: DatabaseColumn[],
+	column: DatabaseColumn,
+): DatabaseColumn[] {
+	if (columns.some((entry) => entry.id === column.id)) return columns;
+	return [...columns, column];
+}

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -286,8 +286,5 @@
 .databaseToolbarGroupByHint {
 	font-size: var(--text-xs);
 	color: var(--text-tertiary);
-	white-space: nowrap;
 	max-width: min(280px, 36vw);
-	overflow: hidden;
-	text-overflow: ellipsis;
 }

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -282,3 +282,12 @@
 		var(--border-default)
 	);
 }
+
+.databaseToolbarGroupByHint {
+	font-size: var(--text-xs);
+	color: var(--text-tertiary);
+	white-space: nowrap;
+	max-width: min(280px, 36vw);
+	overflow: hidden;
+	text-overflow: ellipsis;
+}

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -699,6 +699,25 @@
 	line-height: 1.5;
 }
 
+.databasesOnboardingSteps {
+	margin: 8px 0 4px;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-width: 380px;
+	text-align: left;
+	font-size: calc(var(--text-base) * 0.9);
+	color: var(--text-secondary);
+	line-height: 1.45;
+}
+
+.databasesOnboardingSteps strong {
+	color: var(--text-primary);
+	font-weight: var(--font-medium);
+}
+
 .createCollectionDialog {
 	width: min(460px, calc(100vw - 32px));
 	gap: 0;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/237
Closes #213
Closes #214
Closes #215
Closes #210


## Description

This PR implements the Collections improvement plan from #237: correct filter/query behavior, reliable property grouping, live refresh when notes change, and clearer Kanban UX.

### Summary of changes

**Filter correctness (#215)**
- Extracted collection filter matching into `src-tauri/src/databases/filter.rs` with fail-closed semantics.
- Unknown filter columns, invalid number filters, and unsupported operators now exclude rows instead of passing them through.
- Added Rust unit tests for tag hierarchy, folder equality, multi-filter AND logic, and malformed inputs.

**Property grouping (#213)**
- Added `src/lib/database/columns.ts` with `resolveDatabaseColumns()` to merge indexed YAML/frontmatter properties into the column catalog even when they are not yet saved on the collection config.
- Board and table views now derive grouping options from resolved columns (`getBoardGroupColumns` / `getDatabaseGroupColumns`).
- Selecting a group-by field persists the property column onto the collection config when needed.

**Live refresh (#214)**
- Added `useDebouncedNoteChange` to debounce `space:fs_changed` and `notes:external_changed` events.
- Collection documents, rows, and tag lists refresh after note edits without restarting the app.

**Kanban / board UX (#210)**
- Toolbar shows the active grouping field, hints when no lane-friendly fields exist, and labels multi-lane fields (tags, multi-select).
- Empty lanes use field-specific copy (`No status yet`, `No tags yet`, etc.) instead of generic "No value".
- Board empty state, lane dialogs, source panel labels, and Collections onboarding copy were clarified.
- Columns panel is hidden for board views (lanes are driven by grouping, not table columns).

**Other**
- Filter/sort panels use resolved columns so frontmatter properties appear in pickers.
- Filter column changes persist the selected property column via `ensureDatabaseColumn`.
- `pnpm-workspace.yaml`: allow Biome and esbuild builds.

### Reasoning

The child issues shared one root cause: collection UI only knew about columns explicitly saved on the collection config, while filter correctness depended on permissive backend matching. Resolving columns from the index once, reusing that list across grouping/filter/sort, and tightening filter matching fixes the correctness bugs and makes frontmatter-backed grouping work without a separate grouping system.

### Additional context / review hints

- **#216 (folder filter input focus):** Not addressed in this branch. Filter row React keys still incorporate `value_text` in `filterSignature`, so typing in a text filter value may still remount the input. Recommend a small follow-up to stabilize keys on value edits only.
- Board grouping intentionally limits lane-friendly property kinds (status, priority, checkbox, tags, multi-select). Other properties remain available for table grouping and filters.
- `useDebouncedNoteChange` uses 150–200ms debounce to avoid query storms during rapid saves.

### Child issue mapping

| Issue | Status |
|-------|--------|
| #213 Group by non-tag properties | Done |
| #214 Refresh filters after tag changes | Done |
| #215 Filters returning unrelated notes | Done |
| #216 Folder filter input focus | Follow-up |
| #210 Kanban grouping UX | Done |


## Screenshots

_No screenshots attached — visual changes are mostly copy, toolbar grouping affordances, and empty-state polish. Please verify in-app on macOS._


## Docs

**Resolved columns helper**

```ts
// src/lib/database/columns.ts
resolveDatabaseColumns(config.columns, availableProperties)
// Merges indexed YAML properties into the column list for grouping/filter/sort UI.
```

**Fail-closed filter matching**

```rust
// src-tauri/src/databases/filter.rs
// Unknown columns/operators and invalid numeric filters return false (row excluded).
row_matches_filters(row, columns, filters)
```

**Live collection refresh**

```ts
// src/hooks/useDebouncedNoteChange.ts
useDebouncedNoteChange({ delayMs: 200, onChange: () => refreshCollection() })
```


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

### Verification run locally

- [x] `pnpm test src/lib/database/board.test.ts` (15 passed)
- [x] `cargo test databases::filter` (7 passed)
- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Manual QA on macOS (filter correctness, tag refresh, board grouping, toolbar hints)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved database board grouping and lane handling, including clearer empty-lane labels and support for additional field types.
  * Added automatic refresh behavior when notes change, so database views stay up to date more reliably.
  * Expanded filter and sort controls to better support field selection and grouping in database views.

* **Bug Fixes**
  * Made database filters fail safely when values, columns, or operators are invalid.
  * Updated several empty states, hints, and labels for clearer guidance throughout database views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->