### PR TITLE
Fix Git Sync default for adopted repositories

### DIFF
--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -218,6 +218,7 @@ fn config_to_status(
         status.branch = Some(config.branch);
         status.enabled = config.enabled;
         status.paused = config.paused;
+        status.auto_sync_prompted = config.auto_sync_prompted;
         status.interval_minutes = config.interval_minutes;
         status.conflict_policy = config.conflict_policy;
         status.inclusions = config.inclusions;
@@ -352,6 +353,12 @@ pub fn update_git_sync_config(
     }
     if let Some(paused) = patch.paused {
         config.paused = paused;
+    }
+    if let Some(auto_sync_prompted) = patch.auto_sync_prompted {
+        config.auto_sync_prompted = auto_sync_prompted;
+    }
+    if patch.enabled.is_some() || patch.paused.is_some() {
+        config.auto_sync_prompted = true;
     }
     save_store(&space_root, &config)?;
     let status = read_status_internal(git_state, space_state, window_label)?;

--- a/src-tauri/src/git_sync/store.rs
+++ b/src-tauri/src/git_sync/store.rs
@@ -84,6 +84,27 @@ mod tests {
     }
 
     #[test]
+    fn adopted_existing_repo_defaults_to_manual_sync() {
+        let config = GitSyncConfig::with_remote(
+            "https://github.com/team/repo".to_string(),
+            "main".to_string(),
+            GitSyncRepoMode::AdoptedExistingRepo,
+        );
+        assert!(!config.enabled);
+        assert!(!config.auto_sync_prompted);
+    }
+
+    #[test]
+    fn managed_new_repo_defaults_to_automatic_sync() {
+        let config = GitSyncConfig::with_remote(
+            "https://github.com/team/repo".to_string(),
+            "main".to_string(),
+            GitSyncRepoMode::ManagedNewRepo,
+        );
+        assert!(config.enabled);
+    }
+
+    #[test]
     fn deletes_store() {
         let root = temp_root();
         let config = GitSyncConfig::with_remote(

--- a/src-tauri/src/git_sync/types.rs
+++ b/src-tauri/src/git_sync/types.rs
@@ -78,12 +78,14 @@ pub struct GitSyncConfig {
     pub last_error: Option<String>,
     pub consecutive_auto_sync_failures: u32,
     pub paused: bool,
+    #[serde(default)]
+    pub auto_sync_prompted: bool,
 }
 
 impl GitSyncConfig {
     pub fn with_remote(remote_url: String, branch: String, repo_mode: GitSyncRepoMode) -> Self {
         Self {
-            enabled: true,
+            enabled: repo_mode == GitSyncRepoMode::ManagedNewRepo,
             remote_url,
             branch,
             repo_mode,
@@ -95,6 +97,7 @@ impl GitSyncConfig {
             last_error: None,
             consecutive_auto_sync_failures: 0,
             paused: false,
+            auto_sync_prompted: false,
         }
     }
 }
@@ -127,6 +130,7 @@ pub struct GitSyncConfigPatch {
     pub interval_minutes: Option<u32>,
     pub inclusions: Option<GitSyncInclusionSettings>,
     pub paused: Option<bool>,
+    pub auto_sync_prompted: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -141,6 +145,7 @@ pub struct GitSyncStatus {
     pub branch: Option<String>,
     pub enabled: bool,
     pub paused: bool,
+    pub auto_sync_prompted: bool,
     pub phase: GitSyncPhase,
     pub is_syncing: bool,
     pub interval_minutes: u32,
@@ -173,6 +178,7 @@ impl Default for GitSyncStatus {
             branch: None,
             enabled: false,
             paused: false,
+            auto_sync_prompted: false,
             phase: GitSyncPhase::Idle,
             is_syncing: false,
             interval_minutes: DEFAULT_GIT_SYNC_INTERVAL_MINUTES,

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useUILayoutContext } from "../contexts";
+import {
+	completeAutoSyncPrompt,
+	promptForAutoSync,
+	shouldPromptForAutoSync,
+} from "../lib/gitSyncPrompt";
 import { loadSettings } from "../lib/settings";
 import type { GitSyncRunMode, GitSyncStatus } from "../lib/tauri";
 import { invoke } from "../lib/tauri";
@@ -41,6 +46,7 @@ export function useGitSync({
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
 	const initialAutoRunSpaceRef = useRef<string | null>(null);
+	const autoSyncPromptSpaceRef = useRef<string | null>(null);
 
 	const refreshStatus = useCallback(async () => {
 		if (!spacePath) {
@@ -104,6 +110,7 @@ export function useGitSync({
 			setStatus(null);
 			setError("");
 			initialAutoRunSpaceRef.current = null;
+			autoSyncPromptSpaceRef.current = null;
 			return;
 		}
 		void refreshStatus();
@@ -120,17 +127,49 @@ export function useGitSync({
 	const statusIntervalMinutes = status?.interval_minutes ?? 10;
 
 	useEffect(() => {
-		if (!spacePath || !statusConfigured || !statusEnabled || statusPaused)
+		if (!spacePath || !shouldPromptForAutoSync(status)) return;
+		if (autoSyncPromptSpaceRef.current === spacePath) return;
+		autoSyncPromptSpaceRef.current = spacePath;
+
+		void (async () => {
+			try {
+				const enable = await promptForAutoSync(status);
+				await completeAutoSyncPrompt(enable);
+			} catch (cause) {
+				autoSyncPromptSpaceRef.current = null;
+				setError(
+					cause instanceof Error
+						? cause.message
+						: "Failed to configure Git Sync",
+				);
+			}
+		})();
+	}, [spacePath, status]);
+
+	useEffect(() => {
+		if (
+			!spacePath ||
+			!statusConfigured ||
+			!statusEnabled ||
+			statusPaused ||
+			shouldPromptForAutoSync(status)
+		)
 			return;
 		if (initialAutoRunSpaceRef.current === spacePath) return;
 		initialAutoRunSpaceRef.current = spacePath;
 		void runSync("auto").catch((cause) => {
 			setError(cause instanceof Error ? cause.message : "Git Sync failed");
 		});
-	}, [runSync, spacePath, statusConfigured, statusEnabled, statusPaused]);
+	}, [runSync, spacePath, status, statusConfigured, statusEnabled, statusPaused]);
 
 	useEffect(() => {
-		if (!spacePath || !statusConfigured || !statusEnabled || statusPaused) {
+		if (
+			!spacePath ||
+			!statusConfigured ||
+			!statusEnabled ||
+			statusPaused ||
+			shouldPromptForAutoSync(status)
+		) {
 			return;
 		}
 		const intervalMinutes = Math.max(1, statusIntervalMinutes || 10);
@@ -146,6 +185,7 @@ export function useGitSync({
 	}, [
 		runSync,
 		spacePath,
+		status,
 		statusConfigured,
 		statusEnabled,
 		statusPaused,

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -163,18 +163,27 @@ export function useGitSync({
 		autoSyncPromptSpaceRef.current = spacePath;
 
 		void (async () => {
+			const isCurrentPromptSpace = () =>
+				activeSpacePathRef.current === spacePath &&
+				statusSpaceRef.current === spacePath;
+			const resetPromptForSpace = () => {
+				if (autoSyncPromptSpaceRef.current === spacePath) {
+					autoSyncPromptSpaceRef.current = null;
+				}
+			};
 			try {
 				const enable = await promptForAutoSync(status);
-				if (
-					activeSpacePathRef.current !== spacePath ||
-					statusSpaceRef.current !== spacePath
-				) {
-					autoSyncPromptSpaceRef.current = null;
+				if (!isCurrentPromptSpace()) {
+					resetPromptForSpace();
 					return;
 				}
 				await completeAutoSyncPrompt(enable);
+				if (!isCurrentPromptSpace()) {
+					resetPromptForSpace();
+					return;
+				}
 				setStatus((current) =>
-					current
+					statusSpaceRef.current === spacePath && current
 						? {
 								...current,
 								enabled: enable,
@@ -183,7 +192,10 @@ export function useGitSync({
 						: current,
 				);
 			} catch (cause) {
-				autoSyncPromptSpaceRef.current = null;
+				resetPromptForSpace();
+				if (!isCurrentPromptSpace()) {
+					return;
+				}
 				setError(
 					cause instanceof Error
 						? cause.message

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -47,37 +47,53 @@ export function useGitSync({
 	const [error, setError] = useState("");
 	const initialAutoRunSpaceRef = useRef<string | null>(null);
 	const autoSyncPromptSpaceRef = useRef<string | null>(null);
+	const activeSpacePathRef = useRef<string | null>(spacePath);
+	const statusSpaceRef = useRef<string | null>(null);
+	activeSpacePathRef.current = spacePath;
 
 	const refreshStatus = useCallback(async () => {
 		if (!spacePath) {
+			statusSpaceRef.current = null;
 			setStatus(null);
 			setError("");
 			return;
 		}
+		const refreshSpacePath = spacePath;
 		setLoading(true);
 		setError("");
 		try {
 			const nextStatus = await invoke("git_sync_status_read");
-			setStatus(nextStatus);
+			if (activeSpacePathRef.current === refreshSpacePath) {
+				statusSpaceRef.current = refreshSpacePath;
+				setStatus(nextStatus);
+			}
 		} catch (cause) {
-			setError(
-				cause instanceof Error
-					? cause.message
-					: "Failed to load Git Sync status",
-			);
+			if (activeSpacePathRef.current === refreshSpacePath) {
+				setError(
+					cause instanceof Error
+						? cause.message
+						: "Failed to load Git Sync status",
+				);
+			}
 		} finally {
-			setLoading(false);
+			if (activeSpacePathRef.current === refreshSpacePath) {
+				setLoading(false);
+			}
 		}
 	}, [spacePath]);
 
 	const runSync = useCallback(
 		async (mode: GitSyncRunMode) => {
+			const runSpacePath = activeSpacePathRef.current;
 			await saveCurrentEditor();
 			const context = await buildRunContext();
 			const nextStatus = await invoke("git_sync_run", {
 				request: { mode, context },
 			});
-			setStatus(nextStatus);
+			if (runSpacePath && activeSpacePathRef.current === runSpacePath) {
+				statusSpaceRef.current = runSpacePath;
+				setStatus(nextStatus);
+			}
 			return nextStatus;
 		},
 		[saveCurrentEditor],
@@ -86,11 +102,12 @@ export function useGitSync({
 	const syncNow = useCallback(async () => runSync("manual"), [runSync]);
 
 	const resumeAutoSync = useCallback(async () => {
+		const resumeSpacePath = activeSpacePathRef.current;
 		const nextConfig = await invoke("git_sync_config_update", {
 			patch: { paused: false, enabled: true },
 		});
 		setStatus((current) =>
-			current
+			resumeSpacePath && statusSpaceRef.current === resumeSpacePath && current
 				? {
 						...current,
 						paused: false,
@@ -107,16 +124,24 @@ export function useGitSync({
 
 	useEffect(() => {
 		if (!spacePath) {
+			statusSpaceRef.current = null;
 			setStatus(null);
 			setError("");
 			initialAutoRunSpaceRef.current = null;
 			autoSyncPromptSpaceRef.current = null;
 			return;
 		}
+		statusSpaceRef.current = null;
+		setStatus(null);
+		setError("");
 		void refreshStatus();
 	}, [refreshStatus, spacePath]);
 
 	useTauriEvent("git_sync:status", (payload) => {
+		const currentSpacePath = activeSpacePathRef.current;
+		if (!currentSpacePath || statusSpaceRef.current !== currentSpacePath) {
+			return;
+		}
 		setStatus(payload);
 		setError("");
 	});
@@ -127,7 +152,13 @@ export function useGitSync({
 	const statusIntervalMinutes = status?.interval_minutes ?? 10;
 
 	useEffect(() => {
-		if (!spacePath || !shouldPromptForAutoSync(status)) return;
+		if (
+			!spacePath ||
+			statusSpaceRef.current !== spacePath ||
+			!shouldPromptForAutoSync(status)
+		) {
+			return;
+		}
 		if (autoSyncPromptSpaceRef.current === spacePath) return;
 		autoSyncPromptSpaceRef.current = spacePath;
 
@@ -135,6 +166,21 @@ export function useGitSync({
 			try {
 				const enable = await promptForAutoSync(status);
 				await completeAutoSyncPrompt(enable);
+				if (
+					activeSpacePathRef.current !== spacePath ||
+					statusSpaceRef.current !== spacePath
+				) {
+					return;
+				}
+				setStatus((current) =>
+					current
+						? {
+								...current,
+								enabled: enable,
+								auto_sync_prompted: true,
+							}
+						: current,
+				);
 			} catch (cause) {
 				autoSyncPromptSpaceRef.current = null;
 				setError(
@@ -149,6 +195,7 @@ export function useGitSync({
 	useEffect(() => {
 		if (
 			!spacePath ||
+			statusSpaceRef.current !== spacePath ||
 			!statusConfigured ||
 			!statusEnabled ||
 			statusPaused ||
@@ -160,11 +207,19 @@ export function useGitSync({
 		void runSync("auto").catch((cause) => {
 			setError(cause instanceof Error ? cause.message : "Git Sync failed");
 		});
-	}, [runSync, spacePath, status, statusConfigured, statusEnabled, statusPaused]);
+	}, [
+		runSync,
+		spacePath,
+		status,
+		statusConfigured,
+		statusEnabled,
+		statusPaused,
+	]);
 
 	useEffect(() => {
 		if (
 			!spacePath ||
+			statusSpaceRef.current !== spacePath ||
 			!statusConfigured ||
 			!statusEnabled ||
 			statusPaused ||

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -165,13 +165,14 @@ export function useGitSync({
 		void (async () => {
 			try {
 				const enable = await promptForAutoSync(status);
-				await completeAutoSyncPrompt(enable);
 				if (
 					activeSpacePathRef.current !== spacePath ||
 					statusSpaceRef.current !== spacePath
 				) {
+					autoSyncPromptSpaceRef.current = null;
 					return;
 				}
+				await completeAutoSyncPrompt(enable);
 				setStatus((current) =>
 					current
 						? {

--- a/src/lib/gitSyncPrompt.ts
+++ b/src/lib/gitSyncPrompt.ts
@@ -1,0 +1,42 @@
+import type { GitSyncStatus } from "./tauri";
+import { invoke } from "./tauri";
+
+export function shouldPromptForAutoSync(
+	status: GitSyncStatus | null,
+): status is GitSyncStatus {
+	return (
+		status !== null &&
+		status.configured &&
+		status.repo_mode === "adopted_existing_repo" &&
+		!status.auto_sync_prompted
+	);
+}
+
+export async function promptForAutoSync(
+	status: GitSyncStatus,
+): Promise<boolean> {
+	const remote = status.remote_url ?? status.detected_remote_url;
+	const branch = status.branch ?? status.detected_branch ?? "main";
+	const remoteLabel = remote ? `${remote} (${branch})` : "its remote";
+
+	const { confirm } = await import("@tauri-apps/plugin-dialog");
+	return confirm(
+		`This space is linked to a Git repository at ${remoteLabel}. Enable automatic sync to commit and push changes on a schedule?`,
+		{
+			title: "Enable Git Sync?",
+			okLabel: "Enable Automatic Sync",
+			cancelLabel: "Not Now",
+		},
+	);
+}
+
+export async function completeAutoSyncPrompt(
+	enable: boolean,
+): Promise<void> {
+	await invoke("git_sync_config_update", {
+		patch: {
+			enabled: enable,
+			auto_sync_prompted: true,
+		},
+	});
+}

--- a/src/lib/gitSyncPrompt.ts
+++ b/src/lib/gitSyncPrompt.ts
@@ -5,10 +5,9 @@ export function shouldPromptForAutoSync(
 	status: GitSyncStatus | null,
 ): status is GitSyncStatus {
 	return (
-		status !== null &&
-		status.configured &&
-		status.repo_mode === "adopted_existing_repo" &&
-		!status.auto_sync_prompted
+		status?.configured === true &&
+		status?.repo_mode === "adopted_existing_repo" &&
+		status?.auto_sync_prompted === false
 	);
 }
 
@@ -30,9 +29,7 @@ export async function promptForAutoSync(
 	);
 }
 
-export async function completeAutoSyncPrompt(
-	enable: boolean,
-): Promise<void> {
+export async function completeAutoSyncPrompt(enable: boolean): Promise<void> {
 	await invoke("git_sync_config_update", {
 		patch: {
 			enabled: enable,

--- a/src/lib/gitSyncPrompt.ts
+++ b/src/lib/gitSyncPrompt.ts
@@ -2,18 +2,23 @@ import type { GitSyncStatus } from "./tauri";
 import { invoke } from "./tauri";
 
 function redactRemoteUrl(remote: string): string {
+	const removeQueryAndFragment = (value: string) => value.replace(/[?#].*$/, "");
 	try {
 		if (remote.startsWith("git@")) {
-			return remote;
+			return removeQueryAndFragment(remote);
 		}
 		const url = new URL(remote);
 		if (url.username || url.password) {
 			url.username = "";
 			url.password = "";
 		}
+		url.search = "";
+		url.hash = "";
 		return url.toString();
 	} catch {
-		return remote.replace(/^([^:]+):\/\/[^@/]+@/, "$1://");
+		return removeQueryAndFragment(
+			remote.replace(/^([^:]+):\/\/[^@/]+@/, "$1://"),
+		);
 	}
 }
 

--- a/src/lib/gitSyncPrompt.ts
+++ b/src/lib/gitSyncPrompt.ts
@@ -1,6 +1,22 @@
 import type { GitSyncStatus } from "./tauri";
 import { invoke } from "./tauri";
 
+function redactRemoteUrl(remote: string): string {
+	try {
+		if (remote.startsWith("git@")) {
+			return remote;
+		}
+		const url = new URL(remote);
+		if (url.username || url.password) {
+			url.username = "";
+			url.password = "";
+		}
+		return url.toString();
+	} catch {
+		return remote.replace(/^([^:]+):\/\/[^@/]+@/, "$1://");
+	}
+}
+
 export function shouldPromptForAutoSync(
 	status: GitSyncStatus | null,
 ): status is GitSyncStatus {
@@ -16,7 +32,9 @@ export async function promptForAutoSync(
 ): Promise<boolean> {
 	const remote = status.remote_url ?? status.detected_remote_url;
 	const branch = status.branch ?? status.detected_branch ?? "main";
-	const remoteLabel = remote ? `${remote} (${branch})` : "its remote";
+	const remoteLabel = remote
+		? `${redactRemoteUrl(remote)} (${branch})`
+		: "its remote";
 
 	const { confirm } = await import("@tauri-apps/plugin-dialog");
 	return confirm(

--- a/src/lib/gitSyncUi.test.ts
+++ b/src/lib/gitSyncUi.test.ts
@@ -14,6 +14,7 @@ function makeStatus(overrides: Partial<GitSyncStatus> = {}): GitSyncStatus {
 		branch: "main",
 		enabled: true,
 		paused: false,
+		auto_sync_prompted: true,
 		phase: "idle",
 		is_syncing: false,
 		interval_minutes: 10,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -540,6 +540,7 @@ export interface GitSyncConfig {
 	last_error: string | null;
 	consecutive_auto_sync_failures: number;
 	paused: boolean;
+	auto_sync_prompted: boolean;
 }
 
 export interface GitSyncStatus {
@@ -553,6 +554,7 @@ export interface GitSyncStatus {
 	branch: string | null;
 	enabled: boolean;
 	paused: boolean;
+	auto_sync_prompted: boolean;
 	phase: GitSyncPhase;
 	is_syncing: boolean;
 	interval_minutes: number;
@@ -607,6 +609,7 @@ interface GitSyncConfigPatch {
 	interval_minutes?: number;
 	inclusions?: GitSyncInclusionSettings;
 	paused?: boolean;
+	auto_sync_prompted?: boolean;
 }
 
 type LicenseMode =


### PR DESCRIPTION
## Summary

Adopted existing Git repositories now start with automatic sync disabled and prompt the user once before enabling scheduled commits and pushes. The change persists an `auto_sync_prompted` flag through the backend status/config path and adds frontend prompt handling so initial and interval auto-sync do not run before the user responds.

## Related Issues

Closes #54

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

Not run; workspace instructions list these commands as reference-only unless specifically requested.

## Screenshots or Recordings

N/A

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auto-sync prompt for eligible repositories, letting users choose whether sync should be enabled when first encountered.
  * Sync status now shows whether this prompt has already been displayed.

* **Bug Fixes**
  * Improved sync state handling so updates only apply to the currently active workspace.
  * Refined default sync behavior for newly created vs. adopted repositories.

* **Tests**
  * Added coverage for default sync settings across repository types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->