### PR TITLE
Add separate editor font setting

### DIFF
--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -4,26 +4,18 @@ import {
 	applyUiAccent,
 	applyUiSurfacePreferences,
 	applyUiThemeSelection,
-	applyUiTypography,
 } from "../../lib/appearance";
 import {
 	DEFAULT_UI_TRANSLUCENT_APP,
 	type ThemeMode,
 	type UiAccent,
 	type UiDarkThemeId,
-	type UiFontFamily,
-	type UiFontSize,
 	type UiLightThemeId,
 	loadSettings,
 	setThemeMode,
 	setUiAccent,
 	setUiDarkThemeId,
-	setUiEditorFontFamily,
-	setUiEditorFontSize,
-	setUiFontFamily,
-	setUiFontSize,
 	setUiLightThemeId,
-	setUiMonoFontFamily,
 	setUiTranslucentApp,
 } from "../../lib/settings";
 import {
@@ -41,21 +33,7 @@ import {
 import { AppearanceAccentCard } from "./AppearanceAccentCard";
 import { AppearanceThemeCard } from "./AppearanceThemeCard";
 import { AppearanceTypographyCard } from "./AppearanceTypographyCard";
-import {
-	DEFAULT_FONT_FAMILY,
-	loadAvailableFonts,
-	loadAvailableMonospaceFonts,
-} from "./appearanceOptions";
-
-function includeSelectedFonts(
-	fonts: string[],
-	selectedFonts: string[],
-): string[] {
-	const missingFonts = Array.from(
-		new Set(selectedFonts.filter((font) => !fonts.includes(font))),
-	);
-	return missingFonts.length ? [...missingFonts, ...fonts] : fonts;
-}
+import { useAppearanceTypography } from "./useAppearanceTypography";
 
 export function AppearanceSettingsPane() {
 	const { setTheme } = useTheme();
@@ -67,56 +45,36 @@ export function AppearanceSettingsPane() {
 		GLYPH_DEFAULT_DARK_THEME_ID,
 	);
 	const [accent, setAccentState] = useState<UiAccent>("neutral");
-	const [fontFamily, setFontFamilyState] =
-		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
-	const [editorFontFamily, setEditorFontFamilyState] =
-		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
-	const [monoFontFamily, setMonoFontFamilyState] =
-		useState<UiFontFamily>("JetBrains Mono");
-	const [uiFontSize, setUiFontSizeState] = useState<UiFontSize>(14);
-	const [editorFontSize, setEditorFontSizeState] = useState<UiFontSize>(16);
 	const [translucentApp, setTranslucentAppState] = useState(
 		DEFAULT_UI_TRANSLUCENT_APP,
 	);
-	const [availableFonts, setAvailableFonts] = useState<string[]>([
-		DEFAULT_FONT_FAMILY,
-	]);
-	const [availableMonospaceFonts, setAvailableMonospaceFonts] = useState<
-		string[]
-	>(["JetBrains Mono"]);
 	const [error, setError] = useState("");
+	const {
+		fontFamily,
+		editorFontFamily,
+		monoFontFamily,
+		uiFontSize,
+		editorFontSize,
+		availableFonts,
+		availableMonospaceFonts,
+		onFontFamilyChange,
+		onEditorFontFamilyChange,
+		onMonoFontFamilyChange,
+		onUiFontSizeChange,
+		onEditorFontSizeChange,
+	} = useAppearanceTypography({ setError });
 
 	useEffect(() => {
 		let cancelled = false;
 		void (async () => {
 			try {
-				const [settings, fonts, monoFonts] = await Promise.all([
-					loadSettings(),
-					loadAvailableFonts(),
-					loadAvailableMonospaceFonts(),
-				]);
+				const settings = await loadSettings();
 				if (cancelled) return;
 				setThemeModeState(settings.ui.theme);
 				setLightThemeIdState(settings.ui.lightThemeId);
 				setDarkThemeIdState(settings.ui.darkThemeId);
 				setAccentState(settings.ui.accent);
-				setFontFamilyState(settings.ui.fontFamily);
-				setEditorFontFamilyState(settings.ui.editorFontFamily);
-				setMonoFontFamilyState(settings.ui.monoFontFamily);
-				setUiFontSizeState(settings.ui.fontSize);
-				setEditorFontSizeState(settings.ui.editorFontSize);
 				setTranslucentAppState(settings.ui.translucentApp);
-				setAvailableFonts(
-					includeSelectedFonts(fonts, [
-						settings.ui.fontFamily,
-						settings.ui.editorFontFamily,
-					]),
-				);
-				setAvailableMonospaceFonts(
-					monoFonts.includes(settings.ui.monoFontFamily)
-						? monoFonts
-						: [settings.ui.monoFontFamily, ...monoFonts],
-				);
 				setTheme(settings.ui.theme);
 				applyUiThemeSelection(
 					settings.ui.lightThemeId,
@@ -125,13 +83,6 @@ export function AppearanceSettingsPane() {
 				applyUiAccent(settings.ui.accent);
 				applyUiSurfacePreferences({
 					translucentApp: settings.ui.translucentApp,
-				});
-				applyUiTypography({
-					fontFamily: settings.ui.fontFamily,
-					editorFontFamily: settings.ui.editorFontFamily,
-					monoFontFamily: settings.ui.monoFontFamily,
-					uiFontSize: settings.ui.fontSize,
-					editorFontSize: settings.ui.editorFontSize,
 				});
 			} catch (e) {
 				if (!cancelled) {
@@ -194,106 +145,6 @@ export function AppearanceSettingsPane() {
 			}
 		},
 		[darkThemeId, lightThemeId],
-	);
-
-	const onFontFamilyChange = useCallback(
-		async (next: UiFontFamily) => {
-			setError("");
-			setFontFamilyState(next);
-			applyUiTypography({
-				fontFamily: next,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			});
-			try {
-				await setUiFontFamily(next);
-			} catch (e) {
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[editorFontFamily, editorFontSize, monoFontFamily, uiFontSize],
-	);
-
-	const onEditorFontFamilyChange = useCallback(
-		async (next: UiFontFamily) => {
-			setError("");
-			setEditorFontFamilyState(next);
-			applyUiTypography({
-				fontFamily,
-				editorFontFamily: next,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			});
-			try {
-				await setUiEditorFontFamily(next);
-			} catch (e) {
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[editorFontSize, fontFamily, monoFontFamily, uiFontSize],
-	);
-
-	const onMonoFontFamilyChange = useCallback(
-		async (next: UiFontFamily) => {
-			setError("");
-			setMonoFontFamilyState(next);
-			applyUiTypography({
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily: next,
-				uiFontSize,
-				editorFontSize,
-			});
-			try {
-				await setUiMonoFontFamily(next);
-			} catch (e) {
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[editorFontFamily, editorFontSize, fontFamily, uiFontSize],
-	);
-
-	const onUiFontSizeChange = useCallback(
-		async (next: UiFontSize) => {
-			setError("");
-			setUiFontSizeState(next);
-			applyUiTypography({
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize: next,
-				editorFontSize,
-			});
-			try {
-				await setUiFontSize(next);
-			} catch (e) {
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[editorFontFamily, editorFontSize, fontFamily, monoFontFamily],
-	);
-
-	const onEditorFontSizeChange = useCallback(
-		async (next: UiFontSize) => {
-			setError("");
-			setEditorFontSizeState(next);
-			applyUiTypography({
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize: next,
-			});
-			try {
-				await setUiEditorFontSize(next);
-			} catch (e) {
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[editorFontFamily, fontFamily, monoFontFamily, uiFontSize],
 	);
 
 	const onAccentChange = useCallback(async (next: UiAccent) => {

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -18,6 +18,7 @@ import {
 	setThemeMode,
 	setUiAccent,
 	setUiDarkThemeId,
+	setUiEditorFontFamily,
 	setUiEditorFontSize,
 	setUiFontFamily,
 	setUiFontSize,
@@ -46,6 +47,16 @@ import {
 	loadAvailableMonospaceFonts,
 } from "./appearanceOptions";
 
+function includeSelectedFonts(
+	fonts: string[],
+	selectedFonts: string[],
+): string[] {
+	const missingFonts = Array.from(
+		new Set(selectedFonts.filter((font) => !fonts.includes(font))),
+	);
+	return missingFonts.length ? [...missingFonts, ...fonts] : fonts;
+}
+
 export function AppearanceSettingsPane() {
 	const { setTheme } = useTheme();
 	const [themeMode, setThemeModeState] = useState<ThemeMode>("system");
@@ -57,6 +68,8 @@ export function AppearanceSettingsPane() {
 	);
 	const [accent, setAccentState] = useState<UiAccent>("neutral");
 	const [fontFamily, setFontFamilyState] =
+		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
+	const [editorFontFamily, setEditorFontFamilyState] =
 		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
 	const [monoFontFamily, setMonoFontFamilyState] =
 		useState<UiFontFamily>("JetBrains Mono");
@@ -88,14 +101,16 @@ export function AppearanceSettingsPane() {
 				setDarkThemeIdState(settings.ui.darkThemeId);
 				setAccentState(settings.ui.accent);
 				setFontFamilyState(settings.ui.fontFamily);
+				setEditorFontFamilyState(settings.ui.editorFontFamily);
 				setMonoFontFamilyState(settings.ui.monoFontFamily);
 				setUiFontSizeState(settings.ui.fontSize);
 				setEditorFontSizeState(settings.ui.editorFontSize);
 				setTranslucentAppState(settings.ui.translucentApp);
 				setAvailableFonts(
-					fonts.includes(settings.ui.fontFamily)
-						? fonts
-						: [settings.ui.fontFamily, ...fonts],
+					includeSelectedFonts(fonts, [
+						settings.ui.fontFamily,
+						settings.ui.editorFontFamily,
+					]),
 				);
 				setAvailableMonospaceFonts(
 					monoFonts.includes(settings.ui.monoFontFamily)
@@ -111,12 +126,13 @@ export function AppearanceSettingsPane() {
 				applyUiSurfacePreferences({
 					translucentApp: settings.ui.translucentApp,
 				});
-				applyUiTypography(
-					settings.ui.fontFamily,
-					settings.ui.monoFontFamily,
-					settings.ui.fontSize,
-					settings.ui.editorFontSize,
-				);
+				applyUiTypography({
+					fontFamily: settings.ui.fontFamily,
+					editorFontFamily: settings.ui.editorFontFamily,
+					monoFontFamily: settings.ui.monoFontFamily,
+					uiFontSize: settings.ui.fontSize,
+					editorFontSize: settings.ui.editorFontSize,
+				});
 			} catch (e) {
 				if (!cancelled) {
 					setError(e instanceof Error ? e.message : "Failed to load settings");
@@ -184,56 +200,100 @@ export function AppearanceSettingsPane() {
 		async (next: UiFontFamily) => {
 			setError("");
 			setFontFamilyState(next);
-			applyUiTypography(next, monoFontFamily, uiFontSize, editorFontSize);
+			applyUiTypography({
+				fontFamily: next,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			});
 			try {
 				await setUiFontFamily(next);
 			} catch (e) {
 				setError(e instanceof Error ? e.message : "Failed to save settings");
 			}
 		},
-		[editorFontSize, monoFontFamily, uiFontSize],
+		[editorFontFamily, editorFontSize, monoFontFamily, uiFontSize],
+	);
+
+	const onEditorFontFamilyChange = useCallback(
+		async (next: UiFontFamily) => {
+			setError("");
+			setEditorFontFamilyState(next);
+			applyUiTypography({
+				fontFamily,
+				editorFontFamily: next,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			});
+			try {
+				await setUiEditorFontFamily(next);
+			} catch (e) {
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[editorFontSize, fontFamily, monoFontFamily, uiFontSize],
 	);
 
 	const onMonoFontFamilyChange = useCallback(
 		async (next: UiFontFamily) => {
 			setError("");
 			setMonoFontFamilyState(next);
-			applyUiTypography(fontFamily, next, uiFontSize, editorFontSize);
+			applyUiTypography({
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily: next,
+				uiFontSize,
+				editorFontSize,
+			});
 			try {
 				await setUiMonoFontFamily(next);
 			} catch (e) {
 				setError(e instanceof Error ? e.message : "Failed to save settings");
 			}
 		},
-		[editorFontSize, fontFamily, uiFontSize],
+		[editorFontFamily, editorFontSize, fontFamily, uiFontSize],
 	);
 
 	const onUiFontSizeChange = useCallback(
 		async (next: UiFontSize) => {
 			setError("");
 			setUiFontSizeState(next);
-			applyUiTypography(fontFamily, monoFontFamily, next, editorFontSize);
+			applyUiTypography({
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize: next,
+				editorFontSize,
+			});
 			try {
 				await setUiFontSize(next);
 			} catch (e) {
 				setError(e instanceof Error ? e.message : "Failed to save settings");
 			}
 		},
-		[editorFontSize, fontFamily, monoFontFamily],
+		[editorFontFamily, editorFontSize, fontFamily, monoFontFamily],
 	);
 
 	const onEditorFontSizeChange = useCallback(
 		async (next: UiFontSize) => {
 			setError("");
 			setEditorFontSizeState(next);
-			applyUiTypography(fontFamily, monoFontFamily, uiFontSize, next);
+			applyUiTypography({
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize: next,
+			});
 			try {
 				await setUiEditorFontSize(next);
 			} catch (e) {
 				setError(e instanceof Error ? e.message : "Failed to save settings");
 			}
 		},
-		[fontFamily, monoFontFamily, uiFontSize],
+		[editorFontFamily, fontFamily, monoFontFamily, uiFontSize],
 	);
 
 	const onAccentChange = useCallback(async (next: UiAccent) => {
@@ -297,12 +357,14 @@ export function AppearanceSettingsPane() {
 				) : null}
 				<AppearanceTypographyCard
 					fontFamily={fontFamily}
+					editorFontFamily={editorFontFamily}
 					monoFontFamily={monoFontFamily}
 					uiFontSize={uiFontSize}
 					editorFontSize={editorFontSize}
 					availableFonts={availableFonts}
 					availableMonospaceFonts={availableMonospaceFonts}
 					onFontFamilyChange={onFontFamilyChange}
+					onEditorFontFamilyChange={onEditorFontFamilyChange}
 					onMonoFontFamilyChange={onMonoFontFamilyChange}
 					onUiFontSizeChange={onUiFontSizeChange}
 					onEditorFontSizeChange={onEditorFontSizeChange}

--- a/src/components/settings/AppearanceTypographyCard.tsx
+++ b/src/components/settings/AppearanceTypographyCard.tsx
@@ -12,12 +12,14 @@ import { SettingsSelect } from "./SettingsSelect";
 
 interface AppearanceTypographyCardProps {
 	fontFamily: UiFontFamily;
+	editorFontFamily: UiFontFamily;
 	monoFontFamily: UiFontFamily;
 	uiFontSize: UiFontSize;
 	editorFontSize: UiFontSize;
 	availableFonts: string[];
 	availableMonospaceFonts: string[];
 	onFontFamilyChange: (font: UiFontFamily) => Promise<void>;
+	onEditorFontFamilyChange: (font: UiFontFamily) => Promise<void>;
 	onMonoFontFamilyChange: (font: UiFontFamily) => Promise<void>;
 	onUiFontSizeChange: (size: UiFontSize) => Promise<void>;
 	onEditorFontSizeChange: (size: UiFontSize) => Promise<void>;
@@ -71,12 +73,14 @@ function FontSizeControl({
 
 export function AppearanceTypographyCard({
 	fontFamily,
+	editorFontFamily,
 	monoFontFamily,
 	uiFontSize,
 	editorFontSize,
 	availableFonts,
 	availableMonospaceFonts,
 	onFontFamilyChange,
+	onEditorFontFamilyChange,
 	onMonoFontFamilyChange,
 	onUiFontSizeChange,
 	onEditorFontSizeChange,
@@ -95,6 +99,26 @@ export function AppearanceTypographyCard({
 					id="settingsFontFamily"
 					value={fontFamily}
 					onChange={(event) => void onFontFamilyChange(event.target.value)}
+				>
+					{availableFonts.map((font) => (
+						<option key={font} value={font}>
+							{font}
+						</option>
+					))}
+				</SettingsSelect>
+			</SettingsRow>
+
+			<SettingsRow
+				label="Editor font"
+				htmlFor="settingsEditorFontFamily"
+				description="Used for regular note text outside inline code and code blocks."
+			>
+				<SettingsSelect
+					id="settingsEditorFontFamily"
+					value={editorFontFamily}
+					onChange={(event) =>
+						void onEditorFontFamilyChange(event.target.value)
+					}
 				>
 					{availableFonts.map((font) => (
 						<option key={font} value={font}>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -124,6 +124,13 @@ const SETTINGS_SEARCH_ITEMS = [
 		keywords: ["font", "code", "mono"],
 	},
 	{
+		id: "appearance-editor-font",
+		tab: "appearance",
+		section: "Typography",
+		title: "Editor font",
+		keywords: ["font", "editor", "notes", "prose"],
+	},
+	{
 		id: "appearance-ui-font-size",
 		tab: "appearance",
 		section: "Typography",

--- a/src/components/settings/useAppearanceTypography.ts
+++ b/src/components/settings/useAppearanceTypography.ts
@@ -109,6 +109,7 @@ export function useAppearanceTypography({
 
 	useEffect(() => {
 		let cancelled = false;
+		const hydrationMutationId = typographyMutationRef.current;
 		void (async () => {
 			try {
 				const [settings, fonts, monoFonts] = await Promise.all([
@@ -118,17 +119,24 @@ export function useAppearanceTypography({
 				]);
 				if (cancelled) return;
 				const typography = getTypographyFromSettings(settings);
-				applyTypographyState(typography);
+				const canApplyHydratedTypography =
+					typographyMutationRef.current === hydrationMutationId;
+				const currentTypography = canApplyHydratedTypography
+					? typography
+					: typographyRef.current;
+				if (canApplyHydratedTypography) {
+					applyTypographyState(typography);
+				}
 				setAvailableFonts(
 					includeSelectedFonts(fonts, [
-						settings.ui.fontFamily,
-						settings.ui.editorFontFamily,
+						currentTypography.fontFamily,
+						currentTypography.editorFontFamily,
 					]),
 				);
 				setAvailableMonospaceFonts(
-					monoFonts.includes(settings.ui.monoFontFamily)
+					monoFonts.includes(currentTypography.monoFontFamily)
 						? monoFonts
-						: [settings.ui.monoFontFamily, ...monoFonts],
+						: [currentTypography.monoFontFamily, ...monoFonts],
 				);
 			} catch (e) {
 				if (!cancelled) {

--- a/src/components/settings/useAppearanceTypography.ts
+++ b/src/components/settings/useAppearanceTypography.ts
@@ -1,0 +1,298 @@
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
+import {
+	type UiTypographyPreferences,
+	applyUiTypography,
+} from "../../lib/appearance";
+import {
+	type UiFontFamily,
+	type UiFontSize,
+	loadSettings,
+	setUiEditorFontFamily,
+	setUiEditorFontSize,
+	setUiFontFamily,
+	setUiFontSize,
+	setUiMonoFontFamily,
+} from "../../lib/settings";
+import {
+	DEFAULT_FONT_FAMILY,
+	loadAvailableFonts,
+	loadAvailableMonospaceFonts,
+} from "./appearanceOptions";
+
+function includeSelectedFonts(
+	fonts: string[],
+	selectedFonts: string[],
+): string[] {
+	const missingFonts = Array.from(
+		new Set(selectedFonts.filter((font) => !fonts.includes(font))),
+	);
+	return missingFonts.length ? [...missingFonts, ...fonts] : fonts;
+}
+
+function applyAndSetTypography(
+	next: UiTypographyPreferences,
+	setFontFamilyState: Dispatch<SetStateAction<UiFontFamily>>,
+	setEditorFontFamilyState: Dispatch<SetStateAction<UiFontFamily>>,
+	setMonoFontFamilyState: Dispatch<SetStateAction<UiFontFamily>>,
+	setUiFontSizeState: Dispatch<SetStateAction<UiFontSize>>,
+	setEditorFontSizeState: Dispatch<SetStateAction<UiFontSize>>,
+): void {
+	setFontFamilyState(next.fontFamily);
+	setEditorFontFamilyState(next.editorFontFamily);
+	setMonoFontFamilyState(next.monoFontFamily);
+	setUiFontSizeState(next.uiFontSize);
+	setEditorFontSizeState(next.editorFontSize);
+	applyUiTypography(next);
+}
+
+interface UseAppearanceTypographyOptions {
+	setError: Dispatch<SetStateAction<string>>;
+}
+
+export function useAppearanceTypography({
+	setError,
+}: UseAppearanceTypographyOptions) {
+	const [fontFamily, setFontFamilyState] =
+		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
+	const [editorFontFamily, setEditorFontFamilyState] =
+		useState<UiFontFamily>(DEFAULT_FONT_FAMILY);
+	const [monoFontFamily, setMonoFontFamilyState] =
+		useState<UiFontFamily>("JetBrains Mono");
+	const [uiFontSize, setUiFontSizeState] = useState<UiFontSize>(14);
+	const [editorFontSize, setEditorFontSizeState] = useState<UiFontSize>(16);
+	const [availableFonts, setAvailableFonts] = useState<string[]>([
+		DEFAULT_FONT_FAMILY,
+	]);
+	const [availableMonospaceFonts, setAvailableMonospaceFonts] = useState<
+		string[]
+	>(["JetBrains Mono"]);
+
+	useEffect(() => {
+		let cancelled = false;
+		void (async () => {
+			try {
+				const [settings, fonts, monoFonts] = await Promise.all([
+					loadSettings(),
+					loadAvailableFonts(),
+					loadAvailableMonospaceFonts(),
+				]);
+				if (cancelled) return;
+				const typography = {
+					fontFamily: settings.ui.fontFamily,
+					editorFontFamily: settings.ui.editorFontFamily,
+					monoFontFamily: settings.ui.monoFontFamily,
+					uiFontSize: settings.ui.fontSize,
+					editorFontSize: settings.ui.editorFontSize,
+				};
+				applyAndSetTypography(
+					typography,
+					setFontFamilyState,
+					setEditorFontFamilyState,
+					setMonoFontFamilyState,
+					setUiFontSizeState,
+					setEditorFontSizeState,
+				);
+				setAvailableFonts(
+					includeSelectedFonts(fonts, [
+						settings.ui.fontFamily,
+						settings.ui.editorFontFamily,
+					]),
+				);
+				setAvailableMonospaceFonts(
+					monoFonts.includes(settings.ui.monoFontFamily)
+						? monoFonts
+						: [settings.ui.monoFontFamily, ...monoFonts],
+				);
+			} catch (e) {
+				if (!cancelled) {
+					setError(e instanceof Error ? e.message : "Failed to load settings");
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [setError]);
+
+	const restoreTypography = useCallback((previous: UiTypographyPreferences) => {
+		applyAndSetTypography(
+			previous,
+			setFontFamilyState,
+			setEditorFontFamilyState,
+			setMonoFontFamilyState,
+			setUiFontSizeState,
+			setEditorFontSizeState,
+		);
+	}, []);
+
+	const onFontFamilyChange = useCallback(
+		async (next: UiFontFamily) => {
+			setError("");
+			const previous = {
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			};
+			setFontFamilyState(next);
+			applyUiTypography({ ...previous, fontFamily: next });
+			try {
+				await setUiFontFamily(next);
+			} catch (e) {
+				restoreTypography(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[
+			editorFontFamily,
+			editorFontSize,
+			fontFamily,
+			monoFontFamily,
+			restoreTypography,
+			setError,
+			uiFontSize,
+		],
+	);
+
+	const onEditorFontFamilyChange = useCallback(
+		async (next: UiFontFamily) => {
+			setError("");
+			const previous = {
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			};
+			setEditorFontFamilyState(next);
+			applyUiTypography({ ...previous, editorFontFamily: next });
+			try {
+				await setUiEditorFontFamily(next);
+			} catch (e) {
+				restoreTypography(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[
+			editorFontFamily,
+			editorFontSize,
+			fontFamily,
+			monoFontFamily,
+			restoreTypography,
+			setError,
+			uiFontSize,
+		],
+	);
+
+	const onMonoFontFamilyChange = useCallback(
+		async (next: UiFontFamily) => {
+			setError("");
+			const previous = {
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			};
+			setMonoFontFamilyState(next);
+			applyUiTypography({ ...previous, monoFontFamily: next });
+			try {
+				await setUiMonoFontFamily(next);
+			} catch (e) {
+				restoreTypography(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[
+			editorFontFamily,
+			editorFontSize,
+			fontFamily,
+			monoFontFamily,
+			restoreTypography,
+			setError,
+			uiFontSize,
+		],
+	);
+
+	const onUiFontSizeChange = useCallback(
+		async (next: UiFontSize) => {
+			setError("");
+			const previous = {
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			};
+			setUiFontSizeState(next);
+			applyUiTypography({ ...previous, uiFontSize: next });
+			try {
+				await setUiFontSize(next);
+			} catch (e) {
+				restoreTypography(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[
+			editorFontFamily,
+			editorFontSize,
+			fontFamily,
+			monoFontFamily,
+			restoreTypography,
+			setError,
+			uiFontSize,
+		],
+	);
+
+	const onEditorFontSizeChange = useCallback(
+		async (next: UiFontSize) => {
+			setError("");
+			const previous = {
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			};
+			setEditorFontSizeState(next);
+			applyUiTypography({ ...previous, editorFontSize: next });
+			try {
+				await setUiEditorFontSize(next);
+			} catch (e) {
+				restoreTypography(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[
+			editorFontFamily,
+			editorFontSize,
+			fontFamily,
+			monoFontFamily,
+			restoreTypography,
+			setError,
+			uiFontSize,
+		],
+	);
+
+	return {
+		fontFamily,
+		editorFontFamily,
+		monoFontFamily,
+		uiFontSize,
+		editorFontSize,
+		availableFonts,
+		availableMonospaceFonts,
+		onFontFamilyChange,
+		onEditorFontFamilyChange,
+		onMonoFontFamilyChange,
+		onUiFontSizeChange,
+		onEditorFontSizeChange,
+	};
+}

--- a/src/components/settings/useAppearanceTypography.ts
+++ b/src/components/settings/useAppearanceTypography.ts
@@ -3,6 +3,7 @@ import {
 	type SetStateAction,
 	useCallback,
 	useEffect,
+	useRef,
 	useState,
 } from "react";
 import {
@@ -19,6 +20,7 @@ import {
 	setUiFontSize,
 	setUiMonoFontFamily,
 } from "../../lib/settings";
+import { useTauriEvent } from "../../lib/tauriEvents";
 import {
 	DEFAULT_FONT_FAMILY,
 	loadAvailableFonts,
@@ -51,6 +53,18 @@ function applyAndSetTypography(
 	applyUiTypography(next);
 }
 
+function getTypographyFromSettings(
+	settings: Awaited<ReturnType<typeof loadSettings>>,
+) {
+	return {
+		fontFamily: settings.ui.fontFamily,
+		editorFontFamily: settings.ui.editorFontFamily,
+		monoFontFamily: settings.ui.monoFontFamily,
+		uiFontSize: settings.ui.fontSize,
+		editorFontSize: settings.ui.editorFontSize,
+	};
+}
+
 interface UseAppearanceTypographyOptions {
 	setError: Dispatch<SetStateAction<string>>;
 }
@@ -72,6 +86,26 @@ export function useAppearanceTypography({
 	const [availableMonospaceFonts, setAvailableMonospaceFonts] = useState<
 		string[]
 	>(["JetBrains Mono"]);
+	const typographyMutationRef = useRef(0);
+	const typographyRef = useRef<UiTypographyPreferences>({
+		fontFamily: DEFAULT_FONT_FAMILY,
+		editorFontFamily: DEFAULT_FONT_FAMILY,
+		monoFontFamily: "JetBrains Mono",
+		uiFontSize: 14,
+		editorFontSize: 16,
+	});
+
+	const applyTypographyState = useCallback((next: UiTypographyPreferences) => {
+		typographyRef.current = next;
+		applyAndSetTypography(
+			next,
+			setFontFamilyState,
+			setEditorFontFamilyState,
+			setMonoFontFamilyState,
+			setUiFontSizeState,
+			setEditorFontSizeState,
+		);
+	}, []);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -83,21 +117,8 @@ export function useAppearanceTypography({
 					loadAvailableMonospaceFonts(),
 				]);
 				if (cancelled) return;
-				const typography = {
-					fontFamily: settings.ui.fontFamily,
-					editorFontFamily: settings.ui.editorFontFamily,
-					monoFontFamily: settings.ui.monoFontFamily,
-					uiFontSize: settings.ui.fontSize,
-					editorFontSize: settings.ui.editorFontSize,
-				};
-				applyAndSetTypography(
-					typography,
-					setFontFamilyState,
-					setEditorFontFamilyState,
-					setMonoFontFamilyState,
-					setUiFontSizeState,
-					setEditorFontSizeState,
-				);
+				const typography = getTypographyFromSettings(settings);
+				applyTypographyState(typography);
 				setAvailableFonts(
 					includeSelectedFonts(fonts, [
 						settings.ui.fontFamily,
@@ -118,167 +139,140 @@ export function useAppearanceTypography({
 		return () => {
 			cancelled = true;
 		};
-	}, [setError]);
+	}, [applyTypographyState, setError]);
 
-	const restoreTypography = useCallback((previous: UiTypographyPreferences) => {
-		applyAndSetTypography(
-			previous,
-			setFontFamilyState,
-			setEditorFontFamilyState,
-			setMonoFontFamilyState,
-			setUiFontSizeState,
-			setEditorFontSizeState,
+	useTauriEvent("settings:updated", (payload) => {
+		const ui = payload.ui;
+		if (!ui) return;
+		const previous = typographyRef.current;
+		const next = {
+			fontFamily:
+				typeof ui.fontFamily === "string" ? ui.fontFamily : previous.fontFamily,
+			editorFontFamily:
+				typeof ui.editorFontFamily === "string"
+					? ui.editorFontFamily
+					: previous.editorFontFamily,
+			monoFontFamily:
+				typeof ui.monoFontFamily === "string"
+					? ui.monoFontFamily
+					: previous.monoFontFamily,
+			uiFontSize:
+				typeof ui.fontSize === "number" && Number.isFinite(ui.fontSize)
+					? ui.fontSize
+					: previous.uiFontSize,
+			editorFontSize:
+				typeof ui.editorFontSize === "number" &&
+				Number.isFinite(ui.editorFontSize)
+					? ui.editorFontSize
+					: previous.editorFontSize,
+		};
+		if (
+			next.fontFamily === previous.fontFamily &&
+			next.editorFontFamily === previous.editorFontFamily &&
+			next.monoFontFamily === previous.monoFontFamily &&
+			next.uiFontSize === previous.uiFontSize &&
+			next.editorFontSize === previous.editorFontSize
+		) {
+			return;
+		}
+		typographyMutationRef.current += 1;
+		applyTypographyState(next);
+		setAvailableFonts((fonts) =>
+			includeSelectedFonts(fonts, [next.fontFamily, next.editorFontFamily]),
 		);
-	}, []);
+		setAvailableMonospaceFonts((fonts) =>
+			fonts.includes(next.monoFontFamily)
+				? fonts
+				: [next.monoFontFamily, ...fonts],
+		);
+	});
 
-	const onFontFamilyChange = useCallback(
-		async (next: UiFontFamily) => {
+	const restoreTypography = useCallback(
+		(previous: UiTypographyPreferences) => {
+			applyTypographyState(previous);
+		},
+		[applyTypographyState],
+	);
+
+	const persistTypographyChange = useCallback(
+		async (
+			previous: UiTypographyPreferences,
+			next: UiTypographyPreferences,
+			persist: () => Promise<void>,
+		) => {
+			const mutationId = typographyMutationRef.current + 1;
+			typographyMutationRef.current = mutationId;
 			setError("");
-			const previous = {
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			};
-			setFontFamilyState(next);
-			applyUiTypography({ ...previous, fontFamily: next });
+			applyTypographyState(next);
 			try {
-				await setUiFontFamily(next);
+				await persist();
 			} catch (e) {
+				if (typographyMutationRef.current !== mutationId) return;
 				restoreTypography(previous);
 				setError(e instanceof Error ? e.message : "Failed to save settings");
 			}
 		},
-		[
-			editorFontFamily,
-			editorFontSize,
-			fontFamily,
-			monoFontFamily,
-			restoreTypography,
-			setError,
-			uiFontSize,
-		],
+		[applyTypographyState, restoreTypography, setError],
+	);
+
+	const onFontFamilyChange = useCallback(
+		async (next: UiFontFamily) => {
+			const previous = typographyRef.current;
+			await persistTypographyChange(
+				previous,
+				{ ...previous, fontFamily: next },
+				() => setUiFontFamily(next),
+			);
+		},
+		[persistTypographyChange],
 	);
 
 	const onEditorFontFamilyChange = useCallback(
 		async (next: UiFontFamily) => {
-			setError("");
-			const previous = {
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			};
-			setEditorFontFamilyState(next);
-			applyUiTypography({ ...previous, editorFontFamily: next });
-			try {
-				await setUiEditorFontFamily(next);
-			} catch (e) {
-				restoreTypography(previous);
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
+			const previous = typographyRef.current;
+			await persistTypographyChange(
+				previous,
+				{ ...previous, editorFontFamily: next },
+				() => setUiEditorFontFamily(next),
+			);
 		},
-		[
-			editorFontFamily,
-			editorFontSize,
-			fontFamily,
-			monoFontFamily,
-			restoreTypography,
-			setError,
-			uiFontSize,
-		],
+		[persistTypographyChange],
 	);
 
 	const onMonoFontFamilyChange = useCallback(
 		async (next: UiFontFamily) => {
-			setError("");
-			const previous = {
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			};
-			setMonoFontFamilyState(next);
-			applyUiTypography({ ...previous, monoFontFamily: next });
-			try {
-				await setUiMonoFontFamily(next);
-			} catch (e) {
-				restoreTypography(previous);
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
+			const previous = typographyRef.current;
+			await persistTypographyChange(
+				previous,
+				{ ...previous, monoFontFamily: next },
+				() => setUiMonoFontFamily(next),
+			);
 		},
-		[
-			editorFontFamily,
-			editorFontSize,
-			fontFamily,
-			monoFontFamily,
-			restoreTypography,
-			setError,
-			uiFontSize,
-		],
+		[persistTypographyChange],
 	);
 
 	const onUiFontSizeChange = useCallback(
 		async (next: UiFontSize) => {
-			setError("");
-			const previous = {
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			};
-			setUiFontSizeState(next);
-			applyUiTypography({ ...previous, uiFontSize: next });
-			try {
-				await setUiFontSize(next);
-			} catch (e) {
-				restoreTypography(previous);
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
+			const previous = typographyRef.current;
+			await persistTypographyChange(
+				previous,
+				{ ...previous, uiFontSize: next },
+				() => setUiFontSize(next),
+			);
 		},
-		[
-			editorFontFamily,
-			editorFontSize,
-			fontFamily,
-			monoFontFamily,
-			restoreTypography,
-			setError,
-			uiFontSize,
-		],
+		[persistTypographyChange],
 	);
 
 	const onEditorFontSizeChange = useCallback(
 		async (next: UiFontSize) => {
-			setError("");
-			const previous = {
-				fontFamily,
-				editorFontFamily,
-				monoFontFamily,
-				uiFontSize,
-				editorFontSize,
-			};
-			setEditorFontSizeState(next);
-			applyUiTypography({ ...previous, editorFontSize: next });
-			try {
-				await setUiEditorFontSize(next);
-			} catch (e) {
-				restoreTypography(previous);
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
+			const previous = typographyRef.current;
+			await persistTypographyChange(
+				previous,
+				{ ...previous, editorFontSize: next },
+				() => setUiEditorFontSize(next),
+			);
 		},
-		[
-			editorFontFamily,
-			editorFontSize,
-			fontFamily,
-			monoFontFamily,
-			restoreTypography,
-			setError,
-			uiFontSize,
-		],
+		[persistTypographyChange],
 	);
 
 	return {

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -86,14 +86,24 @@ function getCompactDisplayBoost(): number {
 	return 1;
 }
 
-export function applyUiTypography(
-	fontFamily: UiFontFamily,
-	monoFontFamily: UiFontFamily,
-	uiFontSize: UiFontSize,
-	editorFontSize: UiFontSize,
-): void {
+export interface UiTypographyPreferences {
+	fontFamily: UiFontFamily;
+	editorFontFamily: UiFontFamily;
+	monoFontFamily: UiFontFamily;
+	uiFontSize: UiFontSize;
+	editorFontSize: UiFontSize;
+}
+
+export function applyUiTypography({
+	fontFamily,
+	editorFontFamily,
+	monoFontFamily,
+	uiFontSize,
+	editorFontSize,
+}: UiTypographyPreferences): void {
 	const root = document.documentElement;
 	const safeFamily = fontFamily.trim() || "Geist";
+	const safeEditorFamily = editorFontFamily.trim() || safeFamily;
 	const safeMonoFamily = monoFontFamily.trim() || "JetBrains Mono";
 	const uiScale = Math.max(0.5, Math.min(3, uiFontSize / 14));
 	const compactDisplayBoost = getCompactDisplayBoost();
@@ -119,6 +129,10 @@ export function applyUiTypography(
 	root.style.setProperty(
 		"--font-sans",
 		`"${safeFamily}", "Inter", -apple-system, BlinkMacSystemFont, sans-serif`,
+	);
+	root.style.setProperty(
+		"--font-editor",
+		`"${safeEditorFamily}", "${safeFamily}", "Inter", -apple-system, BlinkMacSystemFont, sans-serif`,
 	);
 	root.style.setProperty(
 		"--font-mono",

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -212,6 +212,18 @@ describe("settings editor font family", () => {
 		expect(storeState.get("ui.editorFontFamily")).toBe("Atkinson Hyperlegible");
 	});
 
+	it("preserves an existing editor font instead of deriving it from the UI font", async () => {
+		storeState.set("ui.fontFamily", "Atkinson Hyperlegible");
+		storeState.set("ui.editorFontFamily", "Literata");
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.ui.fontFamily).toBe("Atkinson Hyperlegible");
+		expect(settings.ui.editorFontFamily).toBe("Literata");
+		expect(storeState.get("ui.editorFontFamily")).toBe("Literata");
+	});
+
 	it("persists and emits editor font changes", async () => {
 		const { setUiEditorFontFamily } = await import("./settings");
 

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -195,6 +195,35 @@ describe("settings app translucency", () => {
 	});
 });
 
+describe("settings editor font family", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("materializes the editor font from the UI font for existing settings", async () => {
+		storeState.set("ui.fontFamily", "Atkinson Hyperlegible");
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.ui.editorFontFamily).toBe("Atkinson Hyperlegible");
+		expect(storeState.get("ui.editorFontFamily")).toBe("Atkinson Hyperlegible");
+	});
+
+	it("persists and emits editor font changes", async () => {
+		const { setUiEditorFontFamily } = await import("./settings");
+
+		await setUiEditorFontFamily("Literata");
+
+		expect(storeState.get("ui.editorFontFamily")).toBe("Literata");
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { editorFontFamily: "Literata" },
+		});
+	});
+});
+
 describe("settings editor width mode", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -170,6 +170,7 @@ export function isUiAccent(value: unknown): value is UiAccent {
 }
 const DEFAULT_UI_ACCENT: UiAccent = "neutral";
 const DEFAULT_UI_FONT_FAMILY = "Geist";
+const DEFAULT_UI_EDITOR_FONT_FAMILY = DEFAULT_UI_FONT_FAMILY;
 const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
 const DEFAULT_AUTO_UPDATE_CHECK_INTERVAL: AutoUpdateCheckInterval = "3h";
 export const MIN_UI_FONT_SIZE = 7;
@@ -308,12 +309,19 @@ function asUiAccent(value: unknown): UiAccent {
 	return isUiAccent(value) ? value : DEFAULT_UI_ACCENT;
 }
 
-function asUiFontFamily(value: unknown): UiFontFamily {
-	if (typeof value !== "string") return DEFAULT_UI_FONT_FAMILY;
+function asUiFontFamily(
+	value: unknown,
+	fallback: UiFontFamily = DEFAULT_UI_FONT_FAMILY,
+): UiFontFamily {
+	if (typeof value !== "string") return fallback;
 	const trimmed = value.trim();
-	if (!trimmed) return DEFAULT_UI_FONT_FAMILY;
-	if (trimmed === "Satoshi") return DEFAULT_UI_FONT_FAMILY;
+	if (!trimmed) return fallback;
+	if (trimmed === "Satoshi") return fallback;
 	return trimmed.slice(0, 80);
+}
+
+function asUiEditorFontFamily(value: unknown): UiFontFamily {
+	return asUiFontFamily(value, DEFAULT_UI_EDITOR_FONT_FAMILY);
 }
 
 function asUiMonoFontFamily(value: unknown): UiFontFamily {
@@ -360,6 +368,7 @@ async function emitSettingsUpdated(payload: {
 		darkThemeId?: UiDarkThemeId;
 		accent?: UiAccent;
 		fontFamily?: UiFontFamily;
+		editorFontFamily?: UiFontFamily;
 		monoFontFamily?: UiFontFamily;
 		fontSize?: UiFontSize;
 		editorFontSize?: UiFontSize;
@@ -430,6 +439,7 @@ interface AppSettings {
 		darkThemeId: UiDarkThemeId;
 		accent: UiAccent;
 		fontFamily: UiFontFamily;
+		editorFontFamily: UiFontFamily;
 		monoFontFamily: UiFontFamily;
 		fontSize: UiFontSize;
 		editorFontSize: UiFontSize;
@@ -497,6 +507,7 @@ const KEYS = {
 	darkThemeId: "ui.darkThemeId",
 	accent: "ui.accent",
 	fontFamily: "ui.fontFamily",
+	editorFontFamily: "ui.editorFontFamily",
 	monoFontFamily: "ui.monoFontFamily",
 	fontSize: "ui.fontSize",
 	editorFontSize: "ui.editorFontSize",
@@ -811,6 +822,7 @@ export async function loadSettings(
 	const rawDarkThemeId = getSettingValue(entries, KEYS.darkThemeId);
 	const rawAccent = getSettingValue(entries, KEYS.accent);
 	const rawFontFamily = getSettingValue(entries, KEYS.fontFamily);
+	const rawEditorFontFamily = getSettingValue(entries, KEYS.editorFontFamily);
 	const rawMonoFontFamily = getSettingValue(entries, KEYS.monoFontFamily);
 	const rawFontSize = getSettingValue(entries, KEYS.fontSize);
 	const rawEditorFontSize = getSettingValue(entries, KEYS.editorFontSize);
@@ -927,6 +939,16 @@ export async function loadSettings(
 		entries.set(KEYS.fontFamily, DEFAULT_UI_FONT_FAMILY);
 	}
 	const monoFontFamily = asUiMonoFontFamily(rawMonoFontFamily);
+	const editorFontFamily =
+		rawEditorFontFamily === undefined || rawEditorFontFamily === null
+			? fontFamily
+			: asUiEditorFontFamily(rawEditorFontFamily);
+	if (rawEditorFontFamily === undefined || rawEditorFontFamily === null) {
+		const store = await getStore();
+		await store.set(KEYS.editorFontFamily, editorFontFamily);
+		await saveSettingsStore(store);
+		entries.set(KEYS.editorFontFamily, editorFontFamily);
+	}
 	const fontSize = asUiFontSize(rawFontSize);
 	const editorFontSize =
 		rawEditorFontSize === undefined || rawEditorFontSize === null
@@ -1025,6 +1047,7 @@ export async function loadSettings(
 			darkThemeId,
 			accent,
 			fontFamily,
+			editorFontFamily,
 			monoFontFamily,
 			fontSize,
 			editorFontSize,
@@ -1224,6 +1247,16 @@ export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {
 	await store.set(KEYS.fontFamily, next);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { fontFamily: next } });
+}
+
+export async function setUiEditorFontFamily(
+	fontFamily: UiFontFamily,
+): Promise<void> {
+	const store = await getStore();
+	const next = asUiEditorFontFamily(fontFamily);
+	await store.set(KEYS.editorFontFamily, next);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { editorFontFamily: next } });
 }
 
 export async function setUiMonoFontFamily(

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -63,6 +63,7 @@ type TauriEventMap = {
 			darkThemeId?: UiDarkThemeId;
 			accent?: UiAccent;
 			fontFamily?: string;
+			editorFontFamily?: string;
 			monoFontFamily?: string;
 			fontSize?: number;
 			editorFontSize?: number;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -35,6 +35,9 @@ function ThemeAndTypographyBridge() {
 		null,
 	);
 	const [fontFamily, setFontFamily] = React.useState<string | null>(null);
+	const [editorFontFamily, setEditorFontFamily] = React.useState<string | null>(
+		null,
+	);
 	const [monoFontFamily, setMonoFontFamily] = React.useState<string | null>(
 		null,
 	);
@@ -61,6 +64,7 @@ function ThemeAndTypographyBridge() {
 				setDarkThemeId(settings.ui.darkThemeId);
 				setAccent(settings.ui.accent);
 				setFontFamily(settings.ui.fontFamily);
+				setEditorFontFamily(settings.ui.editorFontFamily);
 				setMonoFontFamily(settings.ui.monoFontFamily);
 				setUiFontSize(settings.ui.fontSize);
 				setEditorFontSize(settings.ui.editorFontSize);
@@ -118,6 +122,9 @@ function ThemeAndTypographyBridge() {
 		if (typeof payload.ui?.fontFamily === "string") {
 			setFontFamily(payload.ui.fontFamily);
 		}
+		if (typeof payload.ui?.editorFontFamily === "string") {
+			setEditorFontFamily(payload.ui.editorFontFamily);
+		}
 		if (typeof payload.ui?.monoFontFamily === "string") {
 			setMonoFontFamily(payload.ui.monoFontFamily);
 		}
@@ -153,6 +160,7 @@ function ThemeAndTypographyBridge() {
 	React.useEffect(() => {
 		if (
 			!fontFamily ||
+			!editorFontFamily ||
 			!monoFontFamily ||
 			typeof uiFontSize !== "number" ||
 			typeof editorFontSize !== "number"
@@ -160,14 +168,26 @@ function ThemeAndTypographyBridge() {
 			return;
 		}
 		const applyTypography = () => {
-			applyUiTypography(fontFamily, monoFontFamily, uiFontSize, editorFontSize);
+			applyUiTypography({
+				fontFamily,
+				editorFontFamily,
+				monoFontFamily,
+				uiFontSize,
+				editorFontSize,
+			});
 		};
 		applyTypography();
 		window.addEventListener("resize", applyTypography);
 		return () => {
 			window.removeEventListener("resize", applyTypography);
 		};
-	}, [editorFontSize, fontFamily, monoFontFamily, uiFontSize]);
+	}, [
+		editorFontFamily,
+		editorFontSize,
+		fontFamily,
+		monoFontFamily,
+		uiFontSize,
+	]);
 
 	React.useEffect(() => {
 		if (!accent) return;

--- a/src/styles/app/23-raw-markdown-editor.css
+++ b/src/styles/app/23-raw-markdown-editor.css
@@ -11,7 +11,7 @@
 	min-height: 100%;
 	background: transparent;
 	color: color-mix(in srgb, var(--text-primary) 96%, var(--text-secondary));
-	font-family: var(--font-sans);
+	font-family: var(--font-editor);
 	font-size: var(--editor-raw-font-size);
 	font-variant-ligatures: common-ligatures;
 	line-height: 1.68;

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -180,6 +180,7 @@
 }
 
 .tiptapContentInline {
+	font-family: var(--font-editor);
 	letter-spacing: 0;
 	line-height: 1.68;
 	color: var(--editor-body-color);
@@ -618,6 +619,7 @@
 	padding: 2px 5px;
 	border-radius: var(--radius-sm);
 	border: 1px solid color-mix(in srgb, var(--border-light) 68%, transparent);
+	font-family: var(--font-mono);
 }
 
 .tiptapContentInline span[data-glyph-color="gray"] {
@@ -657,6 +659,7 @@
 	padding: calc(var(--space-3) + 22px) var(--space-3) var(--space-3);
 	border-radius: var(--radius-lg);
 	overflow: auto;
+	font-family: var(--font-mono);
 }
 
 .tiptapContentInline pre code {

--- a/src/styles/themes/primitives.css
+++ b/src/styles/themes/primitives.css
@@ -29,6 +29,7 @@
 	--color-red-dark-400: #ff7a74;
 
 	--font-sans: "Geist", "Inter", -apple-system, BlinkMacSystemFont, sans-serif;
+	--font-editor: var(--font-sans);
 	--font-mono: "JetBrains Mono", ui-monospace, monospace;
 
 	--text-base: 0.875rem;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/249


## Description

Adds a separate editor font family preference so users can choose one font for the Glyph interface and another for note editing/reading surfaces.

- Summary of changes
  - Added `ui.editorFontFamily` to settings load, persistence, cross-window update events, and appearance hydration.
  - Added an Editor font selector to Appearance > Typography and made settings search index it.
  - Introduced `--font-editor` and applied it to rich note content and raw markdown editor body text while preserving `--font-mono` for inline code, code blocks, and syntax-oriented spans.
  - Refactored `applyUiTypography` to use a typed object contract instead of positional font/size arguments.
  - Added settings tests for editor font migration and persistence.
- Reasoning
  - Existing UI font selection controlled both the app chrome and note prose. This change lets reading/writing typography diverge without disturbing navigation, settings, panes, and controls.
  - Existing users need a stable migration path: when `ui.editorFontFamily` is missing, it is materialized from the current UI font so later UI font changes do not silently alter the editor font.
  - The typography application boundary now uses named fields to avoid fragile positional call-site churn as typography settings grow.
- Additional context
  - The editor font selector uses the same proportional system font list as the interface font selector.
  - The monospace setting remains the source of truth for inline code, code blocks, raw markdown syntax tokens, and developer-oriented surfaces.


## Screenshots

Not captured. This is a settings/UI change in Appearance > Typography plus editor typography behavior.


## Docs

New setting key: `ui.editorFontFamily`.

Typography CSS variables now include:

```css
--font-sans: interface chrome font
--font-editor: note prose/editor font
--font-mono: code and markdown syntax font
```

Existing settings without `ui.editorFontFamily` are migrated by persisting the current `ui.fontFamily` as the initial editor font.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

Validation run locally:

- `pnpm format`
- `pnpm test`
- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a separate editor font setting in Appearance, letting you choose different fonts for the editor and app UI.
  * Appearance search now includes the new editor font option.
  * Editor and note content now use the editor font styling consistently.

* **Bug Fixes**
  * Improved how typography settings load and sync, including fallback behavior when an editor font isn’t set.
  * Changes to typography now update more reliably and recover cleanly if saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->