### PR TITLE
Add Activity Timeline as default All Notes view

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.5-alpha.4",
+	"version": "0.8.5-alpha.5",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/App.css
+++ b/src/App.css
@@ -8,6 +8,7 @@
 @import "./styles/app/05-main-area.css";
 @import "./styles/app/14-welcome.css";
 @import "./styles/app/15-all-docs.css";
+@import "./styles/app/15-activity-timeline.css";
 @import "./styles/app/16-main-workspace-layout.css";
 @import "./styles/app/17-main-tabs.css";
 @import "./styles/app/20-main-empty-state.css";

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -20,14 +20,7 @@ import {
 	subDays,
 } from "date-fns";
 import { useReducedMotion } from "motion/react";
-import {
-	type RefObject,
-	memo,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -353,7 +346,7 @@ function useActivityRows(feedDays: ActivityDay[]): ActivityVirtualRow[] {
 }
 
 function useActivityVirtualization(
-	paneRef: RefObject<HTMLElement | null>,
+	paneElement: HTMLElement | null,
 	virtualRows: ActivityVirtualRow[],
 ) {
 	const [paneWidth, setPaneWidth] = useState(0);
@@ -383,23 +376,22 @@ function useActivityVirtualization(
 			const cardRows = Math.max(1, Math.ceil(noteCount / columnCount));
 			return cardRows * cardEstimate + 24;
 		},
-		getScrollElement: () => paneRef.current,
+		getScrollElement: () => paneElement,
 		overscan: 3,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 
 	useEffect(() => {
-		const pane = paneRef.current;
-		if (!pane) return;
+		if (!paneElement) return;
 		const observer = new ResizeObserver((entries) => {
 			const entry = entries[0];
 			if (!entry) return;
 			setPaneWidth(entry.contentRect.width);
 		});
-		observer.observe(pane);
-		setPaneWidth(pane.clientWidth);
+		observer.observe(paneElement);
+		setPaneWidth(paneElement.clientWidth);
 		return () => observer.disconnect();
-	}, [paneRef.current]);
+	}, [paneElement]);
 
 	return { rowVirtualizer, virtualItems };
 }
@@ -603,8 +595,11 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 	const { itemAppearance } = useFileTreeContext();
 	const { dailyNotesFolder } = useUILayoutContext();
 	const shouldReduceMotion = useReducedMotion() ?? false;
-	const paneRef = useRef<HTMLElement>(null);
+	const [paneElement, setPaneElement] = useState<HTMLElement | null>(null);
 	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
+	const paneRef = useCallback((node: HTMLElement | null) => {
+		setPaneElement(node);
+	}, []);
 	const {
 		notesQuery,
 		taskSummariesByPath,
@@ -616,7 +611,7 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 	} = useActivityTimelineData(dailyNotesFolder);
 	const virtualRows = useActivityRows(feedDays);
 	const { rowVirtualizer, virtualItems } = useActivityVirtualization(
-		paneRef,
+		paneElement,
 		virtualRows,
 	);
 

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -5,7 +5,11 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+	type VirtualItem,
+	type Virtualizer,
+	useVirtualizer,
+} from "@tanstack/react-virtual";
 import {
 	addDays,
 	format,
@@ -16,7 +20,14 @@ import {
 	subDays,
 } from "date-fns";
 import { useReducedMotion } from "motion/react";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type RefObject,
+	memo,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -27,7 +38,11 @@ import {
 	loadAllDocsPage,
 	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
-import type { AllDocsItem } from "../../lib/tauri";
+import type {
+	AllDocsItem,
+	FileTreeAppearance,
+	NoteTaskSummary,
+} from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
@@ -216,15 +231,17 @@ function monthVisibilityCounts(days: ActivityDay[]): Map<string, number> {
 	return counts;
 }
 
-export const ActivityTimelinePane = memo(function ActivityTimelinePane({
-	onOpenFile,
-}: ActivityTimelinePaneProps) {
-	const { itemAppearance } = useFileTreeContext();
-	const { dailyNotesFolder } = useUILayoutContext();
-	const shouldReduceMotion = useReducedMotion() ?? false;
-	const paneRef = useRef<HTMLElement>(null);
-	const [paneWidth, setPaneWidth] = useState(0);
-	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
+function countUniqueNotes(days: ActivityDay[]): number {
+	const notePaths = new Set<string>();
+	for (const day of days) {
+		for (const notePath of day.notes.keys()) {
+			notePaths.add(notePath);
+		}
+	}
+	return notePaths.size;
+}
+
+function useActivityTimelineData(dailyNotesFolder: string | null) {
 	const queryClient = useQueryClient();
 	const notesQuery = useInfiniteQuery({
 		queryKey: navigationQueryKeys.allDocsPages(null, ACTIVITY_DOCS_PAGE_SIZE),
@@ -282,7 +299,30 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 		() => feedActivityDays.filter((day) => day.notes.size > 0).reverse(),
 		[feedActivityDays],
 	);
-	const virtualRows = useMemo<ActivityVirtualRow[]>(() => {
+	const recentNotesCount = useMemo(
+		() => countUniqueNotes(recentActivityDays),
+		[recentActivityDays],
+	);
+
+	useTauriEvent("notes:external_changed", () => {
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocs(),
+		});
+	});
+
+	return {
+		notesQuery,
+		taskSummariesByPath,
+		columns,
+		visibleMonthCounts,
+		maxCount,
+		feedDays,
+		recentNotesCount,
+	};
+}
+
+function useActivityRows(feedDays: ActivityDay[]): ActivityVirtualRow[] {
+	return useMemo<ActivityVirtualRow[]>(() => {
 		const rows: ActivityVirtualRow[] = [];
 		for (const [dayIndex, day] of feedDays.entries()) {
 			rows.push({
@@ -310,10 +350,13 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 		}
 		return rows;
 	}, [feedDays]);
-	const recentNotesCount = useMemo(
-		() => recentActivityDays.reduce((count, day) => count + day.notes.size, 0),
-		[recentActivityDays],
-	);
+}
+
+function useActivityVirtualization(
+	paneRef: RefObject<HTMLElement | null>,
+	virtualRows: ActivityVirtualRow[],
+) {
+	const [paneWidth, setPaneWidth] = useState(0);
 	const columnCount = useMemo(() => {
 		const contentWidth =
 			paneWidth <= 0 ? ACTIVITY_CONTENT_MAX_WIDTH : Math.min(paneWidth, 860);
@@ -345,15 +388,6 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 
-	useVirtualLoadMore({
-		hasMore: notesQuery.hasNextPage,
-		isLoading: notesQuery.isFetchingNextPage,
-		onLoadMore: notesQuery.fetchNextPage,
-		virtualItems,
-		totalItems: virtualRows.length,
-		remainingItems: 6,
-	});
-
 	useEffect(() => {
 		const pane = paneRef.current;
 		if (!pane) return;
@@ -365,12 +399,234 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 		observer.observe(pane);
 		setPaneWidth(pane.clientWidth);
 		return () => observer.disconnect();
-	}, []);
+	}, [paneRef.current]);
 
-	useTauriEvent("notes:external_changed", () => {
-		void queryClient.invalidateQueries({
-			queryKey: navigationQueryKeys.allDocs(),
-		});
+	return { rowVirtualizer, virtualItems };
+}
+
+interface ActivityHeatmapProps {
+	columns: ActivityDay[][];
+	visibleMonthCounts: Map<string, number>;
+	maxCount: number;
+}
+
+function ActivityHeatmap({
+	columns,
+	visibleMonthCounts,
+	maxCount,
+}: ActivityHeatmapProps) {
+	return (
+		<div className="activityHeatmapBlock" aria-label="Recent note activity">
+			<div className="activityHeatmapMonths" aria-hidden="true">
+				{columns.map((column, index) => {
+					const first = column[0];
+					const previous = columns[index - 1]?.[0];
+					const monthKey = first ? format(first.date, "yyyy-MM") : "";
+					const show =
+						first &&
+						(!previous || first.date.getMonth() !== previous.date.getMonth()) &&
+						(visibleMonthCounts.get(monthKey) ?? 0) >= 15;
+					return (
+						<span key={first?.dateKey ?? index}>
+							{show && first ? monthLabel(first.date) : ""}
+						</span>
+					);
+				})}
+			</div>
+			<div className="activityHeatmapGrid">
+				{columns.map((column) => (
+					<div key={column[0]?.dateKey} className="activityHeatmapColumn">
+						{column.map((day) => {
+							const level = intensity(day, maxCount);
+							const tooltip = heatmapTooltip(day);
+							return (
+								<span
+									key={day.dateKey}
+									className="activityHeatmapCell"
+									data-level={level}
+									data-tooltip={tooltip}
+									title={tooltip}
+									aria-label={tooltip}
+									role="img"
+								/>
+							);
+						})}
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface ActivityFeedProps {
+	feedDays: ActivityDay[];
+	virtualRows: ActivityVirtualRow[];
+	virtualItems: VirtualItem[];
+	rowVirtualizer: Virtualizer<HTMLElement, HTMLDivElement>;
+	itemAppearance: Record<string, FileTreeAppearance>;
+	selectedNotePath: string | null;
+	taskSummariesByPath: Record<string, NoteTaskSummary>;
+	shouldReduceMotion: boolean;
+	onSelectNote: (notePath: string) => void;
+	onOpenFile: (relPath: string) => Promise<void>;
+}
+
+function ActivityFeed({
+	feedDays,
+	virtualRows,
+	virtualItems,
+	rowVirtualizer,
+	itemAppearance,
+	selectedNotePath,
+	taskSummariesByPath,
+	shouldReduceMotion,
+	onSelectNote,
+	onOpenFile,
+}: ActivityFeedProps) {
+	if (feedDays.length === 0) {
+		return (
+			<div className="activityFeed">
+				<div className="databaseLoadingState">
+					No activity yet. Create or edit a note to start the timeline.
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="activityFeed is-virtualized"
+			style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+		>
+			{virtualItems.map((virtualRow) => {
+				const row = virtualRows[virtualRow.index];
+				if (!row) return null;
+				return (
+					<div
+						key={row.id}
+						data-index={virtualRow.index}
+						ref={(node) => rowVirtualizer.measureElement(node)}
+						className="activityVirtualRow"
+						style={{ transform: `translateY(${virtualRow.start}px)` }}
+					>
+						{row.kind === "header" ? (
+							<ActivityDayHeaderRow day={row.day} />
+						) : (
+							<ActivityCardsRow
+								row={row}
+								itemAppearance={itemAppearance}
+								selectedNotePath={selectedNotePath}
+								taskSummariesByPath={taskSummariesByPath}
+								shouldReduceMotion={shouldReduceMotion}
+								onSelectNote={onSelectNote}
+								onOpenFile={onOpenFile}
+							/>
+						)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+function ActivityDayHeaderRow({ day }: { day: ActivityDay }) {
+	return (
+		<section className="activityDayGroup activityDayHeaderRow">
+			<div className="activityDayRail" aria-hidden="true" />
+			<header className="activityDayHeader">
+				<div>
+					<h2>{dayLabel(day.date)}</h2>
+				</div>
+				<div className="activityDayCounts">
+					<span>
+						{day.notes.size} {day.notes.size === 1 ? "note" : "notes"}
+					</span>
+				</div>
+			</header>
+		</section>
+	);
+}
+
+interface ActivityCardsRowProps {
+	row: Extract<ActivityVirtualRow, { kind: "cards" }>;
+	itemAppearance: Record<string, FileTreeAppearance>;
+	selectedNotePath: string | null;
+	taskSummariesByPath: Record<string, NoteTaskSummary>;
+	shouldReduceMotion: boolean;
+	onSelectNote: (notePath: string) => void;
+	onOpenFile: (relPath: string) => Promise<void>;
+}
+
+function ActivityCardsRow({
+	row,
+	itemAppearance,
+	selectedNotePath,
+	taskSummariesByPath,
+	shouldReduceMotion,
+	onSelectNote,
+	onOpenFile,
+}: ActivityCardsRowProps) {
+	return (
+		<section className="activityDayGroup activityDayCardsRow">
+			<div className="activityDayRail" aria-hidden="true" />
+			<div className="activityNoteGrid allDocsGrid">
+				{row.notes.map((item, noteIndex) => {
+					const absoluteNoteIndex = row.startIndex + noteIndex;
+					const cardProps = prepareAllDocsCardProps({
+						note: item.note,
+						index: absoluteNoteIndex,
+						sectionIndex: row.dayIndex,
+						selectedNotePath,
+						taskSummariesByPath,
+						selectNote: onSelectNote,
+						onOpenFile,
+					});
+					return (
+						<AllDocsCard
+							key={item.note.note_path}
+							{...cardProps}
+							noteAppearance={itemAppearance[item.note.note_path] ?? null}
+							shouldReduceMotion={shouldReduceMotion}
+							springPreset={springPresets.snappy}
+							TaskProgressComponent={TaskProgressIndicator}
+						/>
+					);
+				})}
+			</div>
+		</section>
+	);
+}
+
+export const ActivityTimelinePane = memo(function ActivityTimelinePane({
+	onOpenFile,
+}: ActivityTimelinePaneProps) {
+	const { itemAppearance } = useFileTreeContext();
+	const { dailyNotesFolder } = useUILayoutContext();
+	const shouldReduceMotion = useReducedMotion() ?? false;
+	const paneRef = useRef<HTMLElement>(null);
+	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
+	const {
+		notesQuery,
+		taskSummariesByPath,
+		columns,
+		visibleMonthCounts,
+		maxCount,
+		feedDays,
+		recentNotesCount,
+	} = useActivityTimelineData(dailyNotesFolder);
+	const virtualRows = useActivityRows(feedDays);
+	const { rowVirtualizer, virtualItems } = useActivityVirtualization(
+		paneRef,
+		virtualRows,
+	);
+
+	useVirtualLoadMore({
+		hasMore: notesQuery.hasNextPage,
+		isLoading: notesQuery.isFetchingNextPage,
+		onLoadMore: notesQuery.fetchNextPage,
+		virtualItems,
+		totalItems: virtualRows.length,
+		remainingItems: 6,
 	});
 
 	if (notesQuery.isLoading) {
@@ -421,116 +677,23 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 					</div>
 				</div>
 			</header>
-			<div className="activityHeatmapBlock" aria-label="Recent note activity">
-				<div className="activityHeatmapMonths" aria-hidden="true">
-					{columns.map((column, index) => {
-						const first = column[0];
-						const previous = columns[index - 1]?.[0];
-						const monthKey = first ? format(first.date, "yyyy-MM") : "";
-						const show =
-							first &&
-							(!previous ||
-								first.date.getMonth() !== previous.date.getMonth()) &&
-							(visibleMonthCounts.get(monthKey) ?? 0) >= 15;
-						return (
-							<span key={first?.dateKey ?? index}>
-								{show && first ? monthLabel(first.date) : ""}
-							</span>
-						);
-					})}
-				</div>
-				<div className="activityHeatmapGrid">
-					{columns.map((column) => (
-						<div key={column[0]?.dateKey} className="activityHeatmapColumn">
-							{column.map((day) => {
-								const level = intensity(day, maxCount);
-								const tooltip = heatmapTooltip(day);
-								return (
-									<span
-										key={day.dateKey}
-										className="activityHeatmapCell"
-										data-level={level}
-										data-tooltip={tooltip}
-										title={tooltip}
-										aria-label={tooltip}
-										role="img"
-									/>
-								);
-							})}
-						</div>
-					))}
-				</div>
-			</div>
-			<div
-				className="activityFeed is-virtualized"
-				style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
-			>
-				{feedDays.length === 0 ? (
-					<div className="databaseLoadingState">
-						No activity yet. Create or edit a note to start the timeline.
-					</div>
-				) : null}
-				{virtualItems.map((virtualRow) => {
-					const row = virtualRows[virtualRow.index];
-					if (!row) return null;
-					return (
-						<div
-							key={row.id}
-							data-index={virtualRow.index}
-							ref={(node) => rowVirtualizer.measureElement(node)}
-							className="activityVirtualRow"
-							style={{ transform: `translateY(${virtualRow.start}px)` }}
-						>
-							{row.kind === "header" ? (
-								<section className="activityDayGroup activityDayHeaderRow">
-									<div className="activityDayRail" aria-hidden="true" />
-									<header className="activityDayHeader">
-										<div>
-											<h2>{dayLabel(row.day.date)}</h2>
-										</div>
-										<div className="activityDayCounts">
-											<span>
-												{row.day.notes.size}{" "}
-												{row.day.notes.size === 1 ? "note" : "notes"}
-											</span>
-										</div>
-									</header>
-								</section>
-							) : (
-								<section className="activityDayGroup activityDayCardsRow">
-									<div className="activityDayRail" aria-hidden="true" />
-									<div className="activityNoteGrid allDocsGrid">
-										{row.notes.map((item, noteIndex) => {
-											const absoluteNoteIndex = row.startIndex + noteIndex;
-											const cardProps = prepareAllDocsCardProps({
-												note: item.note,
-												index: absoluteNoteIndex,
-												sectionIndex: row.dayIndex,
-												selectedNotePath,
-												taskSummariesByPath,
-												selectNote: setSelectedNotePath,
-												onOpenFile,
-											});
-											return (
-												<AllDocsCard
-													key={item.note.note_path}
-													{...cardProps}
-													noteAppearance={
-														itemAppearance[item.note.note_path] ?? null
-													}
-													shouldReduceMotion={shouldReduceMotion}
-													springPreset={springPresets.snappy}
-													TaskProgressComponent={TaskProgressIndicator}
-												/>
-											);
-										})}
-									</div>
-								</section>
-							)}
-						</div>
-					);
-				})}
-			</div>
+			<ActivityHeatmap
+				columns={columns}
+				visibleMonthCounts={visibleMonthCounts}
+				maxCount={maxCount}
+			/>
+			<ActivityFeed
+				feedDays={feedDays}
+				virtualRows={virtualRows}
+				virtualItems={virtualItems}
+				rowVirtualizer={rowVirtualizer}
+				itemAppearance={itemAppearance}
+				selectedNotePath={selectedNotePath}
+				taskSummariesByPath={taskSummariesByPath}
+				shouldReduceMotion={shouldReduceMotion}
+				onSelectNote={setSelectedNotePath}
+				onOpenFile={onOpenFile}
+			/>
 			{notesQuery.hasNextPage ? (
 				<button
 					type="button"

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -1,0 +1,546 @@
+import { Archive04Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+	useInfiniteQuery,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+	addDays,
+	format,
+	isSameDay,
+	isSameYear,
+	parseISO,
+	startOfDay,
+	subDays,
+} from "date-fns";
+import { useReducedMotion } from "motion/react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { useFileTreeContext, useUILayoutContext } from "../../contexts";
+import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
+import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
+import { getDailyNotePath } from "../../lib/dailyNotes";
+import {
+	ACTIVITY_DOCS_PAGE_SIZE,
+	loadAllDocs,
+	loadAllDocsPage,
+	navigationQueryKeys,
+} from "../../lib/navigationPrefetch";
+import type { AllDocsItem } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
+import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
+import { springPresets } from "../ui/animations";
+import { AllDocsCard, prepareAllDocsCardProps } from "./AllDocsCard";
+import { CanvasPaneAwait } from "./CanvasPaneAwait";
+
+interface ActivityTimelinePaneProps {
+	onOpenFile: (relPath: string) => Promise<void>;
+}
+
+interface ActivityDay {
+	dateKey: string;
+	date: Date;
+	notes: Map<string, ActivityNote>;
+}
+
+interface ActivityNote {
+	note: AllDocsItem;
+	isDaily: boolean;
+}
+
+type ActivityVirtualRow =
+	| {
+			id: string;
+			kind: "header";
+			day: ActivityDay;
+			dayIndex: number;
+	  }
+	| {
+			id: string;
+			kind: "cards";
+			day: ActivityDay;
+			dayIndex: number;
+			chunkIndex: number;
+			startIndex: number;
+			notes: ActivityNote[];
+	  };
+
+const HEATMAP_DAYS = 365;
+const ACTIVITY_CONTENT_MAX_WIDTH = 860;
+
+function parseNoteDate(value: string): Date | null {
+	const parsed = parseISO(value);
+	if (Number.isNaN(parsed.getTime())) return null;
+	return parsed;
+}
+
+function dateKey(date: Date): string {
+	return format(date, "yyyy-MM-dd");
+}
+
+function dayLabel(date: Date): string {
+	const today = startOfDay(new Date());
+	const yesterday = subDays(today, 1);
+	if (isSameDay(date, today)) return "Today";
+	if (isSameDay(date, yesterday)) return "Yesterday";
+	return format(date, isSameYear(date, today) ? "EEEE, MMM d" : "MMM d, yyyy");
+}
+
+function monthLabel(date: Date): string {
+	return format(date, "MMM");
+}
+
+function buildRecentDayShell(): ActivityDay[] {
+	const today = startOfDay(new Date());
+	const start = subDays(today, HEATMAP_DAYS - 1);
+	const days: ActivityDay[] = [];
+	for (let cursor = start; cursor <= today; cursor = addDays(cursor, 1)) {
+		const key = dateKey(cursor);
+		days.push({
+			dateKey: key,
+			date: cursor,
+			notes: new Map(),
+		});
+	}
+	return days;
+}
+
+function isDailyNote(
+	notePath: string,
+	date: string,
+	dailyNotesFolder: string | null,
+): boolean {
+	return Boolean(
+		dailyNotesFolder && notePath === getDailyNotePath(dailyNotesFolder, date),
+	);
+}
+
+function buildActivityDays(
+	notes: AllDocsItem[],
+	dailyNotesFolder: string | null,
+): ActivityDay[] {
+	const byDate = new Map<string, ActivityDay>();
+	for (const day of buildRecentDayShell()) {
+		byDate.set(day.dateKey, day);
+	}
+
+	const ensureDay = (key: string): ActivityDay | null => {
+		const existing = byDate.get(key);
+		if (existing) return existing;
+		const parsed = parseNoteDate(key);
+		if (!parsed) return null;
+		const day = {
+			dateKey: key,
+			date: startOfDay(parsed),
+			notes: new Map<string, ActivityNote>(),
+		};
+		byDate.set(key, day);
+		return day;
+	};
+
+	const addNote = (key: string, note: AllDocsItem, isDaily = false) => {
+		const day = ensureDay(key);
+		if (!day) return;
+		const existing = day.notes.get(note.note_path);
+		if (existing) existing.isDaily ||= isDaily;
+		else day.notes.set(note.note_path, { note, isDaily });
+	};
+
+	for (const note of notes) {
+		const created = parseNoteDate(note.created);
+		const updated = parseNoteDate(note.updated);
+		const createdKey = created ? dateKey(created) : null;
+		const updatedKey = updated ? dateKey(updated) : null;
+		if (createdKey) {
+			addNote(createdKey, note);
+		}
+		if (updatedKey) {
+			addNote(updatedKey, note);
+		}
+		if (
+			createdKey &&
+			isDailyNote(note.note_path, createdKey, dailyNotesFolder)
+		) {
+			addNote(createdKey, note, true);
+		}
+		if (
+			updatedKey &&
+			updatedKey !== createdKey &&
+			isDailyNote(note.note_path, updatedKey, dailyNotesFolder)
+		) {
+			addNote(updatedKey, note, true);
+		}
+	}
+
+	return [...byDate.values()].sort(
+		(left, right) => left.date.getTime() - right.date.getTime(),
+	);
+}
+
+function heatmapColumns(days: ActivityDay[]): ActivityDay[][] {
+	const columns: ActivityDay[][] = [];
+	for (let index = 0; index < days.length; index += 7) {
+		columns.push(days.slice(index, index + 7));
+	}
+	return columns;
+}
+
+function intensity(day: ActivityDay, maxCount: number): number {
+	const total = day.notes.size;
+	if (total === 0 || maxCount === 0) return 0;
+	return Math.max(1, Math.min(4, Math.ceil((total / maxCount) * 4)));
+}
+
+function sortedDayNotes(day: ActivityDay): ActivityNote[] {
+	return [...day.notes.values()].sort((left, right) => {
+		const leftDaily = left.isDaily ? 1 : 0;
+		const rightDaily = right.isDaily ? 1 : 0;
+		if (leftDaily !== rightDaily) return rightDaily - leftDaily;
+		return Date.parse(right.note.updated) - Date.parse(left.note.updated);
+	});
+}
+
+function heatmapTooltip(day: ActivityDay): string {
+	const noteCount = day.notes.size;
+	const countLabel = noteCount === 1 ? "1 note" : `${noteCount} notes`;
+	return `${countLabel} on ${format(day.date, "MMM d")}`;
+}
+
+function monthVisibilityCounts(days: ActivityDay[]): Map<string, number> {
+	const counts = new Map<string, number>();
+	for (const day of days) {
+		const key = format(day.date, "yyyy-MM");
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	}
+	return counts;
+}
+
+export const ActivityTimelinePane = memo(function ActivityTimelinePane({
+	onOpenFile,
+}: ActivityTimelinePaneProps) {
+	const { itemAppearance } = useFileTreeContext();
+	const { dailyNotesFolder } = useUILayoutContext();
+	const shouldReduceMotion = useReducedMotion() ?? false;
+	const paneRef = useRef<HTMLElement>(null);
+	const [paneWidth, setPaneWidth] = useState(0);
+	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
+	const queryClient = useQueryClient();
+	const notesQuery = useInfiniteQuery({
+		queryKey: navigationQueryKeys.allDocsPages(null, ACTIVITY_DOCS_PAGE_SIZE),
+		queryFn: ({ pageParam }) => {
+			const offset = typeof pageParam === "number" ? pageParam : 0;
+			return loadAllDocsPage(null, offset, ACTIVITY_DOCS_PAGE_SIZE);
+		},
+		initialPageParam: 0,
+		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+	});
+	const heatmapNotesQuery = useQuery({
+		queryKey: navigationQueryKeys.allDocsList(null),
+		queryFn: () => loadAllDocs(null),
+	});
+	const feedNotes = useMemo(
+		() => notesQuery.data?.pages.flatMap((page) => page.items) ?? [],
+		[notesQuery.data],
+	);
+	const feedNotePaths = useMemo(
+		() => feedNotes.map((note) => note.note_path),
+		[feedNotes],
+	);
+	const taskSummariesByPath = useTaskSummariesForPaths(feedNotePaths, true, 0);
+	const heatmapNotes = heatmapNotesQuery.data ?? feedNotes;
+	const activityDays = useMemo(
+		() => buildActivityDays(heatmapNotes, dailyNotesFolder),
+		[heatmapNotes, dailyNotesFolder],
+	);
+	const feedActivityDays = useMemo(
+		() => buildActivityDays(feedNotes, dailyNotesFolder),
+		[feedNotes, dailyNotesFolder],
+	);
+	const recentStart = useMemo(
+		() => subDays(startOfDay(new Date()), HEATMAP_DAYS - 1),
+		[],
+	);
+	const recentActivityDays = useMemo(
+		() =>
+			activityDays.filter((day) => day.date.getTime() >= recentStart.getTime()),
+		[activityDays, recentStart],
+	);
+	const columns = useMemo(
+		() => heatmapColumns(recentActivityDays),
+		[recentActivityDays],
+	);
+	const visibleMonthCounts = useMemo(
+		() => monthVisibilityCounts(recentActivityDays),
+		[recentActivityDays],
+	);
+	const maxCount = useMemo(
+		() => Math.max(0, ...recentActivityDays.map((day) => day.notes.size)),
+		[recentActivityDays],
+	);
+	const feedDays = useMemo(
+		() => feedActivityDays.filter((day) => day.notes.size > 0).reverse(),
+		[feedActivityDays],
+	);
+	const virtualRows = useMemo<ActivityVirtualRow[]>(() => {
+		const rows: ActivityVirtualRow[] = [];
+		for (const [dayIndex, day] of feedDays.entries()) {
+			rows.push({
+				id: `header:${day.dateKey}`,
+				kind: "header",
+				day,
+				dayIndex,
+			});
+			const notes = sortedDayNotes(day);
+			for (
+				let startIndex = 0, chunkIndex = 0;
+				startIndex < notes.length;
+				startIndex += ACTIVITY_DOCS_PAGE_SIZE, chunkIndex += 1
+			) {
+				rows.push({
+					id: `cards:${day.dateKey}:${chunkIndex}`,
+					kind: "cards",
+					day,
+					dayIndex,
+					chunkIndex,
+					startIndex,
+					notes: notes.slice(startIndex, startIndex + ACTIVITY_DOCS_PAGE_SIZE),
+				});
+			}
+		}
+		return rows;
+	}, [feedDays]);
+	const recentNotesCount = useMemo(
+		() => recentActivityDays.reduce((count, day) => count + day.notes.size, 0),
+		[recentActivityDays],
+	);
+	const columnCount = useMemo(() => {
+		const contentWidth =
+			paneWidth <= 0 ? ACTIVITY_CONTENT_MAX_WIDTH : Math.min(paneWidth, 860);
+		const minCardWidth =
+			contentWidth <= 640 ? 144 : contentWidth <= 900 ? 160 : 184;
+		const gap = 14;
+		return Math.max(1, Math.floor((contentWidth + gap) / (minCardWidth + gap)));
+	}, [paneWidth]);
+	const cardEstimate = useMemo(() => {
+		const contentWidth =
+			paneWidth <= 0 ? ACTIVITY_CONTENT_MAX_WIDTH : Math.min(paneWidth, 860);
+		const gap = 14;
+		const width = (contentWidth - gap * (columnCount - 1)) / columnCount;
+		const minHeight = contentWidth <= 640 ? 176 : 184;
+		return Math.max(minHeight, width) + gap;
+	}, [columnCount, paneWidth]);
+	const rowVirtualizer = useVirtualizer<HTMLElement, HTMLDivElement>({
+		count: virtualRows.length,
+		estimateSize: (index) => {
+			const row = virtualRows[index];
+			if (!row) return 96;
+			if (row.kind === "header") return 76;
+			const noteCount = row.notes.length;
+			const cardRows = Math.max(1, Math.ceil(noteCount / columnCount));
+			return cardRows * cardEstimate + 24;
+		},
+		getScrollElement: () => paneRef.current,
+		overscan: 3,
+	});
+	const virtualItems = rowVirtualizer.getVirtualItems();
+
+	useVirtualLoadMore({
+		hasMore: notesQuery.hasNextPage,
+		isLoading: notesQuery.isFetchingNextPage,
+		onLoadMore: notesQuery.fetchNextPage,
+		virtualItems,
+		totalItems: virtualRows.length,
+		remainingItems: 6,
+	});
+
+	useEffect(() => {
+		const pane = paneRef.current;
+		if (!pane) return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			setPaneWidth(entry.contentRect.width);
+		});
+		observer.observe(pane);
+		setPaneWidth(pane.clientWidth);
+		return () => observer.disconnect();
+	}, []);
+
+	useTauriEvent("notes:external_changed", () => {
+		void queryClient.invalidateQueries({
+			queryKey: navigationQueryKeys.allDocs(),
+		});
+	});
+
+	if (notesQuery.isLoading) {
+		return <CanvasPaneAwait variant="all-docs" />;
+	}
+
+	if (notesQuery.error) {
+		return (
+			<div className="databaseLoadingState">
+				Could not load activity:{" "}
+				{notesQuery.error instanceof Error
+					? notesQuery.error.message
+					: String(notesQuery.error)}
+			</div>
+		);
+	}
+
+	return (
+		<section ref={paneRef} className="activityTimelinePane">
+			<header className="activityTimelineHeader">
+				<div>
+					<h1 className="activityTimelineTitle">
+						<HugeiconsIcon
+							icon={Archive04Icon}
+							size="var(--icon-2xl)"
+							strokeWidth={0.9}
+						/>
+						<span>All Notes</span>
+					</h1>
+					<p
+						className="activityTimelineSummary"
+						title="Includes note creation dates and latest edit dates."
+					>
+						{recentNotesCount === 0
+							? "No notes worked on in the last year"
+							: `${recentNotesCount} notes created or edited in the last year`}
+					</p>
+					<div className="activityHeatmapLegend" aria-hidden="true">
+						<span>Less</span>
+						{[0, 1, 2, 3, 4].map((level) => (
+							<span
+								key={level}
+								className="activityHeatmapLegendCell"
+								data-level={level}
+							/>
+						))}
+						<span>More</span>
+					</div>
+				</div>
+			</header>
+			<div className="activityHeatmapBlock" aria-label="Recent note activity">
+				<div className="activityHeatmapMonths" aria-hidden="true">
+					{columns.map((column, index) => {
+						const first = column[0];
+						const previous = columns[index - 1]?.[0];
+						const monthKey = first ? format(first.date, "yyyy-MM") : "";
+						const show =
+							first &&
+							(!previous ||
+								first.date.getMonth() !== previous.date.getMonth()) &&
+							(visibleMonthCounts.get(monthKey) ?? 0) >= 15;
+						return (
+							<span key={first?.dateKey ?? index}>
+								{show && first ? monthLabel(first.date) : ""}
+							</span>
+						);
+					})}
+				</div>
+				<div className="activityHeatmapGrid">
+					{columns.map((column) => (
+						<div key={column[0]?.dateKey} className="activityHeatmapColumn">
+							{column.map((day) => {
+								const level = intensity(day, maxCount);
+								const tooltip = heatmapTooltip(day);
+								return (
+									<span
+										key={day.dateKey}
+										className="activityHeatmapCell"
+										data-level={level}
+										data-tooltip={tooltip}
+										title={tooltip}
+										aria-label={tooltip}
+										role="img"
+									/>
+								);
+							})}
+						</div>
+					))}
+				</div>
+			</div>
+			<div
+				className="activityFeed is-virtualized"
+				style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+			>
+				{feedDays.length === 0 ? (
+					<div className="databaseLoadingState">
+						No activity yet. Create or edit a note to start the timeline.
+					</div>
+				) : null}
+				{virtualItems.map((virtualRow) => {
+					const row = virtualRows[virtualRow.index];
+					if (!row) return null;
+					return (
+						<div
+							key={row.id}
+							data-index={virtualRow.index}
+							ref={(node) => rowVirtualizer.measureElement(node)}
+							className="activityVirtualRow"
+							style={{ transform: `translateY(${virtualRow.start}px)` }}
+						>
+							{row.kind === "header" ? (
+								<section className="activityDayGroup activityDayHeaderRow">
+									<div className="activityDayRail" aria-hidden="true" />
+									<header className="activityDayHeader">
+										<div>
+											<h2>{dayLabel(row.day.date)}</h2>
+										</div>
+										<div className="activityDayCounts">
+											<span>
+												{row.day.notes.size}{" "}
+												{row.day.notes.size === 1 ? "note" : "notes"}
+											</span>
+										</div>
+									</header>
+								</section>
+							) : (
+								<section className="activityDayGroup activityDayCardsRow">
+									<div className="activityDayRail" aria-hidden="true" />
+									<div className="activityNoteGrid allDocsGrid">
+										{row.notes.map((item, noteIndex) => {
+											const absoluteNoteIndex = row.startIndex + noteIndex;
+											const cardProps = prepareAllDocsCardProps({
+												note: item.note,
+												index: absoluteNoteIndex,
+												sectionIndex: row.dayIndex,
+												selectedNotePath,
+												taskSummariesByPath,
+												selectNote: setSelectedNotePath,
+												onOpenFile,
+											});
+											return (
+												<AllDocsCard
+													key={item.note.note_path}
+													{...cardProps}
+													noteAppearance={
+														itemAppearance[item.note.note_path] ?? null
+													}
+													shouldReduceMotion={shouldReduceMotion}
+													springPreset={springPresets.snappy}
+													TaskProgressComponent={TaskProgressIndicator}
+												/>
+											);
+										})}
+									</div>
+								</section>
+							)}
+						</div>
+					);
+				})}
+			</div>
+			{notesQuery.hasNextPage ? (
+				<button
+					type="button"
+					className="activityLoadMore"
+					disabled={notesQuery.isFetchingNextPage}
+					onClick={() => void notesQuery.fetchNextPage()}
+				>
+					{notesQuery.isFetchingNextPage ? "Loading..." : "Load older notes"}
+				</button>
+			) : null}
+		</section>
+	);
+});

--- a/src/components/app/AllDocsCard.tsx
+++ b/src/components/app/AllDocsCard.tsx
@@ -38,6 +38,7 @@ function pushPreviewLine(
 export function previewLines(preview: string, title: string): PreviewLine[] {
 	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
 	const parsed: PreviewLine[] = [];
+	const normalizedTitle = normalizeInlineMarkdown(title).trim().toLowerCase();
 	let inFence = false;
 
 	for (const raw of lines) {
@@ -89,9 +90,10 @@ export function previewLines(preview: string, title: string): PreviewLine[] {
 	}
 
 	const filtered = parsed.filter((line) => {
-		const lower = line.text.toLowerCase();
-		const lowerTitle = title.trim().toLowerCase();
-		return !(lowerTitle && lower.startsWith(lowerTitle));
+		const normalizedLine = normalizeInlineMarkdown(line.text)
+			.trim()
+			.toLowerCase();
+		return !(normalizedTitle && normalizedLine === normalizedTitle);
 	});
 
 	return filtered;
@@ -191,7 +193,8 @@ export function AllDocsCard({
 			type="button"
 			className="allDocsCard"
 			data-state={selected ? "selected" : undefined}
-			aria-label={`Open ${title}`}
+			aria-label={`Select ${title}`}
+			aria-pressed={selected}
 			onClick={onSelect}
 			onMouseEnter={onPrefetch}
 			onFocus={onPrefetch}

--- a/src/components/app/AllDocsCard.tsx
+++ b/src/components/app/AllDocsCard.tsx
@@ -1,0 +1,258 @@
+import { m } from "motion/react";
+import type { KeyboardEvent } from "react";
+import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
+import { prefetchNote } from "../../lib/navigationPrefetch";
+import type {
+	AllDocsItem,
+	FileTreeAppearance,
+	NoteTaskSummary,
+} from "../../lib/tauri";
+import type { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
+import {
+	DatabaseNoteAppearanceIcon,
+	databaseNoteAppearanceStyle,
+} from "../database/DatabaseNoteAppearanceIcon";
+import type { springPresets } from "../ui/animations";
+
+export function titleFromPath(notePath: string): string {
+	const fileName = notePath.split("/").pop() ?? notePath;
+	return fileName.replace(/\.md$/i, "");
+}
+
+type PreviewLineKind = "heading" | "quote" | "task" | "list" | "code" | "body";
+
+export type PreviewLine = {
+	key: string;
+	kind: PreviewLineKind;
+	text: string;
+};
+
+function pushPreviewLine(
+	parsed: PreviewLine[],
+	kind: PreviewLineKind,
+	text: string,
+) {
+	parsed.push({ key: `${kind}:${parsed.length}:${text}`, kind, text });
+}
+
+export function previewLines(preview: string, title: string): PreviewLine[] {
+	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
+	const parsed: PreviewLine[] = [];
+	let inFence = false;
+
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line) continue;
+		if (/^```/.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+
+		if (inFence) {
+			const text = normalizeInlineMarkdown(line);
+			if (text) pushPreviewLine(parsed, "code", text);
+			continue;
+		}
+
+		const headingMatch = line.match(/^#{1,6}\s+(.*)$/);
+		if (headingMatch?.[1]) {
+			const text = normalizeInlineMarkdown(headingMatch[1]);
+			if (text) pushPreviewLine(parsed, "heading", text);
+			continue;
+		}
+
+		const quoteMatch = line.match(/^>\s?(.*)$/);
+		if (quoteMatch?.[1]) {
+			const text = normalizeInlineMarkdown(quoteMatch[1]);
+			if (text) pushPreviewLine(parsed, "quote", text);
+			continue;
+		}
+
+		const taskMatch = line.match(
+			/^(?:(?:[-*+]|\d+\.)\s+)?\[(?: |x|X)\]\s+(.*)$/,
+		);
+		if (taskMatch?.[1]) {
+			const text = normalizeInlineMarkdown(taskMatch[1]);
+			if (text) pushPreviewLine(parsed, "task", text);
+			continue;
+		}
+
+		const listMatch = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
+		if (listMatch?.[1]) {
+			const text = normalizeInlineMarkdown(listMatch[1]);
+			if (text) pushPreviewLine(parsed, "list", text);
+			continue;
+		}
+
+		const text = normalizeInlineMarkdown(line);
+		if (text) pushPreviewLine(parsed, "body", text);
+	}
+
+	const filtered = parsed.filter((line) => {
+		const lower = line.text.toLowerCase();
+		const lowerTitle = title.trim().toLowerCase();
+		return !(lowerTitle && lower.startsWith(lowerTitle));
+	});
+
+	return filtered;
+}
+
+export interface AllDocsCardProps {
+	notePath: string;
+	noteAppearance?: FileTreeAppearance | null;
+	title: string;
+	preview: PreviewLine[];
+	taskSummary: NoteTaskSummary | undefined;
+	taskCount: number;
+	selected: boolean;
+	animationIndex: number;
+	shouldReduceMotion: boolean;
+	springPreset: typeof springPresets.snappy;
+	TaskProgressComponent: typeof TaskProgressIndicator;
+	onSelect: () => void;
+	onPrefetch?: () => void;
+	onOpen: () => void;
+}
+
+type PreparedAllDocsCardProps = Omit<
+	AllDocsCardProps,
+	"shouldReduceMotion" | "springPreset" | "TaskProgressComponent"
+>;
+
+export interface PrepareAllDocsCardPropsArgs {
+	note: AllDocsItem;
+	index: number;
+	sectionIndex: number;
+	selectedNotePath: string | null;
+	taskSummariesByPath?: Record<string, NoteTaskSummary>;
+	selectNote: (notePath: string) => void;
+	onOpenFile: (relPath: string) => Promise<void>;
+}
+
+export function prepareAllDocsCardProps({
+	note,
+	index,
+	sectionIndex,
+	selectedNotePath,
+	taskSummariesByPath = {},
+	selectNote,
+	onOpenFile,
+}: PrepareAllDocsCardPropsArgs): PreparedAllDocsCardProps {
+	const noteTitle = note.title.trim() || titleFromPath(note.note_path);
+	const taskSummary = taskSummariesByPath[note.note_path] ?? undefined;
+	return {
+		notePath: note.note_path,
+		title: noteTitle,
+		preview: previewLines(note.preview, noteTitle),
+		taskSummary,
+		taskCount: taskSummary?.total_count ?? 0,
+		selected: selectedNotePath === note.note_path,
+		animationIndex: sectionIndex * 12 + index,
+		onSelect: () => selectNote(note.note_path),
+		onPrefetch: () => prefetchNote(note.note_path),
+		onOpen: () => void onOpenFile(note.note_path),
+	};
+}
+
+export function AllDocsCard({
+	notePath,
+	noteAppearance = null,
+	title,
+	preview,
+	taskSummary,
+	taskCount,
+	selected,
+	animationIndex,
+	shouldReduceMotion,
+	springPreset,
+	TaskProgressComponent,
+	onSelect,
+	onPrefetch,
+	onOpen,
+}: AllDocsCardProps) {
+	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === "Enter") {
+			event.preventDefault();
+			onOpen();
+			return;
+		}
+		if (event.key === " ") {
+			event.preventDefault();
+			onSelect();
+		}
+	};
+	const noteAppearanceStyle = databaseNoteAppearanceStyle(
+		notePath,
+		noteAppearance,
+	);
+
+	return (
+		<m.button
+			type="button"
+			className="allDocsCard"
+			data-state={selected ? "selected" : undefined}
+			aria-label={`Open ${title}`}
+			onClick={onSelect}
+			onMouseEnter={onPrefetch}
+			onFocus={onPrefetch}
+			onDoubleClick={onOpen}
+			onKeyDown={handleKeyDown}
+			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={
+				shouldReduceMotion
+					? { duration: 0 }
+					: {
+							...springPreset,
+							delay: Math.min(animationIndex * 0.02, 0.18),
+						}
+			}
+			title="Double-click to open note"
+		>
+			<div className="allDocsCardSurface">
+				<div className="allDocsCardTop">
+					<span
+						className="allDocsCardTitle"
+						title={title}
+						style={noteAppearanceStyle}
+					>
+						<DatabaseNoteAppearanceIcon
+							notePath={notePath}
+							appearance={noteAppearance}
+							className="allDocsCardTitleIcon"
+							size="var(--icon-md)"
+						/>
+						{title}
+					</span>
+					{taskSummary && taskCount > 0 ? (
+						<span className="allDocsCardTaskSummary is-top">
+							<TaskProgressComponent
+								summary={taskSummary}
+								className="allDocsCardTaskProgress"
+							/>
+							<span className="allDocsCardTaskText">
+								{taskSummary.completed_count}/{taskCount}
+							</span>
+						</span>
+					) : null}
+				</div>
+				{preview.length > 0 ? (
+					<div className="allDocsCardPreview">
+						{preview.map((line) => (
+							<div
+								key={`${notePath}:preview:${line.key}`}
+								className={`allDocsCardPreviewLine is-${line.kind}`}
+							>
+								{line.text}
+							</div>
+						))}
+					</div>
+				) : (
+					<div className="allDocsCardPreview is-placeholder">
+						No preview yet
+					</div>
+				)}
+			</div>
+		</m.button>
+	);
+}

--- a/src/components/app/AllDocsCard.tsx
+++ b/src/components/app/AllDocsCard.tsx
@@ -193,7 +193,7 @@ export function AllDocsCard({
 			type="button"
 			className="allDocsCard"
 			data-state={selected ? "selected" : undefined}
-			aria-label={`Select ${title}`}
+			aria-label={`Select ${title}. Press Enter to open.`}
 			aria-pressed={selected}
 			onClick={onSelect}
 			onMouseEnter={onPrefetch}

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -1,3 +1,5 @@
+import { TimelineEventIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -7,126 +9,29 @@ import {
 	startOfToday,
 	subDays,
 } from "date-fns";
-import { m, useReducedMotion } from "motion/react";
-import {
-	type KeyboardEvent,
-	memo,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react";
+import { useReducedMotion } from "motion/react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
 
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
-import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import {
 	ALL_DOCS_PAGE_SIZE,
 	loadAllDocsPage,
 	navigationQueryKeys,
-	prefetchNote,
 } from "../../lib/navigationPrefetch";
-import type {
-	AllDocsItem,
-	FileTreeAppearance,
-	NoteTaskSummary,
-} from "../../lib/tauri";
+import type { AllDocsItem } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
-import {
-	DatabaseNoteAppearanceIcon,
-	databaseNoteAppearanceStyle,
-} from "../database/DatabaseNoteAppearanceIcon";
 import { springPresets } from "../ui/animations";
+import { AllDocsCard, prepareAllDocsCardProps } from "./AllDocsCard";
 import { CanvasPaneAwait } from "./CanvasPaneAwait";
 
 interface AllDocsPaneProps {
 	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenActivity: () => void;
+	onPrefetchActivity: () => void;
 	initialNotes?: AllDocsItem[] | null;
-}
-
-function titleFromPath(notePath: string): string {
-	const fileName = notePath.split("/").pop() ?? notePath;
-	return fileName.replace(/\.md$/i, "");
-}
-
-type PreviewLineKind = "heading" | "quote" | "task" | "list" | "code" | "body";
-
-type PreviewLine = {
-	key: string;
-	kind: PreviewLineKind;
-	text: string;
-};
-
-function pushPreviewLine(
-	parsed: PreviewLine[],
-	kind: PreviewLineKind,
-	text: string,
-) {
-	parsed.push({ key: `${kind}:${parsed.length}:${text}`, kind, text });
-}
-
-function previewLines(preview: string, title: string): PreviewLine[] {
-	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
-	const parsed: PreviewLine[] = [];
-	let inFence = false;
-
-	for (const raw of lines) {
-		const line = raw.trim();
-		if (!line) continue;
-		if (/^```/.test(line)) {
-			inFence = !inFence;
-			continue;
-		}
-
-		if (inFence) {
-			const text = normalizeInlineMarkdown(line);
-			if (text) pushPreviewLine(parsed, "code", text);
-			continue;
-		}
-
-		const headingMatch = line.match(/^#{1,6}\s+(.*)$/);
-		if (headingMatch?.[1]) {
-			const text = normalizeInlineMarkdown(headingMatch[1]);
-			if (text) pushPreviewLine(parsed, "heading", text);
-			continue;
-		}
-
-		const quoteMatch = line.match(/^>\s?(.*)$/);
-		if (quoteMatch?.[1]) {
-			const text = normalizeInlineMarkdown(quoteMatch[1]);
-			if (text) pushPreviewLine(parsed, "quote", text);
-			continue;
-		}
-
-		const taskMatch = line.match(
-			/^(?:(?:[-*+]|\d+\.)\s+)?\[(?: |x|X)\]\s+(.*)$/,
-		);
-		if (taskMatch?.[1]) {
-			const text = normalizeInlineMarkdown(taskMatch[1]);
-			if (text) pushPreviewLine(parsed, "task", text);
-			continue;
-		}
-
-		const listMatch = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
-		if (listMatch?.[1]) {
-			const text = normalizeInlineMarkdown(listMatch[1]);
-			if (text) pushPreviewLine(parsed, "list", text);
-			continue;
-		}
-
-		const text = normalizeInlineMarkdown(line);
-		if (text) pushPreviewLine(parsed, "body", text);
-	}
-
-	const filtered = parsed.filter((line) => {
-		const lower = line.text.toLowerCase();
-		const lowerTitle = title.trim().toLowerCase();
-		return !(lowerTitle && lower.startsWith(lowerTitle));
-	});
-
-	return filtered;
 }
 
 type AllDocsSection = {
@@ -174,168 +79,10 @@ const SECTION_ORDER: Array<{ id: AllDocsSection["id"]; label: string }> = [
 	{ id: "earlier", label: "Earlier" },
 ];
 
-interface AllDocsCardProps {
-	notePath: string;
-	noteAppearance?: FileTreeAppearance | null;
-	title: string;
-	preview: PreviewLine[];
-	taskSummary: NoteTaskSummary | undefined;
-	taskCount: number;
-	selected: boolean;
-	animationIndex: number;
-	shouldReduceMotion: boolean;
-	springPreset: typeof springPresets.snappy;
-	TaskProgressComponent: typeof TaskProgressIndicator;
-	onSelect: () => void;
-	onPrefetch: () => void;
-	onOpen: () => void;
-}
-
-type PreparedAllDocsCardProps = Omit<
-	AllDocsCardProps,
-	"shouldReduceMotion" | "springPreset" | "TaskProgressComponent"
->;
-
-interface PrepareAllDocsCardPropsArgs {
-	note: AllDocsItem;
-	index: number;
-	sectionIndex: number;
-	selectedNotePath: string | null;
-	taskSummariesByPath?: Record<string, NoteTaskSummary>;
-	selectNote: (notePath: string) => void;
-	onOpenFile: AllDocsPaneProps["onOpenFile"];
-}
-
-function prepareAllDocsCardProps({
-	note,
-	index,
-	sectionIndex,
-	selectedNotePath,
-	taskSummariesByPath = {},
-	selectNote,
-	onOpenFile,
-}: PrepareAllDocsCardPropsArgs): PreparedAllDocsCardProps {
-	const noteTitle = note.title.trim() || titleFromPath(note.note_path);
-	const taskSummary = taskSummariesByPath[note.note_path] ?? undefined;
-	return {
-		notePath: note.note_path,
-		title: noteTitle,
-		preview: previewLines(note.preview, noteTitle),
-		taskSummary,
-		taskCount: taskSummary?.total_count ?? 0,
-		selected: selectedNotePath === note.note_path,
-		animationIndex: sectionIndex * 12 + index,
-		onSelect: () => selectNote(note.note_path),
-		onPrefetch: () => prefetchNote(note.note_path),
-		onOpen: () => void onOpenFile(note.note_path),
-	};
-}
-
-function AllDocsCard({
-	notePath,
-	noteAppearance = null,
-	title,
-	preview,
-	taskSummary,
-	taskCount,
-	selected,
-	animationIndex,
-	shouldReduceMotion,
-	springPreset,
-	TaskProgressComponent,
-	onSelect,
-	onPrefetch,
-	onOpen,
-}: AllDocsCardProps) {
-	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-		if (event.key === "Enter") {
-			event.preventDefault();
-			onOpen();
-			return;
-		}
-		if (event.key === " ") {
-			event.preventDefault();
-			onSelect();
-		}
-	};
-	const noteAppearanceStyle = databaseNoteAppearanceStyle(
-		notePath,
-		noteAppearance,
-	);
-
-	return (
-		<m.button
-			type="button"
-			className="allDocsCard"
-			data-state={selected ? "selected" : undefined}
-			aria-label={`Open ${title}`}
-			onClick={onSelect}
-			onMouseEnter={onPrefetch}
-			onFocus={onPrefetch}
-			onDoubleClick={onOpen}
-			onKeyDown={handleKeyDown}
-			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={
-				shouldReduceMotion
-					? { duration: 0 }
-					: {
-							...springPreset,
-							delay: Math.min(animationIndex * 0.02, 0.18),
-						}
-			}
-			title="Double-click to open note"
-		>
-			<div className="allDocsCardSurface">
-				<div className="allDocsCardTop">
-					<span
-						className="allDocsCardTitle"
-						title={title}
-						style={noteAppearanceStyle}
-					>
-						<DatabaseNoteAppearanceIcon
-							notePath={notePath}
-							appearance={noteAppearance}
-							className="allDocsCardTitleIcon"
-							size="var(--icon-md)"
-						/>
-						{title}
-					</span>
-					{taskSummary && taskCount > 0 ? (
-						<span className="allDocsCardTaskSummary is-top">
-							<TaskProgressComponent
-								summary={taskSummary}
-								className="allDocsCardTaskProgress"
-							/>
-							<span className="allDocsCardTaskText">
-								{taskSummary.completed_count}/{taskCount}
-							</span>
-						</span>
-					) : null}
-				</div>
-				{preview.length > 0 ? (
-					<div className="allDocsCardPreview">
-						{preview.map((line) => (
-							<div
-								key={`${notePath}:preview:${line.key}`}
-								className={`allDocsCardPreviewLine is-${line.kind}`}
-							>
-								{line.text}
-							</div>
-						))}
-					</div>
-				) : (
-					<div className="allDocsCardPreview is-placeholder">
-						No preview yet
-					</div>
-				)}
-			</div>
-		</m.button>
-	);
-}
-
 export const AllDocsPane = memo(function AllDocsPane({
 	onOpenFile,
+	onOpenActivity,
+	onPrefetchActivity,
 	initialNotes = null,
 }: AllDocsPaneProps) {
 	const { itemAppearance } = useFileTreeContext();
@@ -487,6 +234,22 @@ export const AllDocsPane = memo(function AllDocsPane({
 				<div className="allDocsHeadingGroup">
 					<h1 className="allDocsTitle">All Notes</h1>
 				</div>
+				<button
+					type="button"
+					className="allDocsHeaderAction"
+					onClick={onOpenActivity}
+					onMouseEnter={onPrefetchActivity}
+					onFocus={onPrefetchActivity}
+					title="Show activity"
+					aria-label="Show activity"
+				>
+					<HugeiconsIcon
+						icon={TimelineEventIcon}
+						size="var(--icon-md)"
+						strokeWidth={0.9}
+					/>
+					<span>Show activity</span>
+				</button>
 			</header>
 			<div
 				className="allDocsSections is-virtualized"

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -28,6 +28,7 @@ import { useFileTree } from "../../hooks/useFileTree";
 import { useMenuListeners } from "../../hooks/useMenuListeners";
 import { useResizablePanel } from "../../hooks/useResizablePanel";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
+import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import {
 	dispatchEditorMenuAction,
@@ -42,6 +43,7 @@ import {
 } from "../../lib/database/openDatabasesRequest";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import {
+	ACTIVITY_DOCS_PAGE_SIZE,
 	invalidateAllDocsPrefetch,
 	invalidateDatabaseRowsPrefetch,
 	invalidatePrefetchedNote,
@@ -75,7 +77,11 @@ import {
 } from "./TemplatePickerDialog";
 import { WindowChromeIconButton } from "./WindowChromeIconButton";
 import { WindowChromeUpdateButton } from "./WindowChromeUpdateButton";
-import { loadAllDocsPane, loadDatabasesPane } from "./prefetchablePanes";
+import {
+	loadActivityTimelinePane,
+	loadAllDocsPane,
+	loadDatabasesPane,
+} from "./prefetchablePanes";
 import { useAppCommands } from "./useAppCommands";
 import { useTabManager } from "./useTabManager";
 import { useWorkspaceLinkEvents } from "./useWorkspaceLinkEvents";
@@ -166,6 +172,8 @@ export function AppShell() {
 		TemplatePickerItem[]
 	>([]);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
+	const [classicAllNotesByDefault, setClassicAllNotesByDefault] =
+		useState(false);
 	const [commandPaletteSessionId, setCommandPaletteSessionId] = useState(0);
 	const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
 	const autoUpdater = useUpdaterContext();
@@ -237,9 +245,10 @@ export function AppShell() {
 			.then((settings) => {
 				if (cancelled) return;
 				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
+				setClassicAllNotesByDefault(settings.ui.classicAllNotesByDefault);
 			})
 			.catch((error) => {
-				console.error("Failed to load collapsible heading setting", error);
+				console.error("Failed to load workspace display settings", error);
 			});
 		return () => {
 			cancelled = true;
@@ -249,9 +258,15 @@ export function AppShell() {
 	useTauriEvent(
 		"settings:updated",
 		useCallback(
-			(payload: { editor?: { showCollapsibleHeadings?: boolean } }) => {
+			(payload: {
+				editor?: { showCollapsibleHeadings?: boolean };
+				ui?: { classicAllNotesByDefault?: boolean };
+			}) => {
 				if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 					setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+				}
+				if (typeof payload.ui?.classicAllNotesByDefault === "boolean") {
+					setClassicAllNotesByDefault(payload.ui.classicAllNotesByDefault);
 				}
 			},
 			[],
@@ -796,7 +811,11 @@ export function AppShell() {
 	const activeTopSection = useMemo<
 		"all-notes" | "connections" | "databases" | "pinned-notes" | null
 	>(() => {
-		if (activeTabPath === ALL_DOCS_TAB_ID) return "all-notes";
+		if (
+			activeTabPath === ALL_DOCS_TAB_ID ||
+			activeTabPath === ACTIVITY_TIMELINE_TAB_ID
+		)
+			return "all-notes";
 		if (activeTabPath === SPACE_CONNECTIONS_TAB_ID) return "connections";
 		if (activeTabPath === DATABASES_TAB_ID) return "databases";
 		if (activeTabPath === PINNED_DOCS_TAB_ID) return "pinned-notes";
@@ -814,7 +833,12 @@ export function AppShell() {
 		openPalette("search");
 	}, [openCommandPalette, openPalette, spacePath]);
 	const openAllDocsTab = useCallback(() => {
-		openSpecialTab(ALL_DOCS_TAB_ID);
+		openSpecialTab(
+			classicAllNotesByDefault ? ALL_DOCS_TAB_ID : ACTIVITY_TIMELINE_TAB_ID,
+		);
+	}, [classicAllNotesByDefault, openSpecialTab]);
+	const openActivityTab = useCallback(() => {
+		openSpecialTab(ACTIVITY_TIMELINE_TAB_ID);
 	}, [openSpecialTab]);
 	const openPinnedDocsTab = useCallback(() => {
 		openSpecialTab(PINNED_DOCS_TAB_ID);
@@ -851,8 +875,17 @@ export function AppShell() {
 		void prefetchDatabasesLanding(databaseId);
 	}, []);
 	const prefetchAllDocsTab = useCallback(() => {
-		void loadAllDocsPane();
-		void prefetchAllDocs(null);
+		if (classicAllNotesByDefault) {
+			void loadAllDocsPane();
+			void prefetchAllDocs(null);
+		} else {
+			void loadActivityTimelinePane();
+			void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+		}
+	}, [classicAllNotesByDefault]);
+	const prefetchActivityTab = useCallback(() => {
+		void loadActivityTimelinePane();
+		void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
 	}, []);
 	const openGettingStarted = useCallback(() => {
 		setShowGettingStartedRequest((prev) => prev + 1);
@@ -1278,6 +1311,8 @@ export function AppShell() {
 				onOpenCommandPalette={openCommandPalette}
 				onCreateNote={handleCreateNoteFromStarter}
 				onOpenDailyNote={requestOpenDailyNote}
+				onOpenActivity={openActivityTab}
+				onPrefetchActivity={prefetchActivityTab}
 				tabs={tabs}
 				rootEntries={rootEntries}
 				childrenByDir={childrenByDir}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -49,6 +49,7 @@ import {
 	invalidatePrefetchedNote,
 	invalidateTaskSummariesPrefetchForNote,
 	prefetchAllDocs,
+	prefetchAllDocsList,
 	prefetchDatabasesLanding,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
@@ -172,8 +173,9 @@ export function AppShell() {
 		TemplatePickerItem[]
 	>([]);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
-	const [classicAllNotesByDefault, setClassicAllNotesByDefault] =
-		useState(false);
+	const [classicAllNotesByDefault, setClassicAllNotesByDefault] = useState<
+		boolean | null
+	>(null);
 	const [commandPaletteSessionId, setCommandPaletteSessionId] = useState(0);
 	const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
 	const autoUpdater = useUpdaterContext();
@@ -249,6 +251,7 @@ export function AppShell() {
 			})
 			.catch((error) => {
 				console.error("Failed to load workspace display settings", error);
+				if (!cancelled) setClassicAllNotesByDefault(false);
 			});
 		return () => {
 			cancelled = true;
@@ -833,6 +836,7 @@ export function AppShell() {
 		openPalette("search");
 	}, [openCommandPalette, openPalette, spacePath]);
 	const openAllDocsTab = useCallback(() => {
+		if (classicAllNotesByDefault === null) return;
 		openSpecialTab(
 			classicAllNotesByDefault ? ALL_DOCS_TAB_ID : ACTIVITY_TIMELINE_TAB_ID,
 		);
@@ -875,17 +879,20 @@ export function AppShell() {
 		void prefetchDatabasesLanding(databaseId);
 	}, []);
 	const prefetchAllDocsTab = useCallback(() => {
+		if (classicAllNotesByDefault === null) return;
 		if (classicAllNotesByDefault) {
 			void loadAllDocsPane();
 			void prefetchAllDocs(null);
 		} else {
 			void loadActivityTimelinePane();
 			void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+			void prefetchAllDocsList(null);
 		}
 	}, [classicAllNotesByDefault]);
 	const prefetchActivityTab = useCallback(() => {
 		void loadActivityTimelinePane();
 		void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+		void prefetchAllDocsList(null);
 	}, []);
 	const openGettingStarted = useCallback(() => {
 		setShowGettingStartedRequest((prev) => prev + 1);

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../contexts";
 import { useResizablePanel } from "../../hooks/useResizablePanel";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
+import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import {
 	PATH_REMOVED_EVENT,
@@ -31,6 +32,7 @@ import { APP_TAGLINE } from "../../lib/copy";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import {
+	ACTIVITY_DOCS_PAGE_SIZE,
 	getPrefetchedAllDocs,
 	getPrefetchedDatabaseDocument,
 	getPrefetchedNote,
@@ -73,7 +75,11 @@ import { CanvasPaneAwait } from "./CanvasPaneAwait";
 import { GettingStartedPane } from "./GettingStartedPane";
 import { TabBar } from "./TabBar";
 import { WelcomeScreen } from "./WelcomeScreen";
-import { loadAllDocsPane, loadDatabasesPane } from "./prefetchablePanes";
+import {
+	loadActivityTimelinePane,
+	loadAllDocsPane,
+	loadDatabasesPane,
+} from "./prefetchablePanes";
 import type { WorkspaceTab } from "./useTabManager";
 
 const PinnedDocsPane = lazy(() =>
@@ -84,6 +90,7 @@ const PinnedDocsPane = lazy(() =>
 
 const DatabasesPane = lazy(loadDatabasesPane);
 const AllDocsPane = lazy(loadAllDocsPane);
+const ActivityTimelinePane = lazy(loadActivityTimelinePane);
 const ShortcutsSettingsPane = lazy(() =>
 	import("../settings/ShortcutsSettingsPane").then((module) => ({
 		default: module.ShortcutsSettingsPane,
@@ -272,6 +279,8 @@ interface MainContentProps {
 	onOpenCommandPalette: () => void;
 	onCreateNote: () => void;
 	onOpenDailyNote: () => void;
+	onOpenActivity: () => void;
+	onPrefetchActivity: () => void;
 	tabs: WorkspaceTab[];
 	rootEntries: FsEntry[];
 	childrenByDir: Record<string, FsEntry[] | undefined>;
@@ -380,6 +389,8 @@ export const MainContent = memo(function MainContent({
 	onOpenCommandPalette,
 	onCreateNote,
 	onOpenDailyNote,
+	onOpenActivity,
+	onPrefetchActivity,
 	tabs,
 	rootEntries,
 	childrenByDir,
@@ -610,7 +621,12 @@ export const MainContent = memo(function MainContent({
 			const initialNotes = getPrefetchedAllDocs(null);
 			return (
 				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<AllDocsPane onOpenFile={onOpenFile} initialNotes={initialNotes} />
+					<AllDocsPane
+						onOpenFile={onOpenFile}
+						onOpenActivity={onOpenActivity}
+						onPrefetchActivity={onPrefetchActivity}
+						initialNotes={initialNotes}
+					/>
 				</Suspense>
 			);
 		}
@@ -618,6 +634,13 @@ export const MainContent = memo(function MainContent({
 			return (
 				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
 					<PinnedDocsPane onOpenFile={onOpenFile} />
+				</Suspense>
+			);
+		}
+		if (viewerPath === ACTIVITY_TIMELINE_TAB_ID) {
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+					<ActivityTimelinePane onOpenFile={onOpenFile} />
 				</Suspense>
 			);
 		}
@@ -677,6 +700,8 @@ export const MainContent = memo(function MainContent({
 		fileTree,
 		onOpenFile,
 		onOpenFileInNewTab,
+		onOpenActivity,
+		onPrefetchActivity,
 		databasesOpenRequest,
 		onConsumeDatabasesOpenRequest,
 		viewerPath,
@@ -695,6 +720,11 @@ export const MainContent = memo(function MainContent({
 			if (target === ALL_DOCS_TAB_ID) {
 				void loadAllDocsPane();
 				void prefetchAllDocs(null);
+				return;
+			}
+			if (target === ACTIVITY_TIMELINE_TAB_ID) {
+				void loadActivityTimelinePane();
+				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
 				return;
 			}
 			if (target === DATABASES_TAB_ID) {
@@ -731,12 +761,13 @@ export const MainContent = memo(function MainContent({
 	);
 	const isSpaceConnectionsTab = viewerPath === SPACE_CONNECTIONS_TAB_ID;
 	const isAllDocsTab = viewerPath === ALL_DOCS_TAB_ID;
+	const isActivityTab = viewerPath === ACTIVITY_TIMELINE_TAB_ID;
 	const isDatabasesTab = viewerPath === DATABASES_TAB_ID;
 	const editorCanvas = (
 		<div
 			className="canvasPaneHost"
 			data-space-connections={isSpaceConnectionsTab ? "true" : undefined}
-			data-all-docs={isAllDocsTab ? "true" : undefined}
+			data-all-docs={isAllDocsTab || isActivityTab ? "true" : undefined}
 			data-databases={isDatabasesTab ? "true" : undefined}
 		>
 			<DailyNotesSetupToast

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -37,6 +37,7 @@ import {
 	getPrefetchedDatabaseDocument,
 	getPrefetchedNote,
 	prefetchAllDocs,
+	prefetchAllDocsList,
 	prefetchDatabasesLanding,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
@@ -725,6 +726,7 @@ export const MainContent = memo(function MainContent({
 			if (target === ACTIVITY_TIMELINE_TAB_ID) {
 				void loadActivityTimelinePane();
 				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+				void prefetchAllDocsList(null);
 				return;
 			}
 			if (target === DATABASES_TAB_ID) {

--- a/src/components/app/MainTabsBreadcrumbs.tsx
+++ b/src/components/app/MainTabsBreadcrumbs.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import type { MouseEvent } from "react";
 import { toast } from "sonner";
 import { useSpace } from "../../contexts";
+import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
@@ -72,6 +73,7 @@ function menuTitleForDir(path: string) {
 function isPathSpecial(path: string): boolean {
 	return (
 		path === ALL_DOCS_TAB_ID ||
+		path === ACTIVITY_TIMELINE_TAB_ID ||
 		path === DATABASES_TAB_ID ||
 		path === PINNED_DOCS_TAB_ID ||
 		path === SPACE_CONNECTIONS_TAB_ID

--- a/src/components/app/PinnedDocsPane.tsx
+++ b/src/components/app/PinnedDocsPane.tsx
@@ -1,102 +1,14 @@
-import { m, useReducedMotion } from "motion/react";
+import { useReducedMotion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
-import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
-import type { FileTreeAppearance, NoteTaskSummary } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
-import {
-	DatabaseNoteAppearanceIcon,
-	databaseNoteAppearanceStyle,
-} from "../database/DatabaseNoteAppearanceIcon";
 import { springPresets } from "../ui/animations";
+import { AllDocsCard, previewLines, titleFromPath } from "./AllDocsCard";
 
 interface PinnedDocsPaneProps {
 	onOpenFile: (relPath: string) => Promise<void>;
-}
-
-type PreviewLineKind = "heading" | "quote" | "task" | "list" | "code" | "body";
-
-type PreviewLine = {
-	key: string;
-	kind: PreviewLineKind;
-	text: string;
-};
-
-function pushPreviewLine(
-	parsed: PreviewLine[],
-	kind: PreviewLineKind,
-	text: string,
-) {
-	parsed.push({ key: `${kind}:${parsed.length}:${text}`, kind, text });
-}
-
-function previewLines(preview: string, title: string): PreviewLine[] {
-	const lines = preview.replace(/\r\n?/g, "\n").split("\n");
-	const parsed: PreviewLine[] = [];
-	let inFence = false;
-
-	for (const raw of lines) {
-		const line = raw.trim();
-		if (!line) continue;
-		if (/^```/.test(line)) {
-			inFence = !inFence;
-			continue;
-		}
-
-		if (inFence) {
-			const text = normalizeInlineMarkdown(line);
-			if (text) pushPreviewLine(parsed, "code", text);
-			continue;
-		}
-
-		const headingMatch = line.match(/^#{1,6}\s+(.*)$/);
-		if (headingMatch?.[1]) {
-			const text = normalizeInlineMarkdown(headingMatch[1]);
-			if (text) pushPreviewLine(parsed, "heading", text);
-			continue;
-		}
-
-		const quoteMatch = line.match(/^>\s?(.*)$/);
-		if (quoteMatch?.[1]) {
-			const text = normalizeInlineMarkdown(quoteMatch[1]);
-			if (text) pushPreviewLine(parsed, "quote", text);
-			continue;
-		}
-
-		const taskMatch = line.match(
-			/^(?:(?:[-*+]|\d+\.)\s+)?\[(?: |x|X)\]\s+(.*)$/,
-		);
-		if (taskMatch?.[1]) {
-			const text = normalizeInlineMarkdown(taskMatch[1]);
-			if (text) pushPreviewLine(parsed, "task", text);
-			continue;
-		}
-
-		const listMatch = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
-		if (listMatch?.[1]) {
-			const text = normalizeInlineMarkdown(listMatch[1]);
-			if (text) pushPreviewLine(parsed, "list", text);
-			continue;
-		}
-
-		const text = normalizeInlineMarkdown(line);
-		if (text) pushPreviewLine(parsed, "body", text);
-	}
-
-	const filtered = parsed.filter((line) => {
-		const lower = line.text.toLowerCase();
-		const lowerTitle = title.trim().toLowerCase();
-		return !(lowerTitle && lower.startsWith(lowerTitle));
-	});
-
-	return filtered;
-}
-
-function titleFromPath(notePath: string): string {
-	const fileName = notePath.split("/").pop() ?? notePath;
-	return fileName.replace(/\.md$/i, "");
 }
 
 const PREVIEW_MAX_BYTES = 4096;
@@ -105,108 +17,6 @@ interface PinnedFileData {
 	path: string;
 	title: string;
 	previewText: string;
-}
-
-function PinnedCard({
-	path,
-	title,
-	previewText,
-	itemAppearance,
-	taskSummary,
-	taskCount,
-	selected,
-	animationIndex,
-	shouldReduceMotion,
-	onSelect,
-	onOpen,
-}: {
-	path: string;
-	title: string;
-	previewText: string;
-	itemAppearance: FileTreeAppearance | null | undefined;
-	taskSummary: NoteTaskSummary | null | undefined;
-	taskCount: number;
-	selected: boolean;
-	animationIndex: number;
-	shouldReduceMotion: boolean;
-	onSelect: () => void;
-	onOpen: () => void;
-}) {
-	const preview = useMemo(
-		() => previewLines(previewText, title),
-		[previewText, title],
-	);
-	const noteAppearanceStyle = databaseNoteAppearanceStyle(
-		path,
-		itemAppearance ?? null,
-	);
-
-	return (
-		<m.button
-			type="button"
-			className="allDocsCard"
-			data-state={selected ? "selected" : undefined}
-			aria-label={`Open ${title}`}
-			onClick={onSelect}
-			onDoubleClick={onOpen}
-			initial={shouldReduceMotion ? false : { opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={
-				shouldReduceMotion
-					? { duration: 0 }
-					: {
-							...springPresets.snappy,
-							delay: Math.min(animationIndex * 0.02, 0.18),
-						}
-			}
-			title="Double-click to open note"
-		>
-			<div className="allDocsCardSurface">
-				<div className="allDocsCardTop">
-					<span
-						className="allDocsCardTitle"
-						title={title}
-						style={noteAppearanceStyle}
-					>
-						<DatabaseNoteAppearanceIcon
-							notePath={path}
-							appearance={itemAppearance ?? null}
-							className="allDocsCardTitleIcon"
-							size="var(--icon-md)"
-						/>
-						{title}
-					</span>
-					{taskSummary && taskCount > 0 ? (
-						<span className="allDocsCardTaskSummary is-top">
-							<TaskProgressIndicator
-								summary={taskSummary}
-								className="allDocsCardTaskProgress"
-							/>
-							<span className="allDocsCardTaskText">
-								{taskSummary.completed_count}/{taskCount}
-							</span>
-						</span>
-					) : null}
-				</div>
-				{preview.length > 0 ? (
-					<div className="allDocsCardPreview">
-						{preview.map((line) => (
-							<div
-								key={`${path}:preview:${line.key}`}
-								className={`allDocsCardPreviewLine is-${line.kind}`}
-							>
-								{line.text}
-							</div>
-						))}
-					</div>
-				) : (
-					<div className="allDocsCardPreview is-placeholder">
-						No preview yet
-					</div>
-				)}
-			</div>
-		</m.button>
-	);
 }
 
 export const PinnedDocsPane = memo(function PinnedDocsPane({
@@ -306,19 +116,22 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 				<div className="allDocsGrid">
 					{fileData.map((data, index) => {
 						const taskSummary = taskSummariesByPath[data.path] ?? undefined;
+						const preview = previewLines(data.previewText, data.title);
 
 						return (
-							<PinnedCard
+							<AllDocsCard
 								key={data.path}
-								path={data.path}
+								notePath={data.path}
 								title={data.title}
-								previewText={data.previewText}
-								itemAppearance={itemAppearance[data.path]}
+								preview={preview}
+								noteAppearance={itemAppearance[data.path] ?? null}
 								taskSummary={taskSummary}
 								taskCount={taskSummary?.total_count ?? 0}
 								selected={selectedPath === data.path}
 								animationIndex={index}
 								shouldReduceMotion={shouldReduceMotion}
+								springPreset={springPresets.snappy}
+								TaskProgressComponent={TaskProgressIndicator}
 								onSelect={() => setSelectedPath(data.path)}
 								onOpen={() => handleOpen(data.path)}
 							/>

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -8,6 +8,7 @@ import { useSortable } from "@dnd-kit/react/sortable";
 import { memo, useCallback, useRef } from "react";
 import type { MouseEvent, MutableRefObject } from "react";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
+import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import { DATABASES_TAB_ID } from "../../lib/databases";
 import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
@@ -56,6 +57,7 @@ const MAIN_TAB_SENSORS = [
 function isPathSpecial(path: string): boolean {
 	return (
 		path === ALL_DOCS_TAB_ID ||
+		path === ACTIVITY_TIMELINE_TAB_ID ||
 		path === DATABASES_TAB_ID ||
 		path === PINNED_DOCS_TAB_ID ||
 		path === SPACE_CONNECTIONS_TAB_ID
@@ -102,6 +104,7 @@ export function TabBar({
 		(tab: WorkspaceTab) => {
 			if (tab.kind === "blank") return "New Tab";
 			if (tab.target === ALL_DOCS_TAB_ID) return "All Notes";
+			if (tab.target === ACTIVITY_TIMELINE_TAB_ID) return "All Notes";
 			if (tab.target === DATABASES_TAB_ID) return "Collections";
 			if (tab.target === PINNED_DOCS_TAB_ID) return "Pinned";
 			if (tab.target === SPACE_CONNECTIONS_TAB_ID) return "Connections";

--- a/src/components/app/prefetchablePanes.ts
+++ b/src/components/app/prefetchablePanes.ts
@@ -7,3 +7,8 @@ export const loadAllDocsPane = () =>
 	import("./AllDocsPane").then((module) => ({
 		default: module.AllDocsPane,
 	}));
+
+export const loadActivityTimelinePane = () =>
+	import("./ActivityTimelinePane").then((module) => ({
+		default: module.ActivityTimelinePane,
+	}));

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -8,6 +8,7 @@ import {
 	type EditorWidthMode,
 	loadSettings,
 	setAiAssistantMode,
+	setClassicAllNotesByDefault,
 	setDatabaseShowColumnColor,
 	setEditorBeautifulTags,
 	setEditorColorfulHeadings,
@@ -118,6 +119,8 @@ export function AdvancedSettingsPane() {
 	const [aiAssistantMode, setAiAssistantModeState] =
 		useState<AiAssistantMode>("create");
 	const [folioMode, setFolioModeState] = useState(false);
+	const [classicAllNotesByDefault, setClassicAllNotesByDefaultState] =
+		useState(false);
 	const [showFileTreeFolderCounts, setShowFileTreeFolderCountsState] =
 		useState(false);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
@@ -138,6 +141,10 @@ export function AdvancedSettingsPane() {
 	const [isSavingVimKeybindings, setIsSavingVimKeybindings] = useState(false);
 	const [isSavingAiAssistantMode, setIsSavingAiAssistantMode] = useState(false);
 	const [isSavingFolioMode, setIsSavingFolioMode] = useState(false);
+	const [
+		isSavingClassicAllNotesByDefault,
+		setIsSavingClassicAllNotesByDefault,
+	] = useState(false);
 	const [
 		isSavingShowFileTreeFolderCounts,
 		setIsSavingShowFileTreeFolderCounts,
@@ -160,6 +167,7 @@ export function AdvancedSettingsPane() {
 			setShowTocState(settings.ui.showToc);
 			setAiAssistantModeState(settings.ui.aiAssistantMode);
 			setFolioModeState(settings.ui.folioMode);
+			setClassicAllNotesByDefaultState(settings.ui.classicAllNotesByDefault);
 			setShowFileTreeFolderCountsState(settings.ui.showFileTreeFolderCounts);
 			setShowDatabaseColumnColor(settings.database.showColumnColor);
 		} catch (cause) {
@@ -208,6 +216,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.ui?.folioMode === "boolean") {
 			setFolioModeState(payload.ui.folioMode);
+		}
+		if (typeof payload.ui?.classicAllNotesByDefault === "boolean") {
+			setClassicAllNotesByDefaultState(payload.ui.classicAllNotesByDefault);
 		}
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFileTreeFolderCountsState(payload.ui.showFileTreeFolderCounts);
@@ -497,6 +508,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingFolioMode(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Classic All Notes grid"
+						description="Open All Notes as the simple grid instead of the activity timeline."
+					>
+						<SettingsToggle
+							checked={classicAllNotesByDefault}
+							disabled={isSavingClassicAllNotesByDefault}
+							ariaLabel="Classic All Notes grid"
+							onCheckedChange={(checked) => {
+								const previous = classicAllNotesByDefault;
+								setError("");
+								setClassicAllNotesByDefaultState(checked);
+								setIsSavingClassicAllNotesByDefault(true);
+								void setClassicAllNotesByDefault(checked)
+									.catch((cause) => {
+										setClassicAllNotesByDefaultState(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingClassicAllNotesByDefault(false);
 									});
 							}}
 						/>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -491,6 +491,13 @@ const SETTINGS_SEARCH_ITEMS = [
 		keywords: ["layout", "reading"],
 	},
 	{
+		id: "advanced-classic-all-notes",
+		tab: "advanced",
+		section: "App",
+		title: "Classic All Notes grid",
+		keywords: ["all notes", "activity", "timeline", "grid"],
+	},
+	{
 		id: "advanced-folder-counts",
 		tab: "advanced",
 		section: "App",

--- a/src/lib/activityTimeline.ts
+++ b/src/lib/activityTimeline.ts
@@ -1,0 +1,1 @@
+export const ACTIVITY_TIMELINE_TAB_ID = "__glyph_activity_timeline__";

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -79,11 +79,12 @@ export const navigationQueryKeys = {
 			...navigationQueryKeys.allDocs(),
 			normalizeAllDocsFolder(folderPrefix),
 		] as const,
-	allDocsPages: (folderPrefix?: string | null) =>
+	allDocsPages: (folderPrefix?: string | null, pageSize = ALL_DOCS_PAGE_SIZE) =>
 		[
 			...navigationQueryKeys.allDocs(),
 			"pages",
 			normalizeAllDocsFolder(folderPrefix),
+			pageSize,
 		] as const,
 	allDocsCount: (folderPrefix?: string | null) =>
 		[
@@ -212,6 +213,7 @@ export async function prefetchDatabasesLanding(
 
 export const ALL_DOCS_LIST_LIMIT = 2000;
 export const ALL_DOCS_PAGE_SIZE = 48;
+export const ACTIVITY_DOCS_PAGE_SIZE = 40;
 
 export function formatAllDocsCountLabel(count: number): string | null {
 	if (count <= 0) return null;
@@ -268,12 +270,15 @@ export async function loadAllDocs(folderPrefix?: string | null) {
 	return pages;
 }
 
-export function prefetchAllDocs(folderPrefix?: string | null) {
+export function prefetchAllDocs(
+	folderPrefix?: string | null,
+	pageSize = ALL_DOCS_PAGE_SIZE,
+) {
 	return queryClient.prefetchInfiniteQuery({
-		queryKey: navigationQueryKeys.allDocsPages(folderPrefix),
+		queryKey: navigationQueryKeys.allDocsPages(folderPrefix, pageSize),
 		queryFn: ({ pageParam }) => {
 			const offset = typeof pageParam === "number" ? pageParam : 0;
-			return loadAllDocsPage(folderPrefix, offset);
+			return loadAllDocsPage(folderPrefix, offset, pageSize);
 		},
 		initialPageParam: 0,
 		getNextPageParam: (lastPage: AllDocsPage) =>
@@ -281,9 +286,12 @@ export function prefetchAllDocs(folderPrefix?: string | null) {
 	});
 }
 
-export function getPrefetchedAllDocs(folderPrefix?: string | null) {
+export function getPrefetchedAllDocs(
+	folderPrefix?: string | null,
+	pageSize = ALL_DOCS_PAGE_SIZE,
+) {
 	const pages = queryClient.getQueryData<AllDocsPagesData>(
-		navigationQueryKeys.allDocsPages(folderPrefix),
+		navigationQueryKeys.allDocsPages(folderPrefix, pageSize),
 	);
 	if (pages) return pages.pages.flatMap((page) => page.items);
 	return (
@@ -296,6 +304,7 @@ export function getPrefetchedAllDocs(folderPrefix?: string | null) {
 function rebuildAllDocsPages(
 	current: AllDocsPagesData,
 	items: AllDocsItem[],
+	pageSize: number,
 ): AllDocsPagesData {
 	if (current.pages.length === 0 && items.length === 0) {
 		return {
@@ -305,9 +314,9 @@ function rebuildAllDocsPages(
 	}
 	const hadMore = current.pages[current.pages.length - 1]?.nextOffset != null;
 	const pages: AllDocsPage[] = [];
-	for (let offset = 0; offset < items.length; offset += ALL_DOCS_PAGE_SIZE) {
-		const pageItems = items.slice(offset, offset + ALL_DOCS_PAGE_SIZE);
-		const hasLocalNext = offset + ALL_DOCS_PAGE_SIZE < items.length;
+	for (let offset = 0; offset < items.length; offset += pageSize) {
+		const pageItems = items.slice(offset, offset + pageSize);
+		const hasLocalNext = offset + pageSize < items.length;
 		pages.push({
 			items: pageItems,
 			nextOffset: hasLocalNext || hadMore ? offset + pageItems.length : null,
@@ -321,7 +330,7 @@ function rebuildAllDocsPages(
 	}
 	return {
 		pages,
-		pageParams: pages.map((_, index) => index * ALL_DOCS_PAGE_SIZE),
+		pageParams: pages.map((_, index) => index * pageSize),
 	};
 }
 
@@ -345,10 +354,15 @@ function updateAllDocsCaches(
 			);
 			continue;
 		}
-		if (query.queryKey.length !== 4 || query.queryKey[2] !== "pages") {
+		if (query.queryKey.length !== 5 || query.queryKey[2] !== "pages") {
 			continue;
 		}
 		const folderKey = normalizeAllDocsFolder(String(query.queryKey[3] ?? ""));
+		const rawPageSize = query.queryKey[4];
+		const pageSize =
+			typeof rawPageSize === "number" && rawPageSize > 0
+				? rawPageSize
+				: ALL_DOCS_PAGE_SIZE;
 		const current = queryClient.getQueryData<AllDocsPagesData>(query.queryKey);
 		if (!current) continue;
 		const nextItems = updater(
@@ -357,7 +371,7 @@ function updateAllDocsCaches(
 		);
 		queryClient.setQueryData<AllDocsPagesData>(
 			query.queryKey,
-			rebuildAllDocsPages(current, nextItems),
+			rebuildAllDocsPages(current, nextItems, pageSize),
 		);
 	}
 }
@@ -374,7 +388,7 @@ function findCachedAllDocsItem(path: string): AllDocsItem | null {
 		const current =
 			query.queryKey.length === 3
 				? queryClient.getQueryData<AllDocsItem[]>(query.queryKey)
-				: query.queryKey.length === 4 && query.queryKey[2] === "pages"
+				: query.queryKey.length === 5 && query.queryKey[2] === "pages"
 					? queryClient
 							.getQueryData<AllDocsPagesData>(query.queryKey)
 							?.pages.flatMap((page) => page.items)
@@ -489,7 +503,11 @@ export function invalidateAllDocsPrefetch(folderPrefix?: string | null) {
 			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
 		});
 		void queryClient.invalidateQueries({
-			queryKey: navigationQueryKeys.allDocsPages(folderPrefix),
+			queryKey: [
+				...navigationQueryKeys.allDocs(),
+				"pages",
+				normalizeAllDocsFolder(folderPrefix),
+			],
 		});
 		return;
 	}

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -286,6 +286,13 @@ export function prefetchAllDocs(
 	});
 }
 
+export function prefetchAllDocsList(folderPrefix?: string | null) {
+	return queryClient.prefetchQuery({
+		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		queryFn: () => loadAllDocs(folderPrefix),
+	});
+}
+
 export function getPrefetchedAllDocs(
 	folderPrefix?: string | null,
 	pageSize = ALL_DOCS_PAGE_SIZE,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -376,6 +376,7 @@ async function emitSettingsUpdated(payload: {
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
 		folioMode?: boolean;
+		classicAllNotesByDefault?: boolean;
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
 	};
@@ -447,6 +448,7 @@ interface AppSettings {
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
 		folioMode: boolean;
+		classicAllNotesByDefault: boolean;
 		aiAssistantMode: AiAssistantMode;
 	};
 	dailyNotes: {
@@ -515,6 +517,7 @@ const KEYS = {
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
 	folioMode: "ui.folioMode",
+	classicAllNotesByDefault: "ui.classicAllNotesByDefault",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
@@ -836,6 +839,10 @@ export async function loadSettings(
 		KEYS.showFileTreeFolderCounts,
 	);
 	const rawFolioMode = getSettingValue<boolean | null>(entries, KEYS.folioMode);
+	const rawClassicAllNotesByDefault = getSettingValue<boolean | null>(
+		entries,
+		KEYS.classicAllNotesByDefault,
+	);
 	const dailyNotesFolderRaw = getSettingValue<string | null>(
 		entries,
 		KEYS.dailyNotesFolder,
@@ -964,6 +971,10 @@ export async function loadSettings(
 			? rawShowFileTreeFolderCounts
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
+	const classicAllNotesByDefault =
+		typeof rawClassicAllNotesByDefault === "boolean"
+			? rawClassicAllNotesByDefault
+			: false;
 	const dailyNotesFolder = hasActiveSpace
 		? (activeScopedSettings?.dailyNotesFolder ?? null)
 		: typeof dailyNotesFolderRaw === "string"
@@ -1055,6 +1066,7 @@ export async function loadSettings(
 			showToc,
 			showFileTreeFolderCounts,
 			folioMode,
+			classicAllNotesByDefault,
 			aiAssistantMode,
 		},
 		dailyNotes: {
@@ -1313,6 +1325,15 @@ export async function setFolioMode(enabled: boolean): Promise<void> {
 	await store.set(KEYS.folioMode, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { folioMode: enabled } });
+}
+
+export async function setClassicAllNotesByDefault(
+	enabled: boolean,
+): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.classicAllNotesByDefault, enabled);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { classicAllNotesByDefault: enabled } });
 }
 
 export async function setEditorShowCollapsibleHeadings(

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -71,6 +71,7 @@ type TauriEventMap = {
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
 			folioMode?: boolean;
+			classicAllNotesByDefault?: boolean;
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
 		};

--- a/src/styles/app/15-activity-timeline.css
+++ b/src/styles/app/15-activity-timeline.css
@@ -1,0 +1,463 @@
+.activityTimelinePane {
+	--activity-content-width: min(100%, 860px);
+	--activity-heatmap-content-width: min(100%, 1040px);
+	--activity-heatmap-cell: 14px;
+	--activity-heatmap-gap: 5px;
+	--all-docs-card-min-width: 184px;
+	--all-docs-card-min-height: 184px;
+	--all-docs-card-aspect: 1 / 1;
+	--all-docs-card-padding: 12px;
+	--all-docs-card-gap: 14px;
+	--all-docs-card-title-size: var(--text-base);
+	--all-docs-card-preview-size: calc(var(--text-base) * 0.9);
+	--all-docs-card-meta-size: calc(var(--text-base) * 0.8);
+
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	align-items: center;
+	min-height: 0;
+	overflow-y: auto;
+	padding: calc(var(--header-height) + clamp(28px, 3.2vw, 46px))
+		clamp(18px, 4vw, 56px) clamp(34px, 5vw, 64px);
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-secondary));
+	color: var(--text-primary);
+	gap: 26px;
+}
+
+.activityTimelineHeader {
+	display: flex;
+	width: var(--activity-heatmap-content-width);
+	align-items: flex-end;
+	justify-content: flex-end;
+	gap: 16px;
+	text-align: right;
+}
+
+.activityTimelineTitle {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 9px;
+	font-size: calc(var(--text-base) * 2.1);
+	line-height: 1.08;
+	font-weight: var(--font-medium);
+	letter-spacing: 0;
+	color: var(--text-primary);
+	text-wrap: balance;
+}
+
+.activityTimelineTitle svg {
+	flex: 0 0 auto;
+	color: color-mix(in srgb, var(--interactive-accent) 72%, var(--text-primary));
+	transform: translateY(0.08em);
+}
+
+.activityTimelineSummary {
+	margin-top: 6px;
+	color: var(--text-secondary);
+	font-size: var(--text-sm);
+	line-height: 1.4;
+}
+
+.activityTimelineHeader .activityHeatmapLegend {
+	justify-content: flex-end;
+	margin-top: 10px;
+}
+
+.activityHeatmapBlock {
+	display: flex;
+	width: var(--activity-heatmap-content-width);
+	flex-direction: column;
+	align-items: center;
+	gap: 10px;
+	padding: 16px 0 20px;
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 72%, transparent);
+}
+
+.activityHeatmapMonths {
+	display: grid;
+	grid-auto-flow: column;
+	grid-template-columns: repeat(53, var(--activity-heatmap-cell));
+	gap: var(--activity-heatmap-gap);
+	width: max-content;
+	max-width: 100%;
+	padding-left: 1px;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.72);
+	line-height: 1;
+}
+
+.activityHeatmapMonths span {
+	overflow: visible;
+	white-space: nowrap;
+}
+
+.activityHeatmapGrid {
+	position: relative;
+	display: grid;
+	grid-auto-flow: column;
+	grid-template-columns: repeat(53, var(--activity-heatmap-cell));
+	gap: var(--activity-heatmap-gap);
+	width: max-content;
+	max-width: 100%;
+	overflow: visible;
+	padding: 1px 0 2px;
+}
+
+.activityHeatmapColumn {
+	display: grid;
+	grid-template-rows: repeat(7, var(--activity-heatmap-cell));
+	gap: var(--activity-heatmap-gap);
+}
+
+.activityHeatmapCell,
+.activityHeatmapLegendCell {
+	border: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--bg-tertiary) 82%, var(--bg-secondary));
+	box-shadow: none;
+}
+
+.activityHeatmapLegendCell {
+	width: var(--activity-heatmap-cell);
+	height: var(--activity-heatmap-cell);
+}
+
+.activityHeatmapCell {
+	position: relative;
+	display: block;
+	width: var(--activity-heatmap-cell);
+	height: var(--activity-heatmap-cell);
+	padding: 0;
+	cursor: help;
+	transition: background-color 120ms ease, border-color 120ms ease;
+	z-index: 0;
+}
+
+.activityHeatmapCell:hover,
+.activityHeatmapCell:focus-visible {
+	z-index: 10;
+}
+
+.activityHeatmapCell:hover {
+	border-color: color-mix(in srgb, var(--text-primary) 18%, transparent);
+}
+
+.activityHeatmapCell[data-level="1"],
+.activityHeatmapLegendCell[data-level="1"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 24%,
+		var(--bg-tertiary)
+	);
+}
+
+.activityHeatmapCell[data-level="2"],
+.activityHeatmapLegendCell[data-level="2"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 42%,
+		var(--bg-tertiary)
+	);
+}
+
+.activityHeatmapCell[data-level="3"],
+.activityHeatmapLegendCell[data-level="3"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 62%,
+		var(--bg-tertiary)
+	);
+}
+
+.activityHeatmapCell[data-level="4"],
+.activityHeatmapLegendCell[data-level="4"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 82%,
+		var(--text-primary)
+	);
+}
+
+.activityHeatmapCell:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 44%, transparent);
+	outline-offset: 2px;
+}
+
+.activityHeatmapCell::after {
+	content: attr(data-tooltip);
+	position: absolute;
+	left: 50%;
+	bottom: calc(100% + 8px);
+	z-index: 20;
+	width: max-content;
+	max-width: 180px;
+	padding: 5px 7px;
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--text-primary) 92%, var(--bg-primary));
+	color: var(--bg-primary);
+	font-size: calc(var(--text-base) * 0.72);
+	line-height: 1.2;
+	opacity: 0;
+	pointer-events: none;
+	transform: translateX(-50%) translateY(2px);
+	transition: opacity 120ms ease, transform 120ms ease;
+	white-space: nowrap;
+	border: 1px solid color-mix(in srgb, var(--bg-primary) 22%, transparent);
+	box-shadow: none;
+}
+
+.activityHeatmapCell:hover::after,
+.activityHeatmapCell:focus-visible::after {
+	opacity: 1;
+	transform: translateX(-50%) translateY(0);
+}
+
+.activityHeatmapLegend {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.72);
+	line-height: 1;
+	font-variant-numeric: tabular-nums;
+}
+
+.activityFeed {
+	display: flex;
+	width: var(--activity-content-width);
+	flex-direction: column;
+	gap: 0;
+}
+
+.activityFeed.is-virtualized {
+	position: relative;
+	display: block;
+	flex: 0 0 auto;
+	min-height: 0;
+}
+
+.activityVirtualRow {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	will-change: transform;
+}
+
+.activityDayGroup {
+	position: relative;
+	display: grid;
+	grid-template-columns: 24px minmax(0, 1fr);
+	column-gap: 16px;
+	padding-bottom: 32px;
+	scroll-margin-top: calc(var(--header-height) + 18px);
+}
+
+.activityDayHeaderRow {
+	padding-bottom: 12px;
+}
+
+.activityDayCardsRow {
+	padding-bottom: 20px;
+}
+
+.activityDayRail {
+	grid-row: 1 / span 2;
+	position: relative;
+	width: 24px;
+}
+
+.activityDayRail::before {
+	content: "";
+	position: absolute;
+	top: 13px;
+	left: 11px;
+	bottom: -32px;
+	width: 1px;
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--interactive-accent) 32%, transparent),
+		color-mix(in srgb, var(--border-light) 72%, transparent)
+	);
+}
+
+.activityDayRail::after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	left: 5px;
+	width: 13px;
+	height: 13px;
+	border-radius: 50%;
+	background: var(--bg-primary);
+	border: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 68%, var(--text-primary));
+	box-shadow: 0 0 0 4px
+		color-mix(in srgb, var(--interactive-accent) 9%, transparent);
+}
+
+.activityVirtualRow:last-child .activityDayRail::before {
+	display: none;
+}
+
+.activityDayCardsRow .activityDayRail::after {
+	display: none;
+}
+
+.activityDayCardsRow .activityDayRail::before {
+	top: -12px;
+	bottom: -20px;
+}
+
+.activityDayHeader {
+	grid-column: 2;
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	margin-bottom: 14px;
+}
+
+.activityDayHeader h2 {
+	font-size: calc(var(--text-base) * 1.05);
+	font-weight: var(--font-semibold);
+	line-height: 1.25;
+	letter-spacing: 0;
+	color: var(--text-primary);
+	text-wrap: balance;
+}
+
+.activityDayCounts {
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.82);
+	line-height: 1.35;
+}
+
+.activityDayCounts {
+	display: inline-flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 8px;
+	font-variant-numeric: tabular-nums;
+}
+
+.activityNoteGrid {
+	grid-column: 2;
+	min-width: 0;
+}
+
+.activityTimelinePane .allDocsCardSurface {
+	background: color-mix(in srgb, var(--bg-primary) 92%, var(--bg-secondary));
+	border-color: color-mix(in srgb, var(--text-primary) 8%, transparent);
+	box-shadow: none;
+	transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.activityTimelinePane .allDocsCard:hover .allDocsCardSurface {
+	background: color-mix(in srgb, var(--bg-primary) 86%, var(--bg-hover));
+	border-color: color-mix(in srgb, var(--text-primary) 14%, transparent);
+	box-shadow: none;
+}
+
+.activityTimelinePane .allDocsCard[data-state="selected"] .allDocsCardSurface {
+	background: color-mix(
+		in srgb,
+		var(--bg-primary) 90%,
+		var(--interactive-accent)
+	);
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 42%,
+		var(--text-primary)
+	);
+	box-shadow: none;
+}
+
+.activityTimelinePane .allDocsCard:focus-visible .allDocsCardSurface {
+	box-shadow: 0 0 0 2px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+}
+
+.dark .activityTimelinePane .allDocsCardSurface {
+	background: color-mix(in srgb, var(--bg-tertiary) 88%, var(--bg-primary));
+	box-shadow: none;
+}
+
+.dark .activityTimelinePane .allDocsCard:hover .allDocsCardSurface {
+	background: color-mix(in srgb, var(--bg-tertiary) 82%, var(--bg-hover));
+	box-shadow: none;
+}
+
+.dark
+	.activityTimelinePane
+	.allDocsCard[data-state="selected"]
+	.allDocsCardSurface {
+	background: color-mix(
+		in srgb,
+		var(--bg-tertiary) 86%,
+		var(--interactive-accent)
+	);
+	box-shadow: none;
+}
+
+.activityLoadMore {
+	align-self: flex-start;
+	min-height: 30px;
+	padding: 0 12px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 86%, transparent);
+	border-radius: 8px;
+	background: var(--bg-primary);
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	cursor: pointer;
+	transition: transform 120ms ease, background-color 120ms ease;
+}
+
+.activityLoadMore:hover {
+	background: var(--bg-hover);
+}
+
+.activityLoadMore:active {
+	transform: scale(0.96);
+}
+
+.activityLoadMore:disabled {
+	cursor: default;
+	opacity: 0.62;
+}
+
+@media (max-width: 640px) {
+	.activityTimelinePane {
+		padding-right: 18px;
+		padding-left: 18px;
+	}
+
+	.activityDayGroup {
+		grid-template-columns: 18px minmax(0, 1fr);
+		column-gap: 12px;
+	}
+
+	.activityDayRail {
+		width: 18px;
+	}
+
+	.activityDayRail::before {
+		left: 8px;
+	}
+
+	.activityDayRail::after {
+		left: 2px;
+	}
+
+	.activityDayHeader {
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.activityDayCounts {
+		justify-content: flex-start;
+	}
+}

--- a/src/styles/app/15-activity-timeline.css
+++ b/src/styles/app/15-activity-timeline.css
@@ -2,7 +2,7 @@
 	--activity-content-width: min(100%, 860px);
 	--activity-heatmap-content-width: min(100%, 1040px);
 	--activity-heatmap-cell: 14px;
-	--activity-heatmap-gap: 5px;
+	--activity-heatmap-gap: clamp(2px, 0.42vw, 5px);
 	--all-docs-card-min-width: 184px;
 	--all-docs-card-min-height: 184px;
 	--all-docs-card-aspect: 1 / 1;
@@ -67,9 +67,11 @@
 .activityHeatmapBlock {
 	display: flex;
 	width: var(--activity-heatmap-content-width);
+	max-width: 100%;
 	flex-direction: column;
 	align-items: center;
 	gap: 10px;
+	overflow: visible;
 	padding: 16px 0 20px;
 	border-bottom: 1px solid
 		color-mix(in srgb, var(--border-light) 72%, transparent);
@@ -78,10 +80,9 @@
 .activityHeatmapMonths {
 	display: grid;
 	grid-auto-flow: column;
-	grid-template-columns: repeat(53, var(--activity-heatmap-cell));
+	grid-template-columns: repeat(53, minmax(0, 1fr));
 	gap: var(--activity-heatmap-gap);
-	width: max-content;
-	max-width: 100%;
+	width: 100%;
 	padding-left: 1px;
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.72);
@@ -97,18 +98,18 @@
 	position: relative;
 	display: grid;
 	grid-auto-flow: column;
-	grid-template-columns: repeat(53, var(--activity-heatmap-cell));
+	grid-template-columns: repeat(53, minmax(0, 1fr));
 	gap: var(--activity-heatmap-gap);
-	width: max-content;
-	max-width: 100%;
+	width: 100%;
 	overflow: visible;
 	padding: 1px 0 2px;
 }
 
 .activityHeatmapColumn {
 	display: grid;
-	grid-template-rows: repeat(7, var(--activity-heatmap-cell));
+	grid-template-rows: repeat(7, minmax(0, 1fr));
 	gap: var(--activity-heatmap-gap);
+	min-width: 0;
 }
 
 .activityHeatmapCell,
@@ -127,8 +128,9 @@
 .activityHeatmapCell {
 	position: relative;
 	display: block;
-	width: var(--activity-heatmap-cell);
-	height: var(--activity-heatmap-cell);
+	width: 100%;
+	height: auto;
+	aspect-ratio: 1;
 	padding: 0;
 	cursor: help;
 	transition: background-color 120ms ease, border-color 120ms ease;

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -30,6 +30,42 @@
 	gap: 16px;
 }
 
+.allDocsHeaderAction {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	min-height: 32px;
+	padding: 0 10px;
+	border: 1px solid color-mix(in srgb, var(--text-primary) 9%, transparent);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-secondary));
+	color: var(--text-secondary);
+	font: inherit;
+	font-size: var(--text-sm);
+	line-height: 1;
+	cursor: pointer;
+	box-shadow: 0 10px 22px -20px rgb(30 41 59 / 0.25);
+	transition: transform 120ms ease, background-color 120ms ease, color 120ms
+		ease, box-shadow 120ms ease;
+}
+
+.allDocsHeaderAction:hover {
+	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-hover));
+	color: var(--text-primary);
+	box-shadow: 0 14px 26px -22px rgb(30 41 59 / 0.34);
+}
+
+.allDocsHeaderAction:active {
+	transform: scale(0.96);
+}
+
+.allDocsHeaderAction:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 2px;
+}
+
 .allDocsHeadingGroup {
 	display: flex;
 	min-width: 0;

--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -33,7 +33,8 @@
 
 .canvasPaneHost[data-space-connections="true"]
 	:is(.spaceConnectionsHost, .canvasPaneAwait),
-.canvasPaneHost[data-all-docs="true"] :is(.allDocsPane, .canvasPaneAwait),
+.canvasPaneHost[data-all-docs="true"]
+	:is(.allDocsPane, .activityTimelinePane, .canvasPaneAwait),
 .canvasPaneHost[data-databases="true"]
 	:is(.databaseHostPane, .canvasPaneAwait) {
 	position: absolute;


### PR DESCRIPTION
## Description

Replaces the flat All Notes grid with an **Activity Timeline** as the default All Notes experience. Notes are grouped by day (creation and edit dates), with a GitHub-style contribution heatmap for the last year and a virtualized day-by-day feed of note cards.

- **Summary of changes**
  - New `ActivityTimelinePane` with a 365-day activity heatmap, day-grouped virtualized feed, and infinite scroll for older notes
  - Extracted shared `AllDocsCard` component used by both Activity Timeline and Classic All Notes grid
  - Activity Timeline is now the default when opening All Notes; Classic grid remains available via a link in the grid header and a new Advanced setting
  - New `ui.classicAllNotesByDefault` setting ("Classic All Notes grid") to restore the previous behavior
  - Prefetching, tab routing, breadcrumbs, and pinned-docs navigation updated for the new pane

- **Reasoning**
  - Surfaces recent work contextually (today, yesterday, by date) instead of a flat sortable grid
  - Heatmap gives at-a-glance writing/editing patterns over the past year
  - Shared card component reduces duplication between the two All Notes views

- **Additional context**
  - Daily notes are prioritized within each day's card list
  - Heatmap loads the full note list; the feed paginates for performance
  - Tab label remains "All Notes" for both views

## Screenshots

_Screenshots of the activity heatmap and day-grouped feed to be added._

## Docs

- Setting: **Settings → Advanced → Classic All Notes grid** — toggles default All Notes view between Activity Timeline (off) and Classic grid (on)
- Tab ID constant: `ACTIVITY_TIMELINE_TAB_ID` in `src/lib/activityTimeline.ts`
- Setting key: `ui.classicAllNotesByDefault` in `src/lib/settings.ts`

## Ready?

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the All Notes grid with an Activity Timeline by default. Adds a 365‑day heatmap, a day‑grouped virtualized feed, and smarter prefetching for a faster, more accessible experience.

- New Features
  - New `ActivityTimelinePane` with a last‑year heatmap and day‑grouped note feed, with infinite scroll for older notes.
  - All Notes opens to the Activity Timeline by default; a “Show activity” button is available from the classic grid. New setting `ui.classicAllNotesByDefault` (Settings → Advanced) restores the classic grid; new tab id `ACTIVITY_TIMELINE_TAB_ID`.
  - Updated navigation/prefetch to support the new view (`ACTIVITY_DOCS_PAGE_SIZE`) and added `prefetchAllDocsList` to power the heatmap. External note changes invalidate activity data.

- Refactors
  - Extracted shared `AllDocsCard` used by the Activity Timeline, the classic All Notes grid, and Pinned notes; improved preview normalization and clearer aria labels.
  - Prefetch/query keys now include page size; added `loadActivityTimelinePane`, refined virtualization with state-based pane refs, and updated styles for the timeline and header action.

<sup>Written for commit 711fdd57b26583b5a4a26720adac5fa63bfa4ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Activity Timeline view showing note activity over time, with a heatmap and scrollable note feed.
  * Added a new “Classic All Notes grid” setting to choose the default all-notes experience.
  * Added a “Show activity” action from the All Notes area for quicker access.

* **Bug Fixes**
  * Improved navigation and preloading so the All Notes and Activity views load more smoothly.
  * Updated breadcrumbs and tab labels to handle the new activity view correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->