### PR TITLE
Fix editor crash when view is unavailable during selection snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,56 +34,45 @@ Repo extras: internal product and engineering docs live in `docs/`.
 
 ## Frontend Overview (`src/`)
 
-- `main.tsx` / `App.tsx` — Entry point, wraps `<AppShell>` in `<AppProviders>` (app contexts)
-- **`contexts/`** — App state via React Context: `SpaceContext`, `FileTreeContext`, `UIContext`, `EditorContext`, composed in `AppProviders`
-- **`components/app/`** — App shell and navigation: `AppShell`, `Sidebar`, `MainContent`, `TabBar`, `CommandPalette`, welcome flow, command search helpers
-- **`components/editor/`** — TipTap markdown editor, note properties UI, extensions, markdown serialization, slash commands, editor hooks
-- **`components/ai/`** — AI workspace: `AIPanel`, `AIComposer`, `AIChatThread`, `AIToolTimeline`, `ModelSelector`, history/context/profile helpers, `hooks/useRigChat`
-- **`components/filetree/`** — File browser: `FileTreePane`, `FileTreeDirItem`, `FileTreeFileItem`, `fileTypeUtils`
-- **`components/database/`** — Database-note UI: table/board views, source picker, column dialogs, toolbar, cells
-- **`components/licensing/`** — Trial, license gate, lock screen, and settings surfaces
-- **`components/preview/`** — `MarkdownEditorPane`
-- **`components/checklists/`** — `TaskProgressIndicator` (markdown checklist progress rings)
-- **`components/settings/`** — Settings panes: AI, Appearance (accent, typography), Space, DailyNotes, General, About
-- **`components/ui/`** — shadcn/ui primitives under `shadcn/` plus shared motion helpers in `animations.ts`
-- **`components/Icons/`** — Shared icon wrappers for editor, file, navigation, and action icons
-- **`hooks/`** — Core app hooks such as `useFileTree`, `useFileTreeCRUD`, `useViewLoader`, `useSearch`, `useCommandShortcuts`, `useMenuListeners`, `useDailyNote`, `useRecentFiles`, plus `hooks/database/`
-- **`lib/`** — `tauri.ts` (typed IPC wrapper — always use `invoke()` from here), `tauriEvents.ts`, `shortcuts/`, `views/`, `database/`, and utilities like `settings.ts`, `dailyNotes.ts`, `checklistSummary.ts`, `diff.ts`, `errorUtils.ts`, `notePreview.ts`, `windows.ts`
-- **`utils/`** — `path.ts`, `window.ts`
-- **`styles/`** — `shadcn-base.css`, numbered CSS files in `styles/app/`; shared design tokens live in `src/design-tokens.css`
+- App entry is `main.tsx` / `App.tsx`; app-wide state lives in `contexts/`; feature UI lives under `components/`; shared hooks/utilities live in `hooks/`, `lib/`, and `utils/`.
+- Use `src/lib/tauri.ts` for typed IPC, `components/ui/shadcn/` for shared primitives, and `src/design-tokens.css` plus `styles/` for styling.
 
 ## Backend Overview (`src-tauri/src/`)
 
-- `lib.rs` / `main.rs` — Tauri setup, command registration
-- **`space/`** — Space lifecycle: open/close/create, file `watcher.rs`, `state.rs`
-- **`space_fs/`** — Filesystem ops: listing, summaries, view data, link ops, and `read_write/` for text/preview/path/trash operations
-- **`notes/`** — Note CRUD, attachments, frontmatter/properties helpers, and Tauri commands/types
-- **`index/`** — SQLite index: schema, indexer, search, tags, links, frontmatter/properties, helpers, and `checklists/`
-- **`database/`** — Database-note parsing, queries, mutations, config rendering, and shared types
-- **`ai_rig/`** — Rig AI runtime: providers, models, runtime, tools, commands, events, history, audit, store, and context
-- **`ai_codex/`** — Codex/ChatGPT account state, transport, chat flow, and Tauri commands
-- **`license/`** — Trial/license persistence, verification, service layer, and commands
-- **`links/`** — Link fetching, metadata extraction, caching, helpers, commands, and types
-- `paths.rs` — Safe path joining (prevents traversal via `join_under()`)
-- `io_atomic.rs` — Crash-safe atomic writes
-- `net.rs` — SSRF prevention for user-supplied URLs
-- `glyph_paths.rs` / `glyph_fs.rs` — `.glyph/` directory helpers
-- `system_fonts.rs` — System font enumeration
+- Tauri setup and command registration live in `lib.rs` / `main.rs`; native features are grouped by domain such as `space`, `space_fs`, `notes`, `index`, `database`, `ai_*`, `license`, and `links`.
+- Use `paths::join_under()` for safe space paths, `io_atomic::write_atomic()` for durable writes, and `net.rs` checks for user-supplied URLs.
 
 ## Code Style & Safety
 
 - TypeScript strict mode, no `any` (use `unknown` + narrowing). Biome handles formatting/imports.
 - Functional React components, hooks, lazy-load heavy components. State via Context (no prop drilling).
-- Avoid `useEffect` unless it is truly needed; prefer React patterns from https://react.dev/learn/you-might-not-need-an-effect.
 - Rust: serde for serialization, tracing for logs, atomic writes via `io_atomic::write_atomic()`.
 - Aim for roughly 200 LOC per file; treat this as a guideline, not a hard rule. Don't obsess over landing exactly at 200, but do refactor into subfolders when a file is getting out of hand.
 - Use `paths::join_under()` for space paths (prevent traversal). Never log secrets.
 - Use `net.rs` SSRF checks for user-supplied URLs. Version durable documents (`version: 1`).
 - New Tauri commands: implement in `src-tauri/src/`, register in `lib.rs`, add types to `TauriCommands` in `src/lib/tauri.ts`.
-- Make sure we dont over-engineer CSS and use default components as much as possible unless explicitly stated.
-- Make sure we always narrow the code and apply fixes instead of patching the code by adding un-necessary LOCs in places that it doesn't need.
+- Make sure we don't over-engineer CSS and use default components as much as possible unless explicitly stated.
+- Make sure we always narrow the code and apply fixes instead of patching the code by adding unnecessary LOCs in places that don't need them.
 - NEVER make test files unless specifically requested by users.
 - For TSX files extract hooks/subcomponents when rendering, state, effects, and commands start mixing.
+
+## React Code Practices
+
+Agents and reviewers should flag these patterns unless the change includes a clear justification and there is no simpler React/Tauri-safe alternative:
+
+- `useEffect`: avoid unless synchronizing with an external system. Prefer deriving values during render, event handlers for user actions, keys for reset behavior, and React Query for async server/IPC/filesystem state. See https://react.dev/learn/you-might-not-need-an-effect.
+- TanStack Query: prefer queries/mutations for async server, IPC, filesystem, loading, error, retry, cache, and invalidation flows instead of hand-rolled `useState`/`useEffect` state machines.
+- TanStack Virtual: use the existing virtualizer patterns for large lists, tables, boards, timelines, and scroll-heavy surfaces instead of rendering everything or inventing custom windowing logic.
+- `setTimeout`: do not use to sequence React state, paper over races, or wait for rendering. If used for debounce, retry, focus, or transient UI, use cleanup, a named delay constant, and explain why the delay is needed.
+- `setInterval`: prefer React Query polling/refetch behavior or an approved interval hook. Do not create raw intervals inside components.
+- `useImperativeHandle`: avoid; prefer state and props. Only acceptable for narrow wrappers around imperative third-party APIs such as editors.
+- Duplicate state: derive values from existing state instead of mirroring them. Refactor ownership when derivation is awkward.
+- Direct DOM queries/manipulation: avoid `document.querySelector`, `document.getElementById`, manual node creation, and direct mutation in React code. Prefer refs, props, and component state. Exceptions are app bootstrap, portals, sanitized renderers, and third-party integration boundaries.
+- `useRef`: do not use refs as hidden mutable state. Refs are acceptable for DOM handles, external imperative APIs, timers/animation handles, stale-closure avoidance, and measurement/scroll integration.
+- Type assertions with `as`: prefer narrowing, typed helpers, `satisfies`, and explicit annotations. `as const` is allowed.
+- Silent fallbacks: do not hide failed user-initiated actions behind fallback behavior. Surface errors clearly when the product cannot do what the user asked.
+- Async action booleans like `isSaving`, `isLoadingFoo`, or `isDeleting`: prefer React Query mutations/queries for server, IPC, filesystem, and durable async work. Local UI-only state is fine.
+- Lint/type suppression comments such as `eslint-disable`, `biome-ignore`, `@ts-ignore`, or `@ts-expect-error` require explicit human approval.
 
 ## Migration Policy
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.5",
+	"version": "0.8.5-alpha.6",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -695,7 +695,10 @@ describe("useNoteEditor", () => {
 
 		await act(async () => {
 			root.render(
-				<Harness additionalExtensions={[secondExtension]} onChange={onChange} />,
+				<Harness
+					additionalExtensions={[secondExtension]}
+					onChange={onChange}
+				/>,
 			);
 		});
 	});

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -649,6 +649,57 @@ describe("useNoteEditor", () => {
 		expect(mockEditor.view.focus).toHaveBeenCalled();
 	});
 
+	it("does not crash when the editor view is unavailable during content replacement", async () => {
+		const onChange = vi.fn();
+		const editorWithoutMountedView = { ...mockEditor };
+		Object.defineProperty(editorWithoutMountedView, "view", {
+			get: () => {
+				throw new Error("view unavailable");
+			},
+		});
+		setActiveEditor(editorWithoutMountedView as typeof mockEditor);
+
+		await act(async () => {
+			root.render(<Harness markdown="first body" onChange={onChange} />);
+		});
+
+		await act(async () => {
+			root.render(<Harness markdown="changed body" onChange={onChange} />);
+		});
+
+		expect(mockEditor.commands.setContent).toHaveBeenCalledWith(
+			"changed body",
+			{
+				contentType: "markdown",
+			},
+		);
+	});
+
+	it("does not crash when the editor view is unavailable during cleanup", async () => {
+		const onChange = vi.fn();
+		const firstExtension = Extension.create({ name: "first-extension" });
+		const secondExtension = Extension.create({ name: "second-extension" });
+		const editorWithoutMountedView = { ...mockEditor };
+		Object.defineProperty(editorWithoutMountedView, "view", {
+			get: () => {
+				throw new Error("view unavailable");
+			},
+		});
+		setActiveEditor(editorWithoutMountedView as typeof mockEditor);
+
+		await act(async () => {
+			root.render(
+				<Harness additionalExtensions={[firstExtension]} onChange={onChange} />,
+			);
+		});
+
+		await act(async () => {
+			root.render(
+				<Harness additionalExtensions={[secondExtension]} onChange={onChange} />,
+			);
+		});
+	});
+
 	it("tracks colorful headings from settings and live updates", async () => {
 		const onChange = vi.fn();
 		const onState = vi.fn();

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -279,9 +279,14 @@ function snapshotFocusedSelection(
 	editor: NonNullable<ReturnType<typeof useEditor>> | null,
 	relPath: string,
 ): SelectionSnapshot | null {
-	if (!editor?.view.hasFocus()) return null;
-	const { from, to } = editor.state.selection;
-	return { from, relPath, to };
+	if (!editor || editor.isDestroyed) return null;
+	try {
+		if (!editor.view.hasFocus()) return null;
+		const { from, to } = editor.state.selection;
+		return { from, relPath, to };
+	} catch {
+		return null;
+	}
 }
 
 function restoreSelectionSnapshot(


### PR DESCRIPTION
## Description

Fixes a crash in the Rich editor when `snapshotFocusedSelection` accesses `editor.view` while the TipTap view is not yet mounted or has already been torn down — for example during content replacement or editor instance cleanup.

- **Summary of changes:** Guard `snapshotFocusedSelection` with destroyed-editor checks and a try/catch around `editor.view.hasFocus()`, returning `null` instead of throwing. Added two unit tests covering content replacement and extension-driven cleanup when the view is unavailable. Bumped version to `0.8.5-alpha.6`.
- **Reasoning:** TipTap can throw when `view` is accessed before mount or after destroy. Selection snapshotting runs in layout-effect cleanup and content-sync paths, so an unhandled throw here crashes the editor surface.
- **Additional context:** `restoreSelectionSnapshot` already had try/catch fallbacks; this aligns the snapshot side with the same defensive pattern.

## Docs

No user-facing behavior change — the editor simply no longer crashes during transient view unavailability. Selection restore still works when the view is available.

## Ready?

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash in the Rich editor when taking a selection snapshot while the `tiptap` view is unavailable. Also bumps version to `0.8.5-alpha.6` and updates `AGENTS.md` with clearer React practices and a condensed app/backend overview.

- **Bug Fixes**
  - Guard `snapshotFocusedSelection` for null/destroyed editors and wrap `editor.view.hasFocus()` in try/catch, returning `null` safely.
  - Added tests for content replacement and extension-driven cleanup when the view is unavailable.
  - No user-facing changes; selection restore remains unchanged.

<sup>Written for commit 5f6114febdc35af2f56cd2f6159e7b3245ae2819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor stability when restoring or updating content, reducing crashes in edge cases.
  * Made selection handling more resilient so editing feels smoother even when the editor is briefly unavailable.
* **Chores**
  * Updated the app version to `0.8.5-alpha.6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->