### PR TITLE
Redesign floating table of contents with hover previews and outline panel (#257) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.5",
+	"version": "0.8.6-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",
@@ -23,7 +23,7 @@
 				"titleBarStyle": "Overlay",
 				"trafficLightPosition": {
 					"x": 12,
-					"y": 24
+					"y": 28
 				},
 				"hiddenTitle": true,
 				"transparent": true

--- a/src/components/editor/FloatingTOC.tsx
+++ b/src/components/editor/FloatingTOC.tsx
@@ -12,7 +12,7 @@ const DASH_WIDTHS: Record<number, number> = {
 	6: 4,
 };
 
-const INDENT: Record<number, number> = {
+const OUTLINE_INDENT: Record<number, number> = {
 	1: 0,
 	2: 10,
 	3: 20,
@@ -21,79 +21,141 @@ const INDENT: Record<number, number> = {
 	6: 38,
 };
 
+function getWaveState(index: number, previewHeadingIndex: number) {
+	if (previewHeadingIndex === -1) return undefined;
+	if (index === previewHeadingIndex) return "peak";
+	return Math.abs(index - previewHeadingIndex) === 1 ? "near" : undefined;
+}
+
 interface FloatingTOCProps {
 	activeId: string | null;
+	getHeadingPreview: (heading: TOCHeading) => string | null;
 	headings: TOCHeading[];
 	onSelectHeading: (heading: TOCHeading) => void;
 }
 
 export const FloatingTOC = memo(function FloatingTOC({
 	activeId,
+	getHeadingPreview,
 	headings,
 	onSelectHeading,
 }: FloatingTOCProps) {
-	const [expanded, setExpanded] = useState(false);
+	const [previewHeadingId, setPreviewHeadingId] = useState<string | null>(null);
+	const [outlineOpen, setOutlineOpen] = useState(false);
 	const panelId = useId();
+	const previewHeading =
+		headings.find((heading) => heading.id === previewHeadingId) ?? null;
+	const previewHeadingIndex = headings.findIndex(
+		(heading) => heading.id === previewHeadingId,
+	);
+	const previewText = previewHeading ? getHeadingPreview(previewHeading) : null;
 
 	if (headings.length < MIN_HEADINGS) return null;
 
 	return (
 		<div
 			className="floatingToc"
-			data-expanded={expanded ? "true" : undefined}
-			onMouseEnter={() => setExpanded(true)}
-			onMouseLeave={() => setExpanded(false)}
+			onMouseLeave={() => setPreviewHeadingId(null)}
+			onBlur={(event) => {
+				const nextFocus = event.relatedTarget;
+				if (
+					nextFocus instanceof Node &&
+					event.currentTarget.contains(nextFocus)
+				) {
+					return;
+				}
+				setPreviewHeadingId(null);
+			}}
 		>
-			<button
-				type="button"
-				className="floatingTocTrigger"
-				onClick={() => setExpanded((prev) => !prev)}
-				onKeyDown={(e) => {
-					if (e.key === "Escape" && expanded) {
-						e.preventDefault();
-						setExpanded(false);
-					}
-				}}
-				aria-expanded={expanded}
-				aria-controls={panelId}
-				aria-label="Table of contents"
-			>
-				<div className="floatingTocCollapsed">
-					{headings.map((h) => (
-						<div
-							key={h.id}
+			<nav className="floatingTocRail" aria-label="Table of contents">
+				{headings.map((heading, index) => (
+					<button
+						key={heading.id}
+						type="button"
+						className="floatingTocMark"
+						data-active={heading.id === activeId ? "true" : undefined}
+						data-wave={getWaveState(index, previewHeadingIndex)}
+						onMouseEnter={() => setPreviewHeadingId(heading.id)}
+						onFocus={() => setPreviewHeadingId(heading.id)}
+						onClick={() => {
+							if (heading.id === activeId) {
+								setOutlineOpen((prev) => !prev);
+								return;
+							}
+							onSelectHeading(heading);
+						}}
+						onKeyDown={(event) => {
+							if (event.key === "Escape" && (previewHeading || outlineOpen)) {
+								event.preventDefault();
+								setPreviewHeadingId(null);
+								setOutlineOpen(false);
+							}
+						}}
+						aria-describedby={
+							heading.id === previewHeadingId ? panelId : undefined
+						}
+						aria-label={heading.text}
+					>
+						<span
 							className="floatingTocDash"
-							data-active={h.id === activeId ? "true" : undefined}
-							style={{ width: DASH_WIDTHS[h.level] ?? 6 }}
+							style={{ width: DASH_WIDTHS[heading.level] ?? 6 }}
 						/>
-					))}
-				</div>
-			</button>
+					</button>
+				))}
+			</nav>
 
-			{expanded ? (
+			{outlineOpen ? (
 				<nav
-					className="floatingTocExpanded"
-					id={panelId}
-					aria-label="Table of contents"
+					className="floatingTocOutline"
+					aria-label="Document outline"
+					onKeyDown={(event) => {
+						if (event.key === "Escape") {
+							event.preventDefault();
+							setOutlineOpen(false);
+						}
+					}}
 				>
-					<div className="floatingTocItems">
-						{headings.map((h) => (
-							<button
-								key={h.id}
-								type="button"
-								className="floatingTocItem"
-								data-active={h.id === activeId ? "true" : undefined}
-								aria-current={h.id === activeId ? "location" : undefined}
-								data-level={h.level}
-								style={{ paddingLeft: INDENT[h.level] ?? 0 }}
-								onClick={() => onSelectHeading(h)}
-								title={h.text}
-							>
-								{h.text}
-							</button>
-						))}
-					</div>
+					{headings.map((heading) => (
+						<button
+							key={heading.id}
+							type="button"
+							className="floatingTocOutlineItem"
+							data-active={heading.id === activeId ? "true" : undefined}
+							style={{ paddingLeft: OUTLINE_INDENT[heading.level] ?? 0 }}
+							onClick={() => {
+								onSelectHeading(heading);
+								setOutlineOpen(false);
+							}}
+							title={heading.text}
+						>
+							<span className="floatingTocOutlineText">{heading.text}</span>
+							<span className="floatingTocOutlineLevel">H{heading.level}</span>
+						</button>
+					))}
 				</nav>
+			) : null}
+
+			{previewHeading && !outlineOpen ? (
+				<button
+					type="button"
+					className="floatingTocPreview"
+					id={panelId}
+					onMouseEnter={() => setPreviewHeadingId(previewHeading.id)}
+					onClick={() => onSelectHeading(previewHeading)}
+					title={previewHeading.text}
+				>
+					<span className="floatingTocPreviewHeading">
+						<span className="floatingTocPreviewTitle">
+							{previewHeading.text}
+						</span>
+						<span className="floatingTocPreviewLevel">
+							H{previewHeading.level}
+						</span>
+					</span>
+					{previewText ? (
+						<span className="floatingTocPreviewText">{previewText}</span>
+					) : null}
+				</button>
 			) : null}
 		</div>
 	);

--- a/src/components/editor/FloatingTOC.tsx
+++ b/src/components/editor/FloatingTOC.tsx
@@ -142,6 +142,12 @@ export const FloatingTOC = memo(function FloatingTOC({
 					id={panelId}
 					onMouseEnter={() => setPreviewHeadingId(previewHeading.id)}
 					onClick={() => onSelectHeading(previewHeading)}
+					onKeyDown={(event) => {
+						if (event.key === "Escape") {
+							event.preventDefault();
+							setPreviewHeadingId(null);
+						}
+					}}
 					title={previewHeading.text}
 				>
 					<span className="floatingTocPreviewHeading">

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -17,6 +17,8 @@ export interface TOCHeading {
 	slug?: string;
 }
 
+const HEADING_PREVIEW_MAX_LENGTH = 150;
+
 export function getHeadingElement(
 	editor: Editor,
 	heading: TOCHeading,
@@ -61,6 +63,38 @@ export function isSameHeadingList(
 	);
 }
 
+function truncatePreview(text: string): string {
+	if (text.length <= HEADING_PREVIEW_MAX_LENGTH) return text;
+	return `${text.slice(0, HEADING_PREVIEW_MAX_LENGTH).trimEnd()}...`;
+}
+
+function normalizePreviewText(text: string): string {
+	return text.replace(/\s+/g, " ").trim();
+}
+
+export function getHeadingPreview(
+	doc: ProseMirrorNode,
+	heading: TOCHeading,
+	nextHeading: TOCHeading | undefined,
+): string | null {
+	const chunks: string[] = [];
+	const to = nextHeading?.pos ?? doc.content.size;
+
+	doc.nodesBetween(heading.pos, to, (node) => {
+		if (node.type.name === "heading") return false;
+		if (!node.isTextblock) return;
+
+		const text = normalizePreviewText(node.textContent);
+		if (!text) return false;
+
+		chunks.push(text);
+		return chunks.join(" ").length < HEADING_PREVIEW_MAX_LENGTH;
+	});
+
+	const preview = normalizePreviewText(chunks.join(" "));
+	return preview ? truncatePreview(preview) : null;
+}
+
 function headingFromNode(
 	node: ProseMirrorNode,
 	pos: number,
@@ -92,7 +126,9 @@ function expandRangesToTextblocks(
 ): ChangedRange[] {
 	const expanded: ChangedRange[] = [];
 	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos) => {
+		const from = Math.max(0, range.from - 1);
+		const to = Math.min(doc.content.size, range.to + 1);
+		doc.nodesBetween(from, to, (node, pos) => {
 			if (!node.isTextblock) return;
 			expanded.push({ from: pos, to: pos + node.nodeSize });
 			return false;
@@ -118,11 +154,43 @@ function extractHeadingsInRanges(
 	return headings;
 }
 
+function rangesContainHeading(
+	doc: ProseMirrorNode,
+	ranges: readonly ChangedRange[],
+): boolean {
+	for (const range of ranges) {
+		let containsHeading = false;
+		doc.nodesBetween(range.from, range.to, (node) => {
+			if (node.type.name === "heading") {
+				containsHeading = true;
+				return false;
+			}
+			return !containsHeading;
+		});
+		if (containsHeading) return true;
+	}
+	return false;
+}
+
 function rangeTouchesHeading(
 	heading: TOCHeading,
 	range: ChangedRange,
 ): boolean {
 	return heading.pos >= range.from && heading.pos <= range.to;
+}
+
+function mapHeadingsThroughTransaction(
+	current: readonly TOCHeading[],
+	transaction: Transaction,
+): TOCHeading[] {
+	return current
+		.map((heading) => {
+			const result = transaction.mapping.mapResult(heading.pos, -1);
+			return result.deleted
+				? null
+				: { ...heading, id: `toc-${result.pos}`, pos: result.pos };
+		})
+		.filter((heading): heading is TOCHeading => heading !== null);
 }
 
 export function updateHeadingsFromTransaction(
@@ -134,31 +202,29 @@ export function updateHeadingsFromTransaction(
 		transaction.doc.content.size,
 	);
 	if (!changedRanges.length) {
-		return current
-			.map((heading) => {
-				const result = transaction.mapping.mapResult(heading.pos, -1);
-				return result.deleted
-					? null
-					: { ...heading, id: `toc-${result.pos}`, pos: result.pos };
-			})
-			.filter((heading): heading is TOCHeading => heading !== null);
+		return mapHeadingsThroughTransaction(current, transaction);
 	}
 
 	const scanRanges = expandRangesToTextblocks(transaction.doc, changedRanges);
-	const next = current
-		.map((heading) => {
-			const result = transaction.mapping.mapResult(heading.pos, -1);
-			return result.deleted
-				? null
-				: { ...heading, id: `toc-${result.pos}`, pos: result.pos };
-		})
-		.filter(
-			(heading): heading is TOCHeading =>
-				heading !== null &&
-				!scanRanges.some((range) => rangeTouchesHeading(heading, range)),
-		);
+	const mapped = mapHeadingsThroughTransaction(current, transaction);
+	const touchedExistingHeading = mapped.some((heading) =>
+		scanRanges.some((range) => rangeTouchesHeading(heading, range)),
+	);
+	const changedRangeHasHeading = rangesContainHeading(
+		transaction.doc,
+		scanRanges,
+	);
 
-	next.push(...extractHeadingsInRanges(transaction.doc, scanRanges));
+	if (!touchedExistingHeading && !changedRangeHasHeading) {
+		return mapped;
+	}
+
+	const changedHeadings = extractHeadingsInRanges(transaction.doc, scanRanges);
+	const next = mapped.filter(
+		(heading) =>
+			!scanRanges.some((range) => rangeTouchesHeading(heading, range)),
+	);
+	next.push(...changedHeadings);
 	next.sort((a, b) => a.pos - b.pos);
 	return withHeadingSlugs(next);
 }
@@ -290,5 +356,22 @@ export function useTableOfContents(
 		[editor],
 	);
 
-	return { headings, activeId, scrollToHeading };
+	const getPreviewForHeading = useCallback(
+		(heading: TOCHeading) => {
+			if (!editor) return null;
+			const headingIndex = headingsRef.current.findIndex(
+				(item) => item.id === heading.id,
+			);
+			const nextHeading =
+				headingIndex === -1 ? undefined : headingsRef.current[headingIndex + 1];
+			return getHeadingPreview(
+				editor.state.doc,
+				heading,
+				nextHeading,
+			);
+		},
+		[editor],
+	);
+
+	return { headings, activeId, scrollToHeading, getPreviewForHeading };
 }

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -176,7 +176,7 @@ function rangeTouchesHeading(
 	heading: TOCHeading,
 	range: ChangedRange,
 ): boolean {
-	return heading.pos >= range.from && heading.pos <= range.to;
+	return heading.pos >= range.from && heading.pos < range.to;
 }
 
 function mapHeadingsThroughTransaction(
@@ -362,13 +362,11 @@ export function useTableOfContents(
 			const headingIndex = headingsRef.current.findIndex(
 				(item) => item.id === heading.id,
 			);
-			const nextHeading =
-				headingIndex === -1 ? undefined : headingsRef.current[headingIndex + 1];
-			return getHeadingPreview(
-				editor.state.doc,
-				heading,
-				nextHeading,
-			);
+			if (headingIndex === -1) return null;
+			const currentHeading = headingsRef.current[headingIndex];
+			if (!currentHeading) return null;
+			const nextHeading = headingsRef.current[headingIndex + 1];
+			return getHeadingPreview(editor.state.doc, currentHeading, nextHeading);
 		},
 		[editor],
 	);

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -3,7 +3,6 @@ import {
 	LayoutAlignRightIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type { Editor } from "@tiptap/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	useAISidebarContext,
@@ -38,7 +37,6 @@ import { useTauriEvent } from "../../lib/tauriEvents";
 import { normalizeRelPath } from "../../utils/path";
 import { LocalNoteConnectionsDialog } from "../connections/LocalNoteConnectionsDialog";
 import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
-import { FloatingTOC } from "../editor/FloatingTOC";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
@@ -49,13 +47,16 @@ import type {
 } from "../editor/types";
 import { GitDiffView } from "./GitDiffView";
 import { LinkedNotePreviewSheet } from "./LinkedNotePreviewSheet";
+import { MarkdownFloatingToc } from "./MarkdownFloatingToc";
 import { NotesInfoSidebar } from "./NotesInfoSidebar";
+import { initialEditorMode, requiresPlainEditorMode } from "./editorModeSelection";
 import {
 	clearMarkdownDocCache,
 	getCachedMarkdownDoc,
 	peekCachedMarkdownDoc,
 } from "./markdownCache";
 import { analyzeNoteInfo } from "./noteInfoAnalysis";
+import { useDeferredTocSource } from "./useDeferredTocSource";
 import { useInternalAnchorNavigation } from "./useInternalAnchorNavigation";
 
 interface MarkdownEditorPaneProps {
@@ -94,16 +95,6 @@ function noteLabelFromPath(path: string): string {
 
 function noteLinkLabel(label: string | null | undefined, fallbackPath: string) {
 	return label?.trim() || noteLabelFromPath(fallbackPath);
-}
-
-const LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000;
-
-function requiresPlainEditorMode(markdown: string): boolean {
-	return markdown.length >= LARGE_NOTE_RICH_EDITOR_LIMIT;
-}
-
-function initialEditorMode(markdown: string): NoteInlineEditorMode {
-	return requiresPlainEditorMode(markdown) ? "plain" : "rich";
 }
 
 function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
@@ -240,16 +231,7 @@ export function MarkdownEditorPane({
 	const contentScrollRef = useRef<HTMLDivElement | null>(null);
 	const { spacePath } = useSpace();
 	const previousSpacePathRef = useRef<string | null>(spacePath);
-	const [tocSource, setTocSource] = useState<{
-		editor: Editor;
-		contentRoot: HTMLElement;
-	} | null>(null);
-	const handleEditorReady = useCallback(
-		(editor: Editor | null, contentRoot: HTMLElement | null) => {
-			setTocSource(editor && contentRoot ? { editor, contentRoot } : null);
-		},
-		[],
-	);
+	const { tocSource, handleEditorReady } = useDeferredTocSource();
 	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
 	const handleRawEditorReady = useCallback(
 		(editor: RawMarkdownEditorHandle | null) => {
@@ -260,6 +242,7 @@ export function MarkdownEditorPane({
 	const {
 		headings: tocHeadings,
 		activeId: tocActiveId,
+		getPreviewForHeading,
 		scrollToHeading,
 	} = useTableOfContents(
 		tocSource?.editor ?? null,
@@ -968,13 +951,15 @@ export function MarkdownEditorPane({
 					</div>
 				</div>
 			) : null}
-			{showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain" ? (
-				<FloatingTOC
-					headings={tocHeadings}
-					activeId={tocActiveId}
-					onSelectHeading={scrollToHeading}
-				/>
-			) : null}
+			<MarkdownFloatingToc
+				headings={tocHeadings}
+				activeId={tocActiveId}
+				getHeadingPreview={getPreviewForHeading}
+				onSelectHeading={scrollToHeading}
+				visible={
+					showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain"
+				}
+			/>
 
 			<NotesInfoSidebar
 				open={infoPanelOpen}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -49,7 +49,10 @@ import { GitDiffView } from "./GitDiffView";
 import { LinkedNotePreviewSheet } from "./LinkedNotePreviewSheet";
 import { MarkdownFloatingToc } from "./MarkdownFloatingToc";
 import { NotesInfoSidebar } from "./NotesInfoSidebar";
-import { initialEditorMode, requiresPlainEditorMode } from "./editorModeSelection";
+import {
+	initialEditorMode,
+	requiresPlainEditorMode,
+} from "./editorModeSelection";
 import {
 	clearMarkdownDocCache,
 	getCachedMarkdownDoc,

--- a/src/components/preview/MarkdownFloatingToc.tsx
+++ b/src/components/preview/MarkdownFloatingToc.tsx
@@ -1,0 +1,28 @@
+import { FloatingTOC } from "../editor/FloatingTOC";
+import type { TOCHeading } from "../editor/hooks/useTableOfContents";
+
+interface MarkdownFloatingTocProps {
+	activeId: string | null;
+	getHeadingPreview: (heading: TOCHeading) => string | null;
+	headings: TOCHeading[];
+	onSelectHeading: (heading: TOCHeading) => void;
+	visible: boolean;
+}
+
+export function MarkdownFloatingToc({
+	activeId,
+	getHeadingPreview,
+	headings,
+	onSelectHeading,
+	visible,
+}: MarkdownFloatingTocProps) {
+	if (!visible) return null;
+	return (
+		<FloatingTOC
+			headings={headings}
+			activeId={activeId}
+			getHeadingPreview={getHeadingPreview}
+			onSelectHeading={onSelectHeading}
+		/>
+	);
+}

--- a/src/components/preview/editorModeSelection.ts
+++ b/src/components/preview/editorModeSelection.ts
@@ -1,0 +1,11 @@
+import type { NoteInlineEditorMode } from "../editor/types";
+
+const LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000;
+
+export function requiresPlainEditorMode(markdown: string): boolean {
+	return markdown.length >= LARGE_NOTE_RICH_EDITOR_LIMIT;
+}
+
+export function initialEditorMode(markdown: string): NoteInlineEditorMode {
+	return requiresPlainEditorMode(markdown) ? "plain" : "rich";
+}

--- a/src/components/preview/useDeferredTocSource.ts
+++ b/src/components/preview/useDeferredTocSource.ts
@@ -1,0 +1,58 @@
+import type { Editor } from "@tiptap/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TOC_EDITOR_READY_MIN_FRAME_COUNT = 2;
+const TOC_EDITOR_READY_MAX_FRAME_COUNT = 8;
+
+interface TocSource {
+	editor: Editor;
+	contentRoot: HTMLElement;
+}
+
+export function useDeferredTocSource() {
+	const [tocSource, setTocSource] = useState<TocSource | null>(null);
+	const tocReadyFrameRef = useRef<number | null>(null);
+
+	const cancelPendingTocReady = useCallback(() => {
+		if (tocReadyFrameRef.current === null) return;
+		window.cancelAnimationFrame(tocReadyFrameRef.current);
+		tocReadyFrameRef.current = null;
+	}, []);
+
+	const handleEditorReady = useCallback(
+		(editor: Editor | null, contentRoot: HTMLElement | null) => {
+			cancelPendingTocReady();
+			setTocSource(null);
+			if (!editor || !contentRoot) return;
+
+			let frameCount = 0;
+			const markReadyAfterPaint = () => {
+				frameCount += 1;
+				const rootRect = contentRoot.getBoundingClientRect();
+				const rootHasLayout = rootRect.width > 0 && rootRect.height > 0;
+				const minFramesElapsed = frameCount >= TOC_EDITOR_READY_MIN_FRAME_COUNT;
+				const maxFramesElapsed = frameCount >= TOC_EDITOR_READY_MAX_FRAME_COUNT;
+
+				if (!minFramesElapsed || (!rootHasLayout && !maxFramesElapsed)) {
+					tocReadyFrameRef.current =
+						window.requestAnimationFrame(markReadyAfterPaint);
+					return;
+				}
+
+				tocReadyFrameRef.current = null;
+				if (!contentRoot.isConnected || editor.isDestroyed || !rootHasLayout) {
+					return;
+				}
+				setTocSource({ editor, contentRoot });
+			};
+
+			tocReadyFrameRef.current =
+				window.requestAnimationFrame(markReadyAfterPaint);
+		},
+		[cancelPendingTocReady],
+	);
+
+	useEffect(() => cancelPendingTocReady, [cancelPendingTocReady]);
+
+	return { tocSource, handleEditorReady };
+}

--- a/src/components/preview/useDeferredTocSource.ts
+++ b/src/components/preview/useDeferredTocSource.ts
@@ -12,6 +12,8 @@ interface TocSource {
 export function useDeferredTocSource() {
 	const [tocSource, setTocSource] = useState<TocSource | null>(null);
 	const tocReadyFrameRef = useRef<number | null>(null);
+	const tocReadyResizeObserverRef = useRef<ResizeObserver | null>(null);
+	const tocReadyGenerationRef = useRef(0);
 
 	const cancelPendingTocReady = useCallback(() => {
 		if (tocReadyFrameRef.current === null) return;
@@ -19,16 +21,63 @@ export function useDeferredTocSource() {
 		tocReadyFrameRef.current = null;
 	}, []);
 
+	const disconnectPendingTocResizeObserver = useCallback(() => {
+		tocReadyResizeObserverRef.current?.disconnect();
+		tocReadyResizeObserverRef.current = null;
+	}, []);
+
+	const resetPendingTocReady = useCallback(() => {
+		tocReadyGenerationRef.current += 1;
+		cancelPendingTocReady();
+		disconnectPendingTocResizeObserver();
+	}, [cancelPendingTocReady, disconnectPendingTocResizeObserver]);
+
 	const handleEditorReady = useCallback(
 		(editor: Editor | null, contentRoot: HTMLElement | null) => {
-			cancelPendingTocReady();
+			resetPendingTocReady();
 			setTocSource(null);
 			if (!editor || !contentRoot) return;
+			const readyEditor = editor;
+			const readyContentRoot = contentRoot;
+			const readyGeneration = tocReadyGenerationRef.current;
+
+			function rootCanBecomeReady() {
+				return (
+					tocReadyGenerationRef.current === readyGeneration &&
+					readyContentRoot.isConnected &&
+					!readyEditor.isDestroyed
+				);
+			}
+
+			function publishWhenRootHasLayout() {
+				if (!rootCanBecomeReady()) return false;
+				const rootRect = readyContentRoot.getBoundingClientRect();
+				if (rootRect.width === 0 || rootRect.height === 0) return false;
+
+				disconnectPendingTocResizeObserver();
+				setTocSource({ editor: readyEditor, contentRoot: readyContentRoot });
+				return true;
+			}
+
+			function observeRootLayout() {
+				if (!rootCanBecomeReady()) return;
+				if (tocReadyResizeObserverRef.current !== null) return;
+				if (typeof ResizeObserver === "undefined") {
+					tocReadyFrameRef.current =
+						window.requestAnimationFrame(markReadyAfterPaint);
+					return;
+				}
+				const resizeObserver = new ResizeObserver(() => {
+					publishWhenRootHasLayout();
+				});
+				resizeObserver.observe(readyContentRoot);
+				tocReadyResizeObserverRef.current = resizeObserver;
+			}
 
 			let frameCount = 0;
-			const markReadyAfterPaint = () => {
+			function markReadyAfterPaint() {
 				frameCount += 1;
-				const rootRect = contentRoot.getBoundingClientRect();
+				const rootRect = readyContentRoot.getBoundingClientRect();
 				const rootHasLayout = rootRect.width > 0 && rootRect.height > 0;
 				const minFramesElapsed = frameCount >= TOC_EDITOR_READY_MIN_FRAME_COUNT;
 				const maxFramesElapsed = frameCount >= TOC_EDITOR_READY_MAX_FRAME_COUNT;
@@ -40,19 +89,18 @@ export function useDeferredTocSource() {
 				}
 
 				tocReadyFrameRef.current = null;
-				if (!contentRoot.isConnected || editor.isDestroyed || !rootHasLayout) {
-					return;
+				if (!publishWhenRootHasLayout()) {
+					observeRootLayout();
 				}
-				setTocSource({ editor, contentRoot });
-			};
+			}
 
 			tocReadyFrameRef.current =
 				window.requestAnimationFrame(markReadyAfterPaint);
 		},
-		[cancelPendingTocReady],
+		[disconnectPendingTocResizeObserver, resetPendingTocReady],
 	);
 
-	useEffect(() => cancelPendingTocReady, [cancelPendingTocReady]);
+	useEffect(() => resetPendingTocReady, [resetPendingTocReady]);
 
 	return { tocSource, handleEditorReady };
 }

--- a/src/styles/app/39-floating-toc.css
+++ b/src/styles/app/39-floating-toc.css
@@ -3,42 +3,55 @@
    ───────────────────────────────────────────────────────────────────────────── */
 .floatingToc {
 	position: absolute;
-	right: 14px;
+	right: 16px;
 	top: 50%;
 	transform: translateY(-50%);
 	z-index: 14;
 	pointer-events: auto;
 }
 
-/* ── Trigger button (wraps collapsed dashes) ─────────────────────────────── */
-.floatingTocTrigger {
-	all: unset;
-	cursor: pointer;
-	display: block;
-}
-
-/* ── Collapsed: minimap dashes ───────────────────────────────────────────── */
-.floatingTocCollapsed {
+.floatingTocRail {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;
-	gap: 4px;
-	padding: 6px 0;
-	transition: opacity 140ms ease;
+	gap: 0;
+	padding: 4px 0;
+	pointer-events: auto;
 }
 
-.floatingToc[data-expanded="true"] .floatingTocCollapsed {
-	opacity: 0;
+.floatingTocMark {
+	all: unset;
+	cursor: pointer;
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	width: 28px;
+	height: 10px;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: inherit;
+}
+
+.floatingTocMark:hover,
+.floatingTocMark:focus-visible,
+.floatingTocMark:active {
+	background: transparent;
+	color: inherit;
+	outline: none;
 }
 
 .floatingTocDash {
+	display: block;
 	height: 2px;
+	min-width: 4px;
 	border-radius: 1px;
-	background: color-mix(in srgb, var(--text-tertiary) 50%, transparent);
-	transition: background-color 180ms ease, opacity 180ms ease;
+	background: color-mix(in srgb, var(--text-tertiary) 44%, transparent);
+	transform-origin: right center;
+	transition: background-color 140ms ease, opacity 140ms ease, transform 180ms
+		cubic-bezier(0.2, 0, 0, 1);
 }
 
-.floatingTocDash[data-active="true"] {
+.floatingTocMark[data-active="true"] .floatingTocDash {
 	background: color-mix(
 		in srgb,
 		var(--interactive-accent) 68%,
@@ -47,61 +60,174 @@
 	opacity: 0.95;
 }
 
-/* ── Expanded: full heading list ─────────────────────────────────────────── */
-.floatingTocExpanded {
+.floatingTocMark[data-wave="peak"] .floatingTocDash {
+	transform: scaleX(1.35);
+}
+
+.floatingTocMark[data-wave="near"] .floatingTocDash {
+	transform: scaleX(1.16);
+}
+
+.floatingTocOutline {
 	position: absolute;
-	right: 0;
+	right: 34px;
 	top: 50%;
-	transform: translateY(-50%);
-	max-width: 220px;
+	box-sizing: border-box;
+	width: 254px;
+	max-width: calc(100vw - 96px);
 	max-height: 60vh;
 	overflow-y: auto;
 	overflow-x: hidden;
-	scrollbar-width: thin;
-	padding: 8px 10px;
-	border-radius: calc(var(--radius-md) + 2px);
-	border: 1px solid color-mix(in srgb, var(--border-light) 86%, transparent);
-	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
-	backdrop-filter: blur(16px);
-	-webkit-backdrop-filter: blur(16px);
-	box-shadow: 0 16px 36px
-		color-mix(in srgb, var(--shadow-color, #000) 8%, transparent);
-}
-
-.floatingTocItems {
+	scrollbar-width: none;
 	display: flex;
 	flex-direction: column;
 	gap: 1px;
+	padding: 9px 10px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+	border-radius: calc(var(--radius-md) + 4px);
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-secondary));
+	box-shadow: 0 10px 28px
+		color-mix(in srgb, var(--shadow-color, #000) 11%, transparent);
+	pointer-events: auto;
+	transform: translateY(-50%);
 }
 
-.floatingTocItem {
+.floatingTocOutline::-webkit-scrollbar {
+	display: none;
+}
+
+.floatingTocOutlineItem {
 	all: unset;
 	cursor: pointer;
-	display: block;
-	padding: 3px 6px;
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	padding-top: 3px;
+	padding-right: 6px;
+	padding-bottom: 3px;
+	border-radius: var(--radius-sm);
+	color: var(--text-secondary);
 	font-size: calc(var(--text-base) * 0.8);
 	line-height: 1.35;
-	color: var(--text-secondary);
-	border-radius: var(--radius-sm);
-	white-space: nowrap;
+	transition: color 140ms ease;
+}
+
+.floatingTocOutlineItem:hover,
+.floatingTocOutlineItem:focus-visible {
+	background: transparent;
+	color: var(--text-primary);
+	outline: none;
+}
+
+.floatingTocOutlineItem[data-active="true"] {
+	background: transparent;
+	color: color-mix(
+		in srgb,
+		var(--interactive-accent) 74%,
+		var(--text-primary)
+	);
+}
+
+.floatingTocOutlineText {
+	min-width: 0;
+	flex: 1 1 auto;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	transition: background-color 140ms ease, color 140ms ease;
+	white-space: nowrap;
 }
 
-.floatingTocItem:hover {
-	background: var(--bg-hover);
+.floatingTocOutlineLevel {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.66);
+	font-weight: var(--font-medium);
+	letter-spacing: 0;
+}
+
+.floatingTocPreview {
+	all: unset;
+	position: absolute;
+	right: 34px;
+	top: 50%;
+	box-sizing: border-box;
+	width: 254px;
+	max-width: calc(100vw - 96px);
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	padding: 13px 16px 14px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+	border-radius: calc(var(--radius-md) + 4px);
+	background: color-mix(in srgb, var(--bg-primary) 92%, var(--bg-secondary));
 	color: var(--text-primary);
+	box-shadow: 0 10px 28px
+		color-mix(in srgb, var(--shadow-color, #000) 11%, transparent);
+	pointer-events: auto;
+	transform: translateY(-50%);
 }
 
-.floatingTocItem[data-active="true"] {
-	background: color-mix(in srgb, var(--interactive-accent) 7%, transparent);
-	color: color-mix(in srgb, var(--interactive-accent) 74%, var(--text-primary));
+.floatingTocPreview:hover,
+.floatingTocPreview:focus-visible,
+.floatingTocPreview:active {
+	background: color-mix(in srgb, var(--bg-primary) 92%, var(--bg-secondary));
+	color: var(--text-primary);
+	outline: none;
+}
+
+.floatingTocPreviewHeading {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	min-width: 0;
+}
+
+.floatingTocPreviewTitle {
+	min-width: 0;
+	flex: 1 1 auto;
+	font-size: calc(var(--text-base) * 0.92);
+	font-weight: var(--font-semibold);
+	line-height: 1.25;
+	color: var(--text-primary);
+	text-wrap: balance;
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 2;
+}
+
+.floatingTocPreviewLevel {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.66);
+	font-weight: var(--font-medium);
+	letter-spacing: 0;
+}
+
+.floatingTocPreviewText {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 3;
+	overflow: hidden;
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.78);
+	line-height: 1.42;
 }
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 @media (max-width: 860px) {
 	.floatingToc {
 		display: none;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.floatingTocDash {
+		transition: background-color 140ms ease, opacity 140ms ease;
+	}
+
+	.floatingTocMark[data-wave="peak"] .floatingTocDash,
+	.floatingTocMark[data-wave="near"] .floatingTocDash {
+		transform: none;
 	}
 }

--- a/src/styles/app/39-floating-toc.css
+++ b/src/styles/app/39-floating-toc.css
@@ -21,15 +21,20 @@
 
 .floatingTocMark {
 	all: unset;
+	box-sizing: border-box;
 	cursor: pointer;
 	display: flex;
 	justify-content: flex-end;
 	align-items: center;
 	width: 28px;
-	height: 10px;
+	height: 24px;
 	border-radius: var(--radius-sm);
 	background: transparent;
 	color: inherit;
+}
+
+.floatingTocMark + .floatingTocMark {
+	margin-top: -14px;
 }
 
 .floatingTocMark:hover,
@@ -121,11 +126,7 @@
 
 .floatingTocOutlineItem[data-active="true"] {
 	background: transparent;
-	color: color-mix(
-		in srgb,
-		var(--interactive-accent) 74%,
-		var(--text-primary)
-	);
+	color: color-mix(in srgb, var(--interactive-accent) 74%, var(--text-primary));
 }
 
 .floatingTocOutlineText {


### PR DESCRIPTION
Closes _(no linked issue — TOC UX polish for 0.8.6-alpha.1)_


## Description

Redesigns the editor's floating table of contents from a single expand/collapse control into an interactive minimap rail with contextual heading previews, a dedicated outline panel, and more reliable heading tracking.

### Summary of changes

- **Floating TOC interaction model** — Replaces the old hover-to-expand trigger with a persistent minimap rail. Each heading is an individually focusable mark; hovering or focusing a mark shows a preview card with the heading title, level (`H1`–`H6`), and a short excerpt of body text below that heading.
- **Outline panel** — Clicking the currently active heading toggles a full document outline (indented by level) instead of expanding on any hover. Selecting a heading from the outline scrolls to it and closes the panel.
- **Wave animation on the rail** — Adjacent dashes scale subtly on hover (`peak` / `near`) to give spatial feedback; disabled under `prefers-reduced-motion`.
- **Heading preview extraction** — New `getHeadingPreview()` walks the ProseMirror doc between the hovered heading and the next heading, collecting up to 150 characters of normalized body text.
- **Incremental TOC updates** — `updateHeadingsFromTransaction()` now maps heading positions through transactions when edits don't touch headings, avoiding full re-scans on every keystroke. Range expansion and heading detection were tightened for more accurate partial updates.
- **Deferred TOC mounting** — New `useDeferredTocSource` hook waits for the editor content root to have layout (2–8 animation frames) before wiring up `useTableOfContents`, preventing incorrect active-heading detection on first paint.
- **Editor mode selection extracted** — `requiresPlainEditorMode` / `initialEditorMode` moved to `editorModeSelection.ts` for reuse; large notes (≥100k chars) still open in plain/raw mode and hide the TOC.
- **Thin wrapper** — `MarkdownFloatingToc` isolates visibility gating from `FloatingTOC` presentation.
- **Version bump** — `0.8.6-alpha.1`; macOS traffic light `y` offset adjusted `24 → 28`.

### Reasoning

The previous TOC required hovering the entire control to reveal headings, which was easy to miss and offered no context about section content. The new design keeps the minimap always visible (when TOC is enabled in settings) while surfacing richer navigation affordances on demand — preview on hover, full outline on active-heading click.

Deferring TOC source binding avoids a class of bugs where scroll/active-heading tracking ran against a zero-size or not-yet-painted editor root. Incremental heading updates reduce work during typing in long documents.

### Additional context

- TOC is hidden when: settings toggle is off, info sidebar is open, git diff view is active, there's a load error, or the note is in plain/raw mode.
- Minimum 2 headings required before the TOC renders (unchanged).
- No backend/Tauri changes beyond version config.

**Review hints**
- Pay attention to keyboard flow: `Escape` dismisses preview and outline; focus management uses `aria-describedby` on the preview panel.
- `onClick` on the active heading toggles outline rather than re-scrolling — intentional.
- Traffic light offset change is bundled for visual alignment with the updated TOC position.


## Screenshots

_Screenshots or screen recording recommended before merge — hover preview card, minimap rail with wave state, and outline panel are the key surfaces to capture._


## Docs

**Interaction**
- Minimap rail: always visible (when TOC enabled)
- Hover/focus mark → preview card (title + excerpt)
- Click inactive mark → scroll to heading
- Click active mark → toggle full outline
- `Escape` → close preview/outline

**New exports** (`useTableOfContents.ts`)
```ts
getHeadingPreview(doc, heading, nextHeading): string | null
```

**Visibility gate** (`MarkdownEditorPane.tsx`)
```ts
showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain"
```

**Files touched**
| Area | Files |
|------|-------|
| UI component | `FloatingTOC.tsx`, `MarkdownFloatingToc.tsx` |
| TOC logic | `useTableOfContents.ts` |
| Editor pane wiring | `MarkdownEditorPane.tsx`, `useDeferredTocSource.ts`, `editorModeSelection.ts` |
| Styles | `39-floating-toc.css` |
| Config | `tauri.conf.json` |


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features _(existing `MarkdownEditorPane` tests mock `FloatingTOC`; no new unit tests for preview/outline logic)_
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the editor’s floating table of contents into a persistent minimap rail with hover previews and a toggleable outline panel for faster, contextual navigation. Improves heading tracking and startup reliability; updates version to 0.8.6-alpha.1.

- **New Features**
  - Persistent minimap rail with hover/focus previews (title, H level, 150‑char excerpt).
  - Click inactive mark to scroll; click the active mark to toggle a full outline (indented, shows H level).
  - Subtle “wave” feedback around the hovered mark; respects reduced motion; Escape closes preview/outline.

- **Refactors**
  - Incremental TOC updates map heading positions through transactions; partial rescans only when changes touch headings.
  - Added `getHeadingPreview()` and `getPreviewForHeading` with normalized text and 150‑char limit.
  - Deferred TOC binding via `useDeferredTocSource` (2–8 frames) until the editor root has layout.
  - TOC visibility gated by `MarkdownFloatingToc`; editor mode selection extracted to `editorModeSelection.ts` (large notes open in plain mode, TOC hidden).
  - Version bumped to `0.8.6-alpha.1`; macOS traffic light `y` offset set to `28`.

<sup>Written for commit 9a18b1addf87538f082824ad44f346e8eacba059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added floating table-of-contents preview and outline interactions in the editor and preview views.
  * Headings can now show preview text before opening the full outline.
  * Improved editor behavior for very large notes by automatically switching to a plain editor mode.

* **Bug Fixes**
  * Adjusted floating TOC positioning and keyboard interactions for a smoother experience.
  * Updated the app’s Windows control alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->