### PR TITLE
Add note-subfolder attachment storage mode for pasted images

### DIFF
--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -252,6 +252,7 @@ This prevents the active note from reloading while the user has unsaved changes.
    - space root
    - specific attachment folder
    - note folder
+   - subfolder under the note folder
 3. Insert temporary object URL image nodes as placeholders.
 4. Convert each file to a data URL.
 5. Call `space_save_pasted_image` with the browser `File.name` as `original_filename`; the backend derives the on-disk filename from that dedicated parameter. Markdown `alt` remains separate display text on the editor image node.
@@ -259,6 +260,8 @@ This prevents the active note from reloading while the user has unsaved changes.
 7. Revoke object URLs.
 
 The backend writes the image into the space using a sanitized version of `original_filename`, for example `assets/picture-new.png`. The response keeps that filesystem identity in `asset_rel_path`, and returns a note-relative markdown `href` such as `../assets/picture-new.png`; pasted-image nodes store `href` in `originSrc` so markdown serialization, hydration, indexing, and attachment renames all use the same link shape. If that filename already exists with identical bytes, the existing file is reused; if it exists with different bytes, the backend allocates a non-destructive suffix such as `picture-new-2.png`. Unnamed clipboard images fall back to `image.{ext}` and use the same suffixing rules.
+
+In `note-subfolder` mode, the target directory is the configured subfolder under the note's parent folder. For example, a note at `Projects/Upcoming/Plan.md` with subfolder `attachments` saves pasted images to `Projects/Upcoming/attachments/` and inserts links like `attachments/picture-new.png`. Root-level notes such as `Plan.md` save to `attachments/` at the space root.
 
 Existing hash-named pasted assets are not migrated. Notes that already reference paths such as `assets/{hash}.png` keep resolving through the normal markdown-link hydration path.
 

--- a/src-tauri/src/git_sync/git.rs
+++ b/src-tauri/src/git_sync/git.rs
@@ -569,6 +569,22 @@ mod tests {
         assert!(block.contains("!config/templates/**"));
         assert!(!block.contains("!assets/images/**"));
         assert!(!block.contains("assets/images/"));
+
+        let note_subfolder_block = render_managed_gitignore(
+            &GitSyncInclusionSettings {
+                include_templates: true,
+                include_attachments: true,
+                include_non_markdown_files: false,
+            },
+            &crate::git_sync::types::GitSyncContext {
+                templates_folder: Some("config/templates".to_string()),
+                attachment_storage_mode: Some(AttachmentStorageMode::NoteSubfolder),
+                attachment_folder: Some("attachments".to_string()),
+            },
+        );
+        assert!(note_subfolder_block.contains("!config/templates/**"));
+        assert!(!note_subfolder_block.contains("!attachments/**"));
+        assert!(!note_subfolder_block.contains("attachments/"));
     }
 
     #[test]

--- a/src-tauri/src/git_sync/types.rs
+++ b/src-tauri/src/git_sync/types.rs
@@ -45,6 +45,7 @@ pub enum AttachmentStorageMode {
     SpaceRoot,
     SpecificFolder,
     NoteFolder,
+    NoteSubfolder,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -1194,6 +1194,45 @@ describe("useNoteEditor", () => {
 		});
 	});
 
+	it("saves pasted images in a subfolder under the note folder in note-subfolder mode", async () => {
+		const onChange = vi.fn();
+		loadSettingsMock.mockResolvedValue({
+			editor: {
+				attachmentFolder: "attachments",
+				attachmentStorageMode: "note-subfolder",
+				colorfulHeadings: false,
+				showCollapsibleHeadings: false,
+				showFrontmatterInEditor: false,
+				enablePeopleMentionsAsTags: false,
+			},
+		});
+
+		await act(async () => {
+			root.render(
+				<Harness onChange={onChange} pasteMarkdownBehavior="smart-markdown" />,
+			);
+		});
+
+		const options = getEditorOptions() as EditorOptionsWithPaste;
+		const paste = options?.editorProps?.handleDOMEvents?.paste;
+		const file = new File(["image-bytes"], "paste.png", { type: "image/png" });
+		const event = createClipboardEvent({
+			items: [{ type: "image/png", getAsFile: () => file }],
+		});
+
+		await act(async () => {
+			expect(paste?.({}, event)).toBe(true);
+			await flushImageUploadWork();
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("space_save_pasted_image", {
+			source_path: "notes/test.md",
+			target_dir: "notes/attachments",
+			data_url: "data:image/png;base64,abc",
+			original_filename: "paste.png",
+		});
+	});
+
 	it("does not start image uploads when image placeholders cannot be inserted", async () => {
 		const onChange = vi.fn();
 		canCommands.insertContentAt.mockReturnValue(false);

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -10,6 +10,10 @@ import {
 } from "react";
 import { useState } from "react";
 import {
+	DEFAULT_ATTACHMENT_FOLDER,
+	resolveAttachmentTargetDir,
+} from "../../../lib/attachmentStorage";
+import {
 	joinYamlFrontmatter,
 	splitYamlFrontmatter,
 } from "../../../lib/notePreview";
@@ -19,7 +23,6 @@ import {
 } from "../../../lib/settings";
 import { invoke } from "../../../lib/tauri";
 import { useTauriEvent } from "../../../lib/tauriEvents";
-import { parentDir } from "../../../utils/path";
 import { handleEditorClick } from "../editorClickHandlers";
 import { createEditorExtensions } from "../extensions";
 import type { MathEditRequest } from "../extensions/math/mathOptions";
@@ -33,7 +36,6 @@ import type { NoteInlineEditorMode, PasteMarkdownBehavior } from "../types";
 import { useHydrateInlineImages } from "./useHydrateInlineImages";
 
 const PASTE_FAILURE_PREFIX = "Image paste failed";
-const DEFAULT_ATTACHMENT_FOLDER = "assets";
 const MARKDOWN_SYNC_DEBOUNCE_MS = 300;
 const EMPTY_ADDITIONAL_EXTENSIONS: AnyExtension[] = [];
 
@@ -47,23 +49,6 @@ function getClipboardHtml(event: ClipboardEvent): string {
 
 function getClipboardPlainText(event: ClipboardEvent): string {
 	return event.clipboardData?.getData("text/plain") ?? "";
-}
-
-function resolveAttachmentTargetDir(
-	mode: AttachmentStorageMode,
-	attachmentFolder: string | null,
-	notePath: string,
-): string {
-	switch (mode) {
-		case "space-root":
-			return "";
-		case "specific-folder":
-			return attachmentFolder?.trim() || DEFAULT_ATTACHMENT_FOLDER;
-		case "note-folder":
-			return parentDir(notePath);
-		default:
-			return parentDir(notePath);
-	}
 }
 
 function normalizeClipboardMarkdownText(text: string): string {

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -6,6 +6,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ATTACHMENT_LOCATION_OPTIONS } from "../../lib/attachmentStorage";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	getGitSyncConnectionHelp,
@@ -152,10 +153,14 @@ export function GitSettingsPane() {
 		[config, status],
 	);
 	const presentation = useMemo(() => getGitSyncPresentation(status), [status]);
+	const specificFolderModeLabel =
+		ATTACHMENT_LOCATION_OPTIONS.find(
+			(option) => option.value === "specific-folder",
+		)?.label ?? "One folder for all attachments";
 	const attachmentFilteringHelp =
 		attachmentStorageMode === "specific-folder"
 			? "Sync files from the configured attachments folder."
-			: "Attachment-only filtering works only when attachments use Specific folder. In other modes, attachment files follow the broader non-markdown files setting.";
+			: `Attachment-only filtering works only when attachments use ${specificFolderModeLabel}. In other modes, attachment files follow the broader non-markdown files setting.`;
 
 	return (
 		<div className="settingsPane">

--- a/src/components/settings/SpaceSettingsPane.test.tsx
+++ b/src/components/settings/SpaceSettingsPane.test.tsx
@@ -44,15 +44,18 @@ const {
 	}
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-vi.mock("../../lib/settings", () => ({
-	DEFAULT_QUICK_NOTES_FOLDER: "Quick Notes",
-	getDailyNotesFolder: getDailyNotesFolderMock,
-	loadSettings: loadSettingsMock,
-	setDailyNotesFolder: setDailyNotesFolderMock,
-	setEditorAttachmentFolder: setEditorAttachmentFolderMock,
-	setEditorAttachmentStorageMode: setEditorAttachmentStorageModeMock,
-	setQuickNotesFolder: setQuickNotesFolderMock,
-}));
+vi.mock("../../lib/settings", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../lib/settings")>();
+	return {
+		...actual,
+		getDailyNotesFolder: getDailyNotesFolderMock,
+		loadSettings: loadSettingsMock,
+		setDailyNotesFolder: setDailyNotesFolderMock,
+		setEditorAttachmentFolder: setEditorAttachmentFolderMock,
+		setEditorAttachmentStorageMode: setEditorAttachmentStorageModeMock,
+		setQuickNotesFolder: setQuickNotesFolderMock,
+	};
+});
 
 vi.mock("../../lib/tauri", () => ({
 	invoke: invokeMock,
@@ -152,7 +155,7 @@ describe("SpaceSettingsPane", () => {
 		container.remove();
 	});
 
-	it("renders the attachment location dropdown with all three options", async () => {
+	it("renders the attachment location dropdown with all four options", async () => {
 		await act(async () => {
 			root.render(<SpaceSettingsPane />);
 			await Promise.resolve();
@@ -167,9 +170,13 @@ describe("SpaceSettingsPane", () => {
 			value: option.value,
 		}));
 		expect(options).toEqual([
-			{ label: "Main space folder", value: "space-root" },
-			{ label: "Specific folder", value: "specific-folder" },
-			{ label: "Same folder as note", value: "note-folder" },
+			{ label: "At the top of your space", value: "space-root" },
+			{ label: "One folder for all attachments", value: "specific-folder" },
+			{ label: "Next to each note", value: "note-folder" },
+			{
+				label: "In a subfolder with the note",
+				value: "note-subfolder",
+			},
 		]);
 		expect(getAttachmentsSection().textContent).not.toContain("Browse");
 	});
@@ -208,5 +215,132 @@ describe("SpaceSettingsPane", () => {
 			{ spacePath: "/spaces/test" },
 		);
 		expect(getAttachmentsSection().textContent).not.toContain("Browse");
+	});
+
+	it("shows the subfolder text input for note-subfolder mode", async () => {
+		await act(async () => {
+			root.render(<SpaceSettingsPane />);
+			await Promise.resolve();
+		});
+
+		const select = container.querySelector(
+			'select[aria-label="Attachment location"]',
+		) as HTMLSelectElement;
+
+		await act(async () => {
+			select.value = "note-subfolder";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(setEditorAttachmentStorageModeMock).toHaveBeenCalledWith(
+			"note-subfolder",
+			{ spacePath: "/spaces/test" },
+		);
+		expect(
+			container.querySelector('input[aria-label="Attachment subfolder name"]'),
+		).not.toBeNull();
+		expect(getAttachmentsSection().textContent).not.toContain("Browse");
+		expect(getAttachmentsSection().textContent).toContain(
+			"Attachments go in this subfolder inside the note's folder.",
+		);
+	});
+
+	it("resets the attachment folder when switching between folder modes", async () => {
+		loadSettingsMock.mockResolvedValueOnce({
+			currentSpacePath: "/spaces/test",
+			dailyNotes: { folder: null },
+			editor: {
+				attachmentStorageMode: "specific-folder",
+				attachmentFolder: "Projects/Media",
+			},
+			quickNotes: { folder: "Quick Notes" },
+		});
+
+		await act(async () => {
+			root.render(<SpaceSettingsPane />);
+			await Promise.resolve();
+		});
+
+		const select = container.querySelector(
+			'select[aria-label="Attachment location"]',
+		) as HTMLSelectElement;
+
+		await act(async () => {
+			select.value = "note-subfolder";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(setEditorAttachmentFolderMock).toHaveBeenCalledWith("assets", {
+			spacePath: "/spaces/test",
+		});
+	});
+
+	it("resets stale attachment folders when entering note-subfolder from an ignored mode", async () => {
+		loadSettingsMock.mockResolvedValueOnce({
+			currentSpacePath: "/spaces/test",
+			dailyNotes: { folder: null },
+			editor: {
+				attachmentStorageMode: "note-folder",
+				attachmentFolder: "Projects/Media",
+			},
+			quickNotes: { folder: "Quick Notes" },
+		});
+
+		await act(async () => {
+			root.render(<SpaceSettingsPane />);
+			await Promise.resolve();
+		});
+
+		const select = container.querySelector(
+			'select[aria-label="Attachment location"]',
+		) as HTMLSelectElement;
+
+		await act(async () => {
+			select.value = "note-subfolder";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(setEditorAttachmentFolderMock).toHaveBeenCalledWith("assets", {
+			spacePath: "/spaces/test",
+		});
+	});
+
+	it("shows validation errors for invalid subfolder paths on blur", async () => {
+		loadSettingsMock.mockResolvedValueOnce({
+			currentSpacePath: "/spaces/test",
+			dailyNotes: { folder: null },
+			editor: {
+				attachmentStorageMode: "note-subfolder",
+				attachmentFolder: "../secret",
+			},
+			quickNotes: { folder: "Quick Notes" },
+		});
+
+		await act(async () => {
+			root.render(<SpaceSettingsPane />);
+			await Promise.resolve();
+		});
+
+		const input = container.querySelector(
+			'input[aria-label="Attachment subfolder name"]',
+		) as HTMLInputElement;
+
+		await act(async () => {
+			input.focus();
+		});
+
+		await act(async () => {
+			input.blur();
+			await Promise.resolve();
+		});
+
+		expect(setEditorAttachmentFolderMock).not.toHaveBeenCalled();
+		expect(
+			container.querySelector("#attachmentSubfolderError")?.textContent,
+		).toContain("Folder path cannot contain '..'.");
+		expect(input.getAttribute("aria-invalid")).toBe("true");
 	});
 });

--- a/src/components/settings/SpaceSettingsPane.test.tsx
+++ b/src/components/settings/SpaceSettingsPane.test.tsx
@@ -277,7 +277,45 @@ describe("SpaceSettingsPane", () => {
 		});
 	});
 
-	it("resets stale attachment folders when entering note-subfolder from an ignored mode", async () => {
+	it("preserves the attachment folder when switching back to specific-folder", async () => {
+		loadSettingsMock.mockResolvedValueOnce({
+			currentSpacePath: "/spaces/test",
+			dailyNotes: { folder: null },
+			editor: {
+				attachmentStorageMode: "specific-folder",
+				attachmentFolder: "Projects/Media",
+			},
+			quickNotes: { folder: "Quick Notes" },
+		});
+
+		await act(async () => {
+			root.render(<SpaceSettingsPane />);
+			await Promise.resolve();
+		});
+
+		const select = container.querySelector(
+			'select[aria-label="Attachment location"]',
+		) as HTMLSelectElement;
+
+		await act(async () => {
+			select.value = "note-folder";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		setEditorAttachmentFolderMock.mockClear();
+
+		await act(async () => {
+			select.value = "specific-folder";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(setEditorAttachmentFolderMock).not.toHaveBeenCalled();
+		expect(getAttachmentsSection().textContent).toContain("Projects/Media");
+	});
+
+	it("does not reset the attachment folder when entering note-subfolder from note-folder", async () => {
 		loadSettingsMock.mockResolvedValueOnce({
 			currentSpacePath: "/spaces/test",
 			dailyNotes: { folder: null },
@@ -303,9 +341,11 @@ describe("SpaceSettingsPane", () => {
 			await Promise.resolve();
 		});
 
-		expect(setEditorAttachmentFolderMock).toHaveBeenCalledWith("assets", {
-			spacePath: "/spaces/test",
-		});
+		expect(setEditorAttachmentFolderMock).not.toHaveBeenCalled();
+		const input = container.querySelector(
+			'input[aria-label="Attachment subfolder name"]',
+		) as HTMLInputElement | null;
+		expect(input?.value).toBe("Projects/Media");
 	});
 
 	it("shows validation errors for invalid subfolder paths on blur", async () => {

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -174,8 +174,6 @@ export function SpaceSettingsPane() {
 
 				const shouldResetFolder =
 					modesUseDifferentFolderSemantics(attachmentStorageMode, nextMode) ||
-					(modeRequiresAttachmentFolder(nextMode) &&
-						!modeRequiresAttachmentFolder(attachmentStorageMode)) ||
 					(modeRequiresAttachmentFolder(nextMode) && !attachmentFolder);
 				if (shouldResetFolder) {
 					await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, {
@@ -203,7 +201,7 @@ export function SpaceSettingsPane() {
 		try {
 			const spacePath = requireSpacePath(currentSpacePath);
 			await setEditorAttachmentFolder(normalized, { spacePath });
-			setAttachmentFolderState(normalized || DEFAULT_ATTACHMENT_FOLDER);
+			setAttachmentFolderState(normalized);
 		} catch (cause) {
 			setAttachmentError(
 				cause instanceof Error ? cause.message : "Failed to update subfolder",
@@ -279,6 +277,9 @@ export function SpaceSettingsPane() {
 			);
 		}
 	}, [currentSpacePath]);
+
+	const attachmentFolderEditor =
+		ATTACHMENT_MODE_UI[attachmentStorageMode].folderEditor;
 
 	return (
 		<div className="settingsPane">
@@ -407,8 +408,7 @@ export function SpaceSettingsPane() {
 							<div className="settingsHelp">
 								{ATTACHMENT_MODE_UI[attachmentStorageMode].help}
 							</div>
-							{ATTACHMENT_MODE_UI[attachmentStorageMode].folderEditor ===
-							"browse" ? (
+							{attachmentFolderEditor === "browse" ? (
 								<div className="dailyNotesFolderRow">
 									<div className="dailyNotesFolderPath">
 										{attachmentFolder || DEFAULT_ATTACHMENT_FOLDER}
@@ -440,8 +440,7 @@ export function SpaceSettingsPane() {
 									</div>
 								</div>
 							) : null}
-							{ATTACHMENT_MODE_UI[attachmentStorageMode].folderEditor ===
-							"text" ? (
+							{attachmentFolderEditor === "text" ? (
 								<div
 									className="dailyNotesFolderRow"
 									data-invalid={attachmentError ? true : undefined}
@@ -484,7 +483,7 @@ export function SpaceSettingsPane() {
 							{attachmentError ? (
 								<div
 									id={
-										attachmentStorageMode === "note-subfolder"
+										attachmentFolderEditor === "text"
 											? ATTACHMENT_SUBFOLDER_ERROR_ID
 											: undefined
 									}

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -1,8 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
+import {
+	ATTACHMENT_LOCATION_OPTIONS,
+	ATTACHMENT_MODE_UI,
+	DEFAULT_ATTACHMENT_FOLDER,
+	modeRequiresAttachmentFolder,
+	modesUseDifferentFolderSemantics,
+} from "../../lib/attachmentStorage";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type AttachmentStorageMode,
 	DEFAULT_QUICK_NOTES_FOLDER,
+	isAttachmentStorageMode,
 	loadSettings,
 	setDailyNotesFolder,
 	setEditorAttachmentFolder,
@@ -10,22 +18,16 @@ import {
 	setQuickNotesFolder,
 } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
+import { normalizeRelPath, validateRelFolderPath } from "../../utils/path";
 import { Trash2 } from "../Icons";
 import { FolderOpen } from "../Icons/NavigationIcons";
 import { Button } from "../ui/shadcn/button";
+import { Input } from "../ui/shadcn/input";
 import { SettingsRow, SettingsSection } from "./SettingsScaffold";
 import { SettingsSelect } from "./SettingsSelect";
 import { TemplateSettingsSections } from "./TemplatesSettingsPane";
 
-const DEFAULT_ATTACHMENT_FOLDER = "assets";
-const ATTACHMENT_LOCATION_OPTIONS: Array<{
-	label: string;
-	value: AttachmentStorageMode;
-}> = [
-	{ label: "Main space folder", value: "space-root" },
-	{ label: "Specific folder", value: "specific-folder" },
-	{ label: "Same folder as note", value: "note-folder" },
-];
+const ATTACHMENT_SUBFOLDER_ERROR_ID = "attachmentSubfolderError";
 
 interface SpaceFolderSelection {
 	relativePath: string;
@@ -169,7 +171,13 @@ export function SpaceSettingsPane() {
 				const spacePath = requireSpacePath(currentSpacePath);
 				await setEditorAttachmentStorageMode(nextMode, { spacePath });
 				setAttachmentStorageModeState(nextMode);
-				if (nextMode === "specific-folder" && !attachmentFolder) {
+
+				const shouldResetFolder =
+					modesUseDifferentFolderSemantics(attachmentStorageMode, nextMode) ||
+					(modeRequiresAttachmentFolder(nextMode) &&
+						!modeRequiresAttachmentFolder(attachmentStorageMode)) ||
+					(modeRequiresAttachmentFolder(nextMode) && !attachmentFolder);
+				if (shouldResetFolder) {
 					await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, {
 						spacePath,
 					});
@@ -181,8 +189,27 @@ export function SpaceSettingsPane() {
 				);
 			}
 		},
-		[attachmentFolder, currentSpacePath],
+		[attachmentFolder, attachmentStorageMode, currentSpacePath],
 	);
+
+	const handleAttachmentSubfolderBlur = useCallback(async () => {
+		setAttachmentError(null);
+		const validationError = validateRelFolderPath(attachmentFolder);
+		if (validationError) {
+			setAttachmentError(validationError);
+			return;
+		}
+		const normalized = normalizeRelPath(attachmentFolder);
+		try {
+			const spacePath = requireSpacePath(currentSpacePath);
+			await setEditorAttachmentFolder(normalized, { spacePath });
+			setAttachmentFolderState(normalized || DEFAULT_ATTACHMENT_FOLDER);
+		} catch (cause) {
+			setAttachmentError(
+				cause instanceof Error ? cause.message : "Failed to update subfolder",
+			);
+		}
+	}, [attachmentFolder, currentSpacePath]);
 
 	const handleBrowseAttachmentFolder = useCallback(async () => {
 		setAttachmentError(null);
@@ -366,9 +393,9 @@ export function SpaceSettingsPane() {
 								aria-label="Attachment location"
 								value={attachmentStorageMode}
 								onChange={(event) => {
-									void handleAttachmentModeChange(
-										event.target.value as AttachmentStorageMode,
-									);
+									const nextMode = event.target.value;
+									if (!isAttachmentStorageMode(nextMode)) return;
+									void handleAttachmentModeChange(nextMode);
 								}}
 							>
 								{ATTACHMENT_LOCATION_OPTIONS.map((option) => (
@@ -378,13 +405,10 @@ export function SpaceSettingsPane() {
 								))}
 							</SettingsSelect>
 							<div className="settingsHelp">
-								{attachmentStorageMode === "space-root"
-									? "Saved at the top level of your space."
-									: attachmentStorageMode === "note-folder"
-										? "Saved next to the note they are attached to."
-										: "All attachments go in one folder."}
+								{ATTACHMENT_MODE_UI[attachmentStorageMode].help}
 							</div>
-							{attachmentStorageMode === "specific-folder" ? (
+							{ATTACHMENT_MODE_UI[attachmentStorageMode].folderEditor ===
+							"browse" ? (
 								<div className="dailyNotesFolderRow">
 									<div className="dailyNotesFolderPath">
 										{attachmentFolder || DEFAULT_ATTACHMENT_FOLDER}
@@ -405,7 +429,9 @@ export function SpaceSettingsPane() {
 											variant="outline"
 											size="icon-sm"
 											className="rounded-md border-border bg-background justify-center shadow-none"
-											onClick={handleResetAttachmentFolder}
+											onClick={() => {
+												void handleResetAttachmentFolder();
+											}}
 											aria-label="Reset attachments folder"
 											title="Reset attachments folder"
 										>
@@ -414,8 +440,57 @@ export function SpaceSettingsPane() {
 									</div>
 								</div>
 							) : null}
+							{ATTACHMENT_MODE_UI[attachmentStorageMode].folderEditor ===
+							"text" ? (
+								<div
+									className="dailyNotesFolderRow"
+									data-invalid={attachmentError ? true : undefined}
+								>
+									<Input
+										aria-label="Attachment subfolder name"
+										aria-invalid={attachmentError ? true : undefined}
+										aria-describedby={
+											attachmentError
+												? ATTACHMENT_SUBFOLDER_ERROR_ID
+												: undefined
+										}
+										value={attachmentFolder}
+										placeholder={DEFAULT_ATTACHMENT_FOLDER}
+										onChange={(event) => {
+											setAttachmentError(null);
+											setAttachmentFolderState(event.target.value);
+										}}
+										onBlur={() => {
+											void handleAttachmentSubfolderBlur();
+										}}
+									/>
+									<div className="settingsActions dailyNotesActions">
+										<Button
+											type="button"
+											variant="outline"
+											size="icon-sm"
+											className="rounded-md border-border bg-background justify-center shadow-none"
+											onClick={() => {
+												void handleResetAttachmentFolder();
+											}}
+											aria-label="Reset attachment subfolder"
+											title="Reset attachment subfolder"
+										>
+											<Trash2 size="var(--icon-md)" />
+										</Button>
+									</div>
+								</div>
+							) : null}
 							{attachmentError ? (
-								<div className="settingsError dailyNotesError">
+								<div
+									id={
+										attachmentStorageMode === "note-subfolder"
+											? ATTACHMENT_SUBFOLDER_ERROR_ID
+											: undefined
+									}
+									className="settingsError dailyNotesError"
+									role="alert"
+								>
 									{attachmentError}
 								</div>
 							) : null}

--- a/src/lib/attachmentStorage.test.ts
+++ b/src/lib/attachmentStorage.test.ts
@@ -44,6 +44,23 @@ describe("resolveAttachmentTargetDir", () => {
 			resolveAttachmentTargetDir("note-subfolder", "  ", "notes/test.md"),
 		).toBe(`notes/${DEFAULT_ATTACHMENT_FOLDER}`);
 	});
+
+	it("falls back to the default attachment folder for invalid persisted values", () => {
+		expect(
+			resolveAttachmentTargetDir(
+				"note-subfolder",
+				"../secret",
+				"notes/test.md",
+			),
+		).toBe(`notes/${DEFAULT_ATTACHMENT_FOLDER}`);
+		expect(
+			resolveAttachmentTargetDir(
+				"specific-folder",
+				"../secret",
+				"notes/test.md",
+			),
+		).toBe(DEFAULT_ATTACHMENT_FOLDER);
+	});
 });
 
 describe("attachment mode helpers", () => {

--- a/src/lib/attachmentStorage.test.ts
+++ b/src/lib/attachmentStorage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_ATTACHMENT_FOLDER,
+	modeRequiresAttachmentFolder,
+	modesUseDifferentFolderSemantics,
+	resolveAttachmentTargetDir,
+} from "./attachmentStorage";
+
+describe("resolveAttachmentTargetDir", () => {
+	it("resolves each attachment storage mode", () => {
+		expect(
+			resolveAttachmentTargetDir("space-root", "assets", "notes/test.md"),
+		).toBe("");
+		expect(
+			resolveAttachmentTargetDir(
+				"specific-folder",
+				"assets/uploads",
+				"notes/test.md",
+			),
+		).toBe("assets/uploads");
+		expect(
+			resolveAttachmentTargetDir("note-folder", "assets", "notes/test.md"),
+		).toBe("notes");
+		expect(
+			resolveAttachmentTargetDir(
+				"note-subfolder",
+				"attachments",
+				"notes/test.md",
+			),
+		).toBe("notes/attachments");
+	});
+
+	it("saves root-level notes into the configured subfolder at the space root", () => {
+		expect(
+			resolveAttachmentTargetDir("note-subfolder", "attachments", "Plan.md"),
+		).toBe("attachments");
+	});
+
+	it("falls back to the default attachment folder", () => {
+		expect(
+			resolveAttachmentTargetDir("specific-folder", null, "notes/test.md"),
+		).toBe(DEFAULT_ATTACHMENT_FOLDER);
+		expect(
+			resolveAttachmentTargetDir("note-subfolder", "  ", "notes/test.md"),
+		).toBe(`notes/${DEFAULT_ATTACHMENT_FOLDER}`);
+	});
+});
+
+describe("attachment mode helpers", () => {
+	it("detects folder semantics changes between browse and subfolder modes", () => {
+		expect(
+			modesUseDifferentFolderSemantics("specific-folder", "note-subfolder"),
+		).toBe(true);
+		expect(
+			modesUseDifferentFolderSemantics("note-subfolder", "specific-folder"),
+		).toBe(true);
+		expect(
+			modesUseDifferentFolderSemantics("note-folder", "note-subfolder"),
+		).toBe(false);
+	});
+
+	it("identifies modes that require a configured folder", () => {
+		expect(modeRequiresAttachmentFolder("specific-folder")).toBe(true);
+		expect(modeRequiresAttachmentFolder("note-subfolder")).toBe(true);
+		expect(modeRequiresAttachmentFolder("note-folder")).toBe(false);
+	});
+});

--- a/src/lib/attachmentStorage.ts
+++ b/src/lib/attachmentStorage.ts
@@ -1,0 +1,75 @@
+import { joinRelPath, parentDir } from "../utils/path";
+import type { AttachmentStorageMode } from "./settings";
+
+export const DEFAULT_ATTACHMENT_FOLDER = "assets";
+
+export const ATTACHMENT_LOCATION_OPTIONS: Array<{
+	label: string;
+	value: AttachmentStorageMode;
+}> = [
+	{ label: "At the top of your space", value: "space-root" },
+	{ label: "One folder for all attachments", value: "specific-folder" },
+	{ label: "Next to each note", value: "note-folder" },
+	{ label: "In a subfolder with the note", value: "note-subfolder" },
+];
+
+export const ATTACHMENT_MODE_UI = {
+	"space-root": {
+		help: "Saved at the top level of your space.",
+		folderEditor: null,
+	},
+	"note-folder": {
+		help: "Saved next to the note they are attached to.",
+		folderEditor: null,
+	},
+	"specific-folder": {
+		help: "All attachments go in one folder.",
+		folderEditor: "browse",
+	},
+	"note-subfolder": {
+		help: "Attachments go in this subfolder inside the note's folder.",
+		folderEditor: "text",
+	},
+} as const satisfies Record<
+	AttachmentStorageMode,
+	{ help: string; folderEditor: "browse" | "text" | null }
+>;
+
+export function resolveAttachmentTargetDir(
+	mode: AttachmentStorageMode,
+	attachmentFolder: string | null,
+	notePath: string,
+): string {
+	switch (mode) {
+		case "space-root":
+			return "";
+		case "specific-folder":
+			return attachmentFolder?.trim() || DEFAULT_ATTACHMENT_FOLDER;
+		case "note-folder":
+			return parentDir(notePath);
+		case "note-subfolder": {
+			const subfolder = attachmentFolder?.trim() || DEFAULT_ATTACHMENT_FOLDER;
+			return joinRelPath(parentDir(notePath), subfolder);
+		}
+		default: {
+			const _unhandledMode: never = mode;
+			return _unhandledMode;
+		}
+	}
+}
+
+export function modesUseDifferentFolderSemantics(
+	from: AttachmentStorageMode,
+	to: AttachmentStorageMode,
+): boolean {
+	return (
+		(from === "specific-folder" && to === "note-subfolder") ||
+		(from === "note-subfolder" && to === "specific-folder")
+	);
+}
+
+export function modeRequiresAttachmentFolder(
+	mode: AttachmentStorageMode,
+): boolean {
+	return mode === "specific-folder" || mode === "note-subfolder";
+}

--- a/src/lib/attachmentStorage.ts
+++ b/src/lib/attachmentStorage.ts
@@ -1,4 +1,9 @@
-import { joinRelPath, parentDir } from "../utils/path";
+import {
+	joinRelPath,
+	normalizeRelPath,
+	parentDir,
+	validateRelFolderPath,
+} from "../utils/path";
 import type { AttachmentStorageMode } from "./settings";
 
 export const DEFAULT_ATTACHMENT_FOLDER = "assets";
@@ -35,6 +40,13 @@ export const ATTACHMENT_MODE_UI = {
 	{ help: string; folderEditor: "browse" | "text" | null }
 >;
 
+function sanitizedAttachmentFolder(attachmentFolder: string | null): string {
+	const trimmed = attachmentFolder?.trim();
+	if (!trimmed) return DEFAULT_ATTACHMENT_FOLDER;
+	if (validateRelFolderPath(trimmed)) return DEFAULT_ATTACHMENT_FOLDER;
+	return normalizeRelPath(trimmed);
+}
+
 export function resolveAttachmentTargetDir(
 	mode: AttachmentStorageMode,
 	attachmentFolder: string | null,
@@ -44,11 +56,11 @@ export function resolveAttachmentTargetDir(
 		case "space-root":
 			return "";
 		case "specific-folder":
-			return attachmentFolder?.trim() || DEFAULT_ATTACHMENT_FOLDER;
+			return sanitizedAttachmentFolder(attachmentFolder);
 		case "note-folder":
 			return parentDir(notePath);
 		case "note-subfolder": {
-			const subfolder = attachmentFolder?.trim() || DEFAULT_ATTACHMENT_FOLDER;
+			const subfolder = sanitizedAttachmentFolder(attachmentFolder);
 			return joinRelPath(parentDir(notePath), subfolder);
 		}
 		default: {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -328,10 +328,13 @@ describe("attachment storage settings", () => {
 		const { setEditorAttachmentStorageMode } = await import("./settings");
 
 		await setEditorAttachmentStorageMode("space-root");
+		await setEditorAttachmentStorageMode("note-subfolder");
 
-		expect(storeState.get("editor.attachmentStorageMode")).toBe("space-root");
+		expect(storeState.get("editor.attachmentStorageMode")).toBe(
+			"note-subfolder",
+		);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
-			editor: { attachmentStorageMode: "space-root" },
+			editor: { attachmentStorageMode: "note-subfolder" },
 		});
 	});
 
@@ -344,6 +347,22 @@ describe("attachment storage settings", () => {
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			editor: { attachmentFolder: "assets/uploads" },
 		});
+	});
+
+	it("recognizes note-subfolder as a valid attachment storage mode", async () => {
+		const { isAttachmentStorageMode } = await import("./settings");
+
+		expect(isAttachmentStorageMode("note-subfolder")).toBe(true);
+		expect(isAttachmentStorageMode("invalid-mode")).toBe(false);
+	});
+
+	it("rejects invalid attachment folder paths", async () => {
+		const { setEditorAttachmentFolder } = await import("./settings");
+
+		await expect(setEditorAttachmentFolder("../secret")).rejects.toThrow("..");
+		await expect(setEditorAttachmentFolder(".hidden")).rejects.toThrow(
+			"hidden",
+		);
 	});
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,7 +1,9 @@
 import { type UnlistenFn, emit, emitTo, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LazyStore } from "@tauri-apps/plugin-store";
-import { normalizeRelPath } from "../utils/path";
+import { normalizeRelPath, validateRelFolderPath } from "../utils/path";
+import { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
+export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
 import {
 	type Shortcut,
 	areShortcutsEqual,
@@ -145,11 +147,13 @@ const AUTO_UPDATE_CHECK_INTERVALS = new Set<AutoUpdateCheckInterval>(["3h"]);
 export type AttachmentStorageMode =
 	| "space-root"
 	| "specific-folder"
-	| "note-folder";
+	| "note-folder"
+	| "note-subfolder";
 const ATTACHMENT_STORAGE_MODES = new Set<AttachmentStorageMode>([
 	"space-root",
 	"specific-folder",
 	"note-folder",
+	"note-subfolder",
 ]);
 export type UiAccent =
 	| "neutral"
@@ -184,7 +188,6 @@ const DEFAULT_AI_ENABLED = true;
 export const DEFAULT_QUICK_NOTES_FOLDER = "Quick Notes";
 export type UiFontFamily = string;
 export type UiFontSize = number;
-const DEFAULT_ATTACHMENT_FOLDER = "assets";
 const AI_ASSISTANT_MODES = new Set<AiAssistantMode>(["chat", "create"]);
 export type EditorWidthMode = "compact" | "comfortable" | "wide";
 const EDITOR_WIDTH_MODES = new Set<EditorWidthMode>([
@@ -292,10 +295,18 @@ function asAiAssistantMode(value: unknown): AiAssistantMode {
 }
 
 function asAttachmentStorageMode(value: unknown): AttachmentStorageMode {
-	return typeof value === "string" &&
-		ATTACHMENT_STORAGE_MODES.has(value as AttachmentStorageMode)
-		? (value as AttachmentStorageMode)
+	return isAttachmentStorageMode(value)
+		? value
 		: DEFAULT_EDITOR_SETTINGS.attachmentStorageMode;
+}
+
+export function isAttachmentStorageMode(
+	value: unknown,
+): value is AttachmentStorageMode {
+	return (
+		typeof value === "string" &&
+		ATTACHMENT_STORAGE_MODES.has(value as AttachmentStorageMode)
+	);
 }
 
 function asEditorWidthMode(value: unknown): EditorWidthMode {
@@ -1422,6 +1433,10 @@ export async function setEditorAttachmentFolder(
 		typeof folder === "string"
 			? normalizeRelPath(folder) || DEFAULT_ATTACHMENT_FOLDER
 			: DEFAULT_ATTACHMENT_FOLDER;
+	const validationError = validateRelFolderPath(nextFolder);
+	if (validationError) {
+		throw new Error(validationError);
+	}
 	const spacePath = await updateActiveSpaceSettings(
 		{
 			attachmentFolder: nextFolder,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -2,7 +2,10 @@ import { type UnlistenFn, emit, emitTo, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LazyStore } from "@tauri-apps/plugin-store";
 import { normalizeRelPath, validateRelFolderPath } from "../utils/path";
-import { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
+import {
+	ATTACHMENT_MODE_UI,
+	DEFAULT_ATTACHMENT_FOLDER,
+} from "./attachmentStorage";
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
 import {
 	type Shortcut,
@@ -149,12 +152,9 @@ export type AttachmentStorageMode =
 	| "specific-folder"
 	| "note-folder"
 	| "note-subfolder";
-const ATTACHMENT_STORAGE_MODES = new Set<AttachmentStorageMode>([
-	"space-root",
-	"specific-folder",
-	"note-folder",
-	"note-subfolder",
-]);
+const ATTACHMENT_STORAGE_MODES = new Set<AttachmentStorageMode>(
+	Object.keys(ATTACHMENT_MODE_UI) as AttachmentStorageMode[],
+);
 export type UiAccent =
 	| "neutral"
 	| "glyph-orange"

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -16,6 +16,10 @@ describe("validateRelFolderPath", () => {
 		expect(validateRelFolderPath("")).toContain("empty");
 		expect(validateRelFolderPath("   ")).toContain("empty");
 	});
+
+	it("rejects whitespace-only segments", () => {
+		expect(validateRelFolderPath("assets/ /images")).toContain("empty");
+	});
 });
 
 describe("joinRelPath", () => {

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { joinRelPath, validateRelFolderPath } from "./path";
+
+describe("validateRelFolderPath", () => {
+	it("accepts simple and nested folder paths", () => {
+		expect(validateRelFolderPath("attachments")).toBeNull();
+		expect(validateRelFolderPath("assets/images")).toBeNull();
+	});
+
+	it("rejects traversal and hidden segments", () => {
+		expect(validateRelFolderPath("../secret")).toContain("..");
+		expect(validateRelFolderPath(".hidden")).toContain("hidden");
+	});
+
+	it("rejects empty paths", () => {
+		expect(validateRelFolderPath("")).toContain("empty");
+		expect(validateRelFolderPath("   ")).toContain("empty");
+	});
+});
+
+describe("joinRelPath", () => {
+	it("joins normalized path segments", () => {
+		expect(joinRelPath("notes", "attachments")).toBe("notes/attachments");
+		expect(joinRelPath("", "attachments")).toBe("attachments");
+		expect(joinRelPath("notes/", "/attachments/")).toBe("notes/attachments");
+	});
+});

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -105,7 +105,7 @@ export function validateRelFolderPath(path: string): string | null {
 	const normalized = normalizeRelPath(path);
 	if (!normalized) return "Folder path cannot be empty.";
 	for (const segment of normalized.split("/")) {
-		if (!segment) return "Folder path cannot contain empty segments.";
+		if (!segment.trim()) return "Folder path cannot contain empty segments.";
 		if (segment === "..") return "Folder path cannot contain '..'.";
 		if (segment.startsWith(".")) {
 			return "Folder path cannot contain hidden segments.";

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -93,3 +93,23 @@ export function normalizeRelPath(path: string): string {
 		.replace(/\\/g, "/")
 		.replace(/^\/+|\/+$/g, "");
 }
+
+export function joinRelPath(...segments: string[]): string {
+	return segments
+		.flatMap((segment) => normalizeRelPath(segment).split("/"))
+		.filter(Boolean)
+		.join("/");
+}
+
+export function validateRelFolderPath(path: string): string | null {
+	const normalized = normalizeRelPath(path);
+	if (!normalized) return "Folder path cannot be empty.";
+	for (const segment of normalized.split("/")) {
+		if (!segment) return "Folder path cannot contain empty segments.";
+		if (segment === "..") return "Folder path cannot contain '..'.";
+		if (segment.startsWith(".")) {
+			return "Folder path cannot contain hidden segments.";
+		}
+	}
+	return null;
+}


### PR DESCRIPTION
## Summary

Adds a new **In a subfolder with the note** attachment storage mode so pasted images save to a configurable subfolder under each note's folder (for example `Projects/Upcoming/attachments/` for `Projects/Upcoming/Plan.md`). Extracts attachment path resolution into `attachmentStorage.ts`, adds subfolder path validation, updates Space Settings with a text input for the subfolder name, and adjusts git sync so note-subfolder mode does not treat the subfolder as a global attachments directory.

## Related Issues

Closes #270

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “In a subfolder with the note” attachment storage mode so pasted images save to a configurable subfolder inside each note’s folder, with stricter path validation and improved settings UX. Closes #270.

- **New Features**
  - New `note-subfolder` mode in Space Settings with a subfolder text input; blocks `..` and hidden segments; defaults to `assets`.
  - Editor saves pasted images to `<note-dir>/<subfolder>` (root notes to `<subfolder>/`) and inserts relative links; docs and tests updated.
  - Git sync treats `note-subfolder` as per-note storage and does not whitelist a global attachments folder; added test coverage.

- **Refactors**
  - Centralized helpers in `src/lib/attachmentStorage.ts` (`resolveAttachmentTargetDir`, `ATTACHMENT_LOCATION_OPTIONS`, UI copy) and added `validateRelFolderPath`/`joinRelPath`.
  - Settings now preserve custom folders when switching modes; only reset when folder semantics change or a folder is required but missing; sanitize persisted paths on resolve; `setEditorAttachmentFolder` rejects unsafe/empty paths.
  - Git settings help text derives the specific-folder label from `ATTACHMENT_LOCATION_OPTIONS` for consistency.

<sup>Written for commit c61c13ec6145fbb6b6062261983bf9e7c8e89487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “in a subfolder with the note” attachment storage option.
  * Image pastes can now save into a note-specific subfolder, with links generated consistently for nested and root notes.

* **Bug Fixes**
  * Improved attachment-folder handling when switching storage modes.
  * Added validation to prevent invalid or unsafe folder paths.

* **Documentation**
  * Clarified image paste behavior and destination folder selection in the editor docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->