### PR TITLE
Add non-Markdown file visibility setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 .pnpm-store
+package-lock.json
 dist
 dist-ssr
 *.local

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -101,6 +101,7 @@ describe("FileTreePane", () => {
 		loadSettingsMock.mockResolvedValue({
 			ui: {
 				showFileTreeFolderCounts: false,
+				showNonMarkdownFiles: true,
 			},
 		});
 		useFileTreeContextMock.mockReturnValue({
@@ -227,5 +228,60 @@ describe("FileTreePane", () => {
 		});
 
 		expect(container.querySelector(".fileTreePinnedSection")).toBeNull();
+	});
+
+	it("hides non-markdown files when the setting is off", async () => {
+		loadSettingsMock.mockResolvedValue({
+			ui: {
+				showFileTreeFolderCounts: false,
+				showNonMarkdownFiles: false,
+			},
+		});
+
+		await act(async () => {
+			root.render(
+				<QueryClientProvider client={queryClient}>
+					<FileTreePane
+						rootEntries={[
+							{
+								name: "note.md",
+								rel_path: "note.md",
+								kind: "file",
+								is_markdown: true,
+							},
+							{
+								name: "image.png",
+								rel_path: "image.png",
+								kind: "file",
+								is_markdown: false,
+							},
+						]}
+						childrenByDir={{}}
+						expandedDirs={new Set()}
+						activeFilePath={null}
+						activeDirPath={null}
+						onToggleDir={vi.fn()}
+						onSelectDir={vi.fn()}
+						onOpenFile={vi.fn()}
+						onNewFileInDir={vi.fn()}
+						onCreateFromTemplateInDir={vi.fn()}
+						onRequestCreateFolder={vi.fn()}
+						onDuplicateFile={vi.fn()}
+						onDeletePath={vi.fn()}
+						renamingPath={null}
+						onStartRename={vi.fn()}
+						onCancelRename={vi.fn()}
+						onCommitFileRename={vi.fn()}
+						onCommitDirRename={vi.fn()}
+						onMovePath={vi.fn()}
+						pinnedFiles={[]}
+						onTogglePinnedFile={vi.fn()}
+					/>
+				</QueryClientProvider>,
+			);
+		});
+
+		expect(container.textContent).toContain("note");
+		expect(container.textContent).not.toContain("image");
 	});
 });

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -19,6 +19,7 @@ import {
 import { toast } from "sonner";
 import { useFileTreeContext, useSpace } from "../../contexts";
 
+import { filterVisibleFileTreeEntries } from "../../hooks/fileTreeHelpers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
@@ -264,6 +265,7 @@ interface TreeEntriesProps {
 	itemAppearance: Record<string, FileTreeAppearance>;
 	folderFileCounts: Record<string, number>;
 	showFolderFileCounts: boolean;
+	showNonMarkdownFiles: boolean;
 	onChangeAppearance: (
 		entry: FsEntry,
 		appearance: FileTreeAppearance,
@@ -307,6 +309,7 @@ function TreeEntries({
 	itemAppearance,
 	folderFileCounts,
 	showFolderFileCounts,
+	showNonMarkdownFiles,
 	onChangeAppearance,
 	onOpenAppearancePicker,
 	pinnedFiles,
@@ -317,11 +320,15 @@ function TreeEntries({
 	showFilePreviews = false,
 	filePreviewsByPath = {},
 }: TreeEntriesProps) {
-	if (entries.length === 0) return null;
+	const visibleEntries = filterVisibleFileTreeEntries(
+		entries,
+		showNonMarkdownFiles,
+	);
+	if (visibleEntries.length === 0) return null;
 
 	return (
 		<ul className="fileTreeList">
-			{entries.map((e) => {
+			{visibleEntries.map((e) => {
 				const isDir = e.kind === "dir";
 				const depth = parentDepth + 1;
 				const rowKey =
@@ -385,6 +392,7 @@ function TreeEntries({
 									itemAppearance={itemAppearance}
 									folderFileCounts={folderFileCounts}
 									showFolderFileCounts={showFolderFileCounts}
+									showNonMarkdownFiles={showNonMarkdownFiles}
 									onChangeAppearance={onChangeAppearance}
 									onOpenAppearancePicker={onOpenAppearancePicker}
 									pinnedFiles={pinnedFiles}
@@ -466,6 +474,7 @@ export const FileTreePane = memo(function FileTreePane({
 	const { itemAppearance, setItemAppearance } = useFileTreeContext();
 	const { spacePath, setError } = useSpace();
 	const [showFolderFileCounts, setShowFolderFileCounts] = useState(false);
+	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState(false);
 
 	const [folderFileCounts, setFolderFileCounts] = useState<
 		Record<string, number>
@@ -499,6 +508,7 @@ export const FileTreePane = memo(function FileTreePane({
 		void loadSettings().then((settings) => {
 			if (!cancelled) {
 				setShowFolderFileCounts(settings.ui.showFileTreeFolderCounts);
+				setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
 			}
 		});
 		return () => {
@@ -509,6 +519,9 @@ export const FileTreePane = memo(function FileTreePane({
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFolderFileCounts(payload.ui.showFileTreeFolderCounts);
+		}
+		if (typeof payload.ui?.showNonMarkdownFiles === "boolean") {
+			setShowNonMarkdownFiles(payload.ui.showNonMarkdownFiles);
 		}
 	});
 
@@ -756,6 +769,14 @@ export const FileTreePane = memo(function FileTreePane({
 	const focusedEntries = focusedDirPath
 		? (childrenByDir[focusedDirPath] ?? null)
 		: null;
+	const visibleRootEntries = filterVisibleFileTreeEntries(
+		rootEntries,
+		showNonMarkdownFiles,
+	);
+	const visibleFocusedEntries =
+		focusedEntries === null
+			? null
+			: filterVisibleFileTreeEntries(focusedEntries, showNonMarkdownFiles);
 
 	useEffect(() => {
 		if (!focusedDirPath || focusedEntries || !onLoadDir) return;
@@ -924,9 +945,9 @@ export const FileTreePane = memo(function FileTreePane({
 							onNavigate={handleEnterDir}
 							onExit={handleExitFocusedDir}
 						/>
-						{focusedEntries === null ? null : focusedEntries.length ? (
+						{!visibleFocusedEntries ? null : visibleFocusedEntries.length ? (
 							<TreeEntries
-								entries={focusedEntries}
+								entries={visibleFocusedEntries}
 								parentDepth={-1}
 								childrenByDir={childrenByDir}
 								expandedDirs={expandedDirs}
@@ -950,6 +971,7 @@ export const FileTreePane = memo(function FileTreePane({
 								itemAppearance={itemAppearance}
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
+								showNonMarkdownFiles={showNonMarkdownFiles}
 								onChangeAppearance={handleChangeAppearance}
 								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}
@@ -970,9 +992,9 @@ export const FileTreePane = memo(function FileTreePane({
 							</m.div>
 						)}
 					</FileTreeRootDrop>
-				) : rootEntries.length ? (
+				) : visibleRootEntries.length ? (
 					<FileTreeRootDrop>
-						{rootEntries.length ? (
+						{visibleRootEntries.length ? (
 							<TreeEntries
 								entries={rootEntries}
 								parentDepth={-1}
@@ -998,6 +1020,7 @@ export const FileTreePane = memo(function FileTreePane({
 								itemAppearance={itemAppearance}
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
+								showNonMarkdownFiles={showNonMarkdownFiles}
 								onChangeAppearance={handleChangeAppearance}
 								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -474,7 +474,9 @@ export const FileTreePane = memo(function FileTreePane({
 	const { itemAppearance, setItemAppearance } = useFileTreeContext();
 	const { spacePath, setError } = useSpace();
 	const [showFolderFileCounts, setShowFolderFileCounts] = useState(false);
-	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState(false);
+	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState<
+		boolean | null
+	>(null);
 
 	const [folderFileCounts, setFolderFileCounts] = useState<
 		Record<string, number>
@@ -489,6 +491,7 @@ export const FileTreePane = memo(function FileTreePane({
 		useState<AppearancePickerTarget | null>(null);
 	const filePreviewRequestRef = useRef("");
 	const moveClickSuppressRef = useRef(false);
+	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
 	const itemAppearanceRef = useRef(itemAppearance);
 
@@ -505,18 +508,32 @@ export const FileTreePane = memo(function FileTreePane({
 
 	useEffect(() => {
 		let cancelled = false;
-		void loadSettings().then((settings) => {
-			if (!cancelled) {
-				setShowFolderFileCounts(settings.ui.showFileTreeFolderCounts);
-				setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
-			}
-		});
+		const loadId = settingsVersionRef.current + 1;
+		settingsVersionRef.current = loadId;
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled && loadId === settingsVersionRef.current) {
+					setShowFolderFileCounts(settings.ui.showFileTreeFolderCounts);
+					setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
+				}
+			})
+			.catch(() => {
+				if (!cancelled && loadId === settingsVersionRef.current) {
+					setShowNonMarkdownFiles(true);
+				}
+			});
 		return () => {
 			cancelled = true;
 		};
 	}, []);
 
 	useTauriEvent("settings:updated", (payload) => {
+		if (
+			typeof payload.ui?.showFileTreeFolderCounts === "boolean" ||
+			typeof payload.ui?.showNonMarkdownFiles === "boolean"
+		) {
+			settingsVersionRef.current += 1;
+		}
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFolderFileCounts(payload.ui.showFileTreeFolderCounts);
 		}
@@ -552,7 +569,7 @@ export const FileTreePane = memo(function FileTreePane({
 	}, [childrenByDir, rootEntries, summaryParentDirs]);
 
 	useEffect(() => {
-		if (!spacePath || !showFolderFileCounts) {
+		if (!spacePath || !showFolderFileCounts || showNonMarkdownFiles === null) {
 			setFolderFileCounts({});
 			return;
 		}
@@ -584,7 +601,9 @@ export const FileTreePane = memo(function FileTreePane({
 				}
 				hasSuccessfulResult = true;
 				for (const summary of result.value) {
-					nextCounts[summary.dir_rel_path] = summary.total_files_recursive;
+					nextCounts[summary.dir_rel_path] = showNonMarkdownFiles
+						? summary.total_files_recursive
+						: summary.total_markdown_recursive;
 				}
 			}
 
@@ -601,6 +620,7 @@ export const FileTreePane = memo(function FileTreePane({
 	}, [
 		spacePath,
 		showFolderFileCounts,
+		showNonMarkdownFiles,
 		summaryParentDirs,
 		folderCountTreeRevision,
 	]);
@@ -769,14 +789,19 @@ export const FileTreePane = memo(function FileTreePane({
 	const focusedEntries = focusedDirPath
 		? (childrenByDir[focusedDirPath] ?? null)
 		: null;
+	const hasLoadedFileVisibility = showNonMarkdownFiles !== null;
+	const showNonMarkdownFilesSetting = showNonMarkdownFiles ?? false;
 	const visibleRootEntries = filterVisibleFileTreeEntries(
 		rootEntries,
-		showNonMarkdownFiles,
+		showNonMarkdownFilesSetting,
 	);
 	const visibleFocusedEntries =
 		focusedEntries === null
 			? null
-			: filterVisibleFileTreeEntries(focusedEntries, showNonMarkdownFiles);
+			: filterVisibleFileTreeEntries(
+					focusedEntries,
+					showNonMarkdownFilesSetting,
+				);
 
 	useEffect(() => {
 		if (!focusedDirPath || focusedEntries || !onLoadDir) return;
@@ -937,7 +962,7 @@ export const FileTreePane = memo(function FileTreePane({
 						});
 					}}
 				/>
-				{focusedDirPath ? (
+				{!hasLoadedFileVisibility ? null : focusedDirPath ? (
 					<FileTreeRootDrop targetDirPath={focusedDirPath}>
 						<FolderBreadcrumb
 							spacePath={spacePath}
@@ -971,7 +996,7 @@ export const FileTreePane = memo(function FileTreePane({
 								itemAppearance={itemAppearance}
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
-								showNonMarkdownFiles={showNonMarkdownFiles}
+								showNonMarkdownFiles={showNonMarkdownFilesSetting}
 								onChangeAppearance={handleChangeAppearance}
 								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}
@@ -1020,7 +1045,7 @@ export const FileTreePane = memo(function FileTreePane({
 								itemAppearance={itemAppearance}
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
-								showNonMarkdownFiles={showNonMarkdownFiles}
+								showNonMarkdownFiles={showNonMarkdownFilesSetting}
 								onChangeAppearance={handleChangeAppearance}
 								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -92,6 +92,21 @@ vi.mock("../../lib/tauriEvents", () => ({
 	useTauriEvent: () => {},
 }));
 
+vi.mock("../../lib/settings", async () => {
+	const actual =
+		await vi.importActual<typeof import("../../lib/settings")>(
+			"../../lib/settings",
+		);
+	return {
+		...actual,
+		loadSettings: vi.fn().mockResolvedValue({
+			ui: {
+				showNonMarkdownFiles: true,
+			},
+		}),
+	};
+});
+
 (
 	globalThis as typeof globalThis & {
 		IS_REACT_ACT_ENVIRONMENT?: boolean;

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
 import { loadSettings } from "../../lib/settings";
 import type { AllDocsItem, FsEntry, FsEntryList } from "../../lib/tauri";
@@ -129,18 +129,31 @@ function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {
 
 export function useFolioNotes(scope: FolioScope) {
 	const queryClient = useQueryClient();
-	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState(false);
+	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState<
+		boolean | null
+	>(null);
+	const settingsVersionRef = useRef(0);
 	const folderPrefix = folderForScope(scope);
 	const includesNonMarkdownFiles =
-		showNonMarkdownFiles && scope.kind !== "tag" && scope.kind !== "person";
+		showNonMarkdownFiles === true &&
+		scope.kind !== "tag" &&
+		scope.kind !== "person";
 
 	useEffect(() => {
 		let cancelled = false;
-		void loadSettings().then((settings) => {
-			if (!cancelled) {
-				setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
-			}
-		});
+		const loadId = settingsVersionRef.current + 1;
+		settingsVersionRef.current = loadId;
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled && loadId === settingsVersionRef.current) {
+					setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
+				}
+			})
+			.catch(() => {
+				if (!cancelled && loadId === settingsVersionRef.current) {
+					setShowNonMarkdownFiles(true);
+				}
+			});
 		return () => {
 			cancelled = true;
 		};
@@ -148,6 +161,7 @@ export function useFolioNotes(scope: FolioScope) {
 
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.ui?.showNonMarkdownFiles === "boolean") {
+			settingsVersionRef.current += 1;
 			setShowNonMarkdownFiles(payload.ui.showNonMarkdownFiles);
 		}
 	});

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
+import { loadSettings } from "../../lib/settings";
 import type { AllDocsItem, FsEntry, FsEntryList } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
@@ -128,9 +129,29 @@ function mergeFolioItems(notes: AllDocsItem[], files: FolioItem[]) {
 
 export function useFolioNotes(scope: FolioScope) {
 	const queryClient = useQueryClient();
+	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState(false);
 	const folderPrefix = folderForScope(scope);
 	const includesNonMarkdownFiles =
-		scope.kind !== "tag" && scope.kind !== "person";
+		showNonMarkdownFiles && scope.kind !== "tag" && scope.kind !== "person";
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings().then((settings) => {
+			if (!cancelled) {
+				setShowNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
+			}
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		if (typeof payload.ui?.showNonMarkdownFiles === "boolean") {
+			setShowNonMarkdownFiles(payload.ui.showNonMarkdownFiles);
+		}
+	});
+
 	const query = useQuery({
 		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
 		queryFn: () => loadAllDocs(folderPrefix),
@@ -151,17 +172,20 @@ export function useFolioNotes(scope: FolioScope) {
 			queryKey: navigationQueryKeys.allDocsList(folderPrefix),
 		});
 		void queryClient.invalidateQueries({
-			queryKey: folioFilesQueryKey(folderPrefix),
+			queryKey: ["navigation", "folio-files"],
 		});
 	});
 
 	const items = useMemo(
 		() =>
 			filterNotesForScope(
-				mergeFolioItems(query.data ?? [], filesQuery.data?.files ?? []),
+				mergeFolioItems(
+					query.data ?? [],
+					includesNonMarkdownFiles ? (filesQuery.data?.files ?? []) : [],
+				),
 				scope,
 			),
-		[filesQuery.data?.files, query.data, scope],
+		[filesQuery.data?.files, includesNonMarkdownFiles, query.data, scope],
 	);
 
 	return {

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -19,6 +19,7 @@ const {
 	setEditorVimKeybindingsMock,
 	setFolioModeMock,
 	setShowFileTreeFolderCountsMock,
+	setShowNonMarkdownFilesMock,
 	setShowTocMock,
 } = vi.hoisted(() => ({
 	loadSettingsMock: vi.fn(),
@@ -33,6 +34,7 @@ const {
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
 	setFolioModeMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
+	setShowNonMarkdownFilesMock: vi.fn(() => Promise.resolve()),
 	setShowTocMock: vi.fn(() => Promise.resolve()),
 }));
 
@@ -56,6 +58,7 @@ vi.mock("../../lib/settings", () => ({
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
 	setFolioMode: setFolioModeMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
+	setShowNonMarkdownFiles: setShowNonMarkdownFilesMock,
 	setShowToc: setShowTocMock,
 }));
 
@@ -141,6 +144,7 @@ function makeSettings(
 			aiAssistantMode: "create" as const,
 			folioMode: false,
 			showFileTreeFolderCounts: false,
+			showNonMarkdownFiles: true,
 			showToc: true,
 		},
 		database: {
@@ -351,5 +355,35 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setFolioModeMock).toHaveBeenCalledWith(true);
+	});
+
+	it("shows non-Markdown files on by default", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Show non-Markdown files"]',
+		) as HTMLInputElement | null;
+
+		expect(container.textContent).toContain("Show non-Markdown files");
+		expect(toggle?.checked).toBe(true);
+	});
+
+	it("saves show non-Markdown files changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Show non-Markdown files"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setShowNonMarkdownFilesMock).toHaveBeenCalledWith(false);
 	});
 });

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -19,6 +19,7 @@ import {
 	setEditorWidthMode,
 	setFolioMode,
 	setShowFileTreeFolderCounts,
+	setShowNonMarkdownFiles,
 	setShowToc,
 } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
@@ -123,6 +124,7 @@ export function AdvancedSettingsPane() {
 		useState(false);
 	const [showFileTreeFolderCounts, setShowFileTreeFolderCountsState] =
 		useState(false);
+	const [showNonMarkdownFiles, setShowNonMarkdownFilesState] = useState(true);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
 	const [error, setError] = useState("");
 	const [isSavingShowToc, setIsSavingShowToc] = useState(false);
@@ -149,6 +151,8 @@ export function AdvancedSettingsPane() {
 		isSavingShowFileTreeFolderCounts,
 		setIsSavingShowFileTreeFolderCounts,
 	] = useState(false);
+	const [isSavingShowNonMarkdownFiles, setIsSavingShowNonMarkdownFiles] =
+		useState(false);
 	const [isSavingDatabaseColumnColor, setIsSavingDatabaseColumnColor] =
 		useState(false);
 	const { spacePath, startIndexRebuild } = useSpace();
@@ -169,6 +173,7 @@ export function AdvancedSettingsPane() {
 			setFolioModeState(settings.ui.folioMode);
 			setClassicAllNotesByDefaultState(settings.ui.classicAllNotesByDefault);
 			setShowFileTreeFolderCountsState(settings.ui.showFileTreeFolderCounts);
+			setShowNonMarkdownFilesState(settings.ui.showNonMarkdownFiles);
 			setShowDatabaseColumnColor(settings.database.showColumnColor);
 		} catch (cause) {
 			setError(extractErrorMessage(cause));
@@ -222,6 +227,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.ui?.showFileTreeFolderCounts === "boolean") {
 			setShowFileTreeFolderCountsState(payload.ui.showFileTreeFolderCounts);
+		}
+		if (typeof payload.ui?.showNonMarkdownFiles === "boolean") {
+			setShowNonMarkdownFilesState(payload.ui.showNonMarkdownFiles);
 		}
 		if (typeof payload.database?.showColumnColor === "boolean") {
 			setShowDatabaseColumnColor(payload.database.showColumnColor);
@@ -556,6 +564,30 @@ export function AdvancedSettingsPane() {
 									})
 									.finally(() => {
 										setIsSavingShowFileTreeFolderCounts(false);
+									});
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Show non-Markdown files"
+						description="Show PDFs, images, and other attachments in the file tree and Folio list. Turning this off hides them from those views only."
+					>
+						<SettingsToggle
+							checked={showNonMarkdownFiles}
+							disabled={isSavingShowNonMarkdownFiles}
+							ariaLabel="Show non-Markdown files"
+							onCheckedChange={(checked) => {
+								const previous = showNonMarkdownFiles;
+								setError("");
+								setShowNonMarkdownFilesState(checked);
+								setIsSavingShowNonMarkdownFiles(true);
+								void setShowNonMarkdownFiles(checked)
+									.catch((cause) => {
+										setShowNonMarkdownFilesState(previous);
+										setError(extractErrorMessage(cause));
+									})
+									.finally(() => {
+										setIsSavingShowNonMarkdownFiles(false);
 									});
 							}}
 						/>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -505,6 +505,13 @@ const SETTINGS_SEARCH_ITEMS = [
 		keywords: ["sidebar", "counts"],
 	},
 	{
+		id: "advanced-show-non-markdown-files",
+		tab: "advanced",
+		section: "App",
+		title: "Show non-Markdown files",
+		keywords: ["sidebar", "attachments", "pdf", "images", "folio", "file tree"],
+	},
+	{
 		id: "advanced-database-column-color",
 		tab: "advanced",
 		section: "Database",

--- a/src/hooks/fileTreeHelpers.test.ts
+++ b/src/hooks/fileTreeHelpers.test.ts
@@ -4,6 +4,7 @@ import { normalizeRelPath } from "../utils/path";
 import {
 	areEntriesEqual,
 	compareEntries,
+	filterVisibleFileTreeEntries,
 	normalizeEntries,
 	normalizeEntry,
 	withInsertedEntry,
@@ -19,6 +20,26 @@ function mkEntry(partial: Partial<FsEntry>): FsEntry {
 }
 
 describe("fileTreeHelpers", () => {
+	it("filterVisibleFileTreeEntries hides non-markdown files", () => {
+		const entries = [
+			mkEntry({
+				name: "note.md",
+				rel_path: "note.md",
+				kind: "file",
+				is_markdown: true,
+			}),
+			mkEntry({
+				name: "image.png",
+				rel_path: "image.png",
+				kind: "file",
+				is_markdown: false,
+			}),
+		];
+
+		expect(filterVisibleFileTreeEntries(entries, true)).toEqual(entries);
+		expect(filterVisibleFileTreeEntries(entries, false)).toEqual([entries[0]]);
+	});
+
 	it("normalizes rel paths and strips surrounding slashes", () => {
 		expect(normalizeRelPath("\\foo\\bar\\baz.md")).toBe("foo/bar/baz.md");
 		expect(normalizeRelPath(" /foo/bar/ ")).toBe("foo/bar");

--- a/src/hooks/fileTreeHelpers.ts
+++ b/src/hooks/fileTreeHelpers.ts
@@ -1,6 +1,14 @@
 import type { FsEntry } from "../lib/tauri";
 import { normalizeRelPath } from "../utils/path";
 
+export function filterVisibleFileTreeEntries(
+	entries: FsEntry[],
+	showNonMarkdownFiles: boolean,
+): FsEntry[] {
+	if (showNonMarkdownFiles) return entries;
+	return entries.filter((entry) => entry.kind === "dir" || entry.is_markdown);
+}
+
 export function compareEntries(a: FsEntry, b: FsEntry): number {
 	if (a.kind === "dir" && b.kind === "file") return -1;
 	if (a.kind === "file" && b.kind === "dir") return 1;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -233,6 +233,7 @@ interface EditorSettings {
 
 interface FileTreeSettings {
 	showFolderFileCounts: boolean;
+	showNonMarkdownFiles: boolean;
 }
 
 export interface ShortcutSettings {
@@ -269,6 +270,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 
 const DEFAULT_FILE_TREE_SETTINGS: FileTreeSettings = {
 	showFolderFileCounts: false,
+	showNonMarkdownFiles: true,
 };
 
 function asThemeMode(value: unknown): ThemeMode {
@@ -386,6 +388,7 @@ async function emitSettingsUpdated(payload: {
 		translucentApp?: boolean;
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
+		showNonMarkdownFiles?: boolean;
 		folioMode?: boolean;
 		classicAllNotesByDefault?: boolean;
 		aiAssistantMode?: AiAssistantMode;
@@ -458,6 +461,7 @@ interface AppSettings {
 		translucentApp: boolean;
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
+		showNonMarkdownFiles: boolean;
 		folioMode: boolean;
 		classicAllNotesByDefault: boolean;
 		aiAssistantMode: AiAssistantMode;
@@ -527,6 +531,7 @@ const KEYS = {
 	translucentApp: "ui.translucentApp",
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
+	showNonMarkdownFiles: "ui.fileTree.showNonMarkdownFiles",
 	folioMode: "ui.folioMode",
 	classicAllNotesByDefault: "ui.classicAllNotesByDefault",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
@@ -849,6 +854,10 @@ export async function loadSettings(
 		entries,
 		KEYS.showFileTreeFolderCounts,
 	);
+	const rawShowNonMarkdownFiles = getSettingValue<boolean | null>(
+		entries,
+		KEYS.showNonMarkdownFiles,
+	);
 	const rawFolioMode = getSettingValue<boolean | null>(entries, KEYS.folioMode);
 	const rawClassicAllNotesByDefault = getSettingValue<boolean | null>(
 		entries,
@@ -981,6 +990,10 @@ export async function loadSettings(
 		typeof rawShowFileTreeFolderCounts === "boolean"
 			? rawShowFileTreeFolderCounts
 			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
+	const showNonMarkdownFiles =
+		typeof rawShowNonMarkdownFiles === "boolean"
+			? rawShowNonMarkdownFiles
+			: DEFAULT_FILE_TREE_SETTINGS.showNonMarkdownFiles;
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
 	const classicAllNotesByDefault =
 		typeof rawClassicAllNotesByDefault === "boolean"
@@ -1076,6 +1089,7 @@ export async function loadSettings(
 			translucentApp,
 			showToc,
 			showFileTreeFolderCounts,
+			showNonMarkdownFiles,
 			folioMode,
 			classicAllNotesByDefault,
 			aiAssistantMode,
@@ -1329,6 +1343,13 @@ export async function setShowFileTreeFolderCounts(
 	await store.set(KEYS.showFileTreeFolderCounts, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { showFileTreeFolderCounts: enabled } });
+}
+
+export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.showNonMarkdownFiles, enabled);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { showNonMarkdownFiles: enabled } });
 }
 
 export async function setFolioMode(enabled: boolean): Promise<void> {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -70,6 +70,7 @@ type TauriEventMap = {
 			translucentApp?: boolean;
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
+			showNonMarkdownFiles?: boolean;
 			folioMode?: boolean;
 			classicAllNotesByDefault?: boolean;
 			aiEnabled?: boolean;


### PR DESCRIPTION
## Summary

Adds an Advanced setting to show or hide non-Markdown files in the file tree and Folio list, while keeping Markdown notes visible. The setting is persisted, broadcast through settings updates, included in settings search, and defaults to showing non-Markdown files once settings are loaded. This also filters file tree entries and Folio file queries so a disabled setting does not briefly expose hidden attachments during initial load.

## Related Issues

None

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

Not included.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [x] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a toggle to show or hide non-Markdown files in the file tree and Folio. The setting is persisted, searchable, applied before render, and folder counts and lists now reflect it consistently.

- **New Features**
  - Added “Show non-Markdown files” toggle in Advanced Settings (default on). It only affects the file tree and Folio; Markdown notes always show.
  - Persisted via `loadSettings`/`setShowNonMarkdownFiles`, broadcast on `settings:updated` as `ui.showNonMarkdownFiles`, and added a settings search entry.

- **Bug Fixes**
  - File tree filters at all levels and waits for the setting before rendering to avoid flashes; folder counts switch to Markdown-only totals when hidden.
  - Folio only requests/merges attachments when the setting is on and updates live on `settings:updated`.

<sup>Written for commit ce79b1b552bc94578c1740112aa7c8efa1096485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Show non-Markdown files” setting in Advanced settings.
  * File trees and note lists can now hide non-Markdown files when this option is turned off.
  * The new setting is searchable from Settings.

* **Bug Fixes**
  * File tree views now correctly stay empty when filtering removes all visible items.
  * Settings changes update the UI immediately and handle saving errors more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->