### PR TITLE
Add corner radius control and refine appearance settings UI

### DIFF
--- a/src/components/settings/AppearanceAccentCard.tsx
+++ b/src/components/settings/AppearanceAccentCard.tsx
@@ -19,7 +19,7 @@ export function AppearanceAccentCard({
 		<SettingsSection title="Accent" description={description}>
 			<SettingsRow
 				label="Palette"
-				description="Preview and select the accent that feels best for your workspace."
+				description="Applies to links, buttons, focus rings, and emphasis."
 			>
 				<div className="settingsAccentPicker">
 					<div

--- a/src/components/settings/AppearanceCornerRadiusCard.tsx
+++ b/src/components/settings/AppearanceCornerRadiusCard.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/utils";
+import type { UiCornerRadiusStyle } from "../../lib/settings";
+import { AppearancePreviewFrame } from "./AppearancePreviewFrame";
+import { SettingsRow, SettingsSection } from "./SettingsScaffold";
+import { CORNER_RADIUS_OPTIONS } from "./cornerRadiusOptions";
+
+interface AppearanceCornerRadiusCardProps {
+	cornerRadiusStyle: UiCornerRadiusStyle;
+	onCornerRadiusStyleChange: (style: UiCornerRadiusStyle) => Promise<void>;
+}
+
+export function AppearanceCornerRadiusCard({
+	cornerRadiusStyle,
+	onCornerRadiusStyleChange,
+}: AppearanceCornerRadiusCardProps) {
+	return (
+		<SettingsSection
+			title="Shape"
+			description="Choose how rounded panels, buttons, and windows look across the app."
+		>
+			<SettingsRow
+				label="Corners"
+				description="Applies everywhere — sidebars, dialogs, inputs, and cards."
+			>
+				<div className="settingsSegmentedPicker">
+					<div
+						className="settingsSegmentedTrack"
+						role="radiogroup"
+						aria-label="UI shape"
+					>
+						{CORNER_RADIUS_OPTIONS.map((option) => (
+							<label
+								key={option.id}
+								className={cn(
+									"settingsSegmentedOption",
+									cornerRadiusStyle === option.id && "is-active",
+								)}
+								data-corner-radius-style={option.id}
+								title={option.description}
+							>
+								<input
+									type="radio"
+									name="settings-corner-radius"
+									checked={cornerRadiusStyle === option.id}
+									onChange={() => void onCornerRadiusStyleChange(option.id)}
+									className="settingsSegmentedInput"
+									aria-label={option.label}
+								/>
+								<AppearancePreviewFrame />
+								<span className="settingsSegmentedLabel">{option.label}</span>
+							</label>
+						))}
+					</div>
+				</div>
+			</SettingsRow>
+		</SettingsSection>
+	);
+}

--- a/src/components/settings/AppearanceCornerRadiusCard.tsx
+++ b/src/components/settings/AppearanceCornerRadiusCard.tsx
@@ -1,7 +1,7 @@
-import { cn } from "@/lib/utils";
 import type { UiCornerRadiusStyle } from "../../lib/settings";
 import { AppearancePreviewFrame } from "./AppearancePreviewFrame";
 import { SettingsRow, SettingsSection } from "./SettingsScaffold";
+import { SettingsSegmentedPicker } from "./SettingsSegmentedPicker";
 import { CORNER_RADIUS_OPTIONS } from "./cornerRadiusOptions";
 
 interface AppearanceCornerRadiusCardProps {
@@ -21,37 +21,19 @@ export function AppearanceCornerRadiusCard({
 			<SettingsRow
 				label="Corners"
 				description="Applies everywhere — sidebars, dialogs, inputs, and cards."
+				interactive={false}
 			>
-				<div className="settingsSegmentedPicker">
-					<div
-						className="settingsSegmentedTrack"
-						role="radiogroup"
-						aria-label="UI shape"
-					>
-						{CORNER_RADIUS_OPTIONS.map((option) => (
-							<label
-								key={option.id}
-								className={cn(
-									"settingsSegmentedOption",
-									cornerRadiusStyle === option.id && "is-active",
-								)}
-								data-corner-radius-style={option.id}
-								title={option.description}
-							>
-								<input
-									type="radio"
-									name="settings-corner-radius"
-									checked={cornerRadiusStyle === option.id}
-									onChange={() => void onCornerRadiusStyleChange(option.id)}
-									className="settingsSegmentedInput"
-									aria-label={option.label}
-								/>
-								<AppearancePreviewFrame />
-								<span className="settingsSegmentedLabel">{option.label}</span>
-							</label>
-						))}
-					</div>
-				</div>
+				<SettingsSegmentedPicker
+					name="settings-corner-radius"
+					ariaLabel="UI shape"
+					value={cornerRadiusStyle}
+					options={CORNER_RADIUS_OPTIONS}
+					onChange={(next) => void onCornerRadiusStyleChange(next)}
+					renderPreview={() => <AppearancePreviewFrame />}
+					getDataAttributes={(value) => ({
+						"data-corner-radius-style": value,
+					})}
+				/>
 			</SettingsRow>
 		</SettingsSection>
 	);

--- a/src/components/settings/AppearancePreviewFrame.tsx
+++ b/src/components/settings/AppearancePreviewFrame.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+
+interface AppearancePreviewFrameProps {
+	mode?: "default" | "light" | "dark" | "system";
+}
+
+function AppearancePreviewChrome() {
+	return (
+		<span className="settingsAppearancePreviewChrome">
+			<span className="settingsAppearancePreviewDot" />
+			<span className="settingsAppearancePreviewDot" />
+			<span className="settingsAppearancePreviewDot" />
+		</span>
+	);
+}
+
+function AppearancePreviewBody() {
+	return (
+		<span className="settingsAppearancePreviewBody">
+			<span className="settingsAppearancePreviewLine" />
+			<span className="settingsAppearancePreviewLine is-short" />
+			<span className="settingsAppearancePreviewButton" />
+		</span>
+	);
+}
+
+function AppearancePreviewPane({
+	mode,
+}: {
+	mode: Exclude<AppearancePreviewFrameProps["mode"], "system">;
+}) {
+	return (
+		<span
+			className={cn(
+				"settingsAppearancePreviewPane",
+				mode === "light" && "is-light",
+				mode === "dark" && "is-dark",
+			)}
+		>
+			<AppearancePreviewChrome />
+			<AppearancePreviewBody />
+		</span>
+	);
+}
+
+export function AppearancePreviewFrame({
+	mode = "default",
+}: AppearancePreviewFrameProps) {
+	if (mode === "system") {
+		return (
+			<span className="settingsAppearancePreview" aria-hidden="true">
+				<span className="settingsAppearancePreviewFrame is-system">
+					<AppearancePreviewPane mode="light" />
+					<AppearancePreviewPane mode="dark" />
+				</span>
+			</span>
+		);
+	}
+
+	return (
+		<span className="settingsAppearancePreview" aria-hidden="true">
+			<AppearancePreviewPane mode={mode} />
+		</span>
+	);
+}

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -2,18 +2,22 @@ import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
 import {
 	applyUiAccent,
+	applyUiCornerRadius,
 	applyUiSurfacePreferences,
 	applyUiThemeSelection,
 } from "../../lib/appearance";
 import {
+	DEFAULT_UI_CORNER_RADIUS_STYLE,
 	DEFAULT_UI_TRANSLUCENT_APP,
 	type ThemeMode,
 	type UiAccent,
+	type UiCornerRadiusStyle,
 	type UiDarkThemeId,
 	type UiLightThemeId,
 	loadSettings,
 	setThemeMode,
 	setUiAccent,
+	setUiCornerRadiusStyle,
 	setUiDarkThemeId,
 	setUiLightThemeId,
 	setUiTranslucentApp,
@@ -31,6 +35,7 @@ import {
 	isGlyphDefaultLightTheme,
 } from "../../lib/uiThemes";
 import { AppearanceAccentCard } from "./AppearanceAccentCard";
+import { AppearanceCornerRadiusCard } from "./AppearanceCornerRadiusCard";
 import { AppearanceThemeCard } from "./AppearanceThemeCard";
 import { AppearanceTypographyCard } from "./AppearanceTypographyCard";
 import { useAppearanceTypography } from "./useAppearanceTypography";
@@ -48,6 +53,8 @@ export function AppearanceSettingsPane() {
 	const [translucentApp, setTranslucentAppState] = useState(
 		DEFAULT_UI_TRANSLUCENT_APP,
 	);
+	const [cornerRadiusStyle, setCornerRadiusStyleState] =
+		useState<UiCornerRadiusStyle>(DEFAULT_UI_CORNER_RADIUS_STYLE);
 	const [error, setError] = useState("");
 	const {
 		fontFamily,
@@ -75,6 +82,7 @@ export function AppearanceSettingsPane() {
 				setDarkThemeIdState(settings.ui.darkThemeId);
 				setAccentState(settings.ui.accent);
 				setTranslucentAppState(settings.ui.translucentApp);
+				setCornerRadiusStyleState(settings.ui.cornerRadiusStyle);
 				setTheme(settings.ui.theme);
 				applyUiThemeSelection(
 					settings.ui.lightThemeId,
@@ -84,6 +92,7 @@ export function AppearanceSettingsPane() {
 				applyUiSurfacePreferences({
 					translucentApp: settings.ui.translucentApp,
 				});
+				applyUiCornerRadius(settings.ui.cornerRadiusStyle);
 			} catch (e) {
 				if (!cancelled) {
 					setError(e instanceof Error ? e.message : "Failed to load settings");
@@ -169,16 +178,33 @@ export function AppearanceSettingsPane() {
 		}
 	}, []);
 
+	const onCornerRadiusStyleChange = useCallback(
+		async (next: UiCornerRadiusStyle) => {
+			setError("");
+			const previous = cornerRadiusStyle;
+			setCornerRadiusStyleState(next);
+			applyUiCornerRadius(next);
+			try {
+				await setUiCornerRadiusStyle(next);
+			} catch (e) {
+				setCornerRadiusStyleState(previous);
+				applyUiCornerRadius(previous);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[cornerRadiusStyle],
+	);
+
 	const showAccentCard =
 		isGlyphDefaultLightTheme(lightThemeId) ||
 		isGlyphDefaultDarkTheme(darkThemeId);
 	const accentDescription =
 		isGlyphDefaultLightTheme(lightThemeId) &&
 		isGlyphDefaultDarkTheme(darkThemeId)
-			? "Choose the accent used for highlights, focus rings, and emphasis in the default light and dark themes."
+			? "Sets the accent for highlights, focus rings, and emphasis in the default light and dark themes."
 			: isGlyphDefaultLightTheme(lightThemeId)
-				? "Choose the accent used for highlights, focus rings, and emphasis in the default light theme."
-				: "Choose the accent used for highlights, focus rings, and emphasis in the default dark theme.";
+				? "Sets the accent for highlights, focus rings, and emphasis in the default light theme."
+				: "Sets the accent for highlights, focus rings, and emphasis in the default dark theme.";
 	const lightTheme = getUiLightThemeOption(lightThemeId);
 	const darkTheme = getUiDarkThemeOption(darkThemeId);
 
@@ -198,6 +224,10 @@ export function AppearanceSettingsPane() {
 					onLightThemeChange={onLightThemeChange}
 					onDarkThemeChange={onDarkThemeChange}
 					onTranslucentAppChange={onTranslucentAppChange}
+				/>
+				<AppearanceCornerRadiusCard
+					cornerRadiusStyle={cornerRadiusStyle}
+					onCornerRadiusStyleChange={onCornerRadiusStyleChange}
 				/>
 				{showAccentCard ? (
 					<AppearanceAccentCard

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -2,22 +2,18 @@ import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
 import {
 	applyUiAccent,
-	applyUiCornerRadius,
 	applyUiSurfacePreferences,
 	applyUiThemeSelection,
 } from "../../lib/appearance";
 import {
-	DEFAULT_UI_CORNER_RADIUS_STYLE,
 	DEFAULT_UI_TRANSLUCENT_APP,
 	type ThemeMode,
 	type UiAccent,
-	type UiCornerRadiusStyle,
 	type UiDarkThemeId,
 	type UiLightThemeId,
 	loadSettings,
 	setThemeMode,
 	setUiAccent,
-	setUiCornerRadiusStyle,
 	setUiDarkThemeId,
 	setUiLightThemeId,
 	setUiTranslucentApp,
@@ -38,6 +34,7 @@ import { AppearanceAccentCard } from "./AppearanceAccentCard";
 import { AppearanceCornerRadiusCard } from "./AppearanceCornerRadiusCard";
 import { AppearanceThemeCard } from "./AppearanceThemeCard";
 import { AppearanceTypographyCard } from "./AppearanceTypographyCard";
+import { useAppearanceCornerRadius } from "./useAppearanceCornerRadius";
 import { useAppearanceTypography } from "./useAppearanceTypography";
 
 export function AppearanceSettingsPane() {
@@ -53,9 +50,9 @@ export function AppearanceSettingsPane() {
 	const [translucentApp, setTranslucentAppState] = useState(
 		DEFAULT_UI_TRANSLUCENT_APP,
 	);
-	const [cornerRadiusStyle, setCornerRadiusStyleState] =
-		useState<UiCornerRadiusStyle>(DEFAULT_UI_CORNER_RADIUS_STYLE);
 	const [error, setError] = useState("");
+	const { cornerRadiusStyle, onCornerRadiusStyleChange } =
+		useAppearanceCornerRadius({ setError });
 	const {
 		fontFamily,
 		editorFontFamily,
@@ -82,7 +79,6 @@ export function AppearanceSettingsPane() {
 				setDarkThemeIdState(settings.ui.darkThemeId);
 				setAccentState(settings.ui.accent);
 				setTranslucentAppState(settings.ui.translucentApp);
-				setCornerRadiusStyleState(settings.ui.cornerRadiusStyle);
 				setTheme(settings.ui.theme);
 				applyUiThemeSelection(
 					settings.ui.lightThemeId,
@@ -92,7 +88,6 @@ export function AppearanceSettingsPane() {
 				applyUiSurfacePreferences({
 					translucentApp: settings.ui.translucentApp,
 				});
-				applyUiCornerRadius(settings.ui.cornerRadiusStyle);
 			} catch (e) {
 				if (!cancelled) {
 					setError(e instanceof Error ? e.message : "Failed to load settings");
@@ -177,23 +172,6 @@ export function AppearanceSettingsPane() {
 			setError(e instanceof Error ? e.message : "Failed to save settings");
 		}
 	}, []);
-
-	const onCornerRadiusStyleChange = useCallback(
-		async (next: UiCornerRadiusStyle) => {
-			setError("");
-			const previous = cornerRadiusStyle;
-			setCornerRadiusStyleState(next);
-			applyUiCornerRadius(next);
-			try {
-				await setUiCornerRadiusStyle(next);
-			} catch (e) {
-				setCornerRadiusStyleState(previous);
-				applyUiCornerRadius(previous);
-				setError(e instanceof Error ? e.message : "Failed to save settings");
-			}
-		},
-		[cornerRadiusStyle],
-	);
 
 	const showAccentCard =
 		isGlyphDefaultLightTheme(lightThemeId) ||

--- a/src/components/settings/AppearanceThemeCard.tsx
+++ b/src/components/settings/AppearanceThemeCard.tsx
@@ -10,12 +10,12 @@ import type {
 import type { UiThemeOption, UiThemePreview } from "../../lib/uiThemes";
 import { ChevronDown } from "../Icons";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
+import { AppearanceThemeModePicker } from "./AppearanceThemeModePicker";
 import {
 	SettingsRow,
 	SettingsSection,
 	SettingsToggle,
 } from "./SettingsScaffold";
-import { AppearanceThemeModePicker } from "./AppearanceThemeModePicker";
 import { getAccentPreviewColor } from "./accentOptions";
 
 interface AppearanceThemeCardProps {

--- a/src/components/settings/AppearanceThemeCard.tsx
+++ b/src/components/settings/AppearanceThemeCard.tsx
@@ -15,7 +15,7 @@ import {
 	SettingsSection,
 	SettingsToggle,
 } from "./SettingsScaffold";
-import { SettingsSelect } from "./SettingsSelect";
+import { AppearanceThemeModePicker } from "./AppearanceThemeModePicker";
 import { getAccentPreviewColor } from "./accentOptions";
 
 interface AppearanceThemeCardProps {
@@ -31,12 +31,6 @@ interface AppearanceThemeCardProps {
 	onDarkThemeChange: (themeId: UiDarkThemeId) => Promise<void>;
 	onTranslucentAppChange: (enabled: boolean) => Promise<void>;
 }
-
-const THEME_MODE_OPTIONS = [
-	{ label: "System", value: "system" },
-	{ label: "Light", value: "light" },
-	{ label: "Dark", value: "dark" },
-] as const satisfies readonly { label: string; value: ThemeMode }[];
 
 function resolvePreview<T extends string>(
 	option: UiThemeOption<T>,
@@ -216,20 +210,15 @@ export function AppearanceThemeCard({
 			title="Theme"
 			description="Mix and match light and dark theme families."
 		>
-			<SettingsRow label="Select Theme" interactive={false}>
-				<SettingsSelect
-					aria-label="Theme mode"
-					value={themeMode}
-					onChange={(event) =>
-						void onThemeModeChange(event.currentTarget.value as ThemeMode)
-					}
-				>
-					{THEME_MODE_OPTIONS.map((option) => (
-						<option key={option.value} value={option.value}>
-							{option.label}
-						</option>
-					))}
-				</SettingsSelect>
+			<SettingsRow
+				label="Appearance"
+				description="Follow your system or lock Glyph to light or dark mode."
+				interactive={false}
+			>
+				<AppearanceThemeModePicker
+					themeMode={themeMode}
+					onThemeModeChange={onThemeModeChange}
+				/>
 			</SettingsRow>
 
 			<ThemeSelector

--- a/src/components/settings/AppearanceThemeModePicker.tsx
+++ b/src/components/settings/AppearanceThemeModePicker.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@/lib/utils";
 import type { ThemeMode } from "../../lib/settings";
 import { AppearancePreviewFrame } from "./AppearancePreviewFrame";
+import { SettingsSegmentedPicker } from "./SettingsSegmentedPicker";
 import { THEME_MODE_OPTIONS } from "./themeModeOptions";
 
 interface AppearanceThemeModePickerProps {
@@ -13,35 +13,16 @@ export function AppearanceThemeModePicker({
 	onThemeModeChange,
 }: AppearanceThemeModePickerProps) {
 	return (
-		<div className="settingsSegmentedPicker">
-			<div
-				className="settingsSegmentedTrack"
-				role="radiogroup"
-				aria-label="Theme mode"
-			>
-				{THEME_MODE_OPTIONS.map((option) => (
-					<label
-						key={option.value}
-						className={cn(
-							"settingsSegmentedOption",
-							themeMode === option.value && "is-active",
-						)}
-						data-theme-mode-preview={option.value}
-						title={option.description}
-					>
-						<input
-							type="radio"
-							name="settings-theme-mode"
-							checked={themeMode === option.value}
-							onChange={() => void onThemeModeChange(option.value)}
-							className="settingsSegmentedInput"
-							aria-label={option.label}
-						/>
-						<AppearancePreviewFrame mode={option.value} />
-						<span className="settingsSegmentedLabel">{option.label}</span>
-					</label>
-				))}
-			</div>
-		</div>
+		<SettingsSegmentedPicker
+			name="settings-theme-mode"
+			ariaLabel="Theme mode"
+			value={themeMode}
+			options={THEME_MODE_OPTIONS}
+			onChange={(next) => void onThemeModeChange(next)}
+			renderPreview={(value) => <AppearancePreviewFrame mode={value} />}
+			getDataAttributes={(value) => ({
+				"data-theme-mode-preview": value,
+			})}
+		/>
 	);
 }

--- a/src/components/settings/AppearanceThemeModePicker.tsx
+++ b/src/components/settings/AppearanceThemeModePicker.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+import type { ThemeMode } from "../../lib/settings";
+import { AppearancePreviewFrame } from "./AppearancePreviewFrame";
+import { THEME_MODE_OPTIONS } from "./themeModeOptions";
+
+interface AppearanceThemeModePickerProps {
+	themeMode: ThemeMode;
+	onThemeModeChange: (mode: ThemeMode) => Promise<void>;
+}
+
+export function AppearanceThemeModePicker({
+	themeMode,
+	onThemeModeChange,
+}: AppearanceThemeModePickerProps) {
+	return (
+		<div className="settingsSegmentedPicker">
+			<div
+				className="settingsSegmentedTrack"
+				role="radiogroup"
+				aria-label="Theme mode"
+			>
+				{THEME_MODE_OPTIONS.map((option) => (
+					<label
+						key={option.value}
+						className={cn(
+							"settingsSegmentedOption",
+							themeMode === option.value && "is-active",
+						)}
+						data-theme-mode-preview={option.value}
+						title={option.description}
+					>
+						<input
+							type="radio"
+							name="settings-theme-mode"
+							checked={themeMode === option.value}
+							onChange={() => void onThemeModeChange(option.value)}
+							className="settingsSegmentedInput"
+							aria-label={option.label}
+						/>
+						<AppearancePreviewFrame mode={option.value} />
+						<span className="settingsSegmentedLabel">{option.label}</span>
+					</label>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/components/settings/SettingsSegmentedPicker.tsx
+++ b/src/components/settings/SettingsSegmentedPicker.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface SettingsSegmentedPickerOption<T extends string> {
+	value: T;
+	label: string;
+	description: string;
+}
+
+interface SettingsSegmentedPickerProps<T extends string> {
+	name: string;
+	ariaLabel: string;
+	value: T;
+	options: readonly SettingsSegmentedPickerOption<T>[];
+	onChange: (value: T) => void;
+	renderPreview: (value: T) => ReactNode;
+	getDataAttributes?: (value: T) => Record<`data-${string}`, string>;
+}
+
+export function SettingsSegmentedPicker<T extends string>({
+	name,
+	ariaLabel,
+	value,
+	options,
+	onChange,
+	renderPreview,
+	getDataAttributes,
+}: SettingsSegmentedPickerProps<T>) {
+	return (
+		<div className="settingsSegmentedPicker">
+			<div
+				className="settingsSegmentedTrack"
+				role="radiogroup"
+				aria-label={ariaLabel}
+			>
+				{options.map((option) => (
+					<label
+						key={option.value}
+						className={cn(
+							"settingsSegmentedOption",
+							value === option.value && "is-active",
+						)}
+						title={option.description}
+						{...(getDataAttributes?.(option.value) ?? {})}
+					>
+						<input
+							type="radio"
+							name={name}
+							checked={value === option.value}
+							onChange={() => onChange(option.value)}
+							className="settingsSegmentedInput"
+							aria-label={option.label}
+						/>
+						{renderPreview(option.value)}
+						<span className="settingsSegmentedLabel">{option.label}</span>
+					</label>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/components/settings/cornerRadiusOptions.ts
+++ b/src/components/settings/cornerRadiusOptions.ts
@@ -1,22 +1,22 @@
 import type { UiCornerRadiusStyle } from "../../lib/settings";
 
 export const CORNER_RADIUS_OPTIONS: Array<{
-	id: UiCornerRadiusStyle;
+	value: UiCornerRadiusStyle;
 	label: string;
 	description: string;
 }> = [
 	{
-		id: "sharp",
+		value: "sharp",
 		label: "Brutalist",
 		description: "Crisp, square edges throughout the app.",
 	},
 	{
-		id: "default",
+		value: "default",
 		label: "Default",
 		description: "Glyph's balanced look.",
 	},
 	{
-		id: "round",
+		value: "round",
 		label: "Soft",
 		description: "Gentler, more rounded edges throughout the app.",
 	},

--- a/src/components/settings/cornerRadiusOptions.ts
+++ b/src/components/settings/cornerRadiusOptions.ts
@@ -1,0 +1,23 @@
+import type { UiCornerRadiusStyle } from "../../lib/settings";
+
+export const CORNER_RADIUS_OPTIONS: Array<{
+	id: UiCornerRadiusStyle;
+	label: string;
+	description: string;
+}> = [
+	{
+		id: "sharp",
+		label: "Brutalist",
+		description: "Crisp, square edges throughout the app.",
+	},
+	{
+		id: "default",
+		label: "Default",
+		description: "Glyph's balanced look.",
+	},
+	{
+		id: "round",
+		label: "Soft",
+		description: "Gentler, more rounded edges throughout the app.",
+	},
+];

--- a/src/components/settings/themeModeOptions.ts
+++ b/src/components/settings/themeModeOptions.ts
@@ -1,0 +1,23 @@
+import type { ThemeMode } from "../../lib/settings";
+
+export const THEME_MODE_OPTIONS: Array<{
+	value: ThemeMode;
+	label: string;
+	description: string;
+}> = [
+	{
+		value: "system",
+		label: "System",
+		description: "Match your device light or dark appearance.",
+	},
+	{
+		value: "light",
+		label: "Light",
+		description: "Always use light mode.",
+	},
+	{
+		value: "dark",
+		label: "Dark",
+		description: "Always use dark mode.",
+	},
+];

--- a/src/components/settings/useAppearanceCornerRadius.ts
+++ b/src/components/settings/useAppearanceCornerRadius.ts
@@ -1,0 +1,88 @@
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { applyUiCornerRadius } from "../../lib/appearance";
+import {
+	DEFAULT_UI_CORNER_RADIUS_STYLE,
+	type UiCornerRadiusStyle,
+	loadSettings,
+	setUiCornerRadiusStyle,
+} from "../../lib/settings";
+
+interface UseAppearanceCornerRadiusOptions {
+	setError: Dispatch<SetStateAction<string>>;
+}
+
+export function useAppearanceCornerRadius({
+	setError,
+}: UseAppearanceCornerRadiusOptions) {
+	const [cornerRadiusStyle, setCornerRadiusStyleState] =
+		useState<UiCornerRadiusStyle>(DEFAULT_UI_CORNER_RADIUS_STYLE);
+	const cornerRadiusMutationRef = useRef(0);
+	const persistedCornerRadiusStyleRef = useRef<UiCornerRadiusStyle>(
+		DEFAULT_UI_CORNER_RADIUS_STYLE,
+	);
+	const cornerRadiusWriteQueueRef = useRef<Promise<unknown>>(Promise.resolve());
+
+	const applyCornerRadiusState = useCallback((next: UiCornerRadiusStyle) => {
+		setCornerRadiusStyleState(next);
+		applyUiCornerRadius(next);
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		const hydrationMutationId = cornerRadiusMutationRef.current;
+		void (async () => {
+			try {
+				const settings = await loadSettings();
+				if (
+					cancelled ||
+					cornerRadiusMutationRef.current !== hydrationMutationId
+				) {
+					return;
+				}
+				persistedCornerRadiusStyleRef.current = settings.ui.cornerRadiusStyle;
+				applyCornerRadiusState(settings.ui.cornerRadiusStyle);
+			} catch (e) {
+				if (!cancelled) {
+					setError(e instanceof Error ? e.message : "Failed to load settings");
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [applyCornerRadiusState, setError]);
+
+	const onCornerRadiusStyleChange = useCallback(
+		async (next: UiCornerRadiusStyle) => {
+			const mutationId = cornerRadiusMutationRef.current + 1;
+			cornerRadiusMutationRef.current = mutationId;
+			setError("");
+			applyCornerRadiusState(next);
+			const persist = cornerRadiusWriteQueueRef.current.then(() =>
+				setUiCornerRadiusStyle(next),
+			);
+			cornerRadiusWriteQueueRef.current = persist.catch(() => {});
+			try {
+				await persist;
+				persistedCornerRadiusStyleRef.current = next;
+			} catch (e) {
+				if (cornerRadiusMutationRef.current !== mutationId) return;
+				applyCornerRadiusState(persistedCornerRadiusStyleRef.current);
+				setError(e instanceof Error ? e.message : "Failed to save settings");
+			}
+		},
+		[applyCornerRadiusState, setError],
+	);
+
+	return {
+		cornerRadiusStyle,
+		onCornerRadiusStyleChange,
+	};
+}

--- a/src/design-tokens.css
+++ b/src/design-tokens.css
@@ -1,4 +1,5 @@
 @import "./styles/themes/primitives.css";
+@import "./styles/themes/corner-radius.css";
 @import "./styles/themes/semantic-base.css";
 @import "./styles/themes/light-themes.css";
 @import "./styles/themes/dark-themes.css";

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -3,6 +3,7 @@ import {
 	MAX_EDITOR_FONT_SIZE,
 	MIN_EDITOR_FONT_SIZE,
 	type UiAccent,
+	type UiCornerRadiusStyle,
 	type UiFontFamily,
 	type UiFontSize,
 	isUiAccent,
@@ -189,6 +190,15 @@ export function applyUiTypography({
 	for (const property of DERIVED_EDITOR_FONT_SIZE_PROPERTIES) {
 		root.style.removeProperty(property);
 	}
+}
+
+export function applyUiCornerRadius(style: UiCornerRadiusStyle): void {
+	const root = document.documentElement;
+	if (style === "default") {
+		delete root.dataset.cornerRadiusStyle;
+		return;
+	}
+	root.dataset.cornerRadiusStyle = style;
 }
 
 export function applyUiAccent(

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -152,6 +152,58 @@ describe("settings Folio Mode", () => {
 	});
 });
 
+describe("settings corner radius style", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults corner radius style to default", async () => {
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.ui.cornerRadiusStyle).toBe("default");
+	});
+
+	it("loads corner radius style from the store", async () => {
+		storeState.set("ui.cornerRadiusStyle", "round");
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.ui.cornerRadiusStyle).toBe("round");
+	});
+
+	it("falls back to default for invalid corner radius style values", async () => {
+		storeState.set("ui.cornerRadiusStyle", "invalid");
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.ui.cornerRadiusStyle).toBe("default");
+	});
+
+	it("persists and emits corner radius style changes", async () => {
+		const { setUiCornerRadiusStyle } = await import("./settings");
+
+		await setUiCornerRadiusStyle("sharp");
+
+		expect(storeState.get("ui.cornerRadiusStyle")).toBe("sharp");
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { cornerRadiusStyle: "sharp" },
+		});
+
+		await setUiCornerRadiusStyle("round");
+
+		expect(storeState.get("ui.cornerRadiusStyle")).toBe("round");
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { cornerRadiusStyle: "round" },
+		});
+	});
+});
+
 describe("settings app translucency", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -172,6 +172,28 @@ const UI_ACCENTS = new Set<UiAccent>([
 export function isUiAccent(value: unknown): value is UiAccent {
 	return typeof value === "string" && UI_ACCENTS.has(value as UiAccent);
 }
+export type UiCornerRadiusStyle = "default" | "sharp" | "round";
+const UI_CORNER_RADIUS_STYLES = new Set<UiCornerRadiusStyle>([
+	"default",
+	"sharp",
+	"round",
+]);
+
+export function isUiCornerRadiusStyle(
+	value: unknown,
+): value is UiCornerRadiusStyle {
+	return (
+		typeof value === "string" &&
+		UI_CORNER_RADIUS_STYLES.has(value as UiCornerRadiusStyle)
+	);
+}
+
+export const DEFAULT_UI_CORNER_RADIUS_STYLE: UiCornerRadiusStyle = "default";
+
+function asUiCornerRadiusStyle(value: unknown): UiCornerRadiusStyle {
+	return isUiCornerRadiusStyle(value) ? value : DEFAULT_UI_CORNER_RADIUS_STYLE;
+}
+
 const DEFAULT_UI_ACCENT: UiAccent = "neutral";
 const DEFAULT_UI_FONT_FAMILY = "Geist";
 const DEFAULT_UI_EDITOR_FONT_FAMILY = DEFAULT_UI_FONT_FAMILY;
@@ -384,6 +406,7 @@ async function emitSettingsUpdated(payload: {
 		fontSize?: UiFontSize;
 		editorFontSize?: UiFontSize;
 		translucentApp?: boolean;
+		cornerRadiusStyle?: UiCornerRadiusStyle;
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
 		folioMode?: boolean;
@@ -456,6 +479,7 @@ interface AppSettings {
 		fontSize: UiFontSize;
 		editorFontSize: UiFontSize;
 		translucentApp: boolean;
+		cornerRadiusStyle: UiCornerRadiusStyle;
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
 		folioMode: boolean;
@@ -525,6 +549,7 @@ const KEYS = {
 	fontSize: "ui.fontSize",
 	editorFontSize: "ui.editorFontSize",
 	translucentApp: "ui.translucentApp",
+	cornerRadiusStyle: "ui.cornerRadiusStyle",
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
 	folioMode: "ui.folioMode",
@@ -844,6 +869,7 @@ export async function loadSettings(
 		entries,
 		KEYS.translucentApp,
 	);
+	const rawCornerRadiusStyle = getSettingValue(entries, KEYS.cornerRadiusStyle);
 	const rawShowToc = getSettingValue<boolean | null>(entries, KEYS.showToc);
 	const rawShowFileTreeFolderCounts = getSettingValue<boolean | null>(
 		entries,
@@ -976,6 +1002,7 @@ export async function loadSettings(
 		typeof rawTranslucentApp === "boolean"
 			? rawTranslucentApp
 			: DEFAULT_UI_TRANSLUCENT_APP;
+	const cornerRadiusStyle = asUiCornerRadiusStyle(rawCornerRadiusStyle);
 	const showToc = typeof rawShowToc === "boolean" ? rawShowToc : true;
 	const showFileTreeFolderCounts =
 		typeof rawShowFileTreeFolderCounts === "boolean"
@@ -1074,6 +1101,7 @@ export async function loadSettings(
 			fontSize,
 			editorFontSize,
 			translucentApp,
+			cornerRadiusStyle,
 			showToc,
 			showFileTreeFolderCounts,
 			folioMode,
@@ -1313,6 +1341,16 @@ export async function setUiTranslucentApp(enabled: boolean): Promise<void> {
 	await store.set(KEYS.translucentApp, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { translucentApp: enabled } });
+}
+
+export async function setUiCornerRadiusStyle(
+	style: UiCornerRadiusStyle,
+): Promise<void> {
+	const store = await getStore();
+	const next = asUiCornerRadiusStyle(style);
+	await store.set(KEYS.cornerRadiusStyle, next);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { cornerRadiusStyle: next } });
 }
 
 export async function setShowToc(enabled: boolean): Promise<void> {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -6,6 +6,7 @@ import type {
 	EditorWidthMode,
 	ReleaseChannel,
 	UiAccent,
+	UiCornerRadiusStyle,
 } from "./settings";
 import type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 
@@ -68,6 +69,7 @@ type TauriEventMap = {
 			fontSize?: number;
 			editorFontSize?: number;
 			translucentApp?: boolean;
+			cornerRadiusStyle?: UiCornerRadiusStyle;
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
 			folioMode?: boolean;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,12 +10,23 @@ import { Toaster } from "./components/ui/shadcn/sonner";
 import {
 	applyEditorWidthMode,
 	applyUiAccent,
+	applyUiCornerRadius,
 	applyUiSurfacePreferences,
 	applyUiThemeSelection,
 	applyUiTypography,
 } from "./lib/appearance";
-import type { UiAccent, UiDarkThemeId, UiLightThemeId } from "./lib/settings";
-import { isUiAccent, loadSettings, reloadFromDisk } from "./lib/settings";
+import type {
+	UiAccent,
+	UiCornerRadiusStyle,
+	UiDarkThemeId,
+	UiLightThemeId,
+} from "./lib/settings";
+import {
+	isUiAccent,
+	isUiCornerRadiusStyle,
+	loadSettings,
+	reloadFromDisk,
+} from "./lib/settings";
 import { invoke } from "./lib/tauri";
 import { useTauriEvent } from "./lib/tauriEvents";
 import { isUiDarkThemeId, isUiLightThemeId } from "./lib/uiThemes";
@@ -48,6 +59,8 @@ function ThemeAndTypographyBridge() {
 	const [translucentApp, setTranslucentApp] = React.useState<boolean | null>(
 		null,
 	);
+	const [cornerRadiusStyle, setCornerRadiusStyle] =
+		React.useState<UiCornerRadiusStyle | null>(null);
 
 	React.useEffect(() => {
 		let cancelled = false;
@@ -69,6 +82,7 @@ function ThemeAndTypographyBridge() {
 				setUiFontSize(settings.ui.fontSize);
 				setEditorFontSize(settings.ui.editorFontSize);
 				setTranslucentApp(settings.ui.translucentApp);
+				setCornerRadiusStyle(settings.ui.cornerRadiusStyle);
 				applyEditorWidthMode(settings.editor.editorWidthMode);
 				void invoke("index_set_people_mentions_as_tags_enabled", {
 					enabled: settings.editor.enablePeopleMentionsAsTags,
@@ -143,6 +157,9 @@ function ThemeAndTypographyBridge() {
 		if (typeof payload.ui?.translucentApp === "boolean") {
 			setTranslucentApp(payload.ui.translucentApp);
 		}
+		if (isUiCornerRadiusStyle(payload.ui?.cornerRadiusStyle)) {
+			setCornerRadiusStyle(payload.ui.cornerRadiusStyle);
+		}
 		if (
 			payload.editor?.editorWidthMode === "compact" ||
 			payload.editor?.editorWidthMode === "comfortable" ||
@@ -203,6 +220,11 @@ function ThemeAndTypographyBridge() {
 		if (typeof translucentApp !== "boolean") return;
 		applyUiSurfacePreferences({ translucentApp });
 	}, [translucentApp]);
+
+	React.useEffect(() => {
+		if (cornerRadiusStyle === null) return;
+		applyUiCornerRadius(cornerRadiusStyle);
+	}, [cornerRadiusStyle]);
 
 	React.useEffect(() => {
 		if (typeof translucentApp !== "boolean") return;

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -38,7 +38,7 @@
 	transform: translateX(-50%);
 	padding: 10px 12px 9px;
 	border: 1px solid color-mix(in srgb, var(--border-light) 78%, transparent);
-	border-radius: 12px;
+	border-radius: calc(var(--radius-6) + var(--radius-6));
 	background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
 	box-shadow: var(--shadow-md);
 	backdrop-filter: blur(18px) saturate(1.2);

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -124,7 +124,7 @@
 	height: 20px;
 	padding: 0 6px 0 5px;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: rgb(0 112 249);
 	box-shadow: inset 0 0 0 0.5px color-mix(in srgb, white 28%, transparent);
 	color: white;

--- a/src/styles/app/07-ai-panel.css
+++ b/src/styles/app/07-ai-panel.css
@@ -469,7 +469,7 @@
 	bottom: 4px;
 	left: 0;
 	width: 2px;
-	border-radius: 1px;
+	border-radius: var(--radius-2);
 	background: linear-gradient(
 		180deg,
 		var(--ai-mode-accent, var(--interactive-accent)),

--- a/src/styles/app/09-settings-shell.css
+++ b/src/styles/app/09-settings-shell.css
@@ -59,7 +59,7 @@
 	min-height: 26px;
 	padding: 2px 30px 2px 30px;
 	border: 1px solid transparent;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: var(--bg-tertiary);
 	color: var(--text-secondary);
 	font-size: var(--text-sm);
@@ -88,7 +88,7 @@
 	width: 20px;
 	height: 20px;
 	border: 0;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: transparent;
 	color: var(--text-tertiary);
 	cursor: pointer;
@@ -121,7 +121,7 @@
 	align-items: flex-start;
 	gap: 4px;
 	border: 1px solid transparent;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: transparent;
 	color: var(--text-primary);
 	cursor: pointer;
@@ -314,7 +314,7 @@
 	font-weight: var(--font-medium);
 	line-height: 1;
 	border: 1px solid transparent;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	transition: background var(--transition-fast), border-color
 		var(--transition-fast), color var(--transition-fast);
 }

--- a/src/styles/app/10-settings-controls.css
+++ b/src/styles/app/10-settings-controls.css
@@ -286,7 +286,7 @@
 	width: var(--icon-xl);
 	height: var(--icon-xl);
 	object-fit: contain;
-	border-radius: 3px;
+	border-radius: var(--radius-3);
 	display: block;
 }
 

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -97,7 +97,7 @@ button.tagsHeaderTitle:active {
 	gap: var(--space-3);
 	padding: 1px 8px;
 	min-height: 28px;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	color: var(--text-primary);
 	font-size: var(--text-sm);
 }

--- a/src/styles/app/15-activity-timeline.css
+++ b/src/styles/app/15-activity-timeline.css
@@ -115,7 +115,7 @@
 .activityHeatmapCell,
 .activityHeatmapLegendCell {
 	border: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	background: color-mix(in srgb, var(--bg-tertiary) 82%, var(--bg-secondary));
 	box-shadow: none;
 }
@@ -197,7 +197,7 @@
 	width: max-content;
 	max-width: 180px;
 	padding: 5px 7px;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: color-mix(in srgb, var(--text-primary) 92%, var(--bg-primary));
 	color: var(--bg-primary);
 	font-size: calc(var(--text-base) * 0.72);
@@ -410,7 +410,7 @@
 	min-height: 30px;
 	padding: 0 12px;
 	border: 1px solid color-mix(in srgb, var(--border-light) 86%, transparent);
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: var(--bg-primary);
 	color: var(--text-primary);
 	font-size: var(--text-sm);

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -38,7 +38,7 @@
 	min-height: 32px;
 	padding: 0 10px;
 	border: 1px solid color-mix(in srgb, var(--text-primary) 9%, transparent);
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: color-mix(in srgb, var(--bg-primary) 94%, var(--bg-secondary));
 	color: var(--text-secondary);
 	font: inherit;
@@ -174,7 +174,7 @@
 	min-height: var(--all-docs-card-min-height);
 	min-width: 0;
 	padding: var(--all-docs-card-padding);
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
 	border: 1px solid color-mix(in srgb, var(--text-primary) 9%, transparent);
 	box-shadow: 0 10px 22px -18px rgb(30 41 59 / 0.26);

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -151,7 +151,7 @@
 
 .fileTreeItem:hover > .fileTreeRowShell > .fileTreeRow {
 	background: var(--bg-hover);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 }
 
 .fileTreeItem:hover > .fileTreeRowShell > .fileTreeRow .fileTreeIcon {
@@ -161,7 +161,7 @@
 .fileTreeItem.active > .fileTreeRowShell > .fileTreeRow {
 	background: var(--bg-active);
 	color: var(--text-primary);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 }
 
 .fileTreeRowShell {
@@ -182,7 +182,7 @@
 	min-height: 24px;
 	padding: 0 8px;
 	text-align: left;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	margin: 0;
 	border: 1px solid transparent;
 	transition: background var(--transition-fast), color var(--transition-fast),
@@ -239,7 +239,7 @@
 	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	box-shadow: inset 0 0 0 1px
 		color-mix(in srgb, var(--interactive-accent) 34%, transparent);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 }
 
 .fileTreeChildren {
@@ -249,7 +249,7 @@
 .fileTreeChildren[data-drop-target="true"] {
 	box-shadow: inset 0 0 0 1px
 		color-mix(in srgb, var(--interactive-accent) 22%, transparent);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 }
 
 .fileTreeRow[data-draggable="true"]:not([data-dragging="true"]) {

--- a/src/styles/app/23-node-note-editor-a.css
+++ b/src/styles/app/23-node-note-editor-a.css
@@ -265,7 +265,7 @@
 	);
 	margin: 0 auto 6px;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	padding: 5px 10px;
 	background: color-mix(in srgb, var(--bg-secondary) 54%, transparent);
 	color: var(--text-secondary);

--- a/src/styles/app/23-raw-markdown-editor.css
+++ b/src/styles/app/23-raw-markdown-editor.css
@@ -330,7 +330,7 @@
 }
 
 .rfNodeNoteEditorRaw .cm-raw-task-checkbox {
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	background: color-mix(in srgb, var(--bg-secondary) 84%, var(--bg-primary));
 	box-shadow: inset 0 0 0 1px
 		color-mix(in srgb, var(--text-tertiary) 42%, transparent);

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -68,7 +68,7 @@
 	gap: 0;
 	padding: 1px;
 	border: none;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: color-mix(in srgb, var(--bg-secondary) 58%, transparent);
 }
 
@@ -81,7 +81,7 @@
 	height: 24px;
 	padding: 0;
 	border: none;
-	border-radius: 7px;
+	border-radius: var(--radius-7);
 	background: transparent;
 	color: var(--text-secondary);
 	cursor: pointer;
@@ -535,7 +535,7 @@ input.notePropertyValue {
 	outline: 2px solid
 		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	outline-offset: 2px;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 }
 
 .notePropertyStatusMenu {
@@ -558,7 +558,7 @@ input.notePropertyValue {
 	width: 100%;
 	gap: 6px;
 	padding: 3px 24px 3px 5px;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	text-align: left;
 	color: var(--text-secondary);
 }

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -90,7 +90,7 @@
 		var(--bg-secondary)
 	);
 	border: 0;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	padding: 1px 7px;
 	font-weight: var(--font-semibold);
 	line-height: 1.35;
@@ -115,7 +115,7 @@
 	vertical-align: super;
 	line-height: 0;
 	cursor: pointer;
-	border-radius: 3px;
+	border-radius: var(--radius-3);
 	padding: 0 1px;
 	transition: background 120ms ease;
 }
@@ -129,7 +129,7 @@
 	font-size: 0.85em;
 	font-weight: var(--font-semibold);
 	cursor: pointer;
-	border-radius: 3px;
+	border-radius: var(--radius-3);
 	transition: background 120ms ease;
 }
 .tiptapContentInline .footnoteDef:hover {
@@ -188,7 +188,7 @@
 }
 
 .noteSearchMatch {
-	border-radius: 3px;
+	border-radius: var(--radius-3);
 	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	box-shadow: 0 0 0 1px
 		color-mix(in srgb, var(--interactive-accent) 12%, transparent);

--- a/src/styles/app/28-settings-advanced-controls.css
+++ b/src/styles/app/28-settings-advanced-controls.css
@@ -214,6 +214,330 @@
 		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 }
 
+.settingsSegmentedPicker {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	width: 100%;
+}
+
+.settingsSegmentedTrack {
+	display: inline-flex;
+	align-items: stretch;
+	gap: 3px;
+	flex-shrink: 0;
+	padding: 4px;
+	border-radius: calc(var(--radius-lg) + 2px);
+	border: 1px solid color-mix(in srgb, var(--border-light) 58%, transparent);
+	background: color-mix(in srgb, var(--bg-tertiary) 72%, var(--bg-primary));
+	box-shadow: inset 0 1px 0
+		color-mix(in srgb, var(--text-primary) 5%, transparent);
+}
+
+.settingsSegmentedOption {
+	display: inline-flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	min-width: 84px;
+	padding: 10px 12px 9px;
+	border-radius: var(--radius-md);
+	border: 1px solid transparent;
+	background: transparent;
+	cursor: pointer;
+	position: relative;
+	transition: border-color var(--transition-base), box-shadow
+		var(--transition-base), background var(--transition-base), transform
+		var(--transition-base);
+}
+
+.settingsSegmentedOption:active {
+	transform: scale(0.98);
+}
+
+.settingsSegmentedInput {
+	position: absolute;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.settingsSegmentedLabel {
+	font-size: calc(var(--text-base) * 0.74);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.01em;
+	color: var(--text-secondary);
+	transition: color var(--transition-base);
+}
+
+.settingsSegmentedOption:hover {
+	background: color-mix(in srgb, var(--bg-hover) 58%, transparent);
+}
+
+.settingsSegmentedOption.is-active {
+	background: color-mix(in srgb, var(--bg-primary) 96%, transparent);
+	border-color: color-mix(in srgb, var(--border-light) 68%, transparent);
+	box-shadow: 0 1px 3px color-mix(in srgb, black 8%, transparent), 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+}
+
+.settingsSegmentedOption.is-active .settingsSegmentedLabel {
+	color: var(--text-primary);
+}
+
+:root.dark .settingsSegmentedTrack {
+	background: color-mix(in srgb, var(--bg-tertiary) 58%, var(--bg-primary));
+	box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
+}
+
+.settingsSegmentedOption[data-corner-radius-style="sharp"] {
+	--settings-corner-radius-preview: 0px;
+}
+
+.settingsSegmentedOption[data-corner-radius-style="default"] {
+	--settings-corner-radius-preview: 6px;
+}
+
+.settingsSegmentedOption[data-corner-radius-style="round"] {
+	--settings-corner-radius-preview: 12px;
+}
+
+.settingsAppearancePreview {
+	width: 58px;
+	height: 40px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.settingsAppearancePreviewFrame,
+.settingsAppearancePreviewPane {
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	border-radius: var(--settings-corner-radius-preview, var(--radius-md));
+	transition: box-shadow var(--transition-base), transform
+		var(--transition-base);
+}
+
+.settingsAppearancePreviewFrame {
+	display: flex;
+	border: 1px solid rgb(0 0 0 / 12%);
+	box-shadow: 0 1px 2px color-mix(in srgb, black 10%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 14%, transparent);
+}
+
+.settingsAppearancePreviewPane {
+	display: flex;
+	flex-direction: column;
+	gap: 5px;
+	padding: 5px 6px 6px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 62%, transparent);
+	background: linear-gradient(
+		165deg,
+		color-mix(in srgb, var(--bg-primary) 88%, white) 0%,
+		color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary)) 100%
+	);
+	box-shadow: 0 1px 2px color-mix(in srgb, black 10%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 14%, transparent);
+}
+
+.settingsAppearancePreviewFrame .settingsAppearancePreviewPane {
+	flex: 1 1 50%;
+	min-width: 0;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.settingsAppearancePreviewPane.is-light {
+	border-color: rgb(0 0 0 / 10%);
+	background: linear-gradient(165deg, #ffffff 0%, #eef0f4 100%);
+}
+
+.settingsAppearancePreviewFrame .settingsAppearancePreviewPane.is-light {
+	border-right: 1px solid rgb(0 0 0 / 8%);
+}
+
+.settingsAppearancePreviewPane.is-dark {
+	border-color: rgb(255 255 255 / 10%);
+	background: linear-gradient(165deg, #2a2a30 0%, #141418 100%);
+	box-shadow: 0 2px 6px color-mix(in srgb, black 28%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 6%, transparent);
+}
+
+.settingsAppearancePreviewChrome {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+}
+
+.settingsAppearancePreviewDot {
+	width: 4px;
+	height: 4px;
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--text-tertiary) 34%, transparent);
+}
+
+.settingsAppearancePreviewPane.is-dark .settingsAppearancePreviewDot {
+	background: rgb(255 255 255 / 22%);
+}
+
+.settingsAppearancePreviewDot:nth-child(1) {
+	background: color-mix(in srgb, #ff6b63 72%, var(--bg-primary));
+}
+
+.settingsAppearancePreviewDot:nth-child(2) {
+	background: color-mix(in srgb, #f5bf4f 76%, var(--bg-primary));
+}
+
+.settingsAppearancePreviewDot:nth-child(3) {
+	background: color-mix(in srgb, #58c76b 72%, var(--bg-primary));
+}
+
+.settingsAppearancePreviewPane.is-light
+	.settingsAppearancePreviewDot:nth-child(1) {
+	background: color-mix(in srgb, #ff6b63 82%, white);
+}
+
+.settingsAppearancePreviewPane.is-light
+	.settingsAppearancePreviewDot:nth-child(2) {
+	background: color-mix(in srgb, #f5bf4f 86%, white);
+}
+
+.settingsAppearancePreviewPane.is-light
+	.settingsAppearancePreviewDot:nth-child(3) {
+	background: color-mix(in srgb, #58c76b 82%, white);
+}
+
+.settingsAppearancePreviewPane.is-dark
+	.settingsAppearancePreviewDot:nth-child(1) {
+	background: color-mix(in srgb, #ff6b63 72%, #141418);
+}
+
+.settingsAppearancePreviewPane.is-dark
+	.settingsAppearancePreviewDot:nth-child(2) {
+	background: color-mix(in srgb, #f5bf4f 76%, #141418);
+}
+
+.settingsAppearancePreviewPane.is-dark
+	.settingsAppearancePreviewDot:nth-child(3) {
+	background: color-mix(in srgb, #58c76b 72%, #141418);
+}
+
+.settingsAppearancePreviewBody {
+	display: flex;
+	flex-direction: column;
+	gap: 3px;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+.settingsAppearancePreviewLine {
+	display: block;
+	height: 3px;
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+}
+
+.settingsAppearancePreviewPane.is-light .settingsAppearancePreviewLine {
+	background: rgb(0 0 0 / 12%);
+}
+
+.settingsAppearancePreviewPane.is-dark .settingsAppearancePreviewLine {
+	background: rgb(255 255 255 / 16%);
+}
+
+.settingsAppearancePreviewLine.is-short {
+	width: 68%;
+}
+
+.settingsAppearancePreviewButton {
+	display: block;
+	width: 42%;
+	height: 6px;
+	margin-top: auto;
+	margin-left: auto;
+	border-radius: var(--settings-corner-radius-preview, var(--radius-md));
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 72%,
+		var(--bg-primary)
+	);
+	box-shadow: inset 0 1px 0 color-mix(in srgb, white 22%, transparent);
+}
+
+.settingsAppearancePreviewPane.is-light .settingsAppearancePreviewButton,
+.settingsAppearancePreviewPane.is-dark .settingsAppearancePreviewButton {
+	border-radius: var(--radius-4);
+}
+
+.settingsAppearancePreviewPane.is-dark .settingsAppearancePreviewButton {
+	box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.settingsSegmentedOption:hover
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewPane,
+.settingsSegmentedOption:hover
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewFrame {
+	transform: translateY(-1px);
+}
+
+.settingsSegmentedOption:hover
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewPane {
+	box-shadow: 0 3px 8px color-mix(in srgb, black 12%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 14%, transparent);
+}
+
+.settingsSegmentedOption.is-active
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewPane,
+.settingsSegmentedOption.is-active
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewFrame {
+	box-shadow: 0 2px 10px
+		color-mix(in srgb, var(--interactive-accent) 16%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 16%, transparent);
+}
+
+.settingsSegmentedOption.is-active
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewPane.is-light {
+	box-shadow: 0 2px 10px color-mix(in srgb, #8ab4ff 18%, transparent), inset 0
+		1px 0 color-mix(in srgb, white 16%, transparent);
+}
+
+.settingsSegmentedOption.is-active
+	> .settingsAppearancePreview
+	> .settingsAppearancePreviewPane.is-dark {
+	box-shadow: 0 2px 10px color-mix(in srgb, #6e8cff 20%, transparent), inset 0
+		1px 0 color-mix(in srgb, white 8%, transparent);
+}
+
+.settingsSegmentedInput:focus-visible
+	+ .settingsAppearancePreview
+	> .settingsAppearancePreviewPane,
+.settingsSegmentedInput:focus-visible
+	+ .settingsAppearancePreview
+	> .settingsAppearancePreviewFrame {
+	box-shadow: 0 0 0 3px
+		color-mix(in srgb, var(--interactive-accent) 18%, transparent), 0 2px 8px
+		color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+}
+
+:root.dark .settingsAppearancePreviewPane:not(.is-light, .is-dark) {
+	background: linear-gradient(
+		165deg,
+		color-mix(in srgb, var(--bg-secondary) 90%, white) 0%,
+		color-mix(in srgb, var(--bg-tertiary) 88%, var(--bg-primary)) 100%
+	);
+	box-shadow: 0 2px 6px color-mix(in srgb, black 28%, transparent), inset 0 1px
+		0 color-mix(in srgb, white 6%, transparent);
+}
+
 @media (max-width: 760px) {
 	.settingsField {
 		gap: 10px;
@@ -236,7 +560,16 @@
 		justify-content: flex-start;
 	}
 
+	.settingsSegmentedPicker {
+		align-items: flex-start;
+		justify-content: flex-start;
+	}
+
 	.settingsAccentOptions {
+		flex-wrap: wrap;
+	}
+
+	.settingsSegmentedTrack {
 		flex-wrap: wrap;
 	}
 }
@@ -244,12 +577,25 @@
 @media (prefers-reduced-motion: reduce) {
 	.settingsField,
 	.settingsAccentDot,
+	.settingsSegmentedOption,
+	.settingsAppearancePreviewPane,
+	.settingsAppearancePreviewFrame,
 	.settingsKeySaved {
 		transition: none;
 		animation: none;
 	}
 
 	.settingsAccentDot:hover {
+		transform: none;
+	}
+
+	.settingsSegmentedOption:active,
+	.settingsSegmentedOption:hover
+		> .settingsAppearancePreview
+		> .settingsAppearancePreviewPane,
+	.settingsSegmentedOption:hover
+		> .settingsAppearancePreview
+		> .settingsAppearancePreviewFrame {
 		transform: none;
 	}
 }

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -870,7 +870,7 @@
 	font: inherit;
 	text-align: left;
 	padding: 4px 6px;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	border-left: 0;
 	font-size: calc(var(--text-base) * 0.9);
 	color: var(--text-secondary);
@@ -1022,7 +1022,7 @@
 
 .markdownEditorPane .rfNodeNoteEditor {
 	border: none;
-	border-radius: 18px;
+	border-radius: var(--radius-18);
 	background: transparent;
 }
 

--- a/src/styles/app/32-command-palette.css
+++ b/src/styles/app/32-command-palette.css
@@ -442,7 +442,7 @@
 .commandPaletteResultSnippet mark {
 	background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
 	color: color-mix(in srgb, var(--interactive-accent) 75%, var(--text-primary));
-	border-radius: 2px;
+	border-radius: var(--radius-2);
 	padding: 0 1px;
 	font-weight: var(--font-medium);
 	text-decoration: none;

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -10,7 +10,7 @@
 	color: var(--text-primary);
 	background: none;
 	border: 1px solid transparent;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	margin: 0;
 	text-align: left;
 	cursor: pointer;
@@ -51,7 +51,7 @@
 	height: var(--icon-3xl);
 	padding: 0;
 	border: 0;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: transparent;
 	color: var(--text-secondary);
 	cursor: pointer;

--- a/src/styles/app/37-database-views.css
+++ b/src/styles/app/37-database-views.css
@@ -332,7 +332,7 @@ button.databasesViewTab.is-active .databasesViewTabIcon {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	padding: 2px 6px;
 	background: color-mix(
 		in srgb,

--- a/src/styles/app/39-floating-toc.css
+++ b/src/styles/app/39-floating-toc.css
@@ -49,7 +49,7 @@
 	display: block;
 	height: 2px;
 	min-width: 4px;
-	border-radius: 1px;
+	border-radius: var(--radius-2);
 	background: color-mix(in srgb, var(--text-tertiary) 44%, transparent);
 	transform-origin: right center;
 	transition: background-color 140ms ease, opacity 140ms ease, transform 180ms

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -179,7 +179,7 @@
 	min-height: 0;
 	max-width: 100%;
 	padding: 3px 10px 3px 8px;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	border: none;
 	cursor: pointer;
 	font-size: inherit;
@@ -397,7 +397,7 @@
 	flex: 0 0 auto;
 	padding: 2px 6px;
 	border: 0;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-secondary));
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-medium);

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -6,7 +6,7 @@
 	color: var(--text-primary);
 	background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
 	border: 1px solid color-mix(in srgb, var(--border-default) 62%, transparent);
-	border-radius: 22px;
+	border-radius: var(--radius-24);
 	box-shadow: 0 24px 64px color-mix(in srgb, black 24%, transparent);
 	overflow: hidden;
 }
@@ -274,7 +274,7 @@
 	min-height: 28px;
 	padding: 3px 7px 3px 8px;
 	border: 0;
-	border-radius: 7px;
+	border-radius: var(--radius-7);
 	background: var(--interactive-accent);
 	color: var(--text-inverse);
 	cursor: pointer;

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -343,7 +343,7 @@
 	gap: 5px;
 	padding: 2px 8px;
 	border: 0;
-	border-radius: 4px;
+	border-radius: var(--radius-4);
 	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-secondary));
 	font-size: calc(var(--text-base) * 0.9);
 	font-weight: var(--font-medium);
@@ -502,7 +502,7 @@
 	width: 24px;
 	height: 24px;
 	border: none;
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
 	color: var(--interactive-accent);
 	cursor: pointer;
@@ -648,7 +648,7 @@
 	gap: 6px;
 	min-width: 0;
 	padding: 3px 10px 3px 8px;
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	background: color-mix(in srgb, var(--database-tone) 91%, var(--bg-primary));
 }
 

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -57,7 +57,7 @@
 	gap: 8px;
 	padding: 0 9px;
 	border: 1px solid var(--border-light);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: var(--bg-primary);
 	color: var(--text-tertiary);
 	cursor: text;
@@ -106,7 +106,7 @@
 	justify-content: center;
 	padding: 0;
 	border: 1px solid var(--border-light);
-	border-radius: 6px;
+	border-radius: var(--radius-md);
 	background: var(--bg-primary);
 	color: var(--text-secondary);
 }
@@ -211,7 +211,7 @@
 }
 
 .folioNoteRow[data-state="selected"] {
-	border-radius: 8px;
+	border-radius: var(--radius-8);
 	border-bottom-color: transparent;
 	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
 	box-shadow: 0 0 0 1px
@@ -346,7 +346,7 @@
 	height: 52px;
 	overflow: hidden;
 	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
-	border-radius: 5px;
+	border-radius: var(--radius-4);
 	background: var(--bg-secondary);
 }
 

--- a/src/styles/themes/corner-radius.css
+++ b/src/styles/themes/corner-radius.css
@@ -1,0 +1,25 @@
+:root[data-corner-radius-style="sharp"] {
+	--radius-2: 0px;
+	--radius-3: 0px;
+	--radius-4: 0px;
+	--radius-6: 0px;
+	--radius-7: 0px;
+	--radius-8: 0px;
+	--radius-10: 0px;
+	--radius-14: 0px;
+	--radius-18: 0px;
+	--radius-24: 0px;
+}
+
+:root[data-corner-radius-style="round"] {
+	--radius-2: 4px;
+	--radius-3: 5px;
+	--radius-4: 8px;
+	--radius-6: 12px;
+	--radius-7: 14px;
+	--radius-8: 16px;
+	--radius-10: 18px;
+	--radius-14: 22px;
+	--radius-18: 28px;
+	--radius-24: 36px;
+}

--- a/src/styles/themes/primitives.css
+++ b/src/styles/themes/primitives.css
@@ -75,6 +75,7 @@
 	--radius-4: 4px;
 	--radius-6: 6px;
 	--radius-7: 7px;
+	--radius-8: 8px;
 	--radius-10: 10px;
 	--radius-14: 14px;
 	--radius-18: 18px;


### PR DESCRIPTION
## Summary

Adds a persisted corner radius shape setting (default, sharp, round) that drives app-wide border radius through CSS tokens, and refreshes the Appearance settings with segmented preview pickers for theme mode and corner shape. Hardcoded `border-radius` values across the UI are migrated to `--radius-*` variables so shape changes apply consistently.

## Related Issues

Closes #260

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [x] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a corner radius setting (sharp, default, round) with live visual previews and app‑wide application via CSS tokens, and replaces the theme mode dropdown with a segmented, preview‑based picker. Closes #260.

- **New Features**
  - Corner radius control with three styles; persists and updates UI instantly using `--radius-*` tokens and `corner-radius.css` mapping.
  - Segmented preview pickers for theme mode (System shows split light/dark) and shape.

- **Refactors**
  - Replaced hardcoded `border-radius` values with `--radius-*` tokens, added `--radius-8`, and wired `styles/themes/corner-radius.css` via `design-tokens.css`.
  - Introduced `SettingsSegmentedPicker`, `AppearancePreviewFrame`, `AppearanceThemeModePicker`, `useAppearanceCornerRadius`, and `applyUiCornerRadius`; persisted settings through `settings.ts`, propagated via Tauri events, and applied in `main.tsx`. Tests cover defaults, validation, and persistence.

<sup>Written for commit 53b7ae7bcb59f29b74ef7134215daffc71db67c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Shape” setting to choose between sharp, default, and round corner styles.
  * Reworked appearance controls with richer preview-based pickers for theme and shape options.

* **Bug Fixes**
  * Corner radius changes now apply immediately and persist across app restarts.
  * Updated many UI elements to use shared radius values for more consistent rounding.

* **Documentation**
  * Refined appearance setting descriptions to better explain what each option affects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->