### PR TITLE
Restyle wiki link affordance

### DIFF
--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -168,7 +168,7 @@ export const WikiLink = Node.create({
 				class: "wikiLink",
 			}),
 			WIKI_LINK_FILE_ICON,
-			displayName,
+			["span", { class: "wikiLinkLabel" }, displayName],
 		];
 	},
 	renderText({ node }) {

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -48,7 +48,9 @@ export function WikiLinkedText({ value }: { value: string }) {
 					title={detail.target}
 				>
 					<span className="wikiLinkIcon" aria-hidden="true" />
-					{detail.alias || displayNameForTarget(detail.target)}
+					<span className="wikiLinkLabel">
+						{detail.alias || displayNameForTarget(detail.target)}
+					</span>
 				</button>,
 			);
 		}

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -294,7 +294,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 											title={item.id}
 										>
 											<span className="wikiLinkIcon" aria-hidden="true" />
-											{item.label}
+											<span className="wikiLinkLabel">{item.label}</span>
 										</button>
 									))}
 								</div>
@@ -339,7 +339,9 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 																className="wikiLinkIcon"
 																aria-hidden="true"
 															/>
-															{relationshipTargetLabel(item)}
+															<span className="wikiLinkLabel">
+																{relationshipTargetLabel(item)}
+															</span>
 														</button>
 													);
 												})}
@@ -380,7 +382,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 											title={item.id}
 										>
 											<span className="wikiLinkIcon" aria-hidden="true" />
-											{item.label}
+											<span className="wikiLinkLabel">{item.label}</span>
 										</button>
 									))}
 								</div>

--- a/src/styles/app/23-raw-markdown-editor.css
+++ b/src/styles/app/23-raw-markdown-editor.css
@@ -204,34 +204,35 @@
 }
 
 .rfNodeNoteEditorRaw .cm-raw-wiki-link {
-	border-radius: var(--radius-sm);
-	background: color-mix(in srgb, var(--interactive-accent) 7%, transparent);
-	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 10%, transparent);
-	padding: 0.04em 0.2em;
-	color: color-mix(in srgb, var(--interactive-accent) 84%, var(--text-primary));
-	font-weight: var(--font-medium);
-	text-decoration: none;
+	border-radius: 0;
+	background: none;
+	box-shadow: none;
+	padding: 0;
+	color: var(--interactive-accent);
+	font-weight: inherit;
+	text-decoration: underline;
+	text-decoration-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 42%,
+		transparent
+	);
+	text-underline-offset: 0.14em;
 }
 
 .rfNodeNoteEditorRaw .cm-raw-wiki-link[data-embed="true"] {
-	background: color-mix(
-		in srgb,
-		var(--interactive-accent) 5%,
-		var(--bg-secondary)
-	);
-	color: color-mix(
-		in srgb,
-		var(--interactive-accent) 68%,
-		var(--text-secondary)
-	);
+	background: none;
+	color: color-mix(in srgb, var(--interactive-accent) 84%, var(--text-primary));
 }
 
 .rfNodeNoteEditorRaw .cm-raw-wiki-link:hover,
 .rfNodeNoteEditorRaw .cm-raw-wiki-link:focus-visible {
-	background: color-mix(in srgb, var(--interactive-accent) 13%, transparent);
-	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+	background: none;
+	box-shadow: none;
+	text-decoration-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 72%,
+		transparent
+	);
 }
 
 .rfNodeNoteEditorRaw .cm-raw-tag {

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -66,8 +66,8 @@
 	flex: 0 0 auto;
 	width: var(--icon-sm);
 	height: var(--icon-sm);
-	background: currentColor;
-	color: currentColor;
+	background: currentcolor;
+	color: currentcolor;
 	mask: var(--wiki-link-file-icon-mask);
 	-webkit-mask: var(--wiki-link-file-icon-mask);
 	pointer-events: none;
@@ -79,7 +79,7 @@
 	width: 0.72em;
 	height: 0.72em;
 	margin-left: 1px;
-	background: currentColor;
+	background: currentcolor;
 	opacity: 0.58;
 	mask: var(--wiki-link-affordance-mask) center / contain no-repeat;
 	-webkit-mask: var(--wiki-link-affordance-mask) center / contain no-repeat;

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -28,23 +28,35 @@
 }
 
 .wikiLink {
+	--wiki-link-affordance-mask: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%2024%2024'%20fill%3D'none'%3E%3Cpath%20d%3D'M7%2017L17%207M17%207H9M17%207V15'%20stroke%3D'black'%20stroke-width%3D'1.75'%20stroke-linecap%3D'round'%20stroke-linejoin%3D'round'/%3E%3C%2Fsvg%3E");
+
 	height: auto;
 	display: inline-flex;
 	align-items: center;
-	gap: 3px;
+	gap: 2px;
 	vertical-align: baseline;
 	color: var(--interactive-accent);
 	text-decoration: none;
-	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+	background: none;
 	border: none;
-	border-radius: var(--radius-xs);
-	padding: 1px 4px;
+	border-radius: 0;
+	padding: 0;
 	font: inherit;
-	font-weight: var(--font-medium);
+	font-weight: inherit;
 	line-height: inherit;
 	white-space: nowrap;
-	transition: background 120ms ease, color 120ms ease;
+	transition: color 120ms ease, opacity 120ms ease;
 	cursor: pointer;
+}
+
+.wikiLinkLabel {
+	text-decoration: underline;
+	text-decoration-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 42%,
+		transparent
+	);
+	text-underline-offset: 0.14em;
 }
 
 .wikiLinkIcon {
@@ -52,20 +64,46 @@
 		center / contain no-repeat;
 
 	flex: 0 0 auto;
-	width: var(--icon-md);
-	height: var(--icon-md);
-	background: var(--text-accent);
-	color: var(--text-accent);
+	width: var(--icon-sm);
+	height: var(--icon-sm);
+	background: currentColor;
+	color: currentColor;
 	mask: var(--wiki-link-file-icon-mask);
 	-webkit-mask: var(--wiki-link-file-icon-mask);
 	pointer-events: none;
 }
 
+.wikiLink::after {
+	content: "";
+	flex: 0 0 auto;
+	width: 0.72em;
+	height: 0.72em;
+	margin-left: 1px;
+	background: currentColor;
+	opacity: 0.58;
+	mask: var(--wiki-link-affordance-mask) center / contain no-repeat;
+	-webkit-mask: var(--wiki-link-affordance-mask) center / contain no-repeat;
+	pointer-events: none;
+}
+
 .wikiLink:hover,
 .wikiLink:focus-visible {
-	background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
 	color: var(--interactive-accent);
 	outline: none;
+}
+
+.wikiLink:hover .wikiLinkLabel,
+.wikiLink:focus-visible .wikiLinkLabel {
+	text-decoration-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 72%,
+		transparent
+	);
+}
+
+.wikiLink:hover::after,
+.wikiLink:focus-visible::after {
+	opacity: 0.85;
 }
 
 .wikiLink:active {
@@ -78,7 +116,14 @@
 
 .wikiLink[data-unresolved="true"] {
 	color: var(--text-tertiary);
-	background: color-mix(in srgb, var(--text-tertiary) 6%, transparent);
+}
+
+.wikiLink[data-unresolved="true"] .wikiLinkLabel {
+	text-decoration-color: color-mix(
+		in srgb,
+		var(--text-tertiary) 42%,
+		transparent
+	);
 }
 
 .tiptapContentInline .tagToken {


### PR DESCRIPTION
## Summary

Restyles wiki links to read more like standard links while preserving the file icon and adding a small outbound affordance. The rendered editor, note properties, sidebar link lists, and raw markdown decorations now share the same underlined label treatment.

## Related Issues

Closes #

## Testing

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

Not added.

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyles wiki links to look like standard links, keeping the file icon and adding a subtle outbound indicator. Unifies styling across the editor, note properties, sidebar lists, and raw markdown.

- **Refactors**
  - Wrap link text in a span (wikiLinkLabel) in the editor, note properties, and sidebar for consistent underlines.
  - Replace pill backgrounds with underlines; use lowercase currentcolor for icons (Stylelint-compliant); shrink file icon to var(--icon-sm); add an outbound affordance via ::after with hover/focus tweaks.
  - Update raw markdown wiki links to standard link semantics (underlines, no background) with clearer hover contrast and a refined unresolved state underline.

<sup>Written for commit 1d0ba4f17622de38c88ef1c353ae96f287a08d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Wiki links now use a cleaner underline-based look instead of pill/badge styling in the editor, note content, and sidebar.
  * Link text is wrapped for more consistent styling across displays.
  * Hover and focus states now emphasize underline and icon changes rather than background fills.
  * Unresolved wiki links have updated underline coloring for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->