### PR TITLE
Move SQLite index out of space folder to app support (KAR-59)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ GLYPH_DEV_FORCE_TRIAL=1 pnpm tauri dev # Force trial mode to check licensing
 
 ## Architecture
 
-**Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: SQLite + filesystem in `.glyph/` folder.
+**Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: Markdown and space metadata in `.glyph/`; derived SQLite index in app support.
 
 Repo extras: internal product and engineering docs live in `docs/`. 
 

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -29,7 +29,7 @@ src/lib/tauri.ts typed command map
 Tauri command handlers in src-tauri/src/lib.rs
   |
   +--> space files: markdown, attachments, folders
-  +--> .glyph/glyph.sqlite derived index
+  +--> app support index: derived SQLite search index per space
   +--> .glyph/databases.json workspace database definitions
   +--> app config: settings, AI profiles, license, update state
 ```
@@ -97,14 +97,15 @@ The Rust backend owns durable operations and native integration:
 
 The selected space folder contains user-owned content. Markdown notes are first-class files. Attachments and other files can live beside notes.
 
-Glyph stores app metadata under `.glyph/` in the space:
+Glyph stores space-local app metadata under `.glyph/` in the space:
 
-- `.glyph/glyph.sqlite`: derived SQLite index
 - `.glyph/databases.json`: workspace database definitions and status colors
 - `.glyph/cache/ai/`: per-run AI audit JSON
 - `.glyph/Glyph/ai_history/`: AI chat history records
 - `.glyph/Glyph/ai_secrets.json`: per-space AI API keys
 - `.glyph/cache/`: cache material
+
+The derived SQLite search index lives under Tauri app config (`Application Support/com.karatsidhu.glyph/index/<space-key>/.glyph/glyph.sqlite`). Markdown files remain the source of truth; the index rebuilds from notes when missing or empty.
 
 App-level preferences that do not belong to a single space live in Tauri app config through plugins or Rust app config paths.
 
@@ -136,7 +137,7 @@ See `05-editor-markdown-autosave.md`.
 ### Query Notes
 
 1. The UI calls search, all-docs, calendar, tags, graph, database, or task commands.
-2. Rust opens `.glyph/glyph.sqlite`.
+2. Rust opens the app-support SQLite index for the active space.
 3. Rust queries derived rows generated from Markdown content.
 4. If the result needs note content, Rust reads the backing note file after validating the path.
 
@@ -158,7 +159,7 @@ See `08-ai-runtime-tools-history.md`.
 Use these rules when changing the architecture:
 
 - Keep the active space as the root of user data. Do not add a second source of truth for notes.
-- Treat `.glyph/glyph.sqlite` as derived. Rebuild it when the parser or schema behavior changes.
+- Treat the app-support SQLite index as derived. Rebuild it when the parser or schema behavior changes.
 - Route durable filesystem writes through Rust. The frontend may use Tauri plugins for dialogs and opening external files, but note content should go through `space_fs`.
 - Use `paths::join_under()` and hidden-path checks for any space-relative path.
 - Use `io_atomic::write_atomic()` for durable writes unless a create-new operation needs `OpenOptions::create_new`.

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -44,7 +44,7 @@ Code ownership:
 - `src-tauri/src/space/state.rs`: active root, watcher handle, local-change tracking, store mutexes
 - `src-tauri/src/space/watcher.rs`: recursive filesystem watcher and index refresh
 - `src-tauri/src/glyph_paths.rs`: `.glyph/` paths in the space folder
-- `src-tauri/src/index_paths.rs`: app-support SQLite index paths and space-key manifest
+- `src-tauri/src/index/paths.rs`: app-support SQLite index paths and space-key manifest
 - `src-tauri/src/space_fs/`: file tree, read/write, preview, rename, delete, link resolution
 - `src-tauri/src/paths.rs`: traversal-safe joining
 - `src-tauri/src/io_atomic.rs`: crash-safer writes and copies
@@ -259,9 +259,9 @@ The editor and preview panes dispatch link click events. `AppShell` listens and 
 - `glyph_app_dir()`: `.glyph/Glyph`
 - `ai_history_dir()`: `.glyph/Glyph/ai_history`
 
-`index_paths.rs` defines the derived SQLite index under app support:
+`index/paths.rs` defines the derived SQLite index under app support:
 
-- `index_root_dir()`: `Application Support/com.karatsidhu.glyph/index`
+- `index_root_path()`: `Application Support/com.karatsidhu.glyph/index`
 - `index_db_path(space_root)`: `index/<space-key>/.glyph/glyph.sqlite`
 - `spaces.json`: canonical space root to stable index key mapping
 

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -15,7 +15,6 @@ My Space/
   assets/
     pasted-image.png
   .glyph/
-    glyph.sqlite
     databases.json
     cache/
     Glyph/
@@ -23,13 +22,29 @@ My Space/
       ai_secrets.json
 ```
 
+The SQLite search index lives under app support, not in the space folder:
+
+```text
+Application Support/com.karatsidhu.glyph/
+  index/
+    spaces.json
+    <space-key>/
+      .glyph/
+        glyph.sqlite
+        glyph.sqlite-wal
+        glyph.sqlite-shm
+```
+
+Use the space folder name as `<space-key>` when it is unique. Colliding names get a short path-hash suffix. `index/spaces.json` maps canonical space roots to stable keys.
+
 Code ownership:
 
 - `src-tauri/src/space/commands.rs`: create, open, close, onboarding note command
 - `src-tauri/src/space/helpers.rs`: create/open implementation and onboarding helpers
 - `src-tauri/src/space/state.rs`: active root, watcher handle, local-change tracking, store mutexes
 - `src-tauri/src/space/watcher.rs`: recursive filesystem watcher and index refresh
-- `src-tauri/src/glyph_paths.rs`: `.glyph/` paths
+- `src-tauri/src/glyph_paths.rs`: `.glyph/` paths in the space folder
+- `src-tauri/src/index_paths.rs`: app-support SQLite index paths and space-key manifest
 - `src-tauri/src/space_fs/`: file tree, read/write, preview, rename, delete, link resolution
 - `src-tauri/src/paths.rs`: traversal-safe joining
 - `src-tauri/src/io_atomic.rs`: crash-safer writes and copies
@@ -75,11 +90,12 @@ Rust flow in `space_open` and `space_create`:
 
 1. Build a `PathBuf` from the user-selected path.
 2. Canonicalize the directory through helper code.
-3. Create or open Glyph metadata.
-4. Reset the index schema cache with `index::db::reset_schema_cache()`.
-5. Store the canonical root in `SpaceState.current`.
-6. Install the notes watcher with `set_notes_watcher()`.
-7. Enable the native Close Space menu item.
+3. Register the space in the app-support index manifest and remove any stale in-space `glyph.sqlite` sidecars.
+4. Create or open Glyph metadata in `.glyph/`.
+5. Reset the index schema cache with `index::db::reset_schema_cache()`.
+6. Store the canonical root in `SpaceState.current`.
+7. Install the notes watcher with `set_notes_watcher()`.
+8. Enable the native Close Space menu item.
 
 `space_close` clears `current`, drops the watcher, resets the schema cache, and disables Close Space.
 
@@ -236,13 +252,18 @@ The editor and preview panes dispatch link click events. `AppShell` listens and 
 
 ## Storage Stores Under `.glyph/`
 
-`glyph_paths.rs` defines app-controlled paths:
+`glyph_paths.rs` defines space-local app metadata paths:
 
 - `glyph_dir()`: `.glyph`
-- `glyph_db_path()`: `.glyph/glyph.sqlite`
 - `glyph_cache_dir()`: `.glyph/cache`
 - `glyph_app_dir()`: `.glyph/Glyph`
 - `ai_history_dir()`: `.glyph/Glyph/ai_history`
+
+`index_paths.rs` defines the derived SQLite index under app support:
+
+- `index_root_dir()`: `Application Support/com.karatsidhu.glyph/index`
+- `index_db_path(space_root)`: `index/<space-key>/.glyph/glyph.sqlite`
+- `spaces.json`: canonical space root to stable index key mapping
 
 JSON stores under `.glyph/` include:
 

--- a/docs/architecture/06-index-search-graph-tasks.md
+++ b/docs/architecture/06-index-search-graph-tasks.md
@@ -10,7 +10,7 @@ Backend:
 
 - `src-tauri/src/index/schema.rs`: table and FTS schema
 - `src-tauri/src/index/db.rs`: database open, WAL setup, schema cache, migrations
-- `src-tauri/src/index_paths.rs`: app-support index paths and `spaces.json` manifest
+- `src-tauri/src/index/paths.rs`: app-support index paths and `spaces.json` manifest
 - `src-tauri/src/index/indexer.rs`: note indexing, removal, rebuild
 - `src-tauri/src/index/commands.rs`: Tauri commands for search, all docs, tags, checklist summaries, graph
 - `src-tauri/src/index/frontmatter.rs`: frontmatter title and preview parsing
@@ -39,7 +39,7 @@ Frontend consumers:
 
 ## Database Location
 
-`index_paths::index_db_path(space_root)` returns:
+`index::paths::index_db_path(space_root)` returns:
 
 ```text
 Application Support/com.karatsidhu.glyph/index/<space-key>/.glyph/glyph.sqlite

--- a/docs/architecture/06-index-search-graph-tasks.md
+++ b/docs/architecture/06-index-search-graph-tasks.md
@@ -1,6 +1,6 @@
 # SQLite Index, Search, Graph, and Checklists
 
-Glyph keeps Markdown files as the durable source of truth. The SQLite database under `.glyph/glyph.sqlite` is a derived index. It accelerates search, tags, backlinks, relationships, database rows, and checklist progress summaries.
+Glyph keeps Markdown files as the durable source of truth. The SQLite database under app support (`index/<space-key>/.glyph/glyph.sqlite`) is a derived index. It accelerates search, tags, backlinks, relationships, database rows, and checklist progress summaries.
 
 If the index is wrong, rebuild it from Markdown. Do not treat SQLite rows as the authoritative note content.
 
@@ -9,7 +9,8 @@ If the index is wrong, rebuild it from Markdown. Do not treat SQLite rows as the
 Backend:
 
 - `src-tauri/src/index/schema.rs`: table and FTS schema
-- `src-tauri/src/index/db.rs`: database path, WAL setup, schema cache, migrations
+- `src-tauri/src/index/db.rs`: database open, WAL setup, schema cache, migrations
+- `src-tauri/src/index_paths.rs`: app-support index paths and `spaces.json` manifest
 - `src-tauri/src/index/indexer.rs`: note indexing, removal, rebuild
 - `src-tauri/src/index/commands.rs`: Tauri commands for search, all docs, tags, checklist summaries, graph
 - `src-tauri/src/index/frontmatter.rs`: frontmatter title and preview parsing
@@ -38,11 +39,13 @@ Frontend consumers:
 
 ## Database Location
 
-`db_path(space_root)` returns:
+`index_paths::index_db_path(space_root)` returns:
 
 ```text
-.glyph/glyph.sqlite
+Application Support/com.karatsidhu.glyph/index/<space-key>/.glyph/glyph.sqlite
 ```
+
+`space_open` and `space_create` register the canonical space root in `index/spaces.json` and remove any stale in-space `glyph.sqlite` sidecars. On first open after this layout ships, the index is empty and `index_sync` triggers a full rebuild.
 
 `open_db()` creates the parent directory, opens the database, configures WAL, ensures schema, and runs migrations. It caches schema setup by database path so repeated commands do not run schema checks on every open.
 

--- a/docs/architecture/08-ai-runtime-tools-history.md
+++ b/docs/architecture/08-ai-runtime-tools-history.md
@@ -97,7 +97,7 @@ Normal workspace file APIs and AI tools reject hidden `.glyph/` paths, so standa
 Never put API keys into:
 
 - `.glyph/databases.json`
-- `.glyph/glyph.sqlite`
+- the app-support search index database
 - AI audit logs
 - frontend settings JSON
 - app traces

--- a/docs/architecture/10-security-and-operational-invariants.md
+++ b/docs/architecture/10-security-and-operational-invariants.md
@@ -30,7 +30,7 @@ Markdown files are the source of truth for note content.
 
 Allowed derived state:
 
-- `.glyph/glyph.sqlite`
+- app-support `index/<space-key>/.glyph/glyph.sqlite`
 - `.glyph/databases.json`
 - `.glyph/cache/ai/`
 - `.glyph/Glyph/ai_history/`
@@ -113,7 +113,7 @@ This prevents duplicate indexing and reload loops while keeping the UI informed.
 
 ## Invariant 7: SQLite Is Derived
 
-`.glyph/glyph.sqlite` stores derived rows for:
+The app-support search index (`index/<space-key>/.glyph/glyph.sqlite`) stores derived rows for:
 
 - notes
 - links

--- a/src-tauri/src/glyph_paths.rs
+++ b/src-tauri/src/glyph_paths.rs
@@ -10,10 +10,6 @@ pub fn glyph_dir(space_root: &Path) -> Result<PathBuf, String> {
     paths::join_under(space_root, Path::new(GLYPH_DIR_NAME))
 }
 
-pub fn glyph_db_path(space_root: &Path) -> Result<PathBuf, String> {
-    Ok(glyph_dir(space_root)?.join(GLYPH_DB_NAME))
-}
-
 pub fn glyph_cache_dir(space_root: &Path) -> Result<PathBuf, String> {
     Ok(glyph_dir(space_root)?.join("cache"))
 }

--- a/src-tauri/src/index/db.rs
+++ b/src-tauri/src/index/db.rs
@@ -1,5 +1,5 @@
-use crate::index_paths;
 use crate::glyph_paths;
+use crate::index::paths;
 use std::collections::HashSet;
 use std::ffi::CString;
 use std::path::{Path, PathBuf};
@@ -189,7 +189,7 @@ fn migrate_priority_property_kinds(conn: &rusqlite::Connection) -> Result<(), St
 }
 
 pub fn db_path(space_root: &Path) -> Result<PathBuf, String> {
-    Ok(index_paths::ensure_index_dir(space_root)?.join(glyph_paths::GLYPH_DB_NAME))
+    Ok(paths::ensure_index_dir(space_root)?.join(glyph_paths::GLYPH_DB_NAME))
 }
 
 fn configure_wal(conn: &rusqlite::Connection) -> Result<(), String> {
@@ -221,9 +221,6 @@ fn configure_wal(conn: &rusqlite::Connection) -> Result<(), String> {
 
 pub fn open_db(space_root: &Path) -> Result<rusqlite::Connection, String> {
     let path = db_path(space_root)?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-    }
     let conn = rusqlite::Connection::open(&path).map_err(|e| e.to_string())?;
     configure_wal(&conn)?;
 

--- a/src-tauri/src/index/db.rs
+++ b/src-tauri/src/index/db.rs
@@ -1,3 +1,4 @@
+use crate::index_paths;
 use crate::glyph_paths;
 use std::collections::HashSet;
 use std::ffi::CString;
@@ -188,7 +189,7 @@ fn migrate_priority_property_kinds(conn: &rusqlite::Connection) -> Result<(), St
 }
 
 pub fn db_path(space_root: &Path) -> Result<PathBuf, String> {
-    glyph_paths::glyph_db_path(space_root)
+    Ok(index_paths::ensure_index_dir(space_root)?.join(glyph_paths::GLYPH_DB_NAME))
 }
 
 fn configure_wal(conn: &rusqlite::Connection) -> Result<(), String> {

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -538,7 +538,7 @@ where
 mod tests {
     use super::index_note;
     use crate::index::db::open_db;
-    use crate::index_paths;
+    use crate::index::paths;
     use std::path::{Path, PathBuf};
     use std::thread;
     use std::time::Duration;
@@ -574,8 +574,8 @@ mod tests {
             "glyph-indexer-index-root-{}",
             uuid::Uuid::new_v4()
         ));
-        index_paths::init_test_index_root(index_root);
-        index_paths::register_space(root).expect("space should register");
+        paths::init_test_index_root(index_root);
+        paths::register_space(root).expect("space should register");
 
         let note_id = "Projects/Idle Churn.md";
         let markdown = "- [ ] Keep index stable\n";

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -568,6 +568,7 @@ mod tests {
 
     #[test]
     fn refreshes_indexed_timestamps_when_mtime_changes_without_content_changes() {
+        let _guard = paths::test_index_root_lock();
         let temp_space = TempSpace::new();
         let root = temp_space.path();
         let index_root = std::env::temp_dir().join(format!(

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -538,6 +538,7 @@ where
 mod tests {
     use super::index_note;
     use crate::index::db::open_db;
+    use crate::index_paths;
     use std::path::{Path, PathBuf};
     use std::thread;
     use std::time::Duration;
@@ -569,6 +570,13 @@ mod tests {
     fn refreshes_indexed_timestamps_when_mtime_changes_without_content_changes() {
         let temp_space = TempSpace::new();
         let root = temp_space.path();
+        let index_root = std::env::temp_dir().join(format!(
+            "glyph-indexer-index-root-{}",
+            uuid::Uuid::new_v4()
+        ));
+        index_paths::init_test_index_root(index_root);
+        index_paths::register_space(root).expect("space should register");
+
         let note_id = "Projects/Idle Churn.md";
         let markdown = "- [ ] Keep index stable\n";
         let note_path = root.join(note_id);

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod paths;
 pub mod calendar;
 pub mod checklists;
 pub mod commands;

--- a/src-tauri/src/index/paths.rs
+++ b/src-tauri/src/index/paths.rs
@@ -7,6 +7,8 @@ use tauri::{AppHandle, Manager};
 
 const SPACES_MANIFEST_FILE: &str = "spaces.json";
 const MANIFEST_VERSION: u32 = 1;
+const GLYPH_DB_WAL_NAME: &str = "glyph.sqlite-wal";
+const GLYPH_DB_SHM_NAME: &str = "glyph.sqlite-shm";
 
 #[derive(Serialize, Deserialize)]
 struct SpaceManifestEntry {
@@ -20,6 +22,7 @@ struct SpacesManifest {
 }
 
 static INDEX_ROOT: Mutex<Option<PathBuf>> = Mutex::new(None);
+static MANIFEST_MUTEX: Mutex<()> = Mutex::new(());
 
 pub fn init_index_root(app: &AppHandle) -> Result<(), String> {
     let config_dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
@@ -32,7 +35,7 @@ pub fn init_index_root(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-fn index_root_dir() -> Result<PathBuf, String> {
+pub fn index_root_path() -> Result<PathBuf, String> {
     INDEX_ROOT
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -41,10 +44,10 @@ fn index_root_dir() -> Result<PathBuf, String> {
 }
 
 fn manifest_path() -> Result<PathBuf, String> {
-    Ok(index_root_dir()?.join(SPACES_MANIFEST_FILE))
+    Ok(index_root_path()?.join(SPACES_MANIFEST_FILE))
 }
 
-fn load_manifest() -> Result<SpacesManifest, String> {
+fn load_manifest_unlocked() -> Result<SpacesManifest, String> {
     let path = manifest_path()?;
     match std::fs::read(&path) {
         Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| e.to_string()),
@@ -56,7 +59,8 @@ fn load_manifest() -> Result<SpacesManifest, String> {
     }
 }
 
-fn save_manifest(manifest: &SpacesManifest) -> Result<(), String> {
+fn save_manifest_unlocked(manifest: &mut SpacesManifest) -> Result<(), String> {
+    manifest.version = MANIFEST_VERSION;
     let path = manifest_path()?;
     let bytes = serde_json::to_vec_pretty(manifest).map_err(|e| e.to_string())?;
     io_atomic::write_atomic(&path, &bytes).map_err(|e| e.to_string())
@@ -103,9 +107,10 @@ fn short_path_hash(root: &Path) -> String {
 fn resolve_unique_key(manifest: &SpacesManifest, root: &Path) -> String {
     let base = base_key_from_root(root);
     let root_key = canonical_root_key(root);
-    let base_taken = manifest.spaces.iter().any(|(path, entry)| {
-        path != &root_key && entry.key == base
-    });
+    let base_taken = manifest
+        .spaces
+        .iter()
+        .any(|(path, entry)| path != &root_key && entry.key == base);
     if !base_taken {
         return base;
     }
@@ -114,26 +119,38 @@ fn resolve_unique_key(manifest: &SpacesManifest, root: &Path) -> String {
 
 pub fn register_space(canonical_root: &Path) -> Result<String, String> {
     let root_key = canonical_root_key(canonical_root);
-    let mut manifest = load_manifest()?;
+    let _guard = MANIFEST_MUTEX
+        .lock()
+        .map_err(|_| "index manifest state poisoned".to_string())?;
+
+    let mut manifest = load_manifest_unlocked()?;
     if let Some(entry) = manifest.spaces.get(&root_key) {
         return Ok(entry.key.clone());
     }
 
     let key = resolve_unique_key(&manifest, canonical_root);
     manifest.spaces.insert(
-        root_key,
+        root_key.clone(),
         SpaceManifestEntry {
             key: key.clone(),
         },
     );
-    save_manifest(&manifest)?;
+    save_manifest_unlocked(&mut manifest)?;
     ensure_index_glyph_dir(&key)?;
+    tracing::info!(
+        space_root = %root_key,
+        index_key = %key,
+        "Registered space in app-support index manifest"
+    );
     Ok(key)
 }
 
-pub fn space_index_key(canonical_root: &Path) -> Result<String, String> {
+pub(crate) fn space_index_key(canonical_root: &Path) -> Result<String, String> {
     let root_key = canonical_root_key(canonical_root);
-    let manifest = load_manifest()?;
+    let _guard = MANIFEST_MUTEX
+        .lock()
+        .map_err(|_| "index manifest state poisoned".to_string())?;
+    let manifest = load_manifest_unlocked()?;
     manifest
         .spaces
         .get(&root_key)
@@ -142,7 +159,7 @@ pub fn space_index_key(canonical_root: &Path) -> Result<String, String> {
 }
 
 fn index_glyph_dir(key: &str) -> Result<PathBuf, String> {
-    Ok(index_root_dir()?
+    Ok(index_root_path()?
         .join(key)
         .join(glyph_paths::GLYPH_DIR_NAME))
 }
@@ -167,12 +184,23 @@ pub fn remove_stale_in_space_db(space_root: &Path) {
     let Ok(glyph_dir) = glyph_paths::glyph_dir(space_root) else {
         return;
     };
+    let mut removed = 0usize;
     for name in [
         glyph_paths::GLYPH_DB_NAME,
-        &format!("{}-wal", glyph_paths::GLYPH_DB_NAME),
-        &format!("{}-shm", glyph_paths::GLYPH_DB_NAME),
+        GLYPH_DB_WAL_NAME,
+        GLYPH_DB_SHM_NAME,
     ] {
-        let _ = std::fs::remove_file(glyph_dir.join(name));
+        let path = glyph_dir.join(name);
+        if path.exists() && std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(
+            space_root = %space_root.to_string_lossy(),
+            removed,
+            "Removed stale in-space SQLite index files"
+        );
     }
 }
 
@@ -230,15 +258,15 @@ mod tests {
         let glyph_dir = glyph_paths::ensure_glyph_dir(&space_root).expect("glyph dir should exist");
         let marker = glyph_dir.join("onboarding-note-v2.json");
         std::fs::write(&marker, b"{}").expect("marker should be written");
-        for name in ["glyph.sqlite", "glyph.sqlite-wal", "glyph.sqlite-shm"] {
+        for name in [glyph_paths::GLYPH_DB_NAME, GLYPH_DB_WAL_NAME, GLYPH_DB_SHM_NAME] {
             std::fs::write(glyph_dir.join(name), b"x").expect("sqlite file should be written");
         }
 
         remove_stale_in_space_db(&space_root);
 
-        assert!(!glyph_dir.join("glyph.sqlite").exists());
-        assert!(!glyph_dir.join("glyph.sqlite-wal").exists());
-        assert!(!glyph_dir.join("glyph.sqlite-shm").exists());
+        assert!(!glyph_dir.join(glyph_paths::GLYPH_DB_NAME).exists());
+        assert!(!glyph_dir.join(GLYPH_DB_WAL_NAME).exists());
+        assert!(!glyph_dir.join(GLYPH_DB_SHM_NAME).exists());
         assert!(marker.exists());
 
         let _ = std::fs::remove_dir_all(space_root);

--- a/src-tauri/src/index/paths.rs
+++ b/src-tauri/src/index/paths.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+#[cfg(test)]
+use std::sync::MutexGuard;
 use tauri::{AppHandle, Manager};
 
 const SPACES_MANIFEST_FILE: &str = "spaces.json";
@@ -23,6 +25,8 @@ struct SpacesManifest {
 
 static INDEX_ROOT: Mutex<Option<PathBuf>> = Mutex::new(None);
 static MANIFEST_MUTEX: Mutex<()> = Mutex::new(());
+#[cfg(test)]
+static TEST_INDEX_ROOT_MUTEX: Mutex<()> = Mutex::new(());
 
 pub fn init_index_root(app: &AppHandle) -> Result<(), String> {
     let config_dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
@@ -107,14 +111,27 @@ fn short_path_hash(root: &Path) -> String {
 fn resolve_unique_key(manifest: &SpacesManifest, root: &Path) -> String {
     let base = base_key_from_root(root);
     let root_key = canonical_root_key(root);
-    let base_taken = manifest
-        .spaces
-        .iter()
-        .any(|(path, entry)| path != &root_key && entry.key == base);
-    if !base_taken {
+    let key_taken = |candidate: &str| {
+        manifest
+            .spaces
+            .iter()
+            .any(|(path, entry)| path != &root_key && entry.key == candidate)
+    };
+    let base_taken = key_taken(&base);
+    let hash = short_path_hash(root);
+    let fallback_base = format!("{base}-{hash}");
+    let fallback_taken = key_taken(&fallback_base);
+    if !base_taken && !fallback_taken {
         return base;
     }
-    format!("{}-{}", base, short_path_hash(root))
+
+    let mut candidate = fallback_base;
+    let mut suffix = 2;
+    while key_taken(&candidate) {
+        candidate = format!("{base}-{hash}-{suffix}");
+        suffix += 1;
+    }
+    candidate
 }
 
 pub fn register_space(canonical_root: &Path) -> Result<String, String> {
@@ -145,6 +162,7 @@ pub fn register_space(canonical_root: &Path) -> Result<String, String> {
     Ok(key)
 }
 
+#[cfg(test)]
 pub(crate) fn space_index_key(canonical_root: &Path) -> Result<String, String> {
     let root_key = canonical_root_key(canonical_root);
     let _guard = MANIFEST_MUTEX
@@ -170,6 +188,7 @@ fn ensure_index_glyph_dir(key: &str) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
+#[cfg(test)]
 pub fn index_db_path(canonical_root: &Path) -> Result<PathBuf, String> {
     let key = space_index_key(canonical_root)?;
     Ok(index_glyph_dir(&key)?.join(glyph_paths::GLYPH_DB_NAME))
@@ -213,6 +232,13 @@ pub(crate) fn init_test_index_root(path: PathBuf) {
 }
 
 #[cfg(test)]
+pub(crate) fn test_index_root_lock() -> MutexGuard<'static, ()> {
+    TEST_INDEX_ROOT_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -226,6 +252,7 @@ mod tests {
 
     #[test]
     fn assigns_unique_keys_for_same_folder_name() {
+        let _guard = test_index_root_lock();
         let index_root = temp_index_root();
         init_test_index_root(index_root.clone());
 

--- a/src-tauri/src/index/paths.rs
+++ b/src-tauri/src/index/paths.rs
@@ -1,10 +1,8 @@
-use crate::{glyph_paths, io_atomic, utils};
+use crate::{glyph_paths, io_atomic, paths as safe_paths, utils};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-#[cfg(test)]
-use std::sync::MutexGuard;
+use std::sync::{Mutex, MutexGuard};
 use tauri::{AppHandle, Manager};
 
 const SPACES_MANIFEST_FILE: &str = "spaces.json";
@@ -49,6 +47,12 @@ pub fn index_root_path() -> Result<PathBuf, String> {
 
 fn manifest_path() -> Result<PathBuf, String> {
     Ok(index_root_path()?.join(SPACES_MANIFEST_FILE))
+}
+
+fn manifest_lock() -> MutexGuard<'static, ()> {
+    MANIFEST_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn load_manifest_unlocked() -> Result<SpacesManifest, String> {
@@ -136,9 +140,7 @@ fn resolve_unique_key(manifest: &SpacesManifest, root: &Path) -> String {
 
 pub fn register_space(canonical_root: &Path) -> Result<String, String> {
     let root_key = canonical_root_key(canonical_root);
-    let _guard = MANIFEST_MUTEX
-        .lock()
-        .map_err(|_| "index manifest state poisoned".to_string())?;
+    let _guard = manifest_lock();
 
     let mut manifest = load_manifest_unlocked()?;
     if let Some(entry) = manifest.spaces.get(&root_key) {
@@ -165,9 +167,7 @@ pub fn register_space(canonical_root: &Path) -> Result<String, String> {
 #[cfg(test)]
 pub(crate) fn space_index_key(canonical_root: &Path) -> Result<String, String> {
     let root_key = canonical_root_key(canonical_root);
-    let _guard = MANIFEST_MUTEX
-        .lock()
-        .map_err(|_| "index manifest state poisoned".to_string())?;
+    let _guard = manifest_lock();
     let manifest = load_manifest_unlocked()?;
     manifest
         .spaces
@@ -177,9 +177,8 @@ pub(crate) fn space_index_key(canonical_root: &Path) -> Result<String, String> {
 }
 
 fn index_glyph_dir(key: &str) -> Result<PathBuf, String> {
-    Ok(index_root_path()?
-        .join(key)
-        .join(glyph_paths::GLYPH_DIR_NAME))
+    let space_index_dir = safe_paths::join_under(&index_root_path()?, Path::new(key))?;
+    Ok(space_index_dir.join(glyph_paths::GLYPH_DIR_NAME))
 }
 
 fn ensure_index_glyph_dir(key: &str) -> Result<PathBuf, String> {

--- a/src-tauri/src/index_paths.rs
+++ b/src-tauri/src/index_paths.rs
@@ -1,0 +1,246 @@
+use crate::{glyph_paths, io_atomic, utils};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager};
+
+const SPACES_MANIFEST_FILE: &str = "spaces.json";
+const MANIFEST_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize)]
+struct SpaceManifestEntry {
+    key: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SpacesManifest {
+    version: u32,
+    spaces: HashMap<String, SpaceManifestEntry>,
+}
+
+static INDEX_ROOT: Mutex<Option<PathBuf>> = Mutex::new(None);
+
+pub fn init_index_root(app: &AppHandle) -> Result<(), String> {
+    let config_dir = app.path().app_config_dir().map_err(|e| e.to_string())?;
+    let index_dir = config_dir.join("index");
+    std::fs::create_dir_all(&index_dir).map_err(|e| e.to_string())?;
+    let mut guard = INDEX_ROOT.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.is_none() {
+        *guard = Some(index_dir);
+    }
+    Ok(())
+}
+
+fn index_root_dir() -> Result<PathBuf, String> {
+    INDEX_ROOT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+        .ok_or_else(|| "index root is not initialized".to_string())
+}
+
+fn manifest_path() -> Result<PathBuf, String> {
+    Ok(index_root_dir()?.join(SPACES_MANIFEST_FILE))
+}
+
+fn load_manifest() -> Result<SpacesManifest, String> {
+    let path = manifest_path()?;
+    match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).map_err(|e| e.to_string()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(SpacesManifest {
+            version: MANIFEST_VERSION,
+            spaces: HashMap::new(),
+        }),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn save_manifest(manifest: &SpacesManifest) -> Result<(), String> {
+    let path = manifest_path()?;
+    let bytes = serde_json::to_vec_pretty(manifest).map_err(|e| e.to_string())?;
+    io_atomic::write_atomic(&path, &bytes).map_err(|e| e.to_string())
+}
+
+fn canonical_root_key(root: &Path) -> String {
+    root.to_string_lossy().to_string()
+}
+
+fn base_key_from_root(root: &Path) -> String {
+    root.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(sanitize_index_key)
+        .unwrap_or_else(|| "space".to_string())
+}
+
+fn sanitize_index_key(name: &str) -> String {
+    let sanitized = name
+        .chars()
+        .map(|ch| {
+            if ch.is_alphanumeric() || matches!(ch, ' ' | '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim()
+        .to_string();
+    if sanitized.is_empty() {
+        "space".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn short_path_hash(root: &Path) -> String {
+    let hash = utils::sha256_hex(root.to_string_lossy().as_bytes());
+    hash[..8].to_string()
+}
+
+fn resolve_unique_key(manifest: &SpacesManifest, root: &Path) -> String {
+    let base = base_key_from_root(root);
+    let root_key = canonical_root_key(root);
+    let base_taken = manifest.spaces.iter().any(|(path, entry)| {
+        path != &root_key && entry.key == base
+    });
+    if !base_taken {
+        return base;
+    }
+    format!("{}-{}", base, short_path_hash(root))
+}
+
+pub fn register_space(canonical_root: &Path) -> Result<String, String> {
+    let root_key = canonical_root_key(canonical_root);
+    let mut manifest = load_manifest()?;
+    if let Some(entry) = manifest.spaces.get(&root_key) {
+        return Ok(entry.key.clone());
+    }
+
+    let key = resolve_unique_key(&manifest, canonical_root);
+    manifest.spaces.insert(
+        root_key,
+        SpaceManifestEntry {
+            key: key.clone(),
+        },
+    );
+    save_manifest(&manifest)?;
+    ensure_index_glyph_dir(&key)?;
+    Ok(key)
+}
+
+pub fn space_index_key(canonical_root: &Path) -> Result<String, String> {
+    let root_key = canonical_root_key(canonical_root);
+    let manifest = load_manifest()?;
+    manifest
+        .spaces
+        .get(&root_key)
+        .map(|entry| entry.key.clone())
+        .ok_or_else(|| format!("space not registered in index manifest: {root_key}"))
+}
+
+fn index_glyph_dir(key: &str) -> Result<PathBuf, String> {
+    Ok(index_root_dir()?
+        .join(key)
+        .join(glyph_paths::GLYPH_DIR_NAME))
+}
+
+fn ensure_index_glyph_dir(key: &str) -> Result<PathBuf, String> {
+    let dir = index_glyph_dir(key)?;
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir)
+}
+
+pub fn index_db_path(canonical_root: &Path) -> Result<PathBuf, String> {
+    let key = space_index_key(canonical_root)?;
+    Ok(index_glyph_dir(&key)?.join(glyph_paths::GLYPH_DB_NAME))
+}
+
+pub fn ensure_index_dir(canonical_root: &Path) -> Result<PathBuf, String> {
+    let key = register_space(canonical_root)?;
+    ensure_index_glyph_dir(&key)
+}
+
+pub fn remove_stale_in_space_db(space_root: &Path) {
+    let Ok(glyph_dir) = glyph_paths::glyph_dir(space_root) else {
+        return;
+    };
+    for name in [
+        glyph_paths::GLYPH_DB_NAME,
+        &format!("{}-wal", glyph_paths::GLYPH_DB_NAME),
+        &format!("{}-shm", glyph_paths::GLYPH_DB_NAME),
+    ] {
+        let _ = std::fs::remove_file(glyph_dir.join(name));
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn init_test_index_root(path: PathBuf) {
+    std::fs::create_dir_all(&path).ok();
+    *INDEX_ROOT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_index_root() -> PathBuf {
+        let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("glyph-index-paths-test-{id}"))
+    }
+
+    #[test]
+    fn assigns_unique_keys_for_same_folder_name() {
+        let index_root = temp_index_root();
+        init_test_index_root(index_root.clone());
+
+        let notes_a = temp_index_root().join("Notes");
+        let notes_b = temp_index_root().join("Notes");
+        std::fs::create_dir_all(&notes_a).expect("first notes dir should exist");
+        std::fs::create_dir_all(&notes_b).expect("second notes dir should exist");
+
+        let key_a = register_space(&notes_a).expect("first space should register");
+        let key_b = register_space(&notes_b).expect("second space should register");
+
+        assert_eq!(key_a, "Notes");
+        assert_ne!(key_a, key_b);
+        assert!(key_b.starts_with("Notes-"));
+
+        let db_a = index_db_path(&notes_a).expect("first db path should resolve");
+        let db_b = index_db_path(&notes_b).expect("second db path should resolve");
+        assert_ne!(db_a, db_b);
+        assert!(db_a.starts_with(&index_root));
+        assert!(db_b.starts_with(&index_root));
+
+        let _ = std::fs::remove_dir_all(index_root);
+        let _ = std::fs::remove_dir_all(notes_a);
+        let _ = std::fs::remove_dir_all(notes_b);
+    }
+
+    #[test]
+    fn remove_stale_in_space_db_deletes_only_sqlite_sidecars() {
+        let space_root = temp_index_root().join("space");
+        let glyph_dir = glyph_paths::ensure_glyph_dir(&space_root).expect("glyph dir should exist");
+        let marker = glyph_dir.join("onboarding-note-v2.json");
+        std::fs::write(&marker, b"{}").expect("marker should be written");
+        for name in ["glyph.sqlite", "glyph.sqlite-wal", "glyph.sqlite-shm"] {
+            std::fs::write(glyph_dir.join(name), b"x").expect("sqlite file should be written");
+        }
+
+        remove_stale_in_space_db(&space_root);
+
+        assert!(!glyph_dir.join("glyph.sqlite").exists());
+        assert!(!glyph_dir.join("glyph.sqlite-wal").exists());
+        assert!(!glyph_dir.join("glyph.sqlite-shm").exists());
+        assert!(marker.exists());
+
+        let _ = std::fs::remove_dir_all(space_root);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod file_tree_appearance;
 mod git_sync;
 mod glyph_paths;
 mod index;
+mod index_paths;
 mod io_atomic;
 mod license;
 mod menu_manifest;
@@ -1467,6 +1468,9 @@ pub fn run() {
             }
         })
         .setup(|app| {
+            if let Err(error) = index_paths::init_index_root(app.handle()) {
+                warn!("Failed to initialize app-support index root: {error}");
+            }
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
             if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1468,7 +1468,8 @@ pub fn run() {
         })
         .setup(|app| {
             if let Err(error) = index::paths::init_index_root(app.handle()) {
-                warn!("Failed to initialize app-support index root: {error}");
+                error!("Failed to initialize app-support index root: {error}");
+                return Err(std::io::Error::other(error).into());
             }
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,6 @@ mod file_tree_appearance;
 mod git_sync;
 mod glyph_paths;
 mod index;
-mod index_paths;
 mod io_atomic;
 mod license;
 mod menu_manifest;
@@ -1468,7 +1467,7 @@ pub fn run() {
             }
         })
         .setup(|app| {
-            if let Err(error) = index_paths::init_index_root(app.handle()) {
+            if let Err(error) = index::paths::init_index_root(app.handle()) {
                 warn!("Failed to initialize app-support index root: {error}");
             }
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -3,7 +3,6 @@ use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    index_paths,
     paths, utils, window_geometry,
 };
 
@@ -58,11 +57,6 @@ pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState
     let _ = crate::set_space_close_menu_enabled(app, !state.session_roots().is_empty());
 }
 
-fn prepare_space_root(root: &Path) -> Result<SpaceInfo, String> {
-    index_paths::register_space(root)?;
-    index_paths::remove_stale_in_space_db(root);
-    create_or_open_impl(root)
-}
 
 #[tauri::command]
 pub async fn space_create(
@@ -75,7 +69,7 @@ pub async fn space_create(
     let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
         std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
         let root = canonicalize_dir(&root)?;
-        prepare_space_root(&root)
+        create_or_open_impl(&root)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -104,7 +98,7 @@ pub async fn space_open(
     let root = PathBuf::from(path);
     let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
         let root = canonicalize_dir(&root)?;
-        prepare_space_root(&root)
+        create_or_open_impl(&root)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -142,7 +136,7 @@ pub async fn space_get_current_info(
     let Ok(root) = state.root_for_window(&window) else {
         return Ok(None);
     };
-    tauri::async_runtime::spawn_blocking(move || prepare_space_root(&root).map(Some))
+    tauri::async_runtime::spawn_blocking(move || create_or_open_impl(&root).map(Some))
         .await
         .map_err(|e| e.to_string())?
 }
@@ -191,7 +185,7 @@ pub async fn space_open_window(
             std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
         }
         let root = canonicalize_dir(&root)?;
-        prepare_space_root(&root)
+        create_or_open_impl(&root)
     })
     .await
     .map_err(|e| e.to_string())??;

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -3,6 +3,7 @@ use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::{
     index::{self, db::reset_schema_cache},
+    index_paths,
     paths, utils, window_geometry,
 };
 
@@ -57,6 +58,12 @@ pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState
     let _ = crate::set_space_close_menu_enabled(app, !state.session_roots().is_empty());
 }
 
+fn prepare_space_root(root: &Path) -> Result<SpaceInfo, String> {
+    index_paths::register_space(root)?;
+    index_paths::remove_stale_in_space_db(root);
+    create_or_open_impl(root)
+}
+
 #[tauri::command]
 pub async fn space_create(
     app: tauri::AppHandle,
@@ -68,7 +75,7 @@ pub async fn space_create(
     let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
         std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
         let root = canonicalize_dir(&root)?;
-        create_or_open_impl(&root)
+        prepare_space_root(&root)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -97,7 +104,7 @@ pub async fn space_open(
     let root = PathBuf::from(path);
     let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
         let root = canonicalize_dir(&root)?;
-        create_or_open_impl(&root)
+        prepare_space_root(&root)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -135,7 +142,7 @@ pub async fn space_get_current_info(
     let Ok(root) = state.root_for_window(&window) else {
         return Ok(None);
     };
-    tauri::async_runtime::spawn_blocking(move || create_or_open_impl(&root).map(Some))
+    tauri::async_runtime::spawn_blocking(move || prepare_space_root(&root).map(Some))
         .await
         .map_err(|e| e.to_string())?
 }
@@ -184,7 +191,7 @@ pub async fn space_open_window(
             std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
         }
         let root = canonicalize_dir(&root)?;
-        create_or_open_impl(&root)
+        prepare_space_root(&root)
     })
     .await
     .map_err(|e| e.to_string())??;

--- a/src-tauri/src/space/helpers.rs
+++ b/src-tauri/src/space/helpers.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 use std::path::{Path, PathBuf};
 
+use crate::index::paths as index_paths;
 use crate::{glyph_paths, io_atomic, paths};
 
 #[derive(Serialize)]
@@ -93,6 +94,8 @@ pub fn canonicalize_dir(path: &Path) -> Result<PathBuf, String> {
 }
 
 pub fn create_or_open_impl(root: &Path) -> Result<SpaceInfo, String> {
+    index_paths::register_space(root)?;
+    index_paths::remove_stale_in_space_db(root);
     ensure_glyph_dirs(root)?;
     let _ = cleanup_tmp_files(root);
     let onboarding_note_path = ensure_onboarding_note_for_launch(root);

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -526,6 +526,7 @@ pub async fn space_relativize_path(
 mod tests {
     use super::{duplicate_file_under_root, next_duplicate_file_name};
     use crate::index::open_db;
+    use crate::index_paths;
     use crate::space::state::{has_recent_local_change, RecentLocalChanges};
     use std::{
         collections::{HashMap, HashSet},
@@ -558,6 +559,15 @@ mod tests {
 
     fn fresh_recent_local_changes() -> RecentLocalChanges {
         Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn init_test_index_for_space(root: &Path) {
+        let index_root = std::env::temp_dir().join(format!(
+            "glyph-duplicate-index-root-{}",
+            uuid::Uuid::new_v4()
+        ));
+        index_paths::init_test_index_root(index_root);
+        index_paths::register_space(root).expect("space should register");
     }
 
     #[test]
@@ -610,6 +620,7 @@ mod tests {
     fn duplicates_markdown_files_and_indexes_the_copy() {
         let temp_space = TempSpace::new();
         let root = temp_space.path();
+        init_test_index_for_space(root);
         let rel_path = Path::new("notes/Plan.md");
         let abs_path = root.join(rel_path);
         std::fs::create_dir_all(abs_path.parent().expect("file should have parent"))

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -526,7 +526,7 @@ pub async fn space_relativize_path(
 mod tests {
     use super::{duplicate_file_under_root, next_duplicate_file_name};
     use crate::index::open_db;
-    use crate::index_paths;
+    use crate::index::paths;
     use crate::space::state::{has_recent_local_change, RecentLocalChanges};
     use std::{
         collections::{HashMap, HashSet},
@@ -566,8 +566,8 @@ mod tests {
             "glyph-duplicate-index-root-{}",
             uuid::Uuid::new_v4()
         ));
-        index_paths::init_test_index_root(index_root);
-        index_paths::register_space(root).expect("space should register");
+        paths::init_test_index_root(index_root);
+        paths::register_space(root).expect("space should register");
     }
 
     #[test]

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -618,6 +618,7 @@ mod tests {
 
     #[test]
     fn duplicates_markdown_files_and_indexes_the_copy() {
+        let _guard = paths::test_index_root_lock();
         let temp_space = TempSpace::new();
         let root = temp_space.path();
         init_test_index_for_space(root);


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/261


## Description

Moves the derived SQLite search index out of each space's `.glyph/` folder and into Tauri app support storage.

- Stores per-space index databases under the app-support index root with a `spaces.json` manifest.
- Registers spaces through the existing open/create path and removes stale in-space SQLite sidecars on open.
- Keeps manifest updates atomic and guarded by a mutex.
- Resolves review findings around fallback key collisions, setup failure handling, and tests that mutate the shared test index root.
- Uses a hard cutover: old in-space SQLite index files are not migrated; the existing index sync flow rebuilds derived data.

## Docs

Architecture docs were updated in the branch to describe the app-support index location and the space manifest. No visual changes.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

Validation run locally:

- `cargo test index:: -- --test-threads=4`
- `cargo test duplicates_markdown_files_and_indexes_the_copy -- --test-threads=4`
- `cargo test index::paths::tests::assigns_unique_keys_for_same_folder_name -- --test-threads=4`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search indexing now uses a stable app-support location instead of storing the derived database inside each space.
  * Opening or creating a space now cleans up stale index files automatically, helping avoid search issues after layout changes.

* **Documentation**
  * Updated architecture and storage docs to reflect the new index location and clarify that Markdown remains the source of truth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->