### PR TITLE
Persist main window geometry across launches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 *.sw?
 .amp/
 .pi/
+plans/

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1475,7 +1475,7 @@ pub fn run() {
 
             #[cfg(target_os = "macos")]
             {
-                if let Some(window) = app.get_webview_window("main") {
+                if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
                     if let Err(e) = apply_main_window_vibrancy(&window, None) {
                         warn!("Failed to apply vibrancy to main window: {e}");
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod space;
 mod space_fs;
 mod system_fonts;
 mod tag_appearance;
+mod window_geometry;
 pub(crate) mod utils;
 
 use serde::Serialize;
@@ -42,8 +43,7 @@ use tracing::{error, warn};
 use window_vibrancy::{apply_vibrancy, clear_vibrancy, NSVisualEffectMaterial};
 
 use tauri::{
-    PhysicalPosition, PhysicalSize, Position, Size, TitleBarStyle, WebviewUrl,
-    WebviewWindowBuilder,
+    TitleBarStyle, WebviewUrl, WebviewWindowBuilder,
 };
 
 static RECENT_SPACES_MENU_REVISION: AtomicU64 = AtomicU64::new(0);
@@ -1469,17 +1469,8 @@ pub fn run() {
         .setup(|app| {
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
-            if let Some(window) = app.get_webview_window("main") {
-                if let Ok(Some(monitor)) = window.current_monitor() {
-                    let monitor_size = monitor.size();
-                    let monitor_pos = monitor.position();
-                    let width = ((monitor_size.width as f64) * 0.8).round() as u32;
-                    let height = ((monitor_size.height as f64) * 0.8).round() as u32;
-                    let _ = window.set_size(Size::Physical(PhysicalSize::new(width, height)));
-                    let x = monitor_pos.x + ((monitor_size.width as i32 - width as i32) / 2);
-                    let y = monitor_pos.y + ((monitor_size.height as i32 - height as i32) / 2);
-                    let _ = window.set_position(Position::Physical(PhysicalPosition::new(x, y)));
-                }
+            if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
+                window_geometry::install_main_window_persistence(&window);
             }
 
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -3,7 +3,7 @@ use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    paths, utils,
+    paths, utils, window_geometry,
 };
 
 use super::helpers::{
@@ -206,7 +206,10 @@ pub async fn space_open_window(
     )
     .title(space_window_title(&root))
     .inner_size(800.0, 600.0)
-    .min_inner_size(680.0, 460.0)
+    .min_inner_size(
+        window_geometry::MIN_INNER_WIDTH as f64,
+        window_geometry::MIN_INNER_HEIGHT as f64,
+    )
     .decorations(true)
     .title_bar_style(tauri::TitleBarStyle::Overlay)
     .hidden_title(true)

--- a/src-tauri/src/window_geometry/mod.rs
+++ b/src-tauri/src/window_geometry/mod.rs
@@ -1,0 +1,307 @@
+mod store;
+mod types;
+
+use tauri::{
+    Manager, Monitor, PhysicalPosition, PhysicalSize, Position, Size, WebviewWindow, WindowEvent,
+};
+use tracing::warn;
+
+use store::{load_record, save_record, store_path};
+use types::{WindowGeometryRecord, WINDOW_GEOMETRY_STORE_VERSION};
+
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Must match `tauri.conf.json` `minWidth` / `minHeight` for the main window.
+pub const MIN_INNER_WIDTH: u32 = 680;
+/// Must match `tauri.conf.json` `minWidth` / `minHeight` for the main window.
+pub const MIN_INNER_HEIGHT: u32 = 460;
+
+const MIN_VISIBLE_WIDTH: i32 = 200;
+const MIN_VISIBLE_HEIGHT: i32 = 80;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Rect {
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+}
+
+fn monitor_rect(monitor: &Monitor) -> Rect {
+    let position = monitor.position();
+    let size = monitor.size();
+    Rect {
+        x: position.x,
+        y: position.y,
+        width: size.width as i32,
+        height: size.height as i32,
+    }
+}
+
+fn intersection(window: Rect, monitor: Rect) -> Option<Rect> {
+    let left = window.x.max(monitor.x);
+    let top = window.y.max(monitor.y);
+    let right = (window.x + window.width).min(monitor.x + monitor.width);
+    let bottom = (window.y + window.height).min(monitor.y + monitor.height);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    Some(Rect {
+        x: left,
+        y: top,
+        width: right - left,
+        height: bottom - top,
+    })
+}
+
+#[cfg(test)]
+fn is_geometry_visible_for_monitor_rects(
+    width: u32,
+    height: u32,
+    x: i32,
+    y: i32,
+    monitors: &[Rect],
+) -> bool {
+    if width < MIN_INNER_WIDTH || height < MIN_INNER_HEIGHT {
+        return false;
+    }
+    if monitors.is_empty() {
+        return false;
+    }
+
+    let window = Rect {
+        x,
+        y,
+        width: width as i32,
+        height: height as i32,
+    };
+
+    monitors.iter().any(|monitor| {
+        intersection(window, *monitor).is_some_and(|visible| {
+            visible.width >= MIN_VISIBLE_WIDTH && visible.height >= MIN_VISIBLE_HEIGHT
+        })
+    })
+}
+
+fn is_geometry_visible_on_monitors(
+    width: u32,
+    height: u32,
+    x: i32,
+    y: i32,
+    monitors: &[Monitor],
+) -> bool {
+    if width < MIN_INNER_WIDTH || height < MIN_INNER_HEIGHT || monitors.is_empty() {
+        return false;
+    }
+
+    let window = Rect {
+        x,
+        y,
+        width: width as i32,
+        height: height as i32,
+    };
+
+    monitors.iter().any(|monitor| {
+        intersection(window, monitor_rect(monitor)).is_some_and(|visible| {
+            visible.width >= MIN_VISIBLE_WIDTH && visible.height >= MIN_VISIBLE_HEIGHT
+        })
+    })
+}
+
+fn should_restore_record(record: &WindowGeometryRecord, monitors: &[Monitor]) -> bool {
+    if record.maximized {
+        return !monitors.is_empty();
+    }
+    is_geometry_visible_on_monitors(record.width, record.height, record.x, record.y, monitors)
+}
+
+fn apply_default_centered_geometry(window: &WebviewWindow) -> Result<(), String> {
+    let Some(monitor) = window
+        .current_monitor()
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+    let monitor_size = monitor.size();
+    let monitor_pos = monitor.position();
+    let width = ((monitor_size.width as f64) * 0.8).round() as u32;
+    let height = ((monitor_size.height as f64) * 0.8).round() as u32;
+    window
+        .set_size(Size::Physical(PhysicalSize::new(width, height)))
+        .map_err(|error| error.to_string())?;
+    let x = monitor_pos.x + ((monitor_size.width as i32 - width as i32) / 2);
+    let y = monitor_pos.y + ((monitor_size.height as i32 - height as i32) / 2);
+    window
+        .set_position(Position::Physical(PhysicalPosition::new(x, y)))
+        .map_err(|error| error.to_string())
+}
+
+fn apply_geometry(window: &WebviewWindow, record: &WindowGeometryRecord) -> Result<(), String> {
+    if record.maximized {
+        window.maximize().map_err(|error| error.to_string())
+    } else {
+        window
+            .set_size(Size::Physical(PhysicalSize::new(record.width, record.height)))
+            .map_err(|error| error.to_string())?;
+        window
+            .set_position(Position::Physical(PhysicalPosition::new(record.x, record.y)))
+            .map_err(|error| error.to_string())
+    }
+}
+
+fn capture_geometry(window: &WebviewWindow) -> Result<WindowGeometryRecord, String> {
+    let size = window.inner_size().map_err(|error| error.to_string())?;
+    let position = window.outer_position().map_err(|error| error.to_string())?;
+    let maximized = window.is_maximized().unwrap_or(false);
+
+    Ok(WindowGeometryRecord {
+        version: WINDOW_GEOMETRY_STORE_VERSION,
+        width: size.width,
+        height: size.height,
+        x: position.x,
+        y: position.y,
+        maximized,
+    })
+}
+
+fn save_main_window_geometry(window: &WebviewWindow) {
+    let app = window.app_handle();
+    let path = match store_path(app) {
+        Ok(path) => path,
+        Err(error) => {
+            warn!("Failed to resolve main window geometry store path: {error}");
+            return;
+        }
+    };
+    let record = match capture_geometry(window) {
+        Ok(record) => record,
+        Err(error) => {
+            warn!("Failed to capture main window geometry: {error}");
+            return;
+        }
+    };
+    if let Err(error) = save_record(&path, &record) {
+        warn!("Failed to save main window geometry: {error}");
+    }
+}
+
+fn try_restore_saved_geometry(window: &WebviewWindow) -> Result<bool, String> {
+    let path = store_path(window.app_handle())?;
+    let Some(record) = load_record(&path)? else {
+        return Ok(false);
+    };
+    let monitors = window
+        .available_monitors()
+        .map_err(|error| error.to_string())?;
+    if !should_restore_record(&record, &monitors) {
+        return Ok(false);
+    }
+    apply_geometry(window, &record)?;
+    Ok(true)
+}
+
+pub fn restore_main_window(window: &WebviewWindow) {
+    let use_default = match try_restore_saved_geometry(window) {
+        Ok(true) => false,
+        Ok(false) => true,
+        Err(error) => {
+            warn!("Failed to restore main window geometry, using default: {error}");
+            true
+        }
+    };
+
+    if use_default {
+        if let Err(error) = apply_default_centered_geometry(window) {
+            warn!("Failed to apply default main window geometry: {error}");
+        }
+    }
+}
+
+pub fn install_main_window_persistence(window: &WebviewWindow) {
+    restore_main_window(window);
+
+    let window_for_events = window.clone();
+    window_for_events
+        .clone()
+        .on_window_event(move |event| {
+            if matches!(event, WindowEvent::CloseRequested { .. } | WindowEvent::Destroyed) {
+                save_main_window_geometry(&window_for_events);
+            }
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        intersection, is_geometry_visible_for_monitor_rects, Rect, MIN_INNER_HEIGHT,
+        MIN_INNER_WIDTH,
+    };
+
+    #[test]
+    fn intersection_returns_overlap_rect() {
+        let window = Rect {
+            x: 100,
+            y: 100,
+            width: 800,
+            height: 600,
+        };
+        let monitor = Rect {
+            x: 0,
+            y: 0,
+            width: 1440,
+            height: 900,
+        };
+        let overlap = intersection(window, monitor).expect("overlap");
+        assert_eq!(overlap.x, 100);
+        assert_eq!(overlap.y, 100);
+        assert_eq!(overlap.width, 800);
+        assert_eq!(overlap.height, 600);
+    }
+
+    #[test]
+    fn geometry_is_invalid_when_fully_off_screen() {
+        let monitors = vec![Rect {
+            x: 0,
+            y: 0,
+            width: 1440,
+            height: 900,
+        }];
+        assert!(!is_geometry_visible_for_monitor_rects(
+            MIN_INNER_WIDTH,
+            MIN_INNER_HEIGHT,
+            3000,
+            3000,
+            &monitors,
+        ));
+    }
+
+    #[test]
+    fn geometry_is_valid_when_partially_visible() {
+        let monitors = vec![Rect {
+            x: 0,
+            y: 0,
+            width: 1440,
+            height: 900,
+        }];
+        assert!(is_geometry_visible_for_monitor_rects(
+            900, 700, -100, 50, &monitors
+        ));
+    }
+
+    #[test]
+    fn geometry_is_invalid_when_too_small() {
+        let monitors = vec![Rect {
+            x: 0,
+            y: 0,
+            width: 1440,
+            height: 900,
+        }];
+        assert!(!is_geometry_visible_for_monitor_rects(
+            MIN_INNER_WIDTH - 1,
+            MIN_INNER_HEIGHT,
+            100,
+            100,
+            &monitors,
+        ));
+    }
+}

--- a/src-tauri/src/window_geometry/mod.rs
+++ b/src-tauri/src/window_geometry/mod.rs
@@ -54,18 +54,14 @@ fn intersection(window: Rect, monitor: Rect) -> Option<Rect> {
     })
 }
 
-#[cfg(test)]
-fn is_geometry_visible_for_monitor_rects(
+fn is_geometry_visible_for_rects(
     width: u32,
     height: u32,
     x: i32,
     y: i32,
     monitors: &[Rect],
 ) -> bool {
-    if width < MIN_INNER_WIDTH || height < MIN_INNER_HEIGHT {
-        return false;
-    }
-    if monitors.is_empty() {
+    if width < MIN_INNER_WIDTH || height < MIN_INNER_HEIGHT || monitors.is_empty() {
         return false;
     }
 
@@ -90,28 +86,14 @@ fn is_geometry_visible_on_monitors(
     y: i32,
     monitors: &[Monitor],
 ) -> bool {
-    if width < MIN_INNER_WIDTH || height < MIN_INNER_HEIGHT || monitors.is_empty() {
+    if monitors.is_empty() {
         return false;
     }
-
-    let window = Rect {
-        x,
-        y,
-        width: width as i32,
-        height: height as i32,
-    };
-
-    monitors.iter().any(|monitor| {
-        intersection(window, monitor_rect(monitor)).is_some_and(|visible| {
-            visible.width >= MIN_VISIBLE_WIDTH && visible.height >= MIN_VISIBLE_HEIGHT
-        })
-    })
+    let rects: Vec<Rect> = monitors.iter().map(monitor_rect).collect();
+    is_geometry_visible_for_rects(width, height, x, y, &rects)
 }
 
 fn should_restore_record(record: &WindowGeometryRecord, monitors: &[Monitor]) -> bool {
-    if record.maximized {
-        return !monitors.is_empty();
-    }
     is_geometry_visible_on_monitors(record.width, record.height, record.x, record.y, monitors)
 }
 
@@ -137,16 +119,16 @@ fn apply_default_centered_geometry(window: &WebviewWindow) -> Result<(), String>
 }
 
 fn apply_geometry(window: &WebviewWindow, record: &WindowGeometryRecord) -> Result<(), String> {
+    window
+        .set_size(Size::Physical(PhysicalSize::new(record.width, record.height)))
+        .map_err(|error| error.to_string())?;
+    window
+        .set_position(Position::Physical(PhysicalPosition::new(record.x, record.y)))
+        .map_err(|error| error.to_string())?;
     if record.maximized {
-        window.maximize().map_err(|error| error.to_string())
-    } else {
-        window
-            .set_size(Size::Physical(PhysicalSize::new(record.width, record.height)))
-            .map_err(|error| error.to_string())?;
-        window
-            .set_position(Position::Physical(PhysicalPosition::new(record.x, record.y)))
-            .map_err(|error| error.to_string())
+        window.maximize().map_err(|error| error.to_string())?;
     }
+    Ok(())
 }
 
 fn capture_geometry(window: &WebviewWindow) -> Result<WindowGeometryRecord, String> {
@@ -233,7 +215,7 @@ pub fn install_main_window_persistence(window: &WebviewWindow) {
 #[cfg(test)]
 mod tests {
     use super::{
-        intersection, is_geometry_visible_for_monitor_rects, Rect, MIN_INNER_HEIGHT,
+        intersection, is_geometry_visible_for_rects, Rect, MIN_INNER_HEIGHT,
         MIN_INNER_WIDTH,
     };
 
@@ -266,7 +248,7 @@ mod tests {
             width: 1440,
             height: 900,
         }];
-        assert!(!is_geometry_visible_for_monitor_rects(
+        assert!(!is_geometry_visible_for_rects(
             MIN_INNER_WIDTH,
             MIN_INNER_HEIGHT,
             3000,
@@ -283,7 +265,7 @@ mod tests {
             width: 1440,
             height: 900,
         }];
-        assert!(is_geometry_visible_for_monitor_rects(
+        assert!(is_geometry_visible_for_rects(
             900, 700, -100, 50, &monitors
         ));
     }
@@ -296,7 +278,7 @@ mod tests {
             width: 1440,
             height: 900,
         }];
-        assert!(!is_geometry_visible_for_monitor_rects(
+        assert!(!is_geometry_visible_for_rects(
             MIN_INNER_WIDTH - 1,
             MIN_INNER_HEIGHT,
             100,

--- a/src-tauri/src/window_geometry/store.rs
+++ b/src-tauri/src/window_geometry/store.rs
@@ -1,0 +1,38 @@
+use std::path::{Path, PathBuf};
+
+use tauri::{AppHandle, Manager};
+
+use crate::io_atomic;
+
+use super::types::{WindowGeometryRecord, WINDOW_GEOMETRY_STORE_VERSION};
+
+const WINDOW_GEOMETRY_STORE_FILE: &str = "main_window_geometry.json";
+
+pub fn store_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app.path().app_config_dir().map_err(|error| error.to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|error| error.to_string())?;
+    Ok(dir.join(WINDOW_GEOMETRY_STORE_FILE))
+}
+
+pub fn load_record(path: &Path) -> Result<Option<WindowGeometryRecord>, String> {
+    match std::fs::read(path) {
+        Ok(bytes) => {
+            let record: WindowGeometryRecord =
+                serde_json::from_slice(&bytes).map_err(|error| error.to_string())?;
+            if record.version > WINDOW_GEOMETRY_STORE_VERSION {
+                return Err(format!(
+                    "unsupported window geometry store version {} (max supported {})",
+                    record.version, WINDOW_GEOMETRY_STORE_VERSION
+                ));
+            }
+            Ok(Some(record))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+pub fn save_record(path: &Path, record: &WindowGeometryRecord) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(record).map_err(|error| error.to_string())?;
+    io_atomic::write_atomic(path, &bytes).map_err(|error| error.to_string())
+}

--- a/src-tauri/src/window_geometry/types.rs
+++ b/src-tauri/src/window_geometry/types.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+pub const WINDOW_GEOMETRY_STORE_VERSION: u32 = 1;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct WindowGeometryRecord {
+    pub version: u32,
+    pub width: u32,
+    pub height: u32,
+    pub x: i32,
+    pub y: i32,
+    #[serde(default)]
+    pub maximized: bool,
+}


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/281

## Description

Glyph previously resized the main window to 80% of the current monitor and centered it on every launch, overwriting any user-adjusted size or position. This adds persistence so the main window reopens where the user left it.

- Summary of changes
  - New `window_geometry` Rust module: versioned JSON store in app config (`main_window_geometry.json`), restore on startup, save on close/destroy.
  - Validates saved geometry against available monitors before restoring (minimum size + visible overlap) so the window cannot reopen off-screen after display changes.
  - Falls back to the existing 80%-centered default on first run or when saved geometry is invalid.
  - Restores maximized state when monitors are available.
  - Reuses shared min inner size constants for secondary space windows.
- Reasoning
  - Save-on-close avoids debounced resize/move writes and keeps the implementation small; geometry is captured once when the user quits.
  - Monitor intersection checks match the acceptance criteria in the issue without needing per-platform edge-case handling.
- Additional context
  - Scope is the `main` window only; secondary space windows and Quick Note still use fixed defaults (called out in #281 as a follow-up).
  - Also ignores local `plans/` directory in `.gitignore`.

## Docs

Store path: app config dir → `main_window_geometry.json`

Record shape (`version: 1`):

```json
{
  "version": 1,
  "width": 1200,
  "height": 800,
  "x": 100,
  "y": 100,
  "maximized": false
}
```

Restore flow: load record → validate against monitors → apply size/position or maximize → else 80% centered fallback.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the main window size, position, and maximized state across launches. Validates geometry to avoid off-screen windows and applies position before maximizing; falls back to a centered 80% size when missing or invalid.

- **New Features**
  - Added `window_geometry` module with a versioned JSON store (`main_window_geometry.json`) integrated via `MAIN_WINDOW_LABEL`; restores on startup and saves on close/destroy.
  - Validates saved geometry (min size + visible overlap across monitors) and restores maximized state with position set first; otherwise uses the centered 80% default.

- **Refactors**
  - Shared min inner size constants for secondary space windows.
  - Ignored `plans/` in `.gitignore`.

<sup>Written for commit d334073fcce32502af0cb1a75f951f67c4275dbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now remembers the main window’s size, position, and maximized state between launches.
  * If the saved window location is no longer visible, it will reopen in a sensible default position.
* **Bug Fixes**
  * Improved window startup behavior to avoid opening partially or fully off-screen.
  * Standardized the minimum window size for related screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->