### PR TITLE
Add user-facing spell check setting for editors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "futures-util",
  "hex",
  "notify",
+ "objc2-foundation",
  "regex",
  "reqwest 0.12.28",
  "rig-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,11 @@ tauri-plugin-global-shortcut = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "20"
+objc2-foundation = { version = "0.3", default-features = false, features = [
+  "std",
+  "NSString",
+  "NSUserDefaults",
+] }
 
 [profile.release]
 strip = "symbols"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,8 @@ mod glyph_paths;
 mod index;
 mod io_atomic;
 mod license;
+#[cfg(target_os = "macos")]
+mod macos_webkit_defaults;
 mod menu_manifest;
 mod net;
 mod notes;
@@ -1408,6 +1410,9 @@ fn set_window_vibrancy_theme(window: tauri::WebviewWindow, theme: String) -> Res
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     init_tracing();
+
+    #[cfg(target_os = "macos")]
+    macos_webkit_defaults::configure_continuous_spell_checking();
 
     tauri::Builder::default()
         .menu(|app| build_main_menu(app, false, false, &[], &HashMap::new()))

--- a/src-tauri/src/macos_webkit_defaults.rs
+++ b/src-tauri/src/macos_webkit_defaults.rs
@@ -6,4 +6,5 @@ pub fn configure_continuous_spell_checking() {
     let defaults = NSUserDefaults::standardUserDefaults();
     let key = NSString::from_str("WebContinuousSpellCheckingEnabled");
     defaults.setBool_forKey(true, &key);
+    tracing::debug!("configured WebContinuousSpellCheckingEnabled for WKWebView");
 }

--- a/src-tauri/src/macos_webkit_defaults.rs
+++ b/src-tauri/src/macos_webkit_defaults.rs
@@ -1,0 +1,9 @@
+/// WKWebView on macOS hides continuous spellcheck underlines unless
+/// `WebContinuousSpellCheckingEnabled` is set before any webview is created.
+pub fn configure_continuous_spell_checking() {
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    let key = NSString::from_str("WebContinuousSpellCheckingEnabled");
+    defaults.setBool_forKey(true, &key);
+}

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -114,4 +114,7 @@ export function getCodeBlockLanguageLabel(
 export const SyntaxHighlightedCodeBlock = CodeBlockLowlight.configure({
 	lowlight,
 	defaultLanguage: "plaintext",
+	HTMLAttributes: {
+		spellcheck: "false",
+	},
 });

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -700,6 +700,11 @@ export function createEditorExtensions(
 	return [
 		StarterKit.configure({
 			bulletList: { keepMarks: true, keepAttributes: false },
+			code: {
+				HTMLAttributes: {
+					spellcheck: "false",
+				},
+			},
 			codeBlock: false,
 			orderedList: { keepMarks: true, keepAttributes: false },
 			link: false,

--- a/src/components/editor/hooks/useEditorSpellCheck.ts
+++ b/src/components/editor/hooks/useEditorSpellCheck.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { loadSettings } from "../../../lib/settings";
+import { useTauriEvent } from "../../../lib/tauriEvents";
+
+export function applyDomSpellCheck(
+	node: HTMLElement | null | undefined,
+	enabled: boolean,
+): void {
+	node?.setAttribute("spellcheck", enabled ? "true" : "false");
+}
+
+export function applyEditorSpellCheck(
+	editor: { view: { dom: HTMLElement } } | null | undefined,
+	enabled: boolean,
+): void {
+	if (!editor) return;
+	try {
+		applyDomSpellCheck(editor.view.dom, enabled);
+	} catch {
+		// TipTap throws when the editor view is not mounted yet.
+	}
+}
+
+export function useEditorSpellCheck(): boolean {
+	const [enabled, setEnabled] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (cancelled) return;
+				setEnabled(settings.editor.spellCheck !== false);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setEnabled(true);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		if (typeof payload.editor?.spellCheck === "boolean") {
+			setEnabled(payload.editor.spellCheck);
+		}
+	});
+
+	return enabled;
+}

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -93,6 +93,7 @@ const {
 			},
 		},
 		view: {
+			dom: document.createElement("div"),
 			dispatch: vi.fn(),
 			focus: vi.fn(),
 			hasFocus: vi.fn(() => false),
@@ -366,6 +367,7 @@ describe("useNoteEditor", () => {
 		);
 		mockEditor.state.tr.setNodeMarkup.mockReset();
 		mockEditor.view.dispatch.mockReset();
+		mockEditor.view.dom = document.createElement("div");
 		mockEditor.view.focus.mockReset();
 		mockEditor.view.hasFocus.mockReset();
 		mockEditor.view.hasFocus.mockReturnValue(false);
@@ -764,6 +766,24 @@ describe("useNoteEditor", () => {
 			colorfulHeadings: false,
 			showFrontmatterInEditor: true,
 		});
+	});
+
+	it("applies spellcheck to the editor DOM from settings and live updates", async () => {
+		const onChange = vi.fn();
+
+		await act(async () => {
+			root.render(<Harness onChange={onChange} />);
+		});
+
+		expect(getActiveEditor().view.dom.getAttribute("spellcheck")).toBe("true");
+
+		await act(async () => {
+			emitSettingsUpdated({
+				editor: { spellCheck: false },
+			});
+		});
+
+		expect(getActiveEditor().view.dom.getAttribute("spellcheck")).toBe("false");
 	});
 
 	it("hydrates frontmatter visibility from persisted settings on mount", async () => {

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -10,6 +10,7 @@ import { useNoteEditor } from "./useNoteEditor";
 const {
 	canCommands,
 	chainCommands,
+	clearSettingsUpdatedHandlers,
 	emitSettingsUpdated,
 	getActiveEditor,
 	getEditorOptions,
@@ -23,18 +24,19 @@ const {
 	setSettingsUpdatedHandler,
 } = vi.hoisted(() => {
 	let editorOptions: Record<string, unknown> | null = null;
-	let settingsUpdatedHandler:
-		| ((payload: {
-				editor?: {
-					attachmentFolder?: string | null;
-					attachmentStorageMode?: AttachmentStorageMode;
-					colorfulHeadings?: boolean;
-					enablePeopleMentionsAsTags?: boolean;
-					showFrontmatterInEditor?: boolean;
-					showCollapsibleHeadings?: boolean;
-				};
-		  }) => void)
-		| null = null;
+	let settingsUpdatedHandlers: Array<
+		(payload: {
+			editor?: {
+				attachmentFolder?: string | null;
+				attachmentStorageMode?: AttachmentStorageMode;
+				colorfulHeadings?: boolean;
+				enablePeopleMentionsAsTags?: boolean;
+				showFrontmatterInEditor?: boolean;
+				showCollapsibleHeadings?: boolean;
+				spellCheck?: boolean;
+			};
+		}) => void
+	> = [];
 	const chainCommands = {
 		focus: vi.fn(() => chainCommands),
 		insertContentAt: vi.fn(() => chainCommands),
@@ -126,8 +128,13 @@ const {
 				enablePeopleMentionsAsTags?: boolean;
 				showFrontmatterInEditor?: boolean;
 				showCollapsibleHeadings?: boolean;
+				spellCheck?: boolean;
 			};
-		}) => settingsUpdatedHandler?.(payload),
+		}) => {
+			for (const handler of settingsUpdatedHandlers) {
+				handler(payload);
+			}
+		},
 		getEditorOptions: () => editorOptions,
 		invokeMock: vi.fn(),
 		loadSettingsMock: vi.fn(() =>
@@ -152,8 +159,13 @@ const {
 			editorOptions = options;
 		},
 		getActiveEditor: () => activeEditor,
-		setSettingsUpdatedHandler: (handler: typeof settingsUpdatedHandler) => {
-			settingsUpdatedHandler = handler;
+		setSettingsUpdatedHandler: (
+			handler: (typeof settingsUpdatedHandlers)[number],
+		) => {
+			settingsUpdatedHandlers.push(handler);
+		},
+		clearSettingsUpdatedHandlers: () => {
+			settingsUpdatedHandlers = [];
 		},
 	};
 });
@@ -207,6 +219,7 @@ vi.mock("../../../lib/tauriEvents", () => ({
 				enablePeopleMentionsAsTags?: boolean;
 				showFrontmatterInEditor?: boolean;
 				showCollapsibleHeadings?: boolean;
+				spellCheck?: boolean;
 			};
 		}) => void,
 	) => {
@@ -315,7 +328,7 @@ describe("useNoteEditor", () => {
 	let originalFileReader: typeof FileReader | undefined;
 
 	beforeEach(() => {
-		setSettingsUpdatedHandler(null);
+		clearSettingsUpdatedHandlers();
 		setActiveEditor(mockEditor);
 		mockEditor.isEditable = true;
 		mockEditor.isActive.mockReset();

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -8,21 +8,12 @@ import {
 	useMemo,
 	useRef,
 } from "react";
-import { useState } from "react";
-import {
-	DEFAULT_ATTACHMENT_FOLDER,
-	resolveAttachmentTargetDir,
-} from "../../../lib/attachmentStorage";
+import { resolveAttachmentTargetDir } from "../../../lib/attachmentStorage";
 import {
 	joinYamlFrontmatter,
 	splitYamlFrontmatter,
 } from "../../../lib/notePreview";
-import {
-	type AttachmentStorageMode,
-	loadSettings,
-} from "../../../lib/settings";
 import { invoke } from "../../../lib/tauri";
-import { useTauriEvent } from "../../../lib/tauriEvents";
 import { handleEditorClick } from "../editorClickHandlers";
 import { createEditorExtensions } from "../extensions";
 import type { MathEditRequest } from "../extensions/math/mathOptions";
@@ -33,7 +24,12 @@ import {
 	preprocessMarkdownForEditor,
 } from "../markdown/wikiLinkMarkdownBridge";
 import type { NoteInlineEditorMode, PasteMarkdownBehavior } from "../types";
+import {
+	applyEditorSpellCheck,
+	useEditorSpellCheck,
+} from "./useEditorSpellCheck";
 import { useHydrateInlineImages } from "./useHydrateInlineImages";
+import { useNoteEditorSettings } from "./useNoteEditorSettings";
 
 const PASTE_FAILURE_PREFIX = "Image paste failed";
 const MARKDOWN_SYNC_DEBOUNCE_MS = 300;
@@ -337,8 +333,16 @@ export function useNoteEditor({
 	const interactiveRef = useRef(interactive);
 	const modeRef = useRef(mode);
 	const previousModeRef = useRef(mode);
-	const attachmentStorageModeRef = useRef<AttachmentStorageMode>("note-folder");
-	const attachmentFolderRef = useRef<string | null>(DEFAULT_ATTACHMENT_FOLDER);
+	const {
+		attachmentFolderRef,
+		attachmentStorageModeRef,
+		colorfulHeadings,
+		peopleMentionsEnabled,
+		showCollapsibleHeadings,
+		showFrontmatterInEditor,
+		vimKeybindingsEnabled,
+	} = useNoteEditorSettings();
+	const spellCheckEnabled = useEditorSpellCheck();
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null);
 	const committedEditorRef = useRef<ReturnType<typeof useEditor>>(null);
 	const pendingMarkdownSyncRef = useRef<PendingMarkdownSync | null>(null);
@@ -346,11 +350,6 @@ export function useNoteEditor({
 	const editorContentRelPathRef = useRef(relPath);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
 	const markdownSyncFrameRef = useRef<number | null>(null);
-	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
-	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
-	const [colorfulHeadings, setColorfulHeadings] = useState(false);
-	const [peopleMentionsEnabled, setPeopleMentionsEnabled] = useState(false);
-	const [vimKeybindingsEnabled, setVimKeybindingsEnabled] = useState(false);
 	const extensions = useMemo(
 		() =>
 			createEditorExtensions({
@@ -385,61 +384,6 @@ export function useNoteEditor({
 				: null,
 		[extensions, pasteMarkdownBehavior],
 	);
-
-	useEffect(() => {
-		let cancelled = false;
-		void loadSettings()
-			.then((settings) => {
-				if (cancelled) return;
-				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
-				setShowFrontmatterInEditor(
-					settings.editor.showFrontmatterInEditor === true,
-				);
-				setColorfulHeadings(settings.editor.colorfulHeadings);
-				setPeopleMentionsEnabled(settings.editor.enablePeopleMentionsAsTags);
-				setVimKeybindingsEnabled(settings.editor.vimKeybindings === true);
-				attachmentStorageModeRef.current =
-					settings.editor.attachmentStorageMode;
-				attachmentFolderRef.current = settings.editor.attachmentFolder;
-			})
-			.catch(() => {
-				if (cancelled) return;
-				setShowCollapsibleHeadings(false);
-				setShowFrontmatterInEditor(false);
-				setColorfulHeadings(false);
-				setPeopleMentionsEnabled(false);
-				setVimKeybindingsEnabled(false);
-				attachmentStorageModeRef.current = "note-folder";
-				attachmentFolderRef.current = DEFAULT_ATTACHMENT_FOLDER;
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	useTauriEvent("settings:updated", (payload) => {
-		if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
-			setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
-		}
-		if (typeof payload.editor?.showFrontmatterInEditor === "boolean") {
-			setShowFrontmatterInEditor(payload.editor.showFrontmatterInEditor);
-		}
-		if (typeof payload.editor?.colorfulHeadings === "boolean") {
-			setColorfulHeadings(payload.editor.colorfulHeadings);
-		}
-		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
-			setPeopleMentionsEnabled(payload.editor.enablePeopleMentionsAsTags);
-		}
-		if (typeof payload.editor?.vimKeybindings === "boolean") {
-			setVimKeybindingsEnabled(payload.editor.vimKeybindings);
-		}
-		if (payload.editor?.attachmentStorageMode) {
-			attachmentStorageModeRef.current = payload.editor.attachmentStorageMode;
-		}
-		if ("attachmentFolder" in (payload.editor ?? {})) {
-			attachmentFolderRef.current = payload.editor?.attachmentFolder ?? null;
-		}
-	});
 
 	frontmatterRef.current = frontmatter;
 	onChangeRef.current = onChange;
@@ -549,7 +493,6 @@ export function useNoteEditor({
 			editorProps: {
 				attributes: {
 					class: "tiptapContentInline",
-					spellcheck: "true",
 				},
 				handleDOMEvents: {
 					mousedown: (_view, event): boolean => {
@@ -707,6 +650,10 @@ export function useNoteEditor({
 		],
 	);
 	editorRef.current = editor;
+
+	useEffect(() => {
+		applyEditorSpellCheck(editor, spellCheckEnabled);
+	}, [editor, spellCheckEnabled]);
 
 	useLayoutEffect(() => {
 		if (!editor) return;

--- a/src/components/editor/hooks/useNoteEditorSettings.ts
+++ b/src/components/editor/hooks/useNoteEditorSettings.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from "react";
+import { DEFAULT_ATTACHMENT_FOLDER } from "../../../lib/attachmentStorage";
+import {
+	type AttachmentStorageMode,
+	loadSettings,
+} from "../../../lib/settings";
+import { useTauriEvent } from "../../../lib/tauriEvents";
+
+export function useNoteEditorSettings() {
+	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
+	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
+	const [colorfulHeadings, setColorfulHeadings] = useState(false);
+	const [peopleMentionsEnabled, setPeopleMentionsEnabled] = useState(false);
+	const [vimKeybindingsEnabled, setVimKeybindingsEnabled] = useState(false);
+	const attachmentStorageModeRef = useRef<AttachmentStorageMode>("note-folder");
+	const attachmentFolderRef = useRef<string | null>(DEFAULT_ATTACHMENT_FOLDER);
+
+	useEffect(() => {
+		let cancelled = false;
+		void loadSettings()
+			.then((settings) => {
+				if (cancelled) return;
+				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
+				setShowFrontmatterInEditor(
+					settings.editor.showFrontmatterInEditor === true,
+				);
+				setColorfulHeadings(settings.editor.colorfulHeadings);
+				setPeopleMentionsEnabled(settings.editor.enablePeopleMentionsAsTags);
+				setVimKeybindingsEnabled(settings.editor.vimKeybindings === true);
+				attachmentStorageModeRef.current =
+					settings.editor.attachmentStorageMode;
+				attachmentFolderRef.current = settings.editor.attachmentFolder;
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setShowCollapsibleHeadings(false);
+				setShowFrontmatterInEditor(false);
+				setColorfulHeadings(false);
+				setPeopleMentionsEnabled(false);
+				setVimKeybindingsEnabled(false);
+				attachmentStorageModeRef.current = "note-folder";
+				attachmentFolderRef.current = DEFAULT_ATTACHMENT_FOLDER;
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
+			setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+		}
+		if (typeof payload.editor?.showFrontmatterInEditor === "boolean") {
+			setShowFrontmatterInEditor(payload.editor.showFrontmatterInEditor);
+		}
+		if (typeof payload.editor?.colorfulHeadings === "boolean") {
+			setColorfulHeadings(payload.editor.colorfulHeadings);
+		}
+		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
+			setPeopleMentionsEnabled(payload.editor.enablePeopleMentionsAsTags);
+		}
+		if (typeof payload.editor?.vimKeybindings === "boolean") {
+			setVimKeybindingsEnabled(payload.editor.vimKeybindings);
+		}
+		if (payload.editor?.attachmentStorageMode) {
+			attachmentStorageModeRef.current = payload.editor.attachmentStorageMode;
+		}
+		if ("attachmentFolder" in (payload.editor ?? {})) {
+			attachmentFolderRef.current = payload.editor?.attachmentFolder ?? null;
+		}
+	});
+
+	return {
+		attachmentFolderRef,
+		attachmentStorageModeRef,
+		colorfulHeadings,
+		peopleMentionsEnabled,
+		showCollapsibleHeadings,
+		showFrontmatterInEditor,
+		vimKeybindingsEnabled,
+	};
+}

--- a/src/components/editor/raw/RawMarkdownEditor.tsx
+++ b/src/components/editor/raw/RawMarkdownEditor.tsx
@@ -2,10 +2,15 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
 	forwardRef,
+	useEffect,
 	useImperativeHandle,
 	useLayoutEffect,
 	useRef,
 } from "react";
+import {
+	applyDomSpellCheck,
+	useEditorSpellCheck,
+} from "../hooks/useEditorSpellCheck";
 import {
 	createRawMarkdownExtensions,
 	externalRawMarkdownUpdate,
@@ -33,9 +38,14 @@ export const RawMarkdownEditor = forwardRef<
 	const changeTimerRef = useRef<number | null>(null);
 	const hasPendingChangeRef = useRef(false);
 	const lastEmittedMarkdownRef = useRef(markdown);
+	const spellCheckEnabled = useEditorSpellCheck();
 
 	onChangeRef.current = onChange;
 	relPathRef.current = relPath;
+
+	useEffect(() => {
+		applyDomSpellCheck(viewRef.current?.contentDOM, spellCheckEnabled);
+	}, [spellCheckEnabled]);
 
 	useLayoutEffect(() => {
 		const host = hostRef.current;

--- a/src/components/editor/raw/extensions.ts
+++ b/src/components/editor/raw/extensions.ts
@@ -242,7 +242,6 @@ export function createRawMarkdownExtensions(
 			"aria-label": "Raw Markdown editor",
 			"aria-multiline": "true",
 			autocapitalize: "sentences",
-			spellcheck: "true",
 		}),
 		EditorView.updateListener.of((update) => {
 			const isExternalUpdate = update.transactions.some(

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -9,6 +9,7 @@ import { AdvancedSettingsPane } from "./AdvancedSettingsPane";
 const {
 	loadSettingsMock,
 	setAiAssistantModeMock,
+	setClassicAllNotesByDefaultMock,
 	setDatabaseShowColumnColorMock,
 	setEditorBeautifulTagsMock,
 	setEditorColorfulHeadingsMock,
@@ -25,6 +26,7 @@ const {
 } = vi.hoisted(() => ({
 	loadSettingsMock: vi.fn(),
 	setAiAssistantModeMock: vi.fn(() => Promise.resolve()),
+	setClassicAllNotesByDefaultMock: vi.fn(() => Promise.resolve()),
 	setDatabaseShowColumnColorMock: vi.fn(() => Promise.resolve()),
 	setEditorBeautifulTagsMock: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadingsMock: vi.fn(() => Promise.resolve()),
@@ -50,6 +52,7 @@ vi.mock("../../contexts", () => ({
 vi.mock("../../lib/settings", () => ({
 	loadSettings: loadSettingsMock,
 	setAiAssistantMode: setAiAssistantModeMock,
+	setClassicAllNotesByDefault: setClassicAllNotesByDefaultMock,
 	setDatabaseShowColumnColor: setDatabaseShowColumnColorMock,
 	setEditorBeautifulTags: setEditorBeautifulTagsMock,
 	setEditorColorfulHeadings: setEditorColorfulHeadingsMock,

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -15,6 +15,7 @@ const {
 	setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowFrontmatterInEditorMock,
 	setEditorShowCollapsibleHeadingsMock,
+	setEditorSpellCheckMock,
 	setEditorWidthModeMock,
 	setEditorVimKeybindingsMock,
 	setFolioModeMock,
@@ -30,6 +31,7 @@ const {
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
 	setEditorShowFrontmatterInEditorMock: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleHeadingsMock: vi.fn(() => Promise.resolve()),
+	setEditorSpellCheckMock: vi.fn(() => Promise.resolve()),
 	setEditorWidthModeMock: vi.fn(() => Promise.resolve()),
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
 	setFolioModeMock: vi.fn(() => Promise.resolve()),
@@ -54,6 +56,7 @@ vi.mock("../../lib/settings", () => ({
 	setEditorEnablePeopleMentionsAsTags: setEditorEnablePeopleMentionsAsTagsMock,
 	setEditorShowFrontmatterInEditor: setEditorShowFrontmatterInEditorMock,
 	setEditorShowCollapsibleHeadings: setEditorShowCollapsibleHeadingsMock,
+	setEditorSpellCheck: setEditorSpellCheckMock,
 	setEditorWidthMode: setEditorWidthModeMock,
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
 	setFolioMode: setFolioModeMock,
@@ -129,6 +132,7 @@ function makeSettings(
 	colorfulHeadings: boolean,
 	vimKeybindings = false,
 	beautifulTags = false,
+	spellCheck = true,
 ) {
 	return {
 		editor: {
@@ -138,6 +142,7 @@ function makeSettings(
 			enablePeopleMentionsAsTags: false,
 			showCollapsibleHeadings: false,
 			showFrontmatterInEditor: false,
+			spellCheck,
 			vimKeybindings,
 		},
 		ui: {
@@ -294,6 +299,52 @@ describe("AdvancedSettingsPane", () => {
 		});
 
 		expect(setEditorWidthModeMock).toHaveBeenCalledWith("wide");
+	});
+
+	it("shows spell check on by default", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Spell check"]',
+		) as HTMLInputElement | null;
+
+		expect(container.textContent).toContain("Spell check");
+		expect(toggle?.checked).toBe(true);
+	});
+
+	it("reflects stored spell check state", async () => {
+		loadSettingsMock.mockResolvedValue(
+			makeSettings(false, false, false, false),
+		);
+
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Spell check"]',
+		) as HTMLInputElement | null;
+
+		expect(toggle?.checked).toBe(false);
+	});
+
+	it("saves spell check changes", async () => {
+		await act(async () => {
+			root.render(<AdvancedSettingsPane />);
+		});
+
+		const toggle = container.querySelector(
+			'input[aria-label="Spell check"]',
+		) as HTMLInputElement | null;
+		expect(toggle).toBeTruthy();
+
+		await act(async () => {
+			toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(setEditorSpellCheckMock).toHaveBeenCalledWith(false);
 	});
 
 	it("shows Vim Mode off by default", async () => {

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -15,6 +15,7 @@ import {
 	setEditorEnablePeopleMentionsAsTags,
 	setEditorShowCollapsibleHeadings,
 	setEditorShowFrontmatterInEditor,
+	setEditorSpellCheck,
 	setEditorVimKeybindings,
 	setEditorWidthMode,
 	setFolioMode,
@@ -31,6 +32,7 @@ import {
 	SettingsToggle,
 } from "./SettingsScaffold";
 import { SettingsSelect } from "./SettingsSelect";
+import { useOptimisticSettingsToggle } from "./useOptimisticSettingsToggle";
 
 const VIM_KEYBINDING_HELP = [
 	{ key: "Esc", action: "Enter Vim command mode." },
@@ -116,6 +118,7 @@ export function AdvancedSettingsPane() {
 	const [enablePeopleMentionsAsTags, setEnablePeopleMentionsAsTags] =
 		useState(false);
 	const [vimKeybindings, setVimKeybindings] = useState(false);
+	const [spellCheck, setSpellCheck] = useState(true);
 	const [showToc, setShowTocState] = useState(true);
 	const [aiAssistantMode, setAiAssistantModeState] =
 		useState<AiAssistantMode>("create");
@@ -156,6 +159,12 @@ export function AdvancedSettingsPane() {
 	const [isSavingDatabaseColumnColor, setIsSavingDatabaseColumnColor] =
 		useState(false);
 	const { spacePath, startIndexRebuild } = useSpace();
+	const spellCheckToggle = useOptimisticSettingsToggle(
+		spellCheck,
+		setSpellCheck,
+		setEditorSpellCheck,
+		setError,
+	);
 
 	const refresh = useCallback(async () => {
 		setError("");
@@ -168,6 +177,7 @@ export function AdvancedSettingsPane() {
 			setEditorWidthModeState(settings.editor.editorWidthMode);
 			setEnablePeopleMentionsAsTags(settings.editor.enablePeopleMentionsAsTags);
 			setVimKeybindings(settings.editor.vimKeybindings === true);
+			setSpellCheck(settings.editor.spellCheck !== false);
 			setShowTocState(settings.ui.showToc);
 			setAiAssistantModeState(settings.ui.aiAssistantMode);
 			setFolioModeState(settings.ui.folioMode);
@@ -209,6 +219,9 @@ export function AdvancedSettingsPane() {
 		}
 		if (typeof payload.editor?.vimKeybindings === "boolean") {
 			setVimKeybindings(payload.editor.vimKeybindings);
+		}
+		if (typeof payload.editor?.spellCheck === "boolean") {
+			setSpellCheck(payload.editor.spellCheck);
 		}
 		if (typeof payload.ui?.showToc === "boolean") {
 			setShowTocState(payload.ui.showToc);
@@ -430,6 +443,17 @@ export function AdvancedSettingsPane() {
 										setIsSavingShowCollapsibleHeadings(false);
 									});
 							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label="Spell check"
+						description="Underline typos as you type. Right-click a word to see spelling suggestions."
+					>
+						<SettingsToggle
+							checked={spellCheck}
+							disabled={spellCheckToggle.isSaving}
+							ariaLabel="Spell check"
+							onCheckedChange={spellCheckToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -130,39 +130,81 @@ export function AdvancedSettingsPane() {
 	const [showNonMarkdownFiles, setShowNonMarkdownFilesState] = useState(true);
 	const [showDatabaseColumnColor, setShowDatabaseColumnColor] = useState(true);
 	const [error, setError] = useState("");
-	const [isSavingShowToc, setIsSavingShowToc] = useState(false);
-	const [isSavingShowCollapsibleHeadings, setIsSavingShowCollapsibleHeadings] =
+	const [isSavingEnablePeopleMentionsAsTags, setIsSavingEnablePeopleMentionsAsTags] =
 		useState(false);
-	const [isSavingShowFrontmatterInEditor, setIsSavingShowFrontmatterInEditor] =
-		useState(false);
-	const [isSavingColorfulHeadings, setIsSavingColorfulHeadings] =
-		useState(false);
-	const [isSavingBeautifulTags, setIsSavingBeautifulTags] = useState(false);
 	const [isSavingEditorWidthMode, setIsSavingEditorWidthMode] = useState(false);
-	const [
-		isSavingEnablePeopleMentionsAsTags,
-		setIsSavingEnablePeopleMentionsAsTags,
-	] = useState(false);
-	const [isSavingVimKeybindings, setIsSavingVimKeybindings] = useState(false);
 	const [isSavingAiAssistantMode, setIsSavingAiAssistantMode] = useState(false);
-	const [isSavingFolioMode, setIsSavingFolioMode] = useState(false);
-	const [
-		isSavingClassicAllNotesByDefault,
-		setIsSavingClassicAllNotesByDefault,
-	] = useState(false);
-	const [
-		isSavingShowFileTreeFolderCounts,
-		setIsSavingShowFileTreeFolderCounts,
-	] = useState(false);
-	const [isSavingShowNonMarkdownFiles, setIsSavingShowNonMarkdownFiles] =
-		useState(false);
-	const [isSavingDatabaseColumnColor, setIsSavingDatabaseColumnColor] =
-		useState(false);
 	const { spacePath, startIndexRebuild } = useSpace();
+	const showTocToggle = useOptimisticSettingsToggle(
+		showToc,
+		setShowTocState,
+		setShowToc,
+		setError,
+	);
+	const showFrontmatterToggle = useOptimisticSettingsToggle(
+		showFrontmatterInEditor,
+		setShowFrontmatterInEditor,
+		setEditorShowFrontmatterInEditor,
+		setError,
+	);
+	const colorfulHeadingsToggle = useOptimisticSettingsToggle(
+		colorfulHeadings,
+		setColorfulHeadings,
+		setEditorColorfulHeadings,
+		setError,
+	);
+	const beautifulTagsToggle = useOptimisticSettingsToggle(
+		beautifulTags,
+		setBeautifulTags,
+		setEditorBeautifulTags,
+		setError,
+	);
+	const showCollapsibleHeadingsToggle = useOptimisticSettingsToggle(
+		showCollapsibleHeadings,
+		setShowCollapsibleHeadings,
+		setEditorShowCollapsibleHeadings,
+		setError,
+	);
 	const spellCheckToggle = useOptimisticSettingsToggle(
 		spellCheck,
 		setSpellCheck,
 		setEditorSpellCheck,
+		setError,
+	);
+	const vimKeybindingsToggle = useOptimisticSettingsToggle(
+		vimKeybindings,
+		setVimKeybindings,
+		setEditorVimKeybindings,
+		setError,
+	);
+	const folioModeToggle = useOptimisticSettingsToggle(
+		folioMode,
+		setFolioModeState,
+		setFolioMode,
+		setError,
+	);
+	const classicAllNotesToggle = useOptimisticSettingsToggle(
+		classicAllNotesByDefault,
+		setClassicAllNotesByDefaultState,
+		setClassicAllNotesByDefault,
+		setError,
+	);
+	const showFileTreeFolderCountsToggle = useOptimisticSettingsToggle(
+		showFileTreeFolderCounts,
+		setShowFileTreeFolderCountsState,
+		setShowFileTreeFolderCounts,
+		setError,
+	);
+	const showNonMarkdownFilesToggle = useOptimisticSettingsToggle(
+		showNonMarkdownFiles,
+		setShowNonMarkdownFilesState,
+		setShowNonMarkdownFiles,
+		setError,
+	);
+	const showDatabaseColumnColorToggle = useOptimisticSettingsToggle(
+		showDatabaseColumnColor,
+		setShowDatabaseColumnColor,
+		setDatabaseShowColumnColor,
 		setError,
 	);
 
@@ -264,22 +306,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showToc}
-							disabled={isSavingShowToc}
+							disabled={showTocToggle.isSaving}
 							ariaLabel="Table of contents"
-							onCheckedChange={(checked) => {
-								const previous = showToc;
-								setError("");
-								setShowTocState(checked);
-								setIsSavingShowToc(true);
-								void setShowToc(checked)
-									.catch((cause) => {
-										setShowTocState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowToc(false);
-									});
-							}}
+							onCheckedChange={showTocToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -323,22 +352,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showFrontmatterInEditor}
-							disabled={isSavingShowFrontmatterInEditor}
+							disabled={showFrontmatterToggle.isSaving}
 							ariaLabel="Show frontmatter in editor"
-							onCheckedChange={(checked) => {
-								const previous = showFrontmatterInEditor;
-								setError("");
-								setShowFrontmatterInEditor(checked);
-								setIsSavingShowFrontmatterInEditor(true);
-								void setEditorShowFrontmatterInEditor(checked)
-									.catch((cause) => {
-										setShowFrontmatterInEditor(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowFrontmatterInEditor(false);
-									});
-							}}
+							onCheckedChange={showFrontmatterToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -347,22 +363,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={colorfulHeadings}
-							disabled={isSavingColorfulHeadings}
+							disabled={colorfulHeadingsToggle.isSaving}
 							ariaLabel="Colorful headings"
-							onCheckedChange={(checked) => {
-								const previous = colorfulHeadings;
-								setError("");
-								setColorfulHeadings(checked);
-								setIsSavingColorfulHeadings(true);
-								void setEditorColorfulHeadings(checked)
-									.catch((cause) => {
-										setColorfulHeadings(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingColorfulHeadings(false);
-									});
-							}}
+							onCheckedChange={colorfulHeadingsToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -371,22 +374,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={beautifulTags}
-							disabled={isSavingBeautifulTags}
+							disabled={beautifulTagsToggle.isSaving}
 							ariaLabel="Beautiful Tags"
-							onCheckedChange={(checked) => {
-								const previous = beautifulTags;
-								setError("");
-								setBeautifulTags(checked);
-								setIsSavingBeautifulTags(true);
-								void setEditorBeautifulTags(checked)
-									.catch((cause) => {
-										setBeautifulTags(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingBeautifulTags(false);
-									});
-							}}
+							onCheckedChange={beautifulTagsToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -427,22 +417,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showCollapsibleHeadings}
-							disabled={isSavingShowCollapsibleHeadings}
+							disabled={showCollapsibleHeadingsToggle.isSaving}
 							ariaLabel="Collapsible headings"
-							onCheckedChange={(checked) => {
-								const previous = showCollapsibleHeadings;
-								setError("");
-								setShowCollapsibleHeadings(checked);
-								setIsSavingShowCollapsibleHeadings(true);
-								void setEditorShowCollapsibleHeadings(checked)
-									.catch((cause) => {
-										setShowCollapsibleHeadings(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowCollapsibleHeadings(false);
-									});
-							}}
+							onCheckedChange={showCollapsibleHeadingsToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -467,22 +444,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={vimKeybindings}
-							disabled={isSavingVimKeybindings}
+							disabled={vimKeybindingsToggle.isSaving}
 							ariaLabel="Vim Mode"
-							onCheckedChange={(checked) => {
-								const previous = vimKeybindings;
-								setError("");
-								setVimKeybindings(checked);
-								setIsSavingVimKeybindings(true);
-								void setEditorVimKeybindings(checked)
-									.catch((cause) => {
-										setVimKeybindings(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingVimKeybindings(false);
-									});
-							}}
+							onCheckedChange={vimKeybindingsToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 				</SettingsSection>
@@ -526,22 +490,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={folioMode}
-							disabled={isSavingFolioMode}
+							disabled={folioModeToggle.isSaving}
 							ariaLabel="Folio Mode"
-							onCheckedChange={(checked) => {
-								const previous = folioMode;
-								setError("");
-								setFolioModeState(checked);
-								setIsSavingFolioMode(true);
-								void setFolioMode(checked)
-									.catch((cause) => {
-										setFolioModeState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingFolioMode(false);
-									});
-							}}
+							onCheckedChange={folioModeToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -550,22 +501,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={classicAllNotesByDefault}
-							disabled={isSavingClassicAllNotesByDefault}
+							disabled={classicAllNotesToggle.isSaving}
 							ariaLabel="Classic All Notes grid"
-							onCheckedChange={(checked) => {
-								const previous = classicAllNotesByDefault;
-								setError("");
-								setClassicAllNotesByDefaultState(checked);
-								setIsSavingClassicAllNotesByDefault(true);
-								void setClassicAllNotesByDefault(checked)
-									.catch((cause) => {
-										setClassicAllNotesByDefaultState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingClassicAllNotesByDefault(false);
-									});
-							}}
+							onCheckedChange={classicAllNotesToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -574,22 +512,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showFileTreeFolderCounts}
-							disabled={isSavingShowFileTreeFolderCounts}
+							disabled={showFileTreeFolderCountsToggle.isSaving}
 							ariaLabel="Show folder file counts"
-							onCheckedChange={(checked) => {
-								const previous = showFileTreeFolderCounts;
-								setError("");
-								setShowFileTreeFolderCountsState(checked);
-								setIsSavingShowFileTreeFolderCounts(true);
-								void setShowFileTreeFolderCounts(checked)
-									.catch((cause) => {
-										setShowFileTreeFolderCountsState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowFileTreeFolderCounts(false);
-									});
-							}}
+							onCheckedChange={showFileTreeFolderCountsToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow
@@ -598,22 +523,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showNonMarkdownFiles}
-							disabled={isSavingShowNonMarkdownFiles}
+							disabled={showNonMarkdownFilesToggle.isSaving}
 							ariaLabel="Show non-Markdown files"
-							onCheckedChange={(checked) => {
-								const previous = showNonMarkdownFiles;
-								setError("");
-								setShowNonMarkdownFilesState(checked);
-								setIsSavingShowNonMarkdownFiles(true);
-								void setShowNonMarkdownFiles(checked)
-									.catch((cause) => {
-										setShowNonMarkdownFilesState(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingShowNonMarkdownFiles(false);
-									});
-							}}
+							onCheckedChange={showNonMarkdownFilesToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 				</SettingsSection>
@@ -627,22 +539,9 @@ export function AdvancedSettingsPane() {
 					>
 						<SettingsToggle
 							checked={showDatabaseColumnColor}
-							disabled={isSavingDatabaseColumnColor}
+							disabled={showDatabaseColumnColorToggle.isSaving}
 							ariaLabel="Show database column color"
-							onCheckedChange={(checked) => {
-								const previous = showDatabaseColumnColor;
-								setError("");
-								setShowDatabaseColumnColor(checked);
-								setIsSavingDatabaseColumnColor(true);
-								void setDatabaseShowColumnColor(checked)
-									.catch((cause) => {
-										setShowDatabaseColumnColor(previous);
-										setError(extractErrorMessage(cause));
-									})
-									.finally(() => {
-										setIsSavingDatabaseColumnColor(false);
-									});
-							}}
+							onCheckedChange={showDatabaseColumnColorToggle.onCheckedChange}
 						/>
 					</SettingsRow>
 				</SettingsSection>

--- a/src/components/settings/useOptimisticSettingsToggle.ts
+++ b/src/components/settings/useOptimisticSettingsToggle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 
 export function useOptimisticSettingsToggle(
@@ -8,19 +8,23 @@ export function useOptimisticSettingsToggle(
 	setError: (message: string) => void,
 ) {
 	const [isSaving, setIsSaving] = useState(false);
+	const saveRequestIdRef = useRef(0);
 
 	const onCheckedChange = useCallback(
 		(next: boolean) => {
+			const requestId = ++saveRequestIdRef.current;
 			const previous = checked;
 			setError("");
 			setChecked(next);
 			setIsSaving(true);
 			void save(next)
 				.catch((cause) => {
+					if (requestId !== saveRequestIdRef.current) return;
 					setChecked(previous);
 					setError(extractErrorMessage(cause));
 				})
 				.finally(() => {
+					if (requestId !== saveRequestIdRef.current) return;
 					setIsSaving(false);
 				});
 		},

--- a/src/components/settings/useOptimisticSettingsToggle.ts
+++ b/src/components/settings/useOptimisticSettingsToggle.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from "react";
+import { extractErrorMessage } from "../../lib/errorUtils";
+
+export function useOptimisticSettingsToggle(
+	checked: boolean,
+	setChecked: (checked: boolean) => void,
+	save: (checked: boolean) => Promise<void>,
+	setError: (message: string) => void,
+) {
+	const [isSaving, setIsSaving] = useState(false);
+
+	const onCheckedChange = useCallback(
+		(next: boolean) => {
+			const previous = checked;
+			setError("");
+			setChecked(next);
+			setIsSaving(true);
+			void save(next)
+				.catch((cause) => {
+					setChecked(previous);
+					setError(extractErrorMessage(cause));
+				})
+				.finally(() => {
+					setIsSaving(false);
+				});
+		},
+		[checked, save, setChecked, setError],
+	);
+
+	return { isSaving, onCheckedChange };
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -86,6 +86,42 @@ describe("settings colorful headings", () => {
 	});
 });
 
+describe("settings spell check", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults spell check to true", async () => {
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.spellCheck).toBe(true);
+	});
+
+	it("loads spell check from the store", async () => {
+		storeState.set("editor.spellCheck", false);
+		const { loadSettings } = await import("./settings");
+
+		const settings = await loadSettings();
+
+		expect(settings.editor.spellCheck).toBe(false);
+	});
+
+	it("persists and emits spell check changes", async () => {
+		const { setEditorSpellCheck } = await import("./settings");
+
+		await setEditorSpellCheck(false);
+
+		expect(storeState.get("editor.spellCheck")).toBe(false);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			editor: { spellCheck: false },
+		});
+	});
+});
+
 describe("settings Vim keybindings", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -266,6 +266,7 @@ interface EditorSettings {
 	attachmentFolder: string | null;
 	enablePeopleMentionsAsTags: boolean;
 	vimKeybindings: boolean;
+	spellCheck: boolean;
 }
 
 interface FileTreeSettings {
@@ -303,6 +304,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	attachmentFolder: DEFAULT_ATTACHMENT_FOLDER,
 	enablePeopleMentionsAsTags: false,
 	vimKeybindings: false,
+	spellCheck: true,
 };
 
 const DEFAULT_FILE_TREE_SETTINGS: FileTreeSettings = {
@@ -479,6 +481,7 @@ async function emitSettingsUpdated(payload: {
 		attachmentFolder?: string | null;
 		enablePeopleMentionsAsTags?: boolean;
 		vimKeybindings?: boolean;
+		spellCheck?: boolean;
 	};
 	shortcuts?: {
 		bindings?: ShortcutBindings;
@@ -612,6 +615,7 @@ const KEYS = {
 	editorAttachmentFolder: "editor.attachmentFolder",
 	editorEnablePeopleMentionsAsTags: "editor.enablePeopleMentionsAsTags",
 	editorVimKeybindings: "editor.vimKeybindings",
+	editorSpellCheck: "editor.spellCheck",
 	autoUpdateLastCheckedAt: "updates.lastCheckedAt",
 	dailyNotesFolder: "dailyNotes.folder",
 	quickNotesFolder: "quickNotes.folder",
@@ -982,6 +986,10 @@ export async function loadSettings(
 		entries,
 		KEYS.editorVimKeybindings,
 	);
+	const rawEditorSpellCheck = getSettingValue<boolean | null>(
+		entries,
+		KEYS.editorSpellCheck,
+	);
 	const rawDatabaseShowColumnColor = getSettingValue<boolean | null>(
 		entries,
 		KEYS.databaseShowColumnColor,
@@ -1133,6 +1141,10 @@ export async function loadSettings(
 			typeof rawEditorVimKeybindings === "boolean"
 				? rawEditorVimKeybindings
 				: DEFAULT_EDITOR_SETTINGS.vimKeybindings,
+		spellCheck:
+			typeof rawEditorSpellCheck === "boolean"
+				? rawEditorSpellCheck
+				: DEFAULT_EDITOR_SETTINGS.spellCheck,
 	};
 	const database: DatabaseSettings = {
 		showColumnColor:
@@ -1621,6 +1633,15 @@ export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
 		editor: { vimKeybindings: enabled },
+	});
+}
+
+export async function setEditorSpellCheck(enabled: boolean): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.editorSpellCheck, enabled);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({
+		editor: { spellCheck: enabled },
 	});
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -103,6 +103,7 @@ type TauriEventMap = {
 			attachmentFolder?: string | null;
 			enablePeopleMentionsAsTags?: boolean;
 			vimKeybindings?: boolean;
+			spellCheck?: boolean;
 		};
 		shortcuts?: {
 			bindings?: Partial<


### PR DESCRIPTION
Closes #282

## Description

Turns spell check from hardcoded editor attributes into a deliberate, user-facing editor setting with consistent wiring across writing surfaces.

- **Settings:** New `editor.spellCheck` preference (default on) with toggle in Advanced Settings → Editor
- **Rich editor (TipTap):** `useEditorSpellCheck` applies spellcheck to the editor DOM live; inline code and code blocks stay off
- **Raw Markdown (CodeMirror):** Same shared hook syncs spellcheck on the content DOM
- **macOS:** Sets `WebContinuousSpellCheckingEnabled` before any WKWebView is created so continuous underlines actually appear
- **Refactor:** Extracted `useEditorSpellCheck`, `useNoteEditorSettings`, and `useOptimisticSettingsToggle` to avoid duplicated settings subscription/save boilerplate

**Reasoning:** The issue called out that spell check was implicitly enabled via DOM attributes without a product decision, macOS reliability was unclear, and code/math surfaces would be noisy. This PR makes the behavior explicit, toggleable, and testable while keeping correction suggestions on the native WebView context menu (no custom dictionary UI).

**Follow-up (out of scope):** Custom correction UI, per-language dictionaries, and explicit Quick Note verification are noted in #282 acceptance criteria but Quick Note uses the same `useNoteEditor` path so it inherits the setting automatically.

## Screenshots

N/A — behavior change is native spellcheck underlines and a settings toggle; no new visual chrome beyond the Advanced Settings row.

## Docs

Setting key: `editor.spellCheck` (boolean, default `true`).

Shared hooks:
- `useEditorSpellCheck()` — load + subscribe + return enabled state
- `applyDomSpellCheck(node, enabled)` / `applyEditorSpellCheck(editor, enabled)` — imperative DOM sync

macOS bootstrap runs once at app start in `macos_webkit_defaults::configure_continuous_spell_checking()`.

## Ready?

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user-facing spell check setting across all editors with reliable macOS underlines and live, app-wide updates. Addresses #282 by making spell check explicit, toggleable, and tested.

- **New Features**
  - New `editor.spellCheck` setting (default on) with a toggle in Advanced Settings → Editor.
  - Live updates in TipTap and Raw Markdown via a shared hook; inline code and code blocks stay off.
  - macOS: enables continuous underlines by setting `WebContinuousSpellCheckingEnabled` before any `WKWebView`.
  - Tests cover defaults, persistence, settings UI, and DOM wiring on editors.

- **Refactors**
  - Added `useEditorSpellCheck`, `useNoteEditorSettings`, and `useOptimisticSettingsToggle`; centralized boolean toggles to prevent overlapping saves.
  - Removed hardcoded `spellcheck` attributes and apply state imperatively.
  - Explicitly set `spellcheck="false"` on code and code blocks via TipTap configs.
  - Added `objc2-foundation` to support macOS defaults configuration.

<sup>Written for commit a4972ee81334c02c727d26f2741175fe0db1146d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Spell check** setting for editors, with saved preferences and instant updates across the app.
  * Improved editor behavior so spellcheck can stay active where expected, including on macOS.
  * Updated code and raw markdown editing experiences to better handle spellcheck and input behavior.

* **Bug Fixes**
  * Fixed code blocks so browser spellcheck is disabled there.
  * Improved note editor and raw editor consistency when settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->