### PR TITLE
Add file tree sort modes for name, modified, created (#288) [Release]

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1477,7 +1477,7 @@ pub fn run() {
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
             if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
-                window_geometry::install_main_window_persistence(&window);
+                window_geometry::install_host_window_persistence(&window);
             }
 
             #[cfg(target_os = "macos")]
@@ -1682,7 +1682,7 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|app_handle, event| match event {
             RunEvent::ExitRequested { .. } | RunEvent::Exit => {
-                window_geometry::flush_main_window_geometry(app_handle);
+                window_geometry::flush_host_window_geometry(app_handle);
             }
             RunEvent::Opened { urls } => {
                 handle_opened_urls(app_handle, urls);

--- a/src-tauri/src/window_geometry/mod.rs
+++ b/src-tauri/src/window_geometry/mod.rs
@@ -26,7 +26,7 @@ const DEFAULT_INNER_HEIGHT: f64 = 600.0;
 const MIN_VISIBLE_WIDTH: i32 = 200;
 const MIN_VISIBLE_HEIGHT: i32 = 80;
 
-static LATEST_MAIN_WINDOW_GEOMETRY: Mutex<Option<WindowGeometryRecord>> = Mutex::new(None);
+static LATEST_HOST_WINDOW_GEOMETRY: Mutex<Option<WindowGeometryRecord>> = Mutex::new(None);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Rect {
@@ -149,46 +149,46 @@ fn capture_geometry(window: &WebviewWindow) -> Result<WindowGeometryRecord, Stri
     })
 }
 
-fn save_main_window_geometry(window: &WebviewWindow) {
+fn save_host_window_geometry(window: &WebviewWindow) {
     let record = match capture_geometry(window) {
         Ok(record) => record,
         Err(error) => {
-            warn!("Failed to capture main window geometry: {error}");
+            warn!("Failed to capture host window geometry: {error}");
             return;
         }
     };
-    save_main_window_geometry_record(window, &record);
+    save_host_window_geometry_record(window, &record);
 }
 
-fn save_main_window_geometry_record(window: &WebviewWindow, record: &WindowGeometryRecord) {
-    save_main_window_geometry_record_for_app(window.app_handle(), record);
+fn save_host_window_geometry_record(window: &WebviewWindow, record: &WindowGeometryRecord) {
+    save_host_window_geometry_record_for_app(window.app_handle(), record);
 }
 
-fn save_main_window_geometry_record_for_app(app: &AppHandle, record: &WindowGeometryRecord) {
+fn save_host_window_geometry_record_for_app(app: &AppHandle, record: &WindowGeometryRecord) {
     let path = match store_path(app) {
         Ok(path) => path,
         Err(error) => {
-            warn!("Failed to resolve main window geometry store path: {error}");
+            warn!("Failed to resolve host window geometry store path: {error}");
             return;
         }
     };
     if let Err(error) = save_record(&path, record) {
-        warn!("Failed to save main window geometry: {error}");
+        warn!("Failed to save host window geometry: {error}");
     }
 }
 
-fn remember_main_window_geometry(record: WindowGeometryRecord) {
-    match LATEST_MAIN_WINDOW_GEOMETRY.lock() {
+fn remember_host_window_geometry(record: WindowGeometryRecord) {
+    match LATEST_HOST_WINDOW_GEOMETRY.lock() {
         Ok(mut latest) => *latest = Some(record),
-        Err(_) => warn!("Failed to lock main window geometry cache"),
+        Err(_) => warn!("Failed to lock host window geometry cache"),
     }
 }
 
-fn latest_main_window_geometry() -> Option<WindowGeometryRecord> {
-    match LATEST_MAIN_WINDOW_GEOMETRY.lock() {
+fn latest_host_window_geometry() -> Option<WindowGeometryRecord> {
+    match LATEST_HOST_WINDOW_GEOMETRY.lock() {
         Ok(latest) => latest.clone(),
         Err(_) => {
-            warn!("Failed to lock main window geometry cache");
+            warn!("Failed to lock host window geometry cache");
             None
         }
     }
@@ -196,24 +196,24 @@ fn latest_main_window_geometry() -> Option<WindowGeometryRecord> {
 
 fn remember_captured_geometry(window: &WebviewWindow) {
     match capture_geometry(window) {
-        Ok(record) => remember_main_window_geometry(record),
-        Err(error) => warn!("Failed to capture main window geometry: {error}"),
+        Ok(record) => remember_host_window_geometry(record),
+        Err(error) => warn!("Failed to capture host window geometry: {error}"),
     }
 }
 
-fn flush_latest_main_window_geometry(window: &WebviewWindow) {
-    if let Some(record) = latest_main_window_geometry() {
-        save_main_window_geometry_record(window, &record);
+fn flush_latest_host_window_geometry(window: &WebviewWindow) {
+    if let Some(record) = latest_host_window_geometry() {
+        save_host_window_geometry_record(window, &record);
     } else {
-        save_main_window_geometry(window);
+        save_host_window_geometry(window);
     }
 }
 
-pub fn flush_main_window_geometry(app: &AppHandle) {
-    if let Some(record) = latest_main_window_geometry() {
-        save_main_window_geometry_record_for_app(app, &record);
+pub fn flush_host_window_geometry(app: &AppHandle) {
+    if let Some(record) = latest_host_window_geometry() {
+        save_host_window_geometry_record_for_app(app, &record);
     } else if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        save_main_window_geometry(&window);
+        save_host_window_geometry(&window);
     }
 }
 
@@ -232,25 +232,29 @@ fn try_restore_saved_geometry(window: &WebviewWindow) -> Result<bool, String> {
     Ok(true)
 }
 
-pub fn restore_main_window(window: &WebviewWindow) {
+fn restore_host_window(window: &WebviewWindow) {
     let use_default = match try_restore_saved_geometry(window) {
         Ok(true) => false,
         Ok(false) => true,
         Err(error) => {
-            warn!("Failed to restore main window geometry, using default: {error}");
+            warn!("Failed to restore host window geometry, using default: {error}");
             true
         }
     };
 
     if use_default {
         if let Err(error) = apply_default_centered_geometry(window) {
-            warn!("Failed to apply default main window geometry: {error}");
+            warn!("Failed to apply default host window geometry: {error}");
         }
     }
 }
 
-pub fn install_main_window_persistence(window: &WebviewWindow) {
-    restore_main_window(window);
+pub fn install_host_window_persistence(window: &WebviewWindow) {
+    if window.label() != MAIN_WINDOW_LABEL {
+        return;
+    }
+
+    restore_host_window(window);
     remember_captured_geometry(window);
 
     let window_for_events = window.clone();
@@ -263,7 +267,7 @@ pub fn install_main_window_persistence(window: &WebviewWindow) {
                 remember_captured_geometry(&window_for_events);
             }
             WindowEvent::CloseRequested { .. } | WindowEvent::Destroyed => {
-                flush_latest_main_window_geometry(&window_for_events);
+                flush_latest_host_window_geometry(&window_for_events);
             }
             _ => {}
         });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.6-alpha.5",
+	"version": "0.8.6-alpha.6",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -5,6 +5,7 @@ import {
 	ExpandParagraphIcon,
 	LibraryIcon,
 	NoteIcon,
+	Sorting01Icon,
 	StarIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -12,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
+import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -21,6 +23,11 @@ import {
 	loadAllDocsCount,
 	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
+import {
+	FILE_TREE_SORT_OPTIONS,
+	type FileTreeSortMode,
+	isFileTreeSortMode,
+} from "../../lib/settings";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
 import { ChevronDown, ChevronRight } from "../Icons";
@@ -118,6 +125,13 @@ function PinnedNotesCountBadge({ count }: { count: number }) {
 	return <span className="sidebarQuickActionCount">{count}</span>;
 }
 
+function fileTreeSortLabel(sortMode: FileTreeSortMode): string {
+	return (
+		FILE_TREE_SORT_OPTIONS.find((option) => option.value === sortMode)?.label ??
+		"Sort"
+	);
+}
+
 export const SidebarContent = memo(function SidebarContent({
 	onToggleDir,
 	onLoadDir,
@@ -166,6 +180,13 @@ export const SidebarContent = memo(function SidebarContent({
 		null,
 	);
 	const [notesExpanded, setNotesExpanded] = useState(true);
+	const fileTreeSort = useFileTreeSortMode({
+		onError: (message) => {
+			toast.error("Could not update file tree sorting", {
+				description: message,
+			});
+		},
+	});
 	const newNoteShortcut = getBinding("new-note");
 	const activeFolioFolder =
 		folioScope.kind === "folder" ? folioScope.folderPrefix : null;
@@ -281,6 +302,7 @@ export const SidebarContent = memo(function SidebarContent({
 		setFolioScope({ kind: "all" });
 		onPrefetchAllDocs();
 	}, [folioMode, onPrefetchAllDocs, setFolioScope]);
+
 	const handleSelectFolioFolder = useCallback(
 		(dirPath: string) => {
 			onSelectDir(dirPath);
@@ -476,6 +498,33 @@ export const SidebarContent = memo(function SidebarContent({
 									)}
 								</button>
 								<div className="sidebarStackHeaderActions">
+									<label className="sidebarStackHeaderSortNative">
+										<span className="sr-only">Sort notes</span>
+										<HugeiconsIcon
+											icon={Sorting01Icon}
+											size="var(--icon-sm)"
+											strokeWidth={0.9}
+											className="sidebarStackHeaderSortIcon"
+											aria-hidden="true"
+										/>
+										<select
+											className="sidebarStackHeaderSortSelect"
+											value={fileTreeSort.sortMode}
+											title={`Sort notes: ${fileTreeSortLabel(fileTreeSort.sortMode)}`}
+											aria-label="Sort notes"
+											onChange={(event) => {
+												const nextSortMode = event.currentTarget.value;
+												if (!isFileTreeSortMode(nextSortMode)) return;
+												void fileTreeSort.setSortMode(nextSortMode);
+											}}
+										>
+											{FILE_TREE_SORT_OPTIONS.map((option) => (
+												<option key={option.value} value={option.value}>
+													{option.label}
+												</option>
+											))}
+										</select>
+									</label>
 									<button
 										type="button"
 										className="sidebarStackHeaderAction"

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -111,7 +111,6 @@ describe("FileTreeFileItem", () => {
 					parentDirPath="notes"
 					onDeletePath={vi.fn()}
 					appearance={null}
-					onChangeAppearance={vi.fn()}
 					isPinned={false}
 					onTogglePinned={vi.fn()}
 					{...overrides}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -115,7 +115,6 @@ interface FileTreeFileItemProps {
 	parentDirPath: string;
 	onDeletePath: (path: string, kind: "dir" | "file") => void;
 	appearance?: FileTreeAppearance | null;
-	onChangeAppearance?: (appearance: FileTreeAppearance) => void;
 	onOpenAppearancePicker?: () => void;
 	isPinned: boolean;
 	onTogglePinned: (path: string) => Promise<void> | void;

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -102,6 +102,7 @@ describe("FileTreePane", () => {
 			ui: {
 				showFileTreeFolderCounts: false,
 				showNonMarkdownFiles: true,
+				fileTreeSortMode: "name-asc",
 			},
 		});
 		useFileTreeContextMock.mockReturnValue({
@@ -235,6 +236,7 @@ describe("FileTreePane", () => {
 			ui: {
 				showFileTreeFolderCounts: false,
 				showNonMarkdownFiles: false,
+				fileTreeSortMode: "name-asc",
 			},
 		});
 

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -108,6 +108,9 @@ describe("FileTreePane", () => {
 		useFileTreeContextMock.mockReturnValue({
 			itemAppearance: {},
 			setItemAppearance: vi.fn(),
+			fileTreeSortMode: "name-asc",
+			isSavingFileTreeSortMode: false,
+			setFileTreeSortMode: vi.fn(() => Promise.resolve()),
 		});
 		useSpaceMock.mockReturnValue({
 			spacePath: "/space",

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -19,12 +19,16 @@ import {
 import { toast } from "sonner";
 import { useFileTreeContext, useSpace } from "../../contexts";
 
-import { filterVisibleFileTreeEntries } from "../../hooks/fileTreeHelpers";
+import {
+	compareEntriesForSort,
+	filterVisibleFileTreeEntries,
+} from "../../hooks/fileTreeHelpers";
+import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
 import { splitYamlFrontmatter } from "../../lib/notePreview";
-import { loadSettings } from "../../lib/settings";
+import { type FileTreeSortMode, loadSettings } from "../../lib/settings";
 import type {
 	DirChildSummary,
 	FileTreeAppearance,
@@ -84,6 +88,16 @@ const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
 
 interface AppearancePickerTarget {
 	entry: FsEntry;
+}
+
+function sortedVisibleFileTreeEntries(
+	entries: FsEntry[],
+	showNonMarkdownFiles: boolean,
+	sortMode: FileTreeSortMode,
+): FsEntry[] {
+	return filterVisibleFileTreeEntries(entries, showNonMarkdownFiles)
+		.slice()
+		.sort(compareEntriesForSort(sortMode));
 }
 
 function folderBreadcrumbParts(spacePath: string | null, dirPath: string) {
@@ -266,10 +280,6 @@ interface TreeEntriesProps {
 	folderFileCounts: Record<string, number>;
 	showFolderFileCounts: boolean;
 	showNonMarkdownFiles: boolean;
-	onChangeAppearance: (
-		entry: FsEntry,
-		appearance: FileTreeAppearance,
-	) => Promise<void> | void;
 	onOpenAppearancePicker: (entry: FsEntry) => void;
 	pinnedFiles: string[];
 	onTogglePinnedFile: (path: string) => Promise<void>;
@@ -282,6 +292,7 @@ interface TreeEntriesProps {
 	taskSummariesByPath?: Record<string, NoteTaskSummary>;
 	showFilePreviews?: boolean;
 	filePreviewsByPath?: Record<string, string | null | undefined>;
+	sortMode: FileTreeSortMode;
 }
 
 function TreeEntries({
@@ -310,7 +321,6 @@ function TreeEntries({
 	folderFileCounts,
 	showFolderFileCounts,
 	showNonMarkdownFiles,
-	onChangeAppearance,
 	onOpenAppearancePicker,
 	pinnedFiles,
 	onTogglePinnedFile,
@@ -319,10 +329,11 @@ function TreeEntries({
 	taskSummariesByPath = {},
 	showFilePreviews = false,
 	filePreviewsByPath = {},
+	sortMode,
 }: TreeEntriesProps) {
-	const visibleEntries = filterVisibleFileTreeEntries(
-		entries,
-		showNonMarkdownFiles,
+	const visibleEntries = useMemo(
+		() => sortedVisibleFileTreeEntries(entries, showNonMarkdownFiles, sortMode),
+		[entries, showNonMarkdownFiles, sortMode],
 	);
 	if (visibleEntries.length === 0) return null;
 
@@ -393,7 +404,6 @@ function TreeEntries({
 									folderFileCounts={folderFileCounts}
 									showFolderFileCounts={showFolderFileCounts}
 									showNonMarkdownFiles={showNonMarkdownFiles}
-									onChangeAppearance={onChangeAppearance}
 									onOpenAppearancePicker={onOpenAppearancePicker}
 									pinnedFiles={pinnedFiles}
 									onTogglePinnedFile={onTogglePinnedFile}
@@ -402,6 +412,7 @@ function TreeEntries({
 									taskSummariesByPath={taskSummariesByPath}
 									showFilePreviews={showFilePreviews}
 									filePreviewsByPath={filePreviewsByPath}
+									sortMode={sortMode}
 								/>
 							) : null}
 						</FileTreeDirItem>
@@ -477,7 +488,6 @@ export const FileTreePane = memo(function FileTreePane({
 	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState<
 		boolean | null
 	>(null);
-
 	const [folderFileCounts, setFolderFileCounts] = useState<
 		Record<string, number>
 	>({});
@@ -494,6 +504,7 @@ export const FileTreePane = memo(function FileTreePane({
 	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
 	const itemAppearanceRef = useRef(itemAppearance);
+	const { sortMode } = useFileTreeSortMode();
 
 	useEffect(() => {
 		itemAppearanceRef.current = itemAppearance;
@@ -791,17 +802,26 @@ export const FileTreePane = memo(function FileTreePane({
 		: null;
 	const hasLoadedFileVisibility = showNonMarkdownFiles !== null;
 	const showNonMarkdownFilesSetting = showNonMarkdownFiles ?? false;
-	const visibleRootEntries = filterVisibleFileTreeEntries(
-		rootEntries,
-		showNonMarkdownFilesSetting,
+	const visibleRootEntries = useMemo(
+		() =>
+			sortedVisibleFileTreeEntries(
+				rootEntries,
+				showNonMarkdownFilesSetting,
+				sortMode,
+			),
+		[rootEntries, showNonMarkdownFilesSetting, sortMode],
 	);
-	const visibleFocusedEntries =
-		focusedEntries === null
-			? null
-			: filterVisibleFileTreeEntries(
-					focusedEntries,
-					showNonMarkdownFilesSetting,
-				);
+	const visibleFocusedEntries = useMemo(
+		() =>
+			focusedEntries === null
+				? null
+				: sortedVisibleFileTreeEntries(
+						focusedEntries,
+						showNonMarkdownFilesSetting,
+						sortMode,
+					),
+		[focusedEntries, showNonMarkdownFilesSetting, sortMode],
+	);
 
 	useEffect(() => {
 		if (!focusedDirPath || focusedEntries || !onLoadDir) return;
@@ -972,7 +992,7 @@ export const FileTreePane = memo(function FileTreePane({
 						/>
 						{!visibleFocusedEntries ? null : visibleFocusedEntries.length ? (
 							<TreeEntries
-								entries={visibleFocusedEntries}
+								entries={focusedEntries ?? []}
 								parentDepth={-1}
 								childrenByDir={childrenByDir}
 								expandedDirs={expandedDirs}
@@ -997,7 +1017,6 @@ export const FileTreePane = memo(function FileTreePane({
 								folderFileCounts={folderFileCounts}
 								showFolderFileCounts={showFolderFileCounts}
 								showNonMarkdownFiles={showNonMarkdownFilesSetting}
-								onChangeAppearance={handleChangeAppearance}
 								onOpenAppearancePicker={handleOpenAppearancePicker}
 								pinnedFiles={pinnedFiles}
 								onTogglePinnedFile={onTogglePinnedFile}
@@ -1006,6 +1025,7 @@ export const FileTreePane = memo(function FileTreePane({
 								taskSummariesByPath={taskSummariesByPath}
 								showFilePreviews
 								filePreviewsByPath={filePreviewsByPath}
+								sortMode={sortMode}
 							/>
 						) : (
 							<m.div
@@ -1019,42 +1039,40 @@ export const FileTreePane = memo(function FileTreePane({
 					</FileTreeRootDrop>
 				) : visibleRootEntries.length ? (
 					<FileTreeRootDrop>
-						{visibleRootEntries.length ? (
-							<TreeEntries
-								entries={rootEntries}
-								parentDepth={-1}
-								childrenByDir={childrenByDir}
-								expandedDirs={expandedDirs}
-								activeFilePath={activeFilePath}
-								activeDirPath={activeDirPath}
-								renamingPath={renamingPath}
-								onToggleDir={onToggleDir}
-								onEnterDir={handleEnterDir}
-								onSelectDir={onSelectDir}
-								onOpenFile={onOpenFile}
-								onPrefetchFile={onPrefetchFile}
-								onNewFileInDir={onNewFileInDir}
-								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-								onRequestCreateFolder={handleRequestCreateFolder}
-								onDuplicateFile={handleDuplicateFile}
-								onDeletePath={handleDeletePath}
-								onStartRename={onStartRename}
-								onCommitDirRename={onCommitDirRename}
-								onCommitFileRename={onCommitFileRename}
-								onCancelRename={onCancelRename}
-								itemAppearance={itemAppearance}
-								folderFileCounts={folderFileCounts}
-								showFolderFileCounts={showFolderFileCounts}
-								showNonMarkdownFiles={showNonMarkdownFilesSetting}
-								onChangeAppearance={handleChangeAppearance}
-								onOpenAppearancePicker={handleOpenAppearancePicker}
-								pinnedFiles={pinnedFiles}
-								onTogglePinnedFile={onTogglePinnedFile}
-								onMoveClickSuppressRef={moveClickSuppressRef}
-								onArrowNavigate={handleArrowNavigate}
-								taskSummariesByPath={taskSummariesByPath}
-							/>
-						) : null}
+						<TreeEntries
+							entries={rootEntries}
+							parentDepth={-1}
+							childrenByDir={childrenByDir}
+							expandedDirs={expandedDirs}
+							activeFilePath={activeFilePath}
+							activeDirPath={activeDirPath}
+							renamingPath={renamingPath}
+							onToggleDir={onToggleDir}
+							onEnterDir={handleEnterDir}
+							onSelectDir={onSelectDir}
+							onOpenFile={onOpenFile}
+							onPrefetchFile={onPrefetchFile}
+							onNewFileInDir={onNewFileInDir}
+							onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+							onRequestCreateFolder={handleRequestCreateFolder}
+							onDuplicateFile={handleDuplicateFile}
+							onDeletePath={handleDeletePath}
+							onStartRename={onStartRename}
+							onCommitDirRename={onCommitDirRename}
+							onCommitFileRename={onCommitFileRename}
+							onCancelRename={onCancelRename}
+							itemAppearance={itemAppearance}
+							folderFileCounts={folderFileCounts}
+							showFolderFileCounts={showFolderFileCounts}
+							showNonMarkdownFiles={showNonMarkdownFilesSetting}
+							onOpenAppearancePicker={handleOpenAppearancePicker}
+							pinnedFiles={pinnedFiles}
+							onTogglePinnedFile={onTogglePinnedFile}
+							onMoveClickSuppressRef={moveClickSuppressRef}
+							onArrowNavigate={handleArrowNavigate}
+							taskSummariesByPath={taskSummariesByPath}
+							sortMode={sortMode}
+						/>
 					</FileTreeRootDrop>
 				) : (
 					<m.div

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -22,8 +22,8 @@ import { useFileTreeContext, useSpace } from "../../contexts";
 import {
 	compareEntriesForSort,
 	filterVisibleFileTreeEntries,
+	hasVisibleFileTreeEntries,
 } from "../../hooks/fileTreeHelpers";
-import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
@@ -482,7 +482,11 @@ export const FileTreePane = memo(function FileTreePane({
 	onTogglePinnedFile,
 	children,
 }: FileTreePaneProps) {
-	const { itemAppearance, setItemAppearance } = useFileTreeContext();
+	const {
+		itemAppearance,
+		setItemAppearance,
+		fileTreeSortMode: sortMode,
+	} = useFileTreeContext();
 	const { spacePath, setError } = useSpace();
 	const [showFolderFileCounts, setShowFolderFileCounts] = useState(false);
 	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState<
@@ -504,8 +508,6 @@ export const FileTreePane = memo(function FileTreePane({
 	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
 	const itemAppearanceRef = useRef(itemAppearance);
-	const { sortMode } = useFileTreeSortMode();
-
 	useEffect(() => {
 		itemAppearanceRef.current = itemAppearance;
 	}, [itemAppearance]);
@@ -802,25 +804,19 @@ export const FileTreePane = memo(function FileTreePane({
 		: null;
 	const hasLoadedFileVisibility = showNonMarkdownFiles !== null;
 	const showNonMarkdownFilesSetting = showNonMarkdownFiles ?? false;
-	const visibleRootEntries = useMemo(
-		() =>
-			sortedVisibleFileTreeEntries(
-				rootEntries,
-				showNonMarkdownFilesSetting,
-				sortMode,
-			),
-		[rootEntries, showNonMarkdownFilesSetting, sortMode],
+	const hasVisibleRootEntries = useMemo(
+		() => hasVisibleFileTreeEntries(rootEntries, showNonMarkdownFilesSetting),
+		[rootEntries, showNonMarkdownFilesSetting],
 	);
-	const visibleFocusedEntries = useMemo(
+	const hasVisibleFocusedEntries = useMemo(
 		() =>
 			focusedEntries === null
 				? null
-				: sortedVisibleFileTreeEntries(
+				: hasVisibleFileTreeEntries(
 						focusedEntries,
 						showNonMarkdownFilesSetting,
-						sortMode,
 					),
-		[focusedEntries, showNonMarkdownFilesSetting, sortMode],
+		[focusedEntries, showNonMarkdownFilesSetting],
 	);
 
 	useEffect(() => {
@@ -990,7 +986,8 @@ export const FileTreePane = memo(function FileTreePane({
 							onNavigate={handleEnterDir}
 							onExit={handleExitFocusedDir}
 						/>
-						{!visibleFocusedEntries ? null : visibleFocusedEntries.length ? (
+						{hasVisibleFocusedEntries ===
+						null ? null : hasVisibleFocusedEntries ? (
 							<TreeEntries
 								entries={focusedEntries ?? []}
 								parentDepth={-1}
@@ -1037,7 +1034,7 @@ export const FileTreePane = memo(function FileTreePane({
 							</m.div>
 						)}
 					</FileTreeRootDrop>
-				) : visibleRootEntries.length ? (
+				) : hasVisibleRootEntries ? (
 					<FileTreeRootDrop>
 						<TreeEntries
 							entries={rootEntries}

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -49,6 +49,11 @@ vi.mock("../../contexts", () => ({
 		spacePath: null,
 		startIndexRebuild: vi.fn(() => Promise.resolve()),
 	}),
+	useFileTreeContext: () => ({
+		fileTreeSortMode: "name-asc",
+		isSavingFileTreeSortMode: false,
+		setFileTreeSortMode: vi.fn(() => Promise.resolve()),
+	}),
 }));
 
 vi.mock("../../lib/settings", () => ({

--- a/src/components/settings/AdvancedSettingsPane.test.tsx
+++ b/src/components/settings/AdvancedSettingsPane.test.tsx
@@ -19,6 +19,7 @@ const {
 	setEditorSpellCheckMock,
 	setEditorWidthModeMock,
 	setEditorVimKeybindingsMock,
+	setFileTreeSortModeMock,
 	setFolioModeMock,
 	setShowFileTreeFolderCountsMock,
 	setShowNonMarkdownFilesMock,
@@ -36,6 +37,7 @@ const {
 	setEditorSpellCheckMock: vi.fn(() => Promise.resolve()),
 	setEditorWidthModeMock: vi.fn(() => Promise.resolve()),
 	setEditorVimKeybindingsMock: vi.fn(() => Promise.resolve()),
+	setFileTreeSortModeMock: vi.fn(() => Promise.resolve()),
 	setFolioModeMock: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCountsMock: vi.fn(() => Promise.resolve()),
 	setShowNonMarkdownFilesMock: vi.fn(() => Promise.resolve()),
@@ -50,6 +52,14 @@ vi.mock("../../contexts", () => ({
 }));
 
 vi.mock("../../lib/settings", () => ({
+	FILE_TREE_SORT_OPTIONS: [
+		{ label: "Name A-Z", value: "name-asc" },
+		{ label: "Name Z-A", value: "name-desc" },
+		{ label: "Modified newest", value: "modified-desc" },
+		{ label: "Modified oldest", value: "modified-asc" },
+		{ label: "Created newest", value: "created-desc" },
+		{ label: "Created oldest", value: "created-asc" },
+	],
 	loadSettings: loadSettingsMock,
 	setAiAssistantMode: setAiAssistantModeMock,
 	setClassicAllNotesByDefault: setClassicAllNotesByDefaultMock,
@@ -62,10 +72,21 @@ vi.mock("../../lib/settings", () => ({
 	setEditorSpellCheck: setEditorSpellCheckMock,
 	setEditorWidthMode: setEditorWidthModeMock,
 	setEditorVimKeybindings: setEditorVimKeybindingsMock,
+	setFileTreeSortMode: setFileTreeSortModeMock,
 	setFolioMode: setFolioModeMock,
 	setShowFileTreeFolderCounts: setShowFileTreeFolderCountsMock,
 	setShowNonMarkdownFiles: setShowNonMarkdownFilesMock,
 	setShowToc: setShowTocMock,
+	isFileTreeSortMode: (value: unknown) =>
+		typeof value === "string" &&
+		[
+			"name-asc",
+			"name-desc",
+			"modified-desc",
+			"modified-asc",
+			"created-desc",
+			"created-asc",
+		].includes(value),
 }));
 
 vi.mock("../../lib/tauri", () => ({
@@ -153,6 +174,7 @@ function makeSettings(
 			folioMode: false,
 			showFileTreeFolderCounts: false,
 			showNonMarkdownFiles: true,
+			fileTreeSortMode: "name-asc" as const,
 			showToc: true,
 		},
 		database: {

--- a/src/components/settings/AdvancedSettingsPane.tsx
+++ b/src/components/settings/AdvancedSettingsPane.tsx
@@ -2,10 +2,13 @@ import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useState } from "react";
 import { useSpace } from "../../contexts";
+import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type AiAssistantMode,
 	type EditorWidthMode,
+	FILE_TREE_SORT_OPTIONS,
+	isFileTreeSortMode,
 	loadSettings,
 	setAiAssistantMode,
 	setClassicAllNotesByDefault,
@@ -137,6 +140,9 @@ export function AdvancedSettingsPane() {
 	const [isSavingEditorWidthMode, setIsSavingEditorWidthMode] = useState(false);
 	const [isSavingAiAssistantMode, setIsSavingAiAssistantMode] = useState(false);
 	const { spacePath, startIndexRebuild } = useSpace();
+	const fileTreeSort = useFileTreeSortMode({
+		onError: setError,
+	});
 	const showTocToggle = useOptimisticSettingsToggle(
 		showToc,
 		setShowTocState,
@@ -529,6 +535,29 @@ export function AdvancedSettingsPane() {
 							ariaLabel="Show non-Markdown files"
 							onCheckedChange={showNonMarkdownFilesToggle.onCheckedChange}
 						/>
+					</SettingsRow>
+					<SettingsRow
+						label="File tree sort"
+						description="Choose how folders and files are ordered in the sidebar tree."
+						interactive={false}
+					>
+						<SettingsSelect
+							aria-label="File tree sort"
+							value={fileTreeSort.sortMode}
+							disabled={fileTreeSort.isSaving}
+							onChange={(event) => {
+								const nextSortMode = event.currentTarget.value;
+								if (!isFileTreeSortMode(nextSortMode)) return;
+								setError("");
+								void fileTreeSort.setSortMode(nextSortMode);
+							}}
+						>
+							{FILE_TREE_SORT_OPTIONS.map((option) => (
+								<option key={option.value} value={option.value}>
+									{option.label}
+								</option>
+							))}
+						</SettingsSelect>
 					</SettingsRow>
 				</SettingsSection>
 				<SettingsSection

--- a/src/contexts/FileTreeContext.test.tsx
+++ b/src/contexts/FileTreeContext.test.tsx
@@ -33,6 +33,9 @@ vi.mock("../lib/settings", () => ({
 				beautifulTags: false,
 				enablePeopleMentionsAsTags: false,
 			},
+			ui: {
+				fileTreeSortMode: "name-asc",
+			},
 		}),
 }));
 

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -10,7 +10,12 @@ import {
 } from "react";
 import { useDebouncedNoteChange } from "../hooks/useDebouncedNoteChange";
 import { extractErrorMessage } from "../lib/errorUtils";
-import { loadSettings } from "../lib/settings";
+import {
+	type FileTreeSortMode,
+	isFileTreeSortMode,
+	loadSettings,
+	setFileTreeSortMode as persistFileTreeSortMode,
+} from "../lib/settings";
 import { normalizeTagIconKey } from "../lib/tagIcons";
 import type {
 	FileTreeAppearance,
@@ -66,6 +71,9 @@ interface FileTreeContextValue {
 	refreshTags: () => Promise<void>;
 	refreshTagAppearance: () => Promise<void>;
 	setTagAppearance: (tag: string, icon: string | null) => Promise<void>;
+	fileTreeSortMode: FileTreeSortMode;
+	isSavingFileTreeSortMode: boolean;
+	setFileTreeSortMode: (sortMode: FileTreeSortMode) => Promise<void>;
 }
 
 const FileTreeContext = createContext<FileTreeContextValue | null>(null);
@@ -120,9 +128,14 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		Record<string, TagAppearance>
 	>({});
 	const [tagsError, setTagsError] = useState("");
+	const [fileTreeSortMode, setFileTreeSortModeState] =
+		useState<FileTreeSortMode>("name-asc");
+	const [isSavingFileTreeSortMode, setIsSavingFileTreeSortMode] =
+		useState(false);
 	const peopleMentionsEnabledRef = useRef(false);
 	const tagsRequestIdRef = useRef(0);
 	const tagAppearanceRequestIdRef = useRef(0);
+	const fileTreeSortModeRequestVersionRef = useRef(0);
 	const currentSpacePathRef = useRef<string | null>(spacePath);
 	const pinnedFilesRefreshTimerRef = useRef<number | null>(null);
 	currentSpacePathRef.current = spacePath;
@@ -195,12 +208,17 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		let cancelled = false;
+		const requestVersion = fileTreeSortModeRequestVersionRef.current + 1;
+		fileTreeSortModeRequestVersionRef.current = requestVersion;
 		void loadSettings()
 			.then((settings) => {
 				if (cancelled) return;
 				peopleMentionsEnabledRef.current =
 					settings.editor.enablePeopleMentionsAsTags;
 				setBeautifulTags(settings.editor.beautifulTags);
+				if (requestVersion === fileTreeSortModeRequestVersionRef.current) {
+					setFileTreeSortModeState(settings.ui.fileTreeSortMode);
+				}
 				if (currentSpacePathRef.current) {
 					void refreshTags();
 					void refreshTagAppearance();
@@ -233,6 +251,12 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		}
 		if (typeof payload.editor?.beautifulTags === "boolean") {
 			setBeautifulTags(payload.editor.beautifulTags);
+		}
+		const nextSortMode = payload.ui?.fileTreeSortMode;
+		if (isFileTreeSortMode(nextSortMode)) {
+			fileTreeSortModeRequestVersionRef.current += 1;
+			setIsSavingFileTreeSortMode(false);
+			setFileTreeSortModeState(nextSortMode);
 		}
 	});
 
@@ -512,6 +536,31 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 		);
 	}, []);
 
+	const setFileTreeSortMode = useCallback<
+		FileTreeContextValue["setFileTreeSortMode"]
+	>(
+		(nextSortMode) => {
+			if (nextSortMode === fileTreeSortMode) return Promise.resolve();
+			const previous = fileTreeSortMode;
+			const requestVersion = fileTreeSortModeRequestVersionRef.current + 1;
+			fileTreeSortModeRequestVersionRef.current = requestVersion;
+			setFileTreeSortModeState(nextSortMode);
+			setIsSavingFileTreeSortMode(true);
+			return persistFileTreeSortMode(nextSortMode)
+				.catch(() => {
+					if (requestVersion === fileTreeSortModeRequestVersionRef.current) {
+						setFileTreeSortModeState(previous);
+					}
+				})
+				.finally(() => {
+					if (requestVersion === fileTreeSortModeRequestVersionRef.current) {
+						setIsSavingFileTreeSortMode(false);
+					}
+				});
+		},
+		[fileTreeSortMode],
+	);
+
 	const value = useMemo<FileTreeContextValue>(
 		() => ({
 			rootEntries,
@@ -543,6 +592,9 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			refreshTags,
 			refreshTagAppearance,
 			setTagAppearance,
+			fileTreeSortMode,
+			isSavingFileTreeSortMode,
+			setFileTreeSortMode,
 		}),
 		[
 			rootEntries,
@@ -572,6 +624,9 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			refreshTags,
 			refreshTagAppearance,
 			setTagAppearance,
+			fileTreeSortMode,
+			isSavingFileTreeSortMode,
+			setFileTreeSortMode,
 		],
 	);
 

--- a/src/hooks/fileTreeHelpers.test.ts
+++ b/src/hooks/fileTreeHelpers.test.ts
@@ -4,6 +4,7 @@ import { normalizeRelPath } from "../utils/path";
 import {
 	areEntriesEqual,
 	compareEntries,
+	compareEntriesForSort,
 	filterVisibleFileTreeEntries,
 	normalizeEntries,
 	normalizeEntry,
@@ -16,6 +17,8 @@ function mkEntry(partial: Partial<FsEntry>): FsEntry {
 		rel_path: partial.rel_path ?? "",
 		kind: partial.kind ?? "file",
 		is_markdown: partial.is_markdown ?? false,
+		created: partial.created,
+		updated: partial.updated,
 	};
 }
 
@@ -162,5 +165,79 @@ describe("fileTreeHelpers", () => {
 			}),
 		);
 		expect(duplicate).toHaveLength(next.length);
+	});
+
+	it("sorts reverse alphabetical within folder and file groups", () => {
+		const entries = normalizeEntries([
+			mkEntry({ name: "Alpha.md", rel_path: "Alpha.md", kind: "file" }),
+			mkEntry({ name: "Zeta.md", rel_path: "Zeta.md", kind: "file" }),
+			mkEntry({ name: "Bravo", rel_path: "Bravo", kind: "dir" }),
+			mkEntry({ name: "Omega", rel_path: "Omega", kind: "dir" }),
+		]).sort(compareEntriesForSort("name-desc"));
+
+		expect(entries.map((entry) => entry.rel_path)).toEqual([
+			"Omega",
+			"Bravo",
+			"Zeta.md",
+			"Alpha.md",
+		]);
+	});
+
+	it("sorts by modified timestamp with missing values after timestamped entries", () => {
+		const entries = [
+			mkEntry({
+				name: "old.md",
+				rel_path: "old.md",
+				kind: "file",
+				updated: "2024-01-01T00:00:00.000Z",
+			}),
+			mkEntry({ name: "missing.md", rel_path: "missing.md", kind: "file" }),
+			mkEntry({
+				name: "new.md",
+				rel_path: "new.md",
+				kind: "file",
+				updated: "2024-01-03T00:00:00.000Z",
+			}),
+		];
+
+		expect(
+			[...entries]
+				.sort(compareEntriesForSort("modified-desc"))
+				.map((entry) => entry.rel_path),
+		).toEqual(["new.md", "old.md", "missing.md"]);
+		expect(
+			[...entries]
+				.sort(compareEntriesForSort("modified-asc"))
+				.map((entry) => entry.rel_path),
+		).toEqual(["old.md", "new.md", "missing.md"]);
+	});
+
+	it("sorts by created timestamp and falls back to name for ties", () => {
+		const entries = normalizeEntries([
+			mkEntry({
+				name: "Beta.md",
+				rel_path: "Beta.md",
+				kind: "file",
+				created: "2024-01-02T00:00:00.000Z",
+			}),
+			mkEntry({
+				name: "Alpha.md",
+				rel_path: "Alpha.md",
+				kind: "file",
+				created: "2024-01-02T00:00:00.000Z",
+			}),
+			mkEntry({
+				name: "Gamma.md",
+				rel_path: "Gamma.md",
+				kind: "file",
+				created: "2024-01-03T00:00:00.000Z",
+			}),
+		]).sort(compareEntriesForSort("created-asc"));
+
+		expect(entries.map((entry) => entry.rel_path)).toEqual([
+			"Alpha.md",
+			"Beta.md",
+			"Gamma.md",
+		]);
 	});
 });

--- a/src/hooks/fileTreeHelpers.ts
+++ b/src/hooks/fileTreeHelpers.ts
@@ -10,6 +10,14 @@ export function filterVisibleFileTreeEntries(
 	return entries.filter((entry) => entry.kind === "dir" || entry.is_markdown);
 }
 
+export function hasVisibleFileTreeEntries(
+	entries: FsEntry[],
+	showNonMarkdownFiles: boolean,
+): boolean {
+	if (showNonMarkdownFiles) return entries.length > 0;
+	return entries.some((entry) => entry.kind === "dir" || entry.is_markdown);
+}
+
 function compareEntryNames(a: FsEntry, b: FsEntry, direction: 1 | -1): number {
 	const byName = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
 	if (byName !== 0) return byName * direction;
@@ -67,8 +75,10 @@ export function compareEntriesForSort(
 	};
 }
 
+const compareEntriesNameAsc = compareEntriesForSort("name-asc");
+
 export function compareEntries(a: FsEntry, b: FsEntry): number {
-	return compareEntriesForSort("name-asc")(a, b);
+	return compareEntriesNameAsc(a, b);
 }
 
 function entryNameFromRelPath(relPath: string): string {

--- a/src/hooks/fileTreeHelpers.ts
+++ b/src/hooks/fileTreeHelpers.ts
@@ -1,3 +1,4 @@
+import type { FileTreeSortMode } from "../lib/settings";
 import type { FsEntry } from "../lib/tauri";
 import { normalizeRelPath } from "../utils/path";
 
@@ -9,10 +10,65 @@ export function filterVisibleFileTreeEntries(
 	return entries.filter((entry) => entry.kind === "dir" || entry.is_markdown);
 }
 
+function compareEntryNames(a: FsEntry, b: FsEntry, direction: 1 | -1): number {
+	const byName = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+	if (byName !== 0) return byName * direction;
+	return a.rel_path.toLowerCase().localeCompare(b.rel_path.toLowerCase());
+}
+
+function timestampValue(
+	entry: FsEntry,
+	field: "created" | "updated",
+): number | null {
+	const raw = entry[field];
+	if (!raw) return null;
+	const parsed = Date.parse(raw);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function compareEntryTimestamps(
+	a: FsEntry,
+	b: FsEntry,
+	field: "created" | "updated",
+	direction: 1 | -1,
+): number {
+	const left = timestampValue(a, field);
+	const right = timestampValue(b, field);
+	if (left !== null && right === null) return -1;
+	if (left === null && right !== null) return 1;
+	if (left !== null && right !== null && left !== right) {
+		return (left - right) * direction;
+	}
+	return compareEntryNames(a, b, 1);
+}
+
+export function compareEntriesForSort(
+	mode: FileTreeSortMode,
+): (a: FsEntry, b: FsEntry) => number {
+	return (a, b) => {
+		if (a.kind === "dir" && b.kind === "file") return -1;
+		if (a.kind === "file" && b.kind === "dir") return 1;
+		switch (mode) {
+			case "name-desc":
+				return compareEntryNames(a, b, -1);
+			case "modified-desc":
+				return compareEntryTimestamps(a, b, "updated", -1);
+			case "modified-asc":
+				return compareEntryTimestamps(a, b, "updated", 1);
+			case "created-desc":
+				return compareEntryTimestamps(a, b, "created", -1);
+			case "created-asc":
+				return compareEntryTimestamps(a, b, "created", 1);
+			case "name-asc":
+				return compareEntryNames(a, b, 1);
+		}
+		const exhaustive: never = mode;
+		return exhaustive;
+	};
+}
+
 export function compareEntries(a: FsEntry, b: FsEntry): number {
-	if (a.kind === "dir" && b.kind === "file") return -1;
-	if (a.kind === "file" && b.kind === "dir") return 1;
-	return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+	return compareEntriesForSort("name-asc")(a, b);
 }
 
 function entryNameFromRelPath(relPath: string): string {
@@ -59,7 +115,9 @@ export function areEntriesEqual(
 			left.rel_path !== right.rel_path ||
 			left.name !== right.name ||
 			left.kind !== right.kind ||
-			left.is_markdown !== right.is_markdown
+			left.is_markdown !== right.is_markdown ||
+			left.created !== right.created ||
+			left.updated !== right.updated
 		) {
 			return false;
 		}

--- a/src/hooks/useFileTreeSortMode.ts
+++ b/src/hooks/useFileTreeSortMode.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { extractErrorMessage } from "../lib/errorUtils";
+import {
+	type FileTreeSortMode,
+	isFileTreeSortMode,
+	loadSettings,
+	setFileTreeSortMode,
+} from "../lib/settings";
+import { useTauriEvent } from "../lib/tauriEvents";
+
+interface UseFileTreeSortModeOptions {
+	onError?: (message: string) => void;
+}
+
+export function useFileTreeSortMode(options: UseFileTreeSortModeOptions = {}) {
+	const { onError } = options;
+	const [sortMode, setSortMode] = useState<FileTreeSortMode>("name-asc");
+	const [isSaving, setIsSaving] = useState(false);
+	const requestVersionRef = useRef(0);
+
+	useEffect(() => {
+		let cancelled = false;
+		const requestVersion = requestVersionRef.current + 1;
+		requestVersionRef.current = requestVersion;
+		void loadSettings()
+			.then((settings) => {
+				if (cancelled || requestVersion !== requestVersionRef.current) return;
+				setSortMode(settings.ui.fileTreeSortMode);
+			})
+			.catch(() => undefined);
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent("settings:updated", (payload) => {
+		const nextSortMode = payload.ui?.fileTreeSortMode;
+		if (!isFileTreeSortMode(nextSortMode)) return;
+		requestVersionRef.current += 1;
+		setIsSaving(false);
+		setSortMode(nextSortMode);
+	});
+
+	const updateSortMode = useCallback(
+		(nextSortMode: FileTreeSortMode) => {
+			if (nextSortMode === sortMode) return Promise.resolve();
+			const previous = sortMode;
+			const requestVersion = requestVersionRef.current + 1;
+			requestVersionRef.current = requestVersion;
+			setSortMode(nextSortMode);
+			setIsSaving(true);
+			return setFileTreeSortMode(nextSortMode)
+				.catch((error) => {
+					if (requestVersion === requestVersionRef.current) {
+						setSortMode(previous);
+					}
+					onError?.(extractErrorMessage(error));
+				})
+				.finally(() => {
+					if (requestVersion === requestVersionRef.current) {
+						setIsSaving(false);
+					}
+				});
+		},
+		[onError, sortMode],
+	);
+
+	return {
+		sortMode,
+		isSaving,
+		setSortMode: updateSortMode,
+	};
+}

--- a/src/hooks/useFileTreeSortMode.ts
+++ b/src/hooks/useFileTreeSortMode.ts
@@ -1,12 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
+import { useFileTreeContext } from "../contexts";
 import { extractErrorMessage } from "../lib/errorUtils";
-import {
-	type FileTreeSortMode,
-	isFileTreeSortMode,
-	loadSettings,
-	setFileTreeSortMode,
-} from "../lib/settings";
-import { useTauriEvent } from "../lib/tauriEvents";
+import type { FileTreeSortMode } from "../lib/settings";
 
 interface UseFileTreeSortModeOptions {
 	onError?: (message: string) => void;
@@ -14,60 +9,23 @@ interface UseFileTreeSortModeOptions {
 
 export function useFileTreeSortMode(options: UseFileTreeSortModeOptions = {}) {
 	const { onError } = options;
-	const [sortMode, setSortMode] = useState<FileTreeSortMode>("name-asc");
-	const [isSaving, setIsSaving] = useState(false);
-	const requestVersionRef = useRef(0);
+	const {
+		fileTreeSortMode: sortMode,
+		isSavingFileTreeSortMode: isSaving,
+		setFileTreeSortMode,
+	} = useFileTreeContext();
 
-	useEffect(() => {
-		let cancelled = false;
-		const requestVersion = requestVersionRef.current + 1;
-		requestVersionRef.current = requestVersion;
-		void loadSettings()
-			.then((settings) => {
-				if (cancelled || requestVersion !== requestVersionRef.current) return;
-				setSortMode(settings.ui.fileTreeSortMode);
-			})
-			.catch(() => undefined);
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	useTauriEvent("settings:updated", (payload) => {
-		const nextSortMode = payload.ui?.fileTreeSortMode;
-		if (!isFileTreeSortMode(nextSortMode)) return;
-		requestVersionRef.current += 1;
-		setIsSaving(false);
-		setSortMode(nextSortMode);
-	});
-
-	const updateSortMode = useCallback(
-		(nextSortMode: FileTreeSortMode) => {
-			if (nextSortMode === sortMode) return Promise.resolve();
-			const previous = sortMode;
-			const requestVersion = requestVersionRef.current + 1;
-			requestVersionRef.current = requestVersion;
-			setSortMode(nextSortMode);
-			setIsSaving(true);
-			return setFileTreeSortMode(nextSortMode)
-				.catch((error) => {
-					if (requestVersion === requestVersionRef.current) {
-						setSortMode(previous);
-					}
-					onError?.(extractErrorMessage(error));
-				})
-				.finally(() => {
-					if (requestVersion === requestVersionRef.current) {
-						setIsSaving(false);
-					}
-				});
-		},
-		[onError, sortMode],
+	const setSortMode = useCallback(
+		(nextSortMode: FileTreeSortMode) =>
+			setFileTreeSortMode(nextSortMode).catch((error) => {
+				onError?.(extractErrorMessage(error));
+			}),
+		[onError, setFileTreeSortMode],
 	);
 
 	return {
 		sortMode,
 		isSaving,
-		setSortMode: updateSortMode,
+		setSortMode,
 	};
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -47,6 +47,21 @@ export type { AiAssistantMode } from "./tauri";
 export type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 
 export type ReleaseChannel = "stable" | "alpha";
+export type FileTreeSortMode =
+	| "name-asc"
+	| "name-desc"
+	| "modified-desc"
+	| "modified-asc"
+	| "created-desc"
+	| "created-asc";
+const FILE_TREE_SORT_MODES = new Set<FileTreeSortMode>([
+	"name-asc",
+	"name-desc",
+	"modified-desc",
+	"modified-asc",
+	"created-desc",
+	"created-asc",
+]);
 
 let storeInstance: LazyStore | null = null;
 let storeInitPromise: Promise<void> | null = null;
@@ -272,6 +287,7 @@ interface EditorSettings {
 interface FileTreeSettings {
 	showFolderFileCounts: boolean;
 	showNonMarkdownFiles: boolean;
+	sortMode: FileTreeSortMode;
 }
 
 export interface ShortcutSettings {
@@ -310,12 +326,26 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 const DEFAULT_FILE_TREE_SETTINGS: FileTreeSettings = {
 	showFolderFileCounts: false,
 	showNonMarkdownFiles: true,
+	sortMode: "name-asc",
 };
+
+export function isFileTreeSortMode(value: unknown): value is FileTreeSortMode {
+	return (
+		typeof value === "string" &&
+		FILE_TREE_SORT_MODES.has(value as FileTreeSortMode)
+	);
+}
 
 function asThemeMode(value: unknown): ThemeMode {
 	return typeof value === "string" && THEME_MODES.has(value as ThemeMode)
 		? (value as ThemeMode)
 		: "system";
+}
+
+function asFileTreeSortMode(value: unknown): FileTreeSortMode {
+	return isFileTreeSortMode(value)
+		? value
+		: DEFAULT_FILE_TREE_SETTINGS.sortMode;
 }
 
 function asAutoUpdateCheckInterval(value: unknown): AutoUpdateCheckInterval {
@@ -453,6 +483,7 @@ async function emitSettingsUpdated(payload: {
 		showToc?: boolean;
 		showFileTreeFolderCounts?: boolean;
 		showNonMarkdownFiles?: boolean;
+		fileTreeSortMode?: FileTreeSortMode;
 		folioMode?: boolean;
 		classicAllNotesByDefault?: boolean;
 		aiAssistantMode?: AiAssistantMode;
@@ -505,6 +536,15 @@ export interface RecentFile {
 	openedAt: number;
 }
 
+export const FILE_TREE_SORT_OPTIONS = [
+	{ label: "Name A-Z", value: "name-asc" },
+	{ label: "Name Z-A", value: "name-desc" },
+	{ label: "Modified newest", value: "modified-desc" },
+	{ label: "Modified oldest", value: "modified-asc" },
+	{ label: "Created newest", value: "created-desc" },
+	{ label: "Created oldest", value: "created-asc" },
+] as const satisfies readonly { label: string; value: FileTreeSortMode }[];
+
 interface AppSettings {
 	currentSpacePath: string | null;
 	recentSpaces: string[];
@@ -529,6 +569,7 @@ interface AppSettings {
 		showToc: boolean;
 		showFileTreeFolderCounts: boolean;
 		showNonMarkdownFiles: boolean;
+		fileTreeSortMode: FileTreeSortMode;
 		folioMode: boolean;
 		classicAllNotesByDefault: boolean;
 		aiAssistantMode: AiAssistantMode;
@@ -604,6 +645,7 @@ const KEYS = {
 	showToc: "ui.showToc",
 	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
 	showNonMarkdownFiles: "ui.fileTree.showNonMarkdownFiles",
+	fileTreeSortMode: "ui.fileTree.sortMode",
 	folioMode: "ui.folioMode",
 	classicAllNotesByDefault: "ui.classicAllNotesByDefault",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
@@ -932,6 +974,7 @@ export async function loadSettings(
 		entries,
 		KEYS.showNonMarkdownFiles,
 	);
+	const rawFileTreeSortMode = getSettingValue(entries, KEYS.fileTreeSortMode);
 	const rawFolioMode = getSettingValue<boolean | null>(entries, KEYS.folioMode);
 	const rawClassicAllNotesByDefault = getSettingValue<boolean | null>(
 		entries,
@@ -1074,6 +1117,7 @@ export async function loadSettings(
 		typeof rawShowNonMarkdownFiles === "boolean"
 			? rawShowNonMarkdownFiles
 			: DEFAULT_FILE_TREE_SETTINGS.showNonMarkdownFiles;
+	const fileTreeSortMode = asFileTreeSortMode(rawFileTreeSortMode);
 	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
 	const classicAllNotesByDefault =
 		typeof rawClassicAllNotesByDefault === "boolean"
@@ -1176,6 +1220,7 @@ export async function loadSettings(
 			showToc,
 			showFileTreeFolderCounts,
 			showNonMarkdownFiles,
+			fileTreeSortMode,
 			folioMode,
 			classicAllNotesByDefault,
 			aiAssistantMode,
@@ -1487,6 +1532,15 @@ export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
 	await store.set(KEYS.showNonMarkdownFiles, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { showNonMarkdownFiles: enabled } });
+}
+
+export async function setFileTreeSortMode(
+	sortMode: FileTreeSortMode,
+): Promise<void> {
+	const store = await getStore();
+	await store.set(KEYS.fileTreeSortMode, sortMode);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { fileTreeSortMode: sortMode } });
 }
 
 export async function setFolioMode(enabled: boolean): Promise<void> {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -4,6 +4,7 @@ import type {
 	AttachmentStorageMode,
 	AutoUpdateCheckInterval,
 	EditorWidthMode,
+	FileTreeSortMode,
 	ReleaseChannel,
 	UiAccent,
 	UiCornerRadiusStyle,
@@ -75,6 +76,7 @@ type TauriEventMap = {
 			showToc?: boolean;
 			showFileTreeFolderCounts?: boolean;
 			showNonMarkdownFiles?: boolean;
+			fileTreeSortMode?: FileTreeSortMode;
 			folioMode?: boolean;
 			classicAllNotesByDefault?: boolean;
 			aiEnabled?: boolean;

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -251,6 +251,7 @@
 	align-items: center;
 	gap: 2px;
 	flex-shrink: 0;
+	min-width: 0;
 }
 
 .sidebarStackHeaderAction {
@@ -275,6 +276,48 @@
 	box-shadow: none;
 	color: var(--text-primary);
 	outline: none;
+}
+
+.sidebarStackHeaderSortNative {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border-radius: var(--radius-sm);
+	color: var(--text-tertiary);
+	transition: color var(--transition-fast);
+}
+
+.sidebarStackHeaderSortNative:hover,
+.sidebarStackHeaderSortNative:focus-within {
+	color: var(--text-primary);
+}
+
+.sidebarStackHeaderSortIcon {
+	position: absolute;
+	left: 4px;
+	pointer-events: none;
+	color: currentColor;
+}
+
+.sidebarStackHeaderSortSelect {
+	width: 100%;
+	height: 22px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-primary);
+	font-size: var(--text-xs);
+	cursor: pointer;
+	outline: none;
+	opacity: 0;
+}
+
+.sidebarStackHeaderSortSelect:focus {
+	box-shadow: none;
 }
 
 .sidebarStackHeaderChevron {


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/285


## Description

Adds user-selectable sorting for the sidebar file tree so notes and folders can be ordered by name (A-Z / Z-A), modified date (newest / oldest), or created date (newest / oldest).

- **Summary of changes**
  - Introduced `FileTreeSortMode` setting with six sort options, persisted via `ui.fileTree.sortMode`.
  - Added `compareEntriesForSort()` comparator factory in `fileTreeHelpers.ts` (folders-first grouping preserved; timestamp ties fall back to name).
  - Added `useFileTreeSortMode` hook for loading, saving, and syncing sort mode via `settings:updated`.
  - Wired sorting into `FileTreePane` for root, focused folder, and expanded children views.
  - Added a compact native `<select>` sort control in the sidebar Notes header and a matching control in Advanced settings.
  - Updated helper tests for reverse, modified, and created comparators.
  - Minor rename of window geometry helpers from "main" to "host" with a label guard (unrelated cleanup bundled in this branch).

- **Reasoning**
  - `FsEntry` already carries `created` and `updated` timestamps from the Rust listing layer, so this is frontend-only with no Tauri command changes.
  - Sorting at render time in `FileTreePane` keeps optimistic CRUD updates consistent without re-sorting every loaded directory in the file tree hook.

- **Additional context**
  - Default behavior remains name A-Z for existing users.
  - Entries missing timestamps sort after timestamped entries, then by name.


## Screenshots

(Sidebar sort control is a compact icon + native select in the Notes stack header. Add screenshots after manual QA if desired.)


## Docs

Sort mode is stored at `ui.fileTree.sortMode` with values: `name-asc`, `name-desc`, `modified-desc`, `modified-asc`, `created-desc`, `created-asc`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-selectable sort modes for the sidebar file tree (name, modified, created; asc/desc). Sort state is centralized, persisted, and controllable from the Notes header and Advanced settings.

- **New Features**
  - Added `ui.fileTree.sortMode` with options: `name-asc`, `name-desc`, `modified-desc`, `modified-asc`, `created-desc`, `created-asc` (default `name-asc`).
  - Implemented folders‑first sorting across root/focused/expanded views via `compareEntriesForSort`; ties fall back to name; missing timestamps sort after timestamped; avoids sorting when no visible entries.
  - Centralized sort state in `FileTreeContext` with `useFileTreeSortMode`; changes sync via `settings:updated`; compact sort select in Notes header and matching control in Advanced settings.

- **Refactors**
  - Renamed window geometry helpers from “main” to “host”; no behavior change.

<sup>Written for commit 0ced788e1c67fd14f304e7d5a346b5693b698413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-tree sorting in the sidebar and settings, with options for name, creation date, and modified date in ascending or descending order.
  * The chosen sort order is saved and restored automatically.

* **Bug Fixes**
  * Improved window size and position persistence for the host window, helping the app reopen more consistently where you left it.

* **Chores**
  * Updated the app version to `0.8.6-alpha.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->