### PR TITLE
Add Print Note via system print sheet for PDF export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Repo extras: internal product and engineering docs live in `docs/`.
 - Use `net.rs` SSRF checks for user-supplied URLs. Version durable documents (`version: 1`).
 - New Tauri commands: implement in `src-tauri/src/`, register in `lib.rs`, add types to `TauriCommands` in `src/lib/tauri.ts`.
 - Make sure we don't over-engineer CSS and use default components as much as possible unless explicitly stated.
+- Hard subtraction pass: fix the issue by deleting or narrowing code first. Do not add new abstractions, command entries, shortcuts, files, or wiring unless the existing code cannot support the fix.
 - Make sure we always narrow the code and apply fixes instead of patching the code by adding unnecessary LOCs in places that don't need them.
 - NEVER make test files unless specifically requested by users.
 - For TSX files extract hooks/subcomponents when rendering, state, effects, and commands start mixing.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -26,7 +26,7 @@
 				{ "path": "$DOWNLOAD/**" },
 				{ "path": "$DOCUMENT/**" },
 				{ "path": "$DESKTOP/**" },
-				{ "path": "$APPCACHE/**" }
+				{ "path": "$APPCACHE/print/**" }
 			]
 		},
 		"opener:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -25,7 +25,8 @@
 				{ "path": "$HOME/**" },
 				{ "path": "$DOWNLOAD/**" },
 				{ "path": "$DOCUMENT/**" },
-				{ "path": "$DESKTOP/**" }
+				{ "path": "$DESKTOP/**" },
+				{ "path": "$APPCACHE/**" }
 			]
 		},
 		"opener:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod net;
 mod notes;
 mod paths;
 mod pinned_files;
+mod print;
 mod release_channels;
 mod space;
 mod space_fs;
@@ -447,6 +448,14 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         Some("CmdOrCtrl+S"),
     )?;
+    let print_note = menu_item_with_shortcut(
+        app,
+        menu_shortcuts,
+        "file.print_note",
+        "Print Note…",
+        show_markdown_menu,
+        None,
+    )?;
     let close_tab = menu_item_with_shortcut(
         app,
         menu_shortcuts,
@@ -763,6 +772,8 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
             &open_daily_note,
             &PredefinedMenuItem::separator(app)?,
             &save_note,
+            &print_note,
+            &PredefinedMenuItem::separator(app)?,
             &close_tab,
         ],
     )?;
@@ -1454,6 +1465,17 @@ pub fn run() {
                     );
                 }
             }
+            "file.print_note" => {
+                if let Some((label, _window)) = target_space_host_window(app) {
+                    let _ = app.emit_to(
+                        label,
+                        "menu:app_command",
+                        AppCommandPayload {
+                            command_id: "print-note".to_string(),
+                        },
+                    );
+                }
+            }
             id => {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
@@ -1574,6 +1596,7 @@ pub fn run() {
             external_markdown::external_markdown_read,
             external_markdown::external_markdown_write,
             external_markdown::external_markdown_finish_close,
+            print::print_write_html,
             license::commands::license_bootstrap_status,
             license::commands::license_activate,
             license::commands::license_clear_local,

--- a/src-tauri/src/print.rs
+++ b/src-tauri/src/print.rs
@@ -1,0 +1,42 @@
+use tauri::{AppHandle, Manager};
+
+use crate::io_atomic;
+
+fn sanitized_print_file_name(file_stem: &str) -> String {
+    let stem = file_stem
+        .trim()
+        .chars()
+        .map(|ch| match ch {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '-',
+            _ if ch.is_control() => '-',
+            _ => ch,
+        })
+        .collect::<String>();
+    let trimmed = stem.trim_matches(|ch| matches!(ch, ' ' | '.' | '-'));
+    if trimmed.is_empty() {
+        "Glyph Print.html".to_string()
+    } else {
+        format!("{trimmed}.html")
+    }
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn print_write_html(
+    app: AppHandle,
+    file_stem: String,
+    html: String,
+) -> Result<String, String> {
+    let print_dir = app
+        .path()
+        .app_cache_dir()
+        .map_err(|error| error.to_string())?
+        .join("print");
+    tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
+        std::fs::create_dir_all(&print_dir).map_err(|error| error.to_string())?;
+        let path = print_dir.join(sanitized_print_file_name(&file_stem));
+        io_atomic::write_atomic(&path, html.as_bytes()).map_err(|error| error.to_string())?;
+        Ok(path.to_string_lossy().to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -54,14 +54,19 @@ import {
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
 import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
+import { buildPrintHtml } from "../../lib/printHtml";
 import { loadSettings, updateOnboardingSettings } from "../../lib/settings";
 import { getShortcutTooltip, toTauriAccelerator } from "../../lib/shortcuts";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { listTemplates, renderTemplate } from "../../lib/templates";
-
-import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
+import {
+	displayNameFromPath,
+	isMarkdownPath,
+	normalizeRelPath,
+	parentDir,
+} from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { LayoutAlignLeft } from "../Icons";
 import { dispatchAiContextAttach } from "../ai/aiContextEvents";
@@ -910,15 +915,13 @@ export function AppShell() {
 		if (!activeMarkdownTabPath) return;
 
 		try {
-			const editorMarkdown = getCurrentMarkdown(activeMarkdownTabPath);
 			const markdown =
-				editorMarkdown ??
+				getCurrentMarkdown(activeMarkdownTabPath) ??
 				(
 					await invoke("space_read_text", {
 						path: activeMarkdownTabPath,
 					})
 				).text;
-
 			await navigator.clipboard.writeText(markdown);
 			toast.success("Copied note as Markdown.");
 		} catch (error) {
@@ -929,6 +932,41 @@ export function AppShell() {
 			});
 		}
 	}, [activeMarkdownTabPath, getCurrentMarkdown]);
+
+	const handlePrintActiveNote = useCallback(async () => {
+		if (!activeMarkdownTabPath) return;
+		try {
+			await saveCurrentEditor();
+			const markdown =
+				getCurrentMarkdown(activeMarkdownTabPath) ??
+				(
+					await invoke("space_read_text", {
+						path: activeMarkdownTabPath,
+					})
+				).text;
+			const noteAbsPath = await invoke("space_resolve_abs_path", {
+				path: activeMarkdownTabPath,
+			});
+			const html = buildPrintHtml({
+				markdown,
+				notePath: activeMarkdownTabPath,
+				noteAbsPath,
+			});
+			const path = await invoke("print_write_html", {
+				file_stem:
+					displayNameFromPath(activeMarkdownTabPath).trim() || "Untitled",
+				html,
+			});
+			await openPath(path);
+			toast.success("Opened note for printing.");
+		} catch (error) {
+			console.error("Failed to print note", error);
+			toast.error("Could not open the note for printing", {
+				description:
+					error instanceof Error ? error.message : "Try again in a moment.",
+			});
+		}
+	}, [activeMarkdownTabPath, getCurrentMarkdown, saveCurrentEditor]);
 
 	const duplicateFileWithActiveEditorFlush = useCallback(
 		async (path: string) => {
@@ -1043,6 +1081,7 @@ export function AppShell() {
 		onCreateFromTemplate: handleCreateFromTemplateFromMenu,
 		onOpenDailyNote: handleOpenDailyNoteFromMenu,
 		onSaveNote: handleSaveNoteFromMenu,
+		onPrintNote: handlePrintActiveNote,
 		onCloseTab: () => void handleCloseTabOrWindow(),
 		onOpenSpace,
 		onOpenRecentSpaceAtPath: onOpenSpaceAtPath,

--- a/src/components/editor/markdown/wikiLinkCodec.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.ts
@@ -1,3 +1,4 @@
+import { basename } from "../../../utils/path";
 import type { WikiLinkAttrs } from "./wikiLinkTypes";
 
 type WikiLinkAnchorKind = "none" | "heading" | "block";
@@ -91,4 +92,32 @@ export function findWikiLinkSpans(
 		});
 	}
 	return spans;
+}
+
+function wikiLinkSpanToMarkdown(raw: string): string {
+	const attrs = parseWikiLink(raw);
+	if (!attrs) return raw;
+	const ref =
+		attrs.anchorKind === "heading" && attrs.anchor
+			? `${attrs.target}#${attrs.anchor}`
+			: attrs.anchorKind === "block" && attrs.anchor
+				? `${attrs.target}#^${attrs.anchor}`
+				: attrs.target;
+	if (attrs.embed) {
+		return `![${attrs.alias || basename(attrs.target)}](${ref})`;
+	}
+	return `[${attrs.alias || attrs.target.replace(/\.(md|markdown)$/i, "")}](${ref})`;
+}
+
+export function wikiLinksToStandardMarkdown(markdown: string): string {
+	const spans = findWikiLinkSpans(markdown);
+	if (spans.length === 0) return markdown;
+	let cursor = 0;
+	let out = "";
+	for (const span of spans) {
+		out += markdown.slice(cursor, span.start);
+		out += wikiLinkSpanToMarkdown(span.raw);
+		cursor = span.end;
+	}
+	return out + markdown.slice(cursor);
 }

--- a/src/components/editor/markdown/wikiLinkCodec.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.ts
@@ -103,10 +103,11 @@ function wikiLinkSpanToMarkdown(raw: string): string {
 			: attrs.anchorKind === "block" && attrs.anchor
 				? `${attrs.target}#^${attrs.anchor}`
 				: attrs.target;
+	const destination = `<${ref}>`;
 	if (attrs.embed) {
-		return `![${attrs.alias || basename(attrs.target)}](${ref})`;
+		return `![${attrs.alias || basename(attrs.target)}](${destination})`;
 	}
-	return `[${attrs.alias || attrs.target.replace(/\.(md|markdown)$/i, "")}](${ref})`;
+	return `[${attrs.alias || attrs.target.replace(/\.(md|markdown)$/i, "")}](${destination})`;
 }
 
 export function wikiLinksToStandardMarkdown(markdown: string): string {

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -9,6 +9,7 @@ interface UseMenuListenersProps {
 	onCreateFromTemplate: () => void;
 	onOpenDailyNote: () => void;
 	onSaveNote: () => void;
+	onPrintNote: () => void;
 	onCloseTab: () => void;
 	onOpenSpace: () => void;
 	onOpenRecentSpaceAtPath: (path: string) => void | Promise<void>;
@@ -32,6 +33,7 @@ export function useMenuListeners({
 	onCreateFromTemplate,
 	onOpenDailyNote,
 	onSaveNote,
+	onPrintNote,
 	onCloseTab,
 	onOpenSpace,
 	onOpenRecentSpaceAtPath,
@@ -72,6 +74,7 @@ export function useMenuListeners({
 				"create-from-template": onCreateFromTemplate,
 				"open-daily-note": onOpenDailyNote,
 				"save-note": onSaveNote,
+				"print-note": onPrintNote,
 				"close-active-tab": onCloseTab,
 				"open-space": onOpenSpace,
 				"create-space": onCreateSpace,
@@ -157,6 +160,7 @@ export function useMenuListeners({
 			onOpenGitSettings,
 			onOpenSpace,
 			onOpenSpaceSettings,
+			onPrintNote,
 			onRevealSpace,
 			onSaveNote,
 			onToggleAiPane,

--- a/src/lib/printHtml.ts
+++ b/src/lib/printHtml.ts
@@ -1,0 +1,173 @@
+import DOMPurify from "dompurify";
+import { Marked } from "marked";
+import { wikiLinksToStandardMarkdown } from "../components/editor/markdown/wikiLinkCodec";
+import { displayNameFromPath, parentDir } from "../utils/path";
+import { splitYamlFrontmatter } from "./notePreview";
+
+interface BuildPrintHtmlOptions {
+	markdown: string;
+	notePath: string;
+	noteAbsPath: string;
+}
+
+const PRINT_CSS = `
+:root {
+	color-scheme: light;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	color: #171717;
+	background: #ffffff;
+}
+body {
+	margin: 0;
+	background: #ffffff;
+}
+.glyph-print {
+	box-sizing: border-box;
+	width: min(760px, calc(100vw - 48px));
+	margin: 0 auto;
+	padding: 48px 0 72px;
+	line-height: 1.62;
+	font-size: 16px;
+}
+h1, h2, h3, h4, h5, h6 {
+	line-height: 1.2;
+	margin: 1.6em 0 0.55em;
+}
+h1:first-child, h2:first-child, h3:first-child {
+	margin-top: 0;
+}
+p, ul, ol, blockquote, pre, table {
+	margin: 0 0 1em;
+}
+a {
+	color: #0f62fe;
+	text-decoration-thickness: 0.08em;
+	text-underline-offset: 0.16em;
+}
+img {
+	max-width: 100%;
+	height: auto;
+}
+blockquote {
+	border-left: 3px solid #d7d7d7;
+	padding-left: 1em;
+	color: #4b5563;
+}
+pre {
+	overflow: auto;
+	padding: 14px 16px;
+	border: 1px solid #e5e7eb;
+	border-radius: 8px;
+	background: #f7f7f8;
+}
+.glyph-print-fallback {
+	white-space: pre-wrap;
+}
+code {
+	font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+	font-size: 0.92em;
+}
+:not(pre) > code {
+	padding: 0.12em 0.34em;
+	border-radius: 5px;
+	background: #f2f3f5;
+}
+table {
+	width: 100%;
+	border-collapse: collapse;
+}
+th, td {
+	border: 1px solid #e5e7eb;
+	padding: 8px 10px;
+	vertical-align: top;
+}
+th {
+	background: #f8fafc;
+	text-align: left;
+}
+@media print {
+	body {
+		background: #ffffff;
+	}
+	.glyph-print {
+		width: auto;
+		max-width: none;
+		padding: 0;
+	}
+	a {
+		color: inherit;
+	}
+}
+`;
+
+const printMarked = new Marked();
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+}
+
+function fileUrlForPath(path: string): string {
+	const normalized = path.replace(/\\/g, "/");
+	const segments = normalized.split("/").map(encodeURIComponent);
+	if (/^[A-Za-z]%3A$/.test(segments[0] ?? "")) {
+		segments[0] = segments[0].replace("%3A", ":");
+	}
+	const encoded = segments.join("/");
+	return normalized.startsWith("/")
+		? `file://${encoded}`
+		: `file:///${encoded}`;
+}
+
+function baseHrefForNote(noteAbsPath: string): string {
+	const dir = parentDir(noteAbsPath.replace(/\\/g, "/"));
+	return `${fileUrlForPath(dir)}/`;
+}
+
+function parseMarkdownSync(markdown: string): string {
+	const rendered = printMarked.parse(markdown, {
+		async: false,
+		breaks: false,
+		gfm: true,
+	});
+	return typeof rendered === "string" ? rendered : "";
+}
+
+export function buildPrintHtml({
+	markdown,
+	notePath,
+	noteAbsPath,
+}: BuildPrintHtmlOptions): string {
+	const { body: markdownBody } = splitYamlFrontmatter(markdown);
+	const preparedMarkdown = wikiLinksToStandardMarkdown(markdownBody);
+	const rendered = parseMarkdownSync(preparedMarkdown);
+	let body = DOMPurify.sanitize(rendered, {
+		ADD_ATTR: ["class", "checked"],
+	});
+	if (!body.trim() && preparedMarkdown.trim()) {
+		body = `<pre class="glyph-print-fallback">${escapeHtml(preparedMarkdown)}</pre>`;
+	}
+	const title = displayNameFromPath(notePath).trim() || "Glyph Print";
+	return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<base href="${escapeHtml(baseHrefForNote(noteAbsPath))}">
+<title>${escapeHtml(title)}</title>
+<style>${PRINT_CSS}</style>
+</head>
+<body>
+<main class="glyph-print">
+${body}
+</main>
+<script>
+window.addEventListener("load", () => window.print(), { once: true });
+</script>
+</body>
+</html>
+`;
+}

--- a/src/lib/printHtml.ts
+++ b/src/lib/printHtml.ts
@@ -111,19 +111,12 @@ function escapeHtml(value: string): string {
 }
 
 function fileUrlForPath(path: string): string {
-	const normalized = path.replace(/\\/g, "/");
-	const segments = normalized.split("/").map(encodeURIComponent);
-	if (/^[A-Za-z]%3A$/.test(segments[0] ?? "")) {
-		segments[0] = segments[0].replace("%3A", ":");
-	}
-	const encoded = segments.join("/");
-	return normalized.startsWith("/")
-		? `file://${encoded}`
-		: `file:///${encoded}`;
+	const encoded = path.split("/").map(encodeURIComponent).join("/");
+	return `file://${encoded}`;
 }
 
 function baseHrefForNote(noteAbsPath: string): string {
-	const dir = parentDir(noteAbsPath.replace(/\\/g, "/"));
+	const dir = parentDir(noteAbsPath);
 	return `${fileUrlForPath(dir)}/`;
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -785,6 +785,7 @@ interface TauriCommands {
 		ExternalMarkdownWriteResult
 	>;
 	external_markdown_finish_close: CommandDef<void, void>;
+	print_write_html: CommandDef<{ file_stem: string; html: string }, string>;
 	license_bootstrap_status: CommandDef<void, LicenseStatus>;
 	license_activate: CommandDef<{ license_key: string }, LicenseActivateResult>;
 	license_clear_local: CommandDef<void, LicenseActivateResult>;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/279


## Description

Adds **File → Print Note…** for the active Markdown note. This is the platform print-sheet approach from issue #279: the note is rendered to a standalone HTML file, opened in the default browser, and the native print dialog runs automatically so the user can save as PDF.

- **Summary of changes**
  - New `print_write_html` Tauri command writes sanitized HTML to app cache (`src-tauri/src/print.rs`).
  - Frontend builds print-ready HTML from the flushed editor (or disk fallback) via `buildPrintHtml` (`src/lib/printHtml.ts`): YAML frontmatter stripped, wiki links converted to standard Markdown links, Marked + DOMPurify rendering, print CSS, and auto `window.print()` on load.
  - File menu item and `print-note` app command wired through `AppShell` and `useMenuListeners`.
  - `$APPCACHE/**` added to capabilities for the print cache directory.
- **Reasoning**
  - Smallest v1 path to PDF without bundling Pandoc, headless Chromium, or a DOCX converter. Matches the “platform print sheet” direction in the issue.
  - Editor is flushed before export (same pattern as copy/duplicate) so unsaved edits are included.
- **Additional context**
  - DOCX export and a native save dialog are **not** in this PR — only PDF via the system print flow.
  - Wiki links are converted to standard `[text](path)` / `![alt](path)` for rendering; images resolve relative to the note via a `<base href>` pointing at the note’s directory.

## Screenshots

_(Non-visual infrastructure — delete this section if preferred. Manual test: open a note → File → Print Note… → browser opens with print dialog.)_

## Docs

- Print HTML lands in app cache under `print/<note-name>.html` and is opened with the system default handler.
- `wikiLinksToStandardMarkdown` in `wikiLinkCodec.ts` is shared for print rendering.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds File → Print Note… to export the active Markdown note via the system print dialog. Generates sanitized HTML, opens it in the default browser, and auto-triggers print so users can save as PDF.

- New Features
  - New `print_write_html` Tauri command writes HTML to app cache `print/` and returns the path; file names are sanitized and capabilities are narrowed to `$APPCACHE/print/**`.
  - `buildPrintHtml` creates print-ready HTML from the flushed editor (with disk fallback): strips YAML frontmatter, converts wiki links to standard Markdown with correct destinations/anchors, renders with `marked`, sanitizes with `DOMPurify`, adds print CSS, and calls `window.print()` on load.
  - Menu wiring: File → Print Note… and `print-note` app command integrated via `AppShell` and `useMenuListeners`.
  - Editor is saved before print so unsaved edits are included; images and links resolve via a `<base href>` pointing to the note’s directory.

<sup>Written for commit a3d1570f1061a5151f5bba107ce8176d1ca5a0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Print Note” option to the app menu, letting you generate and open a print-ready version of the current note.
  * Improved note rendering for printing, including better handling of wiki links and relative resources.

* **Bug Fixes**
  * Made print file names safer and more reliable when saving generated output.
  * Expanded access to app cache locations needed for printing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->