### PR TITLE
Add in-window space switcher replacing per-space native windows (KAR-25)

### DIFF
--- a/KAR-25-space-switcher-plan.md
+++ b/KAR-25-space-switcher-plan.md
@@ -1,0 +1,601 @@
+# KAR-25 Space Switcher Plan
+
+Linear issue: https://linear.app/karats/issue/KAR-25/spaces-switcher-instead-of-separate-app-windows
+
+Issue status at planning time:
+
+- Title: "Spaces switcher instead of Separate app windows?"
+- Status: Todo
+- Label: Improvement
+- Description: empty
+- Comment context: use one Glyph window for multiple spaces, with an Arc-like compact footer switcher, one dot per open space, optional trackpad swipe, and full in-place space context switching.
+
+## Product Direction
+
+Glyph should stop treating "open another space" as "create another native app window." The app should have one primary workspace window that can remember multiple open space roots and switch the active root in place.
+
+The important invariant is:
+
+> Multiple spaces may be available in the switcher, but only one space is mounted at a time.
+
+"Open spaces" in the new model means "space roots listed in the switcher." It must not mean multiple filesystem watchers, multiple active indexes, or multiple editor/provider trees mounted at once.
+
+The interaction should feel close to Arc spaces:
+
+- The current file tree is the active space.
+- The sidebar footer shows compact dots for the spaces currently in the switcher.
+- Clicking a dot switches to that space in the same window.
+- Opening a recent space or picking a new folder adds it to the switcher and makes it active.
+- Switching should use a quick slide/reveal transition in the file tree area. The "door opens/closes" effect is best implemented as a small horizontal slide with a slight scale/opacity change, not a large page transition.
+- Settings that are already scoped by space should rehydrate for the newly active space.
+
+## Recommended Behavior
+
+### Startup
+
+On launch:
+
+1. Load settings.
+2. Load the persisted open-space list.
+3. Pick the active space:
+   - prefer `space.currentPath` if present;
+   - otherwise use the first open-space path;
+   - otherwise show the current "No space open" state.
+4. Call `space_open` for only the chosen path.
+5. Render dots for the persisted open-space list, with the active path selected.
+
+The persisted list should be app-level UI state, not space-scoped state. A good setting name is `space.openPaths`.
+
+### Opening A Space
+
+When the user chooses File -> Open Space, the command palette action, the welcome screen action, or the recent-spaces menu:
+
+1. If the chosen path is already in `space.openPaths`, switch to it.
+2. If it is not in `space.openPaths`, add it to the end of the list.
+3. Make it active.
+4. Persist:
+   - `space.currentPath`
+   - `space.openPaths`
+   - `space.recent`
+5. Do not create a new native window.
+
+The old `space_open_window` branch in `SpaceContext.applySpaceSelection()` is the current behavior to remove.
+
+### Creating A Space
+
+Creating a space follows the same in-window path:
+
+1. Pick/create the folder.
+2. Add the new root to `space.openPaths`.
+3. Make it active.
+4. Persist current, open, and recent lists.
+5. Mount only that root.
+
+### Switching Spaces
+
+When the user clicks a dot:
+
+1. Ignore the click if it targets the active path.
+2. Save the current editor before switching by calling `saveCurrentEditor()`.
+3. If saving fails, keep the current space active and surface the error.
+4. Clear space-specific frontend caches.
+5. Call `space_open` for the target path. This replaces the backend's current session.
+6. Set `spacePath`, `spaceSchemaVersion`, and `onboardingNotePath` from the returned `SpaceInfo`.
+7. Persist `space.currentPath`.
+8. Let existing providers reset from the `spacePath` change:
+   - `FileTreeProvider` clears and reloads the root tree.
+   - `useTabManager(spacePath)` clears tabs/history/dirty state.
+   - `UIProvider` reloads space-scoped settings.
+   - `GitSyncProvider` refreshes per-space Git state.
+   - navigation prefetch caches are invalidated.
+
+Important: switching should not preserve open tabs across spaces in the first implementation. Preserving per-space workspace view state is useful later, but it adds more state ownership and dirty-editor edge cases. The first version should switch cleanly and predictably.
+
+### Closing A Space
+
+Close Space should remove the active root from the switcher:
+
+1. Save the current editor if needed.
+2. Remove active path from `space.openPaths`.
+3. If another open path remains, switch to the nearest neighbor:
+   - prefer the dot to the right;
+   - otherwise the dot to the left.
+4. If no open path remains, call `space_close`, clear `space.currentPath`, and show "No space open."
+5. Keep the path in `space.recent` so it can be reopened later.
+
+This is a behavior change from "close this native space window." In the one-window model it means "remove this space from my switcher."
+
+### Recent Spaces Menu
+
+The native Recent Spaces menu should keep working. Selecting a recent space should now route to the main window and add/switch that path inside the footer switcher. It should not open or focus a separate space window.
+
+The recent menu should continue to exclude the current active space. It may include spaces already present in `space.openPaths` if they are inactive; selecting one just switches.
+
+### Footer Switcher UI
+
+The sidebar footer should have a dedicated switcher area above or beside the license footer:
+
+- Show one dot button per path in `space.openPaths`.
+- Active dot is visually filled or larger.
+- Inactive dots are smaller/subtler.
+- Each dot has:
+  - `aria-label="Switch to {spaceName}"`
+  - `aria-current="true"` for the active path
+  - `title` with the full path or path basename
+- The active space basename may be shown only in a tooltip or compact accessible label, not as another row of large text.
+- If there are more dots than fit, use horizontal scrolling or collapse overflow into a small menu. Do not let dots resize the sidebar.
+- The footer should still work when the license footer is absent, trial, or community-build mode.
+
+The first version should avoid adding a visible plus button unless the design needs it. Existing Open Space commands already provide the add-space affordance. If a plus affordance is added later, it should call the same `onOpenSpace` action.
+
+### Switch Animation
+
+Use Motion around the file-tree/tags region, keyed by the active `spacePath`.
+
+Recommended effect:
+
+- outgoing tree: translateX(-10px or +10px), opacity 0, maybe scale 0.985
+- incoming tree: translateX(+10px or -10px), opacity 1, scale 1
+- duration: around 140-190ms
+- spring or ease-out, respecting `useReducedMotion()`
+
+The direction can be derived from the previous/next dot index. If the target dot is to the right, content moves left; if target is to the left, content moves right.
+
+This should wrap only the sidebar content body, not the whole app shell. The editor/main area will naturally reset from the active `spacePath`; adding a large editor transition in the first version risks making the app feel slower.
+
+### Trackpad Swipe
+
+Treat swipe as a follow-up after click switching is solid.
+
+If implemented:
+
+- listen for horizontal wheel gestures on the sidebar footer or sidebar body, not globally across the editor;
+- require a threshold so normal scrolling does not switch spaces;
+- throttle until the current switch finishes;
+- respect reduced motion;
+- expose only previous/next space behavior.
+
+## Current Code Shape
+
+### Backend
+
+Current space lifecycle lives in:
+
+- `src-tauri/src/space/commands.rs`
+- `src-tauri/src/space/state.rs`
+- `src-tauri/src/space/helpers.rs`
+- `src-tauri/src/space/watcher.rs`
+- `src-tauri/src/lib.rs`
+- `src/lib/tauri.ts`
+
+The backend currently supports per-window space sessions:
+
+- `SpaceState.sessions: Mutex<HashMap<String, SpaceSession>>`
+- `space_open_window(...)`
+- `SPACE_WINDOW_PREFIX`
+- generated labels like `space-{hash}`
+- window routing helpers in `src-tauri/src/lib.rs`
+
+Most backend commands resolve the root through:
+
+- `state.root_for_window(&window)`
+- `state.root_for_window_label(window_label)`
+- `state.recent_local_changes_for_window(window.label())`
+
+This exists so several native space windows can each talk to a different space.
+
+For KAR-25, that is the old model. The target model needs one active root for the main app window.
+
+### Frontend
+
+Current frontend ownership:
+
+- `src/contexts/SpaceContext.tsx`
+  - app info
+  - active `spacePath`
+  - recent spaces
+  - open/create/close actions
+  - current logic that opens another native window when a session already exists
+- `src/contexts/FileTreeContext.tsx`
+  - clears/reloads file tree when `spacePath` changes
+- `src/contexts/UIContext.tsx`
+  - clears tabs when no space exists
+  - reloads space-scoped settings on `spacePath` changes
+- `src/components/app/useTabManager.ts`
+  - resets tabs, dirty state, and history when `spacePath` changes
+- `src/contexts/GitSyncContext.tsx` and `src/hooks/useGitSync.ts`
+  - refresh per-space Git sync from `spacePath`
+- `src/components/app/SidebarContent.tsx`
+  - owns the file tree/tags/sidebar body
+  - currently ends with `LicenseStatusFooter`
+- `src/components/licensing/LicenseStatusFooter.tsx`
+  - current footer component
+
+This is favorable: most frontend state already responds to `spacePath` as the active-space boundary.
+
+## Recommended Refactor
+
+### Keep A Deep Active-Space Module
+
+Do not spread switcher details through the app shell. The useful seam is `SpaceContext`.
+
+`SpaceContext` should expose a small interface like:
+
+```ts
+type OpenSpace = {
+  path: string;
+  label: string;
+};
+
+interface SpaceContextValue {
+  spacePath: string | null;
+  openSpaces: OpenSpace[];
+  activeSpaceIndex: number;
+  switchSpace: (path: string) => Promise<void>;
+  switchToNextSpace: () => Promise<void>;
+  switchToPreviousSpace: () => Promise<void>;
+  onOpenSpace: () => Promise<void>;
+  onOpenSpaceAtPath: (path: string) => Promise<void>;
+  onCreateSpace: () => Promise<void>;
+  closeSpace: () => Promise<void>;
+}
+```
+
+The implementation hides:
+
+- deduping paths
+- persistence of open/current/recent spaces
+- calling `space_open` versus `space_create`
+- editor save coordination
+- cache invalidation
+- onboarding note handling
+- indexing state reset
+
+Callers should not know whether the target came from a dot, recent menu, command palette, or file picker.
+
+### Coordinate Editor Saving
+
+`SpaceContext` currently cannot call `saveCurrentEditor()` because `EditorProvider` is below it in the provider stack:
+
+```text
+SpaceProvider
+  FileTreeProvider
+    UIProvider
+      EditorProvider
+        GitSyncProvider
+          AppShell
+```
+
+There are two reasonable options:
+
+1. Preferred: keep `SpaceProvider` as the owner of space state, but let `AppShell` wrap switching actions with editor save checks.
+   - Add a helper hook in `AppShell`, e.g. `switchSpaceWithEditorFlush(path)`.
+   - Pass it to `SpaceSwitcherFooter`.
+   - Keep lower-level `SpaceContext.switchSpace(path)` focused on mounting/persistence/cache invalidation.
+2. Larger refactor: move `EditorProvider` above `SpaceProvider`.
+   - This is not recommended for the first slice because it changes provider ordering and could affect existing hooks.
+
+The plan should use option 1.
+
+### Preserve Existing Space-Scoped Settings
+
+`src/lib/settings.ts` already has `SpaceScopedSettingsMap` and `SettingsScope`.
+
+These settings already hydrate by active space:
+
+- daily notes folder
+- quick notes folder
+- templates folder
+- daily note template
+- attachment storage mode
+- attachment folder
+
+`SpaceSettingsPane` already calls `space_get_current` and stores against the active path. Once switching updates the backend active root before settings render/hydrate, settings should populate for the selected dot automatically.
+
+The plan should still audit settings panes after implementation:
+
+- `src/components/settings/SpaceSettingsPane.tsx`
+- `src/components/settings/TemplatesSettingsPane.tsx`
+- `src/components/settings/GitSettingsPane.tsx`
+- `src/components/settings/AiSettingsPane.tsx`
+- `src/components/settings/settingsConfig.tsx`
+
+### Backend Hard Cutover
+
+This is the recommended backend direction after approval:
+
+1. Delete the user-facing multi-space-window path:
+   - remove `space_open_window` command;
+   - remove its TypeScript command entry;
+   - remove frontend calls to it.
+2. Simplify host-window routing:
+   - `main` is the only space host window;
+   - quick note still uses the active main space via `current_root()`;
+   - settings stays in the main surface or its existing settings behavior.
+3. Narrow `SpaceState` back toward a single active session:
+   - `current: Mutex<Option<PathBuf>>`
+   - one watcher handle
+   - one `RecentLocalChanges`
+   - shared mutexes for stores
+4. Keep compatibility shims only if they reduce churn:
+   - `root_for_window(&window)` can still exist, but it should return `current_root()` for main/quick-note flows.
+   - `root_for_window_label(label)` can be narrowed or removed after updating Git sync/service call sites.
+
+Because the project policy says to ask before hard cutovers, the implementation should not start deleting multi-window support until this plan is approved.
+
+## Files To Touch
+
+### Frontend State And Settings
+
+- `src/contexts/SpaceContext.tsx`
+  - add `openSpaces`
+  - add active index
+  - replace `space_open_window` branching with in-window `space_open`/`space_create`
+  - add `switchSpace`
+  - update `closeSpace` to remove active path and switch neighbor
+  - persist current/open/recent lists
+  - clear caches on every active-space change
+  - remove `isSpaceWindow()` and `SPACE_WINDOW_PREFIX` usage after backend cutover
+
+- `src/lib/settings.ts`
+  - add `openSpacePaths` / `space.openPaths`
+  - normalize/dedupe persisted paths
+  - add setters for open-space list and current-space updates
+  - keep `recentSpaces` behavior separate
+  - consider changing `setCurrentSpacePath(path)` into a more explicit helper that updates current/recent/open together
+
+- `src/lib/tauri.ts`
+  - remove `space_open_window` after Rust command removal
+  - keep `space_open`, `space_create`, `space_close`, `space_get_current`, `space_get_current_info`
+
+- `src/lib/windowLabels.ts`
+  - delete if `SPACE_WINDOW_PREFIX` becomes unused
+
+### Frontend Sidebar UI
+
+- `src/components/app/Sidebar.tsx`
+  - pass switcher props down or render a footer wrapper
+  - keep settings-mode behavior in mind; the switcher probably belongs to workspace sidebar mode, not settings sidebar mode
+
+- `src/components/app/SidebarContent.tsx`
+  - replace direct `LicenseStatusFooter` usage with a new sidebar footer module
+  - key file tree/tags content by `spacePath` for the switch animation
+  - keep the empty-state footer behavior sane when no space is open
+
+- `src/components/app/SpaceSwitcherFooter.tsx` (new)
+  - render dots
+  - handle click switching
+  - expose active/inactive accessible labels
+  - optionally handle horizontal wheel swipe in a later slice
+
+- `src/components/app/SidebarFooter.tsx` (new, optional)
+  - compose `SpaceSwitcherFooter` and `LicenseStatusFooter`
+  - keeps licensing unrelated to switcher internals
+
+- `src/styles/app/04-sidebar.css`
+  - add stable footer layout
+  - add dot sizes/states/focus styles
+  - add overflow behavior for many dots
+  - add animation classes only if Motion props are not enough
+
+### Frontend Shell Integration
+
+- `src/components/app/AppShell.tsx`
+  - wrap dot switching with `saveCurrentEditor()`
+  - call `setError`/toast when save or switch fails
+  - pass active index/direction if animation needs it
+  - ensure command/menu open-space paths still route to in-window open
+
+- `src/hooks/useMenuListeners.ts`
+  - likely no API change; it already routes recent-space menu events to `onOpenSpaceAtPath`
+  - confirm recent-space selection switches in-window after `SpaceContext` changes
+
+- `src/components/app/useAppCommands.tsx`
+  - audit command labels if "Open Space" still implies opening a window anywhere
+
+- `src/shared/appCommandManifest.json`
+  - audit command descriptions for "window" language
+
+### Backend Space Runtime
+
+- `src-tauri/src/space/commands.rs`
+  - remove `SPACE_WINDOW_PREFIX`, `is_space_window`, `space_window_label`, `space_window_title`, `focus_window`, and `space_open_window`
+  - make `space_open` replace the single active session
+  - make `space_create` replace the single active session
+  - keep `space_close` as "unmount active"
+
+- `src-tauri/src/space/state.rs`
+  - remove or narrow `sessions`
+  - remove per-window session helpers after call sites are updated
+  - keep one active watcher and one recent-local-change tracker
+
+- `src-tauri/src/lib.rs`
+  - remove space host window helpers that include `space-*` windows
+  - route menu events to `main`
+  - remove destroyed-space-window cleanup
+  - update `space_is_open`
+  - keep quick-note/settings/external-markdown behavior intact
+
+- `src-tauri/src/git_sync/service.rs`
+  - replace `root_for_window_label(window_label)` with active root access or a narrower helper
+  - keep status events emitted to the main window
+
+- Any Rust module currently using `root_for_window` should continue to compile if that helper remains and returns the active root. This is the least risky transition.
+
+### Docs
+
+- `docs/architecture/02-spaces-storage-filesystem.md`
+  - update "Space State" to describe one mounted space plus persisted switcher roots
+  - remove stale per-window language after code cutover
+
+- `docs/architecture/03-frontend-shell-state.md`
+  - document `openSpaces` and the switcher
+  - mention that tabs reset on first-version switches
+
+- `docs/architecture/04-ipc-and-native-runtime.md`
+  - remove `space_open_window`
+  - update native windows section
+  - update recent-spaces menu behavior
+
+- `docs/architecture/09-settings-menus-git-sync-native-windows.md`
+  - update native windows and Git sync sections for one active main space
+
+## Files To Create
+
+Recommended:
+
+- `src/components/app/SpaceSwitcherFooter.tsx`
+- `src/components/app/SidebarFooter.tsx`
+
+Optional only if implementation gets large:
+
+- `src/lib/spaces.ts`
+  - pure helpers for path labels, dedupe, index lookup, next/previous selection
+  - create only if `SpaceContext.tsx` starts mixing too much list logic with async mounting
+
+Avoid creating test files unless explicitly requested. Existing tests can be updated if they break because touched code changed, but this plan should not introduce new test files by default.
+
+## Detailed Implementation Phases
+
+### Phase 1: Frontend In-Window Switching
+
+Goal: stop creating extra windows from React while keeping backend multi-window support temporarily available.
+
+Steps:
+
+1. Add `space.openPaths` support in `settings.ts`.
+2. Extend `SpaceContextValue` with `openSpaces`, active index, and `switchSpace`.
+3. On startup, hydrate `openSpaces` from settings.
+4. Change `applySpaceSelection()`:
+   - remove the `sessionSpacePath ? space_open_window(...) : ...` behavior;
+   - call `space_open` or `space_create` directly;
+   - update `spacePath` even when another space was already active.
+5. Ensure every successful switch clears:
+   - AI panel caches
+   - inline image hydration cache
+   - navigation prefetch
+6. Implement close-space neighbor selection.
+7. Keep native recent-space menu functional.
+
+This phase gives the product behavior without immediately deleting backend support.
+
+### Phase 2: Footer Dots And Animation
+
+Goal: make the switcher visible and polished.
+
+Steps:
+
+1. Create `SpaceSwitcherFooter.tsx`.
+2. Create or adapt `SidebarFooter.tsx`.
+3. Replace the current direct `LicenseStatusFooter` placements in `SidebarContent`.
+4. Add dot styles in `04-sidebar.css`.
+5. Add a keyed Motion wrapper around the file tree/tags content.
+6. Track switch direction from old index to new index.
+7. Respect reduced motion.
+
+### Phase 3: Backend Cutover
+
+Goal: remove the old one-window-per-space runtime.
+
+Steps:
+
+1. Remove `space_open_window` from Rust and TypeScript.
+2. Remove generated `space-*` host-window creation.
+3. Narrow `SpaceState` to one active session.
+4. Update `lib.rs` window routing so menu events go to the main window.
+5. Keep quick note behavior pointed at the active root.
+6. Update Git sync service helpers to use the active root.
+7. Update architecture docs.
+
+This phase is the actual deletion of old behavior. It should happen after you approve the hard cutover.
+
+### Phase 4: Optional Swipe
+
+Goal: add Arc-like trackpad switching only after click switching is reliable.
+
+Steps:
+
+1. Add previous/next actions to `SpaceContext`.
+2. Add horizontal wheel handling to `SpaceSwitcherFooter`.
+3. Use a threshold and cooldown.
+4. Do not bind global editor-area swipes.
+
+## Risks And Decisions
+
+### Unsaved Changes
+
+Switching spaces while a note is dirty can lose work if the editor unmounts before save completes. The switch action must save first and abort on error.
+
+Current `EditorContext.saveCurrentEditor()` returns `true` when an editor existed and save ran. It throws if save fails. The switch wrapper in `AppShell` should use that behavior and show a clear error.
+
+### Stale Async Responses
+
+`FileTreeProvider`, `useGitSync`, and several hooks already protect against stale responses by checking the active `spacePath` or request ids. The switch implementation should keep that pattern and avoid setting state from an old space after a rapid switch.
+
+### Space-Scoped Settings
+
+Space settings already depend on `space_get_current` and `loadSettings({ spacePath })`. The switch must update the backend current root before settings panes read their values.
+
+### Current Root Versus Window Label
+
+Many Rust commands use `root_for_window(&window)`. During the cutover, keeping that method as an active-root adapter will reduce the number of touched command modules.
+
+### Git Sync
+
+Git sync runtime is keyed by root. That is good. The event target is still window-label based. In the one-window model, emit status to `main`.
+
+### Quick Note
+
+Quick note uses the currently active space. After removing multi-window support, there is no focused-space-window ambiguity. Quick note should use the main active root.
+
+### Recent Spaces Versus Open Spaces
+
+Do not conflate the two lists:
+
+- `space.openPaths`: spaces currently represented by dots.
+- `space.recent`: historical menu/list of recently used spaces.
+- `space.currentPath`: active mounted space.
+
+### Multiple Windows Already Open During Upgrade
+
+Because this is a hard cutover, the implementation does not need backward compatibility for existing open `space-*` windows. The app after update should only create/use the main host window. Existing runtime windows disappear when the app restarts.
+
+## Acceptance Criteria
+
+- Opening a second space in an active window does not create a new native window.
+- The new space appears as a dot in the sidebar footer and becomes active.
+- Clicking another dot switches the active file tree in the same window.
+- Only one backend space is mounted at a time.
+- Tabs/editor state from the previous space is not shown after switching.
+- Space settings show values for the currently active dot.
+- Git settings/status reflect the currently active dot.
+- Recent-space native menu switches in-window.
+- Close Space removes the active dot and switches to a neighbor, or leaves no space open.
+- Quick note writes to the currently active space.
+- File tree watcher events after switching do not update the wrong space UI.
+- The old `space_open_window` path is removed after backend cutover.
+
+## Verification Checklist
+
+Manual checks:
+
+1. Start with no space open; open Space A.
+2. Open Space B from File -> Open Space; confirm no new window is created.
+3. Confirm footer shows dots for A and B.
+4. Click A dot; confirm A file tree, settings, tags, pinned files, and Git state load.
+5. Click B dot; confirm B context loads.
+6. Open a note in A, type a change, switch to B; confirm save happens or an error blocks switching.
+7. Close active space with two spaces open; confirm neighbor activates.
+8. Close final space; confirm no-space empty state.
+9. Use native Recent Spaces menu; confirm in-window switch.
+10. Open quick note after switching; confirm it writes to active space.
+11. Trigger file changes in inactive space from Finder/terminal; confirm inactive changes do not mutate the active tree.
+
+Static checks when implementation is ready:
+
+- `pnpm check`
+- `pnpm build`
+- `cd src-tauri && cargo check`
+
+Do not run dev servers; the user handles dev.
+

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -60,13 +60,14 @@ Rust stores active space state in `SpaceState`:
 ```rust
 pub struct SpaceState {
     pub(crate) current: Mutex<Option<PathBuf>>,
-    pub(crate) notes_watcher: Mutex<Option<notify::RecommendedWatcher>>,
-    recent_local_changes: RecentLocalChanges,
+    session: Mutex<Option<SpaceSession>>,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
     pinned_files_mutex: Arc<Mutex<()>>,
 }
 ```
+
+Only one space mounts at a time. The frontend may keep multiple open space roots in `space.openPaths` for the sidebar switcher, but the backend holds a single watcher, recent-local-change tracker, and active root.
 
 The state has three jobs:
 
@@ -80,11 +81,11 @@ The state has three jobs:
 
 Frontend flow in `SpaceContext`:
 
-1. `loadSettings()` reads the last space path.
-2. If a path exists, React calls `invoke("space_open", { path })`.
-3. User actions call `space_open` or `space_create` from `applySpaceSelection()`.
-4. On successful open, React stores the root in settings and updates recent spaces.
-5. On switching spaces, React closes the previous space, clears AI/editor prefetch caches, and clears current space path.
+1. `loadSettings()` reads `space.currentPath`, `space.openPaths`, and `space.recent`.
+2. On startup, open only the chosen active path with `invoke("space_open", { path })`.
+3. User actions call `space_open` or `space_create` through the single activation path in `SpaceContext`.
+4. On successful open or switch, React stores the backend's canonical root in settings and updates recent/open lists.
+5. On switching spaces, React replaces the mounted backend session, clears AI/editor prefetch caches, and persists the new active path.
 
 Rust flow in `space_open` and `space_create`:
 
@@ -93,11 +94,10 @@ Rust flow in `space_open` and `space_create`:
 3. Register the space in the app-support index manifest and remove any stale in-space `glyph.sqlite` sidecars.
 4. Create or open Glyph metadata in `.glyph/`.
 5. Reset the index schema cache with `index::db::reset_schema_cache()`.
-6. Store the canonical root in `SpaceState.current`.
-7. Install the notes watcher with `set_notes_watcher()`.
-8. Enable the native Close Space menu item.
+6. Replace the active session: store the canonical root, install a new notes watcher, and reset recent-local-change tracking.
+7. Enable the native Close Space menu item.
 
-`space_close` clears `current`, drops the watcher, resets the schema cache, and disables Close Space.
+`space_close` clears the active session, resets the schema cache, and disables Close Space.
 
 ## Path Safety
 

--- a/docs/architecture/03-frontend-shell-state.md
+++ b/docs/architecture/03-frontend-shell-state.md
@@ -48,27 +48,32 @@ Do not move providers without checking their hooks. A provider that calls `useSp
 
 - app info
 - current space path
+- open space list for the sidebar switcher (`openSpaces`)
+- active switcher index and last switch direction
 - last space path
 - recent spaces
 - onboarding note path
 - indexing flag
-- open/create/close actions
+- open/create/close/switch actions
 
 On startup, it:
 
 1. Calls `app_info`.
-2. Loads settings.
+2. Loads settings, including `space.openPaths`.
 3. Syncs people-mentions-as-tags to the Rust index runtime.
-4. Reopens the last space when settings contain one.
-5. Syncs native recent-space menu entries.
+4. Mounts only the active space (`space.currentPath` or the first open path).
+5. Rewrites the mounted entry to the backend's canonical root before persisting `space.openPaths`.
+6. Syncs native recent-space menu entries.
 
-When opening a new space, it closes the previous one first and clears caches:
+When opening or switching spaces, it replaces the mounted backend session and clears caches:
 
 - `clearAiPanelCaches()`
 - `clearInlineImageHydrationCache()`
 - `invalidateNavigationPrefetch()`
 
 That prevents a note preview, AI context, or editor image cache from leaking across spaces.
+
+The sidebar footer renders one dot per open space. Clicking a dot switches the active root in place. Tabs and editor state reset on switch in the first version; only one backend space mounts at a time.
 
 ## File Tree Provider
 

--- a/docs/architecture/09-settings-menus-git-sync-native-windows.md
+++ b/docs/architecture/09-settings-menus-git-sync-native-windows.md
@@ -127,7 +127,7 @@ When adding a command:
 
 Rust builds the main menu in `src-tauri/src/lib.rs`. Menu events follow one of two paths:
 
-- Recent-space menu item emits `menu:open_recent_space`.
+- Recent-space menu item emits `menu:open_recent_space` to the main window, which adds or switches the path in the in-window switcher.
 - Command menu item emits `menu:app_command`.
 
 `useMenuListeners()` maps those events to shell actions:

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,13 +2,7 @@
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "default",
 	"description": "Capability for the main window",
-	"windows": [
-		"main",
-		"space-*",
-		"quick-note",
-		"quick-task",
-		"external-markdown-*"
-	],
+	"windows": ["main", "quick-note", "quick-task", "external-markdown-*"],
 	"permissions": [
 		"core:default",
 		"core:window:allow-close",

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, Emitter, Manager, State, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tracing::warn;
 
 use crate::space::SpaceState;
@@ -110,19 +110,18 @@ fn emit_profiles_updated(app: &AppHandle) {
     let _ = app.emit("ai:profiles-updated", ());
 }
 
-fn ai_space_root(space_state: &SpaceState, window: &WebviewWindow) -> Result<PathBuf, String> {
+fn ai_space_root(space_state: &SpaceState) -> Result<PathBuf, String> {
     space_state
-        .root_for_window(window)
+        .current_root()
         .map_err(|_| "Open a space to manage AI settings".to_string())
 }
 
 #[tauri::command]
 pub async fn ai_profiles_list(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Vec<AiProfile>, String> {
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let store = normalized_store_for_space(&app, Some(&space_root))?;
     Ok(store.profiles)
 }
@@ -130,10 +129,9 @@ pub async fn ai_profiles_list(
 #[tauri::command]
 pub async fn ai_active_profile_get(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Option<String>, String> {
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let store = normalized_store_for_space(&app, Some(&space_root))?;
     Ok(store
         .active_profile_id
@@ -143,11 +141,10 @@ pub async fn ai_active_profile_get(
 #[tauri::command]
 pub async fn ai_active_profile_set(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     id: Option<String>,
 ) -> Result<(), String> {
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let path = store_path_for_space(&app, Some(&space_root))?;
     let mut store = normalized_store_for_space(&app, Some(&space_root))?;
     store.active_profile_id = id.filter(|candidate| {
@@ -164,11 +161,10 @@ pub async fn ai_active_profile_set(
 #[tauri::command]
 pub async fn ai_profile_upsert(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile: AiProfile,
 ) -> Result<AiProfile, String> {
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let path = store_path_for_space(&app, Some(&space_root))?;
     let mut store = normalized_store_for_space(&app, Some(&space_root))?;
 
@@ -200,11 +196,10 @@ pub async fn ai_profile_upsert(
 #[tauri::command]
 pub async fn ai_profile_delete(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     id: String,
 ) -> Result<(), String> {
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let path = store_path_for_space(&app, Some(&space_root))?;
     let mut store = normalized_store_for_space(&app, Some(&space_root))?;
     let _ = local_secrets::secret_clear(&space_root, &id);
@@ -232,13 +227,12 @@ pub async fn ai_profile_delete(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_set(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
     api_key: String,
 ) -> Result<(), String> {
     let root = space_state
-        .root_for_window(&window)
+        .current_root()
         .map_err(|_| "Open a space to store API keys locally".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_set(&root, &profile_id, api_key.trim())
@@ -247,12 +241,11 @@ pub async fn ai_secret_set(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_clear(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
 ) -> Result<(), String> {
     let root = space_state
-        .root_for_window(&window)
+        .current_root()
         .map_err(|_| "Open a space to manage API keys".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_clear(&root, &profile_id)
@@ -261,11 +254,10 @@ pub async fn ai_secret_clear(
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_secret_status(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
 ) -> Result<bool, String> {
-    let root = match space_state.root_for_window(&window) {
+    let root = match space_state.current_root() {
         Ok(root) => root,
         Err(_) => return Ok(false),
     };
@@ -276,11 +268,10 @@ pub async fn ai_secret_status(
 #[tauri::command]
 pub async fn ai_secret_list(
     app: AppHandle,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Vec<String>, String> {
     let root = space_state
-        .root_for_window(&window)
+        .current_root()
         .map_err(|_| "Open a space to manage API keys".to_string())?;
     let _ = normalized_store_for_space(&app, Some(&root))?;
     local_secrets::secret_ids(&root)
@@ -305,7 +296,6 @@ pub async fn ai_provider_support(app: AppHandle) -> Result<ProviderSupportDocume
 #[tauri::command]
 pub async fn ai_chat_start(
     ai_state: State<'_, AiState>,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     app: AppHandle,
     mut request: AiChatRequest,
@@ -331,7 +321,7 @@ pub async fn ai_chat_start(
         request.audit = true;
     }
 
-    let space_root = ai_space_root(&space_state, &window)?;
+    let space_root = ai_space_root(&space_state)?;
     let store = normalized_store_for_space(&app, Some(&space_root))?;
 
     let profile = store
@@ -455,20 +445,18 @@ pub async fn ai_chat_cancel(ai_state: State<'_, AiState>, job_id: String) -> Res
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_chat_history_list(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     limit: Option<u32>,
 ) -> Result<Vec<history::AiChatHistorySummary>, String> {
-    history::ai_chat_history_list(window, space_state, limit).await
+    history::ai_chat_history_list(space_state, limit).await
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_chat_history_get(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     job_id: String,
 ) -> Result<history::AiChatHistoryDetail, String> {
-    history::ai_chat_history_get(window, space_state, job_id).await
+    history::ai_chat_history_get(space_state, job_id).await
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src-tauri/src/ai_rig/context.rs
+++ b/src-tauri/src/ai_rig/context.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -169,10 +169,9 @@ fn list_files(root: &Path, dir: &str, limit: usize) -> Result<Vec<String>, Strin
 
 #[tauri::command]
 pub async fn ai_context_index(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<AiContextIndexResponse, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let files = list_files(&root, "", DEFAULT_FILE_LIST_LIMIT)?;
         let mut dirs = std::collections::BTreeSet::<String>::new();
@@ -218,11 +217,10 @@ pub async fn ai_context_index(
 
 #[tauri::command]
 pub async fn ai_context_build(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: AiContextBuildRequest,
 ) -> Result<AiContextBuildResponse, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut remaining = request
             .char_budget
@@ -319,11 +317,10 @@ pub async fn ai_context_build(
 
 #[tauri::command]
 pub async fn ai_context_resolve_paths(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     attachments: Vec<AiContextAttachment>,
 ) -> Result<Vec<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let mut out: Vec<String> = Vec::new();
         let mut seen = std::collections::BTreeSet::<String>::new();

--- a/src-tauri/src/ai_rig/history.rs
+++ b/src-tauri/src/ai_rig/history.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{glyph_paths, space::SpaceState};
 
@@ -60,11 +60,10 @@ pub struct AiChatHistoryDetail {
 }
 
 pub async fn ai_chat_history_list(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     limit: Option<u32>,
 ) -> Result<Vec<AiChatHistorySummary>, String> {
-    let root = space_state.root_for_window(&window)?;
+    let root = space_state.current_root()?;
     let limit = limit
         .unwrap_or(DEFAULT_LIMIT as u32)
         .max(1)
@@ -76,12 +75,11 @@ pub async fn ai_chat_history_list(
 }
 
 pub async fn ai_chat_history_get(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     job_id: String,
 ) -> Result<AiChatHistoryDetail, String> {
     let _ = uuid::Uuid::parse_str(&job_id).map_err(|_| "invalid job_id".to_string())?;
-    let root = space_state.root_for_window(&window)?;
+    let root = space_state.current_root()?;
 
     tauri::async_runtime::spawn_blocking(move || get_history_impl(&root, &job_id))
         .await

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -1,4 +1,4 @@
-use tauri::{AppHandle, State, WebviewWindow};
+use tauri::{AppHandle, State};
 
 use super::helpers::{
     alternate_openai_base_url, apply_extra_headers, http_client, ollama_api_url, parse_base_url,
@@ -571,13 +571,12 @@ fn list_codex_models(codex_state: &CodexState) -> Result<Vec<AiModel>, String> {
 pub async fn ai_models_list(
     app: AppHandle,
     codex_state: State<'_, CodexState>,
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
     provider: Option<AiProviderKind>,
 ) -> Result<Vec<AiModel>, String> {
     let space_root = space_state
-        .root_for_window(&window)
+        .current_root()
         .map_err(|_| "Open a space to manage AI settings".to_string())?;
     let path = store_path_for_space(&app, Some(&space_root))?;
     let mut store = read_store(&path);

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 use serde_yaml::{Mapping, Value};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 use uuid::Uuid;
 
 use crate::index::index_note;
@@ -493,10 +493,9 @@ fn backlink_note_paths(root: &Path, note_path: &str) -> Result<Vec<String>, Stri
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<Vec<DatabaseSummary>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -511,11 +510,10 @@ pub async fn databases_list(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_get(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let store = load_store(&root)?;
         let database = store
@@ -531,12 +529,11 @@ pub async fn databases_get(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_create(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     name: String,
     folder: String,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -577,11 +574,10 @@ pub async fn databases_create(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_update(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database: DatabaseDefinition,
 ) -> Result<DatabaseDocument, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -615,11 +611,10 @@ pub async fn databases_update(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_delete(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -635,14 +630,13 @@ pub async fn databases_delete(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_query_rows(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
     view_id: String,
     offset: Option<u32>,
     limit: Option<u32>,
 ) -> Result<super::types::DatabaseQueryResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let store = load_store(&root)?;
         let database = store
@@ -671,14 +665,13 @@ pub async fn databases_query_rows(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_update_cell(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_path: String,
     column: DatabaseColumn,
     value: DatabaseCellValue,
 ) -> Result<DatabaseRow, String> {
-    let root = state.root_for_window(&window)?;
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let root = state.current_root()?;
+    let recent_local_changes = state.recent_local_changes();
     tauri::async_runtime::spawn_blocking(move || {
         let existing_row = row_by_path(&root, &note_path)?;
         validate_editable_column(&existing_row, &column)?;
@@ -696,15 +689,14 @@ pub async fn databases_update_cell(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_create_row(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     database_id: String,
     title: Option<String>,
     initial_values: Option<Vec<DatabaseCreateRowInitialValue>>,
 ) -> Result<DatabaseCreateRowResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let recent_local_changes = state.recent_local_changes();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
             .lock()
@@ -758,12 +750,11 @@ pub async fn databases_create_row(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_preview_context(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_path: String,
     _space_path: Option<String>,
 ) -> Result<DatabasePreviewContext, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let markdown = read_note_markdown(&root, &note_path)?;
         let row = row_by_path(&root, &note_path)?;
@@ -791,10 +782,9 @@ pub async fn databases_preview_context(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_status_colors_get(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex
@@ -808,12 +798,11 @@ pub async fn databases_status_colors_get(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn databases_status_color_set(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     status: String,
     color: Option<String>,
 ) -> Result<BTreeMap<String, String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let db_store_mutex = state.db_store_mutex();
     tauri::async_runtime::spawn_blocking(move || {
         let _guard = db_store_mutex

--- a/src-tauri/src/file_tree_appearance/commands.rs
+++ b/src-tauri/src/file_tree_appearance/commands.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::space::SpaceState;
 use crate::space_fs::helpers::deny_hidden_rel_path;
@@ -11,10 +11,9 @@ use super::types::FileTreeAppearance;
 
 #[tauri::command]
 pub async fn file_tree_appearance_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, FileTreeAppearance>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         Ok(load_store(&root)?.entries)
     })
@@ -24,13 +23,12 @@ pub async fn file_tree_appearance_list(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_set(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     color: Option<String>,
     icon: Option<String>,
 ) -> Result<Option<FileTreeAppearance>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);
@@ -60,12 +58,11 @@ pub async fn file_tree_appearance_set(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_rename_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let from_rel = PathBuf::from(&from_path);
@@ -97,11 +94,10 @@ pub async fn file_tree_appearance_rename_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn file_tree_appearance_delete_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let appearance_mutex = state.file_tree_appearance_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);

--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -11,19 +11,17 @@ use super::GitSyncState;
 
 #[tauri::command]
 pub fn git_sync_status_read(
-    window: WebviewWindow,
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
 ) -> Result<GitSyncStatus, String> {
-    service::read_status(git_state, space_state, window.label())
+    service::read_status(git_state, space_state)
 }
 
 #[tauri::command]
 pub fn git_sync_config_read(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
 ) -> Result<Option<GitSyncConfig>, String> {
-    service::read_config(&space_state, window.label())
+    service::read_config(&space_state)
 }
 
 #[tauri::command]
@@ -60,12 +58,11 @@ pub fn git_sync_disconnect(
 
 #[tauri::command]
 pub fn git_history_list(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     path: String,
     limit: Option<u32>,
 ) -> Result<Vec<GitHistoryCommit>, String> {
-    let space_root = space_state.root_for_window(&window)?;
+    let space_root = space_state.current_root()?;
     let rel_path = validate_space_rel_path(&space_root, &path)?;
     ensure_repo_at_space_root(&space_root)?;
     let raw = super::git::file_history(&space_root, &rel_path, limit.unwrap_or(30))?;
@@ -74,12 +71,11 @@ pub fn git_history_list(
 
 #[tauri::command]
 pub fn git_history_diff(
-    window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     path: String,
     commit: GitHistoryCommit,
 ) -> Result<GitCommitDiff, String> {
-    let space_root = space_state.root_for_window(&window)?;
+    let space_root = space_state.current_root()?;
     let rel_path = validate_space_rel_path(&space_root, &path)?;
     ensure_repo_at_space_root(&space_root)?;
     validate_commit_hash(&commit.hash)?;

--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use tauri::{AppHandle, Emitter, State};
 
-use crate::space::state::{is_no_space_session_error, SpaceState};
+use crate::space::state::{is_no_space_open_error, SpaceState};
 
 use super::git::{
     ahead_behind_counts, commit_all, fetch_remote, git_is_installed, has_head_commit,
@@ -316,11 +316,10 @@ fn read_status_for_root(
 pub fn read_status_internal(
     git_state: &GitSyncState,
     space_state: &SpaceState,
-    window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = match space_state.root_for_window_label(window_label) {
+    let space_root = match space_state.current_root() {
         Ok(root) => root,
-        Err(error) if is_no_space_session_error(&error) => return Ok(GitSyncStatus::default()),
+        Err(error) if is_no_space_open_error(&error) => return Ok(GitSyncStatus::default()),
         Err(error) => return Err(error),
     };
     read_status_for_root(git_state, Some(&space_root))
@@ -337,7 +336,7 @@ pub fn update_git_sync_config(
     window_label: &str,
     patch: GitSyncConfigPatch,
 ) -> Result<GitSyncConfig, String> {
-    let space_root = space_state.root_for_window_label(window_label)?;
+    let space_root = space_state.current_root()?;
     let mut config = load_config(&space_root)?;
     if let Some(enabled) = patch.enabled {
         config.enabled = enabled;
@@ -361,7 +360,7 @@ pub fn update_git_sync_config(
         config.auto_sync_prompted = true;
     }
     save_store(&space_root, &config)?;
-    let status = read_status_internal(git_state, space_state, window_label)?;
+    let status = read_status_internal(git_state, space_state)?;
     emit_status(&app, window_label, &status);
     Ok(config)
 }
@@ -372,7 +371,7 @@ pub fn disconnect_git_sync(
     space_state: &SpaceState,
     window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = space_state.root_for_window_label(window_label)?;
+    let space_root = space_state.current_root()?;
     delete_store(&space_root)?;
     {
         let mut runtimes = git_state
@@ -381,7 +380,7 @@ pub fn disconnect_git_sync(
             .map_err(|_| "git sync state poisoned".to_string())?;
         runtimes.insert(runtime_key(&space_root), RuntimeStatus::default());
     }
-    let status = read_status_internal(git_state, space_state, window_label)?;
+    let status = read_status_internal(git_state, space_state)?;
     emit_status(&app, window_label, &status);
     Ok(status)
 }
@@ -393,13 +392,13 @@ pub fn run_git_sync(
     window_label: &str,
     request: GitSyncRunRequest,
 ) -> Result<GitSyncStatus, String> {
-    let space_root = space_state.root_for_window_label(window_label)?;
+    let space_root = space_state.current_root()?;
     if !git_is_installed() {
         return Err("Git is not installed on this system.".to_string());
     }
     let config = load_config(&space_root)?;
     if request.mode == GitSyncRunMode::Auto && (!config.enabled || config.paused) {
-        return read_status_internal(git_state, space_state, window_label);
+        return read_status_internal(git_state, space_state);
     }
 
     {
@@ -577,13 +576,10 @@ fn run_git_sync_background(
     }
 }
 
-pub fn read_config(
-    space_state: &SpaceState,
-    window_label: &str,
-) -> Result<Option<GitSyncConfig>, String> {
-    let space_root = match space_state.root_for_window_label(window_label) {
+pub fn read_config(space_state: &SpaceState) -> Result<Option<GitSyncConfig>, String> {
+    let space_root = match space_state.current_root() {
         Ok(root) => root,
-        Err(error) if is_no_space_session_error(&error) => return Ok(None),
+        Err(error) if is_no_space_open_error(&error) => return Ok(None),
         Err(error) => return Err(error),
     };
     load_store(&space_root)
@@ -592,7 +588,6 @@ pub fn read_config(
 pub fn read_status(
     git_state: State<'_, GitSyncState>,
     space_state: State<'_, SpaceState>,
-    window_label: &str,
 ) -> Result<GitSyncStatus, String> {
-    read_status_internal(&git_state, &space_state, window_label)
+    read_status_internal(&git_state, &space_state)
 }

--- a/src-tauri/src/index/calendar.rs
+++ b/src-tauri/src/index/calendar.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{Days, NaiveDate};
 use rusqlite::Connection;
 use serde::Serialize;
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::space::SpaceState;
 
@@ -303,7 +303,6 @@ fn query_calendar_notes_for_date(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn index_calendar_activity(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_date: String,
     to_date: String,
@@ -314,7 +313,7 @@ pub async fn index_calendar_activity(
     if from_date > to_date {
         return Err("from_date must be on or before to_date".to_string());
     }
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let daily_note_folder = normalize_daily_note_folder(daily_note_folder);
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<CalendarDayActivity>, String> {
         let conn = open_db(&root)?;
@@ -326,13 +325,12 @@ pub async fn index_calendar_activity(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn index_calendar_notes_for_date(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     date: String,
     daily_note_folder: Option<String>,
 ) -> Result<Vec<CalendarDateNote>, String> {
     let date = parse_iso_date(&date)?;
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let daily_note_folder = normalize_daily_note_folder(daily_note_folder);
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<CalendarDateNote>, String> {
         let conn = open_db(&root)?;

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -129,7 +129,7 @@ pub async fn index_rebuild(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<IndexRebuildResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let progress_window = window.clone();
     let res = tauri::async_runtime::spawn_blocking(move || {
         rebuild_with_progress(&root, |completed, total| {
@@ -148,7 +148,7 @@ pub async fn index_sync(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<IndexRebuildResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let progress_window = window.clone();
     tauri::async_runtime::spawn_blocking(move || {
         sync(&root, |completed, total| {
@@ -163,11 +163,10 @@ pub async fn index_sync(
 
 #[tauri::command]
 pub async fn search(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     query: String,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
         hybrid_search(&conn, &query, &[], 50)
@@ -178,11 +177,10 @@ pub async fn search(
 
 #[tauri::command]
 pub async fn search_advanced(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: SearchAdvancedRequest,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let conn = open_db(&root)?;
         run_search_advanced(&conn, request)
@@ -193,12 +191,11 @@ pub async fn search_advanced(
 
 #[tauri::command]
 pub async fn search_parse_and_run(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     raw_query: String,
     limit: Option<u32>,
 ) -> Result<Vec<SearchResult>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<SearchResult>, String> {
         let req = parse_raw_search_query(&raw_query, limit);
         let conn = open_db(&root)?;
@@ -216,13 +213,12 @@ pub fn index_set_people_mentions_as_tags_enabled(enabled: bool) -> Result<(), St
 
 #[tauri::command]
 pub async fn all_docs_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
     folder_prefix: Option<String>,
 ) -> Result<Vec<AllDocsItem>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let limit = limit.unwrap_or(2_000).clamp(1, 5_000) as i64;
     let offset = offset.unwrap_or(0) as i64;
     let folder_prefix = folder_prefix
@@ -311,11 +307,10 @@ pub async fn all_docs_list(
 
 #[tauri::command]
 pub async fn all_docs_count(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     folder_prefix: Option<String>,
 ) -> Result<u32, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let folder_prefix = folder_prefix
         .map(|value| value.trim().trim_matches('/').replace('\\', "/"))
         .filter(|value| !value.is_empty());
@@ -343,13 +338,12 @@ pub async fn all_docs_count(
 
 #[tauri::command]
 pub async fn tags_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
     query: Option<String>,
 ) -> Result<Vec<TagCount>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let limit = limit.unwrap_or(200).min(2000) as i64;
     let offset = offset.unwrap_or(0) as i64;
     let query = query
@@ -426,12 +420,11 @@ fn list_tags(
 
 #[tauri::command]
 pub async fn people_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     limit: Option<u32>,
     offset: Option<u32>,
 ) -> Result<Vec<PersonCount>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let limit = limit.unwrap_or(200).min(2000) as i64;
     let offset = offset.unwrap_or(0) as i64;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<PersonCount>, String> {
@@ -586,11 +579,10 @@ pub fn task_summary(markdown: String) -> NoteTaskSummary {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn task_summaries_for_paths(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_paths: Vec<String>,
 ) -> Result<Vec<NoteTaskSummaryItem>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<NoteTaskSummaryItem>, String> {
         let normalized_paths = note_paths
             .into_iter()
@@ -607,12 +599,11 @@ pub async fn task_summaries_for_paths(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn backlinks(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
     _space_path: Option<String>,
 ) -> Result<Vec<BacklinkItem>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<BacklinkItem>, String> {
         let conn = open_db(&root)?;
         let stem = Path::new(&note_id)
@@ -656,11 +647,10 @@ pub async fn backlinks(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn note_relationships(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
 ) -> Result<Vec<NoteRelationship>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<NoteRelationship>, String> {
         let conn = open_db(&root)?;
         query_note_relationships(&conn, &note_id)
@@ -1070,11 +1060,10 @@ fn space_connections_for_conn(conn: &rusqlite::Connection) -> Result<SpaceConnec
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn note_local_connections(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     note_id: String,
 ) -> Result<LocalNoteConnections, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<LocalNoteConnections, String> {
         let conn = open_db(&root)?;
         local_note_connections_for_conn(&conn, &note_id)
@@ -1085,10 +1074,9 @@ pub async fn note_local_connections(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_connections(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<SpaceConnections, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<SpaceConnections, String> {
         let conn = open_db(&root)?;
         space_connections_for_conn(&conn)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1218,11 +1218,10 @@ fn set_recent_spaces_menu(
     recent_spaces: Vec<String>,
 ) -> Result<(), String> {
     let current_space_path = app.try_state::<space::SpaceState>().and_then(|state| {
-        state.current.lock().ok().and_then(|guard| {
-            guard
-                .as_ref()
-                .map(|path| path.to_string_lossy().to_string())
-        })
+        state
+            .current_root()
+            .ok()
+            .map(|path| path.to_string_lossy().to_string())
     });
     let filtered: Vec<String> = recent_spaces
         .into_iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,7 +64,7 @@ fn init_tracing() {
 }
 
 fn space_is_open(state: &space::SpaceState) -> bool {
-    !state.session_roots().is_empty()
+    state.has_open_session()
 }
 
 fn set_menu_item_enabled<R: tauri::Runtime>(
@@ -1061,10 +1061,6 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
     Ok(window)
 }
 
-fn is_space_host_window_label(label: &str) -> bool {
-    label == "main" || space::commands::is_space_window(label)
-}
-
 fn is_auxiliary_persisted_window(label: &str) -> bool {
     label == "settings" || label == QUICK_NOTE_WINDOW_LABEL || label == "quick-task"
 }
@@ -1078,54 +1074,18 @@ fn destroy_auxiliary_persisted_windows(app: &tauri::AppHandle) {
 }
 
 fn prepare_host_window_close(window: &tauri::Window) {
-    if !is_space_host_window_label(window.label()) {
+    if window.label() != "main" {
         return;
     }
-    let app = window.app_handle();
-    let host_count = app
-        .webview_windows()
-        .into_iter()
-        .filter(|(label, _)| is_space_host_window_label(label))
-        .count();
-    if host_count <= 1 {
-        destroy_auxiliary_persisted_windows(&app);
-    }
-}
-
-fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
-    app.webview_windows().into_iter().find(|(label, window)| {
-        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
-    })
+    destroy_auxiliary_persisted_windows(&window.app_handle());
 }
 
 fn target_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
-    focused_space_host_window(app).or_else(|| {
-        let space_state = app.try_state::<space::SpaceState>()?;
-        let current_root = space_state.current_root().ok()?;
-        app.webview_windows().into_iter().find(|(label, _window)| {
-            is_space_host_window_label(label)
-                && space_state
-                    .root_for_window_label(label)
-                    .map(|root| root == current_root)
-                    .unwrap_or(false)
-        })
-    })
-}
-
-fn sync_fallback_space_to_focused_window(app: &tauri::AppHandle) {
-    let Some(space_state) = app.try_state::<space::SpaceState>() else {
-        return;
-    };
-    let focused_root = focused_space_host_window(app)
-        .and_then(|(_label, window)| space_state.root_for_window(&window).ok());
-    let Some(root) = focused_root else {
-        return;
-    };
-    let _ = space_state.set_current_root(root);
+    app.get_webview_window("main")
+        .map(|window| ("main".to_string(), window))
 }
 
 fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
-    sync_fallback_space_to_focused_window(app);
     let window = quick_note_window(app)?;
     let _ = window.center();
     window.show().map_err(|error| error.to_string())?;
@@ -1442,18 +1402,10 @@ pub fn run() {
                 let Some(space_state) = app.try_state::<space::SpaceState>() else {
                     return;
                 };
-                let current_path = app
-                    .webview_windows()
-                    .into_iter()
-                    .find(|(label, window)| {
-                        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
-                    })
-                    .and_then(|(label, _window)| {
-                        space_state
-                            .root_for_window_label(&label)
-                            .ok()
-                            .map(|path| path.to_string_lossy().to_string())
-                    });
+                let current_path = space_state
+                    .current_root()
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string());
                 if current_path.as_deref() == Some(path.as_str()) {
                     return;
                 }
@@ -1548,19 +1500,7 @@ pub fn run() {
                 }
             }
 
-            if space::commands::is_space_window(window.label()) {
-                if let WindowEvent::Destroyed = event {
-                    let state = window.state::<space::SpaceState>();
-                    match state.remove_window_session(window.label()) {
-                        Ok(()) => {
-                            space::commands::update_close_space_menu(window.app_handle(), &state)
-                        }
-                        Err(error) => warn!("Failed to forget space window session: {error}"),
-                    }
-                }
-            }
-
-            if is_space_host_window_label(window.label()) {
+            if window.label() == "main" {
                 if let WindowEvent::CloseRequested { .. } = event {
                     prepare_host_window_close(window);
                 }
@@ -1695,7 +1635,6 @@ pub fn run() {
             git_sync::commands::git_history_diff,
             space::commands::space_create,
             space::commands::space_open,
-            space::commands::space_open_window,
             space::commands::space_get_current,
             space::commands::space_get_current_info,
             space::commands::space_show_onboarding_note,

--- a/src-tauri/src/pinned_files/commands.rs
+++ b/src-tauri/src/pinned_files/commands.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::space::SpaceState;
 use crate::space_fs::helpers::deny_hidden_rel_path;
@@ -11,10 +11,9 @@ use super::store::{
 
 #[tauri::command]
 pub async fn pinned_files_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<Vec<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let _guard = pinned_files_mutex
@@ -32,11 +31,10 @@ pub async fn pinned_files_list(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_toggle(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);
@@ -58,12 +56,11 @@ pub async fn pinned_files_toggle(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_rename_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let from_rel = PathBuf::from(&from_path);
@@ -92,11 +89,10 @@ pub async fn pinned_files_rename_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn pinned_files_delete_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<Vec<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let pinned_files_mutex = state.pinned_files_mutex();
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let rel = PathBuf::from(&path);

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
-use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::State;
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    paths, utils, window_geometry,
+    paths,
 };
 
 use super::helpers::{
@@ -12,55 +12,30 @@ use super::helpers::{
 use super::state::SpaceState;
 use super::watcher::create_notes_watcher;
 
-pub(crate) const SPACE_WINDOW_PREFIX: &str = "space-";
+const MAIN_WINDOW_LABEL: &str = "main";
 
-pub(crate) fn is_space_window(label: &str) -> bool {
-    label.starts_with(SPACE_WINDOW_PREFIX)
-}
-
-fn space_window_label(root: &Path) -> String {
-    let hash = utils::sha256_hex(root.to_string_lossy().as_bytes());
-    format!("{SPACE_WINDOW_PREFIX}{}", &hash[..16])
-}
-
-fn space_window_title(root: &Path) -> String {
-    root.file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.trim().is_empty())
-        .map(|name| format!("{name} - Glyph"))
-        .unwrap_or_else(|| "Glyph".to_string())
-}
-
-fn install_window_session(
+fn install_active_session(
     app: tauri::AppHandle,
     state: &SpaceState,
-    window_label: String,
     root: PathBuf,
 ) -> Result<(), String> {
     let recent_local_changes = state.new_recent_local_changes();
     let watcher = create_notes_watcher(
         app,
         root.clone(),
-        window_label.clone(),
+        MAIN_WINDOW_LABEL.to_string(),
         recent_local_changes.clone(),
     )?;
-    state.set_window_session(window_label, root, watcher, recent_local_changes)
-}
-
-fn focus_window(window: &tauri::WebviewWindow) -> Result<(), String> {
-    window.show().map_err(|error| error.to_string())?;
-    window.unminimize().map_err(|error| error.to_string())?;
-    window.set_focus().map_err(|error| error.to_string())
+    state.replace_session(root, watcher, recent_local_changes)
 }
 
 pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState) {
-    let _ = crate::set_space_close_menu_enabled(app, !state.session_roots().is_empty());
+    let _ = crate::set_space_close_menu_enabled(app, state.has_open_session());
 }
 
 #[tauri::command]
 pub async fn space_create(
     app: tauri::AppHandle,
-    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<SpaceInfo, String> {
@@ -74,15 +49,7 @@ pub async fn space_create(
     .map_err(|e| e.to_string())??;
 
     reset_schema_cache();
-    install_window_session(
-        app.clone(),
-        &state,
-        window.label().to_string(),
-        PathBuf::from(&info.root),
-    )?;
-    if window.label() == "main" {
-        state.set_current_root(PathBuf::from(&info.root))?;
-    }
+    install_active_session(app.clone(), &state, PathBuf::from(&info.root))?;
     update_close_space_menu(&app, &state);
     Ok(info)
 }
@@ -90,7 +57,6 @@ pub async fn space_create(
 #[tauri::command]
 pub async fn space_open(
     app: tauri::AppHandle,
-    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<SpaceInfo, String> {
@@ -103,36 +69,24 @@ pub async fn space_open(
     .map_err(|e| e.to_string())??;
 
     reset_schema_cache();
-    install_window_session(
-        app.clone(),
-        &state,
-        window.label().to_string(),
-        PathBuf::from(&info.root),
-    )?;
-    if window.label() == "main" {
-        state.set_current_root(PathBuf::from(&info.root))?;
-    }
+    install_active_session(app.clone(), &state, PathBuf::from(&info.root))?;
     update_close_space_menu(&app, &state);
     Ok(info)
 }
 
 #[tauri::command]
-pub fn space_get_current(
-    window: tauri::WebviewWindow,
-    state: State<'_, SpaceState>,
-) -> Option<String> {
+pub fn space_get_current(state: State<'_, SpaceState>) -> Option<String> {
     state
-        .root_for_window(&window)
+        .current_root()
         .ok()
         .map(|path| path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
 pub async fn space_get_current_info(
-    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<Option<SpaceInfo>, String> {
-    let Ok(root) = state.root_for_window(&window) else {
+    let Ok(root) = state.current_root() else {
         return Ok(None);
     };
     tauri::async_runtime::spawn_blocking(move || create_or_open_impl(&root).map(Some))
@@ -142,10 +96,9 @@ pub async fn space_get_current_info(
 
 #[tauri::command]
 pub async fn space_show_onboarding_note(
-    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<String, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let note_path = ensure_onboarding_note_for_command(&root)?;
         let abs = paths::join_under(&root, Path::new(&note_path))?;
@@ -161,71 +114,10 @@ pub async fn space_show_onboarding_note(
 #[tauri::command]
 pub fn space_close(
     app: tauri::AppHandle,
-    window: tauri::WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<(), String> {
-    state.remove_window_session(window.label())?;
+    state.clear_session()?;
     reset_schema_cache();
     update_close_space_menu(&app, &state);
     Ok(())
-}
-
-#[tauri::command(rename_all = "snake_case")]
-pub async fn space_open_window(
-    app: tauri::AppHandle,
-    state: State<'_, SpaceState>,
-    path: String,
-    create: Option<bool>,
-) -> Result<SpaceInfo, String> {
-    let root = PathBuf::from(path);
-    let should_create = create.unwrap_or(false);
-    let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
-        if should_create {
-            std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
-        }
-        let root = canonicalize_dir(&root)?;
-        create_or_open_impl(&root)
-    })
-    .await
-    .map_err(|e| e.to_string())??;
-
-    let root = PathBuf::from(&info.root);
-    let label = space_window_label(&root);
-
-    if let Some(window) = app.get_webview_window(&label) {
-        focus_window(&window)?;
-        return Ok(info);
-    }
-
-    install_window_session(app.clone(), &state, label.clone(), root.clone())?;
-
-    let window = match WebviewWindowBuilder::new(
-        &app,
-        &label,
-        WebviewUrl::App(format!("index.html?window={label}").into()),
-    )
-    .title(space_window_title(&root))
-    .inner_size(800.0, 600.0)
-    .min_inner_size(
-        window_geometry::MIN_INNER_WIDTH as f64,
-        window_geometry::MIN_INNER_HEIGHT as f64,
-    )
-    .decorations(true)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true)
-    .transparent(true)
-    .shadow(true)
-    .center()
-    .build()
-    {
-        Ok(window) => window,
-        Err(error) => {
-            let _ = state.remove_window_session(&label);
-            return Err(error.to_string());
-        }
-    };
-
-    focus_window(&window)?;
-    update_close_space_menu(&app, &state);
-    Ok(info)
 }

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 const RECENT_LOCAL_CHANGE_TTL: Duration = Duration::from_secs(2);
-pub(crate) const NO_SPACE_SESSION_FOR_WINDOW: &str = "no space session for window";
+const NO_SPACE_OPEN: &str = "no space open";
 
 pub(crate) type RecentLocalChanges = Arc<Mutex<HashMap<String, Instant>>>;
 
@@ -52,19 +52,16 @@ pub(crate) fn has_recent_local_change(changes: &RecentLocalChanges, rel_path: &s
 }
 
 pub(crate) struct SpaceSession {
-    pub(crate) root: PathBuf,
     pub(crate) _notes_watcher: Option<notify::RecommendedWatcher>,
     pub(crate) recent_local_changes: RecentLocalChanges,
 }
 
 impl SpaceSession {
     fn new(
-        root: PathBuf,
         notes_watcher: notify::RecommendedWatcher,
         recent_local_changes: RecentLocalChanges,
     ) -> Self {
         Self {
-            root,
             _notes_watcher: Some(notes_watcher),
             recent_local_changes,
         }
@@ -73,7 +70,7 @@ impl SpaceSession {
 
 pub struct SpaceState {
     pub(crate) current: Mutex<Option<PathBuf>>,
-    pub(crate) sessions: Mutex<HashMap<String, SpaceSession>>,
+    session: Mutex<Option<SpaceSession>>,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
     pinned_files_mutex: Arc<Mutex<()>>,
@@ -83,7 +80,7 @@ impl Default for SpaceState {
     fn default() -> Self {
         Self {
             current: Mutex::new(None),
-            sessions: Mutex::new(HashMap::new()),
+            session: Mutex::new(None),
             db_store_mutex: Arc::new(Mutex::new(())),
             file_tree_appearance_mutex: Arc::new(Mutex::new(())),
             pinned_files_mutex: Arc::new(Mutex::new(())),
@@ -96,43 +93,32 @@ impl SpaceState {
         Arc::new(Mutex::new(HashMap::new()))
     }
 
-    pub(crate) fn recent_local_changes_for_window(&self, window_label: &str) -> RecentLocalChanges {
-        let Ok(sessions) = self.sessions.lock() else {
-            return Arc::new(Mutex::new(HashMap::new()));
-        };
-        if let Some(session) = sessions.get(window_label) {
-            return Arc::clone(&session.recent_local_changes);
-        }
-        let current_root = self.current.lock().ok().and_then(|guard| guard.clone());
-        if let Some(current_root) = current_root {
-            if let Some(session) = sessions
-                .values()
-                .find(|session| session.root == current_root)
-            {
-                return Arc::clone(&session.recent_local_changes);
-            }
-        }
-        Arc::new(Mutex::new(HashMap::new()))
+    pub(crate) fn recent_local_changes(&self) -> RecentLocalChanges {
+        self.session
+            .lock()
+            .ok()
+            .and_then(|guard| {
+                guard
+                    .as_ref()
+                    .map(|session| Arc::clone(&session.recent_local_changes))
+            })
+            .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())))
     }
 
-    pub(crate) fn set_window_session(
+    pub(crate) fn replace_session(
         &self,
-        window_label: String,
         root: PathBuf,
         notes_watcher: notify::RecommendedWatcher,
         recent_local_changes: RecentLocalChanges,
     ) -> Result<(), String> {
-        self.sessions
+        let mut session = self
+            .session
             .lock()
-            .map_err(|_| "space sessions state poisoned".to_string())?
-            .insert(
-                window_label,
-                SpaceSession::new(root, notes_watcher, recent_local_changes),
-            );
-        Ok(())
-    }
-
-    pub(crate) fn set_current_root(&self, root: PathBuf) -> Result<(), String> {
+            .map_err(|_| "space state poisoned".to_string())?;
+        *session = Some(SpaceSession::new(
+            notes_watcher,
+            recent_local_changes,
+        ));
         let mut current = self
             .current
             .lock()
@@ -141,60 +127,26 @@ impl SpaceState {
         Ok(())
     }
 
-    pub(crate) fn remove_window_session(&self, window_label: &str) -> Result<(), String> {
-        let removed_root = {
-            let mut sessions = self
-                .sessions
-                .lock()
-                .map_err(|_| "space sessions state poisoned".to_string())?;
-            sessions.remove(window_label).map(|session| session.root)
-        };
+    pub(crate) fn clear_session(&self) -> Result<(), String> {
+        let mut session = self
+            .session
+            .lock()
+            .map_err(|_| "space state poisoned".to_string())?;
+        *session = None;
         let mut current = self
             .current
             .lock()
             .map_err(|_| "space state poisoned".to_string())?;
-        if removed_root.as_ref() == current.as_ref() {
-            *current = None;
-        }
+        *current = None;
         Ok(())
     }
 
-    pub(crate) fn root_for_window_label(&self, window_label: &str) -> Result<PathBuf, String> {
-        if let Some(root) = self
-            .sessions
+    pub(crate) fn has_open_session(&self) -> bool {
+        self.current
             .lock()
-            .map_err(|_| "space sessions state poisoned".to_string())?
-            .get(window_label)
-            .map(|session| session.root.clone())
-        {
-            return Ok(root);
-        }
-        Err(format!("{NO_SPACE_SESSION_FOR_WINDOW}: {window_label}"))
-    }
-
-    pub fn root_for_window(&self, window: &tauri::WebviewWindow) -> Result<PathBuf, String> {
-        match self.root_for_window_label(window.label()) {
-            Ok(root) => Ok(root),
-            Err(error)
-                if matches!(window.label(), "quick-note" | "quick-task")
-                    && is_no_space_session_error(&error) =>
-            {
-                self.current_root()
-            }
-            Err(error) => Err(error),
-        }
-    }
-
-    pub(crate) fn session_roots(&self) -> Vec<PathBuf> {
-        self.sessions
-            .lock()
-            .map(|sessions| {
-                sessions
-                    .values()
-                    .map(|session| session.root.clone())
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .is_some()
     }
 
     pub(crate) fn db_store_mutex(&self) -> Arc<Mutex<()>> {
@@ -220,6 +172,6 @@ impl SpaceState {
     }
 }
 
-pub(crate) fn is_no_space_session_error(error: &str) -> bool {
-    error.starts_with(NO_SPACE_SESSION_FOR_WINDOW)
+pub(crate) fn is_no_space_open_error(error: &str) -> bool {
+    error.starts_with(NO_SPACE_OPEN)
 }

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -56,6 +56,11 @@ pub(crate) struct SpaceSession {
     pub(crate) recent_local_changes: RecentLocalChanges,
 }
 
+struct ActiveSpace {
+    root: PathBuf,
+    session: SpaceSession,
+}
+
 impl SpaceSession {
     fn new(
         notes_watcher: notify::RecommendedWatcher,
@@ -69,8 +74,7 @@ impl SpaceSession {
 }
 
 pub struct SpaceState {
-    pub(crate) current: Mutex<Option<PathBuf>>,
-    session: Mutex<Option<SpaceSession>>,
+    active: Mutex<Option<ActiveSpace>>,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
     pinned_files_mutex: Arc<Mutex<()>>,
@@ -79,8 +83,7 @@ pub struct SpaceState {
 impl Default for SpaceState {
     fn default() -> Self {
         Self {
-            current: Mutex::new(None),
-            session: Mutex::new(None),
+            active: Mutex::new(None),
             db_store_mutex: Arc::new(Mutex::new(())),
             file_tree_appearance_mutex: Arc::new(Mutex::new(())),
             pinned_files_mutex: Arc::new(Mutex::new(())),
@@ -94,13 +97,13 @@ impl SpaceState {
     }
 
     pub(crate) fn recent_local_changes(&self) -> RecentLocalChanges {
-        self.session
+        self.active
             .lock()
             .ok()
             .and_then(|guard| {
                 guard
                     .as_ref()
-                    .map(|session| Arc::clone(&session.recent_local_changes))
+                    .map(|active| Arc::clone(&active.session.recent_local_changes))
             })
             .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())))
     }
@@ -111,42 +114,31 @@ impl SpaceState {
         notes_watcher: notify::RecommendedWatcher,
         recent_local_changes: RecentLocalChanges,
     ) -> Result<(), String> {
-        let mut session = self
-            .session
+        let mut active = self
+            .active
             .lock()
             .map_err(|_| "space state poisoned".to_string())?;
-        *session = Some(SpaceSession::new(
-            notes_watcher,
-            recent_local_changes,
-        ));
-        let mut current = self
-            .current
-            .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        *current = Some(root);
+        *active = Some(ActiveSpace {
+            root,
+            session: SpaceSession::new(notes_watcher, recent_local_changes),
+        });
         Ok(())
     }
 
     pub(crate) fn clear_session(&self) -> Result<(), String> {
-        let mut session = self
-            .session
+        let mut active = self
+            .active
             .lock()
             .map_err(|_| "space state poisoned".to_string())?;
-        *session = None;
-        let mut current = self
-            .current
-            .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        *current = None;
+        *active = None;
         Ok(())
     }
 
     pub(crate) fn has_open_session(&self) -> bool {
-        self.current
+        self.active
             .lock()
             .ok()
-            .and_then(|guard| guard.clone())
-            .is_some()
+            .is_some_and(|guard| guard.is_some())
     }
 
     pub(crate) fn db_store_mutex(&self) -> Arc<Mutex<()>> {
@@ -163,12 +155,13 @@ impl SpaceState {
 
     pub fn current_root(&self) -> Result<PathBuf, String> {
         let guard = self
-            .current
+            .active
             .lock()
             .map_err(|_| "space state poisoned".to_string())?;
         guard
-            .clone()
-            .ok_or_else(|| "no space open (select or create a space first)".to_string())
+            .as_ref()
+            .map(|active| active.root.clone())
+            .ok_or_else(|| format!("{NO_SPACE_OPEN} (select or create a space first)"))
     }
 }
 

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -314,11 +314,10 @@ fn resolve_standard_wikilink_target(entries: &[FileEntry], target: &str) -> Opti
 
 #[tauri::command]
 pub async fn space_resolve_wikilink(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     target: String,
 ) -> Result<Option<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         Ok(resolve_standard_wikilink_target(&entries, &target))
@@ -329,11 +328,10 @@ pub async fn space_resolve_wikilink(
 
 #[tauri::command]
 pub async fn space_resolve_image_wikilink(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     target: String,
 ) -> Result<Option<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         Ok(resolve_image_wikilink_target(&entries, &target))
@@ -344,12 +342,11 @@ pub async fn space_resolve_image_wikilink(
 
 #[tauri::command]
 pub async fn space_resolve_markdown_link(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     href: String,
     source_path: String,
 ) -> Result<Option<String>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
         let raw = href
@@ -542,11 +539,10 @@ mod tests {
 
 #[tauri::command]
 pub async fn space_suggest_links(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     request: LinkSuggestRequest,
 ) -> Result<Vec<LinkSuggestionItem>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || {
         let markdown_only = request.markdown_only.unwrap_or(false);
         let include_pdf = request.include_pdf.unwrap_or(false);

--- a/src-tauri/src/space_fs/list.rs
+++ b/src-tauri/src/space_fs/list.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{paths, space::SpaceState, utils};
 
@@ -20,13 +20,12 @@ fn metadata_timestamps(metadata: &std::fs::Metadata) -> (Option<String>, Option<
 
 #[tauri::command]
 pub async fn space_list_markdown_files(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     recursive: Option<bool>,
     limit: Option<u32>,
 ) -> Result<Vec<FsEntry>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let dir = dir.unwrap_or_default();
     let recursive = recursive.unwrap_or(true);
     let limit = limit.unwrap_or(2_000).min(50_000) as usize;
@@ -136,12 +135,11 @@ pub async fn space_list_markdown_files(
 
 #[tauri::command]
 pub async fn space_list_non_markdown_files(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     limit: Option<u32>,
 ) -> Result<FsEntryList, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let dir = dir.unwrap_or_default();
     let limit = limit.unwrap_or(5_000).min(50_000) as usize;
 
@@ -220,11 +218,10 @@ pub async fn space_list_non_markdown_files(
 
 #[tauri::command]
 pub async fn space_list_dir(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
 ) -> Result<Vec<FsEntry>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let dir = dir.unwrap_or_default();
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<FsEntry>, String> {
         let rel = if dir.trim().is_empty() {

--- a/src-tauri/src/space_fs/read_write/binary.rs
+++ b/src-tauri/src/space_fs/read_write/binary.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use serde::Serialize;
 use std::path::PathBuf;
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::space::SpaceState;
 
@@ -82,14 +82,13 @@ fn parse_data_url(data_url: &str) -> Result<(String, Vec<u8>), String> {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_save_pasted_image(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     source_path: String,
     target_dir: String,
     data_url: String,
     original_filename: Option<String>,
 ) -> Result<SavedPastedImage, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<SavedPastedImage, String> {
         let source_rel = PathBuf::from(normalize_rel_path(&source_path));
         let target_rel = PathBuf::from(normalize_rel_path(&target_dir));

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -212,11 +212,10 @@ fn remove_markdown_notes_from_index(
 
 #[tauri::command]
 pub async fn space_create_dir(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -234,10 +233,10 @@ pub async fn space_duplicate_path(
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<FsEntry, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let space_path = root.to_string_lossy().to_string();
     let window_label = window.label().to_string();
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let recent_local_changes = state.recent_local_changes();
     let entry = tauri::async_runtime::spawn_blocking(move || {
         duplicate_file_under_root(&root, Path::new(&path), &recent_local_changes)
     })
@@ -259,11 +258,10 @@ pub async fn space_duplicate_path(
 
 #[tauri::command]
 pub async fn space_resolve_abs_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<String, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -301,11 +299,10 @@ fn reveal_file_manager_path(_abs: &Path) -> Result<(), String> {
 
 #[tauri::command]
 pub async fn space_reveal_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -324,13 +321,12 @@ pub async fn space_reveal_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_rename_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     from_path: String,
     to_path: String,
 ) -> Result<LinkRewriteResult, String> {
-    let root = state.root_for_window(&window)?;
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let root = state.current_root()?;
+    let recent_local_changes = state.recent_local_changes();
     tauri::async_runtime::spawn_blocking(move || -> Result<LinkRewriteResult, String> {
         let from_rel = PathBuf::from(&from_path);
         let to_rel = PathBuf::from(&to_path);
@@ -461,13 +457,12 @@ fn reindex_after_rename(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_delete_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     recursive: Option<bool>,
 ) -> Result<(), String> {
-    let root = state.root_for_window(&window)?;
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let root = state.current_root()?;
+    let recent_local_changes = state.recent_local_changes();
     tauri::async_runtime::spawn_blocking(move || -> Result<(), String> {
         let rel = PathBuf::from(&path);
         if rel.as_os_str().is_empty() {
@@ -493,11 +488,10 @@ pub async fn space_delete_path(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_relativize_path(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     abs_path: String,
 ) -> Result<String, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<String, String> {
         let root = root.canonicalize().map_err(|e| e.to_string())?;
         let abs_input = PathBuf::from(abs_path);

--- a/src-tauri/src/space_fs/read_write/preview.rs
+++ b/src-tauri/src/space_fs/read_write/preview.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use std::{io::Read, path::PathBuf};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{paths, space::SpaceState};
 
@@ -29,12 +29,11 @@ fn mime_for_preview_ext(ext: &str) -> Option<&'static str> {
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_read_text_preview(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     max_bytes: Option<u32>,
 ) -> Result<TextFilePreviewDoc, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<TextFilePreviewDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -76,12 +75,11 @@ pub async fn space_read_text_preview(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_read_binary_preview(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     max_bytes: Option<u32>,
 ) -> Result<BinaryFilePreviewDoc, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<BinaryFilePreviewDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;

--- a/src-tauri/src/space_fs/read_write/text.rs
+++ b/src-tauri/src/space_fs/read_write/text.rs
@@ -19,11 +19,10 @@ struct NoteChangeEvent {
 
 #[tauri::command]
 pub async fn space_read_text(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
 ) -> Result<TextFileDoc, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<TextFileDoc, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;
@@ -44,11 +43,10 @@ pub async fn space_read_text(
 
 #[tauri::command]
 pub async fn space_read_texts_batch(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     paths: Vec<String>,
 ) -> Result<Vec<TextFileDocBatch>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<TextFileDocBatch>, String> {
         let mut results = Vec::with_capacity(paths.len());
         for path in paths {
@@ -93,10 +91,10 @@ pub async fn space_write_text(
     text: String,
     base_mtime_ms: Option<u64>,
 ) -> Result<TextFileWriteResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let space_path = root.to_string_lossy().to_string();
     let window_label = window.label().to_string();
-    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let recent_local_changes = state.recent_local_changes();
     let event_rel_path = PathBuf::from(&path).to_string_lossy().to_string();
     let should_emit_note_change = PathBuf::from(&path).extension() == Some(OsStr::new("md"));
     let result =
@@ -154,12 +152,11 @@ pub async fn space_write_text(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_open_or_create_text(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     path: String,
     text: String,
 ) -> Result<OpenOrCreateTextResult, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<OpenOrCreateTextResult, String> {
         let rel = PathBuf::from(&path);
         deny_hidden_rel_path(&rel)?;

--- a/src-tauri/src/space_fs/summary.rs
+++ b/src-tauri/src/space_fs/summary.rs
@@ -1,5 +1,5 @@
 use std::{cmp::Reverse, collections::BinaryHeap, ffi::OsStr, path::PathBuf};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::{paths, space::SpaceState};
 
@@ -8,7 +8,6 @@ use super::types::{DirChildSummary, RecentMarkdown};
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_dir_children_summary(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
     preview_limit: Option<u32>,
@@ -16,7 +15,7 @@ pub async fn space_dir_children_summary(
     const MAX_PREVIEW_LIMIT: usize = 20;
     const MAX_SCAN_FILES: usize = 200_000;
 
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     let dir = dir.unwrap_or_default();
     let limit = preview_limit
         .unwrap_or(5)

--- a/src-tauri/src/tag_appearance/commands.rs
+++ b/src-tauri/src/tag_appearance/commands.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 use crate::space::SpaceState;
 
@@ -15,10 +15,9 @@ fn tag_appearance_mutex() -> &'static Mutex<()> {
 
 #[tauri::command]
 pub async fn tag_appearance_list(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
 ) -> Result<BTreeMap<String, TagAppearance>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let _guard = tag_appearance_mutex()
             .lock()
@@ -31,12 +30,11 @@ pub async fn tag_appearance_list(
 
 #[tauri::command]
 pub async fn tag_appearance_set(
-    window: WebviewWindow,
     state: State<'_, SpaceState>,
     tag: String,
     icon: Option<String>,
 ) -> Result<Option<TagAppearance>, String> {
-    let root = state.root_for_window(&window)?;
+    let root = state.current_root()?;
     tauri::async_runtime::spawn_blocking(move || -> Result<_, String> {
         let tag = normalize_tag_key(&tag)?;
         let _guard = tag_appearance_mutex()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.6-alpha.6",
+	"version": "0.8.6-alpha.7",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -794,8 +794,9 @@ export function AppShell() {
 	}, [openSettings]);
 
 	const handleSpaceFsChanged = useCallback(
-		(payload: { rel_path: string; removed: boolean }) => {
+		(payload: { space_path?: string; rel_path: string; removed: boolean }) => {
 			if (!spacePath) return;
+			if (payload.space_path && payload.space_path !== spacePath) return;
 			const changedPath = normalizeRelPath(payload.rel_path);
 			if (!changedPath) return;
 			if (payload.removed) {
@@ -823,6 +824,7 @@ export function AppShell() {
 
 	useTauriEvent("space:fs_changed", handleSpaceFsChanged);
 	useTauriEvent("notes:external_changed", (payload) => {
+		if (payload.space_path && payload.space_path !== spacePath) return;
 		const relPath = normalizeRelPath(payload.rel_path);
 		invalidateCalendarPrefetch();
 		invalidateAllDocsPrefetch();

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -89,6 +89,7 @@ import {
 	loadDatabasesPane,
 } from "./prefetchablePanes";
 import { useAppCommands } from "./useAppCommands";
+import { useSpaceActionsWithEditorFlush } from "./useSpaceActionsWithEditorFlush";
 import { useTabManager } from "./useTabManager";
 import { useWorkspaceLinkEvents } from "./useWorkspaceLinkEvents";
 
@@ -108,6 +109,10 @@ export function AppShell() {
 		spacePath,
 		error,
 		setError,
+		switchDirection,
+		switchSpace,
+		switchToNextSpace,
+		switchToPreviousSpace,
 		onOpenSpace,
 		onOpenSpaceAtPath,
 		onCreateSpace,
@@ -746,6 +751,27 @@ export function AppShell() {
 		void openPath(spacePath);
 	}, [spacePath]);
 
+	const {
+		handleSwitchSpace,
+		handleSwitchNextSpace,
+		handleSwitchPreviousSpace,
+		handleOpenSpace,
+		handleOpenSpaceAtPath,
+		handleCreateSpace,
+		handleCloseSpace,
+	} = useSpaceActionsWithEditorFlush({
+		spacePath,
+		saveCurrentEditor,
+		setError,
+		switchSpace,
+		switchToNextSpace,
+		switchToPreviousSpace,
+		onOpenSpace,
+		onOpenSpaceAtPath,
+		onCreateSpace,
+		closeSpace,
+	});
+
 	const handleOpenSpaceSettings = useCallback(() => {
 		openSettings("space");
 	}, [openSettings]);
@@ -1083,10 +1109,10 @@ export function AppShell() {
 		onSaveNote: handleSaveNoteFromMenu,
 		onPrintNote: handlePrintActiveNote,
 		onCloseTab: () => void handleCloseTabOrWindow(),
-		onOpenSpace,
-		onOpenRecentSpaceAtPath: onOpenSpaceAtPath,
-		onCreateSpace,
-		closeSpace,
+		onOpenSpace: handleOpenSpace,
+		onOpenRecentSpaceAtPath: handleOpenSpaceAtPath,
+		onCreateSpace: handleCreateSpace,
+		closeSpace: handleCloseSpace,
 		onRevealSpace: handleRevealSpaceFromMenu,
 		onOpenSpaceSettings: handleOpenSpaceSettings,
 		onGitSyncNow: () => {
@@ -1117,7 +1143,7 @@ export function AppShell() {
 		canGoForward,
 		closeActiveTab,
 		closeAllTabs,
-		closeSpace,
+		closeSpace: handleCloseSpace,
 		createDatabaseAndOpen,
 		createNoteInSelectedFolder,
 		fileTree,
@@ -1134,8 +1160,8 @@ export function AppShell() {
 		handleRevealSpaceFromMenu,
 		movePickerSourcePath,
 		moveTargetDirs,
-		onCreateSpace,
-		onOpenSpace,
+		onCreateSpace: handleCreateSpace,
+		onOpenSpace: handleOpenSpace,
 		openAllDocsTab,
 		openBlankTab,
 		openDatabasesTab,
@@ -1325,6 +1351,10 @@ export function AppShell() {
 				sidebarCollapsed={sidebarCollapsed}
 				onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
 				spacePath={spacePath}
+				switchDirection={switchDirection}
+				onSwitchSpace={handleSwitchSpace}
+				onSwitchNextSpace={handleSwitchNextSpace}
+				onSwitchPreviousSpace={handleSwitchPreviousSpace}
 				onOpenAllDocs={openAllDocsTab}
 				onOpenPinnedDocs={openPinnedDocsTab}
 				onOpenConnections={openConnectionsView}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { memo } from "react";
 import { useUILayoutContext } from "../../contexts";
+import type { SpaceSwitchDirection } from "../../contexts/SpaceContext";
 import { SidebarContent } from "./SidebarContent";
 import { SidebarHeader } from "./SidebarHeader";
 import { SidebarSettingsContent } from "./SidebarSettingsContent";
@@ -33,6 +34,10 @@ interface SidebarProps {
 	sidebarCollapsed: boolean;
 	onToggleSidebar: () => void;
 	spacePath: string | null;
+	switchDirection: SpaceSwitchDirection;
+	onSwitchSpace: (path: string) => void;
+	onSwitchNextSpace?: () => void;
+	onSwitchPreviousSpace?: () => void;
 	onOpenAllDocs: () => void;
 	onOpenPinnedDocs: () => void;
 	onOpenConnections: () => void;
@@ -67,6 +72,10 @@ export const Sidebar = memo(function Sidebar({
 	sidebarCollapsed,
 	onToggleSidebar,
 	spacePath,
+	switchDirection,
+	onSwitchSpace,
+	onSwitchNextSpace,
+	onSwitchPreviousSpace,
 	onOpenAllDocs,
 	onOpenPinnedDocs,
 	onOpenConnections,
@@ -148,6 +157,10 @@ export const Sidebar = memo(function Sidebar({
 									onOpenPinnedDocs={onOpenPinnedDocs}
 									onOpenConnections={onOpenConnections}
 									spacePath={spacePath}
+									switchDirection={switchDirection}
+									onSwitchSpace={onSwitchSpace}
+									onSwitchNextSpace={onSwitchNextSpace}
+									onSwitchPreviousSpace={onSwitchPreviousSpace}
 									activeTopSection={activeTopSection}
 								/>
 							</>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -10,9 +10,11 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
+import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
+import type { SpaceSwitchDirection } from "../../contexts/SpaceContext";
 import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
@@ -33,7 +35,7 @@ import type { FsEntry } from "../../lib/tauri";
 import { ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
-import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
+import { SidebarFooter } from "./SidebarFooter";
 
 interface SidebarContentProps {
 	onToggleDir: (dirPath: string) => void;
@@ -67,6 +69,10 @@ interface SidebarContentProps {
 	onOpenPinnedDocs: () => void;
 	onOpenConnections: () => void;
 	spacePath: string | null;
+	switchDirection: SpaceSwitchDirection;
+	onSwitchSpace: (path: string) => void;
+	onSwitchNextSpace?: () => void;
+	onSwitchPreviousSpace?: () => void;
 	activeTopSection:
 		| "all-notes"
 		| "connections"
@@ -156,9 +162,14 @@ export const SidebarContent = memo(function SidebarContent({
 	onOpenPinnedDocs,
 	onOpenConnections,
 	spacePath,
+	switchDirection,
+	onSwitchSpace,
+	onSwitchNextSpace,
+	onSwitchPreviousSpace,
 	activeTopSection,
 }: SidebarContentProps) {
 	// Contexts
+	const shouldReduceMotion = useReducedMotion();
 	const { getBinding } = useShortcutBindings();
 	const {
 		rootEntries,
@@ -335,6 +346,11 @@ export const SidebarContent = memo(function SidebarContent({
 		[folioMode, onSelectTag, setFolioScope],
 	);
 
+	const slideOffset = switchDirection === 0 ? 10 : switchDirection * 10;
+	const spaceTransition = shouldReduceMotion
+		? { duration: 0 }
+		: { duration: 0.16, ease: "easeOut" as const };
+
 	if (!spacePath) {
 		return (
 			<>
@@ -344,262 +360,307 @@ export const SidebarContent = memo(function SidebarContent({
 						Open or create a space to get started.
 					</div>
 				</div>
-				<LicenseStatusFooter />
+				<SidebarFooter
+					onSwitchSpace={onSwitchSpace}
+					onSwitchNextSpace={onSwitchNextSpace}
+					onSwitchPreviousSpace={onSwitchPreviousSpace}
+					reducedMotion={shouldReduceMotion}
+				/>
 			</>
 		);
 	}
 
 	return (
 		<>
-			<div className="sidebarSection sidebarSectionGrow">
-				<div className="sidebarSectionContent">
-					<div className="sidebarNavRow">
-						<button
-							type="button"
-							className="sidebarQuickActionBtn sidebarNavBtn"
-							data-kind="new-note"
-							aria-label="New Note"
-							onClick={onNewNote}
-							title={`New Note${
-								newNoteShortcut
-									? ` (${formatShortcutForPlatform(newNoteShortcut)})`
-									: ""
-							}`}
-						>
-							<HugeiconsIcon
-								icon={NoteIcon}
-								size="var(--icon-md)"
-								strokeWidth={0.9}
-							/>
-							<span className="sidebarQuickActionLabel">New Note</span>
-							{newNoteShortcut ? (
-								<span className="sidebarQuickActionShortcut">
-									{formatShortcutForPlatform(newNoteShortcut)}
-								</span>
-							) : null}
-						</button>
-						<button
-							type="button"
-							className="sidebarQuickActionBtn sidebarNavBtn"
-							data-kind="pinned-notes"
-							data-active={
-								activeTopSection === "pinned-notes" ? "true" : "false"
-							}
-							aria-label="Pinned"
-							aria-pressed={activeTopSection === "pinned-notes"}
-							aria-current={
-								activeTopSection === "pinned-notes" ? "page" : undefined
-							}
-							onClick={onOpenPinnedDocs}
-							title="Open Pinned"
-						>
-							<HugeiconsIcon
-								icon={StarIcon}
-								size="var(--icon-md)"
-								strokeWidth={0.9}
-							/>
-							<span className="sidebarQuickActionLabel">Pinned</span>
-							<PinnedNotesCountBadge count={pinnedFiles.length} />
-						</button>
-						<button
-							type="button"
-							className="sidebarQuickActionBtn sidebarNavBtn"
-							data-kind="all-notes"
-							data-active={activeTopSection === "all-notes" ? "true" : "false"}
-							aria-label="All Notes"
-							aria-pressed={activeTopSection === "all-notes"}
-							aria-current={
-								activeTopSection === "all-notes" ? "page" : undefined
-							}
-							onClick={handleOpenAllNotes}
-							onMouseEnter={onPrefetchAllDocs}
-							onFocus={onPrefetchAllDocs}
-							title="Open All Notes"
-						>
-							<HugeiconsIcon
-								icon={Archive04Icon}
-								size="var(--icon-md)"
-								strokeWidth={0.9}
-							/>
-							<span className="sidebarQuickActionLabel">All Notes</span>
-							<AllNotesCountBadge />
-						</button>
-						<button
-							type="button"
-							className="sidebarQuickActionBtn sidebarNavBtn"
-							data-kind="databases"
-							data-active={activeTopSection === "databases" ? "true" : "false"}
-							aria-label="Collections"
-							aria-pressed={activeTopSection === "databases"}
-							aria-current={
-								activeTopSection === "databases" ? "page" : undefined
-							}
-							onClick={() => {
-								onOpenDatabases();
-							}}
-							onMouseEnter={() => onPrefetchDatabases()}
-							onFocus={() => onPrefetchDatabases()}
-							title="Open Collections"
-						>
-							<HugeiconsIcon
-								icon={LibraryIcon}
-								size="var(--icon-md)"
-								strokeWidth={0.9}
-							/>
-							<span className="sidebarQuickActionLabel">Collections</span>
-						</button>
-						<button
-							type="button"
-							className="sidebarQuickActionBtn sidebarNavBtn"
-							data-kind="connections"
-							data-active={
-								activeTopSection === "connections" ? "true" : "false"
-							}
-							aria-label="Connections"
-							aria-pressed={activeTopSection === "connections"}
-							aria-current={
-								activeTopSection === "connections" ? "page" : undefined
-							}
-							onClick={onOpenConnections}
-							title="Open Connections"
-						>
-							<HugeiconsIcon
-								icon={ChartRelationshipIcon}
-								size="var(--icon-md)"
-								strokeWidth={0.9}
-							/>
-							<span className="sidebarQuickActionLabel">Connections</span>
-						</button>
-					</div>
-					<div className="sidebarStack">
-						<section
-							className="sidebarStackItem sidebarStackItemGrow"
-							data-section="files"
-						>
-							<div className="sidebarStackHeader">
-								<button
-									type="button"
-									className="sidebarStackHeaderToggle"
-									onClick={handleNotesHeaderClick}
-									aria-expanded={notesExpanded}
-									aria-label={notesExpanded ? "Collapse Notes" : "Expand Notes"}
-								>
-									<span>Notes</span>
-									{notesExpanded ? (
-										<ChevronDown
-											size="var(--icon-xs)"
-											className="sidebarStackHeaderChevron"
-										/>
-									) : (
-										<ChevronRight
-											size="var(--icon-xs)"
-											className="sidebarStackHeaderChevron"
-										/>
-									)}
-								</button>
-								<div className="sidebarStackHeaderActions">
-									<label className="sidebarStackHeaderSortNative">
-										<span className="sr-only">Sort notes</span>
-										<HugeiconsIcon
-											icon={Sorting01Icon}
-											size="var(--icon-sm)"
-											strokeWidth={0.9}
-											className="sidebarStackHeaderSortIcon"
-											aria-hidden="true"
-										/>
-										<select
-											className="sidebarStackHeaderSortSelect"
-											value={fileTreeSort.sortMode}
-											title={`Sort notes: ${fileTreeSortLabel(fileTreeSort.sortMode)}`}
-											aria-label="Sort notes"
-											onChange={(event) => {
-												const nextSortMode = event.currentTarget.value;
-												if (!isFileTreeSortMode(nextSortMode)) return;
-												void fileTreeSort.setSortMode(nextSortMode);
+			<AnimatePresence mode="wait" initial={false}>
+				<m.div
+					key={spacePath}
+					className="sidebarSection sidebarSectionGrow"
+					initial={
+						shouldReduceMotion
+							? false
+							: {
+									opacity: 0,
+									x: -slideOffset,
+									scale: 0.985,
+								}
+					}
+					animate={{ opacity: 1, x: 0, scale: 1 }}
+					exit={
+						shouldReduceMotion
+							? { opacity: 0 }
+							: {
+									opacity: 0,
+									x: slideOffset,
+									scale: 0.985,
+								}
+					}
+					transition={spaceTransition}
+				>
+					<div className="sidebarSectionContent">
+						<div className="sidebarNavRow">
+							<button
+								type="button"
+								className="sidebarQuickActionBtn sidebarNavBtn"
+								data-kind="new-note"
+								aria-label="New Note"
+								onClick={onNewNote}
+								title={`New Note${
+									newNoteShortcut
+										? ` (${formatShortcutForPlatform(newNoteShortcut)})`
+										: ""
+								}`}
+							>
+								<HugeiconsIcon
+									icon={NoteIcon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+								<span className="sidebarQuickActionLabel">New Note</span>
+								{newNoteShortcut ? (
+									<span className="sidebarQuickActionShortcut">
+										{formatShortcutForPlatform(newNoteShortcut)}
+									</span>
+								) : null}
+							</button>
+							<button
+								type="button"
+								className="sidebarQuickActionBtn sidebarNavBtn"
+								data-kind="pinned-notes"
+								data-active={
+									activeTopSection === "pinned-notes" ? "true" : "false"
+								}
+								aria-label="Pinned"
+								aria-pressed={activeTopSection === "pinned-notes"}
+								aria-current={
+									activeTopSection === "pinned-notes" ? "page" : undefined
+								}
+								onClick={onOpenPinnedDocs}
+								title="Open Pinned"
+							>
+								<HugeiconsIcon
+									icon={StarIcon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+								<span className="sidebarQuickActionLabel">Pinned</span>
+								<PinnedNotesCountBadge count={pinnedFiles.length} />
+							</button>
+							<button
+								type="button"
+								className="sidebarQuickActionBtn sidebarNavBtn"
+								data-kind="all-notes"
+								data-active={
+									activeTopSection === "all-notes" ? "true" : "false"
+								}
+								aria-label="All Notes"
+								aria-pressed={activeTopSection === "all-notes"}
+								aria-current={
+									activeTopSection === "all-notes" ? "page" : undefined
+								}
+								onClick={handleOpenAllNotes}
+								onMouseEnter={onPrefetchAllDocs}
+								onFocus={onPrefetchAllDocs}
+								title="Open All Notes"
+							>
+								<HugeiconsIcon
+									icon={Archive04Icon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+								<span className="sidebarQuickActionLabel">All Notes</span>
+								<AllNotesCountBadge />
+							</button>
+							<button
+								type="button"
+								className="sidebarQuickActionBtn sidebarNavBtn"
+								data-kind="databases"
+								data-active={
+									activeTopSection === "databases" ? "true" : "false"
+								}
+								aria-label="Collections"
+								aria-pressed={activeTopSection === "databases"}
+								aria-current={
+									activeTopSection === "databases" ? "page" : undefined
+								}
+								onClick={() => {
+									onOpenDatabases();
+								}}
+								onMouseEnter={() => onPrefetchDatabases()}
+								onFocus={() => onPrefetchDatabases()}
+								title="Open Collections"
+							>
+								<HugeiconsIcon
+									icon={LibraryIcon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+								<span className="sidebarQuickActionLabel">Collections</span>
+							</button>
+							<button
+								type="button"
+								className="sidebarQuickActionBtn sidebarNavBtn"
+								data-kind="connections"
+								data-active={
+									activeTopSection === "connections" ? "true" : "false"
+								}
+								aria-label="Connections"
+								aria-pressed={activeTopSection === "connections"}
+								aria-current={
+									activeTopSection === "connections" ? "page" : undefined
+								}
+								onClick={onOpenConnections}
+								title="Open Connections"
+							>
+								<HugeiconsIcon
+									icon={ChartRelationshipIcon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+								<span className="sidebarQuickActionLabel">Connections</span>
+							</button>
+						</div>
+						<div className="sidebarStack">
+							<section
+								className="sidebarStackItem sidebarStackItemGrow"
+								data-section="files"
+							>
+								<div className="sidebarStackHeader">
+									<button
+										type="button"
+										className="sidebarStackHeaderToggle"
+										onClick={handleNotesHeaderClick}
+										aria-expanded={notesExpanded}
+										aria-label={
+											notesExpanded ? "Collapse Notes" : "Expand Notes"
+										}
+									>
+										<span>Notes</span>
+										{notesExpanded ? (
+											<ChevronDown
+												size="var(--icon-xs)"
+												className="sidebarStackHeaderChevron"
+											/>
+										) : (
+											<ChevronRight
+												size="var(--icon-xs)"
+												className="sidebarStackHeaderChevron"
+											/>
+										)}
+									</button>
+									<div className="sidebarStackHeaderActions">
+										<label className="sidebarStackHeaderSortNative">
+											<span className="sr-only">Sort notes</span>
+											<HugeiconsIcon
+												icon={Sorting01Icon}
+												size="var(--icon-sm)"
+												strokeWidth={0.9}
+												className="sidebarStackHeaderSortIcon"
+												aria-hidden="true"
+											/>
+											<select
+												className="sidebarStackHeaderSortSelect"
+												value={fileTreeSort.sortMode}
+												title={`Sort notes: ${fileTreeSortLabel(fileTreeSort.sortMode)}`}
+												aria-label="Sort notes"
+												onChange={(event) => {
+													const nextSortMode = event.currentTarget.value;
+													if (!isFileTreeSortMode(nextSortMode)) return;
+													void fileTreeSort.setSortMode(nextSortMode);
+												}}
+											>
+												{FILE_TREE_SORT_OPTIONS.map((option) => (
+													<option key={option.value} value={option.value}>
+														{option.label}
+													</option>
+												))}
+											</select>
+										</label>
+										<button
+											type="button"
+											className="sidebarStackHeaderAction"
+											title="Expand all folders"
+											aria-label="Expand all folders"
+											onClick={() => {
+												void onExpandAllDirs();
 											}}
 										>
-											{FILE_TREE_SORT_OPTIONS.map((option) => (
-												<option key={option.value} value={option.value}>
-													{option.label}
-												</option>
-											))}
-										</select>
-									</label>
-									<button
-										type="button"
-										className="sidebarStackHeaderAction"
-										title="Expand all folders"
-										aria-label="Expand all folders"
-										onClick={() => {
-											void onExpandAllDirs();
-										}}
-									>
-										<HugeiconsIcon
-											icon={ExpandParagraphIcon}
-											size="var(--icon-sm)"
-											strokeWidth={0.9}
-										/>
-									</button>
-									<button
-										type="button"
-										className="sidebarStackHeaderAction"
-										title="Collapse all folders"
-										aria-label="Collapse all folders"
-										onClick={onCollapseAllDirs}
-									>
-										<HugeiconsIcon
-											icon={ArrowShrinkIcon}
-											size="var(--icon-sm)"
-											strokeWidth={0.9}
-										/>
-									</button>
+											<HugeiconsIcon
+												icon={ExpandParagraphIcon}
+												size="var(--icon-sm)"
+												strokeWidth={0.9}
+											/>
+										</button>
+										<button
+											type="button"
+											className="sidebarStackHeaderAction"
+											title="Collapse all folders"
+											aria-label="Collapse all folders"
+											onClick={onCollapseAllDirs}
+										>
+											<HugeiconsIcon
+												icon={ArrowShrinkIcon}
+												size="var(--icon-sm)"
+												strokeWidth={0.9}
+											/>
+										</button>
+									</div>
 								</div>
-							</div>
-							{notesExpanded ? (
-								<FileTreePane
-									rootEntries={folioMode ? folioRootEntries : rootEntries}
-									childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
-									expandedDirs={expandedDirs}
-									activeFilePath={folioMode ? null : activeFilePath}
-									activeDirPath={folioMode ? activeFolioFolder : activeDirPath}
-									onToggleDir={onToggleDir}
-									onLoadDir={onLoadDir}
-									onSelectDir={
-										folioMode ? handleSelectFolioFolder : onSelectDir
-									}
-									onOpenFile={onOpenFile}
-									onPrefetchFile={onPrefetchFile}
-									onNewFileInDir={onNewFileInDir}
-									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-									onRequestCreateFolder={onRequestCreateFolder}
-									onDuplicateFile={onDuplicateFile}
-									onDeletePath={onDeletePath}
-									renamingPath={renamingPath}
-									onStartRename={handleStartRename}
-									onCancelRename={handleCancelRename}
-									onCommitFileRename={handleCommitFileRename}
-									onCommitDirRename={handleCommitDirRename}
-									onMovePath={onMovePath}
-									pinnedFiles={folioMode ? [] : pinnedFiles}
-									onTogglePinnedFile={togglePinnedFile}
+								{notesExpanded ? (
+									<FileTreePane
+										rootEntries={folioMode ? folioRootEntries : rootEntries}
+										childrenByDir={
+											folioMode ? folioChildrenByDir : childrenByDir
+										}
+										expandedDirs={expandedDirs}
+										activeFilePath={folioMode ? null : activeFilePath}
+										activeDirPath={
+											folioMode ? activeFolioFolder : activeDirPath
+										}
+										onToggleDir={onToggleDir}
+										onLoadDir={onLoadDir}
+										onSelectDir={
+											folioMode ? handleSelectFolioFolder : onSelectDir
+										}
+										onOpenFile={onOpenFile}
+										onPrefetchFile={onPrefetchFile}
+										onNewFileInDir={onNewFileInDir}
+										onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+										onRequestCreateFolder={onRequestCreateFolder}
+										onDuplicateFile={onDuplicateFile}
+										onDeletePath={onDeletePath}
+										renamingPath={renamingPath}
+										onStartRename={handleStartRename}
+										onCancelRename={handleCancelRename}
+										onCommitFileRename={handleCommitFileRename}
+										onCommitDirRename={handleCommitDirRename}
+										onMovePath={onMovePath}
+										pinnedFiles={folioMode ? [] : pinnedFiles}
+										onTogglePinnedFile={togglePinnedFile}
+									/>
+								) : null}
+							</section>
+							<section className="sidebarStackItem" data-section="tags">
+								<TagsPane
+									tags={tags}
+									people={people}
+									onSelectTag={handleSelectTag}
+									onSelectPerson={handleSelectPerson}
+									beautifulTags={beautifulTags}
+									tagAppearance={tagAppearance}
+									onChangeTagIcon={handleChangeTagIcon}
 								/>
-							) : null}
-						</section>
-						<section className="sidebarStackItem" data-section="tags">
-							<TagsPane
-								tags={tags}
-								people={people}
-								onSelectTag={handleSelectTag}
-								onSelectPerson={handleSelectPerson}
-								beautifulTags={beautifulTags}
-								tagAppearance={tagAppearance}
-								onChangeTagIcon={handleChangeTagIcon}
-							/>
-						</section>
+							</section>
+						</div>
 					</div>
-				</div>
-			</div>
-			<LicenseStatusFooter />
+				</m.div>
+			</AnimatePresence>
+			<SidebarFooter
+				onSwitchSpace={onSwitchSpace}
+				onSwitchNextSpace={onSwitchNextSpace}
+				onSwitchPreviousSpace={onSwitchPreviousSpace}
+				reducedMotion={shouldReduceMotion}
+			/>
 		</>
 	);
 });

--- a/src/components/app/SidebarFooter.tsx
+++ b/src/components/app/SidebarFooter.tsx
@@ -1,0 +1,28 @@
+import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
+import { SpaceSwitcherFooter } from "./SpaceSwitcherFooter";
+
+interface SidebarFooterProps {
+	onSwitchSpace: (path: string) => void;
+	onSwitchNextSpace?: () => void;
+	onSwitchPreviousSpace?: () => void;
+	reducedMotion?: boolean | null;
+}
+
+export function SidebarFooter({
+	onSwitchSpace,
+	onSwitchNextSpace,
+	onSwitchPreviousSpace,
+	reducedMotion,
+}: SidebarFooterProps) {
+	return (
+		<div className="sidebarFooter">
+			<SpaceSwitcherFooter
+				onSwitch={onSwitchSpace}
+				onSwitchNext={onSwitchNextSpace}
+				onSwitchPrevious={onSwitchPreviousSpace}
+				reducedMotion={reducedMotion}
+			/>
+			<LicenseStatusFooter />
+		</div>
+	);
+}

--- a/src/components/app/SpaceSwitcherFooter.tsx
+++ b/src/components/app/SpaceSwitcherFooter.tsx
@@ -1,0 +1,81 @@
+import { useCallback, useRef } from "react";
+import { useSpace } from "../../contexts/SpaceContext";
+
+const SWIPE_THRESHOLD = 48;
+const SWIPE_COOLDOWN_MS = 300;
+
+interface SpaceSwitcherFooterProps {
+	onSwitch: (path: string) => void;
+	onSwitchNext?: () => void;
+	onSwitchPrevious?: () => void;
+	reducedMotion?: boolean | null;
+}
+
+export function SpaceSwitcherFooter({
+	onSwitch,
+	onSwitchNext,
+	onSwitchPrevious,
+	reducedMotion,
+}: SpaceSwitcherFooterProps) {
+	const { activeSpaceIndex, openSpaces } = useSpace();
+	const wheelDeltaRef = useRef(0);
+	const cooldownRef = useRef(false);
+
+	const handleWheel = useCallback(
+		(event: React.WheelEvent<HTMLDivElement>) => {
+			if (reducedMotion || openSpaces.length < 2) return;
+			if (!onSwitchNext || !onSwitchPrevious) return;
+			if (Math.abs(event.deltaX) <= Math.abs(event.deltaY)) return;
+
+			event.preventDefault();
+			if (cooldownRef.current) return;
+
+			wheelDeltaRef.current += event.deltaX;
+			if (Math.abs(wheelDeltaRef.current) < SWIPE_THRESHOLD) return;
+
+			const goNext = wheelDeltaRef.current > 0;
+			wheelDeltaRef.current = 0;
+			cooldownRef.current = true;
+			window.setTimeout(() => {
+				cooldownRef.current = false;
+			}, SWIPE_COOLDOWN_MS);
+
+			if (goNext) {
+				onSwitchNext();
+			} else {
+				onSwitchPrevious();
+			}
+		},
+		[onSwitchNext, onSwitchPrevious, openSpaces.length, reducedMotion],
+	);
+
+	if (openSpaces.length <= 1) return null;
+
+	return (
+		<div
+			className="spaceSwitcher"
+			role="toolbar"
+			aria-label="Open spaces"
+			onWheel={handleWheel}
+		>
+			<div className="spaceSwitcherDots">
+				{openSpaces.map((space, index) => {
+					const isActive = index === activeSpaceIndex;
+					return (
+						<button
+							key={space.path}
+							type="button"
+							className="spaceSwitcherDot"
+							data-active={isActive ? "true" : "false"}
+							aria-label={`Switch to ${space.label}`}
+							aria-current={isActive ? "true" : undefined}
+							title={`${space.label}\n${space.path}`}
+							disabled={isActive}
+							onClick={() => onSwitch(space.path)}
+						/>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/src/components/app/useSpaceActionsWithEditorFlush.ts
+++ b/src/components/app/useSpaceActionsWithEditorFlush.ts
@@ -29,7 +29,11 @@ export function useSpaceActionsWithEditorFlush({
 	const runSpaceActionWithEditorFlush = useCallback(
 		async (action: () => Promise<void>) => {
 			try {
-				await saveCurrentEditor();
+				const saved = await saveCurrentEditor();
+				if (!saved) {
+					setError("Could not save your changes before switching spaces.");
+					return;
+				}
 				await action();
 			} catch (err) {
 				setError(extractErrorMessage(err));

--- a/src/components/app/useSpaceActionsWithEditorFlush.ts
+++ b/src/components/app/useSpaceActionsWithEditorFlush.ts
@@ -1,0 +1,85 @@
+import { useCallback } from "react";
+import { extractErrorMessage } from "../../lib/errorUtils";
+
+interface UseSpaceActionsWithEditorFlushOptions {
+	spacePath: string | null;
+	saveCurrentEditor: () => Promise<boolean>;
+	setError: (error: string) => void;
+	switchSpace: (path: string) => Promise<void>;
+	switchToNextSpace: () => Promise<void>;
+	switchToPreviousSpace: () => Promise<void>;
+	onOpenSpace: () => Promise<void>;
+	onOpenSpaceAtPath: (path: string) => Promise<void>;
+	onCreateSpace: () => Promise<void>;
+	closeSpace: () => Promise<void>;
+}
+
+export function useSpaceActionsWithEditorFlush({
+	spacePath,
+	saveCurrentEditor,
+	setError,
+	switchSpace,
+	switchToNextSpace,
+	switchToPreviousSpace,
+	onOpenSpace,
+	onOpenSpaceAtPath,
+	onCreateSpace,
+	closeSpace,
+}: UseSpaceActionsWithEditorFlushOptions) {
+	const runSpaceActionWithEditorFlush = useCallback(
+		async (action: () => Promise<void>) => {
+			try {
+				await saveCurrentEditor();
+				await action();
+			} catch (err) {
+				setError(extractErrorMessage(err));
+			}
+		},
+		[saveCurrentEditor, setError],
+	);
+
+	const handleSwitchSpace = useCallback(
+		(path: string) => {
+			if (path === spacePath) return;
+			void runSpaceActionWithEditorFlush(() => switchSpace(path));
+		},
+		[runSpaceActionWithEditorFlush, spacePath, switchSpace],
+	);
+
+	const handleSwitchNextSpace = useCallback(() => {
+		void runSpaceActionWithEditorFlush(() => switchToNextSpace());
+	}, [runSpaceActionWithEditorFlush, switchToNextSpace]);
+
+	const handleSwitchPreviousSpace = useCallback(() => {
+		void runSpaceActionWithEditorFlush(() => switchToPreviousSpace());
+	}, [runSpaceActionWithEditorFlush, switchToPreviousSpace]);
+
+	const handleOpenSpace = useCallback(() => {
+		void runSpaceActionWithEditorFlush(onOpenSpace);
+	}, [onOpenSpace, runSpaceActionWithEditorFlush]);
+
+	const handleOpenSpaceAtPath = useCallback(
+		(path: string) => {
+			void runSpaceActionWithEditorFlush(() => onOpenSpaceAtPath(path));
+		},
+		[onOpenSpaceAtPath, runSpaceActionWithEditorFlush],
+	);
+
+	const handleCreateSpace = useCallback(() => {
+		void runSpaceActionWithEditorFlush(onCreateSpace);
+	}, [onCreateSpace, runSpaceActionWithEditorFlush]);
+
+	const handleCloseSpace = useCallback(async () => {
+		await runSpaceActionWithEditorFlush(closeSpace);
+	}, [closeSpace, runSpaceActionWithEditorFlush]);
+
+	return {
+		handleSwitchSpace,
+		handleSwitchNextSpace,
+		handleSwitchPreviousSpace,
+		handleOpenSpace,
+		handleOpenSpaceAtPath,
+		handleCreateSpace,
+		handleCloseSpace,
+	};
+}

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -141,6 +141,10 @@ export function useTabManager(spacePath: string | null) {
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: reset tab state when the active space changes.
 	useEffect(() => {
+		const previousActiveTab = tabsRef.current.find(
+			(tab) => tab.id === activeTabIdRef.current,
+		);
+		const previousActiveTarget = previousActiveTab?.target ?? null;
 		tabsRef.current = [];
 		activeTabIdRef.current = null;
 		historyByTabIdRef.current = {};
@@ -148,7 +152,8 @@ export function useTabManager(spacePath: string | null) {
 		setActiveTabIdState(null);
 		setDirtyByPath({});
 		setHistoryByTabId({});
-	}, [spacePath]);
+		syncWorkspaceState([], null, previousActiveTarget);
+	}, [spacePath, syncWorkspaceState]);
 
 	const focusExistingTab = useCallback(
 		(target: string) => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -607,7 +607,7 @@ export function MarkdownEditorPane({
 		saveRequestTokenRef.current = saveToken;
 		setSaving(true);
 		try {
-			await persistDoc(relPath, textRef.current, sessionId);
+			return await persistDoc(relPath, textRef.current, sessionId);
 		} finally {
 			if (
 				saveRequestTokenRef.current === saveToken &&

--- a/src/contexts/EditorContext.test.tsx
+++ b/src/contexts/EditorContext.test.tsx
@@ -57,8 +57,8 @@ describe("EditorContext", () => {
 	});
 
 	it("keeps the registered save state current across re-renders", async () => {
-		const firstSave = vi.fn(async () => {});
-		const secondSave = vi.fn(async () => {});
+		const firstSave = vi.fn(async () => true);
+		const secondSave = vi.fn(async () => true);
 		const captured = {
 			current: null as CapturedEditorContext | null,
 		};

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -17,7 +17,7 @@ export interface EditorSaveState {
 	/** Whether the current editor has unsaved changes */
 	isDirty: boolean;
 	/** Function to save the current editor content */
-	save: () => Promise<void>;
+	save: () => Promise<boolean>;
 	/** Function to get the current editor content as markdown */
 	getMarkdown?: () => string | null;
 	/** Change the current editor's presentation mode. */
@@ -61,9 +61,8 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 
 	const saveCurrentEditor = useCallback(async () => {
 		const state = editorStateRef.current;
-		if (!state) return false;
-		await state.save();
-		return true;
+		if (!state) return true;
+		return state.save();
 	}, []);
 
 	const hasUnsavedChanges = useCallback(() => {

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -350,6 +350,7 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 
 	useTauriEvent("space:fs_changed", (payload) => {
 		if (!spacePath) return;
+		if (payload.space_path && payload.space_path !== spacePath) return;
 		if (!payload.removed) return;
 		if (pinnedFilesRefreshTimerRef.current !== null) {
 			window.clearTimeout(pinnedFilesRefreshTimerRef.current);

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	type ReactNode,
 	createContext,
@@ -15,26 +14,27 @@ import { extractErrorMessage } from "../lib/errorUtils";
 import { invalidateNavigationPrefetch } from "../lib/navigationPrefetch";
 import {
 	loadSettings,
-	setCurrentSpacePath,
+	normalizeOpenSpacePaths,
 	updateOnboardingSettings,
+	updateSpaceSwitcherState,
 } from "../lib/settings";
 import { type AppInfo, invoke } from "../lib/tauri";
-import { SPACE_WINDOW_PREFIX } from "../lib/windowLabels";
 
-function isSpaceWindow(): boolean {
-	try {
-		return getCurrentWindow().label.startsWith(SPACE_WINDOW_PREFIX);
-	} catch {
-		return false;
-	}
-}
+export type OpenSpace = {
+	path: string;
+	label: string;
+};
+
+export type SpaceSwitchDirection = -1 | 0 | 1;
 
 interface SpaceContextValue {
 	info: AppInfo | null;
 	error: string;
 	setError: (error: string) => void;
 	spacePath: string | null;
-	lastSpacePath: string | null;
+	openSpaces: OpenSpace[];
+	activeSpaceIndex: number;
+	switchDirection: SpaceSwitchDirection;
 	spaceSchemaVersion: number | null;
 	onboardingNotePath: string | null;
 	recentSpaces: string[];
@@ -43,14 +43,23 @@ interface SpaceContextValue {
 	consumeOnboardingNotePath: () => void;
 	startIndexRebuild: () => Promise<void>;
 	startIndexSync: () => Promise<void>;
+	switchSpace: (path: string) => Promise<void>;
+	switchToNextSpace: () => Promise<void>;
+	switchToPreviousSpace: () => Promise<void>;
 	onOpenSpace: () => Promise<void>;
 	onOpenSpaceAtPath: (path: string) => Promise<void>;
-	onContinueLastSpace: () => Promise<void>;
 	onCreateSpace: () => Promise<void>;
 	closeSpace: () => Promise<void>;
 }
 
 const SpaceContext = createContext<SpaceContextValue | null>(null);
+
+function formatSpaceLabel(path: string): string {
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+	const parts = normalized.split("/").filter(Boolean);
+	if (parts.length === 0) return path;
+	return parts[parts.length - 1] ?? path;
+}
 
 function normalizeRecentSpaces(
 	recent: string[],
@@ -80,11 +89,40 @@ function recentSpacesForMenu(
 		.slice(0, 20);
 }
 
+function neighborPath(openPaths: string[], activePath: string): string | null {
+	const index = openPaths.indexOf(activePath);
+	if (index < 0) return null;
+	return openPaths[index + 1] ?? openPaths[index - 1] ?? null;
+}
+
+function rewriteMountedOpenPath(
+	openPaths: string[],
+	requestedPath: string,
+	canonicalRoot: string,
+): string[] {
+	const normalized = normalizeOpenSpacePaths(openPaths);
+	let replaced = false;
+	const rewritten = normalized.map((path) => {
+		if (path !== requestedPath && path !== canonicalRoot) return path;
+		replaced = true;
+		return canonicalRoot;
+	});
+	return normalizeOpenSpacePaths(
+		replaced ? rewritten : [...rewritten, canonicalRoot],
+	);
+}
+
+function clearSpaceCaches(): void {
+	clearAiPanelCaches();
+	clearInlineImageHydrationCache();
+	invalidateNavigationPrefetch();
+}
+
 export function SpaceProvider({ children }: { children: ReactNode }) {
 	const [info, setInfo] = useState<AppInfo | null>(null);
 	const [error, setError] = useState("");
 	const [spacePath, setSpacePath] = useState<string | null>(null);
-	const [lastSpacePath, setLastSpacePath] = useState<string | null>(null);
+	const [openPaths, setOpenPaths] = useState<string[]>([]);
 	const [spaceSchemaVersion, setSpaceSchemaVersion] = useState<number | null>(
 		null,
 	);
@@ -94,13 +132,32 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	const [recentSpaces, setRecentSpaces] = useState<string[]>([]);
 	const [isIndexing, setIsIndexing] = useState(false);
 	const [settingsLoaded, setSettingsLoaded] = useState(false);
+	const [switchDirection, setSwitchDirection] =
+		useState<SpaceSwitchDirection>(0);
 	const isOpeningSpaceRef = useRef(false);
 	const currentSpacePathRef = useRef<string | null>(spacePath);
+	const activeSpaceIndexRef = useRef(-1);
 	const indexSyncRef = useRef<{
 		spacePath: string;
 		promise: Promise<void>;
 	} | null>(null);
 	currentSpacePathRef.current = spacePath;
+
+	const openSpaces = useMemo<OpenSpace[]>(
+		() =>
+			openPaths.map((path) => ({
+				path,
+				label: formatSpaceLabel(path),
+			})),
+		[openPaths],
+	);
+
+	const activeSpaceIndex = useMemo(
+		() => (spacePath ? openPaths.indexOf(spacePath) : -1),
+		[openPaths, spacePath],
+	);
+	activeSpaceIndexRef.current = activeSpaceIndex;
+
 	useEffect(() => {
 		if (!spacePath) indexSyncRef.current = null;
 	}, [spacePath]);
@@ -138,15 +195,17 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			try {
 				const settings = await loadSettings();
 				if (cancelled) return;
-				setRecentSpaces(
-					normalizeRecentSpaces(
-						settings.recentSpaces,
-						settings.currentSpacePath ?? null,
-					),
+
+				let persistedOpenPaths = normalizeOpenSpacePaths(
+					settings.openSpacePaths,
 				);
-				setLastSpacePath(
-					settings.currentSpacePath ?? settings.recentSpaces[0] ?? null,
-				);
+				if (persistedOpenPaths.length === 0 && settings.currentSpacePath) {
+					persistedOpenPaths = [settings.currentSpacePath];
+				}
+
+				const activePath =
+					settings.currentSpacePath ?? persistedOpenPaths[0] ?? null;
+
 				try {
 					await invoke("index_set_people_mentions_as_tags_enabled", {
 						enabled: settings.editor.enablePeopleMentionsAsTags,
@@ -159,26 +218,52 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				}
 
 				const currentWindowSpaceInfo = await invoke("space_get_current_info");
+				let mountedSpaceInfo = currentWindowSpaceInfo;
 				if (currentWindowSpaceInfo) {
 					if (!cancelled) {
 						setSpacePath(currentWindowSpaceInfo.root);
-						setLastSpacePath(currentWindowSpaceInfo.root);
 						setSpaceSchemaVersion(currentWindowSpaceInfo.schema_version);
 						setOnboardingNotePath(
 							currentWindowSpaceInfo.onboarding_note_path ?? null,
 						);
 					}
-				} else if (settings.currentSpacePath && !isSpaceWindow()) {
+				} else if (activePath) {
 					try {
-						const spaceInfo = await invoke("space_open", {
-							path: settings.currentSpacePath,
+						mountedSpaceInfo = await invoke("space_open", {
+							path: activePath,
 						});
 						if (!cancelled) {
-							setSpacePath(spaceInfo.root);
-							setSpaceSchemaVersion(spaceInfo.schema_version);
-							setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+							setSpacePath(mountedSpaceInfo.root);
+							setSpaceSchemaVersion(mountedSpaceInfo.schema_version);
+							setOnboardingNotePath(
+								mountedSpaceInfo.onboarding_note_path ?? null,
+							);
 						}
-					} catch {}
+					} catch (err) {
+						if (!cancelled) setError(extractErrorMessage(err));
+					}
+				}
+
+				if (cancelled) return;
+				if (mountedSpaceInfo) {
+					const nextOpenPaths = rewriteMountedOpenPath(
+						persistedOpenPaths,
+						activePath ?? mountedSpaceInfo.root,
+						mountedSpaceInfo.root,
+					);
+					setOpenPaths(nextOpenPaths);
+					setRecentSpaces(
+						normalizeRecentSpaces(settings.recentSpaces, mountedSpaceInfo.root),
+					);
+					await updateSpaceSwitcherState({
+						currentPath: mountedSpaceInfo.root,
+						openPaths: nextOpenPaths,
+					});
+				} else {
+					setOpenPaths(persistedOpenPaths);
+					setRecentSpaces(
+						normalizeRecentSpaces(settings.recentSpaces, activePath),
+					);
 				}
 			} catch (err) {
 				if (!cancelled) {
@@ -232,58 +317,148 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		return promise;
 	}, []);
 
-	const applySpaceSelection = useCallback(
+	const mountSpace = useCallback(
 		async (path: string, mode: "open" | "create") => {
-			if (isOpeningSpaceRef.current) return;
-			isOpeningSpaceRef.current = true;
-			setError("");
-			try {
-				const sessionSpacePath = await invoke("space_get_current");
-				const spaceInfo = sessionSpacePath
-					? await invoke("space_open_window", {
-							path,
-							create: mode === "create",
-						})
-					: mode === "create"
-						? await invoke("space_create", { path })
-						: await invoke("space_open", { path });
-				await setCurrentSpacePath(spaceInfo.root);
+			const spaceInfo =
+				mode === "create"
+					? await invoke("space_create", { path })
+					: await invoke("space_open", { path });
+
+			clearSpaceCaches();
+			setSpacePath(spaceInfo.root);
+			setSpaceSchemaVersion(spaceInfo.schema_version);
+			setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
+			void updateOnboardingSettings({ launcherSeen: true });
+
+			return spaceInfo;
+		},
+		[],
+	);
+
+	const persistSwitcherState = useCallback(
+		async (
+			currentPath: string | null,
+			nextOpenPaths: string[],
+			requestedPath?: string,
+		) => {
+			const normalizedOpenPaths = currentPath
+				? rewriteMountedOpenPath(
+						nextOpenPaths,
+						requestedPath ?? currentPath,
+						currentPath,
+					)
+				: normalizeOpenSpacePaths(nextOpenPaths);
+			await updateSpaceSwitcherState({
+				currentPath,
+				openPaths: normalizedOpenPaths,
+			});
+			setOpenPaths(normalizedOpenPaths);
+			if (currentPath) {
 				setRecentSpaces((prev) =>
 					normalizeRecentSpaces(
-						[spaceInfo.root, ...prev.filter((p) => p !== spaceInfo.root)],
-						spaceInfo.root,
+						[currentPath, ...prev.filter((p) => p !== currentPath)],
+						currentPath,
 					),
 				);
-				void updateOnboardingSettings({ launcherSeen: true });
-				setLastSpacePath(spaceInfo.root);
-				if (!sessionSpacePath) {
-					setSpacePath(spaceInfo.root);
-					setSpaceSchemaVersion(spaceInfo.schema_version);
-					setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
-				}
-			} catch (err) {
-				setError(extractErrorMessage(err));
-			} finally {
-				isOpeningSpaceRef.current = false;
 			}
 		},
 		[],
 	);
 
+	const activateSpace = useCallback(
+		async (
+			path: string,
+			mode: "open" | "create",
+			updateOpenPaths: (current: string[], target: string) => string[],
+		) => {
+			const trimmed = path.trim();
+			if (!trimmed) return;
+			if (isOpeningSpaceRef.current) return;
+			isOpeningSpaceRef.current = true;
+			setError("");
+			try {
+				const nextOpenPaths = updateOpenPaths(openPaths, trimmed);
+				const previousIndex = activeSpaceIndexRef.current;
+				const nextIndex = openPaths.indexOf(trimmed);
+				const appendedIndex = nextOpenPaths.indexOf(trimmed);
+				const targetIndex = nextIndex >= 0 ? nextIndex : appendedIndex;
+				if (
+					previousIndex >= 0 &&
+					targetIndex >= 0 &&
+					previousIndex !== targetIndex
+				) {
+					setSwitchDirection(targetIndex > previousIndex ? 1 : -1);
+				} else {
+					setSwitchDirection(0);
+				}
+
+				const spaceInfo = await mountSpace(trimmed, mode);
+				await persistSwitcherState(spaceInfo.root, nextOpenPaths, trimmed);
+			} catch (err) {
+				setError(extractErrorMessage(err));
+				throw err;
+			} finally {
+				isOpeningSpaceRef.current = false;
+			}
+		},
+		[mountSpace, openPaths, persistSwitcherState],
+	);
+
+	const switchSpace = useCallback(
+		async (path: string) =>
+			activateSpace(path, "open", (currentOpenPaths) => currentOpenPaths),
+		[activateSpace],
+	);
+
+	const applySpaceSelection = useCallback(
+		async (path: string, mode: "open" | "create") =>
+			activateSpace(path, mode, (currentOpenPaths, target) =>
+				currentOpenPaths.includes(target)
+					? currentOpenPaths
+					: [...currentOpenPaths, target],
+			),
+		[activateSpace],
+	);
+
 	const closeSpace = useCallback(async () => {
+		const activePath = currentSpacePathRef.current;
+		if (!activePath) return;
+		const nextOpenPaths = openPaths.filter((path) => path !== activePath);
+		const neighbor = neighborPath(openPaths, activePath);
+		if (neighbor) {
+			await activateSpace(neighbor, "open", () => nextOpenPaths);
+			return;
+		}
+
+		if (isOpeningSpaceRef.current) return;
+		isOpeningSpaceRef.current = true;
 		setError("");
 		try {
 			await invoke("space_close");
-			clearAiPanelCaches();
-			clearInlineImageHydrationCache();
-			invalidateNavigationPrefetch();
+			clearSpaceCaches();
 			setSpacePath(null);
 			setSpaceSchemaVersion(null);
 			setOnboardingNotePath(null);
+			await persistSwitcherState(null, nextOpenPaths);
 		} catch (err) {
 			setError(extractErrorMessage(err));
+			throw err;
+		} finally {
+			isOpeningSpaceRef.current = false;
 		}
-	}, []);
+	}, [activateSpace, openPaths, persistSwitcherState]);
+
+	const switchToNextSpace = useCallback(async () => {
+		const index = activeSpaceIndexRef.current;
+		if (index < 0 || index >= openPaths.length - 1) return;
+		await switchSpace(openPaths[index + 1]);
+	}, [openPaths, switchSpace]);
+
+	const switchToPreviousSpace = useCallback(async () => {
+		const index = activeSpaceIndexRef.current;
+		if (index <= 0) return;
+		await switchSpace(openPaths[index - 1]);
+	}, [openPaths, switchSpace]);
 
 	const consumeOnboardingNotePath = useCallback(() => {
 		setOnboardingNotePath(null);
@@ -306,10 +481,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		[applySpaceSelection],
 	);
 
-	const onContinueLastSpace = useCallback(async () => {
-		if (lastSpacePath) await applySpaceSelection(lastSpacePath, "open");
-	}, [lastSpacePath, applySpaceSelection]);
-
 	const onCreateSpace = useCallback(async () => {
 		const { open } = await import("@tauri-apps/plugin-dialog");
 		const selection = await open({
@@ -328,7 +499,9 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			error,
 			setError,
 			spacePath,
-			lastSpacePath,
+			openSpaces,
+			activeSpaceIndex,
+			switchDirection,
 			spaceSchemaVersion,
 			onboardingNotePath,
 			recentSpaces,
@@ -337,9 +510,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			consumeOnboardingNotePath,
 			startIndexRebuild,
 			startIndexSync,
+			switchSpace,
+			switchToNextSpace,
+			switchToPreviousSpace,
 			onOpenSpace,
 			onOpenSpaceAtPath,
-			onContinueLastSpace,
 			onCreateSpace,
 			closeSpace,
 		}),
@@ -347,7 +522,9 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			info,
 			error,
 			spacePath,
-			lastSpacePath,
+			openSpaces,
+			activeSpaceIndex,
+			switchDirection,
 			spaceSchemaVersion,
 			onboardingNotePath,
 			recentSpaces,
@@ -356,9 +533,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			consumeOnboardingNotePath,
 			startIndexRebuild,
 			startIndexSync,
+			switchSpace,
+			switchToNextSpace,
+			switchToPreviousSpace,
 			onOpenSpace,
 			onOpenSpaceAtPath,
-			onContinueLastSpace,
 			onCreateSpace,
 			closeSpace,
 		],

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -547,6 +547,7 @@ export const FILE_TREE_SORT_OPTIONS = [
 
 interface AppSettings {
 	currentSpacePath: string | null;
+	openSpacePaths: string[];
 	recentSpaces: string[];
 	recentFiles: RecentFile[];
 	onboarding: OnboardingSettings;
@@ -621,6 +622,7 @@ async function withSpaceScopedSettingsWriteLock<T>(
 
 const KEYS = {
 	currentSpacePath: "space.currentPath",
+	openSpacePaths: "space.openPaths",
 	recentSpaces: "space.recent",
 	recentFiles: "files.recent",
 	aiEnabled: "ui.aiEnabled",
@@ -923,6 +925,10 @@ export async function loadSettings(
 		entries,
 		KEYS.recentSpaces,
 	);
+	const openSpacePathsRaw = getSettingValue<string[] | null>(
+		entries,
+		KEYS.openSpacePaths,
+	);
 	const rawRecentFiles = getSettingValue(entries, KEYS.recentFiles);
 	const rawOnboardingLauncherSeen = getSettingValue<boolean | null>(
 		entries,
@@ -1057,6 +1063,7 @@ export async function loadSettings(
 		: undefined;
 	const hasActiveSpace = Boolean(activeSettingsSpacePath);
 	const recentSpaces = recentSpacesRaw ?? [];
+	const openSpacePaths = normalizeOpenSpacePaths(openSpacePathsRaw ?? []);
 	const recentFiles = isRecentFileArray(rawRecentFiles) ? rawRecentFiles : [];
 	const onboarding: OnboardingSettings = {
 		launcherSeen: rawOnboardingLauncherSeen ?? false,
@@ -1198,6 +1205,7 @@ export async function loadSettings(
 	};
 	return {
 		currentSpacePath,
+		openSpacePaths,
 		recentSpaces: Array.isArray(recentSpaces) ? recentSpaces : [],
 		recentFiles,
 		onboarding,
@@ -1241,18 +1249,38 @@ export async function loadSettings(
 	};
 }
 
-export async function setCurrentSpacePath(path: string): Promise<void> {
-	const store = await getStore();
-	await store.set(KEYS.currentSpacePath, path);
-	const prev = (await store.get<string[] | null>(KEYS.recentSpaces)) ?? [];
-	const next = [path, ...prev.filter((p) => p !== path)].slice(0, 20);
-	await store.set(KEYS.recentSpaces, next);
-	await saveSettingsStore(store);
+export function normalizeOpenSpacePaths(paths: string[]): string[] {
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const value of paths) {
+		const trimmed = value.trim();
+		if (!trimmed || seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		out.push(trimmed);
+	}
+	return out;
 }
 
-export async function clearCurrentSpacePath(): Promise<void> {
+export async function updateSpaceSwitcherState(options: {
+	currentPath: string | null;
+	openPaths: string[];
+}): Promise<void> {
 	const store = await getStore();
-	await store.set(KEYS.currentSpacePath, null);
+	const openPaths = normalizeOpenSpacePaths(options.openPaths);
+	const currentPath = options.currentPath?.trim() || null;
+
+	await store.set(KEYS.openSpacePaths, openPaths);
+	if (currentPath) {
+		await store.set(KEYS.currentSpacePath, currentPath);
+		const prev = (await store.get<string[] | null>(KEYS.recentSpaces)) ?? [];
+		const next = [currentPath, ...prev.filter((p) => p !== currentPath)].slice(
+			0,
+			20,
+		);
+		await store.set(KEYS.recentSpaces, next);
+	} else {
+		await store.set(KEYS.currentSpacePath, null);
+	}
 	await saveSettingsStore(store);
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -791,10 +791,6 @@ interface TauriCommands {
 	license_clear_local: CommandDef<void, LicenseActivateResult>;
 	space_create: CommandDef<{ path: string }, SpaceInfo>;
 	space_open: CommandDef<{ path: string }, SpaceInfo>;
-	space_open_window: CommandDef<
-		{ path: string; create?: boolean | null },
-		SpaceInfo
-	>;
 	space_get_current: CommandDef<void, string | null>;
 	space_get_current_info: CommandDef<void, SpaceInfo | null>;
 	space_show_onboarding_note: CommandDef<void, string>;

--- a/src/lib/windowLabels.ts
+++ b/src/lib/windowLabels.ts
@@ -1,4 +1,3 @@
 export const MAIN_WINDOW_LABEL = "main";
-export const SPACE_WINDOW_PREFIX = "space-";
 export const QUICK_NOTE_WINDOW_LABEL = "quick-note";
 export const EXTERNAL_MARKDOWN_WINDOW_PREFIX = "external-markdown-";

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -275,7 +275,7 @@
 		"close-space": {
 			"id": "close-space",
 			"label": "Close Current Space",
-			"description": "Close the currently open space.",
+			"description": "Remove the active space from the switcher.",
 			"category": "workspace",
 			"context": "space",
 			"defaultBinding": null,

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -352,6 +352,70 @@
 	font-size: var(--text-xs);
 	color: var(--text-tertiary);
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   SIDEBAR FOOTER / SPACE SWITCHER
+   ───────────────────────────────────────────────────────────────────────────── */
+.sidebarFooter {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+}
+
+.spaceSwitcher {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 8px var(--space-3) 4px;
+}
+
+.spaceSwitcherDots {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 100%;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.spaceSwitcherDots::-webkit-scrollbar {
+	display: none;
+}
+
+.spaceSwitcherDot {
+	flex: none;
+	width: 7px;
+	height: 7px;
+	padding: 0;
+	border: none;
+	border-radius: 999px;
+	background: var(--text-tertiary);
+	opacity: 0.45;
+	cursor: pointer;
+	transition: transform 120ms ease, opacity 120ms ease, background-color 120ms
+		ease;
+}
+
+.spaceSwitcherDot:hover:not(:disabled) {
+	opacity: 0.75;
+}
+
+.spaceSwitcherDot:focus-visible {
+	outline: 2px solid var(--focus-ring);
+	outline-offset: 2px;
+}
+
+.spaceSwitcherDot[data-active="true"] {
+	width: 9px;
+	height: 9px;
+	opacity: 1;
+	background: var(--text-primary);
+	cursor: default;
+}
+
+.sidebarFooter .licenseSidebarFooter {
+	border-top: none;
+}
 /* ─────────────────────────────────────────────────────────────────────────────
    SIDEBAR RESIZE HANDLE
    ───────────────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
> **No open GitHub issue to close.** This work tracks [KAR-25 on Linear](https://linear.app/karats/issue/KAR-25/spaces-switcher-instead-of-separate-app-windows). The related GitHub issue [#208](https://github.com/SidhuK/Glyph/issues/208) ("Modified Space Switcher instead of separate windows") is already **closed**.

## Description

Replaces the multi-window space model with a single main Glyph window that switches between space roots in place.

- **Summary of changes**
  - One native window (`main`) mounts one space at a time; `space_open_window` and per-window session state are removed.
  - Backend `SpaceState` simplified to a single active session + `current_root` instead of a window-label → root map.
  - All space-scoped Tauri commands now resolve the active root globally (no `WebviewWindow` parameter).
  - Frontend `SpaceContext` persists `space.openPaths` and `space.currentPath`, supports switch/next/previous, and flushes the editor before switching.
  - New sidebar footer with compact dot switcher (`SpaceSwitcherFooter`) and horizontal trackpad swipe between spaces.
  - File-tree slide transition on space switch; settings rehydrate for the newly active space.
  - Version bump to `0.8.6-alpha.7`.

- **Reasoning**
  - Multiple spaces should feel like Arc-style spaces in one window, not separate app instances.
  - Only one filesystem watcher / SQLite index / provider tree should be active at a time.

- **Additional context**
  - Implementation plan: `KAR-25-space-switcher-plan.md`
  - Architecture docs updated under `docs/architecture/`

## Screenshots

_(Add screenshots of the sidebar footer dot switcher and file-tree transition.)_

## Docs

- `docs/architecture/02-spaces-storage-filesystem.md` — single-session space model
- `docs/architecture/03-frontend-shell-state.md` — `space.openPaths` / switcher state
- `docs/architecture/09-settings-menus-git-sync-native-windows.md` — menu behavior without multi-window spaces
- `KAR-25-space-switcher-plan.md` — full product + implementation plan

## Ready?

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed (`pnpm check`, `pnpm build`, `cargo check`)
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces per-space native windows with a single main window that switches spaces in place. Also hardens switching with atomic root/session updates to prevent race conditions, blocks switch/close when editor save fails, clears tab UI on space change, and ignores stale FS/external events from previously mounted spaces.

- New Features
  - One main window mounts one space at a time.
  - Sidebar footer dot switcher (`SpaceSwitcherFooter`) with horizontal trackpad swipe.
  - Persists open spaces in settings (`space.openPaths`) and restores on launch.
  - `SpaceContext` adds switch/next/previous, tracks active index and direction.
  - Flushes the editor before switching; adds file-tree slide transition.
  - Atomic root+session updates in `SpaceState` to avoid mismatched reads during switches.
  - Version bump to `0.8.6-alpha.7`.
  - Addresses Linear KAR-25 by delivering Arc-style, in-window space switching.

- Migration
  - Remove `space_open_window`; use `space_open` and the new switch actions.
  - Backend commands no longer accept `WebviewWindow`; they resolve via `SpaceState.current_root()`. Update `invoke` calls accordingly.
  - Settings now store `space.openPaths` alongside `space.currentPath`. Recent-space menu targets the `main` window and switches in place.
  - Capabilities drop `space-*` windows; only `main`, `quick-note`, `quick-task`, and `external-markdown-*` remain.

<sup>Written for commit e71808d68c5e784955de11a06f2048971413e36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a space switcher in the sidebar footer with dot controls for quickly moving between open spaces.
  * Improved space switching to work in-place, with smoother sidebar transitions and optional swipe-style navigation.
  * Expanded recent/open space handling so your last-used spaces are remembered more consistently.

* **Bug Fixes**
  * Reduced accidental cross-space updates by ignoring events from other spaces.
  * Improved save coordination when switching spaces, helping preserve editor changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->