### PR TITLE
Route space errors through toasts and add dismiss control (#296) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.6-alpha.8",
+	"version": "0.8.6-alpha.9",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -101,6 +101,15 @@ const LazyCommandPalette = lazy(loadCommandPalette);
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 600;
 const SIDEBAR_AUTO_COLLAPSE_WIDTH = 760;
+const GIT_SYNC_ERROR_TOAST_ID = "glyph-git-sync-error";
+
+function showGitSyncErrorToast(message: string) {
+	toast.error("Git Sync failed", {
+		description: message,
+		id: GIT_SYNC_ERROR_TOAST_ID,
+	});
+}
+
 export function AppShell() {
 	const space = useSpace();
 	const {
@@ -290,10 +299,7 @@ export function AppShell() {
 			} else if (status.phase === "error" || status.last_error) {
 				const message =
 					status.last_error ?? status.message ?? "Git Sync failed.";
-				toast.error("Git Sync failed", {
-					description: message,
-					id: "glyph-git-sync-error",
-				});
+				showGitSyncErrorToast(message);
 			}
 		}
 
@@ -390,10 +396,9 @@ export function AppShell() {
 			await openWorkspaceFile(notePath);
 		} catch (cause) {
 			const message = cause instanceof Error ? cause.message : String(cause);
-			setError(message);
 			toast.error("Could not open the welcome note", { description: message });
 		}
-	}, [fileTree, openWorkspaceFile, setError, spacePath]);
+	}, [fileTree, openWorkspaceFile, spacePath]);
 
 	const openFolioWorkspaceFile = useCallback(
 		async (path: string) => {
@@ -453,7 +458,6 @@ export function AppShell() {
 		void openWorkspaceFile(payload.path).catch((cause) => {
 			console.error("Failed to open quick note", cause);
 			const message = cause instanceof Error ? cause.message : String(cause);
-			setError(message);
 			toast.error("Could not open quick note", { description: message });
 		});
 	});
@@ -1058,10 +1062,7 @@ export function AppShell() {
 
 	const handleGitSyncFailure = useCallback((cause: unknown) => {
 		const message = cause instanceof Error ? cause.message : "Git Sync failed.";
-		toast.error("Git Sync failed", {
-			description: message,
-			id: "glyph-git-sync-error",
-		});
+		showGitSyncErrorToast(message);
 	}, []);
 
 	const handleCloseTabOrWindow = useCallback(async () => {

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -2,7 +2,6 @@ import { cn } from "@/lib/utils";
 import { join } from "@tauri-apps/api/path";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openPath } from "@tauri-apps/plugin-opener";
-import { AnimatePresence } from "motion/react";
 import {
 	Suspense,
 	lazy,
@@ -106,7 +105,6 @@ export function AppShell() {
 	const space = useSpace();
 	const {
 		spacePath,
-		error,
 		setError,
 		onOpenSpace,
 		onOpenSpaceAtPath,
@@ -292,7 +290,10 @@ export function AppShell() {
 			} else if (status.phase === "error" || status.last_error) {
 				const message =
 					status.last_error ?? status.message ?? "Git Sync failed.";
-				setError(message);
+				toast.error("Git Sync failed", {
+					description: message,
+					id: "glyph-git-sync-error",
+				});
 			}
 		}
 
@@ -304,7 +305,7 @@ export function AppShell() {
 					message: status.message,
 				}
 			: null;
-	}, [gitSync.status, setError]);
+	}, [gitSync.status]);
 
 	const fileTree = useFileTree({
 		spacePath,
@@ -1055,17 +1056,13 @@ export function AppShell() {
 		[fileTree.loadDir, setSidebarCollapsed, updateExpandedDirs],
 	);
 
-	const handleGitSyncFailure = useCallback(
-		(cause: unknown) => {
-			const message =
-				cause instanceof Error ? cause.message : "Git Sync failed.";
-			setError(message);
-			toast.error("Git Sync failed", {
-				description: message,
-			});
-		},
-		[setError],
-	);
+	const handleGitSyncFailure = useCallback((cause: unknown) => {
+		const message = cause instanceof Error ? cause.message : "Git Sync failed.";
+		toast.error("Git Sync failed", {
+			description: message,
+			id: "glyph-git-sync-error",
+		});
+	}, []);
 
 	const handleCloseTabOrWindow = useCallback(async () => {
 		if (tabs.length > 0) {
@@ -1387,9 +1384,6 @@ export function AppShell() {
 				onOpenDailyNotesSettings={() => openSettings("space")}
 				onRightSidebarOpenChange={setRightSidebarOpen}
 			/>
-			<AnimatePresence>
-				{error && <div className="appError">{error}</div>}
-			</AnimatePresence>
 			{commandPaletteMounted ? (
 				<Suspense fallback={null}>
 					<LazyCommandPalette

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -19,6 +19,7 @@ import {
 	updateOnboardingSettings,
 } from "../lib/settings";
 import { type AppInfo, invoke } from "../lib/tauri";
+import { toast } from "../lib/toast";
 import { SPACE_WINDOW_PREFIX } from "../lib/windowLabels";
 
 function isSpaceWindow(): boolean {
@@ -31,7 +32,6 @@ function isSpaceWindow(): boolean {
 
 interface SpaceContextValue {
 	info: AppInfo | null;
-	error: string;
 	setError: (error: string) => void;
 	spacePath: string | null;
 	lastSpacePath: string | null;
@@ -80,9 +80,13 @@ function recentSpacesForMenu(
 		.slice(0, 20);
 }
 
+// Space-level errors surface as top toasts; there is no persistent error state.
+function setError(message: string) {
+	if (message) toast.error(message, { id: "glyph-space-error" });
+}
+
 export function SpaceProvider({ children }: { children: ReactNode }) {
 	const [info, setInfo] = useState<AppInfo | null>(null);
-	const [error, setError] = useState("");
 	const [spacePath, setSpacePath] = useState<string | null>(null);
 	const [lastSpacePath, setLastSpacePath] = useState<string | null>(null);
 	const [spaceSchemaVersion, setSpaceSchemaVersion] = useState<number | null>(
@@ -236,7 +240,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		async (path: string, mode: "open" | "create") => {
 			if (isOpeningSpaceRef.current) return;
 			isOpeningSpaceRef.current = true;
-			setError("");
 			try {
 				const sessionSpacePath = await invoke("space_get_current");
 				const spaceInfo = sessionSpacePath
@@ -271,7 +274,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	);
 
 	const closeSpace = useCallback(async () => {
-		setError("");
 		try {
 			await invoke("space_close");
 			clearAiPanelCaches();
@@ -325,7 +327,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	const value = useMemo<SpaceContextValue>(
 		() => ({
 			info,
-			error,
 			setError,
 			spacePath,
 			lastSpacePath,
@@ -345,7 +346,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		}),
 		[
 			info,
-			error,
 			spacePath,
 			lastSpacePath,
 			spaceSchemaVersion,

--- a/src/hooks/useFileTree.ts
+++ b/src/hooks/useFileTree.ts
@@ -337,12 +337,11 @@ export function useFileTree(deps: UseFileTreeDeps): UseFileTreeResult {
 				return createdPath;
 			} catch (error) {
 				const message = extractErrorMessage(error);
-				setError(message);
 				toast.error("Could not create folder", { description: message });
 				return null;
 			}
 		},
-		[createFolderInDir, loadDir, setActiveDirPath, setError, spacePath],
+		[createFolderInDir, loadDir, setActiveDirPath, spacePath],
 	);
 
 	return {

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -15,8 +15,11 @@ interface ToastOptions {
 	id?: string;
 }
 
-interface SileoOptionsWithId extends SileoOptions {
+// Same shape as SileoOptions, but sileo renders `title` as React children,
+// so at runtime it accepts a ReactNode even though its published type is string.
+interface GlyphSileoOptions extends Omit<SileoOptions, "title"> {
 	id: string;
+	title: ReactNode;
 }
 
 let toastId = 0;
@@ -35,13 +38,36 @@ function stylesForClassName(className: string | undefined) {
 	} satisfies SileoOptions["styles"];
 }
 
+function titleWithDismiss(id: string, title: string) {
+	return (
+		<span className="glyphToastTitleRow">
+			{title}
+			{/* Not a <button>: sileo renders the whole toast as a <button>, and
+			    buttons cannot nest. data-sileo-button opts out of swipe-to-dismiss. */}
+			<input
+				type="button"
+				value="✕"
+				data-sileo-button
+				className="glyphToastClose"
+				aria-label="Dismiss notification"
+				onClick={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					sileo.dismiss(id);
+				}}
+			/>
+		</span>
+	);
+}
+
 function toSileoOptions(
 	title: string,
 	options: ToastOptions = {},
-): SileoOptionsWithId {
-	const sileoOptions: SileoOptionsWithId = {
-		id: options.id ?? nextToastId(),
-		title,
+): SileoOptions {
+	const id = options.id ?? nextToastId();
+	const sileoOptions: GlyphSileoOptions = {
+		id,
+		title: titleWithDismiss(id, title),
 	};
 
 	if (options.description !== undefined) {
@@ -65,7 +91,9 @@ function toSileoOptions(
 		sileoOptions.styles = styles;
 	}
 
-	return sileoOptions;
+	// Boundary cast: sileo's published title type (string) is narrower than
+	// what its renderer supports (React children). See GlyphSileoOptions.
+	return sileoOptions as SileoOptions;
 }
 
 export const toast = {

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -15,8 +15,6 @@ interface ToastOptions {
 	id?: string;
 }
 
-// Same shape as SileoOptions, but sileo renders `title` as React children,
-// so at runtime it accepts a ReactNode even though its published type is string.
 interface GlyphSileoOptions extends Omit<SileoOptions, "title"> {
 	id: string;
 	title: ReactNode;
@@ -91,8 +89,6 @@ function toSileoOptions(
 		sileoOptions.styles = styles;
 	}
 
-	// Boundary cast: sileo's published title type (string) is narrower than
-	// what its renderer supports (React children). See GlyphSileoOptions.
 	return sileoOptions as SileoOptions;
 }
 

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -87,6 +87,36 @@ body:has(.indexingNotice) [data-sileo-viewport][data-position="top-center"] {
 	line-height: 1.35 !important;
 }
 
+.glyphToastTitleRow {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.glyphToastClose[data-sileo-button] {
+	flex: none;
+	width: 18px;
+	height: 18px;
+	margin: 0;
+	padding: 0;
+	border: 0;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--glyph-toast-muted);
+	font-size: 10px;
+	line-height: 18px;
+	text-align: center;
+	cursor: pointer;
+	transition: color 120ms ease, background 120ms ease;
+}
+
+.glyphToastClose[data-sileo-button]:hover,
+.glyphToastClose[data-sileo-button]:focus-visible {
+	color: var(--glyph-toast-text);
+	background: color-mix(in srgb, var(--glyph-toast-text) 10%, transparent);
+	outline: 0;
+}
+
 .glyphToastBadge {
 	background: color-mix(in srgb, currentcolor 16%, transparent) !important;
 }

--- a/src/styles/app/31-responsive.css
+++ b/src/styles/app/31-responsive.css
@@ -1,23 +1,3 @@
-/* ─────────────────────────────────────────────────────────────────────────────
-   ERROR STATES
-   ───────────────────────────────────────────────────────────────────────────── */
-.appError {
-	position: fixed;
-	bottom: var(--space-6);
-	left: 50%;
-	transform: translateX(-50%);
-	padding: var(--space-3) var(--space-5);
-	font-size: var(--text-sm);
-	color: var(--text-error);
-	background: var(--glass-bg);
-	backdrop-filter: blur(var(--glass-blur));
-	-webkit-backdrop-filter: blur(var(--glass-blur));
-	border: 1px solid var(--feedback-error-bg);
-	border-radius: var(--radius-full);
-	box-shadow: var(--shadow-xl);
-	z-index: 1000;
-}
-
 @media (max-width: 900px) {
 	.starterPane {
 		padding: var(--space-3);


### PR DESCRIPTION
_No matching open GitHub issue — this is follow-up cleanup after #293 (Sonner → Sileo migration)._

## Description

Completes the notifications cleanup by routing all space-level errors through the Sileo toast system and removing the legacy persistent error banner.

- **Summary of changes**
  - Remove the fixed bottom `appError` banner from `AppShell` and its CSS
  - Change `SpaceContext.setError` to show a top toast (`glyph-space-error`) instead of holding persistent error state
  - Deduplicate git sync failure handling — errors now surface only via toast (`glyph-git-sync-error`), not both toast and banner
  - Add an explicit dismiss (✕) control on every toast title row (uses `<input type="button">` because Sileo renders the toast as a `<button>`)
  - Rename `src/lib/toast.ts` → `src/lib/toast.tsx` for JSX in the dismiss control

- **Reasoning**
  After switching to Sileo (#293), the old bottom error pill duplicated toast feedback and could linger independently of the notification stack. Centralizing errors in toasts keeps one consistent surface for transient feedback.

- **Additional context**
  `setError("")` calls throughout the app remain valid — the new implementation no-ops on empty strings. Stable toast ids prevent duplicate git sync / space error toasts from stacking.

## Screenshots

_(Visual change — screenshots recommended: toast with dismiss control, git sync error toast, space open failure toast.)_

## Docs

Space-level errors no longer live in context state:

```ts
// SpaceContext — setError is now a toast helper, not React state
setError("Could not open space"); // → toast.error(..., { id: "glyph-space-error" })
setError(""); // no-op
```

Every toast title includes a dismiss control wired to `sileo.dismiss(id)`.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all space-level errors through dismissible toasts and removes the persistent bottom error banner. Unifies git sync failures into a single toast to prevent duplicates.

- **New Features**
  - Space and git sync errors now appear as top toasts with stable ids: `glyph-space-error` and `glyph-git-sync-error`.
  - Each toast includes a dismiss (✕) control in the title row.

- **Refactors**
  - Removed the bottom `appError` banner and `SpaceContext.error`; errors are no longer stored in context.
  - `SpaceContext.setError` now just shows a toast (empty strings no-op); deduplicated git sync error handling; renamed `src/lib/toast.ts` to `src/lib/toast.tsx` for the dismiss UI.

<sup>Written for commit 5c4ec92097ab82fb40793c76d7d6205ee5b32744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages are now shown as dismissible toast notifications instead of a persistent banner.
  * Git sync failures now surface more consistently through toasts.
* **UI Improvements**
  * Toast headers now include a built-in close control for easier dismissal.
  * Updated toast styling to better support the new header layout.
* **Chores**
  * Removed unused error-banner styling from the responsive app shell stylesheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->