### PR TITLE
Hover intent delay for navigation prefetching and TanStack Query option helpers

### DIFF
--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -27,8 +27,8 @@ import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { getDailyNotePath } from "../../lib/dailyNotes";
 import {
 	ACTIVITY_DOCS_PAGE_SIZE,
-	loadAllDocs,
-	loadAllDocsPage,
+	allDocsListQueryOptions,
+	allDocsPagesQueryOptions,
 	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import type {
@@ -236,19 +236,10 @@ function countUniqueNotes(days: ActivityDay[]): number {
 
 function useActivityTimelineData(dailyNotesFolder: string | null) {
 	const queryClient = useQueryClient();
-	const notesQuery = useInfiniteQuery({
-		queryKey: navigationQueryKeys.allDocsPages(null, ACTIVITY_DOCS_PAGE_SIZE),
-		queryFn: ({ pageParam }) => {
-			const offset = typeof pageParam === "number" ? pageParam : 0;
-			return loadAllDocsPage(null, offset, ACTIVITY_DOCS_PAGE_SIZE);
-		},
-		initialPageParam: 0,
-		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
-	});
-	const heatmapNotesQuery = useQuery({
-		queryKey: navigationQueryKeys.allDocsList(null),
-		queryFn: () => loadAllDocs(null),
-	});
+	const notesQuery = useInfiniteQuery(
+		allDocsPagesQueryOptions(null, ACTIVITY_DOCS_PAGE_SIZE),
+	);
+	const heatmapNotesQuery = useQuery(allDocsListQueryOptions(null));
 	const feedNotes = useMemo(
 		() => notesQuery.data?.pages.flatMap((page) => page.items) ?? [],
 		[notesQuery.data],

--- a/src/components/app/AllDocsCard.tsx
+++ b/src/components/app/AllDocsCard.tsx
@@ -1,5 +1,6 @@
 import { m } from "motion/react";
 import type { KeyboardEvent } from "react";
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import { prefetchNote } from "../../lib/navigationPrefetch";
 import type {
@@ -172,14 +173,19 @@ export function AllDocsCard({
 	onPrefetch,
 	onOpen,
 }: AllDocsCardProps) {
+	const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {
+		onPrefetch?.();
+	});
 	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
 		if (event.key === "Enter") {
 			event.preventDefault();
+			cancelHoverPrefetch();
 			onOpen();
 			return;
 		}
 		if (event.key === " ") {
 			event.preventDefault();
+			cancelHoverPrefetch();
 			onSelect();
 		}
 	};
@@ -195,8 +201,11 @@ export function AllDocsCard({
 			data-state={selected ? "selected" : undefined}
 			aria-label={`Select ${title}. Press Enter to open.`}
 			aria-pressed={selected}
-			onClick={onSelect}
-			onMouseEnter={onPrefetch}
+			onClick={() => {
+				cancelHoverPrefetch();
+				onSelect();
+			}}
+			{...hoverPrefetchProps}
 			onFocus={onPrefetch}
 			onDoubleClick={onOpen}
 			onKeyDown={handleKeyDown}

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -13,11 +13,12 @@ import { useReducedMotion } from "motion/react";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext } from "../../contexts";
 
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import {
 	ALL_DOCS_PAGE_SIZE,
-	loadAllDocsPage,
+	allDocsPagesQueryOptions,
 	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import type { AllDocsItem } from "../../lib/tauri";
@@ -88,18 +89,16 @@ export const AllDocsPane = memo(function AllDocsPane({
 	const { itemAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion() ?? false;
 	const paneRef = useRef<HTMLElement>(null);
+	const {
+		cancelHoverPrefetch: cancelActivityHoverPrefetch,
+		hoverPrefetchProps: activityHoverPrefetchProps,
+	} = useHoverPrefetch(onPrefetchActivity);
 	const [selectedNotePath, setSelectedNotePath] = useState<string | null>(null);
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const [paneWidth, setPaneWidth] = useState(0);
 	const queryClient = useQueryClient();
 	const notesQuery = useInfiniteQuery({
-		queryKey: navigationQueryKeys.allDocsPages(null),
-		queryFn: ({ pageParam }) => {
-			const offset = typeof pageParam === "number" ? pageParam : 0;
-			return loadAllDocsPage(null, offset);
-		},
-		initialPageParam: 0,
-		getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+		...allDocsPagesQueryOptions(null),
 		initialData: initialNotes
 			? {
 					pages: [
@@ -237,8 +236,11 @@ export const AllDocsPane = memo(function AllDocsPane({
 				<button
 					type="button"
 					className="allDocsHeaderAction"
-					onClick={onOpenActivity}
-					onMouseEnter={onPrefetchActivity}
+					onClick={() => {
+						cancelActivityHoverPrefetch();
+						onOpenActivity();
+					}}
+					{...activityHoverPrefetchProps}
 					onFocus={onPrefetchActivity}
 					title="Show activity"
 					aria-label="Show activity"

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -99,6 +99,8 @@ export const AllDocsPane = memo(function AllDocsPane({
 	const queryClient = useQueryClient();
 	const notesQuery = useInfiniteQuery({
 		...allDocsPagesQueryOptions(null),
+		// Prefetch keeps a 5-minute stale window; the pane should still refetch on open.
+		staleTime: 0,
 		initialData: initialNotes
 			? {
 					pages: [
@@ -113,6 +115,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 					pageParams: [0],
 				}
 			: undefined,
+		initialDataUpdatedAt: initialNotes ? 0 : undefined,
 	});
 	const notes = useMemo(
 		() => notesQuery.data?.pages.flatMap((page) => page.items) ?? [],

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -47,7 +47,6 @@ import {
 	invalidatePrefetchedNote,
 	invalidateTaskSummariesPrefetchForNote,
 	prefetchAllDocs,
-	prefetchAllDocsList,
 	prefetchDatabasesLanding,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
@@ -897,13 +896,11 @@ export function AppShell() {
 		} else {
 			void loadActivityTimelinePane();
 			void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
-			void prefetchAllDocsList(null);
 		}
 	}, [classicAllNotesByDefault]);
 	const prefetchActivityTab = useCallback(() => {
 		void loadActivityTimelinePane();
 		void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
-		void prefetchAllDocsList(null);
 	}, []);
 	const openGettingStarted = useCallback(() => {
 		setShowGettingStartedRequest((prev) => prev + 1);

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -37,7 +37,6 @@ import {
 	getPrefetchedDatabaseDocument,
 	getPrefetchedNote,
 	prefetchAllDocs,
-	prefetchAllDocsList,
 	prefetchDatabasesLanding,
 	prefetchNote,
 } from "../../lib/navigationPrefetch";
@@ -679,7 +678,6 @@ export const MainContent = memo(function MainContent({
 			if (target === ACTIVITY_TIMELINE_TAB_ID) {
 				void loadActivityTimelinePane();
 				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
-				void prefetchAllDocsList(null);
 				return;
 			}
 			if (target === DATABASES_TAB_ID) {

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -13,14 +13,14 @@ import { useQuery } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useFileTreeSortMode } from "../../hooks/useFileTreeSortMode";
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { FILE_TREE_START_RENAME_EVENT } from "../../lib/appEvents";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { scheduleScrollFileTreePathIntoView } from "../../lib/fileTreeScroll";
 import {
+	allDocsCountQueryOptions,
 	formatAllDocsCountLabel,
-	loadAllDocsCount,
-	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import {
 	FILE_TREE_SORT_OPTIONS,
@@ -111,10 +111,7 @@ function folioTreeRootEntries(
 }
 
 function AllNotesCountBadge() {
-	const countQuery = useQuery({
-		queryKey: navigationQueryKeys.allDocsCount(),
-		queryFn: () => loadAllDocsCount(),
-	});
+	const countQuery = useQuery(allDocsCountQueryOptions());
 	const label = formatAllDocsCountLabel(countQuery.data ?? 0);
 	if (!label) return null;
 	return <span className="sidebarQuickActionCount">{label}</span>;
@@ -188,6 +185,16 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 	});
 	const newNoteShortcut = getBinding("new-note");
+	const {
+		cancelHoverPrefetch: cancelAllDocsHoverPrefetch,
+		hoverPrefetchProps: allDocsHoverPrefetchProps,
+	} = useHoverPrefetch(onPrefetchAllDocs);
+	const {
+		cancelHoverPrefetch: cancelDatabasesHoverPrefetch,
+		hoverPrefetchProps: databasesHoverPrefetchProps,
+	} = useHoverPrefetch(() => {
+		onPrefetchDatabases();
+	});
 	const activeFolioFolder =
 		folioScope.kind === "folder" ? folioScope.folderPrefix : null;
 	const spaceLabel = spacePath ? formatSpaceLabel(spacePath) : "Glyph";
@@ -411,8 +418,11 @@ export const SidebarContent = memo(function SidebarContent({
 							aria-current={
 								activeTopSection === "all-notes" ? "page" : undefined
 							}
-							onClick={handleOpenAllNotes}
-							onMouseEnter={onPrefetchAllDocs}
+							onClick={() => {
+								cancelAllDocsHoverPrefetch();
+								handleOpenAllNotes();
+							}}
+							{...allDocsHoverPrefetchProps}
 							onFocus={onPrefetchAllDocs}
 							title="Open All Notes"
 						>
@@ -435,9 +445,10 @@ export const SidebarContent = memo(function SidebarContent({
 								activeTopSection === "databases" ? "page" : undefined
 							}
 							onClick={() => {
+								cancelDatabasesHoverPrefetch();
 								onOpenDatabases();
 							}}
-							onMouseEnter={() => onPrefetchDatabases()}
+							{...databasesHoverPrefetchProps}
 							onFocus={() => onPrefetchDatabases()}
 							title="Open Collections"
 						>

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -7,6 +7,7 @@ import {
 import { useSortable } from "@dnd-kit/react/sortable";
 import { memo, useCallback, useRef } from "react";
 import type { MouseEvent, MutableRefObject } from "react";
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
 import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
@@ -258,10 +259,14 @@ const TabItem = memo(function TabItem({
 		data: { tabId: tab.id },
 		transition: { duration: 160, easing: "ease" },
 	});
+	const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {
+		onPrefetchTab(tab.target);
+	});
 	const handleSelect = useCallback(() => {
+		cancelHoverPrefetch();
 		if (suppressClickRef.current) return;
 		onSelectTab(tab.id);
-	}, [onSelectTab, suppressClickRef, tab.id]);
+	}, [cancelHoverPrefetch, onSelectTab, suppressClickRef, tab.id]);
 	const handleClose = useCallback(
 		(event: MouseEvent<HTMLButtonElement>) => {
 			event.stopPropagation();
@@ -304,7 +309,7 @@ const TabItem = memo(function TabItem({
 				type="button"
 				className={`mainTab ${isActive ? "is-active" : ""}`}
 				onClick={handleSelect}
-				onMouseEnter={() => onPrefetchTab(tab.target)}
+				{...hoverPrefetchProps}
 				onFocus={() => onPrefetchTab(tab.target)}
 				title={title}
 				onDoubleClick={handleDoubleClick}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -5,6 +5,7 @@ import { m } from "motion/react";
 import type { KeyboardEvent, MouseEvent, MutableRefObject } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSpace } from "../../contexts";
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import { invoke } from "../../lib/tauri";
@@ -163,6 +164,9 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 		entry.rel_path,
 		entry.is_markdown,
 	);
+	const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {
+		onPrefetchFile?.(entry.rel_path);
+	});
 	const { stem: fileStem, ext: fileExt } = splitEditableFileName(entry.name);
 	const isMd = fileExt.toLowerCase() === ".md";
 	const displayStem =
@@ -308,11 +312,12 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 							previewText ? "fileTreeRow fileTreePreviewRow" : "fileTreeRow"
 						}
 						onClick={() => {
+							cancelHoverPrefetch();
 							if (onMoveClickSuppressRef.current) return;
 							onOpenFile(entry.rel_path);
 						}}
 						onContextMenu={handleContextMenu}
-						onMouseEnter={() => onPrefetchFile?.(entry.rel_path)}
+						{...hoverPrefetchProps}
 						onFocus={() => onPrefetchFile?.(entry.rel_path)}
 						onKeyDown={handleKeyDown}
 						style={rowStyle}

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -11,6 +11,7 @@ import {
 	useState,
 } from "react";
 import { useSpace } from "../../contexts";
+import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
@@ -451,6 +452,9 @@ export const FolioNoteListItem = memo(
 					className="folioNoteTaskProgress"
 				/>
 			) : null;
+		const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {
+			if (isMarkdown) onPrefetch(note.note_path);
+		});
 		const handleRevealInFinder = useCallback(async () => {
 			try {
 				await invoke("space_reveal_path", { path: note.note_path });
@@ -633,6 +637,7 @@ export const FolioNoteListItem = memo(
 						data-folio-note-path={note.note_path}
 						aria-current={selected ? "page" : undefined}
 						onClick={(event) => {
+							cancelHoverPrefetch();
 							if (event.metaKey || event.ctrlKey) {
 								onOpenInNewTab(note.note_path);
 								return;
@@ -642,11 +647,10 @@ export const FolioNoteListItem = memo(
 						onContextMenu={handleContextMenu}
 						onDoubleClick={() => onOpenInNewTab(note.note_path)}
 						onAuxClick={(event) => {
+							cancelHoverPrefetch();
 							if (event.button === 1) onOpenInNewTab(note.note_path);
 						}}
-						onMouseEnter={() => {
-							if (isMarkdown) onPrefetch(note.note_path);
-						}}
+						{...hoverPrefetchProps}
 						onFocus={() => {
 							onFocus();
 							if (isMarkdown) onPrefetch(note.note_path);

--- a/src/components/folio/useFolioNotes.ts
+++ b/src/components/folio/useFolioNotes.ts
@@ -1,6 +1,9 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { loadAllDocs, navigationQueryKeys } from "../../lib/navigationPrefetch";
+import {
+	allDocsListQueryOptions,
+	navigationQueryKeys,
+} from "../../lib/navigationPrefetch";
 import { loadSettings } from "../../lib/settings";
 import type { AllDocsItem, FsEntry, FsEntryList } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
@@ -166,10 +169,7 @@ export function useFolioNotes(scope: FolioScope) {
 		}
 	});
 
-	const query = useQuery({
-		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
-		queryFn: () => loadAllDocs(folderPrefix),
-	});
+	const query = useQuery(allDocsListQueryOptions(folderPrefix));
 	const filesQuery = useQuery({
 		queryKey: folioFilesQueryKey(folderPrefix),
 		queryFn: () => listNonMarkdownFiles(folderPrefix),

--- a/src/hooks/useHoverPrefetch.ts
+++ b/src/hooks/useHoverPrefetch.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useRef } from "react";
+
+// Hover intent delay filters pointer sweeps without delaying click or focus loads.
+const HOVER_PREFETCH_DELAY_MS = 80;
+
+export function useHoverPrefetch(run: () => void) {
+	const runRef = useRef(run);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	runRef.current = run;
+
+	const cancelHoverPrefetch = useCallback(() => {
+		if (!timerRef.current) return;
+		clearTimeout(timerRef.current);
+		timerRef.current = null;
+	}, []);
+
+	const onMouseEnter = useCallback(() => {
+		cancelHoverPrefetch();
+		timerRef.current = setTimeout(() => {
+			timerRef.current = null;
+			runRef.current();
+		}, HOVER_PREFETCH_DELAY_MS);
+	}, [cancelHoverPrefetch]);
+
+	useEffect(() => cancelHoverPrefetch, [cancelHoverPrefetch]);
+
+	return {
+		hoverPrefetchProps: {
+			onMouseEnter,
+			onMouseLeave: cancelHoverPrefetch,
+		},
+		cancelHoverPrefetch,
+	};
+}

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -18,6 +18,11 @@ import type {
 } from "./tauri";
 import { invoke } from "./tauri";
 
+// Stale time controls refetching; GC time controls memory retention.
+// Hover-prefetched note bodies may be evicted sooner when unused.
+const NOTE_PREFETCH_GC_TIME_MS = 60 * 1000;
+const NAVIGATION_STALE_TIME_MS = 5 * 60 * 1000;
+
 const normalizeAllDocsFolder = (folderPrefix?: string | null) => {
 	const normalized = folderPrefix
 		?.trim()
@@ -107,6 +112,8 @@ export function prefetchNote(path: string) {
 	void queryClient.prefetchQuery({
 		queryKey: navigationQueryKeys.note(normalized),
 		queryFn: () => fetchNote(normalized),
+		gcTime: NOTE_PREFETCH_GC_TIME_MS,
+		staleTime: NAVIGATION_STALE_TIME_MS,
 	});
 }
 
@@ -131,6 +138,7 @@ export function prefetchDatabaseSummaries() {
 	return queryClient.fetchQuery({
 		queryKey: navigationQueryKeys.databaseSummaries(),
 		queryFn: () => invoke("databases_list"),
+		staleTime: NAVIGATION_STALE_TIME_MS,
 	});
 }
 
@@ -156,6 +164,7 @@ export function prefetchDatabaseDocument(databaseId: string) {
 	return queryClient.fetchQuery({
 		queryKey: navigationQueryKeys.databaseDocument(normalized),
 		queryFn: () => invoke("databases_get", { database_id: normalized }),
+		staleTime: NAVIGATION_STALE_TIME_MS,
 	});
 }
 
@@ -201,13 +210,23 @@ export function invalidateDatabasePrefetch(databaseId?: string | null) {
 export async function prefetchDatabasesLanding(
 	initialDatabaseId?: string | null,
 ) {
-	const summaries = await prefetchDatabaseSummaries();
+	const storedId = readStoredSelectedDatabaseId();
+	const candidateId = initialDatabaseId ?? storedId;
+	const summariesPromise = prefetchDatabaseSummaries();
+	const candidateDocumentPromise = candidateId
+		? prefetchDatabaseDocument(candidateId).catch(() => null)
+		: null;
+	const summaries = await summariesPromise;
 	const databaseId = resolveSelectedDatabaseId(summaries, {
 		current: null,
 		openRequestId: initialDatabaseId ?? null,
-		storedId: readStoredSelectedDatabaseId(),
+		storedId,
 	});
 	if (!databaseId) return;
+	if (databaseId === candidateId && candidateDocumentPromise) {
+		const document = await candidateDocumentPromise;
+		if (document) return;
+	}
 	await prefetchDatabaseDocument(databaseId);
 }
 
@@ -270,27 +289,50 @@ export async function loadAllDocs(folderPrefix?: string | null) {
 	return pages;
 }
 
-export function prefetchAllDocs(
+export function allDocsPagesQueryOptions(
 	folderPrefix?: string | null,
 	pageSize = ALL_DOCS_PAGE_SIZE,
 ) {
-	return queryClient.prefetchInfiniteQuery({
+	return {
 		queryKey: navigationQueryKeys.allDocsPages(folderPrefix, pageSize),
-		queryFn: ({ pageParam }) => {
+		queryFn: ({ pageParam }: { pageParam: unknown }) => {
 			const offset = typeof pageParam === "number" ? pageParam : 0;
 			return loadAllDocsPage(folderPrefix, offset, pageSize);
 		},
 		initialPageParam: 0,
 		getNextPageParam: (lastPage: AllDocsPage) =>
 			lastPage.nextOffset ?? undefined,
-	});
+		staleTime: NAVIGATION_STALE_TIME_MS,
+	};
+}
+
+export function allDocsListQueryOptions(folderPrefix?: string | null) {
+	return {
+		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
+		queryFn: () => loadAllDocs(folderPrefix),
+		staleTime: NAVIGATION_STALE_TIME_MS,
+	};
+}
+
+export function allDocsCountQueryOptions(folderPrefix?: string | null) {
+	return {
+		queryKey: navigationQueryKeys.allDocsCount(folderPrefix),
+		queryFn: () => loadAllDocsCount(folderPrefix),
+		staleTime: NAVIGATION_STALE_TIME_MS,
+	};
+}
+
+export function prefetchAllDocs(
+	folderPrefix?: string | null,
+	pageSize = ALL_DOCS_PAGE_SIZE,
+) {
+	return queryClient.prefetchInfiniteQuery(
+		allDocsPagesQueryOptions(folderPrefix, pageSize),
+	);
 }
 
 export function prefetchAllDocsList(folderPrefix?: string | null) {
-	return queryClient.prefetchQuery({
-		queryKey: navigationQueryKeys.allDocsList(folderPrefix),
-		queryFn: () => loadAllDocs(folderPrefix),
-	});
+	return queryClient.prefetchQuery(allDocsListQueryOptions(folderPrefix));
 }
 
 export function getPrefetchedAllDocs(

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -18,6 +18,7 @@ import type {
 } from "./tauri";
 import { invoke } from "./tauri";
 
+const NOTE_PREFETCH_GC_TIME_MS = 60 * 1000;
 const NAVIGATION_STALE_TIME_MS = 5 * 60 * 1000;
 
 const normalizeAllDocsFolder = (folderPrefix?: string | null) => {
@@ -109,7 +110,7 @@ export function prefetchNote(path: string) {
 	void queryClient.prefetchQuery({
 		queryKey: navigationQueryKeys.note(normalized),
 		queryFn: () => fetchNote(normalized),
-		gcTime: NAVIGATION_STALE_TIME_MS,
+		gcTime: NOTE_PREFETCH_GC_TIME_MS,
 		staleTime: NAVIGATION_STALE_TIME_MS,
 	});
 }
@@ -566,6 +567,9 @@ export function optimisticallyRemoveAllDocsPath(
 	const normalizedPath = normalizeAllDocsPath(path);
 	if (!normalizedPath) return;
 	const removedMarkdownPaths = new Set<string>();
+	if (!recursive && normalizedPath.toLowerCase().endsWith(".md")) {
+		removedMarkdownPaths.add(normalizedPath);
+	}
 	updateAllDocsCaches((current) =>
 		current.filter((note) => {
 			const notePath = normalizeAllDocsPath(note.note_path);

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -18,9 +18,6 @@ import type {
 } from "./tauri";
 import { invoke } from "./tauri";
 
-// Stale time controls refetching; GC time controls memory retention.
-// Hover-prefetched note bodies may be evicted sooner when unused.
-const NOTE_PREFETCH_GC_TIME_MS = 60 * 1000;
 const NAVIGATION_STALE_TIME_MS = 5 * 60 * 1000;
 
 const normalizeAllDocsFolder = (folderPrefix?: string | null) => {
@@ -112,7 +109,7 @@ export function prefetchNote(path: string) {
 	void queryClient.prefetchQuery({
 		queryKey: navigationQueryKeys.note(normalized),
 		queryFn: () => fetchNote(normalized),
-		gcTime: NOTE_PREFETCH_GC_TIME_MS,
+		gcTime: NAVIGATION_STALE_TIME_MS,
 		staleTime: NAVIGATION_STALE_TIME_MS,
 	});
 }
@@ -383,6 +380,35 @@ function rebuildAllDocsPages(
 	};
 }
 
+function updateAllDocsCountCaches(
+	updater: (current: number, folderKey: string) => number,
+) {
+	const queries = queryClient
+		.getQueryCache()
+		.findAll({ queryKey: [...navigationQueryKeys.allDocs(), "count"] });
+	for (const query of queries) {
+		if (!Array.isArray(query.queryKey) || query.queryKey.length !== 4) {
+			continue;
+		}
+		const folderKey = normalizeAllDocsFolder(String(query.queryKey[3] ?? ""));
+		const current = queryClient.getQueryData<number>(query.queryKey);
+		if (current === undefined) continue;
+		queryClient.setQueryData<number>(
+			query.queryKey,
+			updater(current, folderKey),
+		);
+	}
+}
+
+function adjustAllDocsCount(path: string, delta: number) {
+	const normalizedPath = normalizeAllDocsPath(path);
+	if (!normalizedPath.toLowerCase().endsWith(".md")) return;
+	updateAllDocsCountCaches((current, folderKey) => {
+		if (!allDocsFolderContainsPath(folderKey, normalizedPath)) return current;
+		return Math.max(0, current + delta);
+	});
+}
+
 function updateAllDocsCaches(
 	updater: (current: AllDocsItem[], folderKey: string) => AllDocsItem[],
 ) {
@@ -477,6 +503,7 @@ export function optimisticallyAddAllDocsNote(args: {
 		: null;
 	const preview = parseNotePreview(normalizedPath, args.text ?? "");
 	const now = new Date().toISOString();
+	const alreadyCached = findCachedAllDocsItem(normalizedPath) !== null;
 	upsertAllDocsPrefetchItem({
 		note_path: normalizedPath,
 		title:
@@ -491,6 +518,9 @@ export function optimisticallyAddAllDocsNote(args: {
 		tags: source?.tags ?? [],
 		people: source?.people ?? [],
 	});
+	if (!alreadyCached) {
+		adjustAllDocsCount(normalizedPath, 1);
+	}
 }
 
 export function optimisticallyRenameAllDocsPath(
@@ -535,15 +565,22 @@ export function optimisticallyRemoveAllDocsPath(
 ) {
 	const normalizedPath = normalizeAllDocsPath(path);
 	if (!normalizedPath) return;
+	const removedMarkdownPaths = new Set<string>();
 	updateAllDocsCaches((current) =>
 		current.filter((note) => {
 			const notePath = normalizeAllDocsPath(note.note_path);
-			return (
-				notePath !== normalizedPath &&
-				(!recursive || !notePath.startsWith(`${normalizedPath}/`))
-			);
+			const shouldRemove =
+				notePath === normalizedPath ||
+				(recursive && notePath.startsWith(`${normalizedPath}/`));
+			if (shouldRemove && notePath.toLowerCase().endsWith(".md")) {
+				removedMarkdownPaths.add(notePath);
+			}
+			return !shouldRemove;
 		}),
 	);
+	for (const removedPath of removedMarkdownPaths) {
+		adjustAllDocsCount(removedPath, -1);
+	}
 }
 
 export function invalidateAllDocsPrefetch(folderPrefix?: string | null) {


### PR DESCRIPTION
Closes None — no open issue tracks this work.

## Description

Improves navigation prefetching with hover intent delay, extracted query option objects, and stale time tuning.

**Summary of changes:**

- **New `useHoverPrefetch` hook** (`src/hooks/useHoverPrefetch.ts`): Adds an 80ms hover intent delay before firing prefetch callbacks, preventing unnecessary prefetches during pointer sweeps. Cancels on click, mouse leave, and keyboard activation.
- **Extracted `allDocsPagesQueryOptions` / `allDocsListQueryOptions` / `allDocsCountQueryOptions`** in `navigationPrefetch.ts`: Provides reusable TanStack Query option objects so consumers (AllDocsPane, ActivityTimelinePane, useFolioNotes, SidebarContent) use consistent stale times and query configs instead of inlining query definitions.
- **Stale time and GC time tuning**: Applied `NAVIGATION_STALE_TIME_MS` (5 min) and `NOTE_PREFETCH_GC_TIME_MS` (1 min) to prefetched navigation data and note bodies respectively.
- **Smarter databases landing prefetch**: Parallelizes fetching summaries and the candidate document, skipping redundant work when the candidate matches the resolved database ID.
- **Applied `useHoverPrefetch`** across: file tree items, folio note list items, tab bar items, sidebar quick actions (All Notes, Databases), All Docs cards, and the Activity pane activity button — replacing raw `onMouseEnter` with the intent-delayed variant and cancelling on click handlers.
- **Removed stale `prefetchAllDocsList` calls** from `AppShell` and `MainContent` that were already handled via the query cache and tab prefetching.

**Reasoning:** Hover prefetching without an intent delay triggered redundant prefetches when users swept the pointer across navigation items. Extracting query option objects (a pattern already used elsewhere in the codebase) centralizes stale time configs and reduces duplication. The databases landing flow was doing serial fetches when a parallel approach is faster and can skip unnecessary document loads.

**Additional context:**
- The `useHoverPrefetch` hook is intentionally scoped to hover-based prefetch triggers; focus-based prefetching (keyboard nav) is left as an immediate call since there is no sweep problem there.
- Stale times were chosen to match the expected lifetime of navigation data — users rarely need real-time counts/lists in the sidebar, but note bodies should GC sooner to keep memory pressure low.

## Screenshots

No visual changes.

## Docs

### `useHoverPrefetch(run)`

A hook that delays the `run` callback by 80ms on mouse enter and cancels on mouse leave or click.

```ts
const { hoverPrefetchProps, cancelHoverPrefetch } = useHoverPrefetch(() => {
  prefetchNote(path);
});
// Spread hoverPrefetchProps ({ onMouseEnter, onMouseLeave }) on the element
// Call cancelHoverPrefetch() in onClick handlers
```

### Query option helpers

Export `allDocsPagesQueryOptions`, `allDocsListQueryOptions`, `allDocsCountQueryOptions` instead of inlining query options:

```ts
// Before
const query = useQuery({
  queryKey: navigationQueryKeys.allDocsList(folderPrefix),
  queryFn: () => loadAllDocs(folderPrefix),
});

// After
const query = useQuery(allDocsListQueryOptions(folderPrefix));
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an 80ms hover-intent delay for navigation prefetching, centralize `@tanstack/react-query` options for All Docs, and run databases landing prefetch in parallel to lower latency. Note prefetch now uses a 5m stale window with a 1m GC, and the All Notes count stays correct on deletes.

- **New Features**
  - Added `useHoverPrefetch` (80ms delay; cancels on mouse leave/click; focus stays instant) and applied it to file tree items, folio notes, tab bar, All Docs cards/header, sidebar quick actions, and the Activity button.
  - Extracted `allDocsPagesQueryOptions`, `allDocsListQueryOptions`, and `allDocsCountQueryOptions` with shared configs (`staleTime` 5m); hover-prefetched note bodies use `staleTime` 5m and `gcTime` 1m.

- **Refactors**
  - Databases landing prefetch parallelizes summaries and the candidate document and skips redundant fetches when IDs match.
  - Adopted the new option helpers in ActivityTimelinePane, AllDocsPane, useFolioNotes, and SidebarContent; removed duplicate `prefetchAllDocsList` calls now covered by the query cache.
  - All Docs pane overrides `staleTime` to 0 so it refetches on open while seeding from cached data.
  - All Notes count badge updates on optimistic add/delete, including when list data isn’t cached.

<sup>Written for commit bf44a66a3aad9956a861707ab36c99a42847ab44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother hover-based preloading across tabs, notes, files, and quick actions for faster navigation.

* **Bug Fixes**
  * Reduced unnecessary loading and duplicate prefetches when switching sections or opening items.
  * Improved click behavior so active actions cancel pending hover loads before opening content.

* **Refactor**
  * Streamlined data fetching for activity, all notes, and counts to use shared loading patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->