### PR TITLE
Virtualize file tree and tune list overscan for large spaces

### DIFF
--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -299,7 +299,7 @@ export function DatabaseTable({
 				: DATABASE_TABLE_ROW_HEIGHT,
 		getScrollElement: () => tableContainerRef.current,
 		getItemKey: (index) => displayItems[index]?.id ?? index,
-		overscan: 8,
+		overscan: 4,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 	useVirtualLoadMore({

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -7,10 +7,12 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m } from "motion/react";
 import type {
+	CSSProperties,
 	KeyboardEvent,
 	MouseEvent,
 	MutableRefObject,
 	ReactNode,
+	Ref,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSpace } from "../../contexts";
@@ -112,6 +114,8 @@ interface FileTreeDirItemProps {
 	onOpenAppearancePicker: () => void;
 	fileCount?: number | null;
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
+	virtualRowRef?: Ref<HTMLLIElement>;
+	virtualRowStyle?: CSSProperties;
 }
 
 export const FileTreeDirItem = memo(function FileTreeDirItem({
@@ -135,6 +139,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	onOpenAppearancePicker,
 	fileCount,
 	onMoveClickSuppressRef,
+	virtualRowRef,
+	virtualRowStyle,
 }: FileTreeDirItemProps) {
 	const { spacePath } = useSpace();
 	const customColor =
@@ -218,7 +224,11 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	);
 
 	return (
-		<li className={isActive ? "fileTreeItem active" : "fileTreeItem"}>
+		<li
+			ref={virtualRowRef}
+			className={isActive ? "fileTreeItem active" : "fileTreeItem"}
+			style={virtualRowStyle}
+		>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (
 					<div className="fileTreeRow" style={rowStyle}>
@@ -331,7 +341,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 				)}
 			</div>
 			<AnimatePresence>
-				{isExpanded ? (
+				{isExpanded && children ? (
 					<m.div
 						ref={childrenDroppableRef}
 						className="fileTreeChildren"

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -5,13 +5,12 @@ import {
 	Folder03Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { AnimatePresence, m } from "motion/react";
+import { m } from "motion/react";
 import type {
 	CSSProperties,
 	KeyboardEvent,
 	MouseEvent,
 	MutableRefObject,
-	ReactNode,
 	Ref,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
@@ -99,7 +98,6 @@ interface FileTreeDirItemProps {
 	isExpanded: boolean;
 	isActive: boolean;
 	isRenaming: boolean;
-	children?: ReactNode;
 	onToggleDir: (dirPath: string) => void;
 	onSelectDir: (dirPath: string) => void;
 	onStartRename: () => void;
@@ -116,6 +114,7 @@ interface FileTreeDirItemProps {
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
 	virtualRowRef?: Ref<HTMLLIElement>;
 	virtualRowStyle?: CSSProperties;
+	virtualRowIndex?: number;
 }
 
 export const FileTreeDirItem = memo(function FileTreeDirItem({
@@ -124,7 +123,6 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	isExpanded,
 	isActive,
 	isRenaming,
-	children,
 	onToggleDir,
 	onSelectDir,
 	onStartRename,
@@ -141,6 +139,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	onMoveClickSuppressRef,
 	virtualRowRef,
 	virtualRowStyle,
+	virtualRowIndex,
 }: FileTreeDirItemProps) {
 	const { spacePath } = useSpace();
 	const customColor =
@@ -162,14 +161,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			kind: "dir",
 		},
 	});
-	const {
-		rowDroppableRef,
-		isRowDropTarget,
-		childrenDroppableRef,
-		isChildrenDropTarget,
-	} = useFileTreeDirDropTargets({
+	const { rowDroppableRef, isRowDropTarget } = useFileTreeDirDropTargets({
 		relPath: entry.rel_path,
-		isExpanded,
 	});
 	const setDragHandleRef = useCallback(
 		(element: HTMLButtonElement | null) => {
@@ -228,6 +221,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			ref={virtualRowRef}
 			className={isActive ? "fileTreeItem active" : "fileTreeItem"}
 			style={virtualRowStyle}
+			data-index={virtualRowIndex}
 		>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (
@@ -340,22 +334,6 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					</>
 				)}
 			</div>
-			<AnimatePresence>
-				{isExpanded && children ? (
-					<m.div
-						ref={childrenDroppableRef}
-						className="fileTreeChildren"
-						initial={{ height: 0, opacity: 0 }}
-						animate={{ height: "auto", opacity: 1 }}
-						exit={{ height: 0, opacity: 0 }}
-						transition={springTransition}
-						style={{ overflow: "hidden" }}
-						data-drop-target={isChildrenDropTarget ? "true" : undefined}
-					>
-						{children}
-					</m.div>
-				) : null}
-			</AnimatePresence>
 		</li>
 	);
 });

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -135,6 +135,7 @@ interface FileTreeFileItemProps {
 	previewText?: string | null;
 	virtualRowRef?: Ref<HTMLLIElement>;
 	virtualRowStyle?: CSSProperties;
+	virtualRowIndex?: number;
 }
 
 export const FileTreeFileItem = memo(function FileTreeFileItem({
@@ -163,6 +164,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	previewText = null,
 	virtualRowRef,
 	virtualRowStyle,
+	virtualRowIndex,
 }: FileTreeFileItemProps) {
 	const { spacePath } = useSpace();
 	const customColor =
@@ -299,6 +301,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			ref={virtualRowRef}
 			className={isActive ? "fileTreeItem active" : "fileTreeItem"}
 			style={virtualRowStyle}
+			data-index={virtualRowIndex}
 		>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -2,7 +2,13 @@ import { useDraggable } from "@dnd-kit/react";
 import { StarIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
-import type { KeyboardEvent, MouseEvent, MutableRefObject } from "react";
+import type {
+	CSSProperties,
+	KeyboardEvent,
+	MouseEvent,
+	MutableRefObject,
+	Ref,
+} from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSpace } from "../../contexts";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
@@ -127,6 +133,8 @@ interface FileTreeFileItemProps {
 	) => void;
 	taskSummary?: NoteTaskSummary | null;
 	previewText?: string | null;
+	virtualRowRef?: Ref<HTMLLIElement>;
+	virtualRowStyle?: CSSProperties;
 }
 
 export const FileTreeFileItem = memo(function FileTreeFileItem({
@@ -153,6 +161,8 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	onArrowNavigate,
 	taskSummary = null,
 	previewText = null,
+	virtualRowRef,
+	virtualRowStyle,
 }: FileTreeFileItemProps) {
 	const { spacePath } = useSpace();
 	const customColor =
@@ -285,7 +295,11 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	);
 
 	return (
-		<li className={isActive ? "fileTreeItem active" : "fileTreeItem"}>
+		<li
+			ref={virtualRowRef}
+			className={isActive ? "fileTreeItem active" : "fileTreeItem"}
+			style={virtualRowStyle}
+		>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (
 					<div

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -7,6 +7,40 @@ import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FileTreePane } from "./FileTreePane";
 
+vi.mock("@tanstack/react-virtual", () => ({
+	useVirtualizer: ({
+		count,
+		estimateSize,
+		getItemKey,
+	}: {
+		count: number;
+		estimateSize: (index: number) => number;
+		getItemKey: (index: number) => string | number;
+	}) => {
+		const starts = Array.from({ length: count }, (_, index) =>
+			Array.from({ length: index }, (__, previousIndex) =>
+				estimateSize(previousIndex),
+			).reduce((total, size) => total + size, 0),
+		);
+		return {
+			getVirtualItems: () =>
+				starts.map((start, index) => ({
+					index,
+					key: getItemKey(index),
+					start,
+				})),
+			getTotalSize: () =>
+				Array.from({ length: count }, (_, index) => estimateSize(index)).reduce(
+					(total, size) => total + size,
+					0,
+				),
+			measureElement: () => {},
+			scrollToIndex: () => {},
+			options: { scrollMargin: 0 },
+		};
+	},
+}));
+
 const {
 	invokeMock,
 	loadSettingsMock,

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -3,9 +3,11 @@ import {
 	type DragEndEvent,
 	useDroppable,
 } from "@dnd-kit/react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
 import { m } from "motion/react";
 import {
+	type CSSProperties,
 	type KeyboardEvent,
 	type MutableRefObject,
 	type ReactNode,
@@ -85,6 +87,8 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const MARKDOWN_PREVIEW_MAX_BYTES = 4096;
 const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
+const FILE_TREE_ROW_ESTIMATE = 32;
+const FILE_TREE_PREVIEW_ROW_ESTIMATE = 52;
 
 interface AppearancePickerTarget {
 	entry: FsEntry;
@@ -284,15 +288,57 @@ interface TreeEntriesProps {
 	pinnedFiles: string[];
 	onTogglePinnedFile: (path: string) => Promise<void>;
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
-	onArrowNavigate: (
-		path: string,
-		direction: -1 | 1,
-		currentTarget: HTMLElement,
-	) => void;
 	taskSummariesByPath?: Record<string, NoteTaskSummary>;
 	showFilePreviews?: boolean;
 	filePreviewsByPath?: Record<string, string | null | undefined>;
 	sortMode: FileTreeSortMode;
+}
+
+interface VirtualFileTreeRow {
+	id: string;
+	entry: FsEntry;
+	depth: number;
+}
+
+function flattenVisibleFileTreeRows({
+	entries,
+	parentDepth,
+	childrenByDir,
+	expandedDirs,
+	showNonMarkdownFiles,
+	sortMode,
+}: Pick<
+	TreeEntriesProps,
+	| "entries"
+	| "parentDepth"
+	| "childrenByDir"
+	| "expandedDirs"
+	| "showNonMarkdownFiles"
+	| "sortMode"
+>): VirtualFileTreeRow[] {
+	const rows: VirtualFileTreeRow[] = [];
+	const walk = (currentEntries: FsEntry[], currentParentDepth: number) => {
+		const visibleEntries = sortedVisibleFileTreeEntries(
+			currentEntries,
+			showNonMarkdownFiles,
+			sortMode,
+		);
+		for (const entry of visibleEntries) {
+			const depth = currentParentDepth + 1;
+			rows.push({
+				id:
+					entry.rel_path.trim() ||
+					`${entry.kind}:${entry.name.trim()}:${depth}`,
+				entry,
+				depth,
+			});
+			if (entry.kind !== "dir" || !expandedDirs.has(entry.rel_path)) continue;
+			const childEntries = childrenByDir[entry.rel_path];
+			if (childEntries) walk(childEntries, depth);
+		}
+	};
+	walk(entries, parentDepth);
+	return rows;
 }
 
 function TreeEntries({
@@ -325,39 +371,124 @@ function TreeEntries({
 	pinnedFiles,
 	onTogglePinnedFile,
 	onMoveClickSuppressRef,
-	onArrowNavigate,
 	taskSummariesByPath = {},
 	showFilePreviews = false,
 	filePreviewsByPath = {},
 	sortMode,
 }: TreeEntriesProps) {
-	const visibleEntries = useMemo(
-		() => sortedVisibleFileTreeEntries(entries, showNonMarkdownFiles, sortMode),
-		[entries, showNonMarkdownFiles, sortMode],
+	const virtualRows = useMemo(
+		() =>
+			flattenVisibleFileTreeRows({
+				entries,
+				parentDepth,
+				childrenByDir,
+				expandedDirs,
+				showNonMarkdownFiles,
+				sortMode,
+			}),
+		[
+			childrenByDir,
+			entries,
+			expandedDirs,
+			parentDepth,
+			showNonMarkdownFiles,
+			sortMode,
+		],
 	);
-	if (visibleEntries.length === 0) return null;
+	const [listElement, setListElement] = useState<HTMLUListElement | null>(null);
+	const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+	const listRef = useCallback((element: HTMLUListElement | null) => {
+		setListElement(element);
+		setScrollElement(
+			element?.closest<HTMLElement>(".sidebarSectionContent") ??
+				element?.parentElement ??
+				null,
+		);
+	}, []);
+	const rowVirtualizer = useVirtualizer<HTMLElement, HTMLLIElement>({
+		count: virtualRows.length,
+		estimateSize: (index) => {
+			const row = virtualRows[index];
+			if (!row) return FILE_TREE_ROW_ESTIMATE;
+			return showFilePreviews &&
+				row.entry.kind === "file" &&
+				row.entry.is_markdown
+				? FILE_TREE_PREVIEW_ROW_ESTIMATE
+				: FILE_TREE_ROW_ESTIMATE;
+		},
+		getScrollElement: () => scrollElement,
+		getItemKey: (index) => virtualRows[index]?.id ?? index,
+		overscan: 4,
+		scrollMargin: listElement?.offsetTop ?? 0,
+	});
+	const virtualItems = rowVirtualizer.getVirtualItems();
+	const handleVirtualArrowNavigate = useCallback(
+		(path: string, direction: -1 | 1, currentTarget: HTMLElement) => {
+			const currentIndex = virtualRows.findIndex(
+				(row) => row.entry.kind === "file" && row.entry.rel_path === path,
+			);
+			if (currentIndex === -1) return;
+			for (
+				let nextIndex = currentIndex + direction;
+				nextIndex >= 0 && nextIndex < virtualRows.length;
+				nextIndex += direction
+			) {
+				const nextRow = virtualRows[nextIndex];
+				if (!nextRow || nextRow.entry.kind !== "file") continue;
+				rowVirtualizer.scrollToIndex(nextIndex, { align: "auto" });
+				onOpenFile(nextRow.entry.rel_path);
+				requestAnimationFrame(() => {
+					const pane = currentTarget.closest(".fileTreePane");
+					const nextButton = Array.from(
+						pane?.querySelectorAll<HTMLElement>(
+							"[data-file-tree-file='true']",
+						) ?? [],
+					).find(
+						(button) => button.dataset.fileTreePath === nextRow.entry.rel_path,
+					);
+					nextButton?.focus();
+				});
+				return;
+			}
+		},
+		[onOpenFile, rowVirtualizer, virtualRows],
+	);
+
+	if (virtualRows.length === 0) return null;
 
 	return (
-		<ul className="fileTreeList">
-			{visibleEntries.map((e) => {
-				const isDir = e.kind === "dir";
-				const depth = parentDepth + 1;
-				const rowKey =
-					e.rel_path.trim() || `${e.kind}:${e.name.trim()}:${depth}`;
+		<ul
+			ref={listRef}
+			className="fileTreeList"
+			style={{ height: rowVirtualizer.getTotalSize() }}
+		>
+			{virtualItems.map((virtualItem) => {
+				const row = virtualRows[virtualItem.index];
+				if (!row) return null;
+				const { entry, depth } = row;
+				const virtualRowStyle: CSSProperties = {
+					position: "absolute",
+					top: 0,
+					left: 0,
+					width: "100%",
+					transform: `translateY(${
+						virtualItem.start - rowVirtualizer.options.scrollMargin
+					}px)`,
+				};
 
-				if (isDir) {
-					const isExpanded = expandedDirs.has(e.rel_path);
-					const childEntries = childrenByDir[e.rel_path];
-					const childEntriesLoaded = childEntries !== undefined;
+				if (entry.kind === "dir") {
+					const isExpanded = expandedDirs.has(entry.rel_path);
 
 					return (
 						<FileTreeDirItem
-							key={rowKey}
-							entry={e}
+							key={virtualItem.key}
+							virtualRowRef={rowVirtualizer.measureElement}
+							virtualRowStyle={virtualRowStyle}
+							entry={entry}
 							depth={depth}
 							isExpanded={isExpanded}
-							isActive={!activeFilePath && e.rel_path === activeDirPath}
-							isRenaming={renamingPath === e.rel_path}
+							isActive={!activeFilePath && entry.rel_path === activeDirPath}
+							isRenaming={renamingPath === entry.rel_path}
 							onToggleDir={onToggleDir}
 							onEnterDir={onEnterDir}
 							onSelectDir={onSelectDir}
@@ -365,88 +496,51 @@ function TreeEntries({
 							onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 							onRequestCreateFolder={onRequestCreateFolder}
 							onDeletePath={onDeletePath}
-							appearance={itemAppearance[e.rel_path] ?? null}
+							appearance={itemAppearance[entry.rel_path] ?? null}
 							fileCount={
 								showFolderFileCounts
-									? (folderFileCounts[e.rel_path] ?? null)
+									? (folderFileCounts[entry.rel_path] ?? null)
 									: null
 							}
-							onOpenAppearancePicker={() => onOpenAppearancePicker(e)}
-							onStartRename={() => onStartRename(e.rel_path)}
+							onOpenAppearancePicker={() => onOpenAppearancePicker(entry)}
+							onStartRename={() => onStartRename(entry.rel_path)}
 							onCommitRename={onCommitDirRename}
 							onCancelRename={onCancelRename}
 							onMoveClickSuppressRef={onMoveClickSuppressRef}
-						>
-							{childEntriesLoaded ? (
-								<TreeEntries
-									entries={childEntries ?? []}
-									parentDepth={depth}
-									childrenByDir={childrenByDir}
-									expandedDirs={expandedDirs}
-									activeFilePath={activeFilePath}
-									activeDirPath={activeDirPath}
-									renamingPath={renamingPath}
-									onToggleDir={onToggleDir}
-									onEnterDir={onEnterDir}
-									onSelectDir={onSelectDir}
-									onOpenFile={onOpenFile}
-									onPrefetchFile={onPrefetchFile}
-									onNewFileInDir={onNewFileInDir}
-									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-									onRequestCreateFolder={onRequestCreateFolder}
-									onDuplicateFile={onDuplicateFile}
-									onDeletePath={onDeletePath}
-									onStartRename={onStartRename}
-									onCommitDirRename={onCommitDirRename}
-									onCommitFileRename={onCommitFileRename}
-									onCancelRename={onCancelRename}
-									itemAppearance={itemAppearance}
-									folderFileCounts={folderFileCounts}
-									showFolderFileCounts={showFolderFileCounts}
-									showNonMarkdownFiles={showNonMarkdownFiles}
-									onOpenAppearancePicker={onOpenAppearancePicker}
-									pinnedFiles={pinnedFiles}
-									onTogglePinnedFile={onTogglePinnedFile}
-									onMoveClickSuppressRef={onMoveClickSuppressRef}
-									onArrowNavigate={onArrowNavigate}
-									taskSummariesByPath={taskSummariesByPath}
-									showFilePreviews={showFilePreviews}
-									filePreviewsByPath={filePreviewsByPath}
-									sortMode={sortMode}
-								/>
-							) : null}
-						</FileTreeDirItem>
+						/>
 					);
 				}
 
 				return (
 					<FileTreeFileItem
-						key={rowKey}
-						entry={e}
+						key={virtualItem.key}
+						virtualRowRef={rowVirtualizer.measureElement}
+						virtualRowStyle={virtualRowStyle}
+						entry={entry}
 						depth={depth}
-						isActive={e.rel_path === activeFilePath}
+						isActive={entry.rel_path === activeFilePath}
 						onOpenFile={onOpenFile}
 						onPrefetchFile={onPrefetchFile}
 						onNewFileInDir={onNewFileInDir}
 						onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 						onRequestCreateFolder={onRequestCreateFolder}
 						onDuplicateFile={onDuplicateFile}
-						isRenaming={renamingPath === e.rel_path}
-						onStartRename={() => onStartRename(e.rel_path)}
+						isRenaming={renamingPath === entry.rel_path}
+						onStartRename={() => onStartRename(entry.rel_path)}
 						onCommitRename={onCommitFileRename}
 						onCancelRename={onCancelRename}
-						parentDirPath={parentDir(e.rel_path)}
+						parentDirPath={parentDir(entry.rel_path)}
 						onDeletePath={onDeletePath}
-						appearance={itemAppearance[e.rel_path] ?? null}
-						onOpenAppearancePicker={() => onOpenAppearancePicker(e)}
-						isPinned={pinnedFiles.includes(e.rel_path)}
+						appearance={itemAppearance[entry.rel_path] ?? null}
+						onOpenAppearancePicker={() => onOpenAppearancePicker(entry)}
+						isPinned={pinnedFiles.includes(entry.rel_path)}
 						onTogglePinned={onTogglePinnedFile}
 						onMoveClickSuppressRef={onMoveClickSuppressRef}
-						onArrowNavigate={onArrowNavigate}
-						taskSummary={taskSummariesByPath[e.rel_path] ?? null}
+						onArrowNavigate={handleVirtualArrowNavigate}
+						taskSummary={taskSummariesByPath[entry.rel_path] ?? null}
 						previewText={
-							showFilePreviews && e.is_markdown
-								? (filePreviewsByPath[e.rel_path] ?? null)
+							showFilePreviews && entry.is_markdown
+								? (filePreviewsByPath[entry.rel_path] ?? null)
 								: null
 						}
 					/>
@@ -901,25 +995,6 @@ export const FileTreePane = memo(function FileTreePane({
 		spacePath,
 	]);
 
-	const handleArrowNavigate = useCallback(
-		(_path: string, direction: -1 | 1, currentTarget: HTMLElement) => {
-			const pane = currentTarget.closest(".fileTreePane");
-			if (!pane) return;
-			const fileButtons = Array.from(
-				pane.querySelectorAll<HTMLElement>("[data-file-tree-file='true']"),
-			);
-			const currentIndex = fileButtons.findIndex(
-				(button) => button === currentTarget,
-			);
-			if (currentIndex === -1) return;
-			const nextButton = fileButtons[currentIndex + direction];
-			if (!nextButton) return;
-			nextButton.focus();
-			nextButton.click();
-		},
-		[],
-	);
-
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {
 			moveClickSuppressRef.current = true;
@@ -1018,7 +1093,6 @@ export const FileTreePane = memo(function FileTreePane({
 								pinnedFiles={pinnedFiles}
 								onTogglePinnedFile={onTogglePinnedFile}
 								onMoveClickSuppressRef={moveClickSuppressRef}
-								onArrowNavigate={handleArrowNavigate}
 								taskSummariesByPath={taskSummariesByPath}
 								showFilePreviews
 								filePreviewsByPath={filePreviewsByPath}
@@ -1066,7 +1140,6 @@ export const FileTreePane = memo(function FileTreePane({
 							pinnedFiles={pinnedFiles}
 							onTogglePinnedFile={onTogglePinnedFile}
 							onMoveClickSuppressRef={moveClickSuppressRef}
-							onArrowNavigate={handleArrowNavigate}
 							taskSummariesByPath={taskSummariesByPath}
 							sortMode={sortMode}
 						/>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -435,10 +435,10 @@ function TreeEntries({
 			) {
 				const nextRow = virtualRows[nextIndex];
 				if (!nextRow || nextRow.entry.kind !== "file") continue;
+				const pane = currentTarget.closest(".fileTreePane");
 				rowVirtualizer.scrollToIndex(nextIndex, { align: "auto" });
 				onOpenFile(nextRow.entry.rel_path);
 				requestAnimationFrame(() => {
-					const pane = currentTarget.closest(".fileTreePane");
 					const nextButton = Array.from(
 						pane?.querySelectorAll<HTMLElement>(
 							"[data-file-tree-file='true']",
@@ -484,6 +484,7 @@ function TreeEntries({
 							key={virtualItem.key}
 							virtualRowRef={rowVirtualizer.measureElement}
 							virtualRowStyle={virtualRowStyle}
+							virtualRowIndex={virtualItem.index}
 							entry={entry}
 							depth={depth}
 							isExpanded={isExpanded}
@@ -516,6 +517,7 @@ function TreeEntries({
 						key={virtualItem.key}
 						virtualRowRef={rowVirtualizer.measureElement}
 						virtualRowStyle={virtualRowStyle}
+						virtualRowIndex={virtualItem.index}
 						entry={entry}
 						depth={depth}
 						isActive={entry.rel_path === activeFilePath}

--- a/src/components/filetree/fileTreeDnd.ts
+++ b/src/components/filetree/fileTreeDnd.ts
@@ -5,8 +5,6 @@ export const FILE_TREE_ENTRY_TYPE = "file-tree-entry";
 
 /** Matches `CollisionPriority.Highest` in @dnd-kit/abstract. */
 const FILE_TREE_DIR_ROW_COLLISION_PRIORITY = 4;
-/** Matches `CollisionPriority.Normal` in @dnd-kit/abstract. */
-const FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY = 2;
 /** Matches `CollisionPriority.Low` in @dnd-kit/abstract. */
 export const FILE_TREE_ROOT_DROP_COLLISION_PRIORITY = 1;
 
@@ -30,27 +28,16 @@ export function fileTreeDirRowDropId(relPath: string): string {
 	return `file-tree-dir-row:${relPath}`;
 }
 
-export function fileTreeDirChildrenDropId(relPath: string): string {
-	return `file-tree-dir-children:${relPath}`;
-}
-
 export function fileTreeDirDropData(relPath: string): {
 	targetDirPath: string;
 } {
 	return { targetDirPath: relPath };
 }
 
-function fileTreeDirChildrenCollisionPriority(relPath: string): number {
-	const depth = relPath.split("/").filter(Boolean).length;
-	return FILE_TREE_DIR_CHILDREN_COLLISION_PRIORITY + depth / (depth + 1);
-}
-
 export function useFileTreeDirDropTargets({
 	relPath,
-	isExpanded,
 }: {
 	relPath: string;
-	isExpanded: boolean;
 }) {
 	const { ref: rowDroppableRef, isDropTarget: isRowDropTarget } = useDroppable({
 		id: fileTreeDirRowDropId(relPath),
@@ -58,19 +45,9 @@ export function useFileTreeDirDropTargets({
 		accept: FILE_TREE_ENTRY_TYPE,
 		collisionPriority: FILE_TREE_DIR_ROW_COLLISION_PRIORITY,
 	});
-	const { ref: childrenDroppableRef, isDropTarget: isChildrenDropTarget } =
-		useDroppable({
-			id: fileTreeDirChildrenDropId(relPath),
-			data: fileTreeDirDropData(relPath),
-			accept: FILE_TREE_ENTRY_TYPE,
-			collisionPriority: fileTreeDirChildrenCollisionPriority(relPath),
-			disabled: !isExpanded,
-		});
 
 	return {
 		rowDroppableRef,
 		isRowDropTarget,
-		childrenDroppableRef,
-		isChildrenDropTarget,
 	};
 }

--- a/src/components/folio/FolioNotesListPane.test.tsx
+++ b/src/components/folio/FolioNotesListPane.test.tsx
@@ -85,6 +85,10 @@ vi.mock("../../lib/navigationPrefetch", async () => {
 		...actual,
 		loadAllDocs: loadAllDocsMock,
 		prefetchNote: prefetchNoteMock,
+		allDocsListQueryOptions: (folderPrefix?: string | null) => ({
+			...actual.allDocsListQueryOptions(folderPrefix),
+			queryFn: () => loadAllDocsMock(folderPrefix),
+		}),
 	};
 });
 

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -228,7 +228,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 		},
 		getScrollElement: () => listRef.current,
 		getItemKey: (index) => virtualRows[index]?.id ?? index,
-		overscan: 8,
+		overscan: 4,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -242,16 +242,6 @@
 	border-radius: var(--radius-md);
 }
 
-.fileTreeChildren {
-	min-height: 28px;
-}
-
-.fileTreeChildren[data-drop-target="true"] {
-	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 22%, transparent);
-	border-radius: var(--radius-md);
-}
-
 .fileTreeRow[data-draggable="true"]:not([data-dragging="true"]) {
 	cursor: pointer;
 }


### PR DESCRIPTION
> **Note:** There is no open GitHub issue that tracks this work. I searched for virtualization, file tree performance, and related terms — nothing open matches this PR. If you'd like one filed for tracking, happy to add it.

## Description

Improves scroll performance in large spaces by virtualizing the sidebar file tree and tightening overscan on other already-virtualized lists.

- **File tree virtualization** — Flatten visible rows (respecting expand/collapse, sort, and non-markdown visibility) into a single TanStack Virtual list. Directory and file items accept `virtualRowRef` / `virtualRowStyle` for absolute positioning and dynamic row measurement (including taller preview rows).
- **Keyboard navigation** — Arrow-key file navigation now walks the flattened virtual row list and scrolls the target into view before focusing.
- **Overscan tuning** — Reduce `overscan` from 8 → 4 on the database table, Folio notes list, and file tree to cut off-screen rendering work while keeping scroll smooth.

### Reasoning

Folio, All Docs, Activity Timeline, and the database table already used TanStack Virtual; the file tree was the main sidebar surface still rendering every visible row. Large expanded trees could mount hundreds of DOM nodes. Flattening + windowing keeps the tree responsive without changing its behavior.

### Additional context

- `pnpm check` passes.
- No new tests (follows existing pattern for virtualized panes).
- Visual change is limited to scroll performance; layout and interactions should match prior behavior.

## Screenshots

N/A — performance/rendering change, no intentional UI differences.

## Docs

Uses the existing TanStack Virtual pattern documented in `AGENTS.md`. File tree rows are flattened via `flattenVisibleFileTreeRows()` in `FileTreePane.tsx`.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualized the sidebar file tree and lowered list overscan to 4 for smoother scrolling in large spaces. Also simplified drag-and-drop and updated tests to match the new virtualization.

- **New Features**
  - File tree is now a single virtualized list using `@tanstack/react-virtual`; rows are flattened and measured dynamically (incl. preview rows). `FileTreeDirItem`/`FileTreeFileItem` accept `virtualRowRef`, `virtualRowStyle`, and `virtualRowIndex`.
  - Arrow-key navigation walks virtual rows and scrolls the next item into view before focusing.
  - Reduced `overscan` from 8 to 4 in the database table, Folio notes list, and file tree.

- **Refactors**
  - Simplified DnD to row-only drop targets; removed the nested children drop zone, related animations, and CSS.
  - Tests updated: wire `allDocsListQueryOptions` to the Folio mock and add a `@tanstack/react-virtual` mock in file tree tests.

<sup>Written for commit f3b9f20b9f6ebfaf5cd4181050687984eac3bf90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved file tree performance with row virtualization for smoother scrolling and better handling of larger folders.
  * Added support for preview-aware row sizing in the file tree.

* **Bug Fixes**
  * Fixed empty folder-child containers from appearing when no children are available.
  * Updated keyboard navigation to work reliably with virtualized rows.
  * Simplified drag-and-drop behavior for directory rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->