### PR TITLE
Add file tree Open in New Window for markdown files

### DIFF
--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -4,9 +4,14 @@ use std::{
     path::{Path, PathBuf},
     sync::Mutex,
 };
-use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::{Manager, State, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 
-use crate::{io_atomic, utils};
+use crate::{
+    io_atomic, paths,
+    space::SpaceState,
+    space_fs::helpers::deny_hidden_rel_path,
+    utils,
+};
 
 const EXTERNAL_MARKDOWN_LABEL_PREFIX: &str = "external-markdown-";
 const EXTERNAL_MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "mdown"];
@@ -141,11 +146,23 @@ pub fn forget_external_markdown_window(
 
 #[tauri::command]
 pub fn open_external_markdown_path(
+    window: WebviewWindow,
     app: tauri::AppHandle,
+    space_state: State<'_, SpaceState>,
     state: State<'_, ExternalMarkdownState>,
     path: String,
 ) -> Result<(), String> {
-    open_external_markdown_window(&app, &state, PathBuf::from(path))
+    let root = space_state.root_for_window(&window)?;
+    let rel = PathBuf::from(path);
+    deny_hidden_rel_path(&rel)?;
+    let abs = paths::join_under(&root, &rel)?;
+    if !abs.exists() {
+        return Err("path does not exist".to_string());
+    }
+    if !abs.is_file() {
+        return Err("path is not a file".to_string());
+    }
+    open_external_markdown_window(&app, &state, abs)
 }
 
 #[tauri::command]

--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -18,9 +18,15 @@ const EXTERNAL_MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "mdown"];
 const EXTERNAL_MARKDOWN_MIN_WIDTH: f64 = 680.0;
 const EXTERNAL_MARKDOWN_MIN_HEIGHT: f64 = 360.0;
 
+#[derive(Clone)]
+struct ExternalMarkdownWindowEntry {
+    abs_path: String,
+    rel_path: Option<String>,
+}
+
 #[derive(Default)]
 pub struct ExternalMarkdownState {
-    paths_by_window: Mutex<HashMap<String, String>>,
+    paths_by_window: Mutex<HashMap<String, ExternalMarkdownWindowEntry>>,
 }
 
 #[derive(Serialize)]
@@ -87,6 +93,7 @@ pub fn open_external_markdown_window(
     app: &tauri::AppHandle,
     state: &ExternalMarkdownState,
     path: PathBuf,
+    rel_path: Option<String>,
 ) -> Result<(), String> {
     validate_markdown_file(&path)?;
 
@@ -96,7 +103,13 @@ pub fn open_external_markdown_window(
             .paths_by_window
             .lock()
             .map_err(|_| "failed to lock external markdown state".to_string())?;
-        paths_by_window.insert(label.clone(), path.to_string_lossy().to_string());
+        paths_by_window.insert(
+            label.clone(),
+            ExternalMarkdownWindowEntry {
+                abs_path: path.to_string_lossy().to_string(),
+                rel_path,
+            },
+        );
     }
 
     if let Some(window) = app.get_webview_window(&label) {
@@ -153,7 +166,7 @@ pub fn open_external_markdown_path(
     path: String,
 ) -> Result<(), String> {
     let root = space_state.root_for_window(&window)?;
-    let rel = PathBuf::from(path);
+    let rel = PathBuf::from(&path);
     deny_hidden_rel_path(&rel)?;
     let abs = paths::join_under(&root, &rel)?;
     if !abs.exists() {
@@ -162,7 +175,7 @@ pub fn open_external_markdown_path(
     if !abs.is_file() {
         return Err("path is not a file".to_string());
     }
-    open_external_markdown_window(&app, &state, abs)
+    open_external_markdown_window(&app, &state, abs, Some(path))
 }
 
 #[tauri::command]
@@ -175,8 +188,21 @@ pub fn external_markdown_window_path(
         .lock()
         .map_err(|_| "failed to lock external markdown state".to_string())?
         .get(window.label())
-        .cloned()
+        .map(|entry| entry.abs_path.clone())
         .ok_or_else(|| "external markdown file is not registered for this window".to_string())
+}
+
+#[tauri::command]
+pub fn external_markdown_window_rel_path(
+    window: tauri::WebviewWindow,
+    state: State<'_, ExternalMarkdownState>,
+) -> Result<Option<String>, String> {
+    Ok(state
+        .paths_by_window
+        .lock()
+        .map_err(|_| "failed to lock external markdown state".to_string())?
+        .get(window.label())
+        .and_then(|entry| entry.rel_path.clone()))
 }
 
 fn registered_path_for_window(
@@ -189,7 +215,7 @@ fn registered_path_for_window(
         .lock()
         .map_err(|_| "failed to lock external markdown state".to_string())?
         .get(window.label())
-        .cloned()
+        .map(|entry| entry.abs_path.clone())
         .ok_or_else(|| "external markdown file is not registered for this window".to_string())?;
     if PathBuf::from(supplied_path) != PathBuf::from(&registered_path) {
         return Err("external markdown path does not match this window".to_string());

--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -10,6 +10,8 @@ use crate::{io_atomic, utils};
 
 const EXTERNAL_MARKDOWN_LABEL_PREFIX: &str = "external-markdown-";
 const EXTERNAL_MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "mdown"];
+const EXTERNAL_MARKDOWN_MIN_WIDTH: f64 = 680.0;
+const EXTERNAL_MARKDOWN_MIN_HEIGHT: f64 = 360.0;
 
 #[derive(Default)]
 pub struct ExternalMarkdownState {
@@ -106,16 +108,21 @@ pub fn open_external_markdown_window(
     )
     .title(format!("{} - Glyph", file_name_for_title(&path)))
     .inner_size(820.0, 720.0)
-    .min_inner_size(520.0, 360.0)
+    .min_inner_size(EXTERNAL_MARKDOWN_MIN_WIDTH, EXTERNAL_MARKDOWN_MIN_HEIGHT)
     .resizable(true)
     .decorations(true)
     .title_bar_style(tauri::TitleBarStyle::Overlay)
     .hidden_title(true)
-    .transparent(false)
+    .transparent(true)
     .shadow(true)
     .center()
     .build()
     .map_err(|error| error.to_string())?;
+
+    #[cfg(target_os = "macos")]
+    if let Err(error) = crate::apply_main_window_vibrancy(&window, None) {
+        tracing::warn!("Failed to apply vibrancy to external markdown window: {error}");
+    }
 
     window.set_focus().map_err(|error| error.to_string())
 }
@@ -130,6 +137,15 @@ pub fn forget_external_markdown_window(
         .map_err(|_| "failed to lock external markdown state".to_string())?
         .remove(label);
     Ok(())
+}
+
+#[tauri::command]
+pub fn open_external_markdown_path(
+    app: tauri::AppHandle,
+    state: State<'_, ExternalMarkdownState>,
+    path: String,
+) -> Result<(), String> {
+    open_external_markdown_window(&app, &state, PathBuf::from(path))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1156,7 +1156,7 @@ fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-fn open_external_markdown_path(app: &tauri::AppHandle, path: std::path::PathBuf) {
+fn open_external_markdown_from_finder(app: &tauri::AppHandle, path: std::path::PathBuf) {
     let state = app.state::<external_markdown::ExternalMarkdownState>();
     if let Err(error) = external_markdown::open_external_markdown_window(app, &state, path) {
         warn!("Failed to open external markdown file: {error}");
@@ -1169,7 +1169,7 @@ fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
             continue;
         }
         match url.to_file_path() {
-            Ok(path) => open_external_markdown_path(app, path),
+            Ok(path) => open_external_markdown_from_finder(app, path),
             Err(()) => warn!("Failed to convert opened URL to file path: {url}"),
         }
     }
@@ -1592,6 +1592,7 @@ pub fn run() {
             set_recent_spaces_menu,
             set_menu_shortcuts,
             set_window_vibrancy_theme,
+            external_markdown::open_external_markdown_path,
             external_markdown::external_markdown_window_path,
             external_markdown::external_markdown_read,
             external_markdown::external_markdown_write,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1158,7 +1158,7 @@ fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
 
 fn open_external_markdown_from_finder(app: &tauri::AppHandle, path: std::path::PathBuf) {
     let state = app.state::<external_markdown::ExternalMarkdownState>();
-    if let Err(error) = external_markdown::open_external_markdown_window(app, &state, path) {
+    if let Err(error) = external_markdown::open_external_markdown_window(app, &state, path, None) {
         warn!("Failed to open external markdown file: {error}");
     }
 }
@@ -1594,6 +1594,7 @@ pub fn run() {
             set_window_vibrancy_theme,
             external_markdown::open_external_markdown_path,
             external_markdown::external_markdown_window_path,
+            external_markdown::external_markdown_window_rel_path,
             external_markdown::external_markdown_read,
             external_markdown::external_markdown_write,
             external_markdown::external_markdown_finish_close,

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -1,30 +1,69 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import { extractErrorMessage } from "../../lib/errorUtils";
+import type { EditorViewMode } from "../../lib/editorMode";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
-import { displayNameFromPath } from "../../utils/path";
+import {
+	displayFolderFromPath,
+	displayNameFromPath,
+	normalizeRelPath,
+} from "../../utils/path";
+import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
-import type { NoteInlineEditorMode } from "../editor/types";
 
 const AUTOSAVE_DELAY_MS = 700;
 
+function fallbackRelPathFromAbs(absPath: string): string {
+	const normalized = normalizeRelPath(absPath);
+	const parts = normalized.split("/").filter(Boolean);
+	return parts[parts.length - 1] ?? normalized;
+}
+
+async function resolveRelPath(absPath: string): Promise<string> {
+	let relPath = fallbackRelPathFromAbs(absPath);
+	try {
+		relPath = await invoke("space_relativize_path", { abs_path: absPath });
+	} catch {
+		// External files opened from Finder may sit outside the active space.
+	}
+	return relPath;
+}
+
 export function ExternalMarkdownWindow() {
-	const [path, setPath] = useState("");
+	const [relPath, setRelPath] = useState("");
 	const [title, setTitle] = useState("Markdown File");
 	const [text, setText] = useState("");
-	const [mode, setMode] = useState<NoteInlineEditorMode>("rich");
+	const [savedText, setSavedText] = useState("");
+	const [mode, setMode] = useState<EditorViewMode>("rich");
 	const [error, setError] = useState("");
 	const textRef = useRef("");
 	const savedTextRef = useRef("");
-	const pathRef = useRef("");
+	const absPathRef = useRef("");
 	const mtimeRef = useRef<number | null>(null);
 	const saveTokenRef = useRef(0);
 	const autosaveTimerRef = useRef<number | null>(null);
 	const mountedRef = useRef(true);
+	const {
+		setSaving,
+		setLoading,
+		flashPulse,
+		clearPulse,
+		resolveLabel,
+		resolveState,
+	} = useEditorSaveIndicator();
+
+	const folderLabel = useMemo(
+		() => (relPath ? displayFolderFromPath(relPath) : ""),
+		[relPath],
+	);
+	const isDirty = text !== savedText;
+	const visibleSaveStatus = resolveLabel({ isDirty, idleLabel: null });
+	const saveStatusState = resolveState({ isDirty });
 
 	const saveNow = useCallback(async (): Promise<boolean> => {
-		const currentPath = pathRef.current;
+		const currentPath = absPathRef.current;
 		if (!currentPath) return true;
 		if (textRef.current === savedTextRef.current) {
 			return true;
@@ -34,6 +73,7 @@ export function ExternalMarkdownWindow() {
 		const textToSave = textRef.current;
 		saveTokenRef.current = token;
 		setError("");
+		setSaving(true);
 
 		try {
 			const result = await invoke("external_markdown_write", {
@@ -44,16 +84,22 @@ export function ExternalMarkdownWindow() {
 			if (!mountedRef.current || token !== saveTokenRef.current) return false;
 			mtimeRef.current = result.mtime_ms;
 			savedTextRef.current = textToSave;
+			setSavedText(textToSave);
 			if (textRef.current !== textToSave) {
 				return false;
 			}
+			flashPulse("saved");
 			return true;
 		} catch (cause) {
 			if (!mountedRef.current || token !== saveTokenRef.current) return false;
 			setError(extractErrorMessage(cause));
 			return false;
+		} finally {
+			if (mountedRef.current && token === saveTokenRef.current) {
+				setSaving(false);
+			}
 		}
-	}, []);
+	}, [flashPulse, setSaving]);
 
 	const closeWindow = useCallback(async () => {
 		if (autosaveTimerRef.current !== null) {
@@ -86,29 +132,41 @@ export function ExternalMarkdownWindow() {
 	useEffect(() => {
 		mountedRef.current = true;
 		let cancelled = false;
+		setLoading(true);
 
 		void (async () => {
 			try {
-				const windowPath = await invoke("external_markdown_window_path");
+				const absPath = await invoke("external_markdown_window_path");
 				if (cancelled) return;
-				pathRef.current = windowPath;
-				setPath(windowPath);
-				const nextTitle = displayNameFromPath(windowPath);
+				absPathRef.current = absPath;
+
+				const nextRelPath = await resolveRelPath(absPath);
+				if (cancelled) return;
+
+				const nextTitle = displayNameFromPath(nextRelPath);
+				setRelPath(nextRelPath);
 				setTitle(nextTitle);
 				await getCurrentWindow().setTitle(`${nextTitle} - Glyph`);
 
 				const doc = await invoke("external_markdown_read", {
-					path: windowPath,
+					path: absPath,
 				});
 				if (cancelled) return;
 				textRef.current = doc.text;
 				savedTextRef.current = doc.text;
 				mtimeRef.current = doc.mtime_ms;
 				setText(doc.text);
+				setSavedText(doc.text);
 				setError("");
+				clearPulse();
 			} catch (cause) {
 				if (cancelled) return;
 				setError(extractErrorMessage(cause));
+				clearPulse();
+			} finally {
+				if (!cancelled) {
+					setLoading(false);
+				}
 			}
 		})();
 
@@ -119,7 +177,7 @@ export function ExternalMarkdownWindow() {
 				window.clearTimeout(autosaveTimerRef.current);
 			}
 		};
-	}, []);
+	}, [clearPulse, setLoading]);
 
 	const handleChange = useCallback(
 		(nextText: string) => {
@@ -132,58 +190,53 @@ export function ExternalMarkdownWindow() {
 
 	return (
 		<div className="externalMarkdownWindow">
-			<header className="externalMarkdownHeader" data-tauri-drag-region>
+			<div className="externalMarkdownOverlayChrome">
+				<div
+					className="externalMarkdownDragRegion"
+					data-tauri-drag-region
+					aria-hidden="true"
+				/>
 				<div className="externalMarkdownTitleBlock">
-					<div className="externalMarkdownTitle">{title}</div>
-					<div className="externalMarkdownPath">
-						{path || "Opening file..."}
-					</div>
+					<h1 className="externalMarkdownTitle">{title}</h1>
+					{folderLabel ? (
+						<p className="externalMarkdownMeta">{folderLabel}</p>
+					) : null}
 				</div>
-				<div className="externalMarkdownActions">
-					<div className="externalMarkdownModeSwitch" aria-label="Editor mode">
-						<button
-							type="button"
-							className="externalMarkdownModeBtn"
-							data-active={mode === "rich" || undefined}
-							aria-pressed={mode === "rich"}
-							onClick={() => setMode("rich")}
-						>
-							Edit
-						</button>
-						<button
-							type="button"
-							className="externalMarkdownModeBtn"
-							data-active={mode === "preview" || undefined}
-							aria-pressed={mode === "preview"}
-							onClick={() => setMode("preview")}
-						>
-							Preview
-						</button>
-						<button
-							type="button"
-							className="externalMarkdownModeBtn"
-							data-active={mode === "plain" || undefined}
-							aria-pressed={mode === "plain"}
-							onClick={() => setMode("plain")}
-						>
-							Raw
-						</button>
-					</div>
-				</div>
-			</header>
+			</div>
 
 			{error ? <div className="externalMarkdownError">{error}</div> : null}
 
-			<main className="externalMarkdownEditor">
-				<NoteInlineEditor
-					markdown={text}
-					relPath={path}
-					mode={mode}
-					deferHeavyFeatures
-					pasteMarkdownBehavior="smart-markdown"
-					onChange={handleChange}
-					onFrontmatterCommit={saveNow}
-				/>
+			<main className="externalMarkdownBody">
+				<div className="externalMarkdownEditorPane">
+					<div className="externalMarkdownFloatActions">
+						{visibleSaveStatus ? (
+							<span
+								className="externalMarkdownSaveStatus"
+								data-state={saveStatusState}
+								aria-live="polite"
+							>
+								{visibleSaveStatus}
+							</span>
+						) : null}
+						<div className="markdownEditorToolbar">
+							<EditorViewModeSwitch mode={mode} onModeChange={setMode} />
+						</div>
+					</div>
+					<div className="externalMarkdownEditorShell">
+						{relPath ? (
+							<NoteInlineEditor
+								markdown={text}
+								relPath={relPath}
+								mode={mode}
+								chrome="minimal"
+								deferHeavyFeatures
+								pasteMarkdownBehavior="smart-markdown"
+								onChange={handleChange}
+								onFrontmatterCommit={saveNow}
+							/>
+						) : null}
+					</div>
+				</div>
 			</main>
 		</div>
 	);

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -23,6 +23,12 @@ function fallbackRelPathFromAbs(absPath: string): string {
 
 async function resolveRelPath(absPath: string): Promise<string> {
 	try {
+		const storedRelPath = await invoke("external_markdown_window_rel_path");
+		if (storedRelPath) return storedRelPath;
+	} catch {
+		// Fall back to relativizing against the active space when available.
+	}
+	try {
 		return await invoke("space_relativize_path", { abs_path: absPath });
 	} catch {
 		// External files opened from Finder may sit outside the active space.

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -1,8 +1,8 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
-import { extractErrorMessage } from "../../lib/errorUtils";
 import type { EditorViewMode } from "../../lib/editorMode";
+import { extractErrorMessage } from "../../lib/errorUtils";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import {
@@ -22,13 +22,12 @@ function fallbackRelPathFromAbs(absPath: string): string {
 }
 
 async function resolveRelPath(absPath: string): Promise<string> {
-	let relPath = fallbackRelPathFromAbs(absPath);
 	try {
-		relPath = await invoke("space_relativize_path", { abs_path: absPath });
+		return await invoke("space_relativize_path", { abs_path: absPath });
 	} catch {
 		// External files opened from Finder may sit outside the active space.
+		return "";
 	}
-	return relPath;
 }
 
 export function ExternalMarkdownWindow() {
@@ -143,7 +142,9 @@ export function ExternalMarkdownWindow() {
 				const nextRelPath = await resolveRelPath(absPath);
 				if (cancelled) return;
 
-				const nextTitle = displayNameFromPath(nextRelPath);
+				const nextTitle = displayNameFromPath(
+					nextRelPath || fallbackRelPathFromAbs(absPath),
+				);
 				setRelPath(nextRelPath);
 				setTitle(nextTitle);
 				await getCurrentWindow().setTitle(`${nextTitle} - Glyph`);
@@ -223,18 +224,16 @@ export function ExternalMarkdownWindow() {
 						</div>
 					</div>
 					<div className="externalMarkdownEditorShell">
-						{relPath ? (
-							<NoteInlineEditor
-								markdown={text}
-								relPath={relPath}
-								mode={mode}
-								chrome="minimal"
-								deferHeavyFeatures
-								pasteMarkdownBehavior="smart-markdown"
-								onChange={handleChange}
-								onFrontmatterCommit={saveNow}
-							/>
-						) : null}
+						<NoteInlineEditor
+							markdown={text}
+							relPath={relPath}
+							mode={mode}
+							chrome="minimal"
+							deferHeavyFeatures
+							pasteMarkdownBehavior="smart-markdown"
+							onChange={handleChange}
+							onFrontmatterCommit={saveNow}
+						/>
 					</div>
 				</div>
 			</main>

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -12,6 +12,12 @@ vi.mock("../../lib/nativeContextMenu", () => ({
 	showNativeContextMenu: showNativeContextMenuMock,
 }));
 
+const openMarkdownInExternalWindowMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/externalMarkdown", () => ({
+	openMarkdownInExternalWindow: openMarkdownInExternalWindowMock,
+}));
+
 vi.mock("../../contexts", () => ({
 	useSpace: () => ({ spacePath: "/space" }),
 }));
@@ -83,6 +89,7 @@ describe("FileTreeFileItem", () => {
 		});
 		container.remove();
 		showNativeContextMenuMock.mockReset();
+		openMarkdownInExternalWindowMock.mockReset();
 	});
 
 	const renderFileTreeFileItem = async (
@@ -159,6 +166,63 @@ describe("FileTreeFileItem", () => {
 			| undefined;
 		expect(menuItems?.map((item) => item.label)).toContain("Unpin file");
 		expect(menuItems?.map((item) => item.label)).not.toContain("Pin file");
+	});
+
+	it("shows Open in New Window for markdown files", async () => {
+		await renderFileTreeFileItem();
+
+		const button = container.querySelector(
+			".fileTreeRow",
+		) as HTMLButtonElement | null;
+		expect(button).not.toBeNull();
+
+		await act(async () => {
+			button?.dispatchEvent(
+				new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		const menuItems = showNativeContextMenuMock.mock.calls[0]?.[1] as
+			| Array<{ label?: string; action?: () => void }>
+			| undefined;
+		expect(menuItems?.map((item) => item.label)).toContain("Open in New Window");
+
+		const openInNewWindow = menuItems?.find(
+			(item) => item.label === "Open in New Window",
+		);
+		openInNewWindow?.action?.();
+		expect(openMarkdownInExternalWindowMock).toHaveBeenCalledWith(
+			"notes/alpha.md",
+		);
+	});
+
+	it("hides Open in New Window for non-markdown files", async () => {
+		await renderFileTreeFileItem({
+			entry: {
+				name: "alpha.txt",
+				rel_path: "notes/alpha.txt",
+				kind: "file",
+				is_markdown: false,
+			},
+		});
+
+		const button = container.querySelector(
+			".fileTreeRow",
+		) as HTMLButtonElement | null;
+		expect(button).not.toBeNull();
+
+		await act(async () => {
+			button?.dispatchEvent(
+				new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		const menuItems = showNativeContextMenuMock.mock.calls[0]?.[1] as
+			| Array<{ label?: string }>
+			| undefined;
+		expect(menuItems?.map((item) => item.label)).not.toContain(
+			"Open in New Window",
+		);
 	});
 
 	it("calls arrow navigation when pressing the up or down keys", async () => {

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -20,6 +20,10 @@ vi.mock("../../lib/externalMarkdown", () => ({
 
 vi.mock("../../contexts", () => ({
 	useSpace: () => ({ spacePath: "/space" }),
+	useEditorContext: () => ({
+		getEditorState: () => null,
+		saveCurrentEditor: vi.fn().mockResolvedValue(false),
+	}),
 }));
 
 vi.mock("motion/react", async () => {
@@ -185,7 +189,9 @@ describe("FileTreeFileItem", () => {
 		const menuItems = showNativeContextMenuMock.mock.calls[0]?.[1] as
 			| Array<{ label?: string; action?: () => void }>
 			| undefined;
-		expect(menuItems?.map((item) => item.label)).toContain("Open in New Window");
+		expect(menuItems?.map((item) => item.label)).toContain(
+			"Open in New Window",
+		);
 
 		const openInNewWindow = menuItems?.find(
 			(item) => item.label === "Open in New Window",

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -12,6 +12,7 @@ import type {
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useSpace } from "../../contexts";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
+import { openMarkdownInExternalWindow } from "../../lib/externalMarkdown";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import { invoke } from "../../lib/tauri";
@@ -228,6 +229,9 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			console.error("Failed to show file in Finder", error);
 		}
 	}, [entry.rel_path]);
+	const handleOpenInSeparateWindow = useCallback(async () => {
+		await openMarkdownInExternalWindow(entry.rel_path);
+	}, [entry.rel_path]);
 	const handleContextMenu = useCallback(
 		(event: MouseEvent) => {
 			void showNativeContextMenu(event, [
@@ -235,6 +239,14 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					label: "Open",
 					action: () => void onOpenFile(entry.rel_path),
 				},
+				...(entry.is_markdown
+					? [
+							{
+								label: "Open in New Window",
+								action: () => void handleOpenInSeparateWindow(),
+							},
+						]
+					: []),
 				{
 					label: "Show in Finder",
 					action: () => void handleRevealInFinder(),
@@ -288,6 +300,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			onDuplicateFile,
 			onNewFileInDir,
 			onRequestCreateFolder,
+			handleOpenInSeparateWindow,
 			onOpenFile,
 			onStartRename,
 			onTogglePinned,

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -10,7 +10,7 @@ import type {
 	Ref,
 } from "react";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { useSpace } from "../../contexts";
+import { useEditorContext, useSpace } from "../../contexts";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { openMarkdownInExternalWindow } from "../../lib/externalMarkdown";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
@@ -168,6 +168,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 	virtualRowIndex,
 }: FileTreeFileItemProps) {
 	const { spacePath } = useSpace();
+	const { getEditorState, saveCurrentEditor } = useEditorContext();
 	const customColor =
 		appearance?.color && isEditorTextColor(appearance.color)
 			? appearance.color
@@ -230,8 +231,12 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 		}
 	}, [entry.rel_path]);
 	const handleOpenInSeparateWindow = useCallback(async () => {
+		const editorState = getEditorState();
+		if (editorState?.relPath === entry.rel_path && editorState.isDirty) {
+			await saveCurrentEditor();
+		}
 		await openMarkdownInExternalWindow(entry.rel_path);
-	}, [entry.rel_path]);
+	}, [entry.rel_path, getEditorState, saveCurrentEditor]);
 	const handleContextMenu = useCallback(
 		(event: MouseEvent) => {
 			void showNativeContextMenu(event, [
@@ -291,6 +296,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 			});
 		},
 		[
+			entry.is_markdown,
 			entry.rel_path,
 			handleRevealInFinder,
 			isPinned,

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -98,6 +98,10 @@ vi.mock("motion/react", async () => {
 vi.mock("../../contexts", () => ({
 	useFileTreeContext: useFileTreeContextMock,
 	useSpace: useSpaceMock,
+	useEditorContext: () => ({
+		getEditorState: () => null,
+		saveCurrentEditor: vi.fn().mockResolvedValue(false),
+	}),
 }));
 
 vi.mock("../../lib/settings", async () => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -4,7 +4,6 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import {
 	useAISidebarContext,
 	useEditorRegistration,
@@ -12,6 +11,7 @@ import {
 	useSpace,
 	useUILayoutContext,
 } from "../../contexts";
+import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import {
 	OPEN_LOCAL_CONNECTIONS_EVENT,
 	type OpenLocalConnectionsDetail,
@@ -414,7 +414,7 @@ export function MarkdownEditorPane({
 		if (initialDoc) {
 			setPrefetchedNote(relPath, initialDoc);
 		}
-	}, [initialDoc, initialError, relPath, resolveEditorModeForNote]);
+	}, [clearPulse, initialDoc, initialError, relPath, resolveEditorModeForNote]);
 
 	useEffect(() => {
 		if (previousSpacePathRef.current === spacePath) return;
@@ -443,7 +443,7 @@ export function MarkdownEditorPane({
 		if (spacePath === null) {
 			return;
 		}
-	}, [spacePath]);
+	}, [clearPulse, spacePath]);
 
 	const loadDoc = useCallback(
 		async (showRefreshFeedback = false) => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -4,6 +4,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import {
 	useAISidebarContext,
 	useEditorRegistration,
@@ -73,7 +74,6 @@ interface MarkdownEditorPaneProps {
 	extractToNoteActions?: ExtractToNoteActions;
 }
 
-type SyncPulse = "saved" | "reloaded" | null;
 type LinkedNoteKind = "wiki" | "markdown";
 
 interface LinkedNoteItem {
@@ -182,7 +182,7 @@ export function MarkdownEditorPane({
 	const [lastSavedMtimeMs, setLastSavedMtimeMs] = useState<number | null>(
 		initialDoc?.mtime_ms ?? null,
 	);
-	const [syncPulse, setSyncPulse] = useState<SyncPulse>(null);
+	const { flashPulse, clearPulse, resolveLabel } = useEditorSaveIndicator();
 	const [linkedMentions, setLinkedMentions] = useState<BacklinkItem[]>([]);
 	const [relationships, setRelationships] = useState<NoteRelationship[]>([]);
 
@@ -226,7 +226,6 @@ export function MarkdownEditorPane({
 	const autosaveQueuedRef = useRef(false);
 	const hasUserEditsRef = useRef(false);
 	const externalSyncTimerRef = useRef<number | null>(null);
-	const syncPulseTimerRef = useRef<number | null>(null);
 	const pendingExternalReloadRef = useRef(false);
 	const activeRelPathRef = useRef(relPath);
 	const infoPanelOpenRef = useRef(infoPanelOpen);
@@ -339,32 +338,13 @@ export function MarkdownEditorPane({
 		selectVisibleHeading,
 	});
 
-	const flashSyncPulse = useCallback((next: Exclude<SyncPulse, null>) => {
-		if (syncPulseTimerRef.current !== null) {
-			window.clearTimeout(syncPulseTimerRef.current);
-		}
-		setSyncPulse(next);
-		syncPulseTimerRef.current = window.setTimeout(() => {
-			syncPulseTimerRef.current = null;
-			setSyncPulse(null);
-		}, 1400);
-	}, []);
-
-	const saveLabel = useMemo(() => {
-		if (saving || autosaveBusy) {
-			return "Saving";
-		}
-		if (isDirty) {
-			return "Edited";
-		}
-		if (syncPulse === "reloaded") {
-			return "Fresh";
-		}
-		if (syncPulse === "saved") {
-			return "Saved";
-		}
-		return lastSavedMtimeMs ? "Saved" : "Ready";
-	}, [autosaveBusy, isDirty, lastSavedMtimeMs, saving, syncPulse]);
+	const saveLabel =
+		resolveLabel({
+			isDirty,
+			saving,
+			autosaveBusy,
+			hasSavedBefore: lastSavedMtimeMs !== null,
+		}) ?? "Ready";
 
 	useEffect(() => {
 		mountedRef.current = true;
@@ -420,7 +400,7 @@ export function MarkdownEditorPane({
 		setLastSavedMtimeMs(initialDoc?.mtime_ms ?? null);
 		setSaving(false);
 		setAutosaveBusy(false);
-		setSyncPulse(null);
+		clearPulse();
 		hasUserEditsRef.current = false;
 		setError(initialError);
 		if (activeRelPathRef.current !== relPath) {
@@ -458,7 +438,7 @@ export function MarkdownEditorPane({
 		setLastSavedMtimeMs(null);
 		setSaving(false);
 		setAutosaveBusy(false);
-		setSyncPulse(null);
+		clearPulse();
 		clearMarkdownDocCache();
 		if (spacePath === null) {
 			return;
@@ -491,14 +471,14 @@ export function MarkdownEditorPane({
 				hasUserEditsRef.current = false;
 				setPrefetchedNote(relPath, doc);
 				if (showRefreshFeedback) {
-					flashSyncPulse("reloaded");
+					flashPulse("reloaded");
 				}
 			} catch (e) {
 				if (!isCurrentSession(sessionId)) return;
 				setError(extractErrorMessage(e));
 			}
 		},
-		[flashSyncPulse, isCurrentSession, relPath, resolveEditorModeForNote],
+		[flashPulse, isCurrentSession, relPath, resolveEditorModeForNote],
 	);
 
 	const loadDocFromExternalChange = useCallback(async () => {
@@ -551,7 +531,7 @@ export function MarkdownEditorPane({
 				setSavedText(saved);
 				setLastSavedMtimeMs(mtimeMs);
 				hasUserEditsRef.current = false;
-				flashSyncPulse("saved");
+				flashPulse("saved");
 			};
 
 			setError("");
@@ -598,7 +578,7 @@ export function MarkdownEditorPane({
 				}
 			}
 		},
-		[flashSyncPulse, isCurrentSession, relPath],
+		[flashPulse, isCurrentSession, relPath],
 	);
 
 	const onSave = useCallback(async () => {
@@ -732,9 +712,6 @@ export function MarkdownEditorPane({
 		() => () => {
 			if (externalSyncTimerRef.current !== null) {
 				window.clearTimeout(externalSyncTimerRef.current);
-			}
-			if (syncPulseTimerRef.current !== null) {
-				window.clearTimeout(syncPulseTimerRef.current);
 			}
 		},
 		[],

--- a/src/hooks/useEditorSaveIndicator.ts
+++ b/src/hooks/useEditorSaveIndicator.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type EditorSavePulse = "saved" | "reloaded";
+
+const EDITOR_SAVE_PULSE_MS = 1400;
+
+export function useEditorSaveIndicator() {
+	const [saving, setSaving] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [pulse, setPulse] = useState<EditorSavePulse | null>(null);
+	const pulseTimerRef = useRef<number | null>(null);
+
+	const clearPulseTimer = useCallback(() => {
+		if (pulseTimerRef.current !== null) {
+			window.clearTimeout(pulseTimerRef.current);
+			pulseTimerRef.current = null;
+		}
+	}, []);
+
+	const flashPulse = useCallback(
+		(next: EditorSavePulse) => {
+			clearPulseTimer();
+			setPulse(next);
+			pulseTimerRef.current = window.setTimeout(() => {
+				pulseTimerRef.current = null;
+				setPulse((current) => (current === next ? null : current));
+			}, EDITOR_SAVE_PULSE_MS);
+		},
+		[clearPulseTimer],
+	);
+
+	const clearPulse = useCallback(() => {
+		clearPulseTimer();
+		setPulse(null);
+	}, [clearPulseTimer]);
+
+	useEffect(() => () => clearPulseTimer(), [clearPulseTimer]);
+
+	const resolveLabel = useCallback(
+		(options: {
+			isDirty: boolean;
+			saving?: boolean;
+			autosaveBusy?: boolean;
+			idleLabel?: string | null;
+			hasSavedBefore?: boolean;
+		}): string | null => {
+			if (loading) return "Opening";
+			if (saving || options.saving || options.autosaveBusy) return "Saving";
+			if (options.isDirty) return "Edited";
+			if (pulse === "reloaded") return "Fresh";
+			if (pulse === "saved") return "Saved";
+			if (options.idleLabel === null) return null;
+			if (options.idleLabel !== undefined) return options.idleLabel;
+			return options.hasSavedBefore ? "Saved" : "Ready";
+		},
+		[loading, pulse, saving],
+	);
+
+	const resolveState = useCallback(
+		(options: {
+			isDirty: boolean;
+			saving?: boolean;
+			autosaveBusy?: boolean;
+		}):
+			| "loading"
+			| "saving"
+			| "edited"
+			| "saved"
+			| undefined => {
+			if (loading) return "loading";
+			if (saving || options.saving || options.autosaveBusy) return "saving";
+			if (options.isDirty) return "edited";
+			if (pulse === "saved") return "saved";
+			return undefined;
+		},
+		[loading, pulse, saving],
+	);
+
+	return {
+		saving,
+		setSaving,
+		loading,
+		setLoading,
+		pulse,
+		flashPulse,
+		clearPulse,
+		resolveLabel,
+		resolveState,
+	};
+}

--- a/src/hooks/useEditorSaveIndicator.ts
+++ b/src/hooks/useEditorSaveIndicator.ts
@@ -61,12 +61,7 @@ export function useEditorSaveIndicator() {
 			isDirty: boolean;
 			saving?: boolean;
 			autosaveBusy?: boolean;
-		}):
-			| "loading"
-			| "saving"
-			| "edited"
-			| "saved"
-			| undefined => {
+		}): "loading" | "saving" | "edited" | "saved" | undefined => {
 			if (loading) return "loading";
 			if (saving || options.saving || options.autosaveBusy) return "saving";
 			if (options.isDirty) return "edited";

--- a/src/lib/externalMarkdown.ts
+++ b/src/lib/externalMarkdown.ts
@@ -8,8 +8,7 @@ export async function openMarkdownInExternalWindow(
 ): Promise<void> {
 	if (!isMarkdownPath(relPath)) return;
 	try {
-		const abs = await invoke("space_resolve_abs_path", { path: relPath });
-		await invoke("open_external_markdown_path", { path: abs });
+		await invoke("open_external_markdown_path", { path: relPath });
 	} catch (error) {
 		const message = extractErrorMessage(error);
 		toast.error("Could not open in new window", { description: message });

--- a/src/lib/externalMarkdown.ts
+++ b/src/lib/externalMarkdown.ts
@@ -1,0 +1,17 @@
+import { isMarkdownPath } from "../utils/path";
+import { extractErrorMessage } from "./errorUtils";
+import { invoke } from "./tauri";
+import { toast } from "./toast";
+
+export async function openMarkdownInExternalWindow(
+	relPath: string,
+): Promise<void> {
+	if (!isMarkdownPath(relPath)) return;
+	try {
+		const abs = await invoke("space_resolve_abs_path", { path: relPath });
+		await invoke("open_external_markdown_path", { path: abs });
+	} catch (error) {
+		const message = extractErrorMessage(error);
+		toast.error("Could not open in new window", { description: message });
+	}
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -780,6 +780,7 @@ interface TauriCommands {
 	set_window_vibrancy_theme: CommandDef<{ theme: string }, void>;
 	open_external_markdown_path: CommandDef<{ path: string }, void>;
 	external_markdown_window_path: CommandDef<void, string>;
+	external_markdown_window_rel_path: CommandDef<void, string | null>;
 	external_markdown_read: CommandDef<{ path: string }, ExternalMarkdownDoc>;
 	external_markdown_write: CommandDef<
 		{ path: string; text: string; base_mtime_ms?: number | null },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -778,6 +778,7 @@ interface TauriCommands {
 		void
 	>;
 	set_window_vibrancy_theme: CommandDef<{ theme: string }, void>;
+	open_external_markdown_path: CommandDef<{ path: string }, void>;
 	external_markdown_window_path: CommandDef<void, string>;
 	external_markdown_read: CommandDef<{ path: string }, ExternalMarkdownDoc>;
 	external_markdown_write: CommandDef<

--- a/src/styles/app/47-external-markdown.css
+++ b/src/styles/app/47-external-markdown.css
@@ -1,4 +1,7 @@
 .externalMarkdownWindow {
+	--external-markdown-chrome-height: 56px;
+
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	width: 100vw;
@@ -6,90 +9,158 @@
 	min-width: 0;
 	min-height: 0;
 	overflow: hidden;
-	background: var(--bg-primary);
 	color: var(--text-primary);
+	background: var(--bg-canvas, var(--bg-primary));
 }
 
-.externalMarkdownHeader {
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto;
-	align-items: center;
-	gap: 16px;
-	min-height: 56px;
-	padding: 9px 14px 8px 82px;
-	border-bottom: 1px solid var(--border-light);
-	background: var(--bg-secondary);
-	flex: 0 0 auto;
+.externalMarkdownDragRegion {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	height: var(--external-markdown-chrome-height);
+	z-index: 0;
+	pointer-events: auto;
+	-webkit-app-region: drag;
+}
+
+.externalMarkdownOverlayChrome {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 4;
+	display: flex;
+	align-items: flex-start;
+	min-height: var(--external-markdown-chrome-height);
+	padding: 8px 16px 10px 82px;
+	background: linear-gradient(
+		to bottom,
+		color-mix(in srgb, var(--bg-canvas, var(--bg-primary)) 96%, transparent) 0%,
+		color-mix(in srgb, var(--bg-canvas, var(--bg-primary)) 84%, transparent) 72%,
+		transparent 100%
+	);
+	pointer-events: none;
 }
 
 .externalMarkdownTitleBlock {
+	position: relative;
+	z-index: 1;
 	min-width: 0;
+	flex: 1 1 auto;
+	max-width: calc(100% - 112px);
+	padding-top: 2px;
+	padding-right: 12px;
+	pointer-events: none;
 }
 
 .externalMarkdownTitle {
-	font-size: calc(var(--text-base) * 0.9);
-	font-weight: var(--font-bold);
-	line-height: 1.35;
-	color: var(--text-primary);
+	min-width: 0;
+	margin: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	font-size: calc(var(--text-base) * 0.9);
+	font-weight: var(--font-medium);
+	line-height: 1.35;
+	color: var(--text-secondary);
 }
 
-.externalMarkdownPath {
-	margin-top: 2px;
-	font-size: calc(var(--text-base) * 0.8);
+.externalMarkdownMeta {
+	margin: 2px 0 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: calc(var(--text-base) * 0.76);
 	line-height: 1.35;
 	color: var(--text-tertiary);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
-.externalMarkdownActions {
+.externalMarkdownBody {
+	flex: 1;
+	min-height: 0;
+	overflow: auto;
+	padding: 0;
+	background: transparent;
+}
+
+.externalMarkdownEditorPane {
+	position: relative;
+	width: 100%;
+	min-height: 100%;
+}
+
+.externalMarkdownFloatActions {
+	position: sticky;
+	top: calc(var(--external-markdown-chrome-height) - 34px);
+	z-index: 6;
 	display: inline-flex;
 	align-items: center;
-	gap: 8px;
+	justify-content: flex-end;
+	gap: 10px;
+	width: min(
+		var(--editor-readable-content-max-width),
+		calc(100% - (2 * var(--editor-readable-content-gutter-compact)))
+	);
+	margin: 0 auto;
+	padding-right: 2px;
+	overflow: visible;
+	pointer-events: none;
 	-webkit-app-region: no-drag;
 }
 
-.externalMarkdownModeSwitch {
-	display: inline-grid;
-	grid-template-columns: repeat(3, minmax(54px, auto));
-	align-items: center;
-	height: 30px;
-	padding: 2px;
-	border: 1px solid var(--border-light);
-	border-radius: var(--radius-md);
-	background: var(--bg-primary);
+.externalMarkdownFloatActions > * {
+	pointer-events: auto;
 }
 
-.externalMarkdownModeBtn {
-	height: 24px;
-	padding: 0 9px;
-	border: 0;
-	border-radius: calc(var(--radius-md) - 2px);
-	background: transparent;
-	color: var(--text-secondary);
-	font-size: calc(var(--text-base) * 0.8);
+.externalMarkdownFloatActions .markdownEditorToolbar {
+	flex: 0 0 auto;
+	overflow: visible;
+}
+
+.externalMarkdownFloatActions .markdownEditorModeSwitch {
+	display: inline-grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	align-items: center;
+	overflow: visible;
+}
+
+.externalMarkdownFloatActions .markdownEditorModeBtn {
+	width: 24px;
+	height: 20px;
+}
+
+.externalMarkdownSaveStatus {
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.76);
+	font-weight: var(--font-medium);
 	line-height: 1;
 	white-space: nowrap;
-	transition: background-color var(--transition-base), color
-		var(--transition-base);
+	transition: color var(--transition-fast);
 }
 
-.externalMarkdownModeBtn:hover {
-	color: var(--text-primary);
+.externalMarkdownSaveStatus[data-state="edited"] {
+	color: color-mix(in srgb, var(--status-warning-fg) 84%, var(--text-tertiary));
 }
 
-.externalMarkdownModeBtn[data-active="true"] {
-	background: var(--bg-tertiary);
-	color: var(--text-primary);
+.externalMarkdownSaveStatus[data-state="saving"],
+.externalMarkdownSaveStatus[data-state="loading"] {
+	color: var(--text-secondary);
+}
+
+.externalMarkdownSaveStatus[data-state="saved"] {
+	color: color-mix(in srgb, var(--status-success-fg) 78%, var(--text-tertiary));
 }
 
 .externalMarkdownError {
-	margin: 12px auto 0;
-	width: min(820px, calc(100vw - 32px));
+	position: absolute;
+	top: calc(var(--external-markdown-chrome-height) + 8px);
+	left: 50%;
+	z-index: 4;
+	width: min(
+		var(--editor-readable-content-max-width),
+		calc(100vw - (2 * var(--editor-readable-content-gutter-compact)))
+	);
 	padding: 8px 10px;
 	border: 1px solid var(--status-danger-border);
 	border-radius: var(--radius-md);
@@ -97,63 +168,57 @@
 	color: var(--status-danger-fg);
 	font-size: calc(var(--text-base) * 0.9);
 	line-height: 1.4;
-	flex: 0 0 auto;
+	transform: translateX(-50%);
 }
 
-.externalMarkdownEditor {
-	flex: 1;
-	min-height: 0;
-	overflow: auto;
-	padding: 34px 18px 56px;
-	background: var(--bg-primary);
-}
+.externalMarkdownEditorShell {
+	--readable-content-outer-width: min(
+		100%,
+		calc(
+			var(--editor-readable-content-max-width) +
+			(2 * var(--editor-readable-content-gutter))
+		)
+	);
 
-.externalMarkdownEditor .rfNodeNoteEditor {
-	width: min(820px, 100%);
+	width: var(--readable-content-outer-width);
 	min-height: 100%;
+	margin: 0 auto;
+	padding: calc(var(--external-markdown-chrome-height) + 6px)
+		var(--editor-readable-content-gutter) 50vh;
+}
+
+.externalMarkdownEditorShell .rfNodeNoteEditor {
+	width: 100%;
+	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
 	margin: 0 auto;
 	border: 0;
 	background: transparent;
 	overflow: visible;
 }
 
-.externalMarkdownEditor .rfNodeNoteEditor:focus-within {
+.externalMarkdownEditorShell .rfNodeNoteEditor:focus-within {
 	box-shadow: none;
 }
 
-.externalMarkdownEditor .rfNodeNoteEditorBody {
+.externalMarkdownEditorShell .rfNodeNoteEditorBody {
 	overflow: visible;
+	padding: 0;
+	background: transparent;
 }
 
-.externalMarkdownEditor .rfNodeNoteEditorRaw {
-	min-height: calc(100vh - 158px);
+.externalMarkdownEditorShell .rfNodeNoteEditorRaw {
+	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
 	padding: 0;
 	border: 0;
 	background: transparent;
 	box-shadow: none;
 }
 
-.externalMarkdownEditor .tiptapHostInline,
-.externalMarkdownEditor .tiptapContentInline {
-	min-height: calc(100vh - 158px);
+.externalMarkdownEditorShell .tiptapHostInline,
+.externalMarkdownEditorShell .tiptapContentInline {
+	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
 }
 
-@media (max-width: 640px) {
-	.externalMarkdownHeader {
-		padding-left: 74px;
-		gap: 10px;
-	}
-
-	.externalMarkdownModeSwitch {
-		grid-template-columns: repeat(3, 1fr);
-		width: 156px;
-	}
-
-	.externalMarkdownModeBtn {
-		padding-inline: 0;
-	}
-
-	.externalMarkdownEditor {
-		padding: 24px 12px 40px;
-	}
+.externalMarkdownEditorShell .tiptapContentInline {
+	padding-bottom: 8px;
 }


### PR DESCRIPTION
## Summary

Adds an "Open in New Window" context menu action for markdown files in the file tree, backed by a new `open_external_markdown_path` Tauri command. Also polishes the external markdown editor window with vibrancy, overlay chrome, a shared save-status indicator hook, and layout aligned with the main editor pane.

## Related Issues

Closes #87

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Open in New Window” for markdown files from the file tree and preserves space‑relative paths in the external editor. Polishes the external window with overlay chrome, macOS vibrancy, shared save status, and safer path handling, implementing KAR-87.

- **New Features**
  - File tree: “Open in New Window” for markdown via `openMarkdownInExternalWindow` and Tauri `open_external_markdown_path`.
  - External window: overlay title chrome, macOS vibrancy, stricter min size, and folder/title display using preserved space‑relative paths via `external_markdown_window_rel_path` with fallback.
  - Editor UX: shared save‑status via `useEditorSaveIndicator` and consistent mode switch using `EditorViewModeSwitch`.

- **Bug Fixes**
  - Autosave the active note if it’s dirty before opening it in a new window.
  - Resolve space‑relative paths on the Rust side, deny hidden paths, and verify file existence/type to prevent invalid opens.
  - Avoid bogus rel paths for files outside the space and show a safe fallback; surface errors via toast on open failure.

<sup>Written for commit dfa8d85747e9299844853995839da56a7a1007cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown files can now be opened in a separate window from the file menu.
  * External markdown windows now show improved save/loading status feedback and file location details.

* **Bug Fixes**
  * Improved handling when opening markdown files externally, with clearer error messages if something goes wrong.
  * External markdown windows now use more reliable sizing and display behavior, including better visual support on macOS.

* **Style**
  * Refreshed the external markdown editor layout with a cleaner window chrome and updated spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->