### PR TITLE
Restore workspace ("start where I left off") (#302) [Release]

### DIFF
--- a/docs/architecture/03-frontend-shell-state.md
+++ b/docs/architecture/03-frontend-shell-state.md
@@ -190,6 +190,8 @@ Special tabs use stable ids such as:
 
 Markdown file tabs sync into `UIProvider` as `openMarkdownTabs` and `activeMarkdownTabPath`. AI context actions use those values.
 
+When `ui.resumeLastSession` is enabled, `AppShell` restores the last saved per-space tab snapshot from `workspace.sessionBySpace` after the space and settings are loaded. The snapshot stores non-blank file and special tabs plus the active target. Missing markdown files are skipped by validating each file against disk before restoring. Tab changes are saved back through `saveWorkspaceSessionSnapshot()` after real tab commits, so switching spaces does not write an empty snapshot.
+
 ### Rename and Delete Behavior
 
 When a path gets renamed:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.6",
+	"version": "0.8.7-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -89,6 +89,7 @@ import {
 import { useAppCommands } from "./useAppCommands";
 import { useTabManager } from "./useTabManager";
 import { useWorkspaceLinkEvents } from "./useWorkspaceLinkEvents";
+import { useWorkspaceSession } from "./useWorkspaceSession";
 
 const loadCommandPalette = () =>
 	import("./CommandPalette").then((module) => ({
@@ -121,6 +122,7 @@ export function AppShell() {
 		onboardingNotePath,
 		consumeOnboardingNotePath,
 		isIndexing,
+		settingsLoaded,
 	} = space;
 	const fileTreeCtx = useFileTreeContext();
 	const {
@@ -187,6 +189,9 @@ export function AppShell() {
 	const [classicAllNotesByDefault, setClassicAllNotesByDefault] = useState<
 		boolean | null
 	>(null);
+	const [resumeLastSession, setResumeLastSession] = useState<boolean | null>(
+		null,
+	);
 	const [commandPaletteSessionId, setCommandPaletteSessionId] = useState(0);
 	const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
 	const autoUpdater = useUpdaterContext();
@@ -260,10 +265,12 @@ export function AppShell() {
 				if (cancelled) return;
 				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
 				setClassicAllNotesByDefault(settings.ui.classicAllNotesByDefault);
+				setResumeLastSession(settings.ui.resumeLastSession);
 			})
 			.catch((error) => {
 				console.error("Failed to load workspace display settings", error);
 				if (!cancelled) setClassicAllNotesByDefault(false);
+				if (!cancelled) setResumeLastSession(false);
 			});
 		return () => {
 			cancelled = true;
@@ -275,13 +282,19 @@ export function AppShell() {
 		useCallback(
 			(payload: {
 				editor?: { showCollapsibleHeadings?: boolean };
-				ui?: { classicAllNotesByDefault?: boolean };
+				ui?: {
+					classicAllNotesByDefault?: boolean;
+					resumeLastSession?: boolean;
+				};
 			}) => {
 				if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 					setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
 				}
 				if (typeof payload.ui?.classicAllNotesByDefault === "boolean") {
 					setClassicAllNotesByDefault(payload.ui.classicAllNotesByDefault);
+				}
+				if (typeof payload.ui?.resumeLastSession === "boolean") {
+					setResumeLastSession(payload.ui.resumeLastSession);
 				}
 			},
 			[],
@@ -344,6 +357,7 @@ export function AppShell() {
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
+		restoreWorkspaceTabs,
 		canGoBack,
 		canGoForward,
 		goBack,
@@ -351,8 +365,19 @@ export function AppShell() {
 		activateNextTab,
 		activatePreviousTab,
 		activateTabByIndex,
+		tabsRevision,
 	} = useTabManager(spacePath);
 	const { getBinding, actionsWithBindings } = useShortcutBindings();
+	useWorkspaceSession({
+		spacePath,
+		settingsLoaded,
+		resumeLastSession,
+		onboardingNotePath,
+		tabs,
+		activeTabPath,
+		tabsRevision,
+		restoreWorkspaceTabs,
+	});
 
 	useEffect(() => {
 		const visible =

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -20,6 +20,11 @@ type TabNoteHistory = {
 
 type TabHistoryById = Record<string, TabNoteHistory>;
 
+interface RestoredWorkspaceTab {
+	kind: "file" | "special";
+	target: string;
+}
+
 function matchesRemovedPath(
 	tab: WorkspaceTab,
 	path: string,
@@ -40,6 +45,7 @@ export function useTabManager(spacePath: string | null) {
 	const [activeTabId, setActiveTabIdState] = useState<string | null>(null);
 	const [dirtyByPath, setDirtyByPath] = useState<Record<string, boolean>>({});
 	const [historyByTabId, setHistoryByTabId] = useState<TabHistoryById>({});
+	const [tabsRevision, setTabsRevision] = useState(0);
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
@@ -127,6 +133,7 @@ export function useTabManager(spacePath: string | null) {
 			activeTabIdRef.current = nextActiveTabId;
 			setTabs(nextTabs);
 			setActiveTabIdState(nextActiveTabId);
+			setTabsRevision((revision) => revision + 1);
 			syncWorkspaceState(nextTabs, nextActiveTabId, previousActiveTarget);
 		},
 		[syncWorkspaceState],
@@ -148,6 +155,7 @@ export function useTabManager(spacePath: string | null) {
 		setActiveTabIdState(null);
 		setDirtyByPath({});
 		setHistoryByTabId({});
+		setTabsRevision(0);
 	}, [spacePath]);
 
 	const focusExistingTab = useCallback(
@@ -362,6 +370,38 @@ export function useTabManager(spacePath: string | null) {
 			updateActiveTabInPlace("special", target);
 		},
 		[clearHistoryForTab, focusExistingTab, updateActiveTabInPlace],
+	);
+
+	const restoreWorkspaceTabs = useCallback(
+		(tabSnapshots: RestoredWorkspaceTab[], activeTabTarget: string | null) => {
+			const seenTargets = new Set<string>();
+			const nextTabs: WorkspaceTab[] = [];
+			const nextHistory: TabHistoryById = {};
+
+			for (const snapshot of tabSnapshots) {
+				if (seenTargets.has(snapshot.target)) continue;
+				seenTargets.add(snapshot.target);
+				const tab = createTab(snapshot.kind, snapshot.target);
+				nextTabs.push(tab);
+				if (snapshot.kind === "file" && isMarkdownPath(snapshot.target)) {
+					nextHistory[tab.id] = {
+						entries: [{ path: snapshot.target }],
+						index: 0,
+					};
+				}
+			}
+
+			const nextActiveTabId =
+				nextTabs.find((tab) => tab.target === activeTabTarget)?.id ??
+				nextTabs[0]?.id ??
+				null;
+
+			historyByTabIdRef.current = nextHistory;
+			setHistoryByTabId(nextHistory);
+			setDirtyByPath({});
+			commitTabsChange(nextTabs, nextActiveTabId);
+		},
+		[commitTabsChange, createTab],
 	);
 
 	const openBlankTab = useCallback(() => {
@@ -665,6 +705,7 @@ export function useTabManager(spacePath: string | null) {
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
+		restoreWorkspaceTabs,
 		canGoBack,
 		canGoForward,
 		goBack,
@@ -672,5 +713,6 @@ export function useTabManager(spacePath: string | null) {
 		activateNextTab,
 		activatePreviousTab,
 		activateTabByIndex,
+		tabsRevision,
 	};
 }

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -31,7 +31,7 @@ function buildWorkspaceSessionTabs(
 
 async function validateRestorableSessionTabs(
 	tabs: WorkspaceSessionTabSnapshot[],
-): Promise<WorkspaceSessionTabSnapshot[]> {
+): Promise<WorkspaceSessionTabSnapshot[] | null> {
 	const fileTargets = tabs
 		.filter((tab) => tab.kind === "file")
 		.map((tab) => tab.target);
@@ -47,7 +47,7 @@ async function validateRestorableSessionTabs(
 			(tab) => tab.kind === "special" || existingTargets.has(tab.target),
 		);
 	} catch {
-		return tabs.filter((tab) => tab.kind === "special");
+		return null;
 	}
 }
 
@@ -85,6 +85,7 @@ export function useWorkspaceSession({
 	const pendingSaveRef = useRef<PendingWorkspaceSessionSave | null>(null);
 	const saveTimerRef = useRef<number | null>(null);
 	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const saveSpaceRef = useRef(spacePath);
 
 	const clearSaveTimer = useCallback(() => {
 		if (saveTimerRef.current === null) return;
@@ -138,6 +139,7 @@ export function useWorkspaceSession({
 			const restorableTabs = await validateRestorableSessionTabs(snapshot.tabs);
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
+				restorableTabs === null ||
 				!restorableTabs.length
 			) {
 				return;
@@ -152,6 +154,9 @@ export function useWorkspaceSession({
 		})().catch((cause) => {
 			console.error("Failed to restore workspace session", cause);
 		});
+		return () => {
+			restoreSessionRequestIdRef.current += 1;
+		};
 	}, [
 		onboardingNotePath,
 		restoreWorkspaceTabs,
@@ -161,6 +166,12 @@ export function useWorkspaceSession({
 	]);
 
 	useEffect(() => {
+		if (saveSpaceRef.current !== spacePath) {
+			pendingSaveRef.current = null;
+			clearSaveTimer();
+			saveSpaceRef.current = spacePath;
+			return;
+		}
 		if (!spacePath || tabsRevision === 0) {
 			return;
 		}

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useRef } from "react";
+import { invoke } from "../../lib/tauri";
+import {
+	type WorkspaceSessionSnapshot,
+	type WorkspaceSessionTabSnapshot,
+	loadWorkspaceSessionSnapshot,
+	saveWorkspaceSessionSnapshot,
+} from "../../lib/workspaceSession";
+import type { WorkspaceTab } from "./useTabManager";
+
+const WORKSPACE_SESSION_SAVE_DEBOUNCE_MS = 250;
+
+function buildWorkspaceSessionTabs(
+	tabs: WorkspaceTab[],
+): WorkspaceSessionTabSnapshot[] {
+	const seenTargets = new Set<string>();
+	const snapshotTabs: WorkspaceSessionTabSnapshot[] = [];
+	for (const tab of tabs) {
+		if (
+			(tab.kind !== "file" && tab.kind !== "special") ||
+			tab.target === null ||
+			seenTargets.has(tab.target)
+		) {
+			continue;
+		}
+		seenTargets.add(tab.target);
+		snapshotTabs.push({ kind: tab.kind, target: tab.target });
+	}
+	return snapshotTabs;
+}
+
+async function validateRestorableSessionTabs(
+	tabs: WorkspaceSessionTabSnapshot[],
+): Promise<WorkspaceSessionTabSnapshot[]> {
+	const fileTargets = tabs
+		.filter((tab) => tab.kind === "file")
+		.map((tab) => tab.target);
+	if (!fileTargets.length) return tabs;
+
+	try {
+		const markdownFiles = await invoke("space_list_markdown_files", {
+			recursive: true,
+			limit: null,
+		});
+		const existingTargets = new Set(markdownFiles.map((file) => file.rel_path));
+		return tabs.filter(
+			(tab) => tab.kind === "special" || existingTargets.has(tab.target),
+		);
+	} catch {
+		return tabs.filter((tab) => tab.kind === "special");
+	}
+}
+
+interface UseWorkspaceSessionArgs {
+	spacePath: string | null;
+	settingsLoaded: boolean;
+	resumeLastSession: boolean | null;
+	onboardingNotePath: string | null;
+	tabs: WorkspaceTab[];
+	activeTabPath: string | null;
+	tabsRevision: number;
+	restoreWorkspaceTabs: (
+		tabSnapshots: WorkspaceSessionTabSnapshot[],
+		activeTabTarget: string | null,
+	) => void;
+}
+
+interface PendingWorkspaceSessionSave {
+	spacePath: string;
+	snapshot: WorkspaceSessionSnapshot;
+}
+
+export function useWorkspaceSession({
+	spacePath,
+	settingsLoaded,
+	resumeLastSession,
+	onboardingNotePath,
+	tabs,
+	activeTabPath,
+	tabsRevision,
+	restoreWorkspaceTabs,
+}: UseWorkspaceSessionArgs) {
+	const restoredSessionSpaceRef = useRef<string | null>(null);
+	const restoreSessionRequestIdRef = useRef(0);
+	const pendingSaveRef = useRef<PendingWorkspaceSessionSave | null>(null);
+	const saveTimerRef = useRef<number | null>(null);
+	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+	const clearSaveTimer = useCallback(() => {
+		if (saveTimerRef.current === null) return;
+		window.clearTimeout(saveTimerRef.current);
+		saveTimerRef.current = null;
+	}, []);
+
+	const flushPendingSave = useCallback(() => {
+		const pending = pendingSaveRef.current;
+		if (!pending) return;
+		pendingSaveRef.current = null;
+		clearSaveTimer();
+		saveQueueRef.current = saveQueueRef.current
+			.catch(() => {})
+			.then(() =>
+				saveWorkspaceSessionSnapshot(pending.spacePath, pending.snapshot),
+			)
+			.catch((cause) => {
+				console.error("Failed to save workspace session", cause);
+			});
+	}, [clearSaveTimer]);
+
+	useEffect(() => {
+		if (restoredSessionSpaceRef.current !== spacePath) {
+			restoredSessionSpaceRef.current = null;
+			restoreSessionRequestIdRef.current += 1;
+		}
+		if (
+			!spacePath ||
+			!settingsLoaded ||
+			resumeLastSession === null ||
+			restoredSessionSpaceRef.current === spacePath
+		) {
+			return;
+		}
+
+		restoredSessionSpaceRef.current = spacePath;
+		if (onboardingNotePath) return;
+		if (!resumeLastSession) return;
+
+		const requestId = ++restoreSessionRequestIdRef.current;
+		void (async () => {
+			const snapshot = await loadWorkspaceSessionSnapshot(spacePath);
+			if (
+				requestId !== restoreSessionRequestIdRef.current ||
+				!snapshot?.tabs.length
+			) {
+				return;
+			}
+
+			const restorableTabs = await validateRestorableSessionTabs(snapshot.tabs);
+			if (
+				requestId !== restoreSessionRequestIdRef.current ||
+				!restorableTabs.length
+			) {
+				return;
+			}
+
+			const activeTabTarget = restorableTabs.some(
+				(tab) => tab.target === snapshot.activeTabTarget,
+			)
+				? snapshot.activeTabTarget
+				: null;
+			restoreWorkspaceTabs(restorableTabs, activeTabTarget);
+		})().catch((cause) => {
+			console.error("Failed to restore workspace session", cause);
+		});
+	}, [
+		onboardingNotePath,
+		restoreWorkspaceTabs,
+		resumeLastSession,
+		settingsLoaded,
+		spacePath,
+	]);
+
+	useEffect(() => {
+		if (!spacePath || tabsRevision === 0) {
+			return;
+		}
+		const snapshotTabs = buildWorkspaceSessionTabs(tabs);
+		const activeTarget =
+			snapshotTabs.find((tab) => tab.target === activeTabPath)?.target ?? null;
+		pendingSaveRef.current = {
+			spacePath,
+			snapshot: {
+				version: 1,
+				savedAt: Date.now(),
+				tabs: snapshotTabs,
+				activeTabTarget: activeTarget,
+			},
+		};
+		clearSaveTimer();
+		saveTimerRef.current = window.setTimeout(
+			flushPendingSave,
+			WORKSPACE_SESSION_SAVE_DEBOUNCE_MS,
+		);
+		return clearSaveTimer;
+	}, [
+		activeTabPath,
+		clearSaveTimer,
+		flushPendingSave,
+		spacePath,
+		tabs,
+		tabsRevision,
+	]);
+
+	useEffect(() => {
+		const currentSpacePath = spacePath;
+		return () => {
+			if (currentSpacePath) flushPendingSave();
+		};
+	}, [flushPendingSave, spacePath]);
+}

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -6,8 +6,9 @@ import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GeneralSettingsPane } from "./GeneralSettingsPane";
 
-const { useLicenseStatusMock } = vi.hoisted(() => ({
+const { useLicenseStatusMock, useTauriEventMock } = vi.hoisted(() => ({
 	useLicenseStatusMock: vi.fn(),
+	useTauriEventMock: vi.fn(),
 }));
 
 vi.mock("../../lib/settings", () => ({
@@ -20,7 +21,7 @@ vi.mock("../../lib/settings", () => ({
 }));
 
 vi.mock("../../lib/tauriEvents", () => ({
-	useTauriEvent: vi.fn(),
+	useTauriEvent: useTauriEventMock,
 }));
 
 vi.mock("../../lib/license", () => ({
@@ -133,5 +134,35 @@ describe("GeneralSettingsPane", () => {
 			"Automatic updates are always on.",
 		);
 		expect(container.textContent).toContain("License Card Stub");
+	});
+
+	it("syncs resume last session from settings update events", async () => {
+		useLicenseStatusMock.mockReturnValue({
+			status: undefined,
+			loading: true,
+			error: "",
+			reload: vi.fn(),
+		} as never);
+
+		await act(async () => {
+			root.render(<GeneralSettingsPane />);
+		});
+
+		const toggle = container.querySelector("input");
+		expect(toggle?.checked).toBe(false);
+
+		const handler = useTauriEventMock.mock.calls.find(
+			([eventName]) => eventName === "settings:updated",
+		)?.[1] as (payload: { ui?: { resumeLastSession?: boolean } }) => void;
+
+		act(() => {
+			handler({ ui: {} });
+		});
+		expect(toggle?.checked).toBe(false);
+
+		act(() => {
+			handler({ ui: { resumeLastSession: true } });
+		});
+		expect(toggle?.checked).toBe(true);
 	});
 });

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -10,15 +10,18 @@ const { useLicenseStatusMock } = vi.hoisted(() => ({
 	useLicenseStatusMock: vi.fn(),
 }));
 
-vi.mock("../../lib/settings", async () => {
-	const actual =
-		await vi.importActual<typeof import("../../lib/settings")>(
-			"../../lib/settings",
-		);
-	return {
-		...actual,
-	};
-});
+vi.mock("../../lib/settings", () => ({
+	loadSettings: vi.fn(() =>
+		Promise.resolve({
+			ui: { resumeLastSession: false },
+		}),
+	),
+	setResumeLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../lib/tauriEvents", () => ({
+	useTauriEvent: vi.fn(),
+}));
 
 vi.mock("../../lib/license", () => ({
 	useLicenseStatus: useLicenseStatusMock,
@@ -69,6 +72,22 @@ vi.mock("./SettingsScaffold", () => ({
 			{description ? <div>{description}</div> : null}
 			{children}
 		</div>
+	),
+	SettingsToggle: ({
+		checked,
+		ariaLabel,
+		onCheckedChange,
+	}: {
+		checked: boolean;
+		ariaLabel: string;
+		onCheckedChange: (checked: boolean) => void;
+	}) => (
+		<input
+			aria-label={ariaLabel}
+			checked={checked}
+			onChange={(event) => onCheckedChange(event.currentTarget.checked)}
+			type="checkbox"
+		/>
 	),
 }));
 

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -1,9 +1,72 @@
+import { useCallback, useEffect, useState } from "react";
+import { loadSettings, setResumeLastSession } from "../../lib/settings";
+import { useTauriEvent } from "../../lib/tauriEvents";
 import { LicenseSettingsCard } from "../licensing/LicenseSettingsCard";
+import {
+	SettingsRow,
+	SettingsSection,
+	SettingsToggle,
+} from "./SettingsScaffold";
+import { useOptimisticSettingsToggle } from "./useOptimisticSettingsToggle";
 
 export function GeneralSettingsPane() {
+	const [resumeLastSession, setResumeLastSessionState] = useState(false);
+	const [error, setError] = useState("");
+	const resumeLastSessionToggle = useOptimisticSettingsToggle(
+		resumeLastSession,
+		setResumeLastSessionState,
+		setResumeLastSession,
+		setError,
+	);
+
+	useEffect(() => {
+		let cancelled = false;
+		setError("");
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled) {
+					setResumeLastSessionState(settings.ui.resumeLastSession);
+				}
+			})
+			.catch((cause) => {
+				if (!cancelled) {
+					setError(cause instanceof Error ? cause.message : String(cause));
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	useTauriEvent(
+		"settings:updated",
+		useCallback((payload: { ui?: { resumeLastSession?: boolean } }) => {
+			if (typeof payload.ui?.resumeLastSession === "boolean") {
+				setResumeLastSessionState(payload.ui.resumeLastSession);
+			}
+		}, []),
+	);
+
 	return (
 		<div className="settingsPane">
+			{error ? <div className="settingsError">{error}</div> : null}
 			<div className="settingsGrid">
+				<SettingsSection
+					title="Startup"
+					description="Choose what Glyph restores when the app launches."
+				>
+					<SettingsRow
+						label="Resume last session"
+						description="Reopen the tabs from this space the next time Glyph launches."
+					>
+						<SettingsToggle
+							checked={resumeLastSession}
+							disabled={resumeLastSessionToggle.isSaving}
+							ariaLabel="Resume last session"
+							onCheckedChange={resumeLastSessionToggle.onCheckedChange}
+						/>
+					</SettingsRow>
+				</SettingsSection>
 				<LicenseSettingsCard />
 			</div>
 		</div>

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -53,11 +53,11 @@ export function GeneralSettingsPane() {
 			<div className="settingsGrid">
 				<SettingsSection
 					title="Startup"
-					description="Choose what Glyph restores when the app launches."
+					description="Choose what opens when you start Glyph."
 				>
 					<SettingsRow
-						label="Resume last session"
-						description="Reopen the tabs from this space the next time Glyph launches."
+						label="Open previous tabs"
+						description="Start this space with the tabs you left open."
 					>
 						<SettingsToggle
 							checked={resumeLastSession}

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -76,9 +76,8 @@ const SETTINGS_SEARCH_ITEMS = [
 		id: "general-resume-last-session",
 		tab: "general",
 		section: "Startup",
-		title: "Resume last session",
-		description:
-			"Reopen the tabs from this space the next time Glyph launches.",
+		title: "Open previous tabs",
+		description: "Start this space with the tabs you left open.",
 		keywords: [
 			"restore",
 			"startup",

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -73,6 +73,22 @@ const SETTINGS_SEARCH_ITEMS = [
 		keywords: ["support", "remove local activation"],
 	},
 	{
+		id: "general-resume-last-session",
+		tab: "general",
+		section: "Startup",
+		title: "Resume last session",
+		description:
+			"Reopen the tabs from this space the next time Glyph launches.",
+		keywords: [
+			"restore",
+			"startup",
+			"launch",
+			"start where I left off",
+			"tabs",
+			"workspace session",
+		],
+	},
+	{
 		id: "appearance-theme-mode",
 		tab: "appearance",
 		section: "Theme",

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -188,6 +188,54 @@ describe("settings Folio Mode", () => {
 	});
 });
 
+describe("settings workspace session restore", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		emitMock.mockClear();
+		storeState.clear();
+	});
+
+	it("defaults resume last session to false", async () => {
+		const { loadSettings } = await import("./settings");
+		const settings = await loadSettings();
+		expect(settings.ui.resumeLastSession).toBe(false);
+	});
+
+	it("persists and emits resume last session changes", async () => {
+		const { setResumeLastSession } = await import("./settings");
+		await setResumeLastSession(true);
+		expect(storeState.get("ui.resumeLastSession")).toBe(true);
+		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
+			ui: { resumeLastSession: true },
+		});
+	});
+
+	it("saves normalized per-space workspace session snapshots", async () => {
+		const { loadWorkspaceSessionSnapshot, saveWorkspaceSessionSnapshot } =
+			await import("./workspaceSession");
+
+		await saveWorkspaceSessionSnapshot("/tmp/space", {
+			version: 1,
+			savedAt: 123.5,
+			tabs: [
+				{ kind: "file", target: "Notes/A.md" },
+				{ kind: "special", target: "all-docs" },
+			],
+			activeTabTarget: "all-docs",
+		});
+
+		expect(await loadWorkspaceSessionSnapshot("/tmp/space")).toEqual({
+			version: 1,
+			savedAt: 123,
+			tabs: [
+				{ kind: "file", target: "Notes/A.md" },
+				{ kind: "special", target: "all-docs" },
+			],
+			activeTabTarget: "all-docs",
+		});
+	});
+});
+
 describe("settings corner radius style", () => {
 	beforeEach(() => {
 		vi.resetModules();

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -234,6 +234,39 @@ describe("settings workspace session restore", () => {
 			activeTabTarget: "all-docs",
 		});
 	});
+
+	it("normalizes malformed persisted workspace session snapshots", async () => {
+		const { loadWorkspaceSessionSnapshot } = await import("./workspaceSession");
+
+		storeState.set("workspace.sessionBySpace", {
+			"/tmp/space": {
+				version: 1,
+				savedAt: Number.POSITIVE_INFINITY,
+				tabs: [
+					{ kind: "file", target: "Notes/A.md" },
+					{ kind: "special", target: "Notes/A.md" },
+					{ kind: "file", target: "Notes/B.markdown" },
+					{ kind: "file", target: "Notes/C.txt" },
+					{ kind: "unknown", target: "Notes/D.md" },
+					{ kind: "special", target: "x".repeat(121) },
+					{ kind: "special", target: "all-docs" },
+				],
+				activeTabTarget: "missing",
+			},
+		});
+
+		expect(await loadWorkspaceSessionSnapshot("/tmp/missing")).toBeNull();
+		expect(await loadWorkspaceSessionSnapshot("/tmp/space")).toEqual({
+			version: 1,
+			savedAt: 0,
+			tabs: [
+				{ kind: "file", target: "Notes/A.md" },
+				{ kind: "file", target: "Notes/B.markdown" },
+				{ kind: "special", target: "all-docs" },
+			],
+			activeTabTarget: null,
+		});
+	});
 });
 
 describe("settings corner radius style", () => {
@@ -338,14 +371,14 @@ describe("settings editor font family", () => {
 		storeState.clear();
 	});
 
-	it("materializes the editor font from the UI font for existing settings", async () => {
+	it("derives the editor font from the UI font when unset", async () => {
 		storeState.set("ui.fontFamily", "Atkinson Hyperlegible");
 		const { loadSettings } = await import("./settings");
 
 		const settings = await loadSettings();
 
 		expect(settings.ui.editorFontFamily).toBe("Atkinson Hyperlegible");
-		expect(storeState.get("ui.editorFontFamily")).toBe("Atkinson Hyperlegible");
+		expect(storeState.get("ui.editorFontFamily")).toBeUndefined();
 	});
 
 	it("preserves an existing editor font instead of deriving it from the UI font", async () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,12 +1,17 @@
-import { type UnlistenFn, emit, emitTo, listen } from "@tauri-apps/api/event";
+import { emit, emitTo } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { LazyStore } from "@tauri-apps/plugin-store";
 import { normalizeRelPath, validateRelFolderPath } from "../utils/path";
 import {
 	ATTACHMENT_MODE_UI,
 	DEFAULT_ATTACHMENT_FOLDER,
 } from "./attachmentStorage";
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
+import {
+	getSettingsStore,
+	invalidateSettingsCache,
+	loadSettingsEntries,
+	saveSettingsStore,
+} from "./settingsStore";
 import {
 	type Shortcut,
 	areShortcutsEqual,
@@ -62,109 +67,6 @@ const FILE_TREE_SORT_MODES = new Set<FileTreeSortMode>([
 	"created-desc",
 	"created-asc",
 ]);
-
-let storeInstance: LazyStore | null = null;
-let storeInitPromise: Promise<void> | null = null;
-let settingsEntriesCache: Map<string, unknown> | null = null;
-let settingsEntriesPromise: Promise<Map<string, unknown>> | null = null;
-let settingsEntriesGeneration = 0;
-let settingsInvalidationUnlisten: UnlistenFn | null = null;
-let settingsInvalidationUnlistenPromise: Promise<UnlistenFn> | null = null;
-
-function runSettingsInvalidationUnlisten(unlisten: UnlistenFn): void {
-	try {
-		const result = unlisten() as unknown;
-		void Promise.resolve(result).catch(() => {});
-	} catch {
-		// Ignore listener cleanup races during Tauri window teardown.
-	}
-}
-
-function ensureSettingsInvalidationListener() {
-	if (settingsInvalidationUnlisten || settingsInvalidationUnlistenPromise)
-		return;
-
-	const unlistenPromise = listen("settings:updated", () => {
-		invalidateSettingsCache();
-	});
-	settingsInvalidationUnlistenPromise = unlistenPromise;
-	void unlistenPromise
-		.then((unlisten) => {
-			if (settingsInvalidationUnlistenPromise !== unlistenPromise) return;
-			settingsInvalidationUnlisten = unlisten;
-			settingsInvalidationUnlistenPromise = null;
-		})
-		.catch(() => {
-			if (settingsInvalidationUnlistenPromise === unlistenPromise) {
-				settingsInvalidationUnlistenPromise = null;
-			}
-		});
-}
-
-export function disposeSettingsInvalidationListener(): void {
-	const unlisten = settingsInvalidationUnlisten;
-	const unlistenPromise = settingsInvalidationUnlistenPromise;
-	settingsInvalidationUnlisten = null;
-	settingsInvalidationUnlistenPromise = null;
-
-	if (unlisten) {
-		runSettingsInvalidationUnlisten(unlisten);
-		return;
-	}
-	if (unlistenPromise) {
-		void unlistenPromise.then(runSettingsInvalidationUnlisten).catch(() => {});
-	}
-}
-
-if (import.meta.hot) {
-	import.meta.hot.dispose(disposeSettingsInvalidationListener);
-}
-
-async function getStore(): Promise<LazyStore> {
-	ensureSettingsInvalidationListener();
-	if (!storeInstance) {
-		storeInstance = new LazyStore("settings.json");
-		storeInitPromise = storeInstance.init();
-	}
-	if (storeInitPromise) {
-		await storeInitPromise;
-	}
-	return storeInstance;
-}
-
-function invalidateSettingsCache() {
-	settingsEntriesGeneration += 1;
-	settingsEntriesCache = null;
-	settingsEntriesPromise = null;
-}
-
-async function saveSettingsStore(store: LazyStore): Promise<void> {
-	await store.save();
-	invalidateSettingsCache();
-}
-
-async function loadSettingsEntries(): Promise<Map<string, unknown>> {
-	if (settingsEntriesCache) return settingsEntriesCache;
-	if (settingsEntriesPromise) return settingsEntriesPromise;
-
-	const generation = settingsEntriesGeneration;
-	const promise = getStore()
-		.then((store) => store.entries<unknown>())
-		.then((entries) => {
-			const next = new Map(entries);
-			if (generation === settingsEntriesGeneration) {
-				settingsEntriesCache = next;
-			}
-			return next;
-		})
-		.finally(() => {
-			if (settingsEntriesPromise === promise) {
-				settingsEntriesPromise = null;
-			}
-		});
-	settingsEntriesPromise = promise;
-	return settingsEntriesPromise;
-}
 
 function getSettingValue<T>(
 	entries: Map<string, unknown>,
@@ -486,6 +388,7 @@ async function emitSettingsUpdated(payload: {
 		fileTreeSortMode?: FileTreeSortMode;
 		folioMode?: boolean;
 		classicAllNotesByDefault?: boolean;
+		resumeLastSession?: boolean;
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
 	};
@@ -572,6 +475,7 @@ interface AppSettings {
 		fileTreeSortMode: FileTreeSortMode;
 		folioMode: boolean;
 		classicAllNotesByDefault: boolean;
+		resumeLastSession: boolean;
 		aiAssistantMode: AiAssistantMode;
 	};
 	dailyNotes: {
@@ -648,6 +552,7 @@ const KEYS = {
 	fileTreeSortMode: "ui.fileTree.sortMode",
 	folioMode: "ui.folioMode",
 	classicAllNotesByDefault: "ui.classicAllNotesByDefault",
+	resumeLastSession: "ui.resumeLastSession",
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
@@ -854,7 +759,7 @@ async function updateActiveSpaceSettings(
 	const spacePath = await activeSpacePath(scope);
 	if (!spacePath) return null;
 	await withSpaceScopedSettingsWriteLock(async () => {
-		const store = await getStore();
+		const store = await getSettingsStore();
 		const map = normalizeSpaceScopedSettingsMap(
 			await store.get<unknown>(KEYS.spaceScopedSettings),
 		);
@@ -889,7 +794,7 @@ function normalizeQuickNotesFolder(value: unknown): string {
 }
 
 export async function reloadFromDisk(): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.reload();
 	invalidateSettingsCache();
 }
@@ -979,6 +884,10 @@ export async function loadSettings(
 	const rawClassicAllNotesByDefault = getSettingValue<boolean | null>(
 		entries,
 		KEYS.classicAllNotesByDefault,
+	);
+	const rawResumeLastSession = getSettingValue<boolean | null>(
+		entries,
+		KEYS.resumeLastSession,
 	);
 	const dailyNotesFolderRaw = getSettingValue<string | null>(
 		entries,
@@ -1083,7 +992,7 @@ export async function loadSettings(
 		rawFontFamily.trim() === "Satoshi" &&
 		fontFamily === DEFAULT_UI_FONT_FAMILY
 	) {
-		const store = await getStore();
+		const store = await getSettingsStore();
 		await store.set(KEYS.fontFamily, DEFAULT_UI_FONT_FAMILY);
 		entries.set(KEYS.fontFamily, DEFAULT_UI_FONT_FAMILY);
 	}
@@ -1093,7 +1002,7 @@ export async function loadSettings(
 			? fontFamily
 			: asUiEditorFontFamily(rawEditorFontFamily);
 	if (rawEditorFontFamily === undefined || rawEditorFontFamily === null) {
-		const store = await getStore();
+		const store = await getSettingsStore();
 		await store.set(KEYS.editorFontFamily, editorFontFamily);
 		await saveSettingsStore(store);
 		entries.set(KEYS.editorFontFamily, editorFontFamily);
@@ -1123,6 +1032,8 @@ export async function loadSettings(
 		typeof rawClassicAllNotesByDefault === "boolean"
 			? rawClassicAllNotesByDefault
 			: false;
+	const resumeLastSession =
+		typeof rawResumeLastSession === "boolean" ? rawResumeLastSession : false;
 	const dailyNotesFolder = hasActiveSpace
 		? (activeScopedSettings?.dailyNotesFolder ?? null)
 		: typeof dailyNotesFolderRaw === "string"
@@ -1223,6 +1134,7 @@ export async function loadSettings(
 			fileTreeSortMode,
 			folioMode,
 			classicAllNotesByDefault,
+			resumeLastSession,
 			aiAssistantMode,
 		},
 		dailyNotes: {
@@ -1242,7 +1154,7 @@ export async function loadSettings(
 }
 
 export async function setCurrentSpacePath(path: string): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.currentSpacePath, path);
 	const prev = (await store.get<string[] | null>(KEYS.recentSpaces)) ?? [];
 	const next = [path, ...prev.filter((p) => p !== path)].slice(0, 20);
@@ -1251,7 +1163,7 @@ export async function setCurrentSpacePath(path: string): Promise<void> {
 }
 
 export async function clearCurrentSpacePath(): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.currentSpacePath, null);
 	await saveSettingsStore(store);
 }
@@ -1264,7 +1176,7 @@ export async function updateOnboardingSettings(
 			typeof entry[1] === "boolean",
 	);
 	if (!entries.length) return;
-	const store = await getStore();
+	const store = await getSettingsStore();
 	for (const [key, value] of entries) {
 		await store.set(ONBOARDING_KEYS[key], value);
 	}
@@ -1275,7 +1187,7 @@ export async function updateOnboardingSettings(
 }
 
 async function saveShortcutBindingsToStore(bindings: ShortcutBindings) {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const sanitized = sanitizeShortcutBindings(bindings);
 	await store.set(KEYS.shortcutsVersion, DEFAULT_SHORTCUT_SETTINGS.version);
 	await store.set(KEYS.shortcutsBindings, sanitized);
@@ -1352,7 +1264,7 @@ export async function resetShortcutBinding(
 
 export async function resetAllShortcutBindings(): Promise<void> {
 	return withShortcutBindingsWriteLock(async () => {
-		const store = await getStore();
+		const store = await getSettingsStore();
 		await store.delete(KEYS.shortcutsVersion);
 		await store.delete(KEYS.shortcutsBindings);
 		await saveSettingsStore(store);
@@ -1361,21 +1273,21 @@ export async function resetAllShortcutBindings(): Promise<void> {
 }
 
 export async function setAiAssistantMode(mode: AiAssistantMode): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.aiAssistantMode, mode);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { aiAssistantMode: mode } });
 }
 
 export async function setAiEnabled(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.aiEnabled, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { aiEnabled: enabled } });
 }
 
 export async function setThemeMode(theme: ThemeMode): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.theme, theme);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { theme } });
@@ -1384,7 +1296,7 @@ export async function setThemeMode(theme: ThemeMode): Promise<void> {
 export async function setUiLightThemeId(
 	lightThemeId: UiLightThemeId,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiLightThemeId(lightThemeId);
 	await store.set(KEYS.lightThemeId, next);
 	await saveSettingsStore(store);
@@ -1394,7 +1306,7 @@ export async function setUiLightThemeId(
 export async function setUiDarkThemeId(
 	darkThemeId: UiDarkThemeId,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiDarkThemeId(darkThemeId);
 	await store.set(KEYS.darkThemeId, next);
 	await saveSettingsStore(store);
@@ -1402,7 +1314,7 @@ export async function setUiDarkThemeId(
 }
 
 export async function setUiAccent(accent: UiAccent): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiAccent(accent);
 	await store.set(KEYS.accent, next);
 	await saveSettingsStore(store);
@@ -1429,7 +1341,7 @@ export async function setUiThemeColorOverride({
 	field: UiThemeColorField;
 	color: string | null;
 }): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = color === null ? null : tryNormalizeThemeColorHex(color);
 	if (color !== null && next === null) {
 		throw new Error("Invalid theme color");
@@ -1451,7 +1363,7 @@ export async function setUiThemeColorOverride({
 }
 
 export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiFontFamily(fontFamily);
 	await store.set(KEYS.fontFamily, next);
 	await saveSettingsStore(store);
@@ -1461,7 +1373,7 @@ export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {
 export async function setUiEditorFontFamily(
 	fontFamily: UiFontFamily,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiEditorFontFamily(fontFamily);
 	await store.set(KEYS.editorFontFamily, next);
 	await saveSettingsStore(store);
@@ -1471,7 +1383,7 @@ export async function setUiEditorFontFamily(
 export async function setUiMonoFontFamily(
 	fontFamily: UiFontFamily,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiMonoFontFamily(fontFamily);
 	await store.set(KEYS.monoFontFamily, next);
 	await saveSettingsStore(store);
@@ -1479,7 +1391,7 @@ export async function setUiMonoFontFamily(
 }
 
 export async function setUiFontSize(fontSize: UiFontSize): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiFontSize(fontSize);
 	await store.set(KEYS.fontSize, next);
 	await saveSettingsStore(store);
@@ -1487,7 +1399,7 @@ export async function setUiFontSize(fontSize: UiFontSize): Promise<void> {
 }
 
 export async function setUiEditorFontSize(fontSize: UiFontSize): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiEditorFontSize(fontSize);
 	await store.set(KEYS.editorFontSize, next);
 	await saveSettingsStore(store);
@@ -1495,7 +1407,7 @@ export async function setUiEditorFontSize(fontSize: UiFontSize): Promise<void> {
 }
 
 export async function setUiTranslucentApp(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.translucentApp, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { translucentApp: enabled } });
@@ -1504,7 +1416,7 @@ export async function setUiTranslucentApp(enabled: boolean): Promise<void> {
 export async function setUiCornerRadiusStyle(
 	style: UiCornerRadiusStyle,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asUiCornerRadiusStyle(style);
 	await store.set(KEYS.cornerRadiusStyle, next);
 	await saveSettingsStore(store);
@@ -1512,7 +1424,7 @@ export async function setUiCornerRadiusStyle(
 }
 
 export async function setShowToc(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.showToc, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { showToc: enabled } });
@@ -1521,14 +1433,14 @@ export async function setShowToc(enabled: boolean): Promise<void> {
 export async function setShowFileTreeFolderCounts(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.showFileTreeFolderCounts, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { showFileTreeFolderCounts: enabled } });
 }
 
 export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.showNonMarkdownFiles, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { showNonMarkdownFiles: enabled } });
@@ -1537,14 +1449,14 @@ export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
 export async function setFileTreeSortMode(
 	sortMode: FileTreeSortMode,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.fileTreeSortMode, sortMode);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { fileTreeSortMode: sortMode } });
 }
 
 export async function setFolioMode(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.folioMode, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { folioMode: enabled } });
@@ -1553,16 +1465,23 @@ export async function setFolioMode(enabled: boolean): Promise<void> {
 export async function setClassicAllNotesByDefault(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.classicAllNotesByDefault, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { classicAllNotesByDefault: enabled } });
 }
 
+export async function setResumeLastSession(enabled: boolean): Promise<void> {
+	const store = await getSettingsStore();
+	await store.set(KEYS.resumeLastSession, enabled);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { resumeLastSession: enabled } });
+}
+
 export async function setEditorShowCollapsibleHeadings(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorShowCollapsibleHeadings, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1573,7 +1492,7 @@ export async function setEditorShowCollapsibleHeadings(
 export async function setEditorColorfulHeadings(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorColorfulHeadings, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1582,7 +1501,7 @@ export async function setEditorColorfulHeadings(
 }
 
 export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorBeautifulTags, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1593,7 +1512,7 @@ export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
 export async function setEditorShowFrontmatterInEditor(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorShowFrontmatterInEditor, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1602,7 +1521,7 @@ export async function setEditorShowFrontmatterInEditor(
 }
 
 export async function setEditorWidthMode(mode: EditorWidthMode): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const next = asEditorWidthMode(mode);
 	await store.set(KEYS.editorEditorWidthMode, next);
 	await saveSettingsStore(store);
@@ -1629,7 +1548,7 @@ export async function setEditorAttachmentStorageMode(
 		});
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorAttachmentStorageMode, nextMode);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1662,7 +1581,7 @@ export async function setEditorAttachmentFolder(
 		});
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorAttachmentFolder, nextFolder);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1673,7 +1592,7 @@ export async function setEditorAttachmentFolder(
 export async function setEditorEnablePeopleMentionsAsTags(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorEnablePeopleMentionsAsTags, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1682,7 +1601,7 @@ export async function setEditorEnablePeopleMentionsAsTags(
 }
 
 export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorVimKeybindings, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1691,7 +1610,7 @@ export async function setEditorVimKeybindings(enabled: boolean): Promise<void> {
 }
 
 export async function setEditorSpellCheck(enabled: boolean): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.editorSpellCheck, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1721,7 +1640,7 @@ export async function setDailyNotesFolder(
 		void emitSettingsUpdated({ spacePath, dailyNotes: { folder: nextFolder } });
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	if (nextFolder === null) {
 		await store.delete(KEYS.dailyNotesFolder);
 	} else {
@@ -1746,7 +1665,7 @@ export async function setQuickNotesFolder(
 		void emitSettingsUpdated({ spacePath, quickNotes: { folder: nextFolder } });
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.quickNotesFolder, nextFolder);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ quickNotes: { folder: nextFolder } });
@@ -1779,7 +1698,7 @@ export async function setTemplatesFolder(
 		});
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	if (nextFolder === null) {
 		await store.delete(KEYS.templatesFolder);
 		await store.delete(KEYS.templatesDailyNoteTemplate);
@@ -1822,7 +1741,7 @@ export async function setDailyNoteTemplate(
 		});
 		return;
 	}
-	const store = await getStore();
+	const store = await getSettingsStore();
 	if (nextPath === null) {
 		await store.delete(KEYS.templatesDailyNoteTemplate);
 	} else {
@@ -1837,7 +1756,7 @@ export async function setDailyNoteTemplate(
 export async function setDatabaseShowColumnColor(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.databaseShowColumnColor, enabled);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ database: { showColumnColor: enabled } });
@@ -1846,7 +1765,7 @@ export async function setDatabaseShowColumnColor(
 export async function setAutoUpdateLastCheckedAt(
 	timestamp: number | null,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	if (
 		typeof timestamp !== "number" ||
 		!Number.isFinite(timestamp) ||
@@ -1863,14 +1782,14 @@ export async function setReleaseChannel(
 	channel: ReleaseChannel,
 ): Promise<void> {
 	const nextChannel = asReleaseChannel(channel);
-	const store = await getStore();
+	const store = await getSettingsStore();
 	await store.set(KEYS.releaseChannel, nextChannel);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { releaseChannel: nextChannel } });
 }
 
 export async function getRecentFiles(): Promise<RecentFile[]> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const raw = await store.get<unknown>(KEYS.recentFiles);
 	return isRecentFileArray(raw) ? raw : [];
 }
@@ -1879,7 +1798,7 @@ export async function addRecentFile(
 	path: string,
 	spacePath: string,
 ): Promise<void> {
-	const store = await getStore();
+	const store = await getSettingsStore();
 	const raw = await store.get<unknown>(KEYS.recentFiles);
 	const recent = isRecentFileArray(raw) ? raw : [];
 	const filtered = recent.filter(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -323,7 +323,6 @@ function asUiFontFamily(
 	if (typeof value !== "string") return fallback;
 	const trimmed = value.trim();
 	if (!trimmed) return fallback;
-	if (trimmed === "Satoshi") return fallback;
 	return trimmed.slice(0, 80);
 }
 
@@ -987,26 +986,11 @@ export async function loadSettings(
 	const accent = asUiAccent(rawAccent);
 	const themeColors = loadUiThemeColorOverrides(entries);
 	const fontFamily = asUiFontFamily(rawFontFamily);
-	if (
-		typeof rawFontFamily === "string" &&
-		rawFontFamily.trim() === "Satoshi" &&
-		fontFamily === DEFAULT_UI_FONT_FAMILY
-	) {
-		const store = await getSettingsStore();
-		await store.set(KEYS.fontFamily, DEFAULT_UI_FONT_FAMILY);
-		entries.set(KEYS.fontFamily, DEFAULT_UI_FONT_FAMILY);
-	}
 	const monoFontFamily = asUiMonoFontFamily(rawMonoFontFamily);
 	const editorFontFamily =
 		rawEditorFontFamily === undefined || rawEditorFontFamily === null
 			? fontFamily
 			: asUiEditorFontFamily(rawEditorFontFamily);
-	if (rawEditorFontFamily === undefined || rawEditorFontFamily === null) {
-		const store = await getSettingsStore();
-		await store.set(KEYS.editorFontFamily, editorFontFamily);
-		await saveSettingsStore(store);
-		entries.set(KEYS.editorFontFamily, editorFontFamily);
-	}
 	const fontSize = asUiFontSize(rawFontSize);
 	const editorFontSize =
 		rawEditorFontSize === undefined || rawEditorFontSize === null

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -1,0 +1,105 @@
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+let storeInstance: LazyStore | null = null;
+let storeInitPromise: Promise<void> | null = null;
+let settingsEntriesCache: Map<string, unknown> | null = null;
+let settingsEntriesPromise: Promise<Map<string, unknown>> | null = null;
+let settingsEntriesGeneration = 0;
+let settingsInvalidationUnlisten: UnlistenFn | null = null;
+let settingsInvalidationUnlistenPromise: Promise<UnlistenFn> | null = null;
+
+function runSettingsInvalidationUnlisten(unlisten: UnlistenFn): void {
+	try {
+		const result = unlisten() as unknown;
+		void Promise.resolve(result).catch(() => {});
+	} catch {
+		// Ignore listener cleanup races during Tauri window teardown.
+	}
+}
+
+function ensureSettingsInvalidationListener() {
+	if (settingsInvalidationUnlisten || settingsInvalidationUnlistenPromise)
+		return;
+
+	const unlistenPromise = listen("settings:updated", () => {
+		invalidateSettingsCache();
+	});
+	settingsInvalidationUnlistenPromise = unlistenPromise;
+	void unlistenPromise
+		.then((unlisten) => {
+			if (settingsInvalidationUnlistenPromise !== unlistenPromise) return;
+			settingsInvalidationUnlisten = unlisten;
+			settingsInvalidationUnlistenPromise = null;
+		})
+		.catch(() => {
+			if (settingsInvalidationUnlistenPromise === unlistenPromise) {
+				settingsInvalidationUnlistenPromise = null;
+			}
+		});
+}
+
+export function disposeSettingsInvalidationListener(): void {
+	const unlisten = settingsInvalidationUnlisten;
+	const unlistenPromise = settingsInvalidationUnlistenPromise;
+	settingsInvalidationUnlisten = null;
+	settingsInvalidationUnlistenPromise = null;
+
+	if (unlisten) {
+		runSettingsInvalidationUnlisten(unlisten);
+		return;
+	}
+	if (unlistenPromise) {
+		void unlistenPromise.then(runSettingsInvalidationUnlisten).catch(() => {});
+	}
+}
+
+if (import.meta.hot) {
+	import.meta.hot.dispose(disposeSettingsInvalidationListener);
+}
+
+export async function getSettingsStore(): Promise<LazyStore> {
+	ensureSettingsInvalidationListener();
+	if (!storeInstance) {
+		storeInstance = new LazyStore("settings.json");
+		storeInitPromise = storeInstance.init();
+	}
+	if (storeInitPromise) {
+		await storeInitPromise;
+	}
+	return storeInstance;
+}
+
+export function invalidateSettingsCache() {
+	settingsEntriesGeneration += 1;
+	settingsEntriesCache = null;
+	settingsEntriesPromise = null;
+}
+
+export async function saveSettingsStore(store: LazyStore): Promise<void> {
+	await store.save();
+	invalidateSettingsCache();
+}
+
+export async function loadSettingsEntries(): Promise<Map<string, unknown>> {
+	if (settingsEntriesCache) return settingsEntriesCache;
+	if (settingsEntriesPromise) return settingsEntriesPromise;
+
+	const generation = settingsEntriesGeneration;
+	const promise = getSettingsStore()
+		.then((store) => store.entries<unknown>())
+		.then((entries) => {
+			const next = new Map(entries);
+			if (generation === settingsEntriesGeneration) {
+				settingsEntriesCache = next;
+			}
+			return next;
+		})
+		.finally(() => {
+			if (settingsEntriesPromise === promise) {
+				settingsEntriesPromise = null;
+			}
+		});
+	settingsEntriesPromise = promise;
+	return settingsEntriesPromise;
+}

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -62,7 +62,11 @@ export async function getSettingsStore(): Promise<LazyStore> {
 	ensureSettingsInvalidationListener();
 	if (!storeInstance) {
 		storeInstance = new LazyStore("settings.json");
-		storeInitPromise = storeInstance.init();
+		storeInitPromise = storeInstance.init().catch((cause) => {
+			storeInstance = null;
+			storeInitPromise = null;
+			throw cause;
+		});
 	}
 	if (storeInitPromise) {
 		await storeInitPromise;

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -79,6 +79,7 @@ type TauriEventMap = {
 			fileTreeSortMode?: FileTreeSortMode;
 			folioMode?: boolean;
 			classicAllNotesByDefault?: boolean;
+			resumeLastSession?: boolean;
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
 		};

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -1,4 +1,4 @@
-import { normalizeRelPath } from "../utils/path";
+import { isMarkdownPath, normalizeRelPath } from "../utils/path";
 import { getSettingsStore, saveSettingsStore } from "./settingsStore";
 
 const WORKSPACE_SESSION_BY_SPACE_KEY = "workspace.sessionBySpace";
@@ -29,7 +29,7 @@ function normalizeWorkspaceSessionTab(
 
 	if (value.kind === "file") {
 		const target = normalizeRelPath(value.target);
-		if (!target.toLowerCase().endsWith(".md")) return null;
+		if (!isMarkdownPath(target)) return null;
 		if (seenTargets.has(target)) return null;
 		seenTargets.add(target);
 		return { kind: "file", target };

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -1,0 +1,112 @@
+import { normalizeRelPath } from "../utils/path";
+import { getSettingsStore, saveSettingsStore } from "./settingsStore";
+
+const WORKSPACE_SESSION_BY_SPACE_KEY = "workspace.sessionBySpace";
+
+export interface WorkspaceSessionTabSnapshot {
+	kind: "file" | "special";
+	target: string;
+}
+
+export interface WorkspaceSessionSnapshot {
+	version: 1;
+	savedAt: number;
+	tabs: WorkspaceSessionTabSnapshot[];
+	activeTabTarget: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeWorkspaceSessionTab(
+	value: unknown,
+	seenTargets: Set<string>,
+): WorkspaceSessionTabSnapshot | null {
+	if (!isRecord(value)) return null;
+	if (value.kind !== "file" && value.kind !== "special") return null;
+	if (typeof value.target !== "string") return null;
+
+	if (value.kind === "file") {
+		const target = normalizeRelPath(value.target);
+		if (!target.toLowerCase().endsWith(".md")) return null;
+		if (seenTargets.has(target)) return null;
+		seenTargets.add(target);
+		return { kind: "file", target };
+	}
+
+	const target = value.target.trim();
+	if (!target || target.length > 120) return null;
+	if (seenTargets.has(target)) return null;
+	seenTargets.add(target);
+	return { kind: "special", target };
+}
+
+function normalizeWorkspaceSessionSnapshot(
+	value: unknown,
+): WorkspaceSessionSnapshot | null {
+	if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.tabs)) {
+		return null;
+	}
+	const seenTargets = new Set<string>();
+	const tabs = value.tabs
+		.map((tab) => normalizeWorkspaceSessionTab(tab, seenTargets))
+		.filter((tab): tab is WorkspaceSessionTabSnapshot => tab !== null);
+	const activeTabTarget =
+		typeof value.activeTabTarget === "string" &&
+		tabs.some((tab) => tab.target === value.activeTabTarget)
+			? value.activeTabTarget
+			: null;
+	const savedAt =
+		typeof value.savedAt === "number" && Number.isFinite(value.savedAt)
+			? Math.floor(value.savedAt)
+			: 0;
+	return {
+		version: 1,
+		savedAt,
+		tabs,
+		activeTabTarget,
+	};
+}
+
+function normalizeWorkspaceSessionMap(
+	value: unknown,
+): Record<string, WorkspaceSessionSnapshot> {
+	if (!isRecord(value)) return {};
+	const out: Record<string, WorkspaceSessionSnapshot> = {};
+	for (const [spacePath, snapshot] of Object.entries(value)) {
+		const key = spacePath.trim();
+		if (!key) continue;
+		const normalized = normalizeWorkspaceSessionSnapshot(snapshot);
+		if (normalized) out[key] = normalized;
+	}
+	return out;
+}
+
+export async function loadWorkspaceSessionSnapshot(
+	spacePath: string,
+): Promise<WorkspaceSessionSnapshot | null> {
+	const store = await getSettingsStore();
+	const sessionBySpace = normalizeWorkspaceSessionMap(
+		await store.get<unknown>(WORKSPACE_SESSION_BY_SPACE_KEY),
+	);
+	return sessionBySpace[spacePath] ?? null;
+}
+
+export async function saveWorkspaceSessionSnapshot(
+	spacePath: string,
+	snapshot: WorkspaceSessionSnapshot,
+): Promise<void> {
+	const store = await getSettingsStore();
+	const sessionBySpace = normalizeWorkspaceSessionMap(
+		await store.get<unknown>(WORKSPACE_SESSION_BY_SPACE_KEY),
+	);
+	sessionBySpace[spacePath] = normalizeWorkspaceSessionSnapshot(snapshot) ?? {
+		version: 1,
+		savedAt: Date.now(),
+		tabs: [],
+		activeTabTarget: null,
+	};
+	await store.set(WORKSPACE_SESSION_BY_SPACE_KEY, sessionBySpace);
+	await saveSettingsStore(store);
+}


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/294


## Description

Adds an opt-in **Resume last session** preference (Settings → General → Startup) that restores open workspace tabs per space on launch.

- **Summary of changes**
  - New `ui.resumeLastSession` setting (default `false`) with a General settings toggle and settings search entry
  - Per-space tab snapshots stored under `workspace.sessionBySpace` in app settings
  - `useWorkspaceSession` hook saves/restores file and special tabs (skips blank tabs); validates markdown paths against disk before restore
  - `useTabManager` gains `restoreWorkspaceTabs` and a `tabsRevision` counter so saves only run after real tab commits (avoids writing empty snapshots on space switch)
  - Settings store logic extracted to `settingsStore.ts` for shared access from settings and workspace session modules
  - Architecture doc updated for the new restore flow

- **Reasoning**
  - Tier 1 MVP from the issue: restore open tabs + active tab only; tree expansion and editor caret/scroll are out of scope for this PR
  - Opt-in default preserves current blank-canvas onboarding UX for new users
  - Debounced saves (250ms) on tab changes plus flush on space unmount keep persistence durable without hammering the store

- **Additional context**
  - Missing or deleted markdown files are skipped silently during restore
  - Onboarding note path still takes precedence over session restore
  - Version bumped to `0.8.7-alpha.1`


## Screenshots

Non-visual feature (settings toggle + restored tabs on relaunch). No screenshots attached.


## Docs

- `docs/architecture/03-frontend-shell-state.md` — documents `ui.resumeLastSession`, `workspace.sessionBySpace`, and the restore/save flow in `AppShell`
- Snapshot shape:

```ts
interface WorkspaceSessionSnapshot {
  version: 1;
  savedAt: number;
  tabs: Array<{ kind: "file" | "special"; target: string }>;
  activeTabTarget: string | null;
}
```


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in “Open previous tabs” startup setting that restores each space’s open tabs on launch, including the active tab. Implements KAR-86 “start where I left off,” default off.

- **New Features**
  - New `ui.resumeLastSession` toggle (Settings → General → Startup; searchable as “Open previous tabs”).
  - Saves per-space snapshots under `workspace.sessionBySpace` and restores file and special tabs plus the active tab on launch.

- **Bug Fixes**
  - Validate files before restore; abort on validation failure and skip missing markdown files.
  - Avoid snapshot writes on space switch; persist only after real tab commits via `tabsRevision` with 250ms debounce and flush on unmount.
  - Normalize session snapshots to dedupe targets and reject malformed entries; stop persisting a derived editor font when unset.

<sup>Written for commit 90ce5fcff3c213799ff46f892312b913d2d2e814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to resume the last session on app launch.
  * Restores open tabs and the active tab for each workspace when enabled.

* **Bug Fixes**
  * Prevents empty workspace snapshots from being saved when switching spaces.
  * Skips missing markdown files during session restore to avoid broken tab state.

* **Documentation**
  * Updated architecture docs to reflect the new session-resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->