### PR TITLE
Harden editor document session and markdown lifecycle handling

### DIFF
--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -342,9 +342,15 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		tiptapHostNode,
 		onOpenLinkDialog: useCallback(
 			(href: string, target: "_self" | "_blank") => {
-				setLinkDialog({ href, target });
+				const selection = editor?.state.selection;
+				if (!selection) return;
+				setLinkDialog({
+					href,
+					range: { from: selection.from, to: selection.to },
+					target,
+				});
 			},
-			[],
+			[editor],
 		),
 		onTriggerExtractToNote: extractToNote.canExtractToNote
 			? extractToNote.openExtractDialog

--- a/src/components/editor/NoteLinkDialog.tsx
+++ b/src/components/editor/NoteLinkDialog.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/core";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { X } from "../Icons";
 import { Button } from "../ui/shadcn/button";
 import {
@@ -14,6 +14,7 @@ import { Input } from "../ui/shadcn/input";
 
 export interface NoteLinkDialogState {
 	href: string;
+	range: { from: number; to: number };
 	target: "_self" | "_blank";
 }
 
@@ -50,6 +51,7 @@ export function NoteLinkDialog({
 	state,
 	onStateChange,
 }: NoteLinkDialogProps) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
 	const close = useCallback(() => onStateChange(null), [onStateChange]);
 
 	const apply = useCallback(() => {
@@ -58,6 +60,7 @@ export function NoteLinkDialog({
 		const chain = editor
 			.chain()
 			.focus(null, { scrollIntoView: false })
+			.setTextSelection(state.range)
 			.extendMarkRange("link");
 		if (!href) {
 			chain.unsetLink().run();
@@ -75,15 +78,16 @@ export function NoteLinkDialog({
 	}, [canEdit, editor, onStateChange, state]);
 
 	const remove = useCallback(() => {
-		if (!editor || !canEdit) return;
+		if (!editor || !canEdit || !state) return;
 		editor
 			.chain()
 			.focus(null, { scrollIntoView: false })
+			.setTextSelection(state.range)
 			.extendMarkRange("link")
 			.unsetLink()
 			.run();
 		onStateChange(null);
-	}, [canEdit, editor, onStateChange]);
+	}, [canEdit, editor, onStateChange, state]);
 
 	return (
 		<Dialog
@@ -95,9 +99,7 @@ export function NoteLinkDialog({
 			<DialogContent
 				className="editorLinkDialog"
 				onOpenAutoFocus={(event) => {
-					const input = document.querySelector<HTMLInputElement>(
-						".editorLinkDialogInput",
-					);
+					const input = inputRef.current;
 					if (!input) return;
 					event.preventDefault();
 					input.focus();
@@ -118,6 +120,7 @@ export function NoteLinkDialog({
 					}}
 				>
 					<Input
+						ref={inputRef}
 						className="editorLinkDialogInput"
 						value={state?.href ?? ""}
 						onChange={(event) =>

--- a/src/components/editor/RibbonLinkPopover.tsx
+++ b/src/components/editor/RibbonLinkPopover.tsx
@@ -41,6 +41,10 @@ export function RibbonLinkPopover({
 	const [linkOpen, setLinkOpen] = useState(false);
 	const [linkHref, setLinkHref] = useState("");
 	const [linkTarget, setLinkTarget] = useState<"_self" | "_blank">("_self");
+	const [linkRange, setLinkRange] = useState<{
+		from: number;
+		to: number;
+	} | null>(null);
 
 	const handleOpenChange = (nextOpen: boolean) => {
 		setLinkOpen(nextOpen);
@@ -51,30 +55,42 @@ export function RibbonLinkPopover({
 		};
 		setLinkHref(linkAttrs.href ?? "");
 		setLinkTarget(linkAttrs.target === "_blank" ? "_blank" : "_self");
+		const { from, to } = editor.state.selection;
+		setLinkRange({ from, to });
 	};
 
 	const applyLink = () => {
 		const href = normalizeHref(linkHref);
 		if (!href) {
-			runCommand(() => focusChain().unsetLink().run());
+			runCommand(() => {
+				const chain = focusChain();
+				if (linkRange) chain.setTextSelection(linkRange);
+				chain.unsetLink().run();
+			});
 			setLinkOpen(false);
 			return;
 		}
-		runCommand(() =>
-			focusChain()
+		runCommand(() => {
+			const chain = focusChain();
+			if (linkRange) chain.setTextSelection(linkRange);
+			chain
 				.extendMarkRange("link")
 				.setLink({
 					href,
 					target: linkTarget,
 					rel: linkTarget === "_blank" ? "noopener noreferrer" : undefined,
 				})
-				.run(),
-		);
+				.run();
+		});
 		setLinkOpen(false);
 	};
 
 	const removeLink = () => {
-		runCommand(() => focusChain().unsetLink().run());
+		runCommand(() => {
+			const chain = focusChain();
+			if (linkRange) chain.setTextSelection(linkRange);
+			chain.unsetLink().run();
+		});
 		setLinkOpen(false);
 	};
 

--- a/src/components/editor/extensions/markdownImageLivePreview.ts
+++ b/src/components/editor/extensions/markdownImageLivePreview.ts
@@ -190,16 +190,13 @@ export const MarkdownImageLivePreview = Extension.create({
 					};
 
 					if (docChanged) {
+						// changedRangesFromTransactions always yields ranges when docChanged.
 						const changedRanges = changedRangesFromTransactions(
 							transactions,
 							newState.doc.content.size,
 						);
-						if (!changedRanges.length) {
-							newState.doc.descendants(visitNode);
-						} else {
-							for (const range of changedRanges) {
-								newState.doc.nodesBetween(range.from, range.to, visitNode);
-							}
+						for (const range of changedRanges) {
+							newState.doc.nodesBetween(range.from, range.to, visitNode);
 						}
 					} else {
 						for (const range of selectionScanRanges(oldState, newState)) {

--- a/src/components/editor/extensions/markdownImageLivePreview.ts
+++ b/src/components/editor/extensions/markdownImageLivePreview.ts
@@ -7,6 +7,7 @@ import {
 	Selection,
 	TextSelection,
 } from "@tiptap/pm/state";
+import { changedRangesFromTransactions } from "./changedRanges";
 import { encodeMarkdownImageSrc } from "./markdownImage";
 
 export const markdownImagePreviewPluginKey = new PluginKey(
@@ -189,7 +190,17 @@ export const MarkdownImageLivePreview = Extension.create({
 					};
 
 					if (docChanged) {
-						newState.doc.descendants(visitNode);
+						const changedRanges = changedRangesFromTransactions(
+							transactions,
+							newState.doc.content.size,
+						);
+						if (!changedRanges.length) {
+							newState.doc.descendants(visitNode);
+						} else {
+							for (const range of changedRanges) {
+								newState.doc.nodesBetween(range.from, range.to, visitNode);
+							}
+						}
 					} else {
 						for (const range of selectionScanRanges(oldState, newState)) {
 							newState.doc.nodesBetween(range.from, range.to, visitNode);

--- a/src/components/editor/extensions/math/mathOptions.ts
+++ b/src/components/editor/extensions/math/mathOptions.ts
@@ -51,6 +51,7 @@ export function matchInlineMath(source: string): RegExpMatchArray | null {
 	const match = source.match(INLINE_MATH_RE);
 	if (!match) return null;
 	const latex = match[1] ?? "";
+	if (/\n\s*\n/.test(latex)) return null;
 	if (/^[\d.,]+$/.test(latex)) return null;
 	return match;
 }

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -32,7 +32,10 @@ export const PersonAutocomplete = Extension.create({
 		};
 	},
 	addProseMirrorPlugins() {
+		let requestId = 0;
 		const getItems = async (query: string): Promise<PersonSuggestionItem[]> => {
+			const currentRequestId = requestId + 1;
+			requestId = currentRequestId;
 			const normalized = normalizeHandle(query);
 			let people: PersonCount[] = [];
 			try {
@@ -43,6 +46,7 @@ export const PersonAutocomplete = Extension.create({
 				console.warn("Failed to load people suggestions", error);
 				return [];
 			}
+			if (currentRequestId !== requestId) return [];
 			const matches: PersonSuggestionItem[] = people
 				.filter((person) =>
 					normalized.length === 0 ? true : person.handle.includes(normalized),

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -44,7 +44,7 @@ export const PersonAutocomplete = Extension.create({
 				});
 			} catch (error) {
 				console.warn("Failed to load people suggestions", error);
-				return [];
+				people = [];
 			}
 			// Stale responses must not resolve as [] — TipTap would clear the active menu.
 			if (currentRequestId !== requestId) {

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -46,7 +46,10 @@ export const PersonAutocomplete = Extension.create({
 				console.warn("Failed to load people suggestions", error);
 				return [];
 			}
-			if (currentRequestId !== requestId) return [];
+			// Stale responses must not resolve as [] — TipTap would clear the active menu.
+			if (currentRequestId !== requestId) {
+				return new Promise<PersonSuggestionItem[]>(() => {});
+			}
 			const matches: PersonSuggestionItem[] = people
 				.filter((person) =>
 					normalized.length === 0 ? true : person.handle.includes(normalized),

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -36,7 +36,10 @@ export const TagAutocomplete = Extension.create({
 		};
 	},
 	addProseMirrorPlugins() {
+		let requestId = 0;
 		const getItems = async (query: string): Promise<TagSuggestionItem[]> => {
+			const currentRequestId = requestId + 1;
+			requestId = currentRequestId;
 			const normalizedQuery = normalizeTagDraftPrefix(query);
 			if (!normalizedQuery) return [];
 			let tags: TagCount[] = [];
@@ -49,6 +52,7 @@ export const TagAutocomplete = Extension.create({
 				console.warn("Failed to load tag suggestions", error);
 				return [];
 			}
+			if (currentRequestId !== requestId) return [];
 			const descendantPrefix = normalizedQuery.endsWith("/")
 				? normalizedQuery
 				: `${normalizedQuery}/`;

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -50,7 +50,7 @@ export const TagAutocomplete = Extension.create({
 				});
 			} catch (error) {
 				console.warn("Failed to load tag suggestions", error);
-				return [];
+				tags = [];
 			}
 			// Stale responses must not resolve as [] — TipTap would clear the active menu.
 			if (currentRequestId !== requestId) {

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -52,7 +52,10 @@ export const TagAutocomplete = Extension.create({
 				console.warn("Failed to load tag suggestions", error);
 				return [];
 			}
-			if (currentRequestId !== requestId) return [];
+			// Stale responses must not resolve as [] — TipTap would clear the active menu.
+			if (currentRequestId !== requestId) {
+				return new Promise<TagSuggestionItem[]>(() => {});
+			}
 			const descendantPrefix = normalizedQuery.endsWith("/")
 				? normalizedQuery
 				: `${normalizedQuery}/`;

--- a/src/components/editor/extractSelectionToNote.ts
+++ b/src/components/editor/extractSelectionToNote.ts
@@ -12,6 +12,7 @@ export interface ExtractToNoteDialogState extends ExtractSelectionDraft {
 	destinationDir: string;
 	loading: boolean;
 	title: string;
+	titleDirty: boolean;
 }
 
 const FALLBACK_TITLE = "Untitled";

--- a/src/components/editor/hooks/useExtractSelectionToNote.ts
+++ b/src/components/editor/hooks/useExtractSelectionToNote.ts
@@ -65,12 +65,17 @@ export function useExtractSelectionToNote({
 			destinationDir,
 			loading: true,
 			title: sanitizeExtractedNoteTitle(draft.suggestedTitle),
+			titleDirty: false,
 		});
 		void loadUniqueExtractTitle(draft.suggestedTitle, destinationDir)
 			.then((title) => {
 				setDialogState((current) =>
 					current && current.range.from === draft.range.from
-						? { ...current, loading: false, title }
+						? {
+								...current,
+								loading: false,
+								title: current.titleDirty ? current.title : title,
+							}
 						: current,
 				);
 			})
@@ -89,7 +94,9 @@ export function useExtractSelectionToNote({
 	}, []);
 
 	const setExtractTitle = useCallback((title: string) => {
-		setDialogState((current) => (current ? { ...current, title } : current));
+		setDialogState((current) =>
+			current ? { ...current, title, titleDirty: true } : current,
+		);
 	}, []);
 
 	const setExtractDestinationDir = useCallback((destinationDir: string) => {

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -277,7 +277,7 @@ function hydrateImageNodesInDocument(
 			typeof node.attrs.originSrc === "string" && node.attrs.originSrc.trim()
 				? node.attrs.originSrc
 				: currentSrc;
-		if (currentOrigin !== originalSrc) return;
+		if (currentOrigin !== originalSrc) continue;
 		if (currentSrc === dataUrl && node.attrs.originSrc === originalSrc) return;
 		tr.setNodeMarkup(pos, undefined, {
 			...node.attrs,

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -258,13 +258,20 @@ function getMountedEditorRoot(editor: Editor): HTMLElement | null {
 
 function hydrateImageNodesInDocument(
 	editor: Editor,
+	image: HTMLImageElement,
 	originalSrc: string,
 	dataUrl: string,
 ) {
+	let domPos: number;
+	try {
+		domPos = editor.view.posAtDOM(image, 0);
+	} catch {
+		return;
+	}
 	const tr = editor.state.tr;
-	let changed = false;
-	editor.state.doc.descendants((node, pos) => {
-		if (node.type.name !== "image") return;
+	for (const pos of [domPos, Math.max(0, domPos - 1)]) {
+		const node = editor.state.doc.nodeAt(pos);
+		if (node?.type.name !== "image") continue;
 		const currentSrc = typeof node.attrs.src === "string" ? node.attrs.src : "";
 		const currentOrigin =
 			typeof node.attrs.originSrc === "string" && node.attrs.originSrc.trim()
@@ -277,10 +284,9 @@ function hydrateImageNodesInDocument(
 			src: dataUrl,
 			originSrc: originalSrc,
 		});
-		changed = true;
-	});
-	if (!changed) return;
-	editor.view.dispatch(tr);
+		editor.view.dispatch(tr);
+		return;
+	}
 }
 
 export function useHydrateInlineImages(
@@ -331,7 +337,7 @@ export function useHydrateInlineImages(
 					image.dataset.glyphHydrationState = "failed";
 					return;
 				}
-				hydrateImageNodesInDocument(editor, originalSrc, dataUrl);
+				hydrateImageNodesInDocument(editor, image, originalSrc, dataUrl);
 				image.setAttribute("data-glyph-hydrated-key", key);
 				image.setAttribute("src", dataUrl);
 				image.dataset.glyphHydrationState = "ready";

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -602,6 +602,13 @@ export function useNoteEditor({
 											originSrc: saved.href,
 										});
 									} catch {
+										if (
+											editorInstance.isDestroyed ||
+											editorRef.current !== editorInstance ||
+											sourcePath !== relPathRef.current
+										) {
+											continue;
+										}
 										replacePlaceholderWithFallbackText(
 											editorInstance,
 											item.uploadId,

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -350,6 +350,8 @@ export function useNoteEditor({
 	const editorContentRelPathRef = useRef(relPath);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
 	const markdownSyncFrameRef = useRef<number | null>(null);
+	const markdownManagerRef = useRef<MarkdownManager | null>(null);
+	const pasteMarkdownBehaviorRef = useRef(pasteMarkdownBehavior);
 	const extensions = useMemo(
 		() =>
 			createEditorExtensions({
@@ -386,7 +388,9 @@ export function useNoteEditor({
 	);
 
 	frontmatterRef.current = frontmatter;
+	markdownManagerRef.current = markdownManager;
 	onChangeRef.current = onChange;
+	pasteMarkdownBehaviorRef.current = pasteMarkdownBehavior;
 	relPathRef.current = relPath;
 	interactiveRef.current = interactive;
 	modeRef.current = mode;
@@ -417,6 +421,7 @@ export function useNoteEditor({
 				return;
 			}
 			const { instance } = pending;
+			if (instance.isDestroyed) return;
 			const nextBody = postprocessMarkdownFromEditor(instance.getMarkdown());
 			const nextMarkdown = joinYamlFrontmatter(
 				pending.frontmatter,
@@ -481,7 +486,7 @@ export function useNoteEditor({
 
 	const pendingSync = pendingMarkdownSyncRef.current;
 	const editorContent =
-		pendingSync?.relPath === relPath
+		pendingSync?.relPath === relPath && !pendingSync.instance.isDestroyed
 			? pendingSync.instance.getMarkdown()
 			: editorBody;
 
@@ -567,6 +572,14 @@ export function useNoteEditor({
 							event.preventDefault();
 							void (async () => {
 								for (const item of placeholders) {
+									if (
+										editorInstance.isDestroyed ||
+										editorRef.current !== editorInstance ||
+										sourcePath !== relPathRef.current
+									) {
+										URL.revokeObjectURL(item.objectUrl);
+										continue;
+									}
 									try {
 										const dataUrl = await readFileAsDataUrl(item.file);
 										const saved = await invoke("space_save_pasted_image", {
@@ -575,6 +588,13 @@ export function useNoteEditor({
 											data_url: dataUrl,
 											original_filename: item.file.name || null,
 										});
+										if (
+											editorInstance.isDestroyed ||
+											editorRef.current !== editorInstance ||
+											sourcePath !== relPathRef.current
+										) {
+											continue;
+										}
 										replacePlaceholderWithImage(editorInstance, item.uploadId, {
 											src: dataUrl,
 											alt: item.file.name || "",
@@ -594,7 +614,9 @@ export function useNoteEditor({
 							})();
 							return true;
 						}
-						if (pasteMarkdownBehavior !== "smart-markdown") return false;
+						if (pasteMarkdownBehaviorRef.current !== "smart-markdown") {
+							return false;
+						}
 						if (editorInstance.isActive("codeBlock")) return false;
 						const clipboardHtml = getClipboardHtml(event);
 						const clipboardText = normalizeClipboardMarkdownText(
@@ -607,9 +629,10 @@ export function useNoteEditor({
 							from: editorInstance.state.selection.from,
 							to: editorInstance.state.selection.to,
 						};
-						if (!markdownManager) return false;
+						const activeMarkdownManager = markdownManagerRef.current;
+						if (!activeMarkdownManager) return false;
 						const insertableContent = getInsertableMarkdownContent(
-							markdownManager,
+							activeMarkdownManager,
 							clipboardText,
 						);
 						if (!insertableContent.length) return false;

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -169,6 +169,17 @@ export function useNoteFind({
 		[effectiveFindActiveIndex, findMatches.length, selectFindMatch],
 	);
 
+	useEffect(() => {
+		if (!findOpen || !findQuery || !findMatches.length) return;
+		selectFindMatch(effectiveFindActiveIndex);
+	}, [
+		effectiveFindActiveIndex,
+		findMatches.length,
+		findOpen,
+		findQuery,
+		selectFindMatch,
+	]);
+
 	const getSelectedSearchText = useCallback(() => {
 		if (mode === "plain") {
 			return selectedTextForQuery(

--- a/src/components/editor/markdown/detailsMarkdown.ts
+++ b/src/components/editor/markdown/detailsMarkdown.ts
@@ -17,15 +17,6 @@ function escapeHtmlText(text: string): string {
 		.replace(/"/g, "&quot;");
 }
 
-function htmlFragmentToPlainText(html: string): string {
-	if (!html.trim() || typeof DOMParser === "undefined") return html.trim();
-	const doc = new DOMParser().parseFromString(
-		`<div>${html}</div>`,
-		"text/html",
-	);
-	return doc.body.textContent?.trim() ?? html.trim();
-}
-
 function nextNonBlankLine(lines: string[], startIndex: number): string | null {
 	let index = startIndex;
 	while (index < lines.length) {
@@ -34,6 +25,20 @@ function nextNonBlankLine(lines: string[], startIndex: number): string | null {
 		index += 1;
 	}
 	return null;
+}
+
+function stripStructuralBlankLines(lines: string[]) {
+	const out = [...lines];
+	if (out[0]?.trim() === "") out.shift();
+	if (out[out.length - 1]?.trim() === "") out.pop();
+	return out.join("\n");
+}
+
+function stripOuterBlankLines(text: string) {
+	const lines = text.split("\n");
+	while (lines[0]?.trim() === "") lines.shift();
+	while (lines[lines.length - 1]?.trim() === "") lines.pop();
+	return lines.join("\n");
 }
 
 function isDetailsSectionEnd(
@@ -63,13 +68,16 @@ function readFencedSection(
 
 	while (index < lines.length) {
 		if (isDetailsSectionEnd(lines, index, section)) {
-			return { content: contentLines.join("\n").trim(), endIndex: index };
+			return {
+				content: stripStructuralBlankLines(contentLines),
+				endIndex: index,
+			};
 		}
 		contentLines.push(lines[index] ?? "");
 		index += 1;
 	}
 
-	return { content: contentLines.join("\n").trim(), endIndex: index };
+	return { content: stripStructuralBlankLines(contentLines), endIndex: index };
 }
 
 function detailsFencesToHtml(
@@ -89,10 +97,10 @@ function detailsFencesToHtml(
 
 function detailsInnerHtmlToFences(isOpen: boolean, inner: string): string {
 	const summaryMatch = inner.match(/<summary[^>]*>([\s\S]*?)<\/summary>/i);
-	const summary = htmlFragmentToPlainText(summaryMatch?.[1] ?? "");
-	const content = inner
-		.replace(/<summary[^>]*>[\s\S]*?<\/summary>/i, "")
-		.trim();
+	const summary = summaryMatch?.[1]?.trim() ?? "";
+	const content = stripOuterBlankLines(
+		inner.replace(/<summary[^>]*>[\s\S]*?<\/summary>/i, ""),
+	);
 	const openLine = isOpen ? ":::details {open}" : ":::details";
 	return [
 		openLine,

--- a/src/components/editor/markdown/detailsMarkdown.ts
+++ b/src/components/editor/markdown/detailsMarkdown.ts
@@ -17,6 +17,15 @@ function escapeHtmlText(text: string): string {
 		.replace(/"/g, "&quot;");
 }
 
+function htmlFragmentToPlainText(html: string): string {
+	if (!html.trim() || typeof DOMParser === "undefined") return html.trim();
+	const doc = new DOMParser().parseFromString(
+		`<div>${html}</div>`,
+		"text/html",
+	);
+	return doc.body.textContent?.trim() ?? html.trim();
+}
+
 function nextNonBlankLine(lines: string[], startIndex: number): string | null {
 	let index = startIndex;
 	while (index < lines.length) {
@@ -97,7 +106,8 @@ function detailsFencesToHtml(
 
 function detailsInnerHtmlToFences(isOpen: boolean, inner: string): string {
 	const summaryMatch = inner.match(/<summary[^>]*>([\s\S]*?)<\/summary>/i);
-	const summary = summaryMatch?.[1]?.trim() ?? "";
+	// Strip tags so postprocess → escapeHtmlText does not double-escape markup.
+	const summary = htmlFragmentToPlainText(summaryMatch?.[1] ?? "");
 	const content = stripOuterBlankLines(
 		inner.replace(/<summary[^>]*>[\s\S]*?<\/summary>/i, ""),
 	);

--- a/src/components/editor/markdown/inlineTocMarkdown.ts
+++ b/src/components/editor/markdown/inlineTocMarkdown.ts
@@ -10,14 +10,9 @@ function replaceMarkerLines(
 ) {
 	const normalizedFromMarker = fromMarker.toLowerCase();
 	return transformMarkdownOutsideCode(input, (text) => {
-		return text
-			.split("\n")
-			.map((line) => {
-				if (line.trim().toLowerCase() !== normalizedFromMarker) return line;
-				const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
-				return `${leadingWhitespace}${toMarker}`;
-			})
-			.join("\n");
+		if (text.trim().toLowerCase() !== normalizedFromMarker) return text;
+		const leadingWhitespace = text.match(/^\s*/)?.[0] ?? "";
+		return `${leadingWhitespace}${toMarker}`;
 	});
 }
 

--- a/src/components/editor/markdown/inlineTocMarkdown.ts
+++ b/src/components/editor/markdown/inlineTocMarkdown.ts
@@ -1,3 +1,5 @@
+import { transformMarkdownOutsideCode } from "./markdownFence";
+
 export const INLINE_TOC_MARKDOWN_MARKER = "<!-- glyph:toc -->";
 export const INLINE_TOC_EDITOR_MARKER = "{{glyph:toc}}";
 
@@ -7,14 +9,16 @@ function replaceMarkerLines(
 	toMarker: string,
 ) {
 	const normalizedFromMarker = fromMarker.toLowerCase();
-	return input
-		.split("\n")
-		.map((line) => {
-			if (line.trim().toLowerCase() !== normalizedFromMarker) return line;
-			const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
-			return `${leadingWhitespace}${toMarker}`;
-		})
-		.join("\n");
+	return transformMarkdownOutsideCode(input, (text) => {
+		return text
+			.split("\n")
+			.map((line) => {
+				if (line.trim().toLowerCase() !== normalizedFromMarker) return line;
+				const leadingWhitespace = line.match(/^\s*/)?.[0] ?? "";
+				return `${leadingWhitespace}${toMarker}`;
+			})
+			.join("\n");
+	});
 }
 
 export function preprocessInlineTocMarkers(markdown: string) {

--- a/src/components/editor/markdown/markdownFence.ts
+++ b/src/components/editor/markdown/markdownFence.ts
@@ -42,6 +42,24 @@ export function isInsideMarkdownCodeFence(
 	return tracker.activeFence !== null;
 }
 
+function findInlineCodeClose(
+	line: string,
+	openStart: number,
+	tickCount: number,
+): number {
+	let search = openStart + tickCount;
+	while (search < line.length) {
+		const next = line.indexOf("`".repeat(tickCount), search);
+		if (next === -1) return -1;
+		const before = next > 0 ? line[next - 1] : "";
+		const after = line[next + tickCount] ?? "";
+		// Closing run must be exactly tickCount and not part of a longer run.
+		if (before !== "`" && after !== "`") return next;
+		search = next + 1;
+	}
+	return -1;
+}
+
 function transformLineOutsideInlineCode(
 	line: string,
 	transform: (text: string) => string,
@@ -57,7 +75,7 @@ function transformLineOutsideInlineCode(
 		output += transform(line.slice(cursor, tickStart));
 		const tickMatch = line.slice(tickStart).match(/^`+/);
 		const ticks = tickMatch?.[0] ?? "`";
-		const close = line.indexOf(ticks, tickStart + ticks.length);
+		const close = findInlineCodeClose(line, tickStart, ticks.length);
 		if (close === -1) {
 			output += line.slice(tickStart);
 			break;
@@ -68,18 +86,31 @@ function transformLineOutsideInlineCode(
 	return output;
 }
 
-export function transformMarkdownOutsideCode(
+/** Transform line-oriented markdown outside fenced/indented code (keeps inline code intact). */
+export function transformMarkdownOutsideFences(
 	markdown: string,
-	transform: (text: string) => string,
+	transform: (line: string) => string,
 ) {
 	const tracker = createMarkdownFenceTracker();
 	return markdown
 		.split("\n")
 		.map((line) => {
+			// Indented code never opens/closes fenced state.
+			if (!isInsideMarkdownCodeFence(tracker) && /^( {4}|\t)/.test(line)) {
+				return line;
+			}
 			if (updateMarkdownFenceTracker(line, tracker)) return line;
 			if (isInsideMarkdownCodeFence(tracker)) return line;
-			if (/^( {4}|\t)/.test(line)) return line;
-			return transformLineOutsideInlineCode(line, transform);
+			return transform(line);
 		})
 		.join("\n");
+}
+
+export function transformMarkdownOutsideCode(
+	markdown: string,
+	transform: (text: string) => string,
+) {
+	return transformMarkdownOutsideFences(markdown, (line) =>
+		transformLineOutsideInlineCode(line, transform),
+	);
 }

--- a/src/components/editor/markdown/markdownFence.ts
+++ b/src/components/editor/markdown/markdownFence.ts
@@ -95,8 +95,8 @@ export function transformMarkdownOutsideFences(
 	return markdown
 		.split("\n")
 		.map((line) => {
-			// Indented code never opens/closes fenced state.
-			if (!isInsideMarkdownCodeFence(tracker) && /^( {4}|\t)/.test(line)) {
+			// Indented code never opens or closes fenced state (incl. inside fences).
+			if (/^( {4}|\t)/.test(line)) {
 				return line;
 			}
 			if (updateMarkdownFenceTracker(line, tracker)) return line;

--- a/src/components/editor/markdown/markdownFence.ts
+++ b/src/components/editor/markdown/markdownFence.ts
@@ -41,3 +41,45 @@ export function isInsideMarkdownCodeFence(
 ): boolean {
 	return tracker.activeFence !== null;
 }
+
+function transformLineOutsideInlineCode(
+	line: string,
+	transform: (text: string) => string,
+) {
+	let output = "";
+	let cursor = 0;
+	while (cursor < line.length) {
+		const tickStart = line.indexOf("`", cursor);
+		if (tickStart === -1) {
+			output += transform(line.slice(cursor));
+			break;
+		}
+		output += transform(line.slice(cursor, tickStart));
+		const tickMatch = line.slice(tickStart).match(/^`+/);
+		const ticks = tickMatch?.[0] ?? "`";
+		const close = line.indexOf(ticks, tickStart + ticks.length);
+		if (close === -1) {
+			output += line.slice(tickStart);
+			break;
+		}
+		output += line.slice(tickStart, close + ticks.length);
+		cursor = close + ticks.length;
+	}
+	return output;
+}
+
+export function transformMarkdownOutsideCode(
+	markdown: string,
+	transform: (text: string) => string,
+) {
+	const tracker = createMarkdownFenceTracker();
+	return markdown
+		.split("\n")
+		.map((line) => {
+			if (updateMarkdownFenceTracker(line, tracker)) return line;
+			if (isInsideMarkdownCodeFence(tracker)) return line;
+			if (/^( {4}|\t)/.test(line)) return line;
+			return transformLineOutsideInlineCode(line, transform);
+		})
+		.join("\n");
+}

--- a/src/components/editor/markdown/rawHtmlEmbedBridge.ts
+++ b/src/components/editor/markdown/rawHtmlEmbedBridge.ts
@@ -20,6 +20,7 @@ const HTML_EMBED_BLOCK_OPEN_RE = new RegExp(
 function isHtmlEmbedBlockStart(text: string, index: number): boolean {
 	const slice = text.slice(index);
 	const trimmed = slice.match(/^[\t ]*/)?.[0]?.length ?? 0;
+	if (trimmed > 3 || slice.startsWith("\t")) return false;
 	return HTML_EMBED_BLOCK_OPEN_RE.test(slice.slice(trimmed));
 }
 
@@ -156,6 +157,9 @@ function readBalancedElement(
 		.match(new RegExp(`^<${tagName}\\b[^>]*>`, "i"));
 	if (!openMatch) return null;
 	const openEnd = start + openMatch[0].length;
+	if (/\/\s*>$/.test(openMatch[0])) {
+		return { content: text.slice(start, openEnd), end: openEnd };
+	}
 	const openTagRe = new RegExp(`<${tagName}\\b[^>]*>`, "gi");
 	const closeTagRe = new RegExp(`</${tagName}\\s*>`, "gi");
 	let depth = 1;
@@ -188,6 +192,7 @@ function readHtmlEmbedBlockElement(
 	start: number,
 ): { content: string; end: number; tagName: HtmlEmbedBlockTagName } | null {
 	const leading = text.slice(start).match(/^[\t ]*/)?.[0]?.length ?? 0;
+	if (leading > 3 || text.slice(start).startsWith("\t")) return null;
 	const tagStart = start + leading;
 	const tagMatch = text.slice(tagStart).match(HTML_EMBED_BLOCK_OPEN_RE);
 	if (!tagMatch) return null;

--- a/src/components/editor/markdown/rawHtmlEmbedBridge.ts
+++ b/src/components/editor/markdown/rawHtmlEmbedBridge.ts
@@ -24,16 +24,36 @@ function isHtmlEmbedBlockStart(text: string, index: number): boolean {
 	return HTML_EMBED_BLOCK_OPEN_RE.test(slice.slice(trimmed));
 }
 
+// Finds the unquoted `>` that closes the tag starting at `tagStart`, so that
+// `/>` or `>` inside a quoted attribute value (e.g. data-x="/>") isn't
+// mistaken for the end of the tag.
+function findOpenTagEnd(text: string, tagStart: number): number | null {
+	let index = tagStart;
+	let quote: '"' | "'" | null = null;
+	while (index < text.length) {
+		const char = text[index];
+		if (quote) {
+			if (char === quote) quote = null;
+		} else if (char === '"' || char === "'") {
+			quote = char;
+		} else if (char === ">") {
+			return index;
+		}
+		index += 1;
+	}
+	return null;
+}
+
 function readScriptOrStyleElement(
 	text: string,
 	start: number,
 	tagName: "script" | "style",
 ): { content: string; end: number } | null {
-	const openMatch = text
-		.slice(start)
-		.match(new RegExp(`^<${tagName}\\b[^>]*>`, "i"));
+	const openMatch = text.slice(start).match(new RegExp(`^<${tagName}\\b`, "i"));
 	if (!openMatch) return null;
-	const openEnd = start + openMatch[0].length;
+	const openTagEnd = findOpenTagEnd(text, start + openMatch[0].length);
+	if (openTagEnd === null) return null;
+	const openEnd = openTagEnd + 1;
 	const closeEnd = findScriptOrStyleClose(text, openEnd, tagName);
 	if (closeEnd === null) return null;
 	return { content: text.slice(start, closeEnd), end: closeEnd };
@@ -152,28 +172,36 @@ function readBalancedElement(
 		return readScriptOrStyleElement(text, start, tagName);
 	}
 
-	const openMatch = text
-		.slice(start)
-		.match(new RegExp(`^<${tagName}\\b[^>]*>`, "i"));
+	const openMatch = text.slice(start).match(new RegExp(`^<${tagName}\\b`, "i"));
 	if (!openMatch) return null;
-	const openEnd = start + openMatch[0].length;
-	if (/\/\s*>$/.test(openMatch[0])) {
+	const openTagEnd = findOpenTagEnd(text, start + openMatch[0].length);
+	if (openTagEnd === null) return null;
+	const openEnd = openTagEnd + 1;
+	if (/\/\s*>$/.test(text.slice(start, openEnd))) {
 		return { content: text.slice(start, openEnd), end: openEnd };
 	}
-	const openTagRe = new RegExp(`<${tagName}\\b[^>]*>`, "gi");
+	const openTagStartRe = new RegExp(`<${tagName}\\b`, "gi");
 	const closeTagRe = new RegExp(`</${tagName}\\s*>`, "gi");
 	let depth = 1;
 	let cursor = openEnd;
 
 	while (depth > 0 && cursor < text.length) {
-		openTagRe.lastIndex = cursor;
+		openTagStartRe.lastIndex = cursor;
 		closeTagRe.lastIndex = cursor;
-		const nextOpen = openTagRe.exec(text);
+		const nextOpen = openTagStartRe.exec(text);
 		const nextClose = closeTagRe.exec(text);
 		if (!nextClose) return null;
 		if (nextOpen && nextOpen.index < nextClose.index) {
-			depth += 1;
-			cursor = nextOpen.index + nextOpen[0].length;
+			const nestedOpenEnd = findOpenTagEnd(
+				text,
+				nextOpen.index + nextOpen[0].length,
+			);
+			if (nestedOpenEnd === null) return null;
+			const nestedOpen = text.slice(nextOpen.index, nestedOpenEnd + 1);
+			cursor = nestedOpenEnd + 1;
+			if (!/\/\s*>$/.test(nestedOpen)) {
+				depth += 1;
+			}
 			continue;
 		}
 		depth -= 1;

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
@@ -26,6 +26,7 @@ import {
 	postprocessInlineTocMarkers,
 	preprocessInlineTocMarkers,
 } from "./inlineTocMarkdown";
+import { transformMarkdownOutsideCode } from "./markdownFence";
 import {
 	findWikiLinkSpans,
 	parseWikiLink,
@@ -37,7 +38,7 @@ const WHITESPACE_SPACE_SENTINEL = "\u2061";
 const WHITESPACE_TAB_SENTINEL = "\u2062";
 const LEGACY_EXTRA_BLANK_LINE_SENTINEL = "\u200b";
 
-function canonicalizeWikiLinks(input: string): string {
+function canonicalizeWikiLinksText(input: string): string {
 	if (!input.includes("[[")) return input;
 	const spans = findWikiLinkSpans(input);
 	if (!spans.length) return input;
@@ -54,21 +55,27 @@ function canonicalizeWikiLinks(input: string): string {
 	return out;
 }
 
+function canonicalizeWikiLinks(input: string): string {
+	return transformMarkdownOutsideCode(input, canonicalizeWikiLinksText);
+}
+
 const MARKDOWN_IMAGE_WITHOUT_TITLE_RE =
 	/!\[([^\]\n]*)\]\(([^)\n"]*\s[^)\n"]*)\)/g;
 
 function encodeMarkdownImageDestinations(input: string): string {
-	return input.replace(
-		MARKDOWN_IMAGE_WITHOUT_TITLE_RE,
-		(match, alt: string, rawHref: string) => {
-			const href = typeof rawHref === "string" ? rawHref.trim() : "";
-			if (!href) return match;
-			try {
-				return `![${alt}](${encodeURI(decodeURI(href))})`;
-			} catch {
-				return `![${alt}](${encodeURI(href)})`;
-			}
-		},
+	return transformMarkdownOutsideCode(input, (text) =>
+		text.replace(
+			MARKDOWN_IMAGE_WITHOUT_TITLE_RE,
+			(match, alt: string, rawHref: string) => {
+				const href = typeof rawHref === "string" ? rawHref.trim() : "";
+				if (!href) return match;
+				try {
+					return `![${alt}](${encodeURI(decodeURI(href))})`;
+				} catch {
+					return `![${alt}](${encodeURI(href)})`;
+				}
+			},
+		),
 	);
 }
 

--- a/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
+++ b/src/components/editor/markdown/wikiLinkMarkdownBridge.ts
@@ -26,7 +26,10 @@ import {
 	postprocessInlineTocMarkers,
 	preprocessInlineTocMarkers,
 } from "./inlineTocMarkdown";
-import { transformMarkdownOutsideCode } from "./markdownFence";
+import {
+	transformMarkdownOutsideCode,
+	transformMarkdownOutsideFences,
+} from "./markdownFence";
 import {
 	findWikiLinkSpans,
 	parseWikiLink,
@@ -63,8 +66,10 @@ const MARKDOWN_IMAGE_WITHOUT_TITLE_RE =
 	/!\[([^\]\n]*)\]\(([^)\n"]*\s[^)\n"]*)\)/g;
 
 function encodeMarkdownImageDestinations(input: string): string {
-	return transformMarkdownOutsideCode(input, (text) =>
-		text.replace(
+	// Fence-aware only: alt text may contain inline code, so the full `![...](...)`
+	// token must stay intact for the image regex.
+	return transformMarkdownOutsideFences(input, (line) =>
+		line.replace(
 			MARKDOWN_IMAGE_WITHOUT_TITLE_RE,
 			(match, alt: string, rawHref: string) => {
 				const href = typeof rawHref === "string" ? rawHref.trim() : "";

--- a/src/components/editor/math/LatexSourceEditor.tsx
+++ b/src/components/editor/math/LatexSourceEditor.tsx
@@ -86,8 +86,13 @@ export function LatexSourceEditor({
 				],
 			}),
 		});
-		if (autoFocus) window.requestAnimationFrame(() => view.focus());
-		return () => view.destroy();
+		const focusFrame = autoFocus
+			? window.requestAnimationFrame(() => view.focus())
+			: null;
+		return () => {
+			if (focusFrame !== null) window.cancelAnimationFrame(focusFrame);
+			view.destroy();
+		};
 	}, [autoFocus]);
 
 	return (

--- a/src/components/editor/raw/RawMarkdownEditor.tsx
+++ b/src/components/editor/raw/RawMarkdownEditor.tsx
@@ -2,6 +2,7 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
 	forwardRef,
+	useCallback,
 	useEffect,
 	useImperativeHandle,
 	useLayoutEffect,
@@ -18,6 +19,23 @@ import {
 import type { RawMarkdownEditorHandle } from "./types";
 
 const RAW_MARKDOWN_CHANGE_DEBOUNCE_MS = 120;
+
+function diffMarkdownChange(current: string, next: string) {
+	let from = 0;
+	const maxPrefix = Math.min(current.length, next.length);
+	while (from < maxPrefix && current[from] === next[from]) from += 1;
+	let currentEnd = current.length;
+	let nextEnd = next.length;
+	while (
+		currentEnd > from &&
+		nextEnd > from &&
+		current[currentEnd - 1] === next[nextEnd - 1]
+	) {
+		currentEnd -= 1;
+		nextEnd -= 1;
+	}
+	return { from, to: currentEnd, insert: next.slice(from, nextEnd) };
+}
 
 interface RawMarkdownEditorProps {
 	markdown: string;
@@ -43,6 +61,20 @@ export const RawMarkdownEditor = forwardRef<
 	onChangeRef.current = onChange;
 	relPathRef.current = relPath;
 
+	const flushPendingChange = useCallback(() => {
+		if (changeTimerRef.current !== null) {
+			window.clearTimeout(changeTimerRef.current);
+			changeTimerRef.current = null;
+		}
+		if (!hasPendingChangeRef.current) return;
+		hasPendingChangeRef.current = false;
+		const currentView = viewRef.current;
+		if (!currentView) return;
+		const nextMarkdown = currentView.state.doc.toString();
+		lastEmittedMarkdownRef.current = nextMarkdown;
+		onChangeRef.current(nextMarkdown);
+	}, []);
+
 	useEffect(() => {
 		applyDomSpellCheck(viewRef.current?.contentDOM, spellCheckEnabled);
 	}, [spellCheckEnabled]);
@@ -50,20 +82,6 @@ export const RawMarkdownEditor = forwardRef<
 	useLayoutEffect(() => {
 		const host = hostRef.current;
 		if (!host) return;
-		const flushPendingChange = () => {
-			if (changeTimerRef.current !== null) {
-				window.clearTimeout(changeTimerRef.current);
-				changeTimerRef.current = null;
-			}
-			if (!hasPendingChangeRef.current) return;
-			hasPendingChangeRef.current = false;
-			const currentView = viewRef.current;
-			if (!currentView) return;
-			const nextMarkdown = currentView.state.doc.toString();
-			lastEmittedMarkdownRef.current = nextMarkdown;
-			onChangeRef.current(nextMarkdown);
-		};
-
 		const view = new EditorView({
 			parent: host,
 			state: EditorState.create({
@@ -90,7 +108,7 @@ export const RawMarkdownEditor = forwardRef<
 			viewRef.current = null;
 			view.destroy();
 		};
-	}, []);
+	}, [flushPendingChange]);
 
 	useLayoutEffect(() => {
 		const view = viewRef.current;
@@ -121,7 +139,7 @@ export const RawMarkdownEditor = forwardRef<
 			changes:
 				currentMarkdown === markdown
 					? undefined
-					: { from: 0, to: currentMarkdown.length, insert: markdown },
+					: diffMarkdownChange(currentMarkdown, markdown),
 			selection,
 			effects: didChangeDocument
 				? EditorView.scrollIntoView(0, { y: "start" })
@@ -133,7 +151,9 @@ export const RawMarkdownEditor = forwardRef<
 	useImperativeHandle(
 		forwardedRef,
 		() => ({
+			flushPendingChange,
 			focus: () => viewRef.current?.focus(),
+			getMarkdown: () => viewRef.current?.state.doc.toString() ?? "",
 			getSelectedText: () => {
 				const view = viewRef.current;
 				if (!view) return "";
@@ -153,7 +173,7 @@ export const RawMarkdownEditor = forwardRef<
 				view.focus();
 			},
 		}),
-		[],
+		[flushPendingChange],
 	);
 
 	return <div ref={hostRef} className="rfNodeNoteEditorRaw" />;

--- a/src/components/editor/raw/linkCompletions.ts
+++ b/src/components/editor/raw/linkCompletions.ts
@@ -12,13 +12,18 @@ import {
 
 const COMPLETION_LIMIT = 8;
 
-function completionApply(markdown: string, closing: string) {
+function completionApply(
+	markdown: string,
+	closing: string,
+	isCurrentContext: (text: string) => boolean,
+) {
 	return (
 		view: EditorView,
 		completion: Completion,
 		from: number,
 		to: number,
 	) => {
+		if (!isCurrentContext(view.state.doc.sliceString(from, to))) return;
 		const existingClosing = view.state.doc.sliceString(to, to + closing.length);
 		const replaceTo = existingClosing === closing ? to + closing.length : to;
 		view.dispatch({
@@ -47,7 +52,11 @@ async function wikiLinkCompletions(
 		(item): Completion => ({
 			label: item.title,
 			detail: item.path,
-			apply: completionApply(`${opening}${item.insertText}]]`, "]]"),
+			apply: completionApply(
+				`${opening}${item.insertText}]]`,
+				"]]",
+				(text) => text.startsWith(opening) && !text.includes("\n"),
+			),
 			type: asEmbed ? "keyword" : "text",
 			boost: item.title ? 1 : 0,
 		}),
@@ -72,7 +81,11 @@ async function markdownLinkCompletions(
 		(item): Completion => ({
 			label: item.title,
 			detail: item.path,
-			apply: completionApply(`](${item.insertText})`, ")"),
+			apply: completionApply(
+				`](${item.insertText})`,
+				")",
+				(text) => text.startsWith("](") && !text.includes("\n"),
+			),
 			type: "text",
 		}),
 	);

--- a/src/components/editor/raw/types.ts
+++ b/src/components/editor/raw/types.ts
@@ -1,5 +1,7 @@
 export interface RawMarkdownEditorHandle {
+	flushPendingChange: () => void;
 	focus: () => void;
+	getMarkdown: () => string;
 	getSelectedText: () => string;
 	selectRange: (from: number, to: number) => void;
 }

--- a/src/components/editor/suggestionScroll.ts
+++ b/src/components/editor/suggestionScroll.ts
@@ -29,11 +29,11 @@ export function lockEditorScrollDuringSuggestion(
 	};
 
 	host.addEventListener("scroll", restoreScroll);
-	document.addEventListener("wheel", preventDocumentScroll, {
+	host.addEventListener("wheel", preventDocumentScroll, {
 		capture: true,
 		passive: false,
 	});
-	document.addEventListener("touchmove", preventDocumentScroll, {
+	host.addEventListener("touchmove", preventDocumentScroll, {
 		capture: true,
 		passive: false,
 	});
@@ -41,10 +41,10 @@ export function lockEditorScrollDuringSuggestion(
 
 	return () => {
 		host.removeEventListener("scroll", restoreScroll);
-		document.removeEventListener("wheel", preventDocumentScroll, {
+		host.removeEventListener("wheel", preventDocumentScroll, {
 			capture: true,
 		});
-		document.removeEventListener("touchmove", preventDocumentScroll, {
+		host.removeEventListener("touchmove", preventDocumentScroll, {
 			capture: true,
 		});
 	};

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -134,11 +134,13 @@ export function createTipTapSuggestionMenu<T>({
 			}
 			if (!items.length) return false;
 			if (event.key === "ArrowDown") {
+				event.preventDefault();
 				selectedIndex = nextSuggestionIndex(selectedIndex, items.length, 1);
 				updateSelection(items);
 				return true;
 			}
 			if (event.key === "ArrowUp") {
+				event.preventDefault();
 				selectedIndex = nextSuggestionIndex(selectedIndex, items.length, -1);
 				updateSelection(items);
 				return true;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -11,16 +11,13 @@ import {
 	useSpace,
 	useUILayoutContext,
 } from "../../contexts";
-import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import {
 	OPEN_LOCAL_CONNECTIONS_EVENT,
 	type OpenLocalConnectionsDetail,
 	TOGGLE_NOTE_INFO_SIDEBAR_EVENT,
 	type ToggleNoteInfoSidebarDetail,
 } from "../../lib/appEvents";
-import { extractErrorMessage } from "../../lib/errorUtils";
 import { canShowGitHistory } from "../../lib/gitSyncUi";
-import { setPrefetchedNote } from "../../lib/navigationPrefetch";
 import {
 	joinYamlFrontmatter,
 	splitYamlFrontmatter,
@@ -34,14 +31,12 @@ import {
 	type WorkspaceDatabasePreviewContext,
 	invoke,
 } from "../../lib/tauri";
-import { useTauriEvent } from "../../lib/tauriEvents";
 import { normalizeRelPath } from "../../utils/path";
 import { LocalNoteConnectionsDialog } from "../connections/LocalNoteConnectionsDialog";
 import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
 import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
-import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import type {
 	ExtractToNoteActions,
 	NoteInlineEditorMode,
@@ -54,14 +49,11 @@ import {
 	initialEditorMode,
 	requiresPlainEditorMode,
 } from "./editorModeSelection";
-import {
-	clearMarkdownDocCache,
-	getCachedMarkdownDoc,
-	peekCachedMarkdownDoc,
-} from "./markdownCache";
+import { peekCachedMarkdownDoc } from "./markdownCache";
 import { analyzeNoteInfo } from "./noteInfoAnalysis";
 import { useDeferredTocSource } from "./useDeferredTocSource";
 import { useInternalAnchorNavigation } from "./useInternalAnchorNavigation";
+import { useMarkdownDocumentSession } from "./useMarkdownDocumentSession";
 
 interface MarkdownEditorPaneProps {
 	relPath: string;
@@ -166,28 +158,16 @@ export function MarkdownEditorPane({
 	initialError = "",
 	extractToNoteActions,
 }: MarkdownEditorPaneProps) {
-	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
-	const [text, setText] = useState(() => initialText);
 	const [infoPanelText, setInfoPanelText] = useState("");
-	const [savedText, setSavedText] = useState(() => initialText);
 	const preferredEditorModeRef = useRef<NoteInlineEditorMode | null>(null);
+	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
 	const [mode, setMode] = useState<NoteInlineEditorMode>(() =>
 		initialEditorMode(initialText),
 	);
-	const [saving, setSaving] = useState(false);
-	const [autosaveBusy, setAutosaveBusy] = useState(false);
-	const [error, setError] = useState(() => initialError || "");
 	const [infoPanelOpen, setInfoPanelOpen] = useState(false);
 	const [localConnectionsOpen, setLocalConnectionsOpen] = useState(false);
-	const [lastSavedMtimeMs, setLastSavedMtimeMs] = useState<number | null>(
-		initialDoc?.mtime_ms ?? null,
-	);
-	const { flashPulse, clearPulse, resolveLabel } = useEditorSaveIndicator();
 	const [linkedMentions, setLinkedMentions] = useState<BacklinkItem[]>([]);
 	const [relationships, setRelationships] = useState<NoteRelationship[]>([]);
-
-	const savedTextRef = useRef(savedText);
-	const textRef = useRef(text);
 	const resolveEditorModeForNote = useCallback(
 		(markdown: string): NoteInlineEditorMode => {
 			if (requiresPlainEditorMode(markdown)) return "plain";
@@ -199,8 +179,39 @@ export function MarkdownEditorPane({
 		preferredEditorModeRef.current = nextMode;
 		setMode(nextMode);
 	}, []);
+	const infoPanelOpenRef = useRef(infoPanelOpen);
+	const paneRef = useRef<HTMLElement | null>(null);
+	const contentScrollRef = useRef<HTMLDivElement | null>(null);
+	const { spacePath } = useSpace();
+	const { tocSource, handleEditorReady } = useDeferredTocSource();
+	const handleDocumentTextReplaced = useCallback((nextText: string) => {
+		if (infoPanelOpenRef.current) setInfoPanelText(nextText);
+	}, []);
+	const {
+		error,
+		flushRawMarkdown,
+		handleRawEditorReady,
+		isDirty,
+		lastSavedMtimeMs,
+		markUserEdit,
+		onSave,
+		rawEditorRef,
+		runAutosave,
+		saveLabel,
+		text,
+		textRef,
+	} = useMarkdownDocumentSession({
+		initialDoc,
+		initialError,
+		onTextReplaced: handleDocumentTextReplaced,
+		relPath,
+		resolveEditorModeForNote,
+		setEditorMode: setMode,
+		spacePath,
+	});
 	const requestEditorMode = useCallback(
 		async (nextMode: NoteInlineEditorMode) => {
+			flushRawMarkdown();
 			if (nextMode !== "plain" && requiresPlainEditorMode(textRef.current)) {
 				const modeLabel = nextMode === "rich" ? "Rich" : "Preview";
 				const { confirm } = await import("@tauri-apps/plugin-dialog");
@@ -216,30 +227,7 @@ export function MarkdownEditorPane({
 			}
 			applyEditorMode(nextMode);
 		},
-		[applyEditorMode],
-	);
-	const mtimeRef = useRef<number | null>(lastSavedMtimeMs);
-	const documentSessionRef = useRef(0);
-	const mountedRef = useRef(true);
-	const saveRequestTokenRef = useRef(0);
-	const autosaveInFlightRef = useRef(false);
-	const autosaveQueuedRef = useRef(false);
-	const hasUserEditsRef = useRef(false);
-	const externalSyncTimerRef = useRef<number | null>(null);
-	const pendingExternalReloadRef = useRef(false);
-	const activeRelPathRef = useRef(relPath);
-	const infoPanelOpenRef = useRef(infoPanelOpen);
-	const paneRef = useRef<HTMLElement | null>(null);
-	const contentScrollRef = useRef<HTMLDivElement | null>(null);
-	const { spacePath } = useSpace();
-	const previousSpacePathRef = useRef<string | null>(spacePath);
-	const { tocSource, handleEditorReady } = useDeferredTocSource();
-	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
-	const handleRawEditorReady = useCallback(
-		(editor: RawMarkdownEditorHandle | null) => {
-			rawEditorRef.current = editor;
-		},
-		[],
+		[applyEditorMode, flushRawMarkdown, textRef],
 	);
 	const {
 		headings: tocHeadings,
@@ -263,7 +251,15 @@ export function MarkdownEditorPane({
 		onGitDiffChange?.(null);
 	}, [hasSupportedGit, onGitDiffChange]);
 
-	const isDirty = text !== savedText;
+	useEffect(() => {
+		setInfoPanelText("");
+		setInfoPanelOpen(false);
+		setLocalConnectionsOpen(false);
+		setPreviewContext(null);
+		setLinkedMentions([]);
+		setRelationships([]);
+	}, [relPath, spacePath]);
+
 	const { frontmatter: currentFrontmatter, body: currentBody } = useMemo(
 		() =>
 			infoPanelOpen
@@ -338,22 +334,6 @@ export function MarkdownEditorPane({
 		selectVisibleHeading,
 	});
 
-	const saveLabel =
-		resolveLabel({
-			isDirty,
-			saving,
-			autosaveBusy,
-			hasSavedBefore: lastSavedMtimeMs !== null,
-		}) ?? "Ready";
-
-	useEffect(() => {
-		mountedRef.current = true;
-		return () => {
-			mountedRef.current = false;
-			documentSessionRef.current += 1;
-		};
-	}, []);
-
 	useEffect(() => {
 		if (!infoPanelOpen) return;
 		setInfoPanelText(textRef.current);
@@ -367,300 +347,6 @@ export function MarkdownEditorPane({
 		return () => window.clearTimeout(timer);
 	}, [infoPanelOpen, text]);
 
-	const isCurrentSession = useCallback((sessionId: number) => {
-		return mountedRef.current && documentSessionRef.current === sessionId;
-	}, []);
-
-	useEffect(() => {
-		// `initialDoc` is a seed for the pane. Autosave also refreshes that cache,
-		// so do not treat the resulting object identity change as a new document.
-		if (
-			activeRelPathRef.current === relPath &&
-			initialDoc?.text === textRef.current
-		) {
-			return;
-		}
-		const sessionId = documentSessionRef.current + 1;
-		documentSessionRef.current = sessionId;
-		saveRequestTokenRef.current += 1;
-		const cached = initialDoc?.text ?? getCachedMarkdownDoc(relPath) ?? "";
-		textRef.current = cached;
-		savedTextRef.current = cached;
-		mtimeRef.current = initialDoc?.mtime_ms ?? null;
-		autosaveInFlightRef.current = false;
-		autosaveQueuedRef.current = false;
-		if (externalSyncTimerRef.current !== null) {
-			window.clearTimeout(externalSyncTimerRef.current);
-			externalSyncTimerRef.current = null;
-		}
-		pendingExternalReloadRef.current = false;
-		setText(cached);
-		setInfoPanelText("");
-		setSavedText(cached);
-		setLastSavedMtimeMs(initialDoc?.mtime_ms ?? null);
-		setSaving(false);
-		setAutosaveBusy(false);
-		clearPulse();
-		hasUserEditsRef.current = false;
-		setError(initialError);
-		if (activeRelPathRef.current !== relPath) {
-			setInfoPanelOpen(false);
-			setMode(resolveEditorModeForNote(cached));
-		}
-		activeRelPathRef.current = relPath;
-		setLocalConnectionsOpen(false);
-		setPreviewContext(null);
-		setLinkedMentions([]);
-		if (initialDoc) {
-			setPrefetchedNote(relPath, initialDoc);
-		}
-	}, [clearPulse, initialDoc, initialError, relPath, resolveEditorModeForNote]);
-
-	useEffect(() => {
-		if (previousSpacePathRef.current === spacePath) return;
-		previousSpacePathRef.current = spacePath;
-		documentSessionRef.current += 1;
-		saveRequestTokenRef.current += 1;
-		if (externalSyncTimerRef.current !== null) {
-			window.clearTimeout(externalSyncTimerRef.current);
-			externalSyncTimerRef.current = null;
-		}
-		pendingExternalReloadRef.current = false;
-		textRef.current = "";
-		savedTextRef.current = "";
-		mtimeRef.current = null;
-		autosaveInFlightRef.current = false;
-		autosaveQueuedRef.current = false;
-		hasUserEditsRef.current = false;
-		setText("");
-		setInfoPanelText("");
-		setSavedText("");
-		setLastSavedMtimeMs(null);
-		setSaving(false);
-		setAutosaveBusy(false);
-		clearPulse();
-		clearMarkdownDocCache();
-		if (spacePath === null) {
-			return;
-		}
-	}, [clearPulse, spacePath]);
-
-	const loadDoc = useCallback(
-		async (showRefreshFeedback = false) => {
-			const sessionId = documentSessionRef.current;
-			setError("");
-			try {
-				const doc = await invoke("space_read_text", { path: relPath });
-				if (!isCurrentSession(sessionId)) return;
-				const shouldReplaceText = textRef.current === savedTextRef.current;
-				const shouldChooseInitialMode =
-					textRef.current.length === 0 && savedTextRef.current.length === 0;
-				setPrefetchedNote(relPath, doc);
-				if (shouldReplaceText) {
-					if (shouldChooseInitialMode) {
-						setMode(resolveEditorModeForNote(doc.text));
-					}
-					textRef.current = doc.text;
-					setText(doc.text);
-					if (infoPanelOpenRef.current) setInfoPanelText(doc.text);
-				}
-				savedTextRef.current = doc.text;
-				mtimeRef.current = doc.mtime_ms;
-				setSavedText(doc.text);
-				setLastSavedMtimeMs(doc.mtime_ms);
-				hasUserEditsRef.current = false;
-				setPrefetchedNote(relPath, doc);
-				if (showRefreshFeedback) {
-					flashPulse("reloaded");
-				}
-			} catch (e) {
-				if (!isCurrentSession(sessionId)) return;
-				setError(extractErrorMessage(e));
-			}
-		},
-		[flashPulse, isCurrentSession, relPath, resolveEditorModeForNote],
-	);
-
-	const loadDocFromExternalChange = useCallback(async () => {
-		const sessionId = documentSessionRef.current;
-		setError("");
-		try {
-			const doc = await invoke("space_read_text", { path: relPath });
-			if (!isCurrentSession(sessionId)) return;
-			if (
-				doc.mtime_ms === mtimeRef.current &&
-				doc.text === savedTextRef.current
-			)
-				return;
-			setPrefetchedNote(relPath, doc);
-			textRef.current = doc.text;
-			savedTextRef.current = doc.text;
-			mtimeRef.current = doc.mtime_ms;
-			setText(doc.text);
-			if (infoPanelOpenRef.current) setInfoPanelText(doc.text);
-			setSavedText(doc.text);
-			setLastSavedMtimeMs(doc.mtime_ms);
-			hasUserEditsRef.current = false;
-		} catch (e) {
-			if (!isCurrentSession(sessionId)) return;
-			setError(extractErrorMessage(e));
-		}
-	}, [isCurrentSession, relPath]);
-
-	useEffect(() => {
-		if (initialDoc) return;
-		void loadDoc();
-	}, [initialDoc, loadDoc]);
-
-	const persistDoc = useCallback(
-		async (
-			path: string,
-			nextText: string,
-			sessionId = documentSessionRef.current,
-		): Promise<boolean> => {
-			const applySaveState = (saved: string, mtimeMs: number) => {
-				if (path !== relPath || !isCurrentSession(sessionId)) return;
-				setPrefetchedNote(path, {
-					rel_path: path,
-					text: saved,
-					etag: "",
-					mtime_ms: mtimeMs,
-				});
-				savedTextRef.current = saved;
-				mtimeRef.current = mtimeMs;
-				setSavedText(saved);
-				setLastSavedMtimeMs(mtimeMs);
-				hasUserEditsRef.current = false;
-				flashPulse("saved");
-			};
-
-			setError("");
-			try {
-				const result = await invoke("space_write_text", {
-					path,
-					text: nextText,
-					base_mtime_ms: mtimeRef.current,
-				});
-				applySaveState(nextText, result.mtime_ms);
-				return true;
-			} catch (e) {
-				if (!isCurrentSession(sessionId)) return false;
-				const message = extractErrorMessage(e);
-				const isConflict = message.includes(
-					"conflict: on-disk file changed since it was opened",
-				);
-				if (!isConflict) {
-					setError(message);
-					return false;
-				}
-
-				// Conflict recovery: refresh latest mtime/content and retry save once.
-				try {
-					const latest = await invoke("space_read_text", { path });
-					if (!isCurrentSession(sessionId)) return false;
-					if (latest.text === nextText) {
-						applySaveState(nextText, latest.mtime_ms);
-						return true;
-					}
-					savedTextRef.current = latest.text;
-					mtimeRef.current = latest.mtime_ms;
-					const retry = await invoke("space_write_text", {
-						path,
-						text: nextText,
-						base_mtime_ms: latest.mtime_ms,
-					});
-					applySaveState(nextText, retry.mtime_ms);
-					return true;
-				} catch (retryError) {
-					if (!isCurrentSession(sessionId)) return false;
-					setError(extractErrorMessage(retryError));
-					return false;
-				}
-			}
-		},
-		[flashPulse, isCurrentSession, relPath],
-	);
-
-	const onSave = useCallback(async () => {
-		const sessionId = documentSessionRef.current;
-		const saveToken = saveRequestTokenRef.current + 1;
-		saveRequestTokenRef.current = saveToken;
-		setSaving(true);
-		try {
-			await persistDoc(relPath, textRef.current, sessionId);
-		} finally {
-			if (
-				saveRequestTokenRef.current === saveToken &&
-				isCurrentSession(sessionId)
-			) {
-				setSaving(false);
-			}
-		}
-	}, [isCurrentSession, persistDoc, relPath]);
-
-	const runAutosave = useCallback(async () => {
-		const sessionId = documentSessionRef.current;
-		if (autosaveInFlightRef.current) {
-			autosaveQueuedRef.current = true;
-			return false;
-		}
-
-		const path = relPath;
-		const snapshot = textRef.current;
-		if (snapshot === savedTextRef.current) return false;
-
-		autosaveInFlightRef.current = true;
-		setAutosaveBusy(true);
-		const ok = await persistDoc(path, snapshot, sessionId);
-		if (!isCurrentSession(sessionId)) return ok;
-		autosaveInFlightRef.current = false;
-		setAutosaveBusy(false);
-		if (autosaveQueuedRef.current) {
-			autosaveQueuedRef.current = false;
-			return runAutosave();
-		}
-		if (ok && textRef.current !== savedTextRef.current) {
-			return runAutosave();
-		}
-		return ok;
-	}, [isCurrentSession, persistDoc, relPath]);
-
-	useEffect(() => {
-		if (!isDirty || !hasUserEditsRef.current) return;
-		const timer = window.setTimeout(() => {
-			runAutosave();
-		}, 900);
-		return () => window.clearTimeout(timer);
-	}, [isDirty, runAutosave]);
-
-	useEffect(() => {
-		return () => {
-			if (textRef.current === savedTextRef.current) return;
-			runAutosave();
-		};
-	}, [runAutosave]);
-
-	const handleExternalNoteChanged = useCallback(
-		(payload: { rel_path: string }) => {
-			const changed = normalizeRelPath(payload.rel_path);
-			const current = normalizeRelPath(relPath);
-			if (!changed || changed !== current) return;
-			if (externalSyncTimerRef.current !== null) {
-				window.clearTimeout(externalSyncTimerRef.current);
-			}
-			externalSyncTimerRef.current = window.setTimeout(() => {
-				externalSyncTimerRef.current = null;
-				if (isDirty || autosaveInFlightRef.current || saving) {
-					pendingExternalReloadRef.current = true;
-					return;
-				}
-				void loadDocFromExternalChange();
-			}, 180);
-		},
-		[isDirty, loadDocFromExternalChange, relPath, saving],
-	);
-
-	useTauriEvent("notes:external_changed", handleExternalNoteChanged);
 	useEffect(() => {
 		const handleOpenLocalConnections = (event: Event) => {
 			const detail = (event as CustomEvent<OpenLocalConnectionsDetail>).detail;
@@ -700,22 +386,6 @@ export function MarkdownEditorPane({
 	useEffect(() => {
 		if (aiPanelOpen) setInfoPanelOpen(false);
 	}, [aiPanelOpen]);
-
-	useEffect(() => {
-		if (!pendingExternalReloadRef.current) return;
-		if (isDirty || saving) return;
-		pendingExternalReloadRef.current = false;
-		void loadDocFromExternalChange();
-	}, [isDirty, loadDocFromExternalChange, saving]);
-
-	useEffect(
-		() => () => {
-			if (externalSyncTimerRef.current !== null) {
-				window.clearTimeout(externalSyncTimerRef.current);
-			}
-		},
-		[],
-	);
 
 	// Register editor state for keyboard shortcuts
 	const editorState = useMemo(
@@ -808,15 +478,13 @@ export function MarkdownEditorPane({
 			const { body } = splitYamlFrontmatter(textRef.current);
 			const nextMarkdown = joinYamlFrontmatter(normalizedFrontmatter, body);
 			if (nextMarkdown === textRef.current) return;
-			hasUserEditsRef.current = true;
-			textRef.current = nextMarkdown;
-			setText(nextMarkdown);
+			markUserEdit(nextMarkdown);
 			setInfoPanelText(nextMarkdown);
 			// Property edits are discrete commits — save immediately so the
 			// indexer picks up the change and databases/backlinks update.
 			void runAutosave();
 		},
-		[runAutosave],
+		[markUserEdit, runAutosave, textRef],
 	);
 
 	const toggleInfoPanel = useCallback(() => {
@@ -918,9 +586,7 @@ export function MarkdownEditorPane({
 								mode={mode}
 								pasteMarkdownBehavior="smart-markdown"
 								onChange={(nextText) => {
-									hasUserEditsRef.current = true;
-									textRef.current = nextText;
-									setText(nextText);
+									markUserEdit(nextText);
 								}}
 								onFrontmatterCommit={runAutosave}
 								onEditorReady={handleEditorReady}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -251,14 +251,18 @@ export function MarkdownEditorPane({
 		onGitDiffChange?.(null);
 	}, [hasSupportedGit, onGitDiffChange]);
 
-	useEffect(() => {
+	// Reset note-local sidebar state when the active note identity changes.
+	const activeNoteKey = `${spacePath ?? ""}\0${relPath}`;
+	const [sidebarNoteKey, setSidebarNoteKey] = useState(activeNoteKey);
+	if (sidebarNoteKey !== activeNoteKey) {
+		setSidebarNoteKey(activeNoteKey);
 		setInfoPanelText("");
 		setInfoPanelOpen(false);
 		setLocalConnectionsOpen(false);
 		setPreviewContext(null);
 		setLinkedMentions([]);
 		setRelationships([]);
-	}, [relPath, spacePath]);
+	}
 
 	const { frontmatter: currentFrontmatter, body: currentBody } = useMemo(
 		() =>
@@ -322,10 +326,10 @@ export function MarkdownEditorPane({
 			}
 			scrollToHeading(heading);
 		},
-		[mode, scrollToHeading],
+		[mode, rawEditorRef, scrollToHeading],
 	);
 
-	const getPlainText = useCallback(() => textRef.current, []);
+	const getPlainText = useCallback(() => textRef.current, [textRef]);
 	useInternalAnchorNavigation({
 		relPath,
 		mode,
@@ -337,7 +341,7 @@ export function MarkdownEditorPane({
 	useEffect(() => {
 		if (!infoPanelOpen) return;
 		setInfoPanelText(textRef.current);
-	}, [infoPanelOpen]);
+	}, [infoPanelOpen, textRef]);
 
 	useEffect(() => {
 		if (!infoPanelOpen) return;
@@ -381,7 +385,7 @@ export function MarkdownEditorPane({
 				handleToggleInfoSidebar,
 			);
 		};
-	}, [relPath, setAiPanelOpen]);
+	}, [relPath, setAiPanelOpen, textRef]);
 
 	useEffect(() => {
 		if (aiPanelOpen) setInfoPanelOpen(false);
@@ -396,7 +400,7 @@ export function MarkdownEditorPane({
 			getMarkdown: () => textRef.current,
 			setMode: requestEditorMode,
 		}),
-		[isDirty, onSave, relPath, requestEditorMode],
+		[isDirty, onSave, relPath, requestEditorMode, textRef],
 	);
 	useEditorRegistration(editorState);
 
@@ -494,7 +498,7 @@ export function MarkdownEditorPane({
 			if (nextOpen) setInfoPanelText(textRef.current);
 			return nextOpen;
 		});
-	}, [setAiPanelOpen]);
+	}, [setAiPanelOpen, textRef]);
 	const closeInfoPanel = useCallback(() => setInfoPanelOpen(false), []);
 
 	const isLargeNote = requiresPlainEditorMode(text);

--- a/src/components/preview/useMarkdownDocumentSession.ts
+++ b/src/components/preview/useMarkdownDocumentSession.ts
@@ -13,6 +13,11 @@ import {
 	peekCachedMarkdownDoc,
 } from "./markdownCache";
 
+/** Debounce typing before persisting so rapid keystrokes coalesce. */
+const AUTOSAVE_DEBOUNCE_MS = 900;
+/** Brief delay so bursty external FS events settle before reload. */
+const EXTERNAL_RELOAD_DEBOUNCE_MS = 180;
+
 interface UseMarkdownDocumentSessionOptions {
 	initialDoc: TextFileDoc | null;
 	initialError: string;
@@ -189,12 +194,16 @@ export function useMarkdownDocumentSession({
 						setEditorMode(resolveEditorModeForNote(doc.text));
 					}
 					replaceText(doc.text);
+					hasUserEditsRef.current = false;
+				} else {
+					// User edited before this read resolved; keep the dirty edit
+					// flagged so it still autosaves instead of going stale.
+					hasUserEditsRef.current = true;
 				}
 				savedTextRef.current = doc.text;
 				mtimeRef.current = doc.mtime_ms;
 				setSavedText(doc.text);
 				setLastSavedMtimeMs(doc.mtime_ms);
-				hasUserEditsRef.current = false;
 				setPrefetchedNote(relPath, doc);
 				if (showRefreshFeedback) {
 					flashPulse("reloaded");
@@ -257,10 +266,17 @@ export function useMarkdownDocumentSession({
 		}
 	}, [flushRawMarkdown, isCurrentSession, relPath, replaceText]);
 
+	const loadedSpacePathRef = useRef(spacePath);
+
 	useEffect(() => {
-		if (initialDoc) return;
+		const spaceChanged = loadedSpacePathRef.current !== spacePath;
+		loadedSpacePathRef.current = spacePath;
+		// A stale `initialDoc` from the previous space must not block a reload:
+		// the space-change effect already cleared local state, so this note
+		// still needs to be fetched from the newly active space.
+		if (initialDoc && !spaceChanged) return;
 		void loadDoc();
-	}, [initialDoc, loadDoc]);
+	}, [initialDoc, loadDoc, spacePath]);
 
 	const persistDoc = useCallback(
 		async (
@@ -424,7 +440,7 @@ export function useMarkdownDocumentSession({
 		if (!isDirty || !hasUserEditsRef.current) return;
 		const timer = window.setTimeout(() => {
 			runAutosave();
-		}, 900);
+		}, AUTOSAVE_DEBOUNCE_MS);
 		return () => window.clearTimeout(timer);
 	}, [isDirty, runAutosave]);
 
@@ -455,7 +471,7 @@ export function useMarkdownDocumentSession({
 					return;
 				}
 				void loadDocFromExternalChange();
-			}, 180);
+			}, EXTERNAL_RELOAD_DEBOUNCE_MS);
 		},
 		[flushRawMarkdown, loadDocFromExternalChange, relPath],
 	);

--- a/src/components/preview/useMarkdownDocumentSession.ts
+++ b/src/components/preview/useMarkdownDocumentSession.ts
@@ -1,0 +1,506 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
+import { extractErrorMessage } from "../../lib/errorUtils";
+import { setPrefetchedNote } from "../../lib/navigationPrefetch";
+import { type TextFileDoc, invoke } from "../../lib/tauri";
+import { useTauriEvent } from "../../lib/tauriEvents";
+import { normalizeRelPath } from "../../utils/path";
+import type { RawMarkdownEditorHandle } from "../editor/raw/types";
+import type { NoteInlineEditorMode } from "../editor/types";
+import {
+	clearMarkdownDocCache,
+	getCachedMarkdownDoc,
+	peekCachedMarkdownDoc,
+} from "./markdownCache";
+
+interface UseMarkdownDocumentSessionOptions {
+	initialDoc: TextFileDoc | null;
+	initialError: string;
+	onTextReplaced: (text: string) => void;
+	relPath: string;
+	resolveEditorModeForNote: (markdown: string) => NoteInlineEditorMode;
+	setEditorMode: (mode: NoteInlineEditorMode) => void;
+	spacePath: string | null;
+}
+
+export function useMarkdownDocumentSession({
+	initialDoc,
+	initialError,
+	onTextReplaced,
+	relPath,
+	resolveEditorModeForNote,
+	setEditorMode,
+	spacePath,
+}: UseMarkdownDocumentSessionOptions) {
+	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
+	const [text, setText] = useState(() => initialText);
+	const [savedText, setSavedText] = useState(() => initialText);
+	const [saving, setSaving] = useState(false);
+	const [autosaveBusy, setAutosaveBusy] = useState(false);
+	const [error, setError] = useState(() => initialError || "");
+	const [lastSavedMtimeMs, setLastSavedMtimeMs] = useState<number | null>(
+		initialDoc?.mtime_ms ?? null,
+	);
+	const { flashPulse, clearPulse, resolveLabel } = useEditorSaveIndicator();
+
+	const savedTextRef = useRef(savedText);
+	const textRef = useRef(text);
+	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
+	const savingRef = useRef(saving);
+	const mtimeRef = useRef<number | null>(lastSavedMtimeMs);
+	const documentSessionRef = useRef(0);
+	const mountedRef = useRef(true);
+	const saveRequestTokenRef = useRef(0);
+	const autosaveInFlightRef = useRef(false);
+	const autosaveQueuedRef = useRef(false);
+	const hasUserEditsRef = useRef(false);
+	const externalSyncTimerRef = useRef<number | null>(null);
+	const pendingExternalReloadRef = useRef(false);
+	const activeRelPathRef = useRef(relPath);
+	const previousSpacePathRef = useRef<string | null>(spacePath);
+
+	savingRef.current = saving;
+
+	const flushRawMarkdown = useCallback(() => {
+		rawEditorRef.current?.flushPendingChange();
+	}, []);
+
+	const handleRawEditorReady = useCallback(
+		(editor: RawMarkdownEditorHandle | null) => {
+			rawEditorRef.current = editor;
+		},
+		[],
+	);
+
+	const replaceText = useCallback(
+		(nextText: string) => {
+			textRef.current = nextText;
+			setText(nextText);
+			onTextReplaced(nextText);
+		},
+		[onTextReplaced],
+	);
+
+	const markUserEdit = useCallback((nextText: string) => {
+		hasUserEditsRef.current = true;
+		textRef.current = nextText;
+		setText(nextText);
+	}, []);
+
+	const isCurrentSession = useCallback((sessionId: number) => {
+		return mountedRef.current && documentSessionRef.current === sessionId;
+	}, []);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+			documentSessionRef.current += 1;
+		};
+	}, []);
+
+	useEffect(() => {
+		// `initialDoc` is a seed for the pane. Autosave also refreshes that cache,
+		// so do not treat the resulting object identity change as a new document.
+		flushRawMarkdown();
+		if (
+			activeRelPathRef.current === relPath &&
+			initialDoc?.text === textRef.current
+		) {
+			return;
+		}
+		const sessionId = documentSessionRef.current + 1;
+		documentSessionRef.current = sessionId;
+		saveRequestTokenRef.current += 1;
+		const cached = initialDoc?.text ?? getCachedMarkdownDoc(relPath) ?? "";
+		textRef.current = cached;
+		savedTextRef.current = cached;
+		mtimeRef.current = initialDoc?.mtime_ms ?? null;
+		autosaveInFlightRef.current = false;
+		autosaveQueuedRef.current = false;
+		if (externalSyncTimerRef.current !== null) {
+			window.clearTimeout(externalSyncTimerRef.current);
+			externalSyncTimerRef.current = null;
+		}
+		pendingExternalReloadRef.current = false;
+		setText(cached);
+		setSavedText(cached);
+		setLastSavedMtimeMs(initialDoc?.mtime_ms ?? null);
+		setSaving(false);
+		setAutosaveBusy(false);
+		clearPulse();
+		hasUserEditsRef.current = false;
+		setError(initialError);
+		if (activeRelPathRef.current !== relPath) {
+			setEditorMode(resolveEditorModeForNote(cached));
+		}
+		activeRelPathRef.current = relPath;
+		if (initialDoc) {
+			setPrefetchedNote(relPath, initialDoc);
+		}
+	}, [
+		clearPulse,
+		flushRawMarkdown,
+		initialDoc,
+		initialError,
+		relPath,
+		resolveEditorModeForNote,
+		setEditorMode,
+	]);
+
+	useEffect(() => {
+		if (previousSpacePathRef.current === spacePath) return;
+		previousSpacePathRef.current = spacePath;
+		documentSessionRef.current += 1;
+		saveRequestTokenRef.current += 1;
+		if (externalSyncTimerRef.current !== null) {
+			window.clearTimeout(externalSyncTimerRef.current);
+			externalSyncTimerRef.current = null;
+		}
+		pendingExternalReloadRef.current = false;
+		textRef.current = "";
+		savedTextRef.current = "";
+		mtimeRef.current = null;
+		autosaveInFlightRef.current = false;
+		autosaveQueuedRef.current = false;
+		hasUserEditsRef.current = false;
+		setText("");
+		setSavedText("");
+		setLastSavedMtimeMs(null);
+		setSaving(false);
+		setAutosaveBusy(false);
+		clearPulse();
+		clearMarkdownDocCache();
+	}, [clearPulse, spacePath]);
+
+	const loadDoc = useCallback(
+		async (showRefreshFeedback = false) => {
+			const sessionId = documentSessionRef.current;
+			setError("");
+			try {
+				const doc = await invoke("space_read_text", { path: relPath });
+				if (!isCurrentSession(sessionId)) return;
+				const shouldReplaceText = textRef.current === savedTextRef.current;
+				const shouldChooseInitialMode =
+					textRef.current.length === 0 && savedTextRef.current.length === 0;
+				setPrefetchedNote(relPath, doc);
+				if (shouldReplaceText) {
+					if (shouldChooseInitialMode) {
+						setEditorMode(resolveEditorModeForNote(doc.text));
+					}
+					replaceText(doc.text);
+				}
+				savedTextRef.current = doc.text;
+				mtimeRef.current = doc.mtime_ms;
+				setSavedText(doc.text);
+				setLastSavedMtimeMs(doc.mtime_ms);
+				hasUserEditsRef.current = false;
+				setPrefetchedNote(relPath, doc);
+				if (showRefreshFeedback) {
+					flashPulse("reloaded");
+				}
+			} catch (e) {
+				if (!isCurrentSession(sessionId)) return;
+				setError(extractErrorMessage(e));
+			}
+		},
+		[
+			flashPulse,
+			isCurrentSession,
+			relPath,
+			replaceText,
+			resolveEditorModeForNote,
+			setEditorMode,
+		],
+	);
+
+	const loadDocFromExternalChange = useCallback(async () => {
+		const sessionId = documentSessionRef.current;
+		flushRawMarkdown();
+		if (
+			textRef.current !== savedTextRef.current ||
+			autosaveInFlightRef.current ||
+			savingRef.current
+		) {
+			pendingExternalReloadRef.current = true;
+			return;
+		}
+		setError("");
+		try {
+			const doc = await invoke("space_read_text", { path: relPath });
+			if (!isCurrentSession(sessionId)) return;
+			flushRawMarkdown();
+			if (
+				textRef.current !== savedTextRef.current ||
+				autosaveInFlightRef.current ||
+				savingRef.current
+			) {
+				pendingExternalReloadRef.current = true;
+				return;
+			}
+			if (
+				doc.mtime_ms === mtimeRef.current &&
+				doc.text === savedTextRef.current
+			) {
+				return;
+			}
+			setPrefetchedNote(relPath, doc);
+			replaceText(doc.text);
+			savedTextRef.current = doc.text;
+			mtimeRef.current = doc.mtime_ms;
+			setSavedText(doc.text);
+			setLastSavedMtimeMs(doc.mtime_ms);
+			hasUserEditsRef.current = false;
+		} catch (e) {
+			if (!isCurrentSession(sessionId)) return;
+			setError(extractErrorMessage(e));
+		}
+	}, [flushRawMarkdown, isCurrentSession, relPath, replaceText]);
+
+	useEffect(() => {
+		if (initialDoc) return;
+		void loadDoc();
+	}, [initialDoc, loadDoc]);
+
+	const persistDoc = useCallback(
+		async (
+			path: string,
+			nextText: string,
+			sessionId = documentSessionRef.current,
+		): Promise<boolean> => {
+			const applySaveState = (saved: string, mtimeMs: number) => {
+				if (path !== relPath || !isCurrentSession(sessionId)) return;
+				setPrefetchedNote(path, {
+					rel_path: path,
+					text: saved,
+					etag: "",
+					mtime_ms: mtimeMs,
+				});
+				savedTextRef.current = saved;
+				mtimeRef.current = mtimeMs;
+				setSavedText(saved);
+				setLastSavedMtimeMs(mtimeMs);
+				if (textRef.current === saved) {
+					hasUserEditsRef.current = false;
+				} else {
+					hasUserEditsRef.current = true;
+					autosaveQueuedRef.current = true;
+				}
+				flashPulse("saved");
+			};
+
+			setError("");
+			try {
+				const result = await invoke("space_write_text", {
+					path,
+					text: nextText,
+					base_mtime_ms: mtimeRef.current,
+				});
+				applySaveState(nextText, result.mtime_ms);
+				return true;
+			} catch (e) {
+				if (!isCurrentSession(sessionId)) return false;
+				const message = extractErrorMessage(e);
+				const isConflict = message.includes(
+					"conflict: on-disk file changed since it was opened",
+				);
+				if (!isConflict) {
+					setError(message);
+					return false;
+				}
+
+				try {
+					const latest = await invoke("space_read_text", { path });
+					if (!isCurrentSession(sessionId)) return false;
+					if (latest.text === nextText) {
+						applySaveState(nextText, latest.mtime_ms);
+						return true;
+					}
+					const { message: showDialog } = await import(
+						"@tauri-apps/plugin-dialog"
+					);
+					const reloadLabel = "Reload";
+					const overwriteLabel = "Overwrite";
+					const choice = await showDialog(
+						"Glyph found a newer version of this note on disk. Reload that version, overwrite it with your edits, or cancel and keep editing.",
+						{
+							title: "Note changed on disk",
+							kind: "warning",
+							buttons: {
+								yes: reloadLabel,
+								no: overwriteLabel,
+								cancel: "Cancel",
+							},
+						},
+					);
+					if (!isCurrentSession(sessionId)) return false;
+					if (choice === reloadLabel || choice === "Yes") {
+						setPrefetchedNote(path, latest);
+						replaceText(latest.text);
+						savedTextRef.current = latest.text;
+						mtimeRef.current = latest.mtime_ms;
+						setSavedText(latest.text);
+						setLastSavedMtimeMs(latest.mtime_ms);
+						hasUserEditsRef.current = false;
+						flashPulse("reloaded");
+						return true;
+					}
+					if (choice === overwriteLabel || choice === "No") {
+						const retry = await invoke("space_write_text", {
+							path,
+							text: nextText,
+							base_mtime_ms: latest.mtime_ms,
+						});
+						applySaveState(nextText, retry.mtime_ms);
+						return true;
+					}
+					hasUserEditsRef.current = true;
+					setError(
+						"This note changed on disk. Reload it or save again after reviewing your local edits.",
+					);
+					return false;
+				} catch (retryError) {
+					if (!isCurrentSession(sessionId)) return false;
+					setError(extractErrorMessage(retryError));
+					return false;
+				}
+			}
+		},
+		[flashPulse, isCurrentSession, relPath, replaceText],
+	);
+
+	const onSave = useCallback(async () => {
+		const sessionId = documentSessionRef.current;
+		const saveToken = saveRequestTokenRef.current + 1;
+		saveRequestTokenRef.current = saveToken;
+		flushRawMarkdown();
+		setSaving(true);
+		try {
+			await persistDoc(relPath, textRef.current, sessionId);
+		} finally {
+			if (
+				saveRequestTokenRef.current === saveToken &&
+				isCurrentSession(sessionId)
+			) {
+				setSaving(false);
+			}
+		}
+	}, [flushRawMarkdown, isCurrentSession, persistDoc, relPath]);
+
+	const runAutosave = useCallback(async () => {
+		const sessionId = documentSessionRef.current;
+		flushRawMarkdown();
+		if (autosaveInFlightRef.current) {
+			autosaveQueuedRef.current = true;
+			return false;
+		}
+
+		const path = relPath;
+		const snapshot = textRef.current;
+		if (snapshot === savedTextRef.current) return false;
+
+		autosaveInFlightRef.current = true;
+		setAutosaveBusy(true);
+		const ok = await persistDoc(path, snapshot, sessionId);
+		if (!isCurrentSession(sessionId)) {
+			autosaveInFlightRef.current = false;
+			return ok;
+		}
+		autosaveInFlightRef.current = false;
+		setAutosaveBusy(false);
+		if (autosaveQueuedRef.current) {
+			autosaveQueuedRef.current = false;
+			return runAutosave();
+		}
+		if (ok && textRef.current !== savedTextRef.current) {
+			return runAutosave();
+		}
+		return ok;
+	}, [flushRawMarkdown, isCurrentSession, persistDoc, relPath]);
+
+	const isDirty = text !== savedText;
+
+	useEffect(() => {
+		if (!isDirty || !hasUserEditsRef.current) return;
+		const timer = window.setTimeout(() => {
+			runAutosave();
+		}, 900);
+		return () => window.clearTimeout(timer);
+	}, [isDirty, runAutosave]);
+
+	useEffect(() => {
+		return () => {
+			if (textRef.current === savedTextRef.current) return;
+			runAutosave();
+		};
+	}, [runAutosave]);
+
+	const handleExternalNoteChanged = useCallback(
+		(payload: { rel_path: string }) => {
+			const changed = normalizeRelPath(payload.rel_path);
+			const current = normalizeRelPath(relPath);
+			if (!changed || changed !== current) return;
+			if (externalSyncTimerRef.current !== null) {
+				window.clearTimeout(externalSyncTimerRef.current);
+			}
+			externalSyncTimerRef.current = window.setTimeout(() => {
+				externalSyncTimerRef.current = null;
+				flushRawMarkdown();
+				if (
+					textRef.current !== savedTextRef.current ||
+					autosaveInFlightRef.current ||
+					savingRef.current
+				) {
+					pendingExternalReloadRef.current = true;
+					return;
+				}
+				void loadDocFromExternalChange();
+			}, 180);
+		},
+		[flushRawMarkdown, loadDocFromExternalChange, relPath],
+	);
+
+	useTauriEvent("notes:external_changed", handleExternalNoteChanged);
+
+	useEffect(() => {
+		if (!pendingExternalReloadRef.current) return;
+		if (isDirty || saving || autosaveInFlightRef.current) return;
+		pendingExternalReloadRef.current = false;
+		void loadDocFromExternalChange();
+	}, [isDirty, loadDocFromExternalChange, saving]);
+
+	useEffect(
+		() => () => {
+			if (externalSyncTimerRef.current !== null) {
+				window.clearTimeout(externalSyncTimerRef.current);
+			}
+		},
+		[],
+	);
+
+	const saveLabel = useMemo(
+		() =>
+			resolveLabel({
+				isDirty,
+				saving,
+				autosaveBusy,
+				hasSavedBefore: lastSavedMtimeMs !== null,
+			}) ?? "Ready",
+		[autosaveBusy, isDirty, lastSavedMtimeMs, resolveLabel, saving],
+	);
+
+	return {
+		error,
+		flushRawMarkdown,
+		handleRawEditorReady,
+		isDirty,
+		lastSavedMtimeMs,
+		markUserEdit,
+		onSave,
+		rawEditorRef,
+		runAutosave,
+		saveLabel,
+		text,
+		textRef,
+	};
+}

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -114,10 +114,12 @@ export function useEditorContext(): EditorContextValue {
  * Hook for editor components to register their save state
  */
 export function useEditorRegistration(state: EditorSaveState | null): void {
-	const { registerEditor } = useEditorContext();
+	const { getEditorState, registerEditor } = useEditorContext();
 
 	useEffect(() => {
 		registerEditor(state);
-		return () => registerEditor(null);
-	}, [registerEditor, state]);
+		return () => {
+			if (getEditorState() === state) registerEditor(null);
+		};
+	}, [getEditorState, registerEditor, state]);
 }


### PR DESCRIPTION
Closes: none — no open GitHub issue matches this editor cleanup/hardening work.


## Description

Hardens the markdown editor around document load/save/autosave and TipTap lifecycle races, and extracts the document session out of `MarkdownEditorPane` so the pane stays focused on UI.

- **Summary of changes**
  - Extract load/save/autosave, external-reload, and dirty-state handling into `useMarkdownDocumentSession`.
  - Slim `MarkdownEditorPane` to mode switching, TOC/info panel, and presentation.
  - Guard TipTap paste/image hydration, markdown sync, and destroyed-editor access in `useNoteEditor`.
  - Preserve link selection ranges in `NoteLinkDialog` / `RibbonLinkPopover` so apply/remove still targets the original range after focus moves.
  - Tighten markdown transforms (details fences, wiki links, TOC, code-fence-aware transforms) and raw-editor flush/completion behavior.
  - Avoid clearing a newer editor registration on cleanup in `EditorContext`.
- **Reasoning**
  Document session logic was intertwined with pane UI, which made note switches and destroyed-editor races harder to reason about. Centralizing session ownership and adding lifecycle guards reduces silent state corruption without changing the product surface.
- **Additional context**
  Non-visual reliability/refactor work. Closest open issue is #292 (CotEditor-style external conflict UI), but this PR does not implement that resolution UX — it only hardens existing session/reload behavior.


## Docs

- New hook: `src/components/preview/useMarkdownDocumentSession.ts` owns text/savedText, save/autosave, mtime, and external reload for the open note.
- `MarkdownEditorPane` now consumes that hook and keeps mode/TOC/info-panel concerns.
- Link editors store `{ from, to }` and restore selection before `setLink` / `unsetLink`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the markdown editor by moving load/save/autosave and external reload into `useMarkdownDocumentSession`, with lifecycle guards to prevent lost edits and stale state during note switches, pastes, and reloads. Adds a simple save-conflict prompt so you can reload the disk version or overwrite with local edits.

- **Refactors**
  - Extracted document session (load/save/autosave, external reload debounce, dirty state, conflict dialog) into `useMarkdownDocumentSession`.
  - Slimmed `MarkdownEditorPane` to mode switching, TOC/info panel, and display; wired to the new session API.
  - Raw editor now exposes `flushPendingChange` and `getMarkdown`, and uses diff-based updates to reduce cursor/scroll jumps.

- **Bug Fixes**
  - Guarded destroyed/stale editor access across paste, image hydration (DOM-mapped via `posAtDOM`), and markdown sync; gated external reloads while dirty/saving.
  - Link dialogs/popovers restore the original text range before apply/remove.
  - Suggestions: cancel stale person/tag requests; lock editor host scroll; preventDefault on Arrow key navigation.
  - Markdown transforms run outside fenced and inline code; improved details fences, wiki links, inline TOC; image live preview scans only changed ranges; raw HTML embed parsing handles quoted attributes, self-closing, and indentation rules.
  - Blocked multiline/number-only inline math; ensured find reselects the active match.
  - Kept user-edited extract titles when unique-title lookup resolves; canceled pending LaTeX focus frames on unmount.
  - Editor registration cleanup no longer clears a newer editor; link completions apply only in the current context.

<sup>Written for commit 8872bfbc01df6965978295acf4a88dfa41d2cb89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved editor behavior when working with links, suggestions, images, and note extraction.
  * Added better save-state handling for markdown editing, including more reliable autosave and conflict recovery.

* **Bug Fixes**
  * Link dialogs and link actions now preserve the selected text range more reliably.
  * Autocomplete results for people and tags now avoid showing outdated suggestions.
  * Markdown content updates now avoid changing text inside code blocks.
  * Inline image loading, scrolling, and find-match selection are more stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->