### PR TITLE
Support Unicode letters in tags

### DIFF
--- a/src-tauri/src/index/tags.rs
+++ b/src-tauri/src/index/tags.rs
@@ -1,12 +1,33 @@
 use super::frontmatter::split_frontmatter;
+use regex::Regex;
 use std::collections::BTreeMap;
+use std::sync::OnceLock;
 
 pub const PEOPLE_TAG_NAMESPACE: &str = "people/";
+
+/// Keep in sync with `INLINE_TAG_PATTERN` / segment rules in
+/// `src/components/editor/noteProperties/utils.ts`.
+static TAG_SEGMENT_PATTERN: OnceLock<Regex> = OnceLock::new();
+static INLINE_TAG_PATTERN: OnceLock<Regex> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexedTag {
     pub tag: String,
     pub is_explicit: bool,
+}
+
+fn tag_segment_pattern() -> &'static Regex {
+    TAG_SEGMENT_PATTERN.get_or_init(|| {
+        Regex::new(r"^[\p{L}\p{N}_][\p{L}\p{M}\p{N}_-]*$")
+            .expect("tag segment pattern must compile")
+    })
+}
+
+fn inline_tag_pattern() -> &'static Regex {
+    INLINE_TAG_PATTERN.get_or_init(|| {
+        Regex::new(r"(^|[^\p{L}\p{M}\p{N}_/#])#([\p{L}\p{N}_][\p{L}\p{M}\p{N}_/-]*)")
+            .expect("inline tag pattern must compile")
+    })
 }
 
 pub fn normalize_tag(raw: &str) -> Option<String> {
@@ -20,13 +41,7 @@ pub fn normalize_tag(raw: &str) -> Option<String> {
     }
     let mut segments = Vec::new();
     for segment in normalized.split('/') {
-        if segment.is_empty() {
-            return None;
-        }
-        if !segment
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-        {
+        if segment.is_empty() || !tag_segment_pattern().is_match(segment) {
             return None;
         }
         segments.push(segment);
@@ -429,39 +444,21 @@ fn is_css_hex_color_literal(text: &str, hash_index: usize, candidate: &str) -> b
 pub fn parse_inline_tags(markdown: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let cleaned = metadata_scan_text(markdown);
-    let bytes = cleaned.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'#' {
-            let prev = if i == 0 { b' ' } else { bytes[i - 1] };
-            let prev_ok = !(prev as char).is_ascii_alphanumeric() && prev != b'/' && prev != b'_';
-            if !prev_ok {
-                i += 1;
-                continue;
-            }
-            let mut j = i + 1;
-            while j < bytes.len() {
-                let c = bytes[j] as char;
-                if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '/' {
-                    j += 1;
-                    continue;
-                }
-                break;
-            }
-            if j > i + 1 {
-                let candidate = &cleaned[i + 1..j];
-                if is_css_hex_color_literal(&cleaned, i, candidate) {
-                    i = j;
-                    continue;
-                }
-                if let Some(t) = normalize_tag(candidate) {
-                    out.push(t);
-                }
-            }
-            i = j;
+    for caps in inline_tag_pattern().captures_iter(&cleaned) {
+        let Some(full) = caps.get(0) else {
+            continue;
+        };
+        let leading_len = caps.get(1).map_or(0, |m| m.len());
+        let Some(candidate) = caps.get(2).map(|m| m.as_str()) else {
+            continue;
+        };
+        let hash_index = full.start() + leading_len;
+        if is_css_hex_color_literal(&cleaned, hash_index, candidate) {
             continue;
         }
-        i += 1;
+        if let Some(t) = normalize_tag(candidate) {
+            out.push(t);
+        }
     }
     out.sort();
     out.dedup();
@@ -540,6 +537,20 @@ mod tests {
         assert_eq!(normalize_tag("#work//today"), None);
         assert_eq!(normalize_tag("#work/"), None);
         assert_eq!(normalize_tag("#/today"), None);
+        assert_eq!(normalize_tag("#\u{0301}accent"), None);
+    }
+
+    #[test]
+    fn normalizes_and_parses_unicode_tags() {
+        assert_eq!(
+            normalize_tag("#Næring/ØL/År"),
+            Some("næring/øl/år".to_string())
+        );
+        assert_eq!(normalize_tag("#İ"), Some("i̇".to_string()));
+        assert_eq!(
+            parse_inline_tags("Topics: #næring, #øl, and #år."),
+            vec!["næring".to_string(), "år".to_string(), "øl".to_string()]
+        );
     }
 
     #[test]

--- a/src/components/editor/extensions/tagDecorations.ts
+++ b/src/components/editor/extensions/tagDecorations.ts
@@ -1,11 +1,11 @@
 import { Extension } from "@tiptap/core";
 import { Decoration } from "@tiptap/pm/view";
+import { INLINE_TAG_PATTERN } from "../noteProperties/utils";
 import {
 	type TextNodeDecorationContext,
 	createIncrementalTextDecorationPlugin,
 } from "./incrementalTextDecorations";
 
-const TAG_PATTERN = /(^|[^\w/])#([A-Za-z0-9_][\w/-]*)/g;
 const PERSON_PATTERN = /(^|[^A-Za-z0-9_.-])@([A-Za-z0-9_][A-Za-z0-9_-]*)/g;
 const TOKEN_SELECTOR = ".tagToken, .personToken";
 
@@ -24,8 +24,8 @@ function collectTagDecorations(
 	const text = node.text;
 	if (!text) return decorations;
 
-	TAG_PATTERN.lastIndex = 0;
-	for (const match of text.matchAll(TAG_PATTERN)) {
+	INLINE_TAG_PATTERN.lastIndex = 0;
+	for (const match of text.matchAll(INLINE_TAG_PATTERN)) {
 		const leading = match[1] ?? "";
 		const tag = match[2] ?? "";
 		if (!tag) continue;

--- a/src/components/editor/markdown/htmlEmbedMarkdown.test.ts
+++ b/src/components/editor/markdown/htmlEmbedMarkdown.test.ts
@@ -66,7 +66,10 @@ describe("htmlEmbedMarkdown", () => {
 
 	it("does not hang on a self-closing svg tag", () => {
 		const md = '<svg width="1" height="1"/>';
-		expect(preprocessHtmlEmbeds(md)).toBe(md);
+		const preprocessed = preprocessHtmlEmbeds(md);
+		expect(preprocessed).toContain("```svg");
+		expect(preprocessed).toContain("<!--glyph-raw-html-embed-->");
+		expect(postprocessHtmlEmbeds(preprocessed)).toBe(md);
 	});
 });
 

--- a/src/components/editor/noteProperties/utils.test.ts
+++ b/src/components/editor/noteProperties/utils.test.ts
@@ -43,6 +43,12 @@ describe("tag utils", () => {
 		expect(normalizeTagToken("#work/")).toBeNull();
 	});
 
+	it("preserves Unicode letters in tag tokens", () => {
+		expect(normalizeTagToken("#Næring/ØL/År")).toBe("næring/øl/år");
+		expect(normalizeTagToken("#İ")).toBe("i̇");
+		expect(normalizeTagToken("#\u0301accent")).toBeNull();
+	});
+
 	it("keeps partial path prefixes for autocomplete", () => {
 		expect(normalizeTagDraftPrefix("#Work/Today/")).toBe("work/today/");
 	});

--- a/src/components/editor/noteProperties/utils.ts
+++ b/src/components/editor/noteProperties/utils.ts
@@ -1,5 +1,12 @@
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 
+/** Keep in sync with `TAG_SEGMENT_PATTERN` / `INLINE_TAG_PATTERN` in `src-tauri/src/index/tags.rs`. */
+const TAG_SEGMENT_PATTERN = /^[\p{L}\p{N}_][\p{L}\p{M}\p{N}_-]*$/u;
+
+/** Inline `#tag` matcher shared by rich and raw editor decorations. */
+export const INLINE_TAG_PATTERN =
+	/(^|[^\p{L}\p{M}\p{N}_/#])#([\p{L}\p{N}_][\p{L}\p{M}\p{N}_/-]*)/gu;
+
 export function humanizePropertyKey(key: string): string {
 	if (!key) return "";
 	return key.replace(/[_-]+/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -47,7 +54,7 @@ function sanitizeTagText(value: string): string {
 		.replace(/^#+/, "")
 		.toLowerCase()
 		.replace(/\s+/g, "-")
-		.replace(/[^a-z0-9_/-]/g, "");
+		.replace(/[^\p{L}\p{M}\p{N}_/-]/gu, "");
 }
 
 export function normalizeTagToken(value: string): string | null {
@@ -61,7 +68,9 @@ export function normalizeTagToken(value: string): string | null {
 		return null;
 	}
 	const segments = normalized.split("/");
-	return segments.every(Boolean) ? normalized : null;
+	return segments.every((segment) => TAG_SEGMENT_PATTERN.test(segment))
+		? normalized
+		: null;
 }
 
 export function normalizeTagDraftPrefix(value: string): string {

--- a/src/components/editor/raw/contentDecorations.ts
+++ b/src/components/editor/raw/contentDecorations.ts
@@ -3,9 +3,9 @@ import type { Range, Text } from "@codemirror/state";
 import { Decoration, type EditorView } from "@codemirror/view";
 import { FOOTNOTE_PATTERN, footnoteKindAt } from "../markdown/footnote";
 import { parseWikiLink } from "../markdown/wikiLinkCodec";
+import { INLINE_TAG_PATTERN } from "../noteProperties/utils";
 
 const WIKI_LINK_PATTERN = /!?\[\[[^\]\n]+\]\]/g;
-const TAG_PATTERN = /(^|[^\w/#])#([A-Za-z0-9_][\w/-]*)/g;
 const HIGHLIGHT_PATTERN = /==([^=\n]+)==/g;
 const COMMENT_PATTERN = /%%(?:[^%]|%(?!%))*%%/g;
 const BLOCK_ID_PATTERN = /(?:^|\s)(\^[A-Za-z0-9-]+)(?=\s*$)/;
@@ -70,8 +70,8 @@ export function addGlyphInlineDecorations(
 		);
 	}
 
-	TAG_PATTERN.lastIndex = 0;
-	for (const match of text.matchAll(TAG_PATTERN)) {
+	INLINE_TAG_PATTERN.lastIndex = 0;
+	for (const match of text.matchAll(INLINE_TAG_PATTERN)) {
 		if (match.index === undefined || !match[2]) continue;
 		const from = lineFrom + match.index + (match[1]?.length ?? 0);
 		if (isCodePosition(view, from)) continue;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/297


## Description

Allow Unicode letters in tag names across normalization, editor highlighting, and Rust indexing so tags such as `#næring`, `#øl`, and `#år` are recognized consistently.

- Summary of changes
  - Share Unicode-aware inline tag matching between rich-text and raw editor decorations.
  - Permit Unicode letters, combining marks, and numbers in normalized tag segments.
  - Update Rust tag parsing and indexing to use the same Unicode rules.
  - Add coverage for Scandinavian and other Unicode letter cases.
- Reasoning
  - Existing ASCII-only sanitization and regexes stripped or failed to recognize Scandinavian letters.
- Additional context
  - Rust and TypeScript patterns are documented as intentionally kept in sync.

## Screenshots

Not applicable; this is a behavior and indexing fix without a distinct visual layout change.

## Docs

Added in-code notes beside the shared tag patterns describing the cross-language synchronization requirement.

## Ready?

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full Unicode support for tag names across normalization, editor highlighting, and Rust indexing. Tags like `#næring`, `#øl`, and `#år` are now parsed, highlighted, and indexed consistently.

- **Bug Fixes**
  - Use a Unicode-aware inline `#tag` pattern in both editors; Rust parsing follows the same rules.
  - Allow Unicode letters, combining marks, and numbers in tag segments; keep `_`, `-`, and `/` namespaces.
  - Normalize with Unicode-safe sanitization and validation; reject invalid segments (e.g., leading combining mark).
  - Keep TS and Rust patterns in sync; add tests for Scandinavian/dotted İ cases and self-closing SVG embed round-trip.

<sup>Written for commit f006b87f38018cba09cf899437a0b78f8db92b1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for Unicode characters and combining marks in tags.
  * Unified inline tag recognition across rich text and raw editors.
  * Tag matching now more consistently handles valid formats and excludes CSS color values.

* **Bug Fixes**
  * Improved tag normalization and validation for multi-segment tags.
  * Prevented self-closing SVG embeds from causing processing issues.

* **Tests**
  * Added coverage for Unicode tags and SVG embed round trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->