### PR TITLE
Scale task checkboxes with editor font size

### DIFF
--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -821,6 +821,7 @@
 .tiptapContentInline ul[data-type="taskList"] > li,
 .tiptapContentInline li[data-type="taskItem"],
 .tiptapContentInline li[data-checked] {
+	--task-checkbox-size: calc(var(--editor-font-size) - 2px);
 	display: flex !important;
 	align-items: flex-start;
 	gap: 0.55em;
@@ -837,13 +838,13 @@
 .tiptapContentInline ul[data-type="taskList"] > li > label,
 .tiptapContentInline li[data-type="taskItem"] > label,
 .tiptapContentInline li[data-checked] > label {
-	margin: calc((1.68em - var(--icon-md)) / 2) 0 0;
+	margin: calc((1.68em - var(--task-checkbox-size)) / 2) 0 0;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	flex: 0 0 var(--icon-md);
-	width: var(--icon-md);
-	height: var(--icon-md);
+	flex: 0 0 var(--task-checkbox-size);
+	width: var(--task-checkbox-size);
+	height: var(--task-checkbox-size);
 	position: relative;
 	user-select: none;
 }
@@ -865,8 +866,8 @@
 	input[type="checkbox"],
 .tiptapContentInline li[data-type="taskItem"] > label input[type="checkbox"],
 .tiptapContentInline li[data-checked] > label input[type="checkbox"] {
-	width: var(--icon-md);
-	height: var(--icon-md);
+	width: var(--task-checkbox-size);
+	height: var(--task-checkbox-size);
 	margin: 0;
 	padding: 0;
 	flex: 0 0 auto;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/304


## Description

Makes editor task-list checkboxes larger and easier to click by sizing them from the editor font size instead of the fixed `--icon-md` token.

- Summary of changes: Introduce `--task-checkbox-size: calc(var(--editor-font-size) - 2px)` for TipTap task list items, and use it for checkbox width/height and label alignment.
- Reasoning: Issue #304 asked for bigger checkboxes (Obsidian-like). Tying size to `--editor-font-size` keeps them readable and clickable as typography scales, without a separate setting.
- Additional context: CSS-only change in `src/styles/app/25-node-note-content.css`.


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

Task checkboxes in the rich editor now scale with `--editor-font-size` via `--task-checkbox-size` (font size minus 2px), instead of the fixed `--icon-md` size.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Editor task-list checkboxes now scale with the editor font size to improve readability and click targets. Added `--task-checkbox-size: calc(var(--editor-font-size) - 2px)` and applied it to checkbox width/height and label margin, replacing the fixed `--icon-md` size.

<sup>Written for commit 4de4b313f8f5da056add818ec660788b15324e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-list checkbox sizing to better match the editor’s font size.
  * Ensured checkbox labels and interactive controls remain consistently aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->