### PR TITLE
Open Finder Markdown files without showing Spaces

### DIFF
--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -98,20 +98,6 @@ pub fn open_external_markdown_window(
     validate_markdown_file(&path)?;
 
     let label = external_markdown_label(&path);
-    {
-        let mut paths_by_window = state
-            .paths_by_window
-            .lock()
-            .map_err(|_| "failed to lock external markdown state".to_string())?;
-        paths_by_window.insert(
-            label.clone(),
-            ExternalMarkdownWindowEntry {
-                abs_path: path.to_string_lossy().to_string(),
-                rel_path,
-            },
-        );
-    }
-
     if let Some(window) = app.get_webview_window(&label) {
         window.show().map_err(|error| error.to_string())?;
         window.unminimize().map_err(|error| error.to_string())?;
@@ -137,6 +123,18 @@ pub fn open_external_markdown_window(
     .build()
     .map_err(|error| error.to_string())?;
 
+    state
+        .paths_by_window
+        .lock()
+        .map_err(|_| "failed to lock external markdown state".to_string())?
+        .insert(
+            label,
+            ExternalMarkdownWindowEntry {
+                abs_path: path.to_string_lossy().to_string(),
+                rel_path,
+            },
+        );
+
     #[cfg(target_os = "macos")]
     if let Err(error) = crate::apply_main_window_vibrancy(&window, None) {
         tracing::warn!("Failed to apply vibrancy to external markdown window: {error}");
@@ -155,6 +153,14 @@ pub fn forget_external_markdown_window(
         .map_err(|_| "failed to lock external markdown state".to_string())?
         .remove(label);
     Ok(())
+}
+
+pub fn has_external_markdown_windows(state: &ExternalMarkdownState) -> Result<bool, String> {
+    Ok(!state
+        .paths_by_window
+        .lock()
+        .map_err(|_| "failed to lock external markdown state".to_string())?
+        .is_empty())
 }
 
 #[tauri::command]

--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -155,14 +155,6 @@ pub fn forget_external_markdown_window(
     Ok(())
 }
 
-pub fn has_external_markdown_windows(state: &ExternalMarkdownState) -> Result<bool, String> {
-    Ok(!state
-        .paths_by_window
-        .lock()
-        .map_err(|_| "failed to lock external markdown state".to_string())?
-        .is_empty())
-}
-
 #[tauri::command]
 pub fn open_external_markdown_path(
     window: WebviewWindow,

--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -17,6 +17,7 @@ const EXTERNAL_MARKDOWN_LABEL_PREFIX: &str = "external-markdown-";
 const EXTERNAL_MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "mdown"];
 const EXTERNAL_MARKDOWN_MIN_WIDTH: f64 = 680.0;
 const EXTERNAL_MARKDOWN_MIN_HEIGHT: f64 = 360.0;
+static EXTERNAL_MARKDOWN_WINDOW_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Clone)]
 struct ExternalMarkdownWindowEntry {
@@ -97,6 +98,10 @@ pub fn open_external_markdown_window(
 ) -> Result<(), String> {
     validate_markdown_file(&path)?;
 
+    let _guard = EXTERNAL_MARKDOWN_WINDOW_LOCK
+        .lock()
+        .map_err(|_| "failed to lock external markdown window state".to_string())?;
+
     let label = external_markdown_label(&path);
     if let Some(window) = app.get_webview_window(&label) {
         window.show().map_err(|error| error.to_string())?;
@@ -105,7 +110,19 @@ pub fn open_external_markdown_window(
         return Ok(());
     }
 
-    let window = WebviewWindowBuilder::new(
+    state
+        .paths_by_window
+        .lock()
+        .map_err(|_| "failed to lock external markdown state".to_string())?
+        .insert(
+            label.clone(),
+            ExternalMarkdownWindowEntry {
+                abs_path: path.to_string_lossy().to_string(),
+                rel_path,
+            },
+        );
+
+    let window_result = WebviewWindowBuilder::new(
         app,
         &label,
         WebviewUrl::App(format!("index.html?window={label}").into()),
@@ -120,20 +137,15 @@ pub fn open_external_markdown_window(
     .transparent(true)
     .shadow(true)
     .center()
-    .build()
-    .map_err(|error| error.to_string())?;
+    .build();
 
-    state
-        .paths_by_window
-        .lock()
-        .map_err(|_| "failed to lock external markdown state".to_string())?
-        .insert(
-            label,
-            ExternalMarkdownWindowEntry {
-                abs_path: path.to_string_lossy().to_string(),
-                rel_path,
-            },
-        );
+    let window = match window_result {
+        Ok(window) => window,
+        Err(error) => {
+            let _ = forget_external_markdown_window(state, &label);
+            return Err(error.to_string());
+        }
+    };
 
     #[cfg(target_os = "macos")]
     if let Err(error) = crate::apply_main_window_vibrancy(&window, None) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -981,6 +981,7 @@ fn main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
         .find(|config| config.label == window_geometry::MAIN_WINDOW_LABEL)
         .ok_or_else(|| "main window configuration not found".to_string())?;
     let window = WebviewWindowBuilder::from_config(app, config)
+        .map_err(|error| error.to_string())?
         .build()
         .map_err(|error| error.to_string())?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1022,36 +1022,29 @@ fn open_external_markdown_from_finder(app: &tauri::AppHandle, path: std::path::P
     }
 }
 
+fn has_external_markdown_windows(app: &tauri::AppHandle) -> bool {
+    app.webview_windows()
+        .keys()
+        .any(|label| external_markdown::is_external_markdown_window(label))
+}
+
 fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) -> bool {
-    let mut received_file_open = false;
     for url in urls {
         if url.scheme() != "file" {
             continue;
         }
-        received_file_open = true;
         match url.to_file_path() {
             Ok(path) => open_external_markdown_from_finder(app, path),
             Err(()) => warn!("Failed to convert opened URL to file path: {url}"),
         }
     }
-    received_file_open
+    has_external_markdown_windows(app)
 }
 
-fn should_exit_after_external_markdown_close(
-    app: &tauri::AppHandle,
-    state: &external_markdown::ExternalMarkdownState,
-) -> bool {
-    match external_markdown::has_external_markdown_windows(state) {
-        Ok(true) => false,
-        Ok(false) => !app
-            .webview_windows()
-            .keys()
-            .any(|label| is_space_host_window_label(label)),
-        Err(error) => {
-            warn!("Failed to inspect external markdown windows: {error}");
-            false
-        }
-    }
+fn should_exit_after_external_markdown_close(app: &tauri::AppHandle) -> bool {
+    !app.webview_windows().keys().any(|label| {
+        external_markdown::is_external_markdown_window(label) || is_space_host_window_label(label)
+    })
 }
 
 #[tauri::command(rename_all = "snake_case")]
@@ -1480,7 +1473,7 @@ pub fn run() {
                         ) {
                             warn!("Failed to forget external markdown window: {error}");
                         }
-                        if should_exit_after_external_markdown_close(window.app_handle(), &state) {
+                        if should_exit_after_external_markdown_close(window.app_handle()) {
                             destroy_auxiliary_persisted_windows(window.app_handle());
                             window.app_handle().exit(0);
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ use tauri::{TitleBarStyle, WebviewUrl, WebviewWindowBuilder};
 
 static RECENT_SPACES_MENU_REVISION: AtomicU64 = AtomicU64::new(0);
 static QUICK_NOTE_WINDOW_LOCK: Mutex<()> = Mutex::new(());
+static MAIN_WINDOW_LOCK: Mutex<()> = Mutex::new(());
 const QUICK_NOTE_WINDOW_LABEL: &str = "quick-note";
 const SPACE_MENU_ID: &str = "space.menu";
 const RECENT_SPACES_MENU_ID: &str = "space.recent.menu";
@@ -964,6 +965,10 @@ fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> 
 }
 
 fn main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
+    let _guard = MAIN_WINDOW_LOCK
+        .lock()
+        .map_err(|_| "failed to lock main window state".to_string())?;
+
     if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
         return Ok(window);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -963,6 +963,39 @@ fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> 
     window.set_focus().map_err(|error| error.to_string())
 }
 
+fn main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
+    if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
+        return Ok(window);
+    }
+
+    let config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == window_geometry::MAIN_WINDOW_LABEL)
+        .ok_or_else(|| "main window configuration not found".to_string())?;
+    let window = WebviewWindowBuilder::from_config(app, config)
+        .build()
+        .map_err(|error| error.to_string())?;
+
+    window_geometry::install_host_window_persistence(&window);
+
+    #[cfg(target_os = "macos")]
+    if let Err(error) = apply_main_window_vibrancy(&window, None) {
+        warn!("Failed to apply vibrancy to main window: {error}");
+    }
+
+    Ok(window)
+}
+
+fn show_main_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
+    let window = main_window(app)?;
+    window.show().map_err(|error| error.to_string())?;
+    window.unminimize().map_err(|error| error.to_string())?;
+    window.set_focus().map_err(|error| error.to_string())
+}
+
 #[tauri::command]
 fn show_quick_note_window(app: tauri::AppHandle) -> Result<(), String> {
     show_quick_note_window_for_app(&app)
@@ -978,29 +1011,45 @@ fn hide_quick_note_window(app: tauri::AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
-    if let Some(window) = app.get_webview_window("main") {
-        window.show().map_err(|error| error.to_string())?;
-        window.unminimize().map_err(|error| error.to_string())?;
-        window.set_focus().map_err(|error| error.to_string())?;
-    }
-    Ok(())
+    show_main_window_for_app(&app)
 }
 
 fn open_external_markdown_from_finder(app: &tauri::AppHandle, path: std::path::PathBuf) {
     let state = app.state::<external_markdown::ExternalMarkdownState>();
-    if let Err(error) = external_markdown::open_external_markdown_window(app, &state, path, None) {
+    if let Err(error) = external_markdown::open_external_markdown_window(app, &state, path, None)
+    {
         warn!("Failed to open external markdown file: {error}");
     }
 }
 
-fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) {
+fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) -> bool {
+    let mut received_file_open = false;
     for url in urls {
         if url.scheme() != "file" {
             continue;
         }
+        received_file_open = true;
         match url.to_file_path() {
             Ok(path) => open_external_markdown_from_finder(app, path),
             Err(()) => warn!("Failed to convert opened URL to file path: {url}"),
+        }
+    }
+    received_file_open
+}
+
+fn should_exit_after_external_markdown_close(
+    app: &tauri::AppHandle,
+    state: &external_markdown::ExternalMarkdownState,
+) -> bool {
+    match external_markdown::has_external_markdown_windows(state) {
+        Ok(true) => false,
+        Ok(false) => !app
+            .webview_windows()
+            .keys()
+            .any(|label| is_space_host_window_label(label)),
+        Err(error) => {
+            warn!("Failed to inspect external markdown windows: {error}");
+            false
         }
     }
 }
@@ -1400,20 +1449,6 @@ pub fn run() {
             }
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
-            if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
-                window_geometry::install_host_window_persistence(&window);
-            }
-
-            #[cfg(target_os = "macos")]
-            {
-                if let Some(window) = app.get_webview_window(window_geometry::MAIN_WINDOW_LABEL) {
-                    if let Err(e) = apply_main_window_vibrancy(&window, None) {
-                        warn!("Failed to apply vibrancy to main window: {e}");
-                    }
-                } else {
-                    warn!("Main window not found during setup");
-                }
-            }
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -1444,6 +1479,10 @@ pub fn run() {
                             window.label(),
                         ) {
                             warn!("Failed to forget external markdown window: {error}");
+                        }
+                        if should_exit_after_external_markdown_close(window.app_handle(), &state) {
+                            destroy_auxiliary_persisted_windows(window.app_handle());
+                            window.app_handle().exit(0);
                         }
                     }
                     _ => {}
@@ -1608,13 +1647,34 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app_handle, event| match event {
-            RunEvent::ExitRequested { .. } | RunEvent::Exit => {
-                window_geometry::flush_host_window_geometry(app_handle);
+        .run({
+            let mut initial_launch_pending = true;
+            let mut initial_launch_received_file_open = false;
+            move |app_handle, event| match event {
+                RunEvent::ExitRequested { .. } | RunEvent::Exit => {
+                    window_geometry::flush_host_window_geometry(app_handle);
+                }
+                RunEvent::Opened { urls } => {
+                    let received_file_open = handle_opened_urls(app_handle, urls);
+                    if initial_launch_pending {
+                        initial_launch_received_file_open |= received_file_open;
+                    }
+                }
+                RunEvent::MainEventsCleared if initial_launch_pending => {
+                    initial_launch_pending = false;
+                    if !initial_launch_received_file_open {
+                        if let Err(error) = show_main_window_for_app(app_handle) {
+                            warn!("Failed to show main window: {error}");
+                        }
+                    }
+                }
+                #[cfg(target_os = "macos")]
+                RunEvent::Reopen { .. } if !initial_launch_pending => {
+                    if let Err(error) = show_main_window_for_app(app_handle) {
+                        warn!("Failed to show main window: {error}");
+                    }
+                }
+                _ => {}
             }
-            RunEvent::Opened { urls } => {
-                handle_opened_urls(app_handle, urls);
-            }
-            _ => {}
         });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,6 +14,8 @@
 		"windows": [
 			{
 				"label": "main",
+				"create": false,
+				"visible": false,
 				"title": "Glyph",
 				"width": 800,
 				"height": 600,


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/326


## Description

Finder-initiated Markdown opens now use the standalone editor without automatically creating or revealing the Spaces window.

- Defers main-window creation until a normal Glyph launch or explicit macOS reactivation.
- Preserves the existing external-editor path for Finder files, including when Spaces is already open.
- Quits an editor-only session after its final external editor closes, while preserving Glyph when a Spaces host is open.

## Screenshots

Not applicable: this changes native window lifecycle rather than in-window visuals.

## Docs

The behavior contract and manual macOS verification matrix are documented in the linked issue.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open Markdown files from Finder in the standalone editor without creating or revealing Spaces. The main window is now built lazily from config and shown only on normal launch or explicit macOS reactivation.

- **Refactors**
  - Lazy main window: built from config under a lock, created/shown on demand; `tauri.conf.json` sets `main` to `create:false` and `visible:false`; installs geometry persistence and macOS vibrancy after build.
  - External Markdown windows: serialized with a lock; pre-register file state before build and roll back on failure.
  - Launch flow: if initial launch receives file-open URLs, do not show the main window; show on normal launch or macOS Reopen.
  - Lifecycle: exit when the last external-editor window closes and no Spaces host exists; destroy auxiliary persisted windows.

<sup>Written for commit bb75ef1f6c3ca172e4168e508aa5a4669dec717d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of external Markdown windows when opening and closing files.
  * Prevented premature application exits while external Markdown windows remain open.
  * Improved restoration and focusing of the main window when reopening the app.

* **Improvements**
  * The main window now opens lazily and remains hidden until needed.
  * Window appearance and position settings continue to apply consistently across launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->