### PR TITLE
Fix workspace tab restore on shutdown

### DIFF
--- a/src-tauri/src/app_exit.rs
+++ b/src-tauri/src/app_exit.rs
@@ -1,0 +1,148 @@
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use tauri::{Emitter, Manager, State};
+use tracing::{error, warn};
+
+#[derive(Default)]
+enum AppExitStatus {
+    #[default]
+    Idle,
+    Waiting(HashSet<String>),
+    Confirmed,
+}
+
+impl AppExitStatus {
+    fn is_waiting_for(&self, window_label: &str) -> bool {
+        matches!(self, Self::Waiting(labels) if labels.contains(window_label))
+    }
+}
+
+#[derive(Default)]
+struct AppExitStateInner {
+    status: AppExitStatus,
+    registered_windows: HashSet<String>,
+    unavailable_windows: HashSet<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct AppExitState {
+    inner: Mutex<AppExitStateInner>,
+}
+
+fn confirm_window(state: &AppExitState, window_label: &str) -> Result<bool, String> {
+    let mut inner = state
+        .inner
+        .lock()
+        .map_err(|_| "app exit state poisoned".to_string())?;
+    let AppExitStatus::Waiting(labels) = &mut inner.status else {
+        return Ok(false);
+    };
+    labels.remove(window_label);
+    if labels.is_empty() {
+        inner.status = AppExitStatus::Confirmed;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+#[tauri::command]
+pub(crate) fn app_confirm_exit(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: State<'_, AppExitState>,
+) -> Result<(), String> {
+    if confirm_window(&state, window.label())? {
+        app.exit(0);
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn app_register_exit_listener(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: State<'_, AppExitState>,
+) -> Result<(), String> {
+    let exit_waiting = {
+        let mut inner = state
+            .inner
+            .lock()
+            .map_err(|_| "app exit state poisoned".to_string())?;
+        inner.unavailable_windows.remove(window.label());
+        inner.registered_windows.insert(window.label().to_string());
+        inner.status.is_waiting_for(window.label())
+    };
+    if exit_waiting {
+        app.emit_to(window.label(), "app:exit_requested", ())
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn app_report_exit_listener_failure(
+    app: tauri::AppHandle,
+    window: tauri::WebviewWindow,
+    state: State<'_, AppExitState>,
+) -> Result<(), String> {
+    let should_exit = {
+        let mut inner = state
+            .inner
+            .lock()
+            .map_err(|_| "app exit state poisoned".to_string())?;
+        inner.registered_windows.remove(window.label());
+        inner.unavailable_windows.insert(window.label().to_string());
+        let AppExitStatus::Waiting(labels) = &mut inner.status else {
+            return Ok(());
+        };
+        labels.remove(window.label());
+        if labels.is_empty() {
+            inner.status = AppExitStatus::Confirmed;
+            true
+        } else {
+            false
+        }
+    };
+    if should_exit {
+        app.exit(0);
+    }
+    Ok(())
+}
+
+pub(crate) fn handle_exit_requested(app: &tauri::AppHandle, api: &tauri::ExitRequestApi) -> bool {
+    let state = app.state::<AppExitState>();
+    let Ok(mut inner) = state.inner.lock() else {
+        error!("App exit state is unavailable; continuing native exit");
+        return false;
+    };
+    if matches!(inner.status, AppExitStatus::Confirmed) {
+        return false;
+    }
+    let labels = app
+        .webview_windows()
+        .into_keys()
+        .filter(|label| super::is_space_host_window_label(label))
+        .filter(|label| !inner.unavailable_windows.contains(label))
+        .collect::<HashSet<_>>();
+    if labels.is_empty() {
+        return false;
+    }
+    let registered_windows = inner.registered_windows.clone();
+
+    api.prevent_exit();
+    inner.status = AppExitStatus::Waiting(labels.clone());
+    drop(inner);
+
+    // Every space window confirms only after its open tabs reach disk.
+    for label in labels.intersection(&registered_windows) {
+        if let Err(error) = app.emit_to(label, "app:exit_requested", ()) {
+            warn!("Failed to request workspace save from {label}: {error}");
+            // A vanished window has no remaining webview session to flush.
+            if confirm_window(&state, label).unwrap_or(false) {
+                app.exit(0);
+            }
+        }
+    }
+    true
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod ai_codex;
 mod ai_opencode;
 mod ai_pi;
 mod ai_rig;
+mod app_exit;
 mod databases;
 mod external_markdown;
 mod file_tree_appearance;
@@ -1510,6 +1511,7 @@ pub fn run() {
         .manage(ai_codex::state::CodexState::default())
         .manage(git_sync::GitSyncState::default())
         .manage(space::SpaceState::default())
+        .manage(app_exit::AppExitState::default())
         .manage(external_markdown::ExternalMarkdownState::default())
         .manage(MenuState::default())
         .manage(QuickNoteShortcutState::default())
@@ -1642,7 +1644,10 @@ pub fn run() {
             space::commands::space_get_current,
             space::commands::space_get_current_info,
             space::commands::space_show_onboarding_note,
-            space::commands::space_close
+            space::commands::space_close,
+            app_exit::app_confirm_exit,
+            app_exit::app_register_exit_listener,
+            app_exit::app_report_exit_listener_failure
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
@@ -1650,7 +1655,12 @@ pub fn run() {
             let mut initial_launch_pending = true;
             let mut initial_launch_received_file_open = false;
             move |app_handle, event| match event {
-                RunEvent::ExitRequested { .. } | RunEvent::Exit => {
+                RunEvent::ExitRequested { api, .. } => {
+                    if !app_exit::handle_exit_requested(app_handle, &api) {
+                        window_geometry::flush_host_window_geometry(app_handle);
+                    }
+                }
+                RunEvent::Exit => {
                     window_geometry::flush_host_window_geometry(app_handle);
                 }
                 RunEvent::Opened { urls } => {

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -368,7 +368,7 @@ export function AppShell() {
 		tabsRevision,
 	} = useTabManager(spacePath);
 	const { getBinding, actionsWithBindings } = useShortcutBindings();
-	useWorkspaceSession({
+	const flushWorkspaceSession = useWorkspaceSession({
 		spacePath,
 		settingsLoaded,
 		resumeLastSession,
@@ -378,6 +378,20 @@ export function AppShell() {
 		tabsRevision,
 		restoreWorkspaceTabs,
 	});
+
+	const handleCloseSpace = useCallback(async () => {
+		try {
+			// Native space teardown happens only after the open-note snapshot is durable.
+			await flushWorkspaceSession();
+			await closeSpace();
+		} catch (cause) {
+			console.error(
+				"Failed to save workspace session before closing space",
+				cause,
+			);
+			setError("The open tabs could not be saved. Please try again.");
+		}
+	}, [closeSpace, flushWorkspaceSession, setError]);
 
 	useEffect(() => {
 		const visible =
@@ -1107,7 +1121,7 @@ export function AppShell() {
 		onOpenSpace,
 		onOpenRecentSpaceAtPath: onOpenSpaceAtPath,
 		onCreateSpace,
-		closeSpace,
+		closeSpace: handleCloseSpace,
 		onRevealSpace: handleRevealSpaceFromMenu,
 		onOpenSpaceSettings: handleOpenSpaceSettings,
 		onGitSyncNow: () => {
@@ -1138,7 +1152,7 @@ export function AppShell() {
 		canGoForward,
 		closeActiveTab,
 		closeAllTabs,
-		closeSpace,
+		closeSpace: handleCloseSpace,
 		createDatabaseAndOpen,
 		createNoteInSelectedFolder,
 		fileTree,

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -1,5 +1,8 @@
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useRef } from "react";
 import { invoke } from "../../lib/tauri";
+import { toast } from "../../lib/toast";
 import {
 	type WorkspaceSessionSnapshot,
 	type WorkspaceSessionTabSnapshot,
@@ -86,6 +89,7 @@ export function useWorkspaceSession({
 	const saveTimerRef = useRef<number | null>(null);
 	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
 	const saveSpaceRef = useRef(spacePath);
+	const windowCloseInProgressRef = useRef(false);
 
 	const clearSaveTimer = useCallback(() => {
 		if (saveTimerRef.current === null) return;
@@ -93,19 +97,31 @@ export function useWorkspaceSession({
 		saveTimerRef.current = null;
 	}, []);
 
-	const flushPendingSave = useCallback(() => {
+	const flushPendingSave = useCallback(async (): Promise<void> => {
 		const pending = pendingSaveRef.current;
-		if (!pending) return;
-		pendingSaveRef.current = null;
-		clearSaveTimer();
-		saveQueueRef.current = saveQueueRef.current
-			.catch(() => {})
-			.then(() =>
-				saveWorkspaceSessionSnapshot(pending.spacePath, pending.snapshot),
-			)
-			.catch((cause) => {
-				console.error("Failed to save workspace session", cause);
-			});
+		if (pending) {
+			pendingSaveRef.current = null;
+			clearSaveTimer();
+			saveQueueRef.current = saveQueueRef.current
+				.catch(() => {})
+				.then(() =>
+					saveWorkspaceSessionSnapshot(pending.spacePath, pending.snapshot),
+				);
+		}
+		// Callers at a teardown boundary must be able to wait for queued writes too.
+		const queuedSave = saveQueueRef.current;
+		try {
+			await queuedSave;
+		} catch (cause) {
+			if (saveQueueRef.current === queuedSave) {
+				saveQueueRef.current = Promise.resolve();
+			}
+			// Preserve the failed snapshot so the user's next close attempt can retry it.
+			if (pending && pendingSaveRef.current === null) {
+				pendingSaveRef.current = pending;
+			}
+			throw cause;
+		}
 	}, [clearSaveTimer]);
 
 	useEffect(() => {
@@ -188,10 +204,11 @@ export function useWorkspaceSession({
 			},
 		};
 		clearSaveTimer();
-		saveTimerRef.current = window.setTimeout(
-			flushPendingSave,
-			WORKSPACE_SESSION_SAVE_DEBOUNCE_MS,
-		);
+		saveTimerRef.current = window.setTimeout(() => {
+			void flushPendingSave().catch((cause) => {
+				console.error("Failed to save workspace session", cause);
+			});
+		}, WORKSPACE_SESSION_SAVE_DEBOUNCE_MS);
 		return clearSaveTimer;
 	}, [
 		activeTabPath,
@@ -203,9 +220,90 @@ export function useWorkspaceSession({
 	]);
 
 	useEffect(() => {
-		const currentSpacePath = spacePath;
+		let disposed = false;
+		let unlisten: (() => void) | null = null;
+		void getCurrentWindow()
+			.onCloseRequested(async (event) => {
+				if (windowCloseInProgressRef.current) return;
+				event.preventDefault();
+				windowCloseInProgressRef.current = true;
+				try {
+					// Keep the webview alive until its open-note snapshot reaches disk.
+					await flushPendingSave();
+					await getCurrentWindow().destroy();
+				} catch (cause) {
+					windowCloseInProgressRef.current = false;
+					console.error(
+						"Failed to save workspace session before closing",
+						cause,
+					);
+					toast.error("Could not close Glyph", {
+						description: "The open tabs could not be saved. Please try again.",
+					});
+				}
+			})
+			.then((stopListening) => {
+				if (disposed) {
+					stopListening();
+					return;
+				}
+				unlisten = stopListening;
+			})
+			.catch((cause) => {
+				console.error("Failed to install workspace close handler", cause);
+				toast.error("Session saving is unavailable", {
+					description:
+						"Restart Glyph before closing to preserve your open tabs.",
+				});
+			});
 		return () => {
-			if (currentSpacePath) flushPendingSave();
+			disposed = true;
+			unlisten?.();
 		};
-	}, [flushPendingSave, spacePath]);
+	}, [flushPendingSave]);
+
+	useEffect(() => {
+		let disposed = false;
+		let unlisten: (() => void) | null = null;
+		void listen("app:exit_requested", () => {
+			void flushPendingSave()
+				.then(() => invoke("app_confirm_exit"))
+				.catch((cause) => {
+					console.error(
+						"Failed to save workspace session before quitting",
+						cause,
+					);
+					toast.error("Could not quit Glyph", {
+						description: "The open tabs could not be saved. Please try again.",
+					});
+				});
+		})
+			.then(async (stopListening) => {
+				if (disposed) {
+					stopListening();
+					return;
+				}
+				unlisten = stopListening;
+				await invoke("app_register_exit_listener");
+			})
+			.catch((cause) => {
+				void invoke("app_report_exit_listener_failure").catch((reportCause) => {
+					console.error(
+						"Failed to report unavailable app exit handler",
+						reportCause,
+					);
+				});
+				console.error("Failed to install app exit handler", cause);
+				toast.error("Session saving is unavailable", {
+					description:
+						"Restart Glyph before quitting to preserve your open tabs.",
+				});
+			});
+		return () => {
+			disposed = true;
+			unlisten?.();
+		};
+	}, [flushPendingSave]);
+
+	return flushPendingSave;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -802,6 +802,9 @@ interface TauriCommands {
 	space_get_current_info: CommandDef<void, SpaceInfo | null>;
 	space_show_onboarding_note: CommandDef<void, string>;
 	space_close: CommandDef<void, void>;
+	app_confirm_exit: CommandDef<void, void>;
+	app_register_exit_listener: CommandDef<void, void>;
+	app_report_exit_listener_failure: CommandDef<void, void>;
 	space_list_dir: CommandDef<{ dir?: string | null }, FsEntry[]>;
 	file_tree_appearance_list: CommandDef<
 		void,


### PR DESCRIPTION
No issue linked.


## Description

This PR makes workspace-session persistence reliable during app and window shutdown.

- Summary of changes
  - Adds a Tauri exit coordinator that requests each open space window to flush its pending session save before the app exits.
  - Adds typed frontend IPC commands for registering exit listeners, confirming exit, and reporting listener failures.
  - Updates `useWorkspaceSession` to flush queued and pending saves on exit requests and window close requests, with failure feedback and retry behavior.
  - Flushes the session before `AppShell` closes a space window.
- Reasoning
  - Previously, shutdown could tear down the webview before the workspace session had been durably saved, causing tabs to be lost on the next launch.
- Additional context
  - The changes are limited to the shutdown/save coordination path across Tauri and the React frontend.


## Screenshots

No visual changes; screenshots are not applicable.


## Docs

No documentation changes included.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated application shutdown across open workspace windows.
  * The app now waits for pending workspace changes to be saved before exiting.
  * Windows can confirm readiness or report save failures during shutdown.

* **Bug Fixes**
  * Prevented workspace session data from being lost when closing windows or exiting the app.
  * Added error handling and notifications when session data cannot be saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->