### PR TITLE
Remove space-open feature preloads

### DIFF
--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -538,29 +538,6 @@ export const MainContent = memo(function MainContent({
 		toast.dismiss(DAILY_NOTES_SETUP_TOAST_ID);
 	}, [spacePath]);
 
-	useEffect(() => {
-		if (!spacePath) return;
-		let cancelled = false;
-		const run = () => {
-			if (cancelled) return;
-			void loadDatabasesPane();
-			void loadAllDocsPane();
-			void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
-		};
-		if (typeof window.requestIdleCallback === "function") {
-			const idleId = window.requestIdleCallback(run, { timeout: 900 });
-			return () => {
-				cancelled = true;
-				window.cancelIdleCallback(idleId);
-			};
-		}
-		const timeout = window.setTimeout(run, 180);
-		return () => {
-			cancelled = true;
-			window.clearTimeout(timeout);
-		};
-	}, [databasesOpenRequest.databaseId, spacePath]);
-
 	const handleInfoSidebarResizePointerDown = useCallback(
 		(event: React.PointerEvent<HTMLDivElement>) => {
 			if (!rightSidebarOpen) return;


### PR DESCRIPTION
No issue is associated with this change.

## Description

Remove the unused space-open feature preloads from the main content component.

- Summary of changes: Delete the obsolete preload-related code from `MainContent.tsx`.
- Reasoning: Keep the component focused and remove dead code that is no longer needed.
- Additional context: This is a small cleanup with no user-facing visual changes.

## Screenshots

Not applicable; this is a non-visual cleanup.

## Docs

No documentation changes are needed.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed obsolete space-open preloads from `MainContent.tsx` to simplify the component and eliminate unnecessary background work. Removes the idle/timeout `useEffect` that called `loadDatabasesPane`, `loadAllDocsPane`, and `prefetchDatabasesLanding`; no UI changes.

<sup>Written for commit ee440ba7ce7482a96b60916eb5b7534ecb9ff7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

