### PR TITLE
Defer highlight.js grammar loading until a code block needs it

### DIFF
--- a/src/components/ai/AIMessageMarkdown.tsx
+++ b/src/components/ai/AIMessageMarkdown.tsx
@@ -1,18 +1,14 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import DOMPurify from "dompurify";
 import hljs from "highlight.js/lib/core";
-import bash from "highlight.js/lib/languages/bash";
-import javascript from "highlight.js/lib/languages/javascript";
-import json from "highlight.js/lib/languages/json";
-import markdownLanguage from "highlight.js/lib/languages/markdown";
-import plaintext from "highlight.js/lib/languages/plaintext";
-import python from "highlight.js/lib/languages/python";
-import rust from "highlight.js/lib/languages/rust";
-import typescript from "highlight.js/lib/languages/typescript";
-import xml from "highlight.js/lib/languages/xml";
-import yaml from "highlight.js/lib/languages/yaml";
 import { marked } from "marked";
 import { memo, useEffect, useMemo, useRef } from "react";
+import {
+	GRAMMAR_ALIASES,
+	PLAINTEXT_GRAMMAR,
+	loadGrammar,
+	resolveGrammarName,
+} from "../../lib/highlightGrammars";
 import { dispatchMarkdownLinkClick } from "../editor/markdown/editorEvents";
 
 interface AIMessageMarkdownProps {
@@ -28,27 +24,21 @@ const CODE_BLOCK_PROCESSED_ATTR = "data-ai-code-block-enhanced";
 const UNPROCESSED_CODE_BLOCK_SELECTOR = `pre:not([${CODE_BLOCK_PROCESSED_ATTR}])`;
 const COPY_RESET_MS = 1500;
 
-hljs.registerLanguage("bash", bash);
-hljs.registerLanguage("javascript", javascript);
-hljs.registerLanguage("json", json);
-hljs.registerLanguage("markdown", markdownLanguage);
-hljs.registerLanguage("mermaid", plaintext);
-hljs.registerLanguage("plaintext", plaintext);
-hljs.registerLanguage("python", python);
-hljs.registerLanguage("rust", rust);
-hljs.registerLanguage("typescript", typescript);
-hljs.registerLanguage("xml", xml);
-hljs.registerLanguage("yaml", yaml);
-hljs.registerAliases(["shell", "sh", "zsh"], { languageName: "bash" });
-hljs.registerAliases(["cjs", "js", "jsx", "mjs"], {
-	languageName: "javascript",
-});
-hljs.registerAliases(["md"], { languageName: "markdown" });
-hljs.registerAliases(["text", "txt"], { languageName: "plaintext" });
-hljs.registerAliases(["py"], { languageName: "python" });
-hljs.registerAliases(["ts", "tsx"], { languageName: "typescript" });
-hljs.registerAliases(["html", "svg"], { languageName: "xml" });
-hljs.registerAliases(["yml"], { languageName: "yaml" });
+// Grammars load lazily via ensureGrammar; aliases are just a name map and are
+// safe to register before the grammars they point at.
+hljs.registerLanguage("plaintext", PLAINTEXT_GRAMMAR);
+for (const [languageName, aliases] of Object.entries(GRAMMAR_ALIASES)) {
+	hljs.registerAliases([...aliases], { languageName });
+}
+
+async function ensureGrammar(language: string): Promise<void> {
+	const grammar = resolveGrammarName(language);
+	if (!grammar || hljs.getLanguage(grammar)) return;
+	const languageFn = await loadGrammar(grammar);
+	if (languageFn && !hljs.getLanguage(grammar)) {
+		hljs.registerLanguage(grammar, languageFn);
+	}
+}
 
 function renderMarkdown(markdown: string): string {
 	const html = marked.parse(markdown, {
@@ -87,11 +77,13 @@ function enhanceCodeBlock(pre: HTMLPreElement) {
 	const lang = langClass?.[1] ?? "";
 
 	if (codeEl) {
-		try {
-			hljs.highlightElement(codeEl);
-		} catch {
-			// Keep the escaped code visible if highlight.js cannot parse a language.
-		}
+		void ensureGrammar(lang).then(() => {
+			try {
+				hljs.highlightElement(codeEl);
+			} catch {
+				// Keep the escaped code visible if highlight.js cannot parse a language.
+			}
+		});
 	}
 
 	const header = document.createElement("div");

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -85,10 +85,7 @@ function refreshCodeBlockDecorations(editor: Editor) {
 	}
 }
 
-function loadGrammarsForLanguages(
-	editor: Editor,
-	languages: Iterable<string>,
-) {
+function loadGrammarsForLanguages(editor: Editor, languages: Iterable<string>) {
 	for (const language of languages) {
 		ensureGrammar(language)?.then((registered) => {
 			if (registered && !editor.isDestroyed) {

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -1,34 +1,22 @@
 import { type Editor, findChildren } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import type { LanguageFn } from "highlight.js";
-import plaintext from "highlight.js/lib/languages/plaintext";
 import { createLowlight } from "lowlight";
 import { i18n } from "../../../i18n";
+import {
+	GRAMMAR_ALIASES,
+	PLAINTEXT_GRAMMAR,
+	loadGrammar,
+	resolveGrammarName,
+} from "../../../lib/highlightGrammars";
 
 const lowlight = createLowlight();
 
 // Plaintext is registered eagerly (it is tiny) so that plain/mermaid blocks
 // never fall through to highlightAuto and get mis-detected as another
-// language. All real grammars load on demand via ensureGrammar().
-lowlight.register({ plaintext });
-
-const CODE_BLOCK_LANGUAGE_ALIASES = {
-	bash: ["shell", "sh", "zsh"],
-	javascript: ["cjs", "js", "jsx", "mjs"],
-	markdown: ["md"],
-	plaintext: ["text", "txt"],
-	python: ["py"],
-	typescript: ["ts", "tsx"],
-	yaml: ["yml"],
-} as const;
-
-// Lowlight resolves aliases lazily, so these are safe to register before the
-// grammars themselves. html/svg/mermaid map onto the grammars that back them.
-lowlight.registerAlias({
-	...CODE_BLOCK_LANGUAGE_ALIASES,
-	plaintext: [...CODE_BLOCK_LANGUAGE_ALIASES.plaintext, "mermaid"],
-	xml: ["html", "svg"],
-});
+// language. All real grammars load on demand via ensureGrammar(). Aliases are
+// just a name map, safe to register before the grammars they point at.
+lowlight.register({ plaintext: PLAINTEXT_GRAMMAR });
+lowlight.registerAlias(GRAMMAR_ALIASES);
 
 const SUPPORTED_CODE_BLOCK_LANGUAGES = [
 	"plaintext",
@@ -49,62 +37,21 @@ const SUPPORTED_CODE_BLOCK_LANGUAGES = [
 export type SupportedCodeBlockLanguage =
 	(typeof SUPPORTED_CODE_BLOCK_LANGUAGES)[number];
 
-// The highlight.js grammar module that backs each supported language.
-const GRAMMAR_BY_LANGUAGE: Record<SupportedCodeBlockLanguage, string> = {
-	bash: "bash",
-	html: "xml",
-	javascript: "javascript",
-	json: "json",
-	markdown: "markdown",
-	mermaid: "plaintext",
-	plaintext: "plaintext",
-	python: "python",
-	rust: "rust",
-	svg: "xml",
-	typescript: "typescript",
-	xml: "xml",
-	yaml: "yaml",
-};
-
-const GRAMMAR_LOADERS: Record<string, () => Promise<{ default: LanguageFn }>> =
-	{
-		bash: () => import("highlight.js/lib/languages/bash"),
-		javascript: () => import("highlight.js/lib/languages/javascript"),
-		json: () => import("highlight.js/lib/languages/json"),
-		markdown: () => import("highlight.js/lib/languages/markdown"),
-		python: () => import("highlight.js/lib/languages/python"),
-		rust: () => import("highlight.js/lib/languages/rust"),
-		typescript: () => import("highlight.js/lib/languages/typescript"),
-		xml: () => import("highlight.js/lib/languages/xml"),
-		yaml: () => import("highlight.js/lib/languages/yaml"),
-	};
-
-const grammarLoads = new Map<string, Promise<boolean>>();
-
 /**
  * Loads and registers the grammar backing `language` if it is supported and
  * not yet registered. Returns null when nothing needs loading, otherwise a
  * promise resolving to whether the grammar was registered.
  */
 function ensureGrammar(language: string): Promise<boolean> | null {
-	const normalized = normalizeCodeBlockLanguage(language);
-	if (!normalized) return null;
-	const grammar = GRAMMAR_BY_LANGUAGE[normalized];
-	if (lowlight.registered(grammar)) return null;
-	let load = grammarLoads.get(grammar);
-	if (!load) {
-		load = GRAMMAR_LOADERS[grammar]()
-			.then((module) => {
-				lowlight.register(grammar, module.default);
-				return true;
-			})
-			.catch(() => {
-				grammarLoads.delete(grammar);
-				return false;
-			});
-		grammarLoads.set(grammar, load);
-	}
-	return load;
+	const grammar = resolveGrammarName(language);
+	if (!grammar || lowlight.registered(grammar)) return null;
+	return loadGrammar(grammar).then((languageFn) => {
+		if (!languageFn) return false;
+		if (!lowlight.registered(grammar)) {
+			lowlight.register(grammar, languageFn);
+		}
+		return true;
+	});
 }
 
 function codeBlocksIn(editor: Editor) {
@@ -175,12 +122,16 @@ const NORMALIZED_LANGUAGE_BY_ALIAS = new Map<
 	SupportedCodeBlockLanguage
 >(SUPPORTED_CODE_BLOCK_LANGUAGES.map((language) => [language, language]));
 
-for (const [language, aliases] of Object.entries(CODE_BLOCK_LANGUAGE_ALIASES)) {
+// Derive UI-level aliases from the grammar alias table. Aliases that are
+// themselves supported languages (html, svg, mermaid) keep their own entry so
+// their labels stay distinct.
+for (const [language, aliases] of Object.entries(GRAMMAR_ALIASES)) {
+	const supported = NORMALIZED_LANGUAGE_BY_ALIAS.get(language);
+	if (!supported) continue;
 	for (const alias of aliases) {
-		NORMALIZED_LANGUAGE_BY_ALIAS.set(
-			alias,
-			language as SupportedCodeBlockLanguage,
-		);
+		if (!NORMALIZED_LANGUAGE_BY_ALIAS.has(alias)) {
+			NORMALIZED_LANGUAGE_BY_ALIAS.set(alias, supported);
+		}
 	}
 }
 

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -1,34 +1,16 @@
+import { type Editor, findChildren } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
-import bash from "highlight.js/lib/languages/bash";
-import javascript from "highlight.js/lib/languages/javascript";
-import json from "highlight.js/lib/languages/json";
-import markdown from "highlight.js/lib/languages/markdown";
+import type { LanguageFn } from "highlight.js";
 import plaintext from "highlight.js/lib/languages/plaintext";
-import python from "highlight.js/lib/languages/python";
-import rust from "highlight.js/lib/languages/rust";
-import typescript from "highlight.js/lib/languages/typescript";
-import xml from "highlight.js/lib/languages/xml";
-import yaml from "highlight.js/lib/languages/yaml";
 import { createLowlight } from "lowlight";
 import { i18n } from "../../../i18n";
 
 const lowlight = createLowlight();
 
-lowlight.register({
-	bash,
-	html: xml,
-	javascript,
-	json,
-	markdown,
-	mermaid: plaintext,
-	plaintext,
-	python,
-	rust,
-	svg: xml,
-	typescript,
-	xml,
-	yaml,
-});
+// Plaintext is registered eagerly (it is tiny) so that plain/mermaid blocks
+// never fall through to highlightAuto and get mis-detected as another
+// language. All real grammars load on demand via ensureGrammar().
+lowlight.register({ plaintext });
 
 const CODE_BLOCK_LANGUAGE_ALIASES = {
 	bash: ["shell", "sh", "zsh"],
@@ -40,7 +22,13 @@ const CODE_BLOCK_LANGUAGE_ALIASES = {
 	yaml: ["yml"],
 } as const;
 
-lowlight.registerAlias(CODE_BLOCK_LANGUAGE_ALIASES);
+// Lowlight resolves aliases lazily, so these are safe to register before the
+// grammars themselves. html/svg/mermaid map onto the grammars that back them.
+lowlight.registerAlias({
+	...CODE_BLOCK_LANGUAGE_ALIASES,
+	plaintext: [...CODE_BLOCK_LANGUAGE_ALIASES.plaintext, "mermaid"],
+	xml: ["html", "svg"],
+});
 
 const SUPPORTED_CODE_BLOCK_LANGUAGES = [
 	"plaintext",
@@ -60,6 +48,101 @@ const SUPPORTED_CODE_BLOCK_LANGUAGES = [
 
 export type SupportedCodeBlockLanguage =
 	(typeof SUPPORTED_CODE_BLOCK_LANGUAGES)[number];
+
+// The highlight.js grammar module that backs each supported language.
+const GRAMMAR_BY_LANGUAGE: Record<SupportedCodeBlockLanguage, string> = {
+	bash: "bash",
+	html: "xml",
+	javascript: "javascript",
+	json: "json",
+	markdown: "markdown",
+	mermaid: "plaintext",
+	plaintext: "plaintext",
+	python: "python",
+	rust: "rust",
+	svg: "xml",
+	typescript: "typescript",
+	xml: "xml",
+	yaml: "yaml",
+};
+
+const GRAMMAR_LOADERS: Record<string, () => Promise<{ default: LanguageFn }>> =
+	{
+		bash: () => import("highlight.js/lib/languages/bash"),
+		javascript: () => import("highlight.js/lib/languages/javascript"),
+		json: () => import("highlight.js/lib/languages/json"),
+		markdown: () => import("highlight.js/lib/languages/markdown"),
+		python: () => import("highlight.js/lib/languages/python"),
+		rust: () => import("highlight.js/lib/languages/rust"),
+		typescript: () => import("highlight.js/lib/languages/typescript"),
+		xml: () => import("highlight.js/lib/languages/xml"),
+		yaml: () => import("highlight.js/lib/languages/yaml"),
+	};
+
+const grammarLoads = new Map<string, Promise<boolean>>();
+
+/**
+ * Loads and registers the grammar backing `language` if it is supported and
+ * not yet registered. Returns null when nothing needs loading, otherwise a
+ * promise resolving to whether the grammar was registered.
+ */
+function ensureGrammar(language: string): Promise<boolean> | null {
+	const normalized = normalizeCodeBlockLanguage(language);
+	if (!normalized) return null;
+	const grammar = GRAMMAR_BY_LANGUAGE[normalized];
+	if (lowlight.registered(grammar)) return null;
+	let load = grammarLoads.get(grammar);
+	if (!load) {
+		load = GRAMMAR_LOADERS[grammar]()
+			.then((module) => {
+				lowlight.register(grammar, module.default);
+				return true;
+			})
+			.catch(() => {
+				grammarLoads.delete(grammar);
+				return false;
+			});
+		grammarLoads.set(grammar, load);
+	}
+	return load;
+}
+
+function codeBlocksIn(editor: Editor) {
+	return findChildren(
+		editor.state.doc,
+		(node) => node.type.name === "codeBlock",
+	);
+}
+
+/**
+ * The lowlight plugin only recomputes decorations on doc changes, so after a
+ * grammar registers asynchronously we dispatch a no-op setNodeMarkup on each
+ * code block to force a re-highlight. Content and attrs are unchanged.
+ */
+function refreshCodeBlockDecorations(editor: Editor) {
+	const { tr } = editor.state;
+	for (const block of codeBlocksIn(editor)) {
+		tr.setNodeMarkup(block.pos, undefined, { ...block.node.attrs });
+	}
+	if (tr.steps.length > 0) {
+		tr.setMeta("addToHistory", false);
+		editor.view.dispatch(tr);
+	}
+}
+
+function loadGrammarsForDoc(editor: Editor) {
+	const languages = new Set<string>();
+	for (const block of codeBlocksIn(editor)) {
+		languages.add(block.node.attrs.language || "plaintext");
+	}
+	for (const language of languages) {
+		ensureGrammar(language)?.then((registered) => {
+			if (registered && !editor.isDestroyed) {
+				refreshCodeBlockDecorations(editor);
+			}
+		});
+	}
+}
 
 const CODE_BLOCK_LANGUAGE_OPTION_ORDER = [
 	"plaintext",
@@ -123,7 +206,14 @@ export function getCodeBlockLanguageLabel(
 	return i18n.t(`editor:codeBlock.languages.${value}`);
 }
 
-export const SyntaxHighlightedCodeBlock = CodeBlockLowlight.configure({
+export const SyntaxHighlightedCodeBlock = CodeBlockLowlight.extend({
+	onCreate() {
+		loadGrammarsForDoc(this.editor);
+	},
+	onUpdate() {
+		loadGrammarsForDoc(this.editor);
+	},
+}).configure({
 	lowlight,
 	defaultLanguage: "plaintext",
 	HTMLAttributes: {

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -1,5 +1,6 @@
 import { type Editor, findChildren } from "@tiptap/core";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import type { Transaction } from "@tiptap/pm/state";
 import { createLowlight } from "lowlight";
 import { i18n } from "../../../i18n";
 import {
@@ -17,6 +18,9 @@ const lowlight = createLowlight();
 // just a name map, safe to register before the grammars they point at.
 lowlight.register({ plaintext: PLAINTEXT_GRAMMAR });
 lowlight.registerAlias(GRAMMAR_ALIASES);
+
+/** Languages already handed to ensureGrammar (loaded, unsupported, or failed). */
+const ensuredLanguages = new Set<string>();
 
 const SUPPORTED_CODE_BLOCK_LANGUAGES = [
 	"plaintext",
@@ -43,6 +47,10 @@ export type SupportedCodeBlockLanguage =
  * promise resolving to whether the grammar was registered.
  */
 function ensureGrammar(language: string): Promise<boolean> | null {
+	const key = language || "plaintext";
+	if (ensuredLanguages.has(key)) return null;
+	ensuredLanguages.add(key);
+
 	const grammar = resolveGrammarName(language);
 	if (!grammar || lowlight.registered(grammar)) return null;
 	return loadGrammar(grammar).then((languageFn) => {
@@ -77,11 +85,10 @@ function refreshCodeBlockDecorations(editor: Editor) {
 	}
 }
 
-function loadGrammarsForDoc(editor: Editor) {
-	const languages = new Set<string>();
-	for (const block of codeBlocksIn(editor)) {
-		languages.add(block.node.attrs.language || "plaintext");
-	}
+function loadGrammarsForLanguages(
+	editor: Editor,
+	languages: Iterable<string>,
+) {
 	for (const language of languages) {
 		ensureGrammar(language)?.then((registered) => {
 			if (registered && !editor.isDestroyed) {
@@ -89,6 +96,39 @@ function loadGrammarsForDoc(editor: Editor) {
 			}
 		});
 	}
+}
+
+function loadGrammarsForDoc(editor: Editor) {
+	const languages = new Set<string>();
+	for (const block of codeBlocksIn(editor)) {
+		languages.add(block.node.attrs.language || "plaintext");
+	}
+	loadGrammarsForLanguages(editor, languages);
+}
+
+/**
+ * Collect code-block languages only from ranges touched by `tr`, so ordinary
+ * typing outside code blocks does not walk the whole document.
+ */
+function languagesInChangedRanges(tr: Transaction): Set<string> {
+	const languages = new Set<string>();
+	if (!tr.docChanged) return languages;
+
+	tr.mapping.maps.forEach((stepMap, i) => {
+		stepMap.forEach((_oldStart, _oldEnd, newStart, newEnd) => {
+			const from = tr.mapping.slice(i + 1).map(newStart, -1);
+			const to = tr.mapping.slice(i + 1).map(newEnd, 1);
+			const start = Math.max(0, Math.min(from, to));
+			const end = Math.min(tr.doc.content.size, Math.max(from, to));
+			if (start > end) return;
+			tr.doc.nodesBetween(start, end, (node) => {
+				if (node.type.name !== "codeBlock") return;
+				languages.add(node.attrs.language || "plaintext");
+				return false;
+			});
+		});
+	});
+	return languages;
 }
 
 const CODE_BLOCK_LANGUAGE_OPTION_ORDER = [
@@ -161,8 +201,10 @@ export const SyntaxHighlightedCodeBlock = CodeBlockLowlight.extend({
 	onCreate() {
 		loadGrammarsForDoc(this.editor);
 	},
-	onUpdate() {
-		loadGrammarsForDoc(this.editor);
+	onUpdate({ transaction }) {
+		const languages = languagesInChangedRanges(transaction);
+		if (languages.size === 0) return;
+		loadGrammarsForLanguages(this.editor, languages);
 	},
 }).configure({
 	lowlight,

--- a/src/lib/highlightGrammars.ts
+++ b/src/lib/highlightGrammars.ts
@@ -1,0 +1,78 @@
+import type { LanguageFn } from "highlight.js";
+import plaintext from "highlight.js/lib/languages/plaintext";
+
+/**
+ * Shared lazy loader for highlight.js grammar modules, used by both the
+ * note editor (lowlight) and AI message rendering (hljs core). Grammars are
+ * dynamic imports so they stay out of eager chunks; only the tiny plaintext
+ * grammar is bundled statically so plain blocks never get auto-detected as
+ * another language.
+ */
+export const PLAINTEXT_GRAMMAR: LanguageFn = plaintext;
+
+const GRAMMAR_LOADERS: Record<string, () => Promise<{ default: LanguageFn }>> =
+	{
+		bash: () => import("highlight.js/lib/languages/bash"),
+		javascript: () => import("highlight.js/lib/languages/javascript"),
+		json: () => import("highlight.js/lib/languages/json"),
+		markdown: () => import("highlight.js/lib/languages/markdown"),
+		python: () => import("highlight.js/lib/languages/python"),
+		rust: () => import("highlight.js/lib/languages/rust"),
+		typescript: () => import("highlight.js/lib/languages/typescript"),
+		xml: () => import("highlight.js/lib/languages/xml"),
+		yaml: () => import("highlight.js/lib/languages/yaml"),
+	};
+
+/** Registry-level aliases, keyed by grammar module name. */
+export const GRAMMAR_ALIASES: Readonly<Record<string, readonly string[]>> = {
+	bash: ["shell", "sh", "zsh"],
+	javascript: ["cjs", "js", "jsx", "mjs"],
+	markdown: ["md"],
+	plaintext: ["text", "txt", "mermaid"],
+	python: ["py"],
+	typescript: ["ts", "tsx"],
+	xml: ["html", "svg"],
+	yaml: ["yml"],
+};
+
+const GRAMMAR_NAME_BY_ALIAS = new Map<string, string>();
+for (const name of [...Object.keys(GRAMMAR_LOADERS), "plaintext"]) {
+	GRAMMAR_NAME_BY_ALIAS.set(name, name);
+}
+for (const [name, aliases] of Object.entries(GRAMMAR_ALIASES)) {
+	for (const alias of aliases) {
+		GRAMMAR_NAME_BY_ALIAS.set(alias, name);
+	}
+}
+
+/** Maps a language or alias to its grammar module name, or null if unsupported. */
+export function resolveGrammarName(
+	language: string | null | undefined,
+): string | null {
+	if (!language) return "plaintext";
+	return GRAMMAR_NAME_BY_ALIAS.get(language.toLowerCase()) ?? null;
+}
+
+const grammarLoads = new Map<string, Promise<LanguageFn | null>>();
+
+/**
+ * Loads the grammar module for `name` (a grammar module name, not an alias).
+ * Cached; failed loads clear the cache entry so they can retry. Resolves to
+ * null for unsupported names or failed loads.
+ */
+export function loadGrammar(name: string): Promise<LanguageFn | null> {
+	if (name === "plaintext") return Promise.resolve(PLAINTEXT_GRAMMAR);
+	const loader = GRAMMAR_LOADERS[name];
+	if (!loader) return Promise.resolve(null);
+	let load = grammarLoads.get(name);
+	if (!load) {
+		load = loader()
+			.then((module) => module.default)
+			.catch(() => {
+				grammarLoads.delete(name);
+				return null;
+			});
+		grammarLoads.set(name, load);
+	}
+	return load;
+}


### PR DESCRIPTION
Closes N/A (no issue — branch self-contained)

## Description

Split the eagerly-registered highlight.js grammar modules into dynamic imports so they only load on demand, reducing the initial bundle size and parse cost. Both the note editor (lowlight) and AI message markdown renderer (hljs core) share a single lazy-loading module.

- **New shared module** `src/lib/highlightGrammars.ts` — provides `loadGrammar()`, `resolveGrammarName()`, the alias table, and the statically-bundled plaintext grammar (tiny, needed to prevent `highlightAuto` misdetection on plain/mermaid blocks).
- **Editor (`codeBlockHighlighting.ts`)** — registers only plaintext eagerly; real grammars load on `onCreate`/`onUpdate` by scanning the doc for code block languages. A `refreshCodeBlockDecorations` helper dispatches a no-op transaction to force lowlight to re-highlight after an async grammar arrives.
- **AI renderer (`AIMessageMarkdown.tsx`)** — replaced eager `import` + `registerLanguage` calls with an `ensureGrammar` that lazy-loads via the shared module and highlights the code element inside a `.then()`.
- **Aliases consolidated** — both consumers use the same `GRAMMAR_ALIASES` table, eliminating the duplicatve editor-only `CODE_BLOCK_LANGUAGE_ALIASES` map.

## Screenshots

N/A — no visual changes. Functionally identical after grammars finish loading.

## Docs

The new `src/lib/highlightGrammars.ts` module is the single source of truth for:
- Which languages are supported
- What their aliases are
- How to load a grammar asynchronously

To add a new language: add its dynamic import to `GRAMMAR_LOADERS`, any aliases to `GRAMMAR_ALIASES`, and optionally add it to `SUPPORTED_CODE_BLOCK_LANGUAGES` in the editor extension if it should appear in the language picker.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load `highlight.js` grammars only when a code block needs them to cut initial bundle size and parse time. Editor updates now scan only changed ranges and cache ensured languages to keep large notes responsive; plaintext stays eager to avoid misdetection.

- **Refactors**
  - Added `src/lib/highlightGrammars.ts` with `PLAINTEXT_GRAMMAR`, `loadGrammar()`, `resolveGrammarName()`, and `GRAMMAR_ALIASES` shared by the editor and message renderer.
  - Editor (`codeBlockHighlighting.ts`): register plaintext and aliases; load grammars on create/update for touched code blocks only; cache ensured languages; refresh decorations via a no-op `setNodeMarkup`.
  - Message Markdown (`AIMessageMarkdown.tsx`): load grammars via `ensureGrammar()` before `highlightElement`; register aliases up front.
  - Minor: fixed Biome formatting in the grammar loader.

<sup>Written for commit 1b9202649d1edc89f10677989c9fad002121a300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved initial loading by loading syntax-highlighting support only when needed.
  * Reduced unnecessary resources for languages not used in the current content.

* **Bug Fixes**
  * Preserved readable code when highlighting cannot be loaded or fails.
  * Added consistent handling for supported language names and aliases in AI messages and the editor.

* **User Experience**
  * Code blocks continue to support syntax highlighting, copying, links, and markdown rendering as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->