### PR TITLE
Fix rich-text callouts and native code language picker

### DIFF
--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -1,8 +1,4 @@
-import {
-	Copy01Icon,
-	PlayIcon,
-	Tick02Icon,
-} from "@hugeicons/core-free-icons";
+import { Copy01Icon, PlayIcon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { EditorContent } from "@tiptap/react";

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -1,7 +1,6 @@
 import {
 	Copy01Icon,
 	PlayIcon,
-	SourceCodeIcon,
 	Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -9,12 +8,9 @@ import type { Editor } from "@tiptap/core";
 import { EditorContent } from "@tiptap/react";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "../ui/shadcn/button";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
 import { TableInlineControls } from "./TableInlineControls";
 import {
 	type SupportedCodeBlockLanguage,
-	getCodeBlockLanguageLabel,
 	getCodeBlockLanguageOptions,
 } from "./extensions/codeBlockHighlighting";
 import type {
@@ -33,11 +29,9 @@ interface NoteEditorSurfaceProps {
 
 	codeBlock: {
 		selected: SelectedCodeBlockState | null;
-		pickerOpen: boolean;
-		onPickerOpenChange: (open: boolean) => void;
 		language: SupportedCodeBlockLanguage | null;
 		copied: boolean;
-		onPickerMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
+		onCodeBlockActionMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
 		onApplyLanguage: (language: SupportedCodeBlockLanguage) => void;
 		onCopy: () => void;
 		canPreview: boolean;
@@ -56,9 +50,6 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 }: NoteEditorSurfaceProps) {
 	const { t } = useTranslation("editor");
 	const languageOptions = getCodeBlockLanguageOptions();
-	const languageLabel = getCodeBlockLanguageLabel(
-		codeBlock.selected?.language ?? codeBlock.language,
-	);
 	const hostClassName = [
 		"tiptapHostInline",
 		mode === "preview" ? "is-preview" : "",
@@ -89,55 +80,23 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						left: `${codeBlock.selected.controlsLeft}px`,
 					}}
 				>
-					<Popover
-						open={codeBlock.pickerOpen}
-						onOpenChange={codeBlock.onPickerOpenChange}
+					<select
+						className="codeBlockLanguageSelect mono"
+						value={codeBlock.language ?? "plaintext"}
+						onChange={(event) => {
+							const option = languageOptions.find(
+								(candidate) => candidate.value === event.currentTarget.value,
+							);
+							if (option) codeBlock.onApplyLanguage(option.value);
+						}}
+						aria-label={t("codeBlock.setLanguage")}
 					>
-						<PopoverTrigger asChild>
-							<button
-								type="button"
-								className="codeBlockLanguageBtn"
-								onMouseDown={codeBlock.onPickerMouseDown}
-								title={t("codeBlock.setLanguage")}
-								aria-label={t("codeBlock.setLanguage")}
-							>
-								<span className="codeBlockLanguageBtnIcon" aria-hidden>
-									<HugeiconsIcon
-										icon={SourceCodeIcon}
-										size="var(--icon-sm)"
-										strokeWidth={0.9}
-									/>
-								</span>
-								<span className="codeBlockLanguageBtnLabel mono">
-									{languageLabel}
-								</span>
-							</button>
-						</PopoverTrigger>
-						<PopoverContent className="codeBlockLanguagePopover" align="start">
-							<div className="codeBlockLanguagePopoverHeader">
-								{t("codeBlock.languageHeader")}
-							</div>
-							<div className="codeBlockLanguageOptions">
-								{languageOptions.map((option) => (
-									<Button
-										key={option.value}
-										type="button"
-										size="xs"
-										variant={
-											option.value === codeBlock.language
-												? "secondary"
-												: "ghost"
-										}
-										className="codeBlockLanguageOption"
-										onMouseDown={codeBlock.onPickerMouseDown}
-										onClick={() => codeBlock.onApplyLanguage(option.value)}
-									>
-										{option.label}
-									</Button>
-								))}
-							</div>
-						</PopoverContent>
-					</Popover>
+						{languageOptions.map((option) => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
 				</div>
 			) : null}
 			{canEdit && codeBlock.selected ? (
@@ -152,7 +111,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						<button
 							type="button"
 							className="codeBlockActionBtn"
-							onMouseDown={codeBlock.onPickerMouseDown}
+							onMouseDown={codeBlock.onCodeBlockActionMouseDown}
 							onClick={codeBlock.onPreview}
 							title={t("codeBlock.runPreview")}
 							aria-label={t("codeBlock.runPreview")}
@@ -168,7 +127,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						type="button"
 						className="codeBlockActionBtn"
 						data-copied={codeBlock.copied || undefined}
-						onMouseDown={codeBlock.onPickerMouseDown}
+						onMouseDown={codeBlock.onCodeBlockActionMouseDown}
 						onClick={codeBlock.onCopy}
 						title={
 							codeBlock.copied ? t("codeBlock.copied") : t("codeBlock.copy")

--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -174,7 +174,6 @@ vi.mock("./markdown/wikiLinkCodec", () => ({
 
 vi.mock("./extensions/codeBlockHighlighting", () => ({
 	getCodeBlockLanguageOptions: () => [],
-	getCodeBlockLanguageLabel: () => "Plain text",
 	normalizeCodeBlockLanguage: () => "plaintext",
 }));
 

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -239,7 +239,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	const [tiptapHostNode, setTiptapHostNode] = useState<HTMLDivElement | null>(
 		null,
 	);
-	const [codeBlockPickerOpen, setCodeBlockPickerOpen] = useState(false);
 	const [selectedCodeBlock, setSelectedCodeBlock] =
 		useState<SelectedCodeBlockState | null>(null);
 	const selectedCodeBlockRef = useRef<SelectedCodeBlockState | null>(null);
@@ -439,7 +438,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				codeBlockCopyResetTimerRef.current = null;
 			}
 			setSelectedCodeBlock(null);
-			setCodeBlockPickerOpen(false);
 			setCodeBlockCopied(false);
 			return;
 		}
@@ -454,7 +452,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				codeBlockCopyResetTimerRef.current = null;
 			}
 			setSelectedCodeBlock(null);
-			setCodeBlockPickerOpen(false);
 			setCodeBlockCopied(false);
 		};
 
@@ -486,7 +483,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			}
 
 			const codeOffset = getOffsetWithinAncestor(codeElement, host);
-			const nextTop = codeOffset.top + 8;
+			const nextTop = codeOffset.top + 4;
 			const nextControlsLeft = codeOffset.left + 10;
 			const nextControlsRight = codeOffset.left + codeElement.offsetWidth - 10;
 			const nextLanguage =
@@ -572,7 +569,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					language: language === "plaintext" ? null : language,
 				})
 				.run();
-			setCodeBlockPickerOpen(false);
 		},
 		[editor],
 	);
@@ -669,12 +665,10 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	const codeBlockControls = useMemo(
 		() => ({
 			selected: selectedCodeBlock,
-			pickerOpen: codeBlockPickerOpen,
-			onPickerOpenChange: setCodeBlockPickerOpen,
 			language: selectedCodeBlockLanguage,
 			copied: codeBlockCopied,
 			canPreview: selectedCodeBlockCanPreview,
-			onPickerMouseDown: preventOverlayMouseDown,
+			onCodeBlockActionMouseDown: preventOverlayMouseDown,
 			onApplyLanguage: applyCodeBlockLanguage,
 			onCopy: copySelectedCodeBlock,
 			onPreview: previewSelectedCodeBlock,
@@ -682,7 +676,6 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		[
 			applyCodeBlockLanguage,
 			codeBlockCopied,
-			codeBlockPickerOpen,
 			copySelectedCodeBlock,
 			previewSelectedCodeBlock,
 			preventOverlayMouseDown,

--- a/src/components/editor/extensions/codeBlockHighlighting.ts
+++ b/src/components/editor/extensions/codeBlockHighlighting.ts
@@ -179,21 +179,6 @@ export function normalizeCodeBlockLanguage(
 	return NORMALIZED_LANGUAGE_BY_ALIAS.get(language.toLowerCase()) ?? null;
 }
 
-export function getCodeBlockLanguageLabel(
-	language: string | null | undefined,
-): string {
-	if (!language) {
-		return i18n.t("editor:codeBlock.languages.plaintext");
-	}
-	const raw = language.trim();
-	const normalized = normalizeCodeBlockLanguage(raw);
-	if (!normalized && raw.length > 0) {
-		return raw;
-	}
-	const value = normalized ?? "plaintext";
-	return i18n.t(`editor:codeBlock.languages.${value}`);
-}
-
 export const SyntaxHighlightedCodeBlock = CodeBlockLowlight.extend({
 	onCreate() {
 		loadGrammarsForDoc(this.editor);

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -11,14 +11,13 @@ import TaskList from "@tiptap/extension-task-list";
 import { Markdown } from "@tiptap/markdown";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
-import type { EditorState, Transaction } from "@tiptap/pm/state";
+import type { EditorState } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import StarterKit from "@tiptap/starter-kit";
 import { SlashCommand } from "../slashCommands";
 import {
 	type ChangedRange,
 	changedRangesFromTransactions,
-	mergeChangedRanges,
 	visitChangedNodes,
 	visitNodesInRanges,
 } from "./changedRanges";
@@ -128,18 +127,11 @@ const CalloutDecorations = Extension.create({
 						}),
 					]
 				: []),
-			new Plugin<DecorationSet>({
+			new Plugin({
 				key,
-				state: {
-					init: (_config, state) => buildCalloutDecorations(state.doc),
-					apply(tr, decorations) {
-						if (!tr.docChanged) return decorations;
-						return updateCalloutDecorations(tr, decorations);
-					},
-				},
 				props: {
 					decorations(state) {
-						return key.getState(state) ?? DecorationSet.empty;
+						return buildCalloutDecorations(state.doc);
 					},
 				},
 			}),
@@ -177,68 +169,6 @@ function calloutDecorationForNode(
 		"data-callout": parsed.kind,
 		"data-callout-title": parsed.title,
 	});
-}
-
-function calloutScanRanges(tr: Transaction): ChangedRange[] {
-	const ranges = changedRangesFromTransactions([tr], tr.doc.content.size);
-	if (!ranges.length) return [];
-	const expanded: ChangedRange[] = [];
-
-	const addContainingBlockquote = (pos: number) => {
-		const resolvedPos = tr.doc.resolve(
-			Math.max(0, Math.min(pos, tr.doc.content.size)),
-		);
-		for (let depth = resolvedPos.depth; depth > 0; depth -= 1) {
-			const node = resolvedPos.node(depth);
-			if (node.type.name !== "blockquote") continue;
-			const from = resolvedPos.before(depth);
-			expanded.push({ from, to: from + node.nodeSize });
-		}
-	};
-
-	for (const range of ranges) {
-		addContainingBlockquote(range.from);
-		addContainingBlockquote(Math.max(range.from, range.to - 1));
-		tr.doc.nodesBetween(range.from, range.to, (node, pos) => {
-			if (node.type.name !== "blockquote") return;
-			expanded.push({ from: pos, to: pos + node.nodeSize });
-			return false;
-		});
-	}
-	return mergeChangedRanges(expanded.length ? expanded : ranges);
-}
-
-function buildCalloutDecorationsInRanges(
-	doc: ProseMirrorNode,
-	ranges: readonly ChangedRange[],
-): Decoration[] {
-	const decorations: Decoration[] = [];
-	const seen = new Set<number>();
-	for (const range of ranges) {
-		doc.nodesBetween(range.from, range.to, (node, pos) => {
-			if (seen.has(pos)) return false;
-			const decoration = calloutDecorationForNode(node, pos);
-			if (!decoration) return;
-			seen.add(pos);
-			decorations.push(decoration);
-			return false;
-		});
-	}
-	return decorations;
-}
-
-function updateCalloutDecorations(
-	tr: Transaction,
-	decorations: DecorationSet,
-): DecorationSet {
-	const scanRanges = calloutScanRanges(tr);
-	if (!scanRanges.length) return decorations.map(tr.mapping, tr.doc);
-	const mapped = decorations.map(tr.mapping, tr.doc);
-	const staleDecorations = scanRanges.flatMap((range) =>
-		mapped.find(range.from, range.to),
-	);
-	const nextDecorations = buildCalloutDecorationsInRanges(tr.doc, scanRanges);
-	return mapped.remove(staleDecorations).add(tr.doc, nextDecorations);
 }
 
 const MARKDOWN_LINK_TEXT_RE = /(?<!!)\[([^\]\n]+)\]\(([^)\n]+)\)/g;

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -62,7 +62,7 @@ const CalloutDecorations = Extension.create({
 		};
 	},
 	addProseMirrorPlugins() {
-		const key = new PluginKey("callout-decorations");
+		const key = new PluginKey<DecorationSet>("callout-decorations");
 		const plugins = [
 			...(this.options.enableShortcutTransform
 				? [
@@ -127,11 +127,18 @@ const CalloutDecorations = Extension.create({
 						}),
 					]
 				: []),
-			new Plugin({
+			new Plugin<DecorationSet>({
 				key,
+				state: {
+					init: (_config, state) => buildCalloutDecorations(state.doc),
+					apply(tr, decorations) {
+						if (!tr.docChanged) return decorations;
+						return buildCalloutDecorations(tr.doc);
+					},
+				},
 				props: {
 					decorations(state) {
-						return buildCalloutDecorations(state.doc);
+						return key.getState(state) ?? DecorationSet.empty;
 					},
 				},
 			}),

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "Codeblock-Sprache festlegen",
-		"languageHeader": "Codeblock-Sprache",
 		"runPreview": "Vorschau ausführen",
 		"copy": "Code kopieren",
 		"copied": "Code kopiert",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -43,7 +43,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "Set code block language",
-		"languageHeader": "Code block language",
 		"runPreview": "Run preview",
 		"copy": "Copy code",
 		"copied": "Copied code",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "Establecer idioma del bloque de código",
-		"languageHeader": "Idioma del bloque de código",
 		"runPreview": "Ejecutar vista previa",
 		"copy": "Copiar código",
 		"copied": "Código copiado",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "Définir le langage du bloc de code",
-		"languageHeader": "Langage du bloc de code",
 		"runPreview": "Exécuter l’aperçu",
 		"copy": "Copier le code",
 		"copied": "Code copié",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "コードブロックの言語を設定",
-		"languageHeader": "コードブロックの言語",
 		"runPreview": "プレビューを実行",
 		"copy": "コードをコピー",
 		"copied": "コードをコピーしました",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "코드 블록 언어 설정",
-		"languageHeader": "코드 블록 언어",
 		"runPreview": "미리보기 실행",
 		"copy": "코드 복사",
 		"copied": "코드 복사됨",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -42,7 +42,6 @@
 	},
 	"codeBlock": {
 		"setLanguage": "Definir linguagem do bloco de código",
-		"languageHeader": "Linguagem do bloco de código",
 		"runPreview": "Executar pré-visualização",
 		"copy": "Copiar código",
 		"copied": "Código copiado",

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -696,14 +696,12 @@
 	padding: calc(var(--space-3) + 22px) var(--space-3) var(--space-3);
 	border-radius: var(--radius-lg);
 	overflow: auto;
-	font-family: var(--font-mono);
 }
 
 .tiptapContentInline pre code {
 	background: transparent;
 	padding: 0;
 	border: none;
-	border-radius: 0;
 }
 
 .tiptapContentInline hr {

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -589,21 +589,17 @@
 .tiptapContentInline blockquote {
 	margin: var(--space-3) 0;
 	padding: calc(var(--space-2) + 1px) var(--space-3);
-	border-left: 3px solid
-		color-mix(in srgb, var(--interactive-accent) 48%, var(--border-default));
-	border-radius: 0 var(--radius-lg) var(--radius-lg) 0;
+	border-radius: var(--radius-lg);
 	background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary));
 	color: var(--text-secondary);
 }
 
 .tiptapContentInline blockquote.callout {
-	border-left: 4px solid var(--callout-accent, var(--interactive-accent));
 	background: color-mix(
 		in srgb,
 		var(--callout-accent, var(--interactive-accent)) 14%,
 		var(--bg-secondary)
 	);
-	border-radius: var(--radius-lg);
 	padding: var(--space-3);
 	color: var(--text-primary);
 }
@@ -644,10 +640,6 @@
 }
 
 .tiptapContentInline blockquote.callout[data-callout="warning"] {
-	--callout-accent: var(--callout-warning);
-}
-
-.tiptapContentInline blockquote.callout[data-callout="warn"] {
 	--callout-accent: var(--callout-warning);
 }
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -692,8 +692,8 @@
 }
 
 .tiptapContentInline pre {
-	background: color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary));
-	padding: calc(var(--space-3) + 22px) var(--space-3) var(--space-3);
+	background: color-mix(in srgb, var(--bg-secondary) 86%, var(--bg-primary));
+	padding: var(--space-6) var(--space-4) var(--space-4);
 	border-radius: var(--radius-lg);
 	overflow: auto;
 }

--- a/src/styles/app/26-node-note-overlays.css
+++ b/src/styles/app/26-node-note-overlays.css
@@ -39,40 +39,23 @@
 	z-index: 15;
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
 }
 
-.codeBlockLanguageBtn {
+.codeBlockLanguageSelect {
 	height: 18px;
 	padding: 0 5px;
 	border: none;
 	border-radius: var(--radius-sm);
 	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
 	color: color-mix(in srgb, var(--text-tertiary) 88%, transparent);
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-normal);
 	backdrop-filter: blur(4px);
-	z-index: 15;
 }
 
-.codeBlockLanguageBtn:hover {
+.codeBlockLanguageSelect:hover {
 	background: color-mix(in srgb, var(--bg-primary) 88%, var(--bg-hover));
 	color: var(--text-primary);
-}
-
-.codeBlockLanguageBtnIcon {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	flex: 0 0 auto;
-}
-
-.codeBlockLanguageBtnLabel {
-	min-width: 0;
-	white-space: nowrap;
 }
 
 .codeBlockActionBtns {
@@ -109,31 +92,6 @@
 
 .codeBlockActionBtn[data-copied] {
 	color: var(--success);
-}
-
-.codeBlockLanguagePopover {
-	width: 176px;
-	padding: 8px;
-}
-
-.codeBlockLanguagePopoverHeader {
-	padding: 2px 4px 8px;
-	font-size: calc(var(--text-base) * 0.8);
-	font-weight: var(--font-semibold);
-	letter-spacing: 0.04em;
-	text-transform: uppercase;
-	color: var(--text-tertiary);
-}
-
-.codeBlockLanguageOptions {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: 4px;
-}
-
-.codeBlockLanguageOption {
-	justify-content: flex-start;
-	width: 100%;
 }
 
 .mermaidCodeBlockHiddenInPreview {


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/335


## Description

This PR removes the rich-text quote/callout rails, stabilizes callout decorations during editing, and simplifies code-block language selection.

- Summary of changes
  - Removed the left rail from rich-text quotes and callouts while preserving tinted callout backgrounds.
  - Reworked callout decorations to derive from the current document and removed fragile incremental bookkeeping.
  - Replaced the custom Radix language picker with the native HTML select control rendered by the macOS WebView.
  - Removed picker-specific state, helpers, styles, translations, and other dead code.
  - Preserved code-block syntax highlighting, copy, preview, and raw Markdown styling.
- Reasoning
  - The previous callout decoration mapping could leave valid callouts visually degraded during editing.
  - Native language selection reduces custom UI and gives macOS users the platform dropdown behavior.
- Additional context
  - Code-block controls remain available for copy and preview.
  - Existing language metadata and syntax highlighting behavior are preserved.


## Screenshots

Not included; visual verification should be performed in the macOS app.


## Docs

No additional documentation is needed for this styling and editor-behavior cleanup.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes rich‑text callouts and replaces the custom code‑block language picker with a native select for a simpler, more reliable editor. Removes the callout left rail while keeping tinted backgrounds; code‑block highlighting, copy, and preview remain.

- **Bug Fixes**
  - Always rebuild callout decorations from the current document to avoid stale styles while typing; remove incremental caching.
  - Remove left rail from quotes/callouts; keep accent‑tinted backgrounds and refine spacing.

- **Refactors**
  - Replace the custom popover language picker with a native `<select>` in the macOS WebView; remove related state, helpers, styles, and i18n strings.
  - Tighter code‑block overlay offsets and updated padding; preview/copy and language metadata are preserved.

<sup>Written for commit 94958ee62d641bf4da6727459980d0da73b35b47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the code block language popover with a more direct dropdown selector.
  * Improved code block action interactions for previewing and copying.

* **Bug Fixes**
  * Updated callout and code block styling for a cleaner editor appearance.
  * Removed outdated warning callout support.

* **Localization**
  * Updated translated code block language controls across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->