### PR TITLE
Fix Codex app-server startup and rollout handling

### DIFF
--- a/src-tauri/src/ai_codex/chat.rs
+++ b/src-tauri/src/ai_codex/chat.rs
@@ -183,81 +183,49 @@ pub async fn run_with_codex(
     let input_text = as_text_input(system, messages);
     let root_str = root.to_string_lossy().to_string();
 
-    let thread_id = {
-        if let Some(existing) = thread_hint {
-            if !existing.trim().is_empty() {
-                let resumed = rpc_call(
-                    app.clone(),
-                    "thread/resume",
-                    json!({ "threadId": existing }),
-                    Duration::from_secs(20),
-                )
-                .await?;
-                if let Some(thread_id) = extract_thread_id(&resumed) {
-                    thread_id
-                } else {
-                    let started = rpc_call(
-                        app.clone(),
-                        "thread/start",
-                        json!({
-                            "model": model,
-                            "cwd": root_str.clone(),
-                            "approvalPolicy": "never"
-                        }),
-                        Duration::from_secs(20),
-                    )
-                    .await?;
-                    extract_thread_id(&started)
-                        .or_else(|| {
-                            started
-                                .get("id")
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string())
-                        })
-                        .ok_or_else(|| "missing thread id from codex thread/start".to_string())?
-                }
-            } else {
-                let started = rpc_call(
-                    app.clone(),
-                    "thread/start",
-                    json!({
-                        "model": model,
-                        "cwd": root_str.clone(),
-                        "approvalPolicy": "never"
-                    }),
-                    Duration::from_secs(20),
-                )
-                .await?;
-                extract_thread_id(&started)
-                    .or_else(|| {
-                        started
-                            .get("id")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .ok_or_else(|| "missing thread id from codex thread/start".to_string())?
-            }
-        } else {
-            let started = rpc_call(
+    async fn start_thread(app: AppHandle, model: &str, cwd: &str) -> Result<String, String> {
+        let started = rpc_call(
+            app,
+            "thread/start",
+            json!({
+                "model": model,
+                "cwd": cwd,
+                "approvalPolicy": "never"
+            }),
+            Duration::from_secs(20),
+        )
+        .await?;
+        extract_thread_id(&started)
+            .or_else(|| {
+                started
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .ok_or_else(|| "missing thread id from codex thread/start".to_string())
+    }
+
+    let thread_id = match thread_hint.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(existing) => {
+            let resumed = rpc_call(
                 app.clone(),
-                "thread/start",
-                json!({
-                    "model": model,
-                    "cwd": root_str.clone(),
-                    "approvalPolicy": "never"
-                }),
+                "thread/resume",
+                json!({ "threadId": existing }),
                 Duration::from_secs(20),
             )
-            .await?;
-            extract_thread_id(&started)
-                .or_else(|| {
-                    started
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                })
-                .ok_or_else(|| "missing thread id from codex thread/start".to_string())?
+            .await;
+            match resumed {
+                Ok(resumed) => {
+                    if let Some(thread_id) = extract_thread_id(&resumed) {
+                        thread_id
+                    } else {
+                        start_thread(app.clone(), model, &root_str).await?
+                    }
+                }
+                Err(_) => start_thread(app.clone(), model, &root_str).await?,
+            }
         }
+        None => start_thread(app.clone(), model, &root_str).await?,
     };
 
     let mut seq = latest_seq(app.clone()).await?;

--- a/src-tauri/src/ai_codex/chat.rs
+++ b/src-tauri/src/ai_codex/chat.rs
@@ -1,6 +1,6 @@
 use serde_json::{json, Value};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, Emitter};
 use tokio_util::sync::CancellationToken;
 
 use crate::ai_rig::events::AiStatusEvent;
@@ -10,7 +10,6 @@ use crate::ai_rig::types::{
     AiStoredToolEvent, AiToolEvent,
 };
 
-use super::state::CodexState;
 use super::transport::{latest_seq, rpc_call, wait_notification_after};
 
 fn as_text_input(system: &str, messages: &[AiMessage]) -> String {
@@ -154,7 +153,6 @@ fn push_tool_event(
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_with_codex(
-    codex_state: State<'_, CodexState>,
     cancel: &CancellationToken,
     app: &AppHandle,
     job_id: &str,
@@ -187,18 +185,19 @@ pub async fn run_with_codex(
 
     let thread_id = {
         if let Some(existing) = thread_hint {
-            if existing.starts_with("thr_") {
+            if !existing.trim().is_empty() {
                 let resumed = rpc_call(
-                    codex_state.inner(),
+                    app.clone(),
                     "thread/resume",
                     json!({ "threadId": existing }),
                     Duration::from_secs(20),
-                )?;
+                )
+                .await?;
                 if let Some(thread_id) = extract_thread_id(&resumed) {
                     thread_id
                 } else {
                     let started = rpc_call(
-                        codex_state.inner(),
+                        app.clone(),
                         "thread/start",
                         json!({
                             "model": model,
@@ -206,7 +205,8 @@ pub async fn run_with_codex(
                             "approvalPolicy": "never"
                         }),
                         Duration::from_secs(20),
-                    )?;
+                    )
+                    .await?;
                     extract_thread_id(&started)
                         .or_else(|| {
                             started
@@ -218,7 +218,7 @@ pub async fn run_with_codex(
                 }
             } else {
                 let started = rpc_call(
-                    codex_state.inner(),
+                    app.clone(),
                     "thread/start",
                     json!({
                         "model": model,
@@ -226,7 +226,8 @@ pub async fn run_with_codex(
                         "approvalPolicy": "never"
                     }),
                     Duration::from_secs(20),
-                )?;
+                )
+                .await?;
                 extract_thread_id(&started)
                     .or_else(|| {
                         started
@@ -238,7 +239,7 @@ pub async fn run_with_codex(
             }
         } else {
             let started = rpc_call(
-                codex_state.inner(),
+                app.clone(),
                 "thread/start",
                 json!({
                     "model": model,
@@ -246,7 +247,8 @@ pub async fn run_with_codex(
                     "approvalPolicy": "never"
                 }),
                 Duration::from_secs(20),
-            )?;
+            )
+            .await?;
             extract_thread_id(&started)
                 .or_else(|| {
                     started
@@ -258,7 +260,7 @@ pub async fn run_with_codex(
         }
     };
 
-    let mut seq = latest_seq(codex_state.inner())?;
+    let mut seq = latest_seq(app.clone()).await?;
     let mut turn_params = json!({
         "threadId": thread_id,
         "input": [
@@ -287,11 +289,12 @@ pub async fn run_with_codex(
         }
     }
     let started = rpc_call(
-        codex_state.inner(),
+        app.clone(),
         "turn/start",
         turn_params,
         Duration::from_secs(30),
-    )?;
+    )
+    .await?;
     let turn_id = extract_turn_id(&started)
         .or_else(|| {
             started
@@ -314,15 +317,16 @@ pub async fn run_with_codex(
         if cancel.is_cancelled() && !interrupted {
             interrupted = true;
             let _ = rpc_call(
-                codex_state.inner(),
+                app.clone(),
                 "turn/interrupt",
                 json!({ "threadId": thread_id }),
                 Duration::from_secs(10),
-            );
+            )
+            .await;
         }
 
         let maybe_notification =
-            wait_notification_after(codex_state.inner(), seq, Duration::from_millis(500))?;
+            wait_notification_after(app.clone(), seq, Duration::from_millis(500)).await?;
 
         let Some(notification) = maybe_notification else {
             continue;

--- a/src-tauri/src/ai_codex/commands.rs
+++ b/src-tauri/src/ai_codex/commands.rs
@@ -87,6 +87,10 @@ pub async fn codex_login_complete(
         };
         seq = notification.seq;
 
+        if notification.method == "codex/process/exited" {
+            return Err("codex app-server exited while waiting for login".to_string());
+        }
+
         if notification.method == "account/login/completed" {
             let login_id = notification
                 .params

--- a/src-tauri/src/ai_codex/commands.rs
+++ b/src-tauri/src/ai_codex/commands.rs
@@ -1,8 +1,7 @@
 use serde_json::json;
 use std::time::Duration;
-use tauri::State;
+use tauri::AppHandle;
 
-use super::state::CodexState;
 use super::transport::{latest_seq, rpc_call, wait_notification_after};
 use super::types::{
     CodexAccountInfo, CodexLoginCompleteResult, CodexLoginStartResult, CodexRateLimitBucket,
@@ -10,13 +9,14 @@ use super::types::{
 };
 
 #[tauri::command]
-pub async fn codex_account_read(state: State<'_, CodexState>) -> Result<CodexAccountInfo, String> {
+pub async fn codex_account_read(app: AppHandle) -> Result<CodexAccountInfo, String> {
     let value = rpc_call(
-        &state,
+        app,
         "account/read",
         json!({ "refreshToken": false }),
         Duration::from_secs(20),
-    )?;
+    )
+    .await?;
     let auth_mode = value
         .get("authMode")
         .and_then(|v| v.as_str())
@@ -46,15 +46,14 @@ pub async fn codex_account_read(state: State<'_, CodexState>) -> Result<CodexAcc
 }
 
 #[tauri::command]
-pub async fn codex_login_start(
-    state: State<'_, CodexState>,
-) -> Result<CodexLoginStartResult, String> {
+pub async fn codex_login_start(app: AppHandle) -> Result<CodexLoginStartResult, String> {
     let value = rpc_call(
-        &state,
+        app,
         "account/login/start",
         json!({ "type": "chatgpt" }),
         Duration::from_secs(30),
-    )?;
+    )
+    .await?;
 
     let auth_url = value
         .get("authUrl")
@@ -74,15 +73,15 @@ pub async fn codex_login_start(
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn codex_login_complete(
-    state: State<'_, CodexState>,
+    app: AppHandle,
     flow_id: String,
 ) -> Result<CodexLoginCompleteResult, String> {
-    let mut seq = latest_seq(&state)?;
+    let mut seq = latest_seq(app.clone()).await?;
     let deadline = std::time::Instant::now() + Duration::from_secs(180);
 
     while std::time::Instant::now() < deadline {
         let timeout = Duration::from_millis(800);
-        let notification = wait_notification_after(&state, seq, timeout)?;
+        let notification = wait_notification_after(app.clone(), seq, timeout).await?;
         let Some(notification) = notification else {
             continue;
         };
@@ -109,21 +108,20 @@ pub async fn codex_login_complete(
 }
 
 #[tauri::command]
-pub async fn codex_logout(state: State<'_, CodexState>) -> Result<(), String> {
-    let _ = rpc_call(&state, "account/logout", json!({}), Duration::from_secs(20))?;
+pub async fn codex_logout(app: AppHandle) -> Result<(), String> {
+    let _ = rpc_call(app, "account/logout", json!({}), Duration::from_secs(20)).await?;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn codex_rate_limits_read(
-    state: State<'_, CodexState>,
-) -> Result<CodexRateLimits, String> {
+pub async fn codex_rate_limits_read(app: AppHandle) -> Result<CodexRateLimits, String> {
     let value = rpc_call(
-        &state,
+        app,
         "account/rateLimits/read",
         json!({}),
         Duration::from_secs(20),
-    )?;
+    )
+    .await?;
     let parse_window = |v: &serde_json::Value| -> Option<CodexRateLimitWindow> {
         let used_percent = v
             .get("usedPercent")

--- a/src-tauri/src/ai_codex/state.rs
+++ b/src-tauri/src/ai_codex/state.rs
@@ -367,7 +367,7 @@ impl CodexState {
     }
 
     pub fn call(&self, method: &str, params: Value, timeout: Duration) -> Result<Value, String> {
-        let process = {
+        let mut process = {
             let mut guard = self
                 .process
                 .lock()
@@ -393,21 +393,22 @@ impl CodexState {
 
             debug!("{error:?}; restarting codex app-server");
             self.discard_if_current(&process)?;
-            let process = {
+            let replacement = {
                 let mut guard = self
                     .process
                     .lock()
                     .map_err(|_| "codex process lock poisoned".to_string())?;
                 self.ensure_process_locked(&mut guard)?
             };
-            if let Err(error) = self.ensure_initialized(&process) {
+            if let Err(error) = self.ensure_initialized(&replacement) {
                 let transport_failure = error.is_transport();
                 let message = error.into_message();
                 if transport_failure {
-                    let _ = self.discard_if_current(&process);
+                    let _ = self.discard_if_current(&replacement);
                 }
                 return Err(message);
             }
+            process = replacement;
         }
 
         let result = self.call_process(&process, method, params, timeout);

--- a/src-tauri/src/ai_codex/state.rs
+++ b/src-tauri/src/ai_codex/state.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::time::Duration;
 use tracing::{debug, warn};
@@ -18,32 +18,48 @@ pub struct CodexNotification {
 enum RpcReply {
     Result(Value),
     Error(String),
+    ProcessExited,
+}
+
+#[derive(Debug)]
+enum CodexError {
+    Transport(String),
+    Message(String),
+}
+
+impl CodexError {
+    fn is_transport(&self) -> bool {
+        matches!(self, Self::Transport(_))
+    }
+
+    fn into_message(self) -> String {
+        match self {
+            Self::Transport(message) | Self::Message(message) => message,
+        }
+    }
 }
 
 struct RuntimeProcess {
-    child: Child,
+    child: Mutex<Child>,
     stdin: Arc<Mutex<ChildStdin>>,
     pending: Arc<Mutex<HashMap<u64, mpsc::Sender<RpcReply>>>>,
     notifications: Arc<(Mutex<NotificationQueue>, Condvar)>,
-    initialized: bool,
+    initialized: AtomicBool,
+    initialization: Mutex<()>,
 }
 
 struct NotificationQueue {
-    next_seq: u64,
     items: VecDeque<CodexNotification>,
 }
 
 impl NotificationQueue {
     fn new() -> Self {
         Self {
-            next_seq: 1,
             items: VecDeque::new(),
         }
     }
 
-    fn push(&mut self, method: String, params: Value) -> u64 {
-        let seq = self.next_seq;
-        self.next_seq = self.next_seq.saturating_add(1);
+    fn push(&mut self, seq: u64, method: String, params: Value) -> u64 {
         self.items.push_back(CodexNotification {
             seq,
             method,
@@ -65,8 +81,9 @@ impl NotificationQueue {
 }
 
 pub struct CodexState {
-    process: Mutex<Option<RuntimeProcess>>,
+    process: Mutex<Option<Arc<RuntimeProcess>>>,
     next_id: AtomicU64,
+    next_notification_seq: Arc<AtomicU64>,
 }
 
 impl Default for CodexState {
@@ -74,6 +91,7 @@ impl Default for CodexState {
         Self {
             process: Mutex::new(None),
             next_id: AtomicU64::new(1),
+            next_notification_seq: Arc::new(AtomicU64::new(1)),
         }
     }
 }
@@ -176,35 +194,49 @@ impl CodexState {
         let notifications = Arc::new((Mutex::new(NotificationQueue::new()), Condvar::new()));
         let pending_for_reader = Arc::clone(&pending);
         let notifications_for_reader = Arc::clone(&notifications);
+        let next_notification_seq = Arc::clone(&self.next_notification_seq);
         std::thread::spawn(move || {
-            read_stdout_loop(stdout, pending_for_reader, notifications_for_reader)
+            read_stdout_loop(
+                stdout,
+                pending_for_reader,
+                notifications_for_reader,
+                next_notification_seq,
+            )
         });
         std::thread::spawn(move || read_stderr_loop(stderr));
 
         Ok(RuntimeProcess {
-            child,
+            child: Mutex::new(child),
             stdin: Arc::new(Mutex::new(stdin)),
             pending,
             notifications,
-            initialized: false,
+            initialized: AtomicBool::new(false),
+            initialization: Mutex::new(()),
         })
     }
 
-    fn write_line(process: &RuntimeProcess, value: &Value) -> Result<(), String> {
-        let mut line = serde_json::to_vec(value).map_err(|e| e.to_string())?;
+    fn write_line(process: &RuntimeProcess, value: &Value) -> Result<(), CodexError> {
+        let mut line =
+            serde_json::to_vec(value).map_err(|error| CodexError::Message(error.to_string()))?;
         line.push(b'\n');
         let mut guard = process
             .stdin
             .lock()
-            .map_err(|_| "codex stdin lock poisoned".to_string())?;
+            .map_err(|_| CodexError::Message("codex stdin lock poisoned".to_string()))?;
         guard
             .write_all(&line)
             .and_then(|_| guard.flush())
-            .map_err(|e| format!("failed writing to codex app-server: {e}"))
+            .map_err(|error| {
+                CodexError::Transport(format!("failed writing to codex app-server: {error}"))
+            })
     }
 
-    fn child_exit_message(process: &mut RuntimeProcess) -> Option<String> {
-        match process.child.try_wait() {
+    fn child_exit_message(process: &RuntimeProcess) -> Option<String> {
+        let mut child = match process.child.lock() {
+            Ok(child) => child,
+            Err(_) => return Some("codex child lock poisoned".to_string()),
+        };
+        match child.try_wait() {
             Ok(Some(status)) => Some(format!("codex app-server exited with {status}")),
             Ok(None) => None,
             Err(error) => Some(format!("failed checking codex app-server: {error}")),
@@ -216,38 +248,54 @@ impl CodexState {
         let _ = child.wait();
     }
 
-    fn stop_process(process: RuntimeProcess) {
-        let mut child = process.child;
-        Self::stop_child(&mut child);
+    fn stop_process(process: Arc<RuntimeProcess>) {
+        if let Ok(mut child) = process.child.lock() {
+            Self::stop_child(&mut child);
+        }
     }
 
-    fn discard_process(guard: &mut Option<RuntimeProcess>) {
+    fn discard_process(guard: &mut Option<Arc<RuntimeProcess>>) {
         if let Some(stale) = guard.take() {
             Self::stop_process(stale);
         }
     }
 
-    fn is_transport_failure(error: &str) -> bool {
-        let error = error.to_ascii_lowercase();
-        error.contains("broken pipe")
-            || error.contains("failed writing to codex app-server")
-            || error.contains("codex app-server process exited")
-    }
-
-    fn ensure_process_locked<'a>(
-        &'a self,
-        guard: &'a mut Option<RuntimeProcess>,
-    ) -> Result<&'a mut RuntimeProcess, String> {
+    fn ensure_process_locked(
+        &self,
+        guard: &mut Option<Arc<RuntimeProcess>>,
+    ) -> Result<Arc<RuntimeProcess>, String> {
         if guard.is_none() {
-            *guard = Some(self.spawn_process()?);
+            *guard = Some(Arc::new(self.spawn_process()?));
         }
         guard
-            .as_mut()
+            .as_ref()
+            .map(Arc::clone)
             .ok_or_else(|| "codex runtime unavailable".to_string())
     }
 
-    fn ensure_initialized_locked(&self, process: &mut RuntimeProcess) -> Result<(), String> {
-        if process.initialized {
+    fn discard_if_current(&self, process: &Arc<RuntimeProcess>) -> Result<(), String> {
+        let mut guard = self
+            .process
+            .lock()
+            .map_err(|_| "codex process lock poisoned".to_string())?;
+        if guard
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, process))
+        {
+            Self::discard_process(&mut guard);
+        }
+        Ok(())
+    }
+
+    fn ensure_initialized(&self, process: &RuntimeProcess) -> Result<(), CodexError> {
+        if process.initialized.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let _initialization = process
+            .initialization
+            .lock()
+            .map_err(|_| CodexError::Message("codex initialization lock poisoned".to_string()))?;
+        if process.initialized.load(Ordering::Acquire) {
             return Ok(());
         }
 
@@ -258,7 +306,7 @@ impl CodexState {
                 "version": "0.1.0"
             }
         });
-        let _ = self.call_locked(process, "initialize", init_params, Duration::from_secs(20))?;
+        let _ = self.call_process(process, "initialize", init_params, Duration::from_secs(20))?;
         Self::write_line(
             process,
             &json!({
@@ -266,24 +314,24 @@ impl CodexState {
                 "params": {}
             }),
         )?;
-        process.initialized = true;
+        process.initialized.store(true, Ordering::Release);
         Ok(())
     }
 
-    fn call_locked(
+    fn call_process(
         &self,
-        process: &mut RuntimeProcess,
+        process: &RuntimeProcess,
         method: &str,
         params: Value,
         timeout: Duration,
-    ) -> Result<Value, String> {
+    ) -> Result<Value, CodexError> {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel::<RpcReply>();
         {
             let mut pending = process
                 .pending
                 .lock()
-                .map_err(|_| "pending map lock poisoned".to_string())?;
+                .map_err(|_| CodexError::Message("pending map lock poisoned".to_string()))?;
             pending.insert(id, tx);
         }
 
@@ -292,39 +340,41 @@ impl CodexState {
             "method": method,
             "params": params,
         });
-        if let Err(e) = Self::write_line(process, &msg) {
-            let mut pending = process
-                .pending
-                .lock()
-                .map_err(|_| "pending map lock poisoned".to_string())?;
-            pending.remove(&id);
-            return Err(e);
+        if let Err(error) = Self::write_line(process, &msg) {
+            if let Ok(mut pending) = process.pending.lock() {
+                pending.remove(&id);
+            }
+            return Err(error);
         }
 
         match rx.recv_timeout(timeout) {
             Ok(RpcReply::Result(v)) => Ok(v),
-            Ok(RpcReply::Error(e)) => Err(e),
+            Ok(RpcReply::Error(error)) => Err(CodexError::Message(error)),
+            Ok(RpcReply::ProcessExited) => Err(CodexError::Transport(
+                "codex app-server process exited".to_string(),
+            )),
             Err(_) => {
                 let mut pending = process
                     .pending
                     .lock()
-                    .map_err(|_| "pending map lock poisoned".to_string())?;
+                    .map_err(|_| CodexError::Message("pending map lock poisoned".to_string()))?;
                 pending.remove(&id);
-                Err(format!("codex request timed out: {method}"))
+                Err(CodexError::Message(format!(
+                    "codex request timed out: {method}"
+                )))
             }
         }
     }
 
     pub fn call(&self, method: &str, params: Value, timeout: Duration) -> Result<Value, String> {
-        let mut guard = self
-            .process
-            .lock()
-            .map_err(|_| "codex process lock poisoned".to_string())?;
-
-        for attempt in 0..2 {
+        let process = {
+            let mut guard = self
+                .process
+                .lock()
+                .map_err(|_| "codex process lock poisoned".to_string())?;
             let exited = guard
-                .as_mut()
-                .and_then(Self::child_exit_message)
+                .as_ref()
+                .and_then(|process| Self::child_exit_message(process))
                 .map(|error| {
                     debug!("{error}; restarting codex app-server");
                 })
@@ -332,30 +382,42 @@ impl CodexState {
             if exited {
                 Self::discard_process(&mut guard);
             }
+            self.ensure_process_locked(&mut guard)?
+        };
 
-            let process = self.ensure_process_locked(&mut guard)?;
-            if let Err(error) = self.ensure_initialized_locked(process) {
-                if attempt == 0 && Self::is_transport_failure(&error) {
-                    debug!("{error}; restarting codex app-server");
-                    Self::discard_process(&mut guard);
-                    continue;
-                }
-                return Err(error);
+        let initialized = self.ensure_initialized(&process);
+        if let Err(error) = initialized {
+            if !error.is_transport() {
+                return Err(error.into_message());
             }
 
-            let result = self.call_locked(process, method, params.clone(), timeout);
-            if let Err(error) = &result {
-                let child_exited = guard.as_mut().and_then(Self::child_exit_message).is_some();
-                if child_exited || Self::is_transport_failure(error) {
-                    Self::discard_process(&mut guard);
+            debug!("{error:?}; restarting codex app-server");
+            self.discard_if_current(&process)?;
+            let process = {
+                let mut guard = self
+                    .process
+                    .lock()
+                    .map_err(|_| "codex process lock poisoned".to_string())?;
+                self.ensure_process_locked(&mut guard)?
+            };
+            if let Err(error) = self.ensure_initialized(&process) {
+                let transport_failure = error.is_transport();
+                let message = error.into_message();
+                if transport_failure {
+                    let _ = self.discard_if_current(&process);
                 }
+                return Err(message);
             }
-            return result;
         }
 
-        Err(format!(
-            "codex app-server unavailable while calling {method}"
-        ))
+        let result = self.call_process(&process, method, params, timeout);
+        if let Err(error) = &result {
+            let child_exited = Self::child_exit_message(&process).is_some();
+            if child_exited || error.is_transport() {
+                let _ = self.discard_if_current(&process);
+            }
+        }
+        result.map_err(CodexError::into_message)
     }
 
     pub fn latest_notification_seq(&self) -> Result<u64, String> {
@@ -424,6 +486,7 @@ fn read_stdout_loop(
     stdout: ChildStdout,
     pending: Arc<Mutex<HashMap<u64, mpsc::Sender<RpcReply>>>>,
     notifications: Arc<(Mutex<NotificationQueue>, Condvar)>,
+    next_notification_seq: Arc<AtomicU64>,
 ) {
     let reader = BufReader::new(stdout);
     for line in reader.lines() {
@@ -472,7 +535,8 @@ fn read_stdout_loop(
             let params = parsed.get("params").cloned().unwrap_or_else(|| json!({}));
             let (lock, cv) = &*notifications;
             if let Ok(mut q) = lock.lock() {
-                let seq = q.push(method.to_string(), params);
+                let seq = next_notification_seq.fetch_add(1, Ordering::Relaxed);
+                let seq = q.push(seq, method.to_string(), params);
                 debug!("codex notification seq={seq} method={method}");
                 cv.notify_all();
             }
@@ -481,15 +545,14 @@ fn read_stdout_loop(
 
     if let Ok(mut map) = pending.lock() {
         for (_, tx) in map.drain() {
-            let _ = tx.send(RpcReply::Error(
-                "codex app-server process exited".to_string(),
-            ));
+            let _ = tx.send(RpcReply::ProcessExited);
         }
     }
 
     let (lock, cv) = &*notifications;
     if let Ok(mut q) = lock.lock() {
-        let _ = q.push("codex/process/exited".to_string(), json!({}));
+        let seq = next_notification_seq.fetch_add(1, Ordering::Relaxed);
+        let _ = q.push(seq, "codex/process/exited".to_string(), json!({}));
         cv.notify_all();
     }
 }

--- a/src-tauri/src/ai_codex/state.rs
+++ b/src-tauri/src/ai_codex/state.rs
@@ -23,6 +23,8 @@ enum RpcReply {
 struct RuntimeProcess {
     child: Child,
     stdin: Arc<Mutex<ChildStdin>>,
+    pending: Arc<Mutex<HashMap<u64, mpsc::Sender<RpcReply>>>>,
+    notifications: Arc<(Mutex<NotificationQueue>, Condvar)>,
     initialized: bool,
 }
 
@@ -64,8 +66,6 @@ impl NotificationQueue {
 
 pub struct CodexState {
     process: Mutex<Option<RuntimeProcess>>,
-    pending: Arc<Mutex<HashMap<u64, mpsc::Sender<RpcReply>>>>,
-    notifications: Arc<(Mutex<NotificationQueue>, Condvar)>,
     next_id: AtomicU64,
 }
 
@@ -73,8 +73,6 @@ impl Default for CodexState {
     fn default() -> Self {
         Self {
             process: Mutex::new(None),
-            pending: Arc::new(Mutex::new(HashMap::new())),
-            notifications: Arc::new((Mutex::new(NotificationQueue::new()), Condvar::new())),
             next_id: AtomicU64::new(1),
         }
     }
@@ -139,7 +137,7 @@ impl CodexState {
     fn spawn_process(&self) -> Result<RuntimeProcess, String> {
         let codex_bin = Self::resolve_codex_binary()?;
         let mut child = Command::new(&codex_bin)
-            .args(["app-server"])
+            .args(["app-server", "--listen", "stdio://"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -152,27 +150,42 @@ impl CodexState {
                 )
             })?;
 
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| "failed to capture codex stdin".to_string())?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| "failed to capture codex stdout".to_string())?;
-        let stderr = child
-            .stderr
-            .take()
-            .ok_or_else(|| "failed to capture codex stderr".to_string())?;
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                Self::stop_child(&mut child);
+                return Err("failed to capture codex stdin".to_string());
+            }
+        };
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                Self::stop_child(&mut child);
+                return Err("failed to capture codex stdout".to_string());
+            }
+        };
+        let stderr = match child.stderr.take() {
+            Some(stderr) => stderr,
+            None => {
+                Self::stop_child(&mut child);
+                return Err("failed to capture codex stderr".to_string());
+            }
+        };
 
-        let pending = Arc::clone(&self.pending);
-        let notifications = Arc::clone(&self.notifications);
-        std::thread::spawn(move || read_stdout_loop(stdout, pending, notifications));
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let notifications = Arc::new((Mutex::new(NotificationQueue::new()), Condvar::new()));
+        let pending_for_reader = Arc::clone(&pending);
+        let notifications_for_reader = Arc::clone(&notifications);
+        std::thread::spawn(move || {
+            read_stdout_loop(stdout, pending_for_reader, notifications_for_reader)
+        });
         std::thread::spawn(move || read_stderr_loop(stderr));
 
         Ok(RuntimeProcess {
             child,
             stdin: Arc::new(Mutex::new(stdin)),
+            pending,
+            notifications,
             initialized: false,
         })
     }
@@ -188,6 +201,37 @@ impl CodexState {
             .write_all(&line)
             .and_then(|_| guard.flush())
             .map_err(|e| format!("failed writing to codex app-server: {e}"))
+    }
+
+    fn child_exit_message(process: &mut RuntimeProcess) -> Option<String> {
+        match process.child.try_wait() {
+            Ok(Some(status)) => Some(format!("codex app-server exited with {status}")),
+            Ok(None) => None,
+            Err(error) => Some(format!("failed checking codex app-server: {error}")),
+        }
+    }
+
+    fn stop_child(child: &mut Child) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    fn stop_process(process: RuntimeProcess) {
+        let mut child = process.child;
+        Self::stop_child(&mut child);
+    }
+
+    fn discard_process(guard: &mut Option<RuntimeProcess>) {
+        if let Some(stale) = guard.take() {
+            Self::stop_process(stale);
+        }
+    }
+
+    fn is_transport_failure(error: &str) -> bool {
+        let error = error.to_ascii_lowercase();
+        error.contains("broken pipe")
+            || error.contains("failed writing to codex app-server")
+            || error.contains("codex app-server process exited")
     }
 
     fn ensure_process_locked<'a>(
@@ -208,9 +252,9 @@ impl CodexState {
         }
 
         let init_params = json!({
-            "protocolVersion": "1",
             "clientInfo": {
                 "name": "Glyph",
+                "title": "Glyph",
                 "version": "0.1.0"
             }
         });
@@ -218,7 +262,6 @@ impl CodexState {
         Self::write_line(
             process,
             &json!({
-                "jsonrpc": "2.0",
                 "method": "initialized",
                 "params": {}
             }),
@@ -237,7 +280,7 @@ impl CodexState {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel::<RpcReply>();
         {
-            let mut pending = self
+            let mut pending = process
                 .pending
                 .lock()
                 .map_err(|_| "pending map lock poisoned".to_string())?;
@@ -245,13 +288,12 @@ impl CodexState {
         }
 
         let msg = json!({
-            "jsonrpc": "2.0",
             "id": id,
             "method": method,
             "params": params,
         });
         if let Err(e) = Self::write_line(process, &msg) {
-            let mut pending = self
+            let mut pending = process
                 .pending
                 .lock()
                 .map_err(|_| "pending map lock poisoned".to_string())?;
@@ -263,7 +305,7 @@ impl CodexState {
             Ok(RpcReply::Result(v)) => Ok(v),
             Ok(RpcReply::Error(e)) => Err(e),
             Err(_) => {
-                let mut pending = self
+                let mut pending = process
                     .pending
                     .lock()
                     .map_err(|_| "pending map lock poisoned".to_string())?;
@@ -278,13 +320,58 @@ impl CodexState {
             .process
             .lock()
             .map_err(|_| "codex process lock poisoned".to_string())?;
-        let process = self.ensure_process_locked(&mut guard)?;
-        self.ensure_initialized_locked(process)?;
-        self.call_locked(process, method, params, timeout)
+
+        for attempt in 0..2 {
+            let exited = guard
+                .as_mut()
+                .and_then(Self::child_exit_message)
+                .map(|error| {
+                    debug!("{error}; restarting codex app-server");
+                })
+                .is_some();
+            if exited {
+                Self::discard_process(&mut guard);
+            }
+
+            let process = self.ensure_process_locked(&mut guard)?;
+            if let Err(error) = self.ensure_initialized_locked(process) {
+                if attempt == 0 && Self::is_transport_failure(&error) {
+                    debug!("{error}; restarting codex app-server");
+                    Self::discard_process(&mut guard);
+                    continue;
+                }
+                return Err(error);
+            }
+
+            let result = self.call_locked(process, method, params.clone(), timeout);
+            if let Err(error) = &result {
+                let child_exited = guard.as_mut().and_then(Self::child_exit_message).is_some();
+                if child_exited || Self::is_transport_failure(error) {
+                    Self::discard_process(&mut guard);
+                }
+            }
+            return result;
+        }
+
+        Err(format!(
+            "codex app-server unavailable while calling {method}"
+        ))
     }
 
     pub fn latest_notification_seq(&self) -> Result<u64, String> {
-        let (lock, _) = &*self.notifications;
+        let notifications = {
+            let guard = self
+                .process
+                .lock()
+                .map_err(|_| "codex process lock poisoned".to_string())?;
+            guard
+                .as_ref()
+                .map(|process| Arc::clone(&process.notifications))
+        };
+        let Some(notifications) = notifications else {
+            return Ok(0);
+        };
+        let (lock, _) = &*notifications;
         let queue = lock
             .lock()
             .map_err(|_| "codex notification lock poisoned".to_string())?;
@@ -296,7 +383,19 @@ impl CodexState {
         after_seq: u64,
         timeout: Duration,
     ) -> Result<Option<CodexNotification>, String> {
-        let (lock, cv) = &*self.notifications;
+        let notifications = {
+            let guard = self
+                .process
+                .lock()
+                .map_err(|_| "codex process lock poisoned".to_string())?;
+            guard
+                .as_ref()
+                .map(|process| Arc::clone(&process.notifications))
+        };
+        let Some(notifications) = notifications else {
+            return Ok(None);
+        };
+        let (lock, cv) = &*notifications;
         let mut queue = lock
             .lock()
             .map_err(|_| "codex notification lock poisoned".to_string())?;
@@ -316,10 +415,7 @@ impl CodexState {
 impl Drop for CodexState {
     fn drop(&mut self) {
         if let Ok(mut guard) = self.process.lock() {
-            if let Some(mut process) = guard.take() {
-                let _ = process.child.kill();
-                let _ = process.child.wait();
-            }
+            Self::discard_process(&mut guard);
         }
     }
 }
@@ -380,6 +476,14 @@ fn read_stdout_loop(
                 debug!("codex notification seq={seq} method={method}");
                 cv.notify_all();
             }
+        }
+    }
+
+    if let Ok(mut map) = pending.lock() {
+        for (_, tx) in map.drain() {
+            let _ = tx.send(RpcReply::Error(
+                "codex app-server process exited".to_string(),
+            ));
         }
     }
 

--- a/src-tauri/src/ai_codex/transport.rs
+++ b/src-tauri/src/ai_codex/transport.rs
@@ -1,25 +1,42 @@
 use serde_json::Value;
 use std::time::Duration;
+use tauri::{AppHandle, Manager};
 
 use super::state::{CodexNotification, CodexState};
 
-pub fn rpc_call(
-    state: &CodexState,
+pub async fn rpc_call(
+    app: AppHandle,
     method: &str,
     params: Value,
     timeout: Duration,
 ) -> Result<Value, String> {
-    state.call(method, params, timeout)
+    let method = method.to_string();
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<CodexState>();
+        state.call(&method, params, timeout)
+    })
+    .await
+    .map_err(|error| format!("codex RPC task failed: {error}"))?
 }
 
-pub fn latest_seq(state: &CodexState) -> Result<u64, String> {
-    state.latest_notification_seq()
+pub async fn latest_seq(app: AppHandle) -> Result<u64, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<CodexState>();
+        state.latest_notification_seq()
+    })
+    .await
+    .map_err(|error| format!("codex notification task failed: {error}"))?
 }
 
-pub fn wait_notification_after(
-    state: &CodexState,
+pub async fn wait_notification_after(
+    app: AppHandle,
     after_seq: u64,
     timeout: Duration,
 ) -> Result<Option<CodexNotification>, String> {
-    state.wait_notification_after(after_seq, timeout)
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<CodexState>();
+        state.wait_notification_after(after_seq, timeout)
+    })
+    .await
+    .map_err(|error| format!("codex notification task failed: {error}"))?
 }

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -358,7 +358,6 @@ pub async fn ai_chat_start(
 
     tauri::async_runtime::spawn(async move {
         let ai_state_for_task = app_for_task.state::<AiState>();
-        let codex_state = app_for_task.state::<crate::ai_codex::state::CodexState>();
 
         let api_key = local_secrets::secret_get(&space_root, &profile.id)
             .ok()
@@ -368,7 +367,6 @@ pub async fn ai_chat_start(
 
         let mut result = run_request(
             &cancel,
-            codex_state.clone(),
             &app_for_task,
             &job_id_for_task,
             &profile,
@@ -385,7 +383,6 @@ pub async fn ai_chat_start(
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 result = run_request(
                     &cancel,
-                    codex_state.clone(),
                     &app_for_task,
                     &job_id_for_task,
                     &profile,
@@ -474,7 +471,6 @@ pub async fn ai_chat_history_get(
 #[allow(clippy::too_many_arguments)]
 pub async fn run_request(
     cancel: &CancellationToken,
-    codex_state: State<'_, crate::ai_codex::state::CodexState>,
     app: &AppHandle,
     job_id: &str,
     profile: &AiProfile,
@@ -487,16 +483,7 @@ pub async fn run_request(
 ) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
     if matches!(profile.provider, super::types::AiProviderKind::CodexChatgpt) {
         return crate::ai_codex::chat::run_with_codex(
-            codex_state,
-            cancel,
-            app,
-            job_id,
-            profile,
-            system,
-            messages,
-            mode,
-            space_root,
-            thread_id,
+            cancel, app, job_id, profile, system, messages, mode, space_root, thread_id,
         )
         .await;
     }

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -6,7 +6,7 @@ use super::helpers::{
 use super::local_secrets;
 use super::store::{ensure_default_profiles, read_store, store_path_for_space, write_store};
 use super::types::{AiModel, AiProviderKind, AiReasoningEffortOption};
-use crate::ai_codex::{state::CodexState, transport::rpc_call};
+use crate::ai_codex::transport::rpc_call;
 use crate::space::SpaceState;
 
 #[derive(serde::Deserialize)]
@@ -539,13 +539,14 @@ fn parse_codex_model_item(value: &serde_json::Value) -> Option<AiModel> {
     })
 }
 
-fn list_codex_models(codex_state: &CodexState) -> Result<Vec<AiModel>, String> {
+async fn list_codex_models(app: AppHandle) -> Result<Vec<AiModel>, String> {
     let result = rpc_call(
-        codex_state,
+        app,
         "model/list",
         serde_json::json!({}),
         std::time::Duration::from_secs(20),
-    )?;
+    )
+    .await?;
 
     let list = if let Some(arr) = result.as_array() {
         arr
@@ -570,7 +571,6 @@ fn list_codex_models(codex_state: &CodexState) -> Result<Vec<AiModel>, String> {
 #[tauri::command(rename_all = "snake_case")]
 pub async fn ai_models_list(
     app: AppHandle,
-    codex_state: State<'_, CodexState>,
     window: WebviewWindow,
     space_state: State<'_, SpaceState>,
     profile_id: String,
@@ -618,7 +618,7 @@ pub async fn ai_models_list(
         AiProviderKind::Openrouter => list_openrouter(&client, &profile, &api_key).await,
         AiProviderKind::Anthropic => list_anthropic(&client, &profile, &api_key).await,
         AiProviderKind::Gemini => list_gemini(&client, &profile, &api_key).await,
-        AiProviderKind::CodexChatgpt => list_codex_models(codex_state.inner()),
+        AiProviderKind::CodexChatgpt => list_codex_models(app).await,
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
         AiProviderKind::ClaudeCode => crate::ai_claude_code::list_models(&space_root, &profile),
         AiProviderKind::Opencode => crate::ai_opencode::list_models(&space_root).await,

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -267,7 +267,6 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 						: Date.now(),
 			})) as ToolTimelineEvent[];
 			toolEvents.setToolTimeline(restoredTimeline);
-			chat.setThreadId(jobId);
 			chat.setMessages(loaded.messages);
 			chat.clearError();
 		},

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -152,9 +152,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 			try {
 				clearDoneTimer();
 				const requestedThreadId = options?.body?.thread_id?.trim() ?? "";
-				const threadId =
-					requestedThreadId || activeThreadIdRef.current || crypto.randomUUID();
-				activeThreadIdRef.current = threadId;
+				const threadId = requestedThreadId || activeThreadIdRef.current;
+				if (threadId) activeThreadIdRef.current = threadId;
 				const systemPrompt = options?.body?.system_prompt?.trim() ?? "";
 				const requestMessages = asAiMessages([
 					...previousMessages,
@@ -241,7 +240,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					request: {
 						profile_id: profileId,
 						messages: requestMessages,
-						thread_id: threadId,
+						thread_id: threadId || undefined,
 						mode: options?.body?.mode ?? "create",
 						context: options?.body?.context || undefined,
 						context_manifest: options?.body?.context_manifest,


### PR DESCRIPTION
Closes {LINK TO GH ISSUE}


## Description

A clear and concise description of the PR.

Use this section for review hints, explanations or discussion points/todos.

- Summary of changes
  - Make Codex app-server startup and initialization resilient to exited processes and broken pipes.
  - Keep pending RPCs and notifications scoped to the active Codex process.
  - Stop sending fabricated/local Glyph IDs as Codex rollout IDs.
  - Keep blocking Codex process I/O off the Tauri async runtime workers.
- Reasoning
  - Prevents stale stdin writes and hanging requests after the Codex app-server exits.
  - Prevents "no rollout found for thread id" when Glyph history/job UUIDs are not valid Codex thread IDs.
- Additional context
  - Glyph currently starts a fresh Codex rollout per message and supplies the visible conversation as context; native Codex rollout persistence/resume is not part of this change.


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- Validation: `cargo check` passed.
- Targeted Rust formatting checks passed.
- `git diff --check` passed.
- No visual changes.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI conversation continuity when resuming or starting chats.
  * Prevented unnecessary thread creation when no existing thread is available.
  * Improved recovery from AI service process exits and communication failures.
  * Preserved chat history and tool activity without incorrectly changing the active thread.
* **Improvements**
  * AI account, login, logout, rate-limit, model-listing, and chat operations now use more reliable background communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->