### PR TITLE
Add default editor mode setting for opening notes (#363) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.8-alpha.3",
+	"version": "0.8.8-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -143,15 +143,8 @@ export function ExternalMarkdownWindow() {
 		let cancelled = false;
 		setLoading(true);
 
-		void loadSettings()
-			.then((settings) => {
-				if (!cancelled) setMode(settings.editor.defaultEditorMode);
-			})
-			.catch(() => {
-				// Keep the built-in default mode when settings are unavailable.
-			});
-
 		void (async () => {
+			const settingsPromise = loadSettings().catch(() => null);
 			try {
 				const absPath = await invoke("external_markdown_window_path");
 				if (cancelled) return;
@@ -171,6 +164,14 @@ export function ExternalMarkdownWindow() {
 					path: absPath,
 				});
 				if (cancelled) return;
+
+				const settings = await settingsPromise;
+				if (cancelled) return;
+				// Keep the built-in default when settings are unavailable.
+				if (settings) {
+					setMode(settings.editor.defaultEditorMode);
+				}
+
 				textRef.current = doc.text;
 				savedTextRef.current = doc.text;
 				mtimeRef.current = doc.mtime_ms;

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -1,8 +1,12 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
-import type { EditorViewMode } from "../../lib/editorMode";
+import {
+	type EditorViewMode,
+	getDefaultEditorViewMode,
+} from "../../lib/editorMode";
 import { extractErrorMessage } from "../../lib/errorUtils";
+import { loadSettings } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import {
@@ -41,7 +45,7 @@ export function ExternalMarkdownWindow() {
 	const [title, setTitle] = useState("Markdown File");
 	const [text, setText] = useState("");
 	const [savedText, setSavedText] = useState("");
-	const [mode, setMode] = useState<EditorViewMode>("rich");
+	const [mode, setMode] = useState<EditorViewMode>(getDefaultEditorViewMode);
 	const [error, setError] = useState("");
 	const textRef = useRef("");
 	const savedTextRef = useRef("");
@@ -138,6 +142,14 @@ export function ExternalMarkdownWindow() {
 		mountedRef.current = true;
 		let cancelled = false;
 		setLoading(true);
+
+		void loadSettings()
+			.then((settings) => {
+				if (!cancelled) setMode(settings.editor.defaultEditorMode);
+			})
+			.catch(() => {
+				// Keep the built-in default mode when settings are unavailable.
+			});
 
 		void (async () => {
 			try {

--- a/src/components/preview/editorModeSelection.ts
+++ b/src/components/preview/editorModeSelection.ts
@@ -1,3 +1,4 @@
+import { getDefaultEditorViewMode } from "../../lib/editorMode";
 import type { NoteInlineEditorMode } from "../editor/types";
 
 const LARGE_NOTE_RICH_EDITOR_LIMIT = 100_000;
@@ -7,5 +8,7 @@ export function requiresPlainEditorMode(markdown: string): boolean {
 }
 
 export function initialEditorMode(markdown: string): NoteInlineEditorMode {
-	return requiresPlainEditorMode(markdown) ? "plain" : "rich";
+	return requiresPlainEditorMode(markdown)
+		? "plain"
+		: getDefaultEditorViewMode();
 }

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -27,6 +27,7 @@ vi.mock("../../lib/settings", () => ({
 				showCollapsibleHeadings: false,
 				spellCheck: true,
 				rawMarkdownVimMode: false,
+				defaultEditorMode: "rich",
 			},
 		}),
 	),
@@ -38,6 +39,7 @@ vi.mock("../../lib/settings", () => ({
 	setEditorShowCollapsibleHeadings: vi.fn(() => Promise.resolve()),
 	setEditorSpellCheck: vi.fn(() => Promise.resolve()),
 	setEditorRawMarkdownVimMode: vi.fn(() => Promise.resolve()),
+	setEditorDefaultEditorMode: vi.fn(() => Promise.resolve()),
 	setShowFileTreeFolderCounts: vi.fn(() => Promise.resolve()),
 	setShowNonMarkdownFiles: vi.fn(() => Promise.resolve()),
 }));

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -4,10 +4,12 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { type AppLanguage, LANGUAGE_OPTIONS } from "../../i18n/locales";
+import { type EditorViewMode, isEditorViewMode } from "../../lib/editorMode";
 import { GLYPH_LINKS } from "../../lib/helpMenu";
 import {
 	loadSettings,
 	setEditorColorfulHeadings,
+	setEditorDefaultEditorMode,
 	setEditorRawMarkdownVimMode,
 	setEditorShowCollapsibleHeadings,
 	setEditorShowFrontmatterInEditor,
@@ -29,6 +31,12 @@ import {
 } from "./SettingsScaffold";
 import { SettingsSelect } from "./SettingsSelect";
 import { applyIfBoolean, useSettingsBoolean } from "./useSettingsBoolean";
+
+const DEFAULT_EDITOR_MODE_VALUES = [
+	"rich",
+	"preview",
+	"plain",
+] as const satisfies readonly EditorViewMode[];
 
 function VimModeInfo() {
 	const { t } = useTranslation("settings.general");
@@ -63,6 +71,10 @@ export function GeneralSettingsPane() {
 	const { t } = useTranslation("settings.general");
 	const [error, setError] = useState("");
 	const [language, setLanguageState] = useState<AppLanguage>("en");
+	const [defaultEditorMode, setDefaultEditorModeState] =
+		useState<EditorViewMode>("rich");
+	const [isSavingDefaultEditorMode, setIsSavingDefaultEditorMode] =
+		useState(false);
 	const resumeLastSession = useSettingsBoolean(
 		false,
 		setResumeLastSession,
@@ -118,6 +130,7 @@ export function GeneralSettingsPane() {
 			.then((settings) => {
 				if (cancelled) return;
 				setLanguageState(settings.ui.language);
+				setDefaultEditorModeState(settings.editor.defaultEditorMode);
 				setResumeLastSessionChecked(settings.ui.resumeLastSession);
 				setShowTocChecked(settings.ui.showToc);
 				setShowFrontmatterChecked(settings.editor.showFrontmatterInEditor);
@@ -154,6 +167,9 @@ export function GeneralSettingsPane() {
 			(payload) => {
 				if (payload.ui?.language) {
 					setLanguageState(payload.ui.language);
+				}
+				if (isEditorViewMode(payload.editor?.defaultEditorMode)) {
+					setDefaultEditorModeState(payload.editor.defaultEditorMode);
 				}
 				applyIfBoolean(
 					payload.ui?.resumeLastSession,
@@ -235,6 +251,41 @@ export function GeneralSettingsPane() {
 					title={t("editor.sectionTitle")}
 					description={t("editor.sectionDescription")}
 				>
+					<SettingsRow
+						label={t("editor.defaultEditorMode.label")}
+						description={t("editor.defaultEditorMode.description")}
+						interactive={false}
+					>
+						<SettingsSelect
+							aria-label={t("editor.defaultEditorMode.ariaLabel")}
+							value={defaultEditorMode}
+							disabled={isSavingDefaultEditorMode}
+							onChange={(event) => {
+								const nextMode = event.currentTarget.value;
+								if (!isEditorViewMode(nextMode)) return;
+								const previous = defaultEditorMode;
+								setError("");
+								setDefaultEditorModeState(nextMode);
+								setIsSavingDefaultEditorMode(true);
+								void setEditorDefaultEditorMode(nextMode)
+									.catch((cause) => {
+										setDefaultEditorModeState(previous);
+										setError(
+											cause instanceof Error ? cause.message : String(cause),
+										);
+									})
+									.finally(() => {
+										setIsSavingDefaultEditorMode(false);
+									});
+							}}
+						>
+							{DEFAULT_EDITOR_MODE_VALUES.map((value) => (
+								<option key={value} value={value}>
+									{t(`editor.defaultEditorMode.options.${value}`)}
+								</option>
+							))}
+						</SettingsSelect>
+					</SettingsRow>
 					<SettingsRow
 						label={t("editor.tableOfContents.label")}
 						description={t("editor.tableOfContents.description")}

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -1,10 +1,14 @@
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { type AppLanguage, LANGUAGE_OPTIONS } from "../../i18n/locales";
-import { type EditorViewMode, isEditorViewMode } from "../../lib/editorMode";
+import {
+	type EditorViewMode,
+	getDefaultEditorViewMode,
+	isEditorViewMode,
+} from "../../lib/editorMode";
 import { GLYPH_LINKS } from "../../lib/helpMenu";
 import {
 	loadSettings,
@@ -72,9 +76,10 @@ export function GeneralSettingsPane() {
 	const [error, setError] = useState("");
 	const [language, setLanguageState] = useState<AppLanguage>("en");
 	const [defaultEditorMode, setDefaultEditorModeState] =
-		useState<EditorViewMode>("rich");
+		useState<EditorViewMode>(getDefaultEditorViewMode);
 	const [isSavingDefaultEditorMode, setIsSavingDefaultEditorMode] =
 		useState(false);
+	const defaultEditorModeEpochRef = useRef(0);
 	const resumeLastSession = useSettingsBoolean(
 		false,
 		setResumeLastSession,
@@ -125,12 +130,15 @@ export function GeneralSettingsPane() {
 
 	useEffect(() => {
 		let cancelled = false;
+		const defaultEditorModeEpoch = defaultEditorModeEpochRef.current;
 		setError("");
 		void loadSettings()
 			.then((settings) => {
 				if (cancelled) return;
 				setLanguageState(settings.ui.language);
-				setDefaultEditorModeState(settings.editor.defaultEditorMode);
+				if (defaultEditorModeEpoch === defaultEditorModeEpochRef.current) {
+					setDefaultEditorModeState(settings.editor.defaultEditorMode);
+				}
 				setResumeLastSessionChecked(settings.ui.resumeLastSession);
 				setShowTocChecked(settings.ui.showToc);
 				setShowFrontmatterChecked(settings.editor.showFrontmatterInEditor);
@@ -319,6 +327,7 @@ export function GeneralSettingsPane() {
 								const nextMode = event.currentTarget.value;
 								if (!isEditorViewMode(nextMode)) return;
 								const previous = defaultEditorMode;
+								defaultEditorModeEpochRef.current += 1;
 								setError("");
 								setDefaultEditorModeState(nextMode);
 								setIsSavingDefaultEditorMode(true);

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -252,41 +252,6 @@ export function GeneralSettingsPane() {
 					description={t("editor.sectionDescription")}
 				>
 					<SettingsRow
-						label={t("editor.defaultEditorMode.label")}
-						description={t("editor.defaultEditorMode.description")}
-						interactive={false}
-					>
-						<SettingsSelect
-							aria-label={t("editor.defaultEditorMode.ariaLabel")}
-							value={defaultEditorMode}
-							disabled={isSavingDefaultEditorMode}
-							onChange={(event) => {
-								const nextMode = event.currentTarget.value;
-								if (!isEditorViewMode(nextMode)) return;
-								const previous = defaultEditorMode;
-								setError("");
-								setDefaultEditorModeState(nextMode);
-								setIsSavingDefaultEditorMode(true);
-								void setEditorDefaultEditorMode(nextMode)
-									.catch((cause) => {
-										setDefaultEditorModeState(previous);
-										setError(
-											cause instanceof Error ? cause.message : String(cause),
-										);
-									})
-									.finally(() => {
-										setIsSavingDefaultEditorMode(false);
-									});
-							}}
-						>
-							{DEFAULT_EDITOR_MODE_VALUES.map((value) => (
-								<option key={value} value={value}>
-									{t(`editor.defaultEditorMode.options.${value}`)}
-								</option>
-							))}
-						</SettingsSelect>
-					</SettingsRow>
-					<SettingsRow
 						label={t("editor.tableOfContents.label")}
 						description={t("editor.tableOfContents.description")}
 					>
@@ -340,6 +305,41 @@ export function GeneralSettingsPane() {
 							ariaLabel={t("editor.spellCheck.ariaLabel")}
 							onCheckedChange={spellCheck.onCheckedChange}
 						/>
+					</SettingsRow>
+					<SettingsRow
+						label={t("editor.defaultEditorMode.label")}
+						description={t("editor.defaultEditorMode.description")}
+						interactive={false}
+					>
+						<SettingsSelect
+							aria-label={t("editor.defaultEditorMode.ariaLabel")}
+							value={defaultEditorMode}
+							disabled={isSavingDefaultEditorMode}
+							onChange={(event) => {
+								const nextMode = event.currentTarget.value;
+								if (!isEditorViewMode(nextMode)) return;
+								const previous = defaultEditorMode;
+								setError("");
+								setDefaultEditorModeState(nextMode);
+								setIsSavingDefaultEditorMode(true);
+								void setEditorDefaultEditorMode(nextMode)
+									.catch((cause) => {
+										setDefaultEditorModeState(previous);
+										setError(
+											cause instanceof Error ? cause.message : String(cause),
+										);
+									})
+									.finally(() => {
+										setIsSavingDefaultEditorMode(false);
+									});
+							}}
+						>
+							{DEFAULT_EDITOR_MODE_VALUES.map((value) => (
+								<option key={value} value={value}>
+									{t(`editor.defaultEditorMode.options.${value}`)}
+								</option>
+							))}
+						</SettingsSelect>
 					</SettingsRow>
 					<SettingsRow
 						title={t("editor.vimMode.title")}

--- a/src/i18n/locales/de/settings.general.json
+++ b/src/i18n/locales/de/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "Editor",
 		"sectionDescription": "Steuerung für Bearbeitungsverhalten und Notizstruktur in Glyph.",
+		"defaultEditorMode": {
+			"label": "Standard-Editormodus",
+			"description": "Wie Notizen standardmäßig geöffnet werden: Rich zum Bearbeiten, Vorschau als Nur-Lesen-Ansicht oder Raw für reines Markdown.",
+			"ariaLabel": "Standard-Editormodus",
+			"options": {
+				"rich": "Rich (Bearbeiten)",
+				"preview": "Vorschau (nur lesen)",
+				"plain": "Raw Markdown"
+			}
+		},
 		"tableOfContents": {
 			"label": "Inhaltsverzeichnis",
 			"description": "Ein schwebendes Inhaltsverzeichnis für jede Notiz anzeigen.",

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "Editor",
 		"sectionDescription": "Controls for editing behavior and note structure inside Glyph.",
+		"defaultEditorMode": {
+			"label": "Default editor mode",
+			"description": "How notes open by default: Rich for editing, Preview for read-only viewing, or Raw for plain Markdown.",
+			"ariaLabel": "Default editor mode",
+			"options": {
+				"rich": "Rich (editing)",
+				"preview": "Preview (read-only)",
+				"plain": "Raw Markdown"
+			}
+		},
 		"tableOfContents": {
 			"label": "Table of contents",
 			"description": "Show a floating table of contents for each note.",

--- a/src/i18n/locales/es/settings.general.json
+++ b/src/i18n/locales/es/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "Editor",
 		"sectionDescription": "Controles del comportamiento de edición y la estructura de las notas en Glyph.",
+		"defaultEditorMode": {
+			"label": "Modo de editor predeterminado",
+			"description": "Cómo se abren las notas de forma predeterminada: Enriquecido para editar, Vista previa para solo lectura o Sin formato para Markdown puro.",
+			"ariaLabel": "Modo de editor predeterminado",
+			"options": {
+				"rich": "Enriquecido (edición)",
+				"preview": "Vista previa (solo lectura)",
+				"plain": "Markdown sin formato"
+			}
+		},
 		"tableOfContents": {
 			"label": "Tabla de contenidos",
 			"description": "Mostrar una tabla de contenidos flotante en cada nota.",

--- a/src/i18n/locales/fr/settings.general.json
+++ b/src/i18n/locales/fr/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "Éditeur",
 		"sectionDescription": "Contrôles du comportement d’édition et de la structure des notes dans Glyph.",
+		"defaultEditorMode": {
+			"label": "Mode d’éditeur par défaut",
+			"description": "Comment les notes s’ouvrent par défaut : Enrichi pour modifier, Aperçu en lecture seule ou Brut pour le Markdown pur.",
+			"ariaLabel": "Mode d’éditeur par défaut",
+			"options": {
+				"rich": "Enrichi (édition)",
+				"preview": "Aperçu (lecture seule)",
+				"plain": "Markdown brut"
+			}
+		},
 		"tableOfContents": {
 			"label": "Table des matières",
 			"description": "Afficher une table des matières flottante pour chaque note.",

--- a/src/i18n/locales/ja/settings.general.json
+++ b/src/i18n/locales/ja/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "エディタ",
 		"sectionDescription": "Glyph 内の編集動作とノート構造のコントロールです。",
+		"defaultEditorMode": {
+			"label": "デフォルトのエディタモード",
+			"description": "ノートを開くときのデフォルトモード：編集用のリッチ、読み取り専用のプレビュー、またはプレーンMarkdownのRaw。",
+			"ariaLabel": "デフォルトのエディタモード",
+			"options": {
+				"rich": "リッチ（編集）",
+				"preview": "プレビュー（読み取り専用）",
+				"plain": "Raw Markdown"
+			}
+		},
 		"tableOfContents": {
 			"label": "目次",
 			"description": "各ノートにフローティングの目次を表示します。",

--- a/src/i18n/locales/ko/settings.general.json
+++ b/src/i18n/locales/ko/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "편집기",
 		"sectionDescription": "Glyph 내 편집 동작과 노트 구조에 대한 제어입니다.",
+		"defaultEditorMode": {
+			"label": "기본 편집기 모드",
+			"description": "노트를 열 때 기본 모드: 편집용 리치, 읽기 전용 미리보기 또는 일반 Markdown용 Raw.",
+			"ariaLabel": "기본 편집기 모드",
+			"options": {
+				"rich": "리치(편집)",
+				"preview": "미리보기(읽기 전용)",
+				"plain": "Raw Markdown"
+			}
+		},
 		"tableOfContents": {
 			"label": "목차",
 			"description": "각 노트에 떠 있는 목차를 표시합니다.",

--- a/src/i18n/locales/pt-BR/settings.general.json
+++ b/src/i18n/locales/pt-BR/settings.general.json
@@ -27,6 +27,16 @@
 	"editor": {
 		"sectionTitle": "Editor",
 		"sectionDescription": "Controles do comportamento de edição e da estrutura das notas no Glyph.",
+		"defaultEditorMode": {
+			"label": "Modo de editor padrão",
+			"description": "Como as notas abrem por padrão: Rico para editar, Pré-visualização para somente leitura ou Bruto para Markdown puro.",
+			"ariaLabel": "Modo de editor padrão",
+			"options": {
+				"rich": "Rico (edição)",
+				"preview": "Pré-visualização (somente leitura)",
+				"plain": "Markdown bruto"
+			}
+		},
 		"tableOfContents": {
 			"label": "Sumário",
 			"description": "Mostrar um sumário flutuante em cada nota.",

--- a/src/lib/editorMode.ts
+++ b/src/lib/editorMode.ts
@@ -1,1 +1,24 @@
 export type EditorViewMode = "plain" | "rich" | "preview";
+
+const EDITOR_VIEW_MODES = new Set<EditorViewMode>(["plain", "rich", "preview"]);
+
+export const DEFAULT_EDITOR_VIEW_MODE: EditorViewMode = "rich";
+
+export function isEditorViewMode(value: unknown): value is EditorViewMode {
+	return (
+		typeof value === "string" && EDITOR_VIEW_MODES.has(value as EditorViewMode)
+	);
+}
+
+// Cached copy of the persisted `editor.defaultEditorMode` setting so note
+// panes can pick their initial mode synchronously at mount. Hydrated by
+// `loadSettings()` and kept fresh by `setEditorDefaultEditorMode()`.
+let cachedDefaultEditorViewMode: EditorViewMode = DEFAULT_EDITOR_VIEW_MODE;
+
+export function getDefaultEditorViewMode(): EditorViewMode {
+	return cachedDefaultEditorViewMode;
+}
+
+export function setCachedDefaultEditorViewMode(mode: EditorViewMode): void {
+	cachedDefaultEditorViewMode = mode;
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,6 +5,12 @@ import {
 	ATTACHMENT_MODE_UI,
 	DEFAULT_ATTACHMENT_FOLDER,
 } from "./attachmentStorage";
+import {
+	DEFAULT_EDITOR_VIEW_MODE,
+	type EditorViewMode,
+	isEditorViewMode,
+	setCachedDefaultEditorViewMode,
+} from "./editorMode";
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
 import { type AppLanguage, normalizeAppLanguage } from "../i18n/locales";
 import {
@@ -181,6 +187,7 @@ interface EditorSettings {
 	colorfulHeadings: boolean;
 	beautifulTags: boolean;
 	editorWidthMode: EditorWidthMode;
+	defaultEditorMode: EditorViewMode;
 	attachmentStorageMode: AttachmentStorageMode;
 	attachmentFolder: string | null;
 	enablePeopleMentionsAsTags: boolean;
@@ -220,6 +227,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	colorfulHeadings: false,
 	beautifulTags: false,
 	editorWidthMode: "compact",
+	defaultEditorMode: DEFAULT_EDITOR_VIEW_MODE,
 	attachmentStorageMode: "note-folder",
 	attachmentFolder: DEFAULT_ATTACHMENT_FOLDER,
 	enablePeopleMentionsAsTags: false,
@@ -289,6 +297,12 @@ function asEditorWidthMode(value: unknown): EditorWidthMode {
 		EDITOR_WIDTH_MODES.has(value as EditorWidthMode)
 		? (value as EditorWidthMode)
 		: DEFAULT_EDITOR_SETTINGS.editorWidthMode;
+}
+
+function asDefaultEditorMode(value: unknown): EditorViewMode {
+	return isEditorViewMode(value)
+		? value
+		: DEFAULT_EDITOR_SETTINGS.defaultEditorMode;
 }
 
 function asUiAccent(value: unknown): UiAccent {
@@ -413,6 +427,7 @@ async function emitSettingsUpdated(payload: {
 		colorfulHeadings?: boolean;
 		beautifulTags?: boolean;
 		editorWidthMode?: EditorWidthMode;
+		defaultEditorMode?: EditorViewMode;
 		attachmentStorageMode?: AttachmentStorageMode;
 		attachmentFolder?: string | null;
 		enablePeopleMentionsAsTags?: boolean;
@@ -553,6 +568,7 @@ const KEYS = {
 	editorColorfulHeadings: "editor.colorfulHeadings",
 	editorBeautifulTags: "editor.beautifulTags",
 	editorEditorWidthMode: "editor.editorWidthMode",
+	editorDefaultEditorMode: "editor.defaultEditorMode",
 	editorAttachmentStorageMode: "editor.attachmentStorageMode",
 	editorAttachmentFolder: "editor.attachmentFolder",
 	editorEnablePeopleMentionsAsTags: "editor.enablePeopleMentionsAsTags",
@@ -918,6 +934,10 @@ export async function loadSettings(
 		entries,
 		KEYS.editorEditorWidthMode,
 	);
+	const rawEditorDefaultEditorMode = getSettingValue(
+		entries,
+		KEYS.editorDefaultEditorMode,
+	);
 	const rawEditorAttachmentStorageMode = getSettingValue(
 		entries,
 		KEYS.editorAttachmentStorageMode,
@@ -1068,6 +1088,7 @@ export async function loadSettings(
 				? rawEditorBeautifulTags
 				: DEFAULT_EDITOR_SETTINGS.beautifulTags,
 		editorWidthMode: asEditorWidthMode(rawEditorWidthMode),
+		defaultEditorMode: asDefaultEditorMode(rawEditorDefaultEditorMode),
 		attachmentStorageMode,
 		attachmentFolder,
 		enablePeopleMentionsAsTags:
@@ -1089,6 +1110,7 @@ export async function loadSettings(
 				? rawDatabaseShowColumnColor
 				: DEFAULT_DATABASE_SETTINGS.showColumnColor,
 	};
+	setCachedDefaultEditorViewMode(editor.defaultEditorMode);
 	return {
 		currentSpacePath,
 		recentSpaces: Array.isArray(recentSpaces) ? recentSpaces : [],
@@ -1508,6 +1530,19 @@ export async function setEditorShowFrontmatterInEditor(
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
 		editor: { showFrontmatterInEditor: enabled },
+	});
+}
+
+export async function setEditorDefaultEditorMode(
+	mode: EditorViewMode,
+): Promise<void> {
+	const store = await getSettingsStore();
+	const next = asDefaultEditorMode(mode);
+	await store.set(KEYS.editorDefaultEditorMode, next);
+	await saveSettingsStore(store);
+	setCachedDefaultEditorViewMode(next);
+	void emitSettingsUpdated({
+		editor: { defaultEditorMode: next },
 	});
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
+import type { EditorViewMode } from "./editorMode";
 import type {
 	AppLanguage,
 	AttachmentStorageMode,
@@ -104,6 +105,7 @@ type TauriEventMap = {
 			colorfulHeadings?: boolean;
 			beautifulTags?: boolean;
 			editorWidthMode?: EditorWidthMode;
+			defaultEditorMode?: EditorViewMode;
 			attachmentStorageMode?: AttachmentStorageMode;
 			attachmentFolder?: string | null;
 			enablePeopleMentionsAsTags?: boolean;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/362


## Description

Adds a General settings option so notes can open in rich, preview, or raw mode by default, instead of always starting in edit.

Use this section for review hints, explanations or discussion points/todos.

- Summary of changes
  - Persist a default editor mode (`rich` / `preview` / `raw`) in settings
  - Apply that mode when opening notes (including external markdown windows)
  - Expose the control in General settings (above Vim Mode), with i18n across locales
- Reasoning
  - Users who mostly edit via the AI agent want to open notes in view/preview by default to avoid accidental modifications (issue #362)
- Additional context
  - Default remains rich/edit so existing behavior is unchanged unless the user opts in


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- Setting lives under **General → Default editor mode**
- Values: rich (edit), preview, raw
- Stored via existing settings persistence; applied on note open


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a General setting to choose the default editor mode when opening notes, with a cached sync default so panes open in the right mode. Applies to note panes and external Markdown windows; also bumps app version to `0.8.8-alpha.4`.

- **New Features**
  - Added General → Default editor mode (`rich` | `preview` | `plain`) above Vim Mode.
  - Persisted the setting and read a cached value synchronously at mount; updates broadcast via Tauri events.
  - Applied the mode on note open, including external Markdown windows; large notes still switch to `plain`.
  - Added i18n copy for all supported locales.

- **Bug Fixes**
  - Fixed races on open and settings load to prevent mode flicker or mismatches; external Markdown windows now hydrate the mode from settings when available.

<sup>Written for commit 1559d9c13cb8b9f4034954e825a2c9983512a24f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose the default note-opening mode: rich editing, read-only preview, or plain Markdown.
  * New default mode is applied when opening notes and external Markdown content.
  * Settings changes are saved automatically and synchronized across windows.

* **Localization**
  * Added translations for the new setting in English, German, Spanish, French, Japanese, Korean, and Portuguese (Brazil).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->