### PR TITLE
Polish database and sidebar UI

### DIFF
--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -14,7 +14,6 @@ import {
 	tagIconOverridesFromAppearance,
 } from "../lib/tagIcons";
 import type { PersonCount, TagAppearance, TagCount } from "../lib/tauri";
-import { ChevronDown, ChevronRight } from "./Icons";
 import { TagIconPicker } from "./TagIconPicker";
 import { springPresets } from "./ui/animations";
 
@@ -126,11 +125,6 @@ export const TagsPane = memo(function TagsPane({
 					aria-label={sectionExpanded ? t("tags.collapse") : t("tags.expand")}
 				>
 					<span>{t("tags.header")}</span>
-					{sectionExpanded ? (
-						<ChevronDown size="var(--icon-xs)" className="tagsHeaderChevron" />
-					) : (
-						<ChevronRight size="var(--icon-xs)" className="tagsHeaderChevron" />
-					)}
 				</button>
 			</div>
 			{!sectionExpanded ? null : rows.length ? (

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -31,7 +31,6 @@ import { isFileTreeSortMode } from "../../lib/settings";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
 import type { FsEntry } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
-import { ChevronDown, ChevronRight } from "../Icons";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
 import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
@@ -505,17 +504,6 @@ export const SidebarContent = memo(function SidebarContent({
 									}
 								>
 									<span>{t("sidebar.notes")}</span>
-									{notesExpanded ? (
-										<ChevronDown
-											size="var(--icon-xs)"
-											className="sidebarStackHeaderChevron"
-										/>
-									) : (
-										<ChevronRight
-											size="var(--icon-xs)"
-											className="sidebarStackHeaderChevron"
-										/>
-									)}
 								</button>
 								<div className="sidebarStackHeaderActions">
 									<label className="sidebarStackHeaderSortNative">

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -48,7 +48,7 @@ import {
 import { buildDatabaseTagPickerOptions } from "./DatabaseTagPicker";
 import { formatDatabaseTagLabel } from "./databaseTagLabel";
 
-const DATABASE_CELL_PILL_GAP = 6;
+const DATABASE_CELL_PILL_GAP = 4;
 const DATABASE_CELL_TAG_SUGGESTION_LIMIT = 8;
 
 interface DatabaseCellProps {

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type GitCommitDiff,
@@ -39,6 +39,12 @@ export function GitHistorySidebar({
 	onSelectDiff,
 }: GitHistorySidebarProps) {
 	const latestDiffRequestId = useRef(0);
+	useEffect(
+		() => () => {
+			latestDiffRequestId.current += 1;
+		},
+		[],
+	);
 	const historyQuery = useQuery({
 		queryKey: ["git", "history", relPath],
 		queryFn: () =>

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,6 +1,5 @@
-import { GitCommitHorizontalIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type GitCommitDiff,
@@ -8,7 +7,6 @@ import {
 	invoke,
 } from "../../lib/tauri";
 import { cn } from "../../lib/utils";
-import { ChevronDown, ChevronRight } from "../Icons";
 
 interface GitHistorySidebarProps {
 	open: boolean;
@@ -17,74 +15,21 @@ interface GitHistorySidebarProps {
 	onSelectDiff: (diff: GitCommitDiff) => void;
 }
 
-interface GitHistoryGroup {
-	key: string;
-	label: string;
-	commits: GitHistoryCommit[];
-}
-
-function startOfDayMs(date: Date): number {
-	return new Date(
-		date.getFullYear(),
-		date.getMonth(),
-		date.getDate(),
-	).getTime();
-}
-
-function formatGroupLabel(timestampMs: number, nowMs: number): string {
-	if (!timestampMs) return "Earlier";
-	const date = new Date(timestampMs);
-	const dayMs = startOfDayMs(date);
-	const todayMs = startOfDayMs(new Date(nowMs));
-	const dayDelta = Math.round((todayMs - dayMs) / 86_400_000);
-	if (dayDelta === 0) return "Today";
-	if (dayDelta === 1) return "Yesterday";
-	return new Intl.DateTimeFormat(undefined, {
-		weekday: "long",
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	}).format(date);
-}
-
-function formatCommitDate(timestampMs: number, nowMs: number): string {
+function formatCommitDate(timestampMs: number): string {
 	if (!timestampMs) return "";
-	const elapsedMs = Math.max(0, nowMs - timestampMs);
-	const dayCount = Math.floor(elapsedMs / 86_400_000);
-	if (dayCount === 0) return "Today";
-	if (dayCount === 1) return "1d ago";
-	if (dayCount < 7) return `${dayCount}d ago`;
 	return new Intl.DateTimeFormat(undefined, {
 		month: "short",
 		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
 	}).format(new Date(timestampMs));
 }
 
-function groupHistoryCommits(
-	commits: GitHistoryCommit[],
-	nowMs: number,
-): GitHistoryGroup[] {
-	const groups = new Map<string, GitHistoryGroup>();
-	for (const commit of commits) {
-		const key = commit.timestamp_ms
-			? startOfDayMs(new Date(commit.timestamp_ms)).toString()
-			: "unknown";
-		const group = groups.get(key);
-		if (group) {
-			group.commits.push(commit);
-			continue;
-		}
-		groups.set(key, {
-			key,
-			label: formatGroupLabel(commit.timestamp_ms, nowMs),
-			commits: [commit],
-		});
-	}
-	return [...groups.values()];
-}
-
-function commitCountLabel(count: number): string {
-	return `${count} ${count === 1 ? "commit" : "commits"}`;
+function changeCounts(commit: GitHistoryCommit) {
+	return {
+		added: commit.added_count + commit.modified_count,
+		deleted: commit.deleted_count + commit.modified_count,
+	};
 }
 
 export function GitHistorySidebar({
@@ -93,214 +38,95 @@ export function GitHistorySidebar({
 	selectedCommitHash = null,
 	onSelectDiff,
 }: GitHistorySidebarProps) {
-	const [commits, setCommits] = useState<GitHistoryCommit[]>([]);
-	const [expandedGroupKeys, setExpandedGroupKeys] = useState<Set<string>>(
-		() => new Set(),
-	);
-	const [loading, setLoading] = useState(false);
-	const [loadingCommit, setLoadingCommit] = useState<string | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const diffRequestIdRef = useRef(0);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: recompute the reference time whenever commits change.
-	const nowMs = useMemo(() => Date.now(), [commits]);
-	const groups = useMemo(
-		() => groupHistoryCommits(commits, nowMs),
-		[commits, nowMs],
-	);
-
-	useEffect(() => {
-		return () => {
-			diffRequestIdRef.current += 1;
-		};
-	}, []);
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: reset history state when the active note path changes.
-	useEffect(() => {
-		diffRequestIdRef.current += 1;
-		setCommits([]);
-		setExpandedGroupKeys(new Set());
-		setError(null);
-	}, [relPath]);
-
-	useEffect(() => {
-		setExpandedGroupKeys(new Set(groups.map((group) => group.key)));
-	}, [groups]);
-
-	useEffect(() => {
-		if (!open || !relPath) return;
-		let cancelled = false;
-		setLoading(true);
-		setError(null);
-		void invoke("git_history_list", { path: relPath, limit: 40 })
-			.then((items) => {
-				if (cancelled) return;
-				setCommits(items);
-			})
-			.catch((cause: unknown) => {
-				if (cancelled) return;
-				setCommits([]);
-				setError(extractErrorMessage(cause));
-			})
-			.finally(() => {
-				if (!cancelled) setLoading(false);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [open, relPath]);
-
-	const noteName = useMemo(() => {
-		if (!relPath) return "Current note";
-		const segments = relPath.split("/").filter(Boolean);
-		return segments[segments.length - 1] ?? "Current note";
-	}, [relPath]);
-
-	const handleSelectCommit = useCallback(
-		async (commit: GitHistoryCommit) => {
-			if (!relPath) return;
-			const requestId = diffRequestIdRef.current + 1;
-			diffRequestIdRef.current = requestId;
-			setLoadingCommit(commit.hash);
-			setError(null);
-			try {
-				const diff = await invoke("git_history_diff", {
-					path: relPath,
-					commit,
-				});
-				if (diffRequestIdRef.current !== requestId) return;
-				onSelectDiff(diff);
-			} catch (cause) {
-				if (diffRequestIdRef.current !== requestId) return;
-				setError(extractErrorMessage(cause));
-			} finally {
-				if (diffRequestIdRef.current === requestId) {
-					setLoadingCommit(null);
-				}
-			}
+	const latestDiffRequestId = useRef(0);
+	const historyQuery = useQuery({
+		queryKey: ["git", "history", relPath],
+		queryFn: () =>
+			relPath ? invoke("git_history_list", { path: relPath, limit: 40 }) : [],
+		enabled: open && Boolean(relPath),
+		staleTime: 0,
+	});
+	const diffMutation = useMutation({
+		mutationFn: async (commit: GitHistoryCommit) => {
+			if (!relPath) throw new Error("No note is selected.");
+			const requestId = latestDiffRequestId.current + 1;
+			latestDiffRequestId.current = requestId;
+			const diff = await invoke("git_history_diff", { path: relPath, commit });
+			return { diff, requestId };
 		},
-		[onSelectDiff, relPath],
-	);
-
-	const toggleGroup = useCallback((key: string) => {
-		setExpandedGroupKeys((prev) => {
-			const next = new Set(prev);
-			if (next.has(key)) {
-				next.delete(key);
-			} else {
-				next.add(key);
-			}
-			return next;
-		});
-	}, []);
+		onSuccess: ({ diff, requestId }) => {
+			if (latestDiffRequestId.current === requestId) onSelectDiff(diff);
+		},
+	});
+	const commits = historyQuery.data ?? [];
+	const error = historyQuery.error ?? diffMutation.error;
 
 	return (
 		<section className="markdownEditorInfoSection gitHistoryPanel">
 			<header className="gitHistoryHeader">
-				<strong>Version history</strong>
-				<span>{noteName}</span>
+				<strong>Previous saves</strong>
+				<span>Select a version to review its changes.</span>
 			</header>
 			<div className="gitHistoryBody">
-				{loading ? (
-					<div className="markdownEditorInfoEmpty">Loading history</div>
+				{historyQuery.isLoading ? (
+					<div className="markdownEditorInfoEmpty">Loading versions</div>
 				) : null}
-				{error ? <div className="markdownEditorInfoEmpty">{error}</div> : null}
-				{!loading && !error && commits.length === 0 ? (
+				{error ? (
+					<div className="markdownEditorInfoEmpty">
+						{extractErrorMessage(error)}
+					</div>
+				) : null}
+				{!historyQuery.isLoading && !error && commits.length === 0 ? (
 					<div className="markdownEditorInfoEmpty">No saved versions yet.</div>
 				) : null}
-				{groups.length ? (
-					<div className="gitHistoryList">
-						{groups.map((group) => {
-							const isExpanded = expandedGroupKeys.has(group.key);
+				{commits.length ? (
+					<ol className="gitHistoryList">
+						{commits.map((commit) => {
+							const isSelected = selectedCommitHash === commit.hash;
+							const isLoading =
+								diffMutation.isPending &&
+								diffMutation.variables?.hash === commit.hash;
+							const changes = changeCounts(commit);
 							return (
-								<div className="gitHistoryGroup" key={group.key}>
+								<li className="gitHistoryEntry" key={commit.hash}>
 									<button
 										type="button"
-										className="gitHistoryGroupHeader"
-										onClick={() => toggleGroup(group.key)}
-										aria-expanded={isExpanded}
-									>
-										{isExpanded ? (
-											<ChevronDown size="var(--icon-sm)" />
-										) : (
-											<ChevronRight size="var(--icon-sm)" />
+										className={cn(
+											"gitHistoryItem",
+											isSelected && "gitHistoryItemSelected",
 										)}
-										<span>{group.label}</span>
-										<em>({commitCountLabel(group.commits.length)})</em>
+										onClick={() => diffMutation.mutate(commit)}
+										aria-pressed={isSelected}
+									>
+										<span className="gitHistoryContent">
+											<span className="gitHistorySubject">
+												{commit.subject || "Untitled version"}
+											</span>
+											<span className="gitHistoryMeta">
+												{isLoading
+													? "Opening changes…"
+													: formatCommitDate(commit.timestamp_ms)}
+											</span>
+											{changes.added > 0 || changes.deleted > 0 ? (
+												<span className="gitHistoryStats">
+													{changes.added > 0 ? (
+														<span className="gitHistoryStat gitHistoryStatAdd">
+															+{changes.added.toLocaleString()}
+														</span>
+													) : null}
+													{changes.deleted > 0 ? (
+														<span className="gitHistoryStat gitHistoryStatDelete">
+															-{changes.deleted.toLocaleString()}
+														</span>
+													) : null}
+												</span>
+											) : null}
+										</span>
 									</button>
-									{isExpanded ? (
-										<div className="gitHistoryGroupItems">
-											{group.commits.map((commit) => {
-												const isSelected = selectedCommitHash === commit.hash;
-												const isLoading = loadingCommit === commit.hash;
-												return (
-													<button
-														type="button"
-														key={commit.hash}
-														className={cn(
-															"gitHistoryItem",
-															isSelected && "gitHistoryItemSelected",
-														)}
-														onClick={() => void handleSelectCommit(commit)}
-														aria-pressed={isSelected}
-													>
-														<span
-															className="gitHistoryMarker"
-															aria-hidden="true"
-														>
-															<HugeiconsIcon
-																icon={GitCommitHorizontalIcon}
-																size="var(--icon-sm)"
-																strokeWidth={1.1}
-															/>
-														</span>
-														<span className="gitHistoryContent">
-															<span className="gitHistoryTopLine">
-																<span className="gitHistorySubject">
-																	{commit.subject || "Untitled version"}
-																</span>
-																<span className="gitHistoryHash">
-																	{commit.short_hash}
-																</span>
-																<ChevronRight
-																	size="var(--icon-sm)"
-																	className="gitHistoryOpenIcon"
-																/>
-															</span>
-															<span className="gitHistoryMeta">
-																<span>
-																	{formatCommitDate(commit.timestamp_ms, nowMs)}
-																</span>
-																{commit.added_count > 0 ? (
-																	<span className="gitHistoryStat gitHistoryStatAdd">
-																		+{commit.added_count.toLocaleString()}
-																	</span>
-																) : null}
-																{commit.modified_count > 0 ? (
-																	<span className="gitHistoryStat gitHistoryStatModify">
-																		~{commit.modified_count.toLocaleString()}
-																	</span>
-																) : null}
-																{commit.deleted_count > 0 ? (
-																	<span className="gitHistoryStat gitHistoryStatDelete">
-																		-{commit.deleted_count.toLocaleString()}
-																	</span>
-																) : null}
-															</span>
-														</span>
-														{isLoading ? (
-															<span className="gitHistoryLoading">
-																Opening diff
-															</span>
-														) : null}
-													</button>
-												);
-											})}
-										</div>
-									) : null}
-								</div>
+								</li>
 							);
 						})}
-					</div>
+					</ol>
 				) : null}
 			</div>
 		</section>

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -191,7 +191,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 								size="var(--icon-sm)"
 								strokeWidth={1}
 							/>
-							History
+							Version history
 						</button>
 					) : null}
 				</div>
@@ -444,6 +444,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 
 				{activeTab === "history" && hasGitHistoryTab && onSelectGitDiff ? (
 					<GitHistorySidebar
+						key={relPath}
 						open={open}
 						relPath={relPath}
 						selectedCommitHash={selectedGitCommitHash}

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -222,6 +222,14 @@
 	flex-shrink: 0;
 }
 
+.sidebarStackHeaderToggle,
+.tagsHeaderTitle {
+	font-size: var(--text-sm);
+	font-weight: var(--font-normal);
+	line-height: 1.3;
+	letter-spacing: normal;
+}
+
 .sidebarStackHeaderToggle {
 	appearance: none;
 	background: transparent;
@@ -234,8 +242,6 @@
 	text-align: left;
 	font: inherit;
 	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.9);
-	letter-spacing: 0.07em;
 	transition: color var(--transition-fast);
 	display: flex;
 	align-items: center;
@@ -324,11 +330,6 @@
 
 .sidebarStackHeaderSortSelect:focus {
 	box-shadow: none;
-}
-
-.sidebarStackHeaderChevron {
-	color: inherit;
-	flex-shrink: 0;
 }
 
 .sidebarStackItem {

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -85,7 +85,7 @@ button.tagsHeaderTitle:active {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
-	gap: var(--space-3);
+	gap: 6px;
 	padding: 1px 8px;
 	min-height: 28px;
 	border-radius: var(--radius-8);
@@ -136,14 +136,15 @@ button.tagsHeaderTitle:active {
 }
 
 .tagsIcon {
-	width: var(--icon-sm);
-	height: var(--icon-sm);
+	width: var(--icon-md);
+	height: var(--icon-md);
 }
 
-.tagsIconPicker {
-	width: var(--icon-xl);
-	height: var(--icon-xl);
-	margin-left: -3px;
+button.tagsIconPicker {
+	width: var(--icon-md);
+	height: var(--icon-md);
+	padding: 0;
+	margin-left: 0;
 	color: currentcolor;
 }
 

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -32,8 +32,6 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	font-size: calc(var(--text-base) * 0.9);
-	letter-spacing: 0.07em;
 	color: var(--text-tertiary);
 }
 
@@ -51,10 +49,8 @@ button.tagsHeaderTitle {
 	flex: 1;
 	cursor: pointer;
 	text-align: left;
-	font: inherit;
+	font-family: inherit;
 	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.9);
-	letter-spacing: 0.07em;
 	transition: color var(--transition-fast);
 	display: flex;
 	align-items: center;
@@ -69,11 +65,6 @@ button.tagsHeaderTitle:active {
 	box-shadow: none;
 	color: var(--text-secondary);
 	outline: none;
-}
-
-.tagsHeaderChevron {
-	color: inherit;
-	flex-shrink: 0;
 }
 
 .tagsList {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -465,7 +465,7 @@
 }
 
 .gitHistoryPanel {
-	padding-top: 2px;
+	padding-top: 8px;
 }
 
 .gitHistoryHeader {
@@ -473,7 +473,7 @@
 	flex-direction: column;
 	align-items: flex-start;
 	width: 100%;
-	padding: 2px 12px 10px;
+	padding: 2px 8px 14px;
 	color: var(--text-primary);
 	text-align: left;
 }
@@ -481,214 +481,116 @@
 .gitHistoryHeader strong {
 	font-size: var(--text-sm);
 	font-weight: var(--font-medium);
-	line-height: 1.1;
+	line-height: 1.2;
 	text-wrap: balance;
 }
 
 .gitHistoryHeader span {
 	max-width: 100%;
-	overflow: hidden;
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.76);
-	line-height: 1.6;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	line-height: 1.5;
+	text-wrap: pretty;
 }
 
 .gitHistoryBody {
-	padding: 0 0 4px;
+	padding: 0 2px 4px;
 }
 
 .gitHistoryList {
 	display: flex;
 	flex-direction: column;
-	margin: 0 -10px;
+	gap: 2px;
+	margin: 0;
+	padding: 0;
+	list-style: none;
 }
 
-.gitHistoryGroup {
-	display: flex;
-	flex-direction: column;
-	border-top: 1px solid color-mix(in srgb, var(--border-light) 70%, transparent);
-}
-
-.gitHistoryGroup:last-child {
-	border-bottom: 1px solid
-		color-mix(in srgb, var(--border-light) 70%, transparent);
-}
-
-.gitHistoryGroupHeader {
-	display: flex;
-	min-height: 38px;
-	width: 100%;
-	align-items: center;
-	gap: 8px;
-	padding: 0 20px;
-	border: 0;
-	background: color-mix(in srgb, var(--bg-secondary) 48%, transparent);
-	color: var(--text-secondary);
-	text-align: left;
-	cursor: pointer;
-}
-
-.gitHistoryGroupHeader:hover {
-	background: color-mix(in srgb, var(--bg-secondary) 64%, transparent);
-	color: var(--text-primary);
-}
-
-.gitHistoryGroupHeader:focus-visible {
-	outline: 2px solid var(--focus);
-	outline-offset: -2px;
-}
-
-.gitHistoryGroupHeader span {
-	min-width: 0;
-	overflow: hidden;
-	font-size: var(--text-sm);
-	font-weight: var(--font-medium);
-	line-height: 1.1;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.gitHistoryGroupHeader em {
-	flex: 0 0 auto;
-	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.78);
-	font-style: normal;
-	font-variant-numeric: tabular-nums;
-}
-
-.gitHistoryGroupItems {
-	display: flex;
-	flex-direction: column;
+.gitHistoryEntry {
+	position: relative;
 }
 
 .gitHistoryItem {
 	position: relative;
 	display: flex;
 	width: 100%;
-	min-height: 76px;
+	min-height: 40px;
 	align-items: center;
-	gap: 10px;
-	padding: 13px 18px 13px 20px;
+	padding: 6px 10px;
 	border: 0;
-	border-radius: 0;
+	border-radius: var(--radius-md);
 	background: transparent;
 	color: var(--text-primary);
 	text-align: left;
 	cursor: pointer;
-	transition: none;
+	transition: background-color 120ms ease, color 120ms ease;
 }
 
-.gitHistoryItem + .gitHistoryItem {
-	border-top: 1px solid color-mix(in srgb, var(--border-light) 58%, transparent);
-}
-
-.gitHistoryItem:hover,
-.gitHistoryItemSelected {
-	background: color-mix(in srgb, var(--bg-hover) 56%, transparent);
+.gitHistoryItem:hover {
+	background: color-mix(in srgb, var(--bg-hover) 38%, transparent);
 }
 
 .gitHistoryItem:focus-visible {
 	outline: 2px solid var(--focus);
-	outline-offset: -2px;
+	outline-offset: 1px;
 }
 
 .gitHistoryItemSelected {
 	background: color-mix(in srgb, var(--accent) 7%, var(--bg-hover));
 }
 
-.gitHistoryMarker {
-	display: inline-flex;
-	flex: 0 0 24px;
-	align-items: center;
-	justify-content: center;
-	width: 24px;
-	height: 24px;
-	border-radius: var(--radius-full);
-	color: var(--text-tertiary);
-	box-shadow: none;
-	transition: none;
-}
-
-.gitHistoryItem:hover .gitHistoryMarker,
-.gitHistoryItemSelected .gitHistoryMarker {
-	color: var(--text-primary);
+.gitHistoryItemSelected:hover {
+	background: color-mix(in srgb, var(--accent) 9%, var(--bg-hover));
 }
 
 .gitHistoryContent {
 	display: flex;
 	min-width: 0;
 	flex: 1;
-	flex-direction: column;
-	gap: 8px;
-}
-
-.gitHistoryTopLine {
-	display: grid;
-	min-width: 0;
-	grid-template-columns: minmax(0, 1fr) auto auto;
 	align-items: center;
-	gap: 8px;
+	gap: 10px;
 }
 
 .gitHistorySubject {
+	min-width: 0;
+	flex: 1;
 	overflow: hidden;
 	color: var(--text-primary);
-	font-size: calc(var(--text-base) * 0.96);
+	font-size: calc(var(--text-base) * 0.9);
 	font-weight: var(--font-medium);
-	line-height: 1.2;
+	line-height: 1.25;
 	text-overflow: ellipsis;
-	text-wrap: pretty;
 	white-space: nowrap;
 }
 
-.gitHistoryMeta {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px 10px;
-	color: var(--text-secondary);
-	font-size: calc(var(--text-base) * 0.82);
-	line-height: 1.15;
-	font-variant-numeric: tabular-nums;
-}
-
-.gitHistoryHash {
-	color: var(--accent);
-	font-family: var(--font-mono);
-	font-size: calc(var(--text-base) * 0.84);
-	font-variant-numeric: tabular-nums;
-	line-height: 1;
-	white-space: nowrap;
-}
-
-.gitHistoryOpenIcon {
+.gitHistoryStats {
+	display: inline-flex;
 	flex: 0 0 auto;
-	color: var(--text-tertiary);
+	align-items: center;
+	gap: 6px;
 }
 
 .gitHistoryStat {
+	flex: 0 0 auto;
+	font-size: calc(var(--text-base) * 0.82);
 	font-weight: var(--font-medium);
+	font-variant-numeric: tabular-nums;
+	line-height: 1.2;
 }
 
 .gitHistoryStatAdd {
 	color: color-mix(in srgb, #059669 82%, var(--text-primary));
 }
 
-.gitHistoryStatModify {
-	color: color-mix(in srgb, #d97706 86%, var(--text-primary));
-}
-
 .gitHistoryStatDelete {
 	color: color-mix(in srgb, #dc2626 84%, var(--text-primary));
 }
 
-.gitHistoryLoading {
-	position: absolute;
-	right: 18px;
-	bottom: 10px;
+.gitHistoryMeta {
 	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.74);
+	font-size: calc(var(--text-base) * 0.82);
+	line-height: 1.2;
+	font-variant-numeric: tabular-nums;
 }
 
 .markdownEditorInfoSection + .markdownEditorInfoSection {

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -123,10 +123,6 @@
 .databaseToolbarActions {
 	display: flex;
 	align-items: center;
-	gap: 10px;
-}
-
-.databaseToolbarActions {
 	gap: 3px;
 }
 

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -376,8 +376,7 @@
 	flex: 0 0 auto;
 	min-height: 24px;
 	padding: 0 8px;
-	border: 1px solid
-		color-mix(in srgb, var(--border-default) 76%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border-default) 76%, transparent);
 	border-radius: var(--pill-radius);
 	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
 	font-size: calc(var(--text-base) * 0.8);
@@ -401,8 +400,7 @@
 	flex: 0 0 auto;
 	min-height: 24px;
 	padding: 0 8px;
-	border: 1px solid
-		color-mix(in srgb, var(--border-default) 76%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border-default) 76%, transparent);
 	border-radius: var(--pill-radius);
 	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
 	font-size: calc(var(--text-base) * 0.8);

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -158,7 +158,7 @@
 .databaseBoardLaneTitle {
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-semibold);
-	color: color-mix(in srgb, white 92%, var(--text-primary));
+	color: color-mix(in srgb, var(--database-tone) 78%, var(--text-primary));
 	letter-spacing: 0.045em;
 	text-transform: uppercase;
 	line-height: 1;
@@ -166,7 +166,7 @@
 
 .databaseBoardLaneTitleIcon {
 	flex: 0 0 auto;
-	color: color-mix(in srgb, white 88%, var(--text-primary));
+	color: var(--database-tone);
 }
 
 .databaseBoardLaneTitleButton {
@@ -231,9 +231,9 @@
 	width: 100%;
 	min-width: 0;
 	height: auto;
-	gap: 7px;
-	padding: 11px 10px 10px;
-	border: none;
+	gap: 8px;
+	padding: 12px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 68%, transparent);
 	border-radius: var(--database-radius-md);
 	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
 	color: inherit;
@@ -243,7 +243,6 @@
 	justify-content: flex-start;
 	white-space: normal;
 	line-height: normal;
-	outline: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
 	overflow: hidden;
 	user-select: none;
 	-webkit-user-select: none;
@@ -252,17 +251,15 @@
 
 .databaseBoardCard[data-dragging="true"] {
 	opacity: 0.7;
-	outline-color: color-mix(in srgb, var(--interactive-accent) 38%, transparent);
+	border-color: color-mix(in srgb, var(--interactive-accent) 38%, transparent);
 }
 
 .databaseBoardCard[data-drop-target="true"] {
-	outline-color: color-mix(in srgb, var(--interactive-accent) 50%, transparent);
-	box-shadow: inset 0 2px 0
-		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	border-color: color-mix(in srgb, var(--interactive-accent) 50%, transparent);
 }
 
 .dark .databaseBoardCard {
-	background: var(--bg-tertiary);
+	background: color-mix(in srgb, var(--bg-primary) 84%, var(--bg-secondary));
 }
 
 .dark .databaseBoardCard[data-state="selected"] {
@@ -279,7 +276,7 @@
 		var(--interactive-accent) 7%,
 		var(--bg-primary)
 	);
-	outline-color: color-mix(in srgb, var(--interactive-accent) 46%, transparent);
+	border-color: color-mix(in srgb, var(--interactive-accent) 46%, transparent);
 }
 
 .databaseBoardCardTitle {
@@ -294,6 +291,7 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	white-space: normal;
+	text-wrap: balance;
 }
 
 .databaseBoardCardTitleIcon {
@@ -345,7 +343,8 @@
 .databaseBoardCardMetaRow {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
+	justify-content: flex-start;
+	flex-wrap: wrap;
 	gap: 8px;
 	min-width: 0;
 	overflow: hidden;
@@ -360,7 +359,7 @@
 }
 
 .databaseBoardCardMetaGroup.is-priority {
-	justify-content: flex-end;
+	justify-content: flex-start;
 }
 
 .databaseBoardCardTags {
@@ -375,7 +374,12 @@
 
 .databaseBoardCardStatus.propertyValueText {
 	flex: 0 0 auto;
-	height: auto;
+	min-height: 24px;
+	padding: 0 8px;
+	border: 1px solid
+		color-mix(in srgb, var(--border-default) 76%, transparent);
+	border-radius: var(--pill-radius);
+	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-medium);
 	line-height: 1.2;
@@ -395,10 +399,12 @@
 	gap: 3px;
 	max-width: 100%;
 	flex: 0 0 auto;
-	padding: 2px 6px;
-	border: 0;
-	border-radius: var(--radius-4);
-	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-secondary));
+	min-height: 24px;
+	padding: 0 8px;
+	border: 1px solid
+		color-mix(in srgb, var(--border-default) 76%, transparent);
+	border-radius: var(--pill-radius);
+	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: var(--font-medium);
 	line-height: 1.2;
@@ -409,7 +415,7 @@
 
 .databaseBoardTag.is-muted {
 	color: var(--text-tertiary);
-	background: color-mix(in srgb, var(--bg-secondary) 78%, transparent);
+	border-color: color-mix(in srgb, var(--border-default) 70%, transparent);
 	font-variant-numeric: tabular-nums;
 }
 
@@ -438,6 +444,10 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.databaseBoardCardTimestamp svg {
+	transform: translateY(-1px);
 }
 
 .databaseBoardCardTitleMeta .databaseBoardCardTimestamp {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -1,5 +1,5 @@
 .databaseTableShell {
-	--database-table-header-height: 42px;
+	--database-table-header-height: 34px;
 
 	flex: 1;
 	min-height: 0;

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -509,7 +509,8 @@
 	background: transparent;
 	color: var(--text-tertiary);
 	cursor: pointer;
-	transition: color var(--transition-fast), background-color var(--transition-fast);
+	transition: color var(--transition-fast), background-color
+		var(--transition-fast);
 }
 
 .databaseGroupAddButton svg {

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -18,12 +18,15 @@
 	isolation: isolate;
 }
 
-.databaseHeadCell {
+.databaseTable .databaseHeadCell {
 	position: sticky;
 	top: 0;
 	z-index: 7;
+	height: var(--database-table-header-height);
 	background: var(--bg-primary);
 	text-align: left;
+	padding-top: 0;
+	padding-bottom: 0;
 	padding-right: 10px;
 	border-bottom: 1px solid var(--border-light);
 	font-size: calc(var(--text-base) * 0.9);
@@ -40,10 +43,6 @@
 
 .databaseHeadCell:last-child {
 	padding-right: 14px;
-}
-
-.databaseHeadCell:not(:last-child) {
-	border-right: none;
 }
 
 .databaseColumnResizeHandle {
@@ -105,14 +104,14 @@
 }
 
 .databaseHeaderButton {
-	font-weight: 700;
+	font-weight: var(--font-semibold);
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	line-height: 1.4;
+	line-height: 1.25;
 	transition: color 140ms ease;
 }
 
@@ -136,14 +135,14 @@
 .databaseHeaderLabel {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 6px;
 	width: 100%;
 	min-width: 0;
 }
 
 .databaseHeaderIconPicker {
-	width: var(--icon-xl);
-	height: var(--icon-xl);
+	width: var(--icon-md);
+	height: var(--icon-md);
 	color: var(--text-tertiary);
 }
 
@@ -170,7 +169,7 @@
 	padding-top: 0;
 	padding-bottom: 0;
 	padding-right: 10px;
-	border-top: 1px solid color-mix(in srgb, var(--border-light) 60%, transparent);
+	border-top: 1px solid color-mix(in srgb, var(--border-light) 44%, transparent);
 }
 
 .databaseBodyCell:has(.databaseTagSuggestions),
@@ -193,11 +192,6 @@
 
 .databaseBodyCell:last-child {
 	padding-right: 14px;
-}
-
-.databaseBodyCell:not(:last-child) {
-	border-right: 1px solid
-		color-mix(in srgb, var(--border-light) 82%, transparent);
 }
 
 .databaseCellInput,
@@ -250,8 +244,10 @@
 
 .databaseCellPills {
 	display: flex;
+	flex: 1 1 auto;
 	flex-wrap: nowrap;
-	gap: 6px;
+	gap: 4px;
+	width: 100%;
 	min-height: 0;
 	min-width: 0;
 	overflow: hidden;
@@ -341,11 +337,12 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 5px;
-	padding: 2px 8px;
-	border: 0;
-	border-radius: var(--radius-4);
-	background: color-mix(in srgb, var(--database-tone) 10%, var(--bg-secondary));
-	font-size: calc(var(--text-base) * 0.9);
+	min-height: 22px;
+	padding: 0 7px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 72%, transparent);
+	border-radius: var(--pill-radius);
+	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
+	font-size: var(--text-xs);
 	font-weight: var(--font-medium);
 	color: color-mix(in srgb, var(--database-tone) 68%, var(--text-primary));
 	box-shadow: none;
@@ -366,7 +363,7 @@
 	top: -9999px;
 	left: -9999px;
 	display: flex;
-	gap: 6px;
+	gap: 4px;
 	visibility: hidden;
 	pointer-events: none;
 	white-space: nowrap;
@@ -386,6 +383,11 @@
 .databaseCellButton.is-pill-list {
 	width: 100%;
 	overflow: hidden;
+}
+
+.databaseCellButton .propertyValueText {
+	min-height: 24px;
+	line-height: 1.25;
 }
 
 .databaseCellButton.is-title {
@@ -462,7 +464,7 @@
 }
 
 .databaseRow:hover {
-	background: var(--bg-hover);
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
 }
 
 .databaseRow[data-state="selected"] {
@@ -489,8 +491,8 @@
 	gap: 6px;
 	min-height: 34px;
 	padding: 10px 14px 6px;
-	background: color-mix(in srgb, var(--bg-secondary) 34%, var(--bg-primary));
-	color: var(--text-primary);
+	background: color-mix(in srgb, var(--bg-secondary) 20%, var(--bg-primary));
+	color: var(--text-secondary);
 }
 
 .databaseGroupAddButton {
@@ -499,13 +501,15 @@
 	align-items: center;
 	justify-content: center;
 	flex: 0 0 auto;
-	width: 24px;
-	height: 24px;
+	margin-left: auto;
+	width: 20px;
+	height: 20px;
 	border: none;
-	border-radius: var(--radius-md);
-	background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
-	color: var(--interactive-accent);
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-tertiary);
 	cursor: pointer;
+	transition: color var(--transition-fast), background-color var(--transition-fast);
 }
 
 .databaseGroupAddButton svg {
@@ -515,8 +519,8 @@
 }
 
 .databaseGroupAddButton:hover {
-	background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
-	color: var(--interactive-accent-hover);
+	background: var(--bg-hover);
+	color: var(--text-primary);
 }
 
 .databaseTable .databaseGroupCell {
@@ -530,12 +534,12 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--text-primary);
-	font-size: calc(var(--text-base) * 0.9);
-	font-weight: 750;
-	letter-spacing: 0.06em;
+	color: var(--text-secondary);
+	font-size: var(--text-xs);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.02em;
 	line-height: 1.15;
-	text-transform: uppercase;
+	text-transform: none;
 }
 
 .databaseLoadingState,
@@ -918,8 +922,4 @@
 .createCollectionCta[data-slot="button"]:hover:not(:disabled) {
 	background: var(--interactive-accent-hover);
 	color: var(--text-inverse);
-}
-
-.databaseHeaderRow {
-	border-bottom: 1px solid var(--border-light);
 }

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -647,9 +647,9 @@
 	align-items: center;
 	gap: 6px;
 	min-width: 0;
-	padding: 3px 10px 3px 8px;
-	border-radius: var(--radius-8);
-	background: color-mix(in srgb, var(--database-tone) 91%, var(--bg-primary));
+	padding: 0;
+	border-radius: 0;
+	background: transparent;
 }
 
 .databaseBoardLaneDot {


### PR DESCRIPTION
## Description

Refines the sidebar and database views for a denser, more consistent interface.

- Summary of changes
  - Removed Notes and Tags chevrons; aligned their typography and tag icon spacing with the file tree.
  - Refined database kanban cards, lane labels, pills, table rows, group headers, and add controls.
  - Removed redundant table styling while preserving the virtualized table and drag states.
- Reasoning
  - Bring information density and pill treatment closer to the Linear-inspired reference while keeping the existing Glyph visual language.
- Additional context
  - This is a visual CSS/TSX polish pass; no behavior or data model changes.


## Screenshots

Visual changes were reviewed during implementation; no repository screenshot asset was added.


## Docs

No documentation changes needed; this is UI polish only.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the sidebar, database, and version history UI for higher density and consistency, and fixed stale version diffs when switching commits or notes.

- **Refactors**
  - Sidebar/Tags: removed Notes/Tags chevrons; unified header font size/weight; matched tag icon sizes and spacing to the file tree; tightened tag icon picker to `var(--icon-md)`.
  - Version history: simplified to a flat list with concise copy and combined add/delete stats; removed day groups, hashes, and extra icons; shows month/day and time; loading/error and diff handled via `@tanstack/react-query`; tab reads “Version history,” header reads “Previous saves,” and the view resets per note.
  - Database board: refreshed card padding, borders, and background; tone-forward lane titles; status/tags use bordered pills with consistent heights; clearer drag/drop borders; balanced title/meta wrapping and timestamp alignment.
  - Database table: header set to 34px with tighter styles and smaller icons; consistent, bordered pill badges in cells and suggestions; reduced pill gap (`DATABASE_CELL_PILL_GAP` 6→4); lighter row hover; tighter toolbar gaps; semibold, non‑uppercase group headers with an icon‑only, right‑aligned add button; minor CSS cleanups.

- **Bug Fixes**
  - Prevented stale Git diffs by guarding the latest diff request via a mutation and request ID, ensuring only the newest result is applied.

<sup>Written for commit ea8cd6e6d309092c0318e89bd396103231a4abcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Simplified sidebar and tags section headers by removing chevron icons while preserving expand/collapse controls.
  - Refined tags spacing, icon sizing, typography, and picker alignment.
  - Improved database board and table layouts, including compact headers, clearer cards, balanced text wrapping, and consistent tag/status pills.
  - Updated database dialogs with refined headers, row states, group controls, lane styling, and cell spacing.
  - Tightened spacing in database toolbar actions and pill-based cell layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->