### PR TITLE
Polish git history sidebar UI for 0.8.8-alpha.5 (#366) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.8-alpha.4",
+	"version": "0.8.8-alpha.5",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,3 +1,5 @@
+import { GitCompareIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -23,6 +25,28 @@ function formatCommitDate(timestampMs: number): string {
 		hour: "numeric",
 		minute: "2-digit",
 	}).format(new Date(timestampMs));
+}
+
+function formatCommitAge(
+	timestampMs: number,
+	currentTimestampMs: number,
+): string {
+	if (!timestampMs) return "";
+	const elapsedMinutes = Math.max(
+		0,
+		Math.floor((currentTimestampMs - timestampMs) / 60_000),
+	);
+	if (elapsedMinutes < 1) return "now";
+	if (elapsedMinutes < 60) return `${elapsedMinutes}m`;
+
+	const elapsedHours = Math.floor(elapsedMinutes / 60);
+	if (elapsedHours < 24) return `${elapsedHours}h`;
+
+	const elapsedDays = Math.floor(elapsedHours / 24);
+	if (elapsedDays < 7) return `${elapsedDays}d`;
+	if (elapsedDays < 30) return `${Math.floor(elapsedDays / 7)}w`;
+	if (elapsedDays < 365) return `${Math.floor(elapsedDays / 30)}mo`;
+	return `${Math.floor(elapsedDays / 365)}y`;
 }
 
 function changeCounts(commit: GitHistoryCommit) {
@@ -66,6 +90,7 @@ export function GitHistorySidebar({
 	});
 	const commits = historyQuery.data ?? [];
 	const error = historyQuery.error ?? diffMutation.error;
+	const currentTimestampMs = Date.now();
 
 	return (
 		<section className="markdownEditorInfoSection gitHistoryPanel">
@@ -104,29 +129,44 @@ export function GitHistorySidebar({
 										onClick={() => diffMutation.mutate(commit)}
 										aria-pressed={isSelected}
 									>
+										<span className="gitHistoryGraphIcon" aria-hidden>
+											<HugeiconsIcon
+												icon={GitCompareIcon}
+												size="var(--icon-sm)"
+												strokeWidth={1.6}
+											/>
+										</span>
 										<span className="gitHistoryContent">
 											<span className="gitHistorySubject">
 												{commit.subject || "Untitled version"}
 											</span>
-											<span className="gitHistoryMeta">
-												{isLoading
-													? "Opening changes…"
-													: formatCommitDate(commit.timestamp_ms)}
-											</span>
-											{changes.added > 0 || changes.deleted > 0 ? (
-												<span className="gitHistoryStats">
-													{changes.added > 0 ? (
-														<span className="gitHistoryStat gitHistoryStatAdd">
-															+{changes.added.toLocaleString()}
-														</span>
-													) : null}
-													{changes.deleted > 0 ? (
-														<span className="gitHistoryStat gitHistoryStatDelete">
-															-{changes.deleted.toLocaleString()}
-														</span>
-													) : null}
+											<span className="gitHistoryAside">
+												{changes.added > 0 || changes.deleted > 0 ? (
+													<span className="gitHistoryStats">
+														{changes.added > 0 ? (
+															<span className="gitHistoryStat gitHistoryStatAdd">
+																+{changes.added.toLocaleString()}
+															</span>
+														) : null}
+														{changes.deleted > 0 ? (
+															<span className="gitHistoryStat gitHistoryStatDelete">
+																-{changes.deleted.toLocaleString()}
+															</span>
+														) : null}
+													</span>
+												) : null}
+												<span
+													className="gitHistoryMeta"
+													title={formatCommitDate(commit.timestamp_ms)}
+												>
+													{isLoading
+														? "Opening…"
+														: formatCommitAge(
+																commit.timestamp_ms,
+																currentTimestampMs,
+															)}
 												</span>
-											) : null}
+											</span>
 										</span>
 									</button>
 								</li>

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,5 +1,3 @@
-import { GitCompareIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -27,14 +25,11 @@ function formatCommitDate(timestampMs: number): string {
 	}).format(new Date(timestampMs));
 }
 
-function formatCommitAge(
-	timestampMs: number,
-	currentTimestampMs: number,
-): string {
+function formatCommitAge(timestampMs: number): string {
 	if (!timestampMs) return "";
 	const elapsedMinutes = Math.max(
 		0,
-		Math.floor((currentTimestampMs - timestampMs) / 60_000),
+		Math.floor((Date.now() - timestampMs) / 60_000),
 	);
 	if (elapsedMinutes < 1) return "now";
 	if (elapsedMinutes < 60) return `${elapsedMinutes}m`;
@@ -90,7 +85,6 @@ export function GitHistorySidebar({
 	});
 	const commits = historyQuery.data ?? [];
 	const error = historyQuery.error ?? diffMutation.error;
-	const currentTimestampMs = Date.now();
 
 	return (
 		<section className="markdownEditorInfoSection gitHistoryPanel">
@@ -129,19 +123,13 @@ export function GitHistorySidebar({
 										onClick={() => diffMutation.mutate(commit)}
 										aria-pressed={isSelected}
 									>
-										<span className="gitHistoryGraphIcon" aria-hidden>
-											<HugeiconsIcon
-												icon={GitCompareIcon}
-												size="var(--icon-sm)"
-												strokeWidth={1.6}
-											/>
-										</span>
 										<span className="gitHistoryContent">
 											<span className="gitHistorySubject">
 												{commit.subject || "Untitled version"}
 											</span>
 											<span className="gitHistoryAside">
-												{changes.added > 0 || changes.deleted > 0 ? (
+												{!isLoading &&
+												(changes.added > 0 || changes.deleted > 0) ? (
 													<span className="gitHistoryStats">
 														{changes.added > 0 ? (
 															<span className="gitHistoryStat gitHistoryStatAdd">
@@ -161,10 +149,7 @@ export function GitHistorySidebar({
 												>
 													{isLoading
 														? "Opening…"
-														: formatCommitAge(
-																commit.timestamp_ms,
-																currentTimestampMs,
-															)}
+														: formatCommitAge(commit.timestamp_ms)}
 												</span>
 											</span>
 										</span>

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -494,13 +494,13 @@
 }
 
 .gitHistoryBody {
-	padding: 0 2px 4px;
+	padding: 0 0 4px;
 }
 
 .gitHistoryList {
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
+	gap: 0;
 	margin: 0;
 	padding: 0;
 	list-style: none;
@@ -514,9 +514,10 @@
 	position: relative;
 	display: flex;
 	width: 100%;
-	min-height: 40px;
+	min-height: 32px;
 	align-items: center;
-	padding: 6px 10px;
+	gap: 8px;
+	padding: 3px 8px;
 	border: 0;
 	border-radius: var(--radius-md);
 	background: transparent;
@@ -527,7 +528,7 @@
 }
 
 .gitHistoryItem:hover {
-	background: color-mix(in srgb, var(--bg-hover) 38%, transparent);
+	background: color-mix(in srgb, var(--bg-hover) 68%, transparent);
 }
 
 .gitHistoryItem:focus-visible {
@@ -536,11 +537,19 @@
 }
 
 .gitHistoryItemSelected {
-	background: color-mix(in srgb, var(--accent) 7%, var(--bg-hover));
+	background: color-mix(in srgb, var(--accent-color) 7%, var(--bg-hover));
 }
 
 .gitHistoryItemSelected:hover {
-	background: color-mix(in srgb, var(--accent) 9%, var(--bg-hover));
+	background: color-mix(in srgb, var(--accent-color) 9%, var(--bg-hover));
+}
+
+.gitHistoryGraphIcon {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	color: var(--accent-color);
 }
 
 .gitHistoryContent {
@@ -548,7 +557,7 @@
 	min-width: 0;
 	flex: 1;
 	align-items: center;
-	gap: 10px;
+	gap: 8px;
 }
 
 .gitHistorySubject {
@@ -563,11 +572,24 @@
 	white-space: nowrap;
 }
 
+.gitHistoryAside {
+	display: grid;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-items: end;
+}
+
+.gitHistoryAside > * {
+	grid-area: 1 / 1;
+}
+
 .gitHistoryStats {
 	display: inline-flex;
 	flex: 0 0 auto;
 	align-items: center;
 	gap: 6px;
+	opacity: 1;
+	transition: opacity 120ms ease;
 }
 
 .gitHistoryStat {
@@ -591,6 +613,18 @@
 	font-size: calc(var(--text-base) * 0.82);
 	line-height: 1.2;
 	font-variant-numeric: tabular-nums;
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.gitHistoryItem:hover .gitHistoryStats,
+.gitHistoryItem:focus-visible .gitHistoryStats {
+	opacity: 0;
+}
+
+.gitHistoryItem:hover .gitHistoryMeta,
+.gitHistoryItem:focus-visible .gitHistoryMeta {
+	opacity: 1;
 }
 
 .markdownEditorInfoSection + .markdownEditorInfoSection {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -333,7 +333,7 @@
 
 .gitDiffLine[data-kind="hunk"] {
 	margin-top: 12px;
-	background: color-mix(in srgb, var(--accent) 8%, transparent);
+	background: color-mix(in srgb, var(--accent-color) 8%, transparent);
 	color: var(--text-primary);
 	font-weight: var(--font-medium);
 }
@@ -516,7 +516,6 @@
 	width: 100%;
 	min-height: 32px;
 	align-items: center;
-	gap: 8px;
 	padding: 3px 8px;
 	border: 0;
 	border-radius: var(--radius-md);
@@ -542,14 +541,6 @@
 
 .gitHistoryItemSelected:hover {
 	background: color-mix(in srgb, var(--accent-color) 9%, var(--bg-hover));
-}
-
-.gitHistoryGraphIcon {
-	display: inline-flex;
-	flex: 0 0 auto;
-	align-items: center;
-	justify-content: center;
-	color: var(--accent-color);
 }
 
 .gitHistoryContent {
@@ -615,6 +606,10 @@
 	font-variant-numeric: tabular-nums;
 	opacity: 0;
 	transition: opacity 120ms ease;
+}
+
+.gitHistoryAside:not(:has(.gitHistoryStats)) .gitHistoryMeta {
+	opacity: 1;
 }
 
 .gitHistoryItem:hover .gitHistoryStats,


### PR DESCRIPTION
Closes N/A


## Description

Final UI pass on the git history sidebar: denser commit rows, relative ages with full dates on hover, and +/- stats that swap to the age on hover. Also bumps the app version to 0.8.8-alpha.5 and fixes accent token usage in git diff/history styles.

- Summary of changes
  - Compact git history list (tighter padding/height, less gap)
  - Show relative commit age (`now` / `5m` / `2h` / …) with absolute date in the tooltip
  - Overlay +/- change stats with age on hover/focus
  - Use `--accent-color` instead of `--accent` for hunk/selection backgrounds
  - Bump version to `0.8.8-alpha.5`
- Reasoning
  - Make history scan faster and closer to a familiar git client density, without losing change counts or exact timestamps
- Additional context
  - No linked GitHub issue for this PR


## Screenshots

N/A — please attach a quick screen recording of the history sidebar if useful for review.


## Docs

- `GitHistorySidebar` now formats ages via `formatCommitAge` and keeps `formatCommitDate` for the `title` tooltip
- `.gitHistoryAside` stacks stats + meta so hover can crossfade between them


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the git history sidebar for faster scanning: denser rows, relative ages with full dates on hover, and hover swap between +/- stats and age. Also fixed accent token usage in diff/history styles and bumped the app to 0.8.8-alpha.5.

- **New Features**
  - Compact commit list (smaller padding/height).
  - Show relative age (now/5m/2h/…) with absolute date in the tooltip.
  - Hover/focus swaps +/- change stats with the age.

- **Bug Fixes**
  - Use `--accent-color` for diff/history backgrounds.

<sup>Written for commit 773bc909439e56ca9fdcf863630be9da05ad074b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git history entries now show easier-to-read relative times, such as “5 minutes ago” or “2 weeks ago.”
  * Entries display “Opening…” while a commit diff is being loaded.
* **UI Improvements**
  * Git history rows are more compact, with clearer hover and selection states.
  * Hovering over an entry smoothly reveals commit details while keeping change statistics accessible.
  * Diff highlighting and sidebar styling are more visually consistent.
* **Release**
  * Updated the application version to 0.8.8-alpha.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->