### PR TITLE
Batch visible folder preview reads

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1618,6 +1618,7 @@ pub fn run() {
             space_fs::read_write::text::space_read_text,
             space_fs::read_write::text::space_read_texts_batch,
             space_fs::read_write::preview::space_read_text_preview,
+            space_fs::read_write::preview::space_read_text_previews_batch,
             space_fs::read_write::preview::space_read_binary_preview,
             space_fs::read_write::binary::space_save_pasted_image,
             space_fs::read_write::text::space_write_text,

--- a/src-tauri/src/space_fs/read_write/preview.rs
+++ b/src-tauri/src/space_fs/read_write/preview.rs
@@ -14,8 +14,11 @@ use super::super::types::{
 
 const TEXT_PREVIEW_DEFAULT_MAX_BYTES: u64 = 1_048_576;
 const TEXT_PREVIEW_MAX_BYTES_CAP: u64 = 5_242_880;
-// Visible virtual rows plus overscan stay well below this command boundary.
+// Callers must chunk above this bound (tall viewports / zoom can exceed it).
 const TEXT_PREVIEW_BATCH_MAX_PATHS: usize = 100;
+// Cap total requested preview bytes (paths × effective per-path max) before reads.
+const TEXT_PREVIEW_BATCH_MAX_TOTAL_BYTES: u64 =
+    TEXT_PREVIEW_BATCH_MAX_PATHS as u64 * TEXT_PREVIEW_DEFAULT_MAX_BYTES;
 const BINARY_PREVIEW_DEFAULT_MAX_BYTES: u64 = 20 * 1024 * 1024;
 const BINARY_PREVIEW_MAX_BYTES_CAP: u64 = 30 * 1024 * 1024;
 
@@ -97,6 +100,17 @@ pub async fn space_read_text_previews_batch(
     if paths.len() > TEXT_PREVIEW_BATCH_MAX_PATHS {
         return Err(format!(
             "too many preview paths (maximum {TEXT_PREVIEW_BATCH_MAX_PATHS})"
+        ));
+    }
+
+    let per_path_max = max_bytes
+        .map(|value| value as u64)
+        .unwrap_or(TEXT_PREVIEW_DEFAULT_MAX_BYTES)
+        .clamp(1, TEXT_PREVIEW_MAX_BYTES_CAP);
+    let aggregate_budget = per_path_max.saturating_mul(paths.len() as u64);
+    if aggregate_budget > TEXT_PREVIEW_BATCH_MAX_TOTAL_BYTES {
+        return Err(format!(
+            "preview batch byte budget exceeded (maximum {TEXT_PREVIEW_BATCH_MAX_TOTAL_BYTES})"
         ));
     }
 

--- a/src-tauri/src/space_fs/read_write/preview.rs
+++ b/src-tauri/src/space_fs/read_write/preview.rs
@@ -1,14 +1,21 @@
 use base64::Engine;
-use std::{io::Read, path::PathBuf};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
 use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState};
 
 use super::super::helpers::{deny_hidden_rel_path, file_mtime_ms};
-use super::super::types::{BinaryFilePreviewDoc, TextFilePreviewDoc};
+use super::super::types::{
+    BinaryFilePreviewDoc, TextFilePreviewDoc, TextFilePreviewDocBatch,
+};
 
 const TEXT_PREVIEW_DEFAULT_MAX_BYTES: u64 = 1_048_576;
 const TEXT_PREVIEW_MAX_BYTES_CAP: u64 = 5_242_880;
+// Visible virtual rows plus overscan stay well below this command boundary.
+const TEXT_PREVIEW_BATCH_MAX_PATHS: usize = 100;
 const BINARY_PREVIEW_DEFAULT_MAX_BYTES: u64 = 20 * 1024 * 1024;
 const BINARY_PREVIEW_MAX_BYTES_CAP: u64 = 30 * 1024 * 1024;
 
@@ -27,6 +34,46 @@ fn mime_for_preview_ext(ext: &str) -> Option<&'static str> {
     }
 }
 
+fn read_text_preview(
+    root: &Path,
+    path: &str,
+    max_bytes: Option<u32>,
+) -> Result<TextFilePreviewDoc, String> {
+    let rel = PathBuf::from(path);
+    deny_hidden_rel_path(&rel)?;
+    let abs = paths::join_under(root, &rel)?;
+    if !abs.exists() {
+        return Err("path does not exist".to_string());
+    }
+    if !abs.is_file() {
+        return Err("path is not a file".to_string());
+    }
+    let total_bytes = std::fs::metadata(&abs).map_err(|e| e.to_string())?.len();
+    let requested = max_bytes
+        .map(|value| value as u64)
+        .unwrap_or(TEXT_PREVIEW_DEFAULT_MAX_BYTES);
+    let max = requested.clamp(1, TEXT_PREVIEW_MAX_BYTES_CAP);
+
+    let file = std::fs::File::open(&abs).map_err(|e| e.to_string())?;
+    let mut bytes = Vec::new();
+    file.take(max + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    let truncated = bytes.len() as u64 > max;
+    if truncated {
+        bytes.truncate(max as usize);
+    }
+
+    Ok(TextFilePreviewDoc {
+        rel_path: rel.to_string_lossy().to_string(),
+        text: String::from_utf8_lossy(&bytes).into_owned(),
+        mtime_ms: file_mtime_ms(&abs),
+        truncated,
+        bytes_read: bytes.len() as u64,
+        total_bytes,
+    })
+}
+
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_read_text_preview(
     window: WebviewWindow,
@@ -35,43 +82,53 @@ pub async fn space_read_text_preview(
     max_bytes: Option<u32>,
 ) -> Result<TextFilePreviewDoc, String> {
     let root = state.root_for_window(&window)?;
-    tauri::async_runtime::spawn_blocking(move || -> Result<TextFilePreviewDoc, String> {
-        let rel = PathBuf::from(&path);
-        deny_hidden_rel_path(&rel)?;
-        let abs = paths::join_under(&root, &rel)?;
-        if !abs.exists() {
-            return Err("path does not exist".to_string());
-        }
-        if !abs.is_file() {
-            return Err("path is not a file".to_string());
-        }
-        let total_bytes = std::fs::metadata(&abs).map_err(|e| e.to_string())?.len();
-        let requested = max_bytes
-            .map(|value| value as u64)
-            .unwrap_or(TEXT_PREVIEW_DEFAULT_MAX_BYTES);
-        let max = requested.clamp(1, TEXT_PREVIEW_MAX_BYTES_CAP);
-
-        let file = std::fs::File::open(&abs).map_err(|e| e.to_string())?;
-        let mut bytes = Vec::new();
-        file.take(max + 1)
-            .read_to_end(&mut bytes)
-            .map_err(|e| e.to_string())?;
-        let truncated = bytes.len() as u64 > max;
-        if truncated {
-            bytes.truncate(max as usize);
-        }
-
-        Ok(TextFilePreviewDoc {
-            rel_path: rel.to_string_lossy().to_string(),
-            text: String::from_utf8_lossy(&bytes).into_owned(),
-            mtime_ms: file_mtime_ms(&abs),
-            truncated,
-            bytes_read: bytes.len() as u64,
-            total_bytes,
-        })
-    })
+    tauri::async_runtime::spawn_blocking(move || read_text_preview(&root, &path, max_bytes))
     .await
     .map_err(|e| e.to_string())?
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_read_text_previews_batch(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    paths: Vec<String>,
+    max_bytes: Option<u32>,
+) -> Result<Vec<TextFilePreviewDocBatch>, String> {
+    if paths.len() > TEXT_PREVIEW_BATCH_MAX_PATHS {
+        return Err(format!(
+            "too many preview paths (maximum {TEXT_PREVIEW_BATCH_MAX_PATHS})"
+        ));
+    }
+
+    let root = state.root_for_window(&window)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut results = Vec::with_capacity(paths.len());
+        for path in paths {
+            match read_text_preview(&root, &path, max_bytes) {
+                Ok(preview) => results.push(TextFilePreviewDocBatch {
+                    rel_path: preview.rel_path,
+                    text: Some(preview.text),
+                    mtime_ms: Some(preview.mtime_ms),
+                    truncated: Some(preview.truncated),
+                    bytes_read: Some(preview.bytes_read),
+                    total_bytes: Some(preview.total_bytes),
+                    error: None,
+                }),
+                Err(error) => results.push(TextFilePreviewDocBatch {
+                    rel_path: path,
+                    text: None,
+                    mtime_ms: None,
+                    truncated: None,
+                    bytes_read: None,
+                    total_bytes: None,
+                    error: Some(error),
+                }),
+            }
+        }
+        results
+    })
+    .await
+    .map_err(|e| e.to_string())
 }
 
 #[tauri::command(rename_all = "snake_case")]

--- a/src-tauri/src/space_fs/types.rs
+++ b/src-tauri/src/space_fs/types.rs
@@ -73,6 +73,17 @@ pub struct TextFilePreviewDoc {
 }
 
 #[derive(Serialize)]
+pub struct TextFilePreviewDocBatch {
+    pub rel_path: String,
+    pub text: Option<String>,
+    pub mtime_ms: Option<u64>,
+    pub truncated: Option<bool>,
+    pub bytes_read: Option<u64>,
+    pub total_bytes: Option<u64>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
 pub struct BinaryFilePreviewDoc {
     pub rel_path: String,
     pub mime: String,

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -291,6 +291,7 @@ interface TreeEntriesProps {
 	taskSummariesByPath?: Record<string, NoteTaskSummary>;
 	showFilePreviews?: boolean;
 	filePreviewsByPath?: Record<string, string | null | undefined>;
+	onVisiblePreviewPathsChange?: (paths: string[]) => void;
 	sortMode: FileTreeSortMode;
 }
 
@@ -374,6 +375,7 @@ function TreeEntries({
 	taskSummariesByPath = {},
 	showFilePreviews = false,
 	filePreviewsByPath = {},
+	onVisiblePreviewPathsChange,
 	sortMode,
 }: TreeEntriesProps) {
 	const virtualRows = useMemo(
@@ -422,6 +424,22 @@ function TreeEntries({
 		scrollMargin: listElement?.offsetTop ?? 0,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
+	const visiblePreviewPathKey = useMemo(() => {
+		if (!showFilePreviews) return "";
+		const paths = new Set<string>();
+		for (const virtualItem of virtualItems) {
+			const entry = virtualRows[virtualItem.index]?.entry;
+			if (entry?.kind === "file" && entry.is_markdown) {
+				paths.add(entry.rel_path);
+			}
+		}
+		return [...paths].sort().join("\0");
+	}, [showFilePreviews, virtualItems, virtualRows]);
+	useEffect(() => {
+		onVisiblePreviewPathsChange?.(
+			visiblePreviewPathKey ? visiblePreviewPathKey.split("\0") : [],
+		);
+	}, [onVisiblePreviewPathsChange, visiblePreviewPathKey]);
 	const handleVirtualArrowNavigate = useCallback(
 		(path: string, direction: -1 | 1, currentTarget: HTMLElement) => {
 			const currentIndex = virtualRows.findIndex(
@@ -596,6 +614,7 @@ export const FileTreePane = memo(function FileTreePane({
 	const [filePreviewsByPath, setFilePreviewsByPath] = useState<
 		Record<string, string | null | undefined>
 	>({});
+	const [filePreviewPaths, setFilePreviewPaths] = useState<string[]>([]);
 	const [filePreviewRefreshKey, setFilePreviewRefreshKey] = useState(0);
 	const [appearancePickerTarget, setAppearancePickerTarget] =
 		useState<AppearancePickerTarget | null>(null);
@@ -612,6 +631,7 @@ export const FileTreePane = memo(function FileTreePane({
 		if (previousSpacePathRef.current === spacePath) return;
 		previousSpacePathRef.current = spacePath;
 		setFocusedDirPath(null);
+		setFilePreviewPaths([]);
 		setFilePreviewsByPath({});
 	}, [spacePath]);
 
@@ -763,15 +783,14 @@ export const FileTreePane = memo(function FileTreePane({
 		const relPath = normalizeRelPath(payload.rel_path);
 		if (!relPath || !isMarkdownPath(relPath)) return;
 		if (!taskSummaryPaths.includes(relPath)) return;
-		if (filePreviewPaths.includes(relPath)) {
-			setFilePreviewsByPath((current) => {
-				const next = { ...current };
-				delete next[relPath];
-				return next;
-			});
-			if (!payload.removed) {
-				setFilePreviewRefreshKey((key) => key + 1);
-			}
+		setFilePreviewsByPath((current) => {
+			if (!(relPath in current)) return current;
+			const next = { ...current };
+			delete next[relPath];
+			return next;
+		});
+		if (!payload.removed && filePreviewPaths.includes(relPath)) {
+			setFilePreviewRefreshKey((key) => key + 1);
 		}
 		if (payload.removed) {
 			setTaskSummaryRefreshKey((key) => key + 1);
@@ -881,6 +900,7 @@ export const FileTreePane = memo(function FileTreePane({
 
 	const handleEnterDir = useCallback(
 		(dirPath: string) => {
+			setFilePreviewPaths([]);
 			setFocusedDirPath(dirPath);
 			onSelectDir(dirPath);
 			if (!onLoadDir && !childrenByDir[dirPath] && !expandedDirs.has(dirPath)) {
@@ -891,9 +911,21 @@ export const FileTreePane = memo(function FileTreePane({
 	);
 
 	const handleExitFocusedDir = useCallback(() => {
+		setFilePreviewPaths([]);
 		setFocusedDirPath(null);
 		onSelectDir("");
 	}, [onSelectDir]);
+	const handleVisiblePreviewPathsChange = useCallback((paths: string[]) => {
+		setFilePreviewPaths((current) => {
+			if (
+				current.length === paths.length &&
+				current.every((path, index) => path === paths[index])
+			) {
+				return current;
+			}
+			return paths;
+		});
+	}, []);
 
 	const focusedEntries = focusedDirPath
 		? (childrenByDir[focusedDirPath] ?? null)
@@ -920,13 +952,6 @@ export const FileTreePane = memo(function FileTreePane({
 		void onLoadDir(focusedDirPath);
 	}, [focusedDirPath, focusedEntries, onLoadDir]);
 
-	const filePreviewPaths = useMemo(() => {
-		if (!focusedEntries) return [];
-		return focusedEntries
-			.filter((entry) => entry.kind === "file" && entry.is_markdown)
-			.map((entry) => entry.rel_path)
-			.sort();
-	}, [focusedEntries]);
 	const filePreviewRequestKey = useMemo(
 		() => `${filePreviewRefreshKey}:${filePreviewPaths.join("\0")}`,
 		[filePreviewPaths, filePreviewRefreshKey],
@@ -946,45 +971,45 @@ export const FileTreePane = memo(function FileTreePane({
 		if (missingPaths.length === 0) return;
 
 		let cancelled = false;
-		void Promise.allSettled(
-			missingPaths.map(async (path) => {
-				const preview = await invoke("space_read_text_preview", {
-					path,
-					max_bytes: MARKDOWN_PREVIEW_MAX_BYTES,
-				});
-				return {
-					path,
-					snippet: markdownPreviewSnippet(preview.text),
-				};
-			}),
-		).then((results) => {
-			if (
-				cancelled ||
-				filePreviewRequestRef.current !== filePreviewRequestKey
-			) {
-				return;
-			}
-			setFilePreviewsByPath((prev) => {
-				let changed = false;
-				const next = { ...prev };
-				for (const [index, result] of results.entries()) {
-					if (result.status === "fulfilled") {
-						const snippet = result.value.snippet || null;
-						if (next[result.value.path] !== snippet) {
-							next[result.value.path] = snippet;
-							changed = true;
-						}
-					} else {
+		void invoke("space_read_text_previews_batch", {
+			paths: missingPaths,
+			max_bytes: MARKDOWN_PREVIEW_MAX_BYTES,
+		})
+			.then((results) => {
+				if (
+					cancelled ||
+					filePreviewRequestRef.current !== filePreviewRequestKey
+				) {
+					return;
+				}
+				setFilePreviewsByPath((prev) => {
+					let changed = false;
+					const next = { ...prev };
+					for (const [index, result] of results.entries()) {
 						const path = missingPaths[index];
-						if (path && path in next) {
+						if (!path) continue;
+						if (result.error === null && result.text !== null) {
+							const snippet = markdownPreviewSnippet(result.text) || null;
+							if (next[path] !== snippet) {
+								next[path] = snippet;
+								changed = true;
+							}
+						} else if (path in next) {
 							delete next[path];
 							changed = true;
 						}
 					}
+					return changed ? next : prev;
+				});
+			})
+			.catch((error: unknown) => {
+				if (
+					!cancelled &&
+					filePreviewRequestRef.current === filePreviewRequestKey
+				) {
+					console.warn("Failed to load file previews", error);
 				}
-				return changed ? next : prev;
 			});
-		});
 
 		return () => {
 			cancelled = true;
@@ -1098,6 +1123,7 @@ export const FileTreePane = memo(function FileTreePane({
 								taskSummariesByPath={taskSummariesByPath}
 								showFilePreviews
 								filePreviewsByPath={filePreviewsByPath}
+								onVisiblePreviewPathsChange={handleVisiblePreviewPathsChange}
 								sortMode={sortMode}
 							/>
 						) : (

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -29,7 +29,6 @@ import {
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
-import { splitYamlFrontmatter } from "../../lib/notePreview";
 import { type FileTreeSortMode, loadSettings } from "../../lib/settings";
 import type {
 	DirChildSummary,
@@ -52,6 +51,7 @@ import {
 	FILE_TREE_ROOT_DROP_COLLISION_PRIORITY,
 } from "./fileTreeDnd";
 import { useFileTreeCreateFolderScroll } from "./useFileTreeCreateFolderScroll";
+import { useVisibleFilePreviews } from "./useVisibleFilePreviews";
 
 interface FileTreePaneProps {
 	rootEntries: FsEntry[];
@@ -85,8 +85,6 @@ interface FileTreePaneProps {
 }
 
 const springTransition = springPresets.bouncy;
-const MARKDOWN_PREVIEW_MAX_BYTES = 4096;
-const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
 const FILE_TREE_ROW_ESTIMATE = 32;
 const FILE_TREE_PREVIEW_ROW_ESTIMATE = 52;
 
@@ -116,41 +114,6 @@ function folderBreadcrumbParts(spacePath: string | null, dirPath: string) {
 			})),
 	];
 	return parts;
-}
-
-function plainMarkdownLine(line: string): string {
-	return line
-		.replace(/^#{1,6}\s+/, "")
-		.replace(/^>\s?/, "")
-		.replace(/^[-*+]\s+\[[ xX]\]\s+/, "")
-		.replace(/^[-*+]\s+/, "")
-		.replace(/^\d+\.\s+/, "")
-		.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
-		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-		.replace(/[*_`~]/g, "")
-		.replace(/\s+/g, " ")
-		.trim();
-}
-
-function markdownPreviewSnippet(markdown: string): string {
-	const { body } = splitYamlFrontmatter(markdown);
-	const lines: string[] = [];
-	let inFence = false;
-
-	for (const rawLine of body.replace(/\r\n?/g, "\n").split("\n")) {
-		const trimmed = rawLine.trim();
-		if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
-			inFence = !inFence;
-			continue;
-		}
-		if (inFence || !trimmed) continue;
-		const line = plainMarkdownLine(trimmed);
-		if (!line) continue;
-		lines.push(line);
-		if (lines.length >= MARKDOWN_PREVIEW_LINE_LIMIT) break;
-	}
-
-	return lines.join(" ");
 }
 
 interface FileTreeRootDropProps {
@@ -440,6 +403,13 @@ function TreeEntries({
 			visiblePreviewPathKey ? visiblePreviewPathKey.split("\0") : [],
 		);
 	}, [onVisiblePreviewPathsChange, visiblePreviewPathKey]);
+	const onVisiblePreviewPathsChangeRef = useRef(onVisiblePreviewPathsChange);
+	onVisiblePreviewPathsChangeRef.current = onVisiblePreviewPathsChange;
+	useEffect(() => {
+		return () => {
+			onVisiblePreviewPathsChangeRef.current?.([]);
+		};
+	}, []);
 	const handleVirtualArrowNavigate = useCallback(
 		(path: string, direction: -1 | 1, currentTarget: HTMLElement) => {
 			const currentIndex = virtualRows.findIndex(
@@ -611,14 +581,14 @@ export const FileTreePane = memo(function FileTreePane({
 	>({});
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
 	const [focusedDirPath, setFocusedDirPath] = useState<string | null>(null);
-	const [filePreviewsByPath, setFilePreviewsByPath] = useState<
-		Record<string, string | null | undefined>
-	>({});
-	const [filePreviewPaths, setFilePreviewPaths] = useState<string[]>([]);
-	const [filePreviewRefreshKey, setFilePreviewRefreshKey] = useState(0);
+	const {
+		filePreviewsByPath,
+		clearVisiblePreviewPaths,
+		handleVisiblePreviewPathsChange,
+		invalidatePreviewForPath,
+	} = useVisibleFilePreviews(spacePath, focusedDirPath);
 	const [appearancePickerTarget, setAppearancePickerTarget] =
 		useState<AppearancePickerTarget | null>(null);
-	const filePreviewRequestRef = useRef("");
 	const moveClickSuppressRef = useRef(false);
 	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
@@ -631,8 +601,6 @@ export const FileTreePane = memo(function FileTreePane({
 		if (previousSpacePathRef.current === spacePath) return;
 		previousSpacePathRef.current = spacePath;
 		setFocusedDirPath(null);
-		setFilePreviewPaths([]);
-		setFilePreviewsByPath({});
 	}, [spacePath]);
 
 	useEffect(() => {
@@ -782,20 +750,8 @@ export const FileTreePane = memo(function FileTreePane({
 	useTauriEvent("notes:external_changed", (payload) => {
 		const relPath = normalizeRelPath(payload.rel_path);
 		if (!relPath || !isMarkdownPath(relPath)) return;
+		invalidatePreviewForPath(relPath, Boolean(payload.removed));
 		if (!taskSummaryPaths.includes(relPath)) return;
-		setFilePreviewsByPath((current) => {
-			if (!(relPath in current)) return current;
-			const next = { ...current };
-			delete next[relPath];
-			return next;
-		});
-		if (!payload.removed && filePreviewPaths.includes(relPath)) {
-			setFilePreviewRefreshKey((key) => key + 1);
-		}
-		if (payload.removed) {
-			setTaskSummaryRefreshKey((key) => key + 1);
-			return;
-		}
 		setTaskSummaryRefreshKey((key) => key + 1);
 	});
 
@@ -900,32 +856,28 @@ export const FileTreePane = memo(function FileTreePane({
 
 	const handleEnterDir = useCallback(
 		(dirPath: string) => {
-			setFilePreviewPaths([]);
+			clearVisiblePreviewPaths();
 			setFocusedDirPath(dirPath);
 			onSelectDir(dirPath);
 			if (!onLoadDir && !childrenByDir[dirPath] && !expandedDirs.has(dirPath)) {
 				onToggleDir(dirPath);
 			}
 		},
-		[childrenByDir, expandedDirs, onLoadDir, onSelectDir, onToggleDir],
+		[
+			childrenByDir,
+			clearVisiblePreviewPaths,
+			expandedDirs,
+			onLoadDir,
+			onSelectDir,
+			onToggleDir,
+		],
 	);
 
 	const handleExitFocusedDir = useCallback(() => {
-		setFilePreviewPaths([]);
+		clearVisiblePreviewPaths();
 		setFocusedDirPath(null);
 		onSelectDir("");
-	}, [onSelectDir]);
-	const handleVisiblePreviewPathsChange = useCallback((paths: string[]) => {
-		setFilePreviewPaths((current) => {
-			if (
-				current.length === paths.length &&
-				current.every((path, index) => path === paths[index])
-			) {
-				return current;
-			}
-			return paths;
-		});
-	}, []);
+	}, [clearVisiblePreviewPaths, onSelectDir]);
 
 	const focusedEntries = focusedDirPath
 		? (childrenByDir[focusedDirPath] ?? null)
@@ -951,76 +903,6 @@ export const FileTreePane = memo(function FileTreePane({
 		if (!focusedDirPath || focusedEntries || !onLoadDir) return;
 		void onLoadDir(focusedDirPath);
 	}, [focusedDirPath, focusedEntries, onLoadDir]);
-
-	const filePreviewRequestKey = useMemo(
-		() => `${filePreviewRefreshKey}:${filePreviewPaths.join("\0")}`,
-		[filePreviewPaths, filePreviewRefreshKey],
-	);
-
-	useEffect(() => {
-		filePreviewRequestRef.current = filePreviewRequestKey;
-		if (!spacePath || !focusedDirPath || filePreviewPaths.length === 0) {
-			return;
-		}
-
-		const missingPaths = filePreviewPaths.filter(
-			(path) =>
-				filePreviewsByPath[path] === undefined ||
-				filePreviewsByPath[path] === "",
-		);
-		if (missingPaths.length === 0) return;
-
-		let cancelled = false;
-		void invoke("space_read_text_previews_batch", {
-			paths: missingPaths,
-			max_bytes: MARKDOWN_PREVIEW_MAX_BYTES,
-		})
-			.then((results) => {
-				if (
-					cancelled ||
-					filePreviewRequestRef.current !== filePreviewRequestKey
-				) {
-					return;
-				}
-				setFilePreviewsByPath((prev) => {
-					let changed = false;
-					const next = { ...prev };
-					for (const [index, result] of results.entries()) {
-						const path = missingPaths[index];
-						if (!path) continue;
-						if (result.error === null && result.text !== null) {
-							const snippet = markdownPreviewSnippet(result.text) || null;
-							if (next[path] !== snippet) {
-								next[path] = snippet;
-								changed = true;
-							}
-						} else if (path in next) {
-							delete next[path];
-							changed = true;
-						}
-					}
-					return changed ? next : prev;
-				});
-			})
-			.catch((error: unknown) => {
-				if (
-					!cancelled &&
-					filePreviewRequestRef.current === filePreviewRequestKey
-				) {
-					console.warn("Failed to load file previews", error);
-				}
-			});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
-		filePreviewPaths,
-		filePreviewRequestKey,
-		filePreviewsByPath,
-		focusedDirPath,
-		spacePath,
-	]);
 
 	const handleDragEnd = useCallback(
 		(event: DragEndEvent) => {

--- a/src/components/filetree/useVisibleFilePreviews.ts
+++ b/src/components/filetree/useVisibleFilePreviews.ts
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { splitYamlFrontmatter } from "../../lib/notePreview";
+import { invoke } from "../../lib/tauri";
+
+const MARKDOWN_PREVIEW_MAX_BYTES = 4096;
+const MARKDOWN_PREVIEW_LINE_LIMIT = 1;
+/** Must match `TEXT_PREVIEW_BATCH_MAX_PATHS` in space_fs preview.rs. */
+const TEXT_PREVIEW_BATCH_MAX_PATHS = 100;
+
+function plainMarkdownLine(line: string): string {
+	return line
+		.replace(/^#{1,6}\s+/, "")
+		.replace(/^>\s?/, "")
+		.replace(/^[-*+]\s+\[[ xX]\]\s+/, "")
+		.replace(/^[-*+]\s+/, "")
+		.replace(/^\d+\.\s+/, "")
+		.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+		.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+		.replace(/[*_`~]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function markdownPreviewSnippet(markdown: string): string {
+	const { body } = splitYamlFrontmatter(markdown);
+	const lines: string[] = [];
+	let inFence = false;
+
+	for (const rawLine of body.replace(/\r\n?/g, "\n").split("\n")) {
+		const trimmed = rawLine.trim();
+		if (trimmed.startsWith("```") || trimmed.startsWith("~~~")) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence || !trimmed) continue;
+		const line = plainMarkdownLine(trimmed);
+		if (!line) continue;
+		lines.push(line);
+		if (lines.length >= MARKDOWN_PREVIEW_LINE_LIMIT) break;
+	}
+
+	return lines.join(" ");
+}
+
+export function useVisibleFilePreviews(
+	spacePath: string | null,
+	focusedDirPath: string | null,
+) {
+	const [filePreviewsByPath, setFilePreviewsByPath] = useState<
+		Record<string, string | null | undefined>
+	>({});
+	const [filePreviewPaths, setFilePreviewPaths] = useState<string[]>([]);
+	const [filePreviewRefreshKey, setFilePreviewRefreshKey] = useState(0);
+	const filePreviewRequestRef = useRef("");
+	const previousSpacePathRef = useRef(spacePath);
+
+	useEffect(() => {
+		if (previousSpacePathRef.current === spacePath) return;
+		previousSpacePathRef.current = spacePath;
+		setFilePreviewPaths([]);
+		setFilePreviewsByPath({});
+	}, [spacePath]);
+
+	const clearVisiblePreviewPaths = useCallback(() => {
+		setFilePreviewPaths([]);
+	}, []);
+
+	const handleVisiblePreviewPathsChange = useCallback((paths: string[]) => {
+		setFilePreviewPaths((current) => {
+			if (
+				current.length === paths.length &&
+				current.every((path, index) => path === paths[index])
+			) {
+				return current;
+			}
+			return paths;
+		});
+	}, []);
+
+	const invalidatePreviewForPath = useCallback(
+		(relPath: string, removed: boolean) => {
+			setFilePreviewsByPath((current) => {
+				if (!(relPath in current)) return current;
+				const next = { ...current };
+				delete next[relPath];
+				return next;
+			});
+			if (!removed && filePreviewPaths.includes(relPath)) {
+				setFilePreviewRefreshKey((key) => key + 1);
+			}
+		},
+		[filePreviewPaths],
+	);
+
+	const filePreviewRequestKey = useMemo(
+		() => `${filePreviewRefreshKey}:${filePreviewPaths.join("\0")}`,
+		[filePreviewPaths, filePreviewRefreshKey],
+	);
+
+	useEffect(() => {
+		filePreviewRequestRef.current = filePreviewRequestKey;
+		if (!spacePath || !focusedDirPath || filePreviewPaths.length === 0) {
+			return;
+		}
+
+		const missingPaths = filePreviewPaths.filter(
+			(path) =>
+				filePreviewsByPath[path] === undefined ||
+				filePreviewsByPath[path] === "",
+		);
+		if (missingPaths.length === 0) return;
+
+		const chunks: string[][] = [];
+		for (
+			let offset = 0;
+			offset < missingPaths.length;
+			offset += TEXT_PREVIEW_BATCH_MAX_PATHS
+		) {
+			chunks.push(
+				missingPaths.slice(offset, offset + TEXT_PREVIEW_BATCH_MAX_PATHS),
+			);
+		}
+
+		let cancelled = false;
+		void Promise.allSettled(
+			chunks.map((chunkPaths) =>
+				invoke("space_read_text_previews_batch", {
+					paths: chunkPaths,
+					max_bytes: MARKDOWN_PREVIEW_MAX_BYTES,
+				}).then((results) => ({ chunkPaths, results })),
+			),
+		).then((settled) => {
+			if (
+				cancelled ||
+				filePreviewRequestRef.current !== filePreviewRequestKey
+			) {
+				return;
+			}
+			setFilePreviewsByPath((prev) => {
+				let changed = false;
+				const next = { ...prev };
+				for (const outcome of settled) {
+					if (outcome.status !== "fulfilled") {
+						console.warn("Failed to load file previews", outcome.reason);
+						continue;
+					}
+					const { chunkPaths, results } = outcome.value;
+					for (const [index, result] of results.entries()) {
+						const path = chunkPaths[index] ?? result.rel_path;
+						if (!path) continue;
+						if (result.error === null && result.text !== null) {
+							const snippet = markdownPreviewSnippet(result.text) || null;
+							if (next[path] !== snippet) {
+								next[path] = snippet;
+								changed = true;
+							}
+						} else if (path in next) {
+							delete next[path];
+							changed = true;
+						}
+					}
+				}
+				return changed ? next : prev;
+			});
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		filePreviewPaths,
+		filePreviewRequestKey,
+		filePreviewsByPath,
+		focusedDirPath,
+		spacePath,
+	]);
+
+	return {
+		filePreviewsByPath,
+		clearVisiblePreviewPaths,
+		handleVisiblePreviewPathsChange,
+		invalidatePreviewForPath,
+	};
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -98,6 +98,16 @@ interface TextFilePreviewDoc {
 	total_bytes: number;
 }
 
+interface TextFilePreviewDocBatch {
+	rel_path: string;
+	text: string | null;
+	mtime_ms: number | null;
+	truncated: boolean | null;
+	bytes_read: number | null;
+	total_bytes: number | null;
+	error: string | null;
+}
+
 interface BinaryFilePreviewDoc {
 	rel_path: string;
 	mime: string;
@@ -848,6 +858,10 @@ interface TauriCommands {
 	space_read_text_preview: CommandDef<
 		{ path: string; max_bytes?: number | null },
 		TextFilePreviewDoc
+	>;
+	space_read_text_previews_batch: CommandDef<
+		{ paths: string[]; max_bytes?: number | null },
+		TextFilePreviewDocBatch[]
 	>;
 	space_read_binary_preview: CommandDef<
 		{ path: string; max_bytes?: number | null },


### PR DESCRIPTION
## Summary
- Add `space_read_text_previews_batch` with per-path partial success, sharing the bounded preview helper with the single-path command.
- Load focused-folder markdown previews only for virtualized visible rows (+ overscan) via one batch IPC call instead of one call per file.
- Keep cached offscreen snippets and ignore stale responses after folder/range changes.

Fixes #376

## Test plan
- [ ] Open a large focused folder with file previews enabled; confirm only ~visible+overscan previews load (not every markdown file)
- [ ] Scroll the folder; newly visible uncached rows fetch previews, previously seen rows reuse cache
- [ ] Switch folders quickly; stale batch responses do not overwrite the new folder’s previews
- [ ] A failed path in a batch does not discard successful snippets for other paths
- [ ] `pnpm test -- src/components/filetree/FileTreePane.test.tsx`
- [ ] `pnpm check && pnpm test && pnpm build`
- [ ] `cd src-tauri && cargo check && cargo test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-loads markdown previews for the focused folder and only fetches previews for visible virtualized rows to cut IPC calls and offscreen work. Adds chunked batch reads with a byte-budget cap and clears stale visible paths on unmount. Fixes #376.

- **New Features**
  - Added `space_read_text_previews_batch` (max 100 paths) with per-path partial success, an aggregate byte-budget cap, and shared reader with `space_read_text_preview`; introduced `TextFilePreviewDocBatch` and wired the command in `src-tauri/src/lib.rs` and `src/lib/tauri.ts`.
  - Batches previews only for visible markdown rows (+ overscan), chunks oversize requests, and ignores stale responses after folder or range changes.

- **Refactors**
  - Moved preview loading into `useVisibleFilePreviews`; `FileTreePane` now reports visible paths and reuses cached snippets while scrolling.
  - Clears visible preview paths on folder changes/unmount and adds `invalidatePreviewForPath` to refresh on external changes.

<sup>Written for commit 2fbb08875d7ca80efc3e89ebd05ecc59a0f9a3b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch loading for text previews in the file tree.
  * Displays preview results and per-file errors without blocking other previews.
  * Limits batch requests to prevent excessive loading.

* **Performance**
  * Loads previews only for currently visible markdown files.
  * Reduces preview requests by combining them into a single batch operation.

* **Bug Fixes**
  * Improved preview cache updates when files change or leave the visible tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->