### PR TITLE
Add paste without formatting (#400) [Release]

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# Glyph Editor Context
+
+Shared language for Glyph's note-editing surfaces and paste behavior.
+
+## Language
+
+**Editable rich-editor surface**:
+An editor surface backed by the shared rich Markdown editor where the user can edit structured note content. In this context, this includes the main editor, external Markdown windows, and quick notes; it excludes read-only previews and the raw Markdown editor.
+_Avoid_: rich editor when the surface is read-only or raw Markdown.
+
+**Raw Markdown editor**:
+The plain-text editing surface where Markdown source is edited directly rather than represented as structured rich content.
+
+**Paste without formatting**:
+An explicit paste command for an editable rich-editor surface that inserts the clipboard's plain-text value literally. It preserves line structure and meaningful whitespace, while leaving syntax such as headings, list markers, checkboxes, emphasis, links, tables, and code markers as ordinary text.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "futures-util",
  "hex",
  "notify",
+ "objc2-app-kit",
  "objc2-foundation",
  "regex",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,10 @@ tauri-plugin-global-shortcut = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "20"
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "std",
+  "NSPasteboard",
+] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
   "std",
   "NSString",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -612,7 +612,7 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         menu_shortcuts,
         "edit.paste_without_formatting",
         true,
-        None,
+        Some("CmdOrCtrl+Alt+Shift+V"),
     )?;
     let recent_spaces_menu = build_recent_spaces_submenu(app, recent_spaces, menu_labels)?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,8 @@ mod index;
 mod io_atomic;
 mod license;
 #[cfg(target_os = "macos")]
+mod macos_clipboard;
+#[cfg(target_os = "macos")]
 mod macos_webkit_defaults;
 mod menu_manifest;
 mod net;
@@ -603,6 +605,15 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         None,
     )?;
+    #[cfg(target_os = "macos")]
+    let paste_without_formatting = menu_item_with_shortcut(
+        app,
+        menu_labels,
+        menu_shortcuts,
+        "edit.paste_without_formatting",
+        true,
+        None,
+    )?;
     let recent_spaces_menu = build_recent_spaces_submenu(app, recent_spaces, menu_labels)?;
 
     let file_menu = Submenu::with_items(
@@ -735,6 +746,8 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
             &PredefinedMenuItem::cut(app, None)?,
             &PredefinedMenuItem::copy(app, None)?,
             &PredefinedMenuItem::paste(app, None)?,
+            #[cfg(target_os = "macos")]
+            &paste_without_formatting,
             &PredefinedMenuItem::select_all(app, None)?,
         ],
     )?;
@@ -930,6 +943,15 @@ fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::W
     })
 }
 
+fn focused_editor_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
+    app.webview_windows().into_iter().find(|(label, window)| {
+        (is_space_host_window_label(label)
+            || label == QUICK_NOTE_WINDOW_LABEL
+            || external_markdown::is_external_markdown_window(label))
+            && window.is_focused().unwrap_or(false)
+    })
+}
+
 fn target_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
     focused_space_host_window(app).or_else(|| {
         let space_state = app.try_state::<space::SpaceState>()?;
@@ -1019,6 +1041,20 @@ fn hide_quick_note_window(app: tauri::AppHandle) -> Result<(), String> {
 #[tauri::command]
 fn show_main_window(app: tauri::AppHandle) -> Result<(), String> {
     show_main_window_for_app(&app)
+}
+
+/// Plain-text pasteboard read for "Paste without Formatting".
+/// Kept as an invoke (not a menu event payload) so the editor owns insertion.
+#[tauri::command]
+fn read_clipboard_plain_text() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos_clipboard::read_plain_text()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
 }
 
 fn open_external_markdown_from_finder(app: &tauri::AppHandle, path: std::path::PathBuf) {
@@ -1427,6 +1463,20 @@ pub fn run() {
                     );
                 }
             }
+            #[cfg(target_os = "macos")]
+            "edit.paste_without_formatting" => {
+                // Editor surfaces live in space hosts, quick note, and external markdown
+                // windows — target the focused one rather than only the space host.
+                if let Some((label, _window)) = focused_editor_window(app) {
+                    let _ = app.emit_to(
+                        label,
+                        "menu:app_command",
+                        AppCommandPayload {
+                            command_id: "paste_without_formatting".to_string(),
+                        },
+                    );
+                }
+            }
             id => {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
@@ -1529,6 +1579,7 @@ pub fn run() {
             show_quick_note_window,
             hide_quick_note_window,
             show_main_window,
+            read_clipboard_plain_text,
             set_quick_note_global_shortcut,
             set_markdown_menu_visible,
             set_recent_spaces_menu,

--- a/src-tauri/src/macos_clipboard.rs
+++ b/src-tauri/src/macos_clipboard.rs
@@ -1,0 +1,8 @@
+use objc2_app_kit::{NSPasteboard, NSPasteboardTypeString};
+
+pub fn read_plain_text() -> Option<String> {
+    let type_string = unsafe { NSPasteboardTypeString };
+    NSPasteboard::generalPasteboard()
+        .stringForType(type_string)
+        .map(|value| value.to_string())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.9-alpha.1",
+	"version": "0.8.9-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/hooks/useRibbonCommands.ts
+++ b/src/components/editor/hooks/useRibbonCommands.ts
@@ -1,4 +1,4 @@
-import type { Editor } from "@tiptap/core";
+import type { Editor, JSONContent } from "@tiptap/core";
 import { useEffect } from "react";
 import {
 	EDITOR_MENU_ACTION_EVENT,
@@ -45,6 +45,35 @@ function createCalloutContent(type: string) {
 	};
 }
 
+function createPlainTextPasteContent(text: string): JSONContent[] {
+	const paragraphs: JSONContent[] = [];
+	let lines: string[] = [];
+
+	const appendParagraph = () => {
+		const content: JSONContent[] = [];
+		for (const [index, line] of lines.entries()) {
+			if (line.length) content.push({ type: "text", text: line });
+			if (index < lines.length - 1) content.push({ type: "hardBreak" });
+		}
+		paragraphs.push({
+			type: "paragraph",
+			...(content.length ? { content } : {}),
+		});
+		lines = [];
+	};
+
+	for (const line of text.split("\n")) {
+		if (!line.length) {
+			appendParagraph();
+			continue;
+		}
+		lines.push(line);
+	}
+	if (lines.length) appendParagraph();
+
+	return paragraphs;
+}
+
 /**
  * Sets up the global editor menu action listener (keyboard shortcuts, slash commands)
  * and the callout inserter registration for the note editor.
@@ -87,10 +116,6 @@ export function useRibbonCommands({
 			if (!canEdit && !isReadOnlySafeAction) return;
 
 			if (action === "paste_without_formatting") {
-				const selection = {
-					from: editor.state.selection.from,
-					to: editor.state.selection.to,
-				};
 				void invoke("read_clipboard_plain_text")
 					.then((text) => {
 						if (text == null || editor.isDestroyed || !editor.isEditable) {
@@ -98,9 +123,24 @@ export function useRibbonCommands({
 						}
 						const plain = text.replace(/\r\n?/g, "\n");
 						if (!plain.length) return;
-						editor.view.dispatch(
-							editor.state.tr.insertText(plain, selection.from, selection.to),
-						);
+						const selection = {
+							from: editor.state.selection.from,
+							to: editor.state.selection.to,
+						};
+						if (plain.includes("\n") && !editor.isActive("codeBlock")) {
+							if (
+								!editor.commands.insertContentAt(
+									selection,
+									createPlainTextPasteContent(plain),
+								)
+							) {
+								return;
+							}
+						} else {
+							editor.view.dispatch(
+								editor.state.tr.insertText(plain, selection.from, selection.to),
+							);
+						}
 						editor.view.focus();
 						if (scrollHost) {
 							requestAnimationFrame(() => {

--- a/src/components/editor/hooks/useRibbonCommands.ts
+++ b/src/components/editor/hooks/useRibbonCommands.ts
@@ -4,6 +4,7 @@ import {
 	EDITOR_MENU_ACTION_EVENT,
 	type EditorMenuActionDetail,
 } from "../../../lib/appEvents";
+import { invoke } from "../../../lib/tauri";
 import { createDetailsBlockContent } from "../extensions/detailsBlock";
 import { isEditorTextColor } from "../textColors";
 import { isEditorTextHighlight } from "../textHighlights";
@@ -84,6 +85,35 @@ export function useRibbonCommands({
 			const isReadOnlySafeAction =
 				action === "collapse_all_headings" || action === "expand_all_headings";
 			if (!canEdit && !isReadOnlySafeAction) return;
+
+			if (action === "paste_without_formatting") {
+				const selection = {
+					from: editor.state.selection.from,
+					to: editor.state.selection.to,
+				};
+				void invoke("read_clipboard_plain_text")
+					.then((text) => {
+						if (text == null || editor.isDestroyed || !editor.isEditable) {
+							return;
+						}
+						const plain = text.replace(/\r\n?/g, "\n");
+						if (!plain.length) return;
+						editor.view.dispatch(
+							editor.state.tr.insertText(plain, selection.from, selection.to),
+						);
+						editor.view.focus();
+						if (scrollHost) {
+							requestAnimationFrame(() => {
+								scrollHost.scrollTop = scrollTop;
+							});
+						}
+					})
+					.catch((cause) => {
+						console.warn("Paste without formatting failed", cause);
+					});
+				return;
+			}
+
 			const chain = editor
 				.chain()
 				.focus(null, { scrollIntoView: false })

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -1,6 +1,7 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
+import { dispatchEditorMenuAction } from "../../lib/appEvents";
 import {
 	type EditorViewMode,
 	getDefaultEditorViewMode,
@@ -121,8 +122,13 @@ export function ExternalMarkdownWindow() {
 	}, [saveNow]);
 
 	useTauriEvent("menu:app_command", (payload) => {
-		if (payload.command_id !== "close-active-tab") return;
-		void closeWindow();
+		if (payload.command_id === "close-active-tab") {
+			void closeWindow();
+			return;
+		}
+		if (payload.command_id === "paste_without_formatting") {
+			dispatchEditorMenuAction({ action: "paste_without_formatting" });
+		}
 	});
 	useTauriEvent("external-markdown:close_requested", () => {
 		void closeWindow();

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -1,6 +1,7 @@
 import { emit } from "@tauri-apps/api/event";
 import type { Editor } from "@tiptap/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { dispatchEditorMenuAction } from "../../lib/appEvents";
 import { isMissingFileError } from "../../lib/fsErrors";
 import { loadSettings, reloadFromDisk } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
@@ -172,6 +173,11 @@ export function QuickNoteWindow() {
 	useTauriEvent("settings:updated", (payload) => {
 		if (typeof payload.quickNotes?.folder === "string") {
 			setFolder(payload.quickNotes.folder);
+		}
+	});
+	useTauriEvent("menu:app_command", (payload) => {
+		if (payload.command_id === "paste_without_formatting") {
+			dispatchEditorMenuAction({ action: "paste_without_formatting" });
 		}
 	});
 

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -129,6 +129,8 @@ export function useMenuListeners({
 				highlight_green: () => onEditorAction("highlight_green"),
 				highlight_red: () => onEditorAction("highlight_red"),
 				highlight_clear: () => onEditorAction("highlight_clear"),
+				paste_without_formatting: () =>
+					onEditorAction("paste_without_formatting"),
 			})
 				.then((handled) => {
 					if (!handled) {

--- a/src/i18n/locales/de/commands.json
+++ b/src/i18n/locales/de/commands.json
@@ -318,6 +318,10 @@
 			"label": "Space-Einstellungen öffnen",
 			"description": "Einstellungen für den aktuellen Space öffnen."
 		},
+		"paste_without_formatting": {
+			"label": "Ohne Formatierung einfügen",
+			"description": "Text aus der Zwischenablage ohne Formatierung einfügen."
+		},
 		"previous-tab": {
 			"label": "Vorheriger Tab",
 			"description": "Zum vorherigen Tab wechseln."

--- a/src/i18n/locales/en/commands.json
+++ b/src/i18n/locales/en/commands.json
@@ -318,6 +318,10 @@
 			"label": "Open Space Settings",
 			"description": "Open settings for the current space."
 		},
+		"paste_without_formatting": {
+			"label": "Paste without Formatting",
+			"description": "Paste clipboard text without formatting."
+		},
 		"previous-tab": {
 			"label": "Previous Tab",
 			"description": "Move to the previous tab."

--- a/src/i18n/locales/es/commands.json
+++ b/src/i18n/locales/es/commands.json
@@ -318,6 +318,10 @@
 			"label": "Abrir ajustes del espacio",
 			"description": "Abrir los ajustes del espacio actual."
 		},
+		"paste_without_formatting": {
+			"label": "Pegar sin formato",
+			"description": "Pegar el texto del portapapeles sin formato."
+		},
 		"previous-tab": {
 			"label": "Pestaña anterior",
 			"description": "Ir a la pestaña anterior."

--- a/src/i18n/locales/fr/commands.json
+++ b/src/i18n/locales/fr/commands.json
@@ -318,6 +318,10 @@
 			"label": "Ouvrir les réglages de l’espace",
 			"description": "Ouvrir les réglages de l’espace actuel."
 		},
+		"paste_without_formatting": {
+			"label": "Coller sans mise en forme",
+			"description": "Coller le texte du presse-papiers sans mise en forme."
+		},
 		"previous-tab": {
 			"label": "Onglet précédent",
 			"description": "Passer à l’onglet précédent."

--- a/src/i18n/locales/ja/commands.json
+++ b/src/i18n/locales/ja/commands.json
@@ -318,6 +318,10 @@
 			"label": "スペース設定を開く",
 			"description": "現在のスペースの設定を開きます。"
 		},
+		"paste_without_formatting": {
+			"label": "書式なしでペースト",
+			"description": "クリップボードのテキストを書式なしでペーストします。"
+		},
 		"previous-tab": {
 			"label": "前のタブ",
 			"description": "前のタブに移動します。"

--- a/src/i18n/locales/ko/commands.json
+++ b/src/i18n/locales/ko/commands.json
@@ -318,6 +318,10 @@
 			"label": "스페이스 설정 열기",
 			"description": "현재 스페이스의 설정을 엽니다."
 		},
+		"paste_without_formatting": {
+			"label": "서식 없이 붙여넣기",
+			"description": "클립보드의 텍스트를 서식 없이 붙여넣습니다."
+		},
 		"previous-tab": {
 			"label": "이전 탭",
 			"description": "이전 탭으로 이동합니다."

--- a/src/i18n/locales/pt-BR/commands.json
+++ b/src/i18n/locales/pt-BR/commands.json
@@ -318,6 +318,10 @@
 			"label": "Abrir configurações do espaço",
 			"description": "Abrir as configurações do espaço atual."
 		},
+		"paste_without_formatting": {
+			"label": "Colar sem formatação",
+			"description": "Colar o texto da área de transferência sem formatação."
+		},
 		"previous-tab": {
 			"label": "Aba anterior",
 			"description": "Ir para a aba anterior."

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -776,6 +776,7 @@ interface TauriCommands {
 	show_quick_note_window: CommandDef<void, void>;
 	hide_quick_note_window: CommandDef<void, void>;
 	show_main_window: CommandDef<void, void>;
+	read_clipboard_plain_text: CommandDef<void, string | null>;
 	set_quick_note_global_shortcut: CommandDef<
 		{ accelerator?: string | null },
 		void

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -922,6 +922,22 @@
 			"commandPalette": true,
 			"menuId": "space.settings"
 		},
+		"paste_without_formatting": {
+			"id": "paste_without_formatting",
+			"label": "Paste without Formatting",
+			"description": "Paste clipboard text without formatting.",
+			"category": "editor",
+			"context": "editor",
+			"defaultBinding": {
+				"meta": true,
+				"alt": true,
+				"shift": true,
+				"key": "v"
+			},
+			"allowInEditable": true,
+			"commandPalette": false,
+			"menuId": "edit.paste_without_formatting"
+		},
 		"previous-tab": {
 			"id": "previous-tab",
 			"label": "Previous Tab",


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/398


## Description

Adds macOS Edit → Paste without Formatting with the `⌘⌥⇧V` shortcut across the main editor, Quick Notes, and external Markdown windows.

- Summary of changes
  - Adds the localized Edit menu command and macOS shortcut.
  - Reads plain text through the native macOS pasteboard and inserts it into the focused rich editor.
  - Preserves paragraphs, line breaks, and meaningful whitespace while removing formatting semantics.
  - Routes the command to all supported editor window types.
- Reasoning
  - The browser clipboard API was triggering macOS/WebKit paste confirmation after the menu shortcut. Native pasteboard access keeps the shortcut immediate and avoids that prompt.
- Additional context
  - Normal `⌘V` behavior and existing undo behavior are unchanged.
  - Includes the existing `0.8.9-alpha.2` version bump.


## Screenshots

No screenshots: this is a behavior-only change.


## Docs

Added shared editor terminology and paste behavior notes in `CONTEXT.md`. The native macOS clipboard helper and routing code include focused comments where needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds macOS “Paste without Formatting” with ⌘⌥⇧V to paste plain text into rich editors without styling. Works in the main editor, Quick Notes, and external Markdown windows, and avoids the WebKit paste confirmation.

- **New Features**
  - Edit menu command and shortcut; targeted to the focused editor window.
  - Tauri command `read_clipboard_plain_text` reads macOS pasteboard as plain text, preserving paragraphs and line breaks, and keeps scroll position. Skips multi-line transformations inside code blocks.
  - Normal ⌘V and undo behavior unchanged.
  - Added command to `src/shared/appCommandManifest.json` (editor context). Updated i18n labels. Added `CONTEXT.md` with paste behavior notes.

- **Dependencies**
  - Add `objc2-app-kit` (macOS) for `NSPasteboard` access.
  - Bump version to `0.8.9-alpha.2`.

<sup>Written for commit ea0594362a40ea8ea7a870d22e188cb90fd99817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Paste without Formatting” command for editor surfaces.
  * Pastes clipboard text as plain text while preserving line breaks and meaningful whitespace.
  * Available from the Edit menu and via a keyboard shortcut.
  * Works across notes and external Markdown editors.
  * Added translations for English, German, Spanish, French, Japanese, Korean, and Brazilian Portuguese.

* **Documentation**
  * Added shared terminology and behavior guidance for editing and paste interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->