### PR TITLE
Fix rich editor losing recently typed words (#402) [Release]

### DIFF
--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -353,6 +353,62 @@ When changing editor behavior:
 8. Flush the editor before operations that duplicate, sync, or export the current note.
 9. Keep image paste storage tied to a real space file.
 
+## Postmortem: Rich Editor Lost the Last Words Typed (Issue #399)
+
+Fixed on branch `fix/rich-editor-word-loss`. In Rich mode, the last couple of
+words occasionally disappeared, most often after pausing a few seconds and
+then resuming typing. The loss also reached disk because the rollback cleared
+the dirty flag.
+
+### Root cause
+
+`useMarkdownDocumentSession` reset the whole document session whenever the
+`initialDoc` prop changed identity, guarded only by
+`initialDoc?.text === textRef.current`. But `initialDoc` is read from the
+navigation prefetch cache in `MainContent`, and that cache gets a **new
+object for the same note on every autosave** (`persistDoc` calls
+`setPrefetchedNote` with the just-saved text). Any re-render that recomputed
+the `MainContent` memo (for example, the file-tree refresh that follows every
+save because the note is reindexed) then delivered a new `initialDoc` whose
+text was the *last saved* snapshot.
+
+The failure sequence:
+
+1. Type, pause. The 300ms Markdown sync flushes; 900ms later autosave writes
+   and refreshes the prefetch cache with a new object.
+2. Resume typing, so `textRef.current` moves ahead of the saved text.
+3. A `MainContent` re-render hands the pane the new `initialDoc` (saved
+   text). The equality guard fails, the session performs a full reset:
+   `text` rolls back to the saved snapshot and `hasUserEditsRef` clears.
+4. The rolled-back `markdown` prop no longer matches
+   `lastEmittedMarkdownRef` in `useNoteEditor`, so the hydration effect runs
+   `editor.commands.setContent(stale body)` — the words typed since the last
+   autosave visibly vanish, and nothing re-saves them.
+
+### Fix
+
+- The session reset in `useMarkdownDocumentSession` now runs only when the
+  note identity (`relPath`) changes. Same-note `initialDoc` refreshes are
+  cache noise and are ignored.
+- `flushRawMarkdown` became `flushPendingEdits` and now also flushes the
+  rich editor's debounced Markdown sync (registered through
+  `onFlushPendingEditsReady` on `NoteInlineEditor`). Autosave snapshots,
+  manual save, mode switches, and external-reload guards previously compared
+  `textRef` against saved text while up to ~300ms of typing lived only
+  inside TipTap; the guards can no longer observe falsely-clean text.
+- `scheduleMarkdownSync` no longer defers its flush through
+  `requestAnimationFrame`. macOS suspends rAF for occluded windows, which
+  could strand a pending sync — and the text it carried — indefinitely.
+
+A considered-and-rejected change: tagging the self-emitted
+`notes:external_changed` event from `space_write_text` so the session could
+ignore its own saves. AI actions and quick notes also write the open note
+via `space_write_text` in the same window, and the session must keep
+reloading for those, so the reload path stays guarded instead.
+
+Regression coverage: "keeps newer typed text when the initialDoc cache
+refreshes mid-session" in `MarkdownEditorPane.test.tsx`.
+
 ## Debugging Map
 
 - Text jumps to old content: inspect external reload path and dirty checks.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.9-alpha.2",
+	"version": "0.8.9-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -166,6 +166,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	onRegisterCalloutInserter,
 	onEditorReady,
 	onRawEditorReady,
+	onFlushPendingEditsReady,
 	onChange,
 	onFrontmatterCommit,
 	extractToNoteActions,
@@ -210,6 +211,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 
 	const {
 		editor,
+		flushMarkdownSync,
 		frontmatter,
 		frontmatterRef,
 		lastAppliedBodyRef,
@@ -248,6 +250,12 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	const [linkDialog, setLinkDialog] = useState<NoteLinkDialogState | null>(
 		null,
 	);
+	useEffect(() => {
+		if (!onFlushPendingEditsReady) return;
+		onFlushPendingEditsReady(() => flushMarkdownSync());
+		return () => onFlushPendingEditsReady(null);
+	}, [flushMarkdownSync, onFlushPendingEditsReady]);
+
 	const rawEditorRef = useRef<RawMarkdownEditorHandle | null>(null);
 	const handleRawEditorRef = useCallback(
 		(editor: RawMarkdownEditorHandle | null) => {

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -349,7 +349,6 @@ export function useNoteEditor({
 	const pendingSelectionRestoreRef = useRef<SelectionSnapshot | null>(null);
 	const editorContentRelPathRef = useRef(relPath);
 	const markdownSyncTimeoutRef = useRef<number | null>(null);
-	const markdownSyncFrameRef = useRef<number | null>(null);
 	const markdownManagerRef = useRef<MarkdownManager | null>(null);
 	const pasteMarkdownBehaviorRef = useRef(pasteMarkdownBehavior);
 	const extensions = useMemo(
@@ -398,10 +397,6 @@ export function useNoteEditor({
 			window.clearTimeout(markdownSyncTimeoutRef.current);
 			markdownSyncTimeoutRef.current = null;
 		}
-		if (markdownSyncFrameRef.current !== null) {
-			window.cancelAnimationFrame(markdownSyncFrameRef.current);
-			markdownSyncFrameRef.current = null;
-		}
 	}, []);
 
 	const flushMarkdownSync = useCallback(
@@ -445,12 +440,12 @@ export function useNoteEditor({
 				relPath: relPathRef.current,
 			};
 			clearScheduledMarkdownSync();
+			// No requestAnimationFrame hop here: macOS suspends rAF callbacks for
+			// occluded windows, which would strand the pending sync (and the text
+			// it carries) until the window is next painted.
 			markdownSyncTimeoutRef.current = window.setTimeout(() => {
 				markdownSyncTimeoutRef.current = null;
-				markdownSyncFrameRef.current = window.requestAnimationFrame(() => {
-					markdownSyncFrameRef.current = null;
-					flushMarkdownSync();
-				});
+				flushMarkdownSync();
 			}, MARKDOWN_SYNC_DEBOUNCE_MS);
 		},
 		[clearScheduledMarkdownSync, flushMarkdownSync],
@@ -739,6 +734,7 @@ export function useNoteEditor({
 
 	return {
 		editor,
+		flushMarkdownSync,
 		frontmatter,
 		colorfulHeadings,
 		showFrontmatterInEditor,

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -42,4 +42,10 @@ export interface NoteInlineEditorProps {
 	onRawEditorReady?:
 		| ((editor: RawMarkdownEditorHandle | null) => void)
 		| undefined;
+	/**
+	 * Registers a callback that synchronously flushes the rich editor's
+	 * debounced Markdown sync into `onChange`. Callers use it to make
+	 * autosave snapshots and reload guards see the newest typed text.
+	 */
+	onFlushPendingEditsReady?: ((flush: (() => void) | null) => void) | undefined;
 }

--- a/src/components/preview/MarkdownEditorPane.test.tsx
+++ b/src/components/preview/MarkdownEditorPane.test.tsx
@@ -251,6 +251,49 @@ describe("MarkdownEditorPane", () => {
 		});
 	});
 
+	it("keeps newer typed text when the initialDoc cache refreshes mid-session", async () => {
+		// Regression test for issue #399: autosave and file-tree refreshes hand
+		// the pane a new `initialDoc` object for the same note. That must not
+		// reset the session, or text typed since the last save is rolled back
+		// and silently lost.
+		await act(async () => {
+			root.render(
+				<MarkdownEditorPane
+					relPath="notes/race.md"
+					initialDoc={makeDoc("notes/race.md", "initial text")}
+				/>,
+			);
+		});
+
+		const changeButton = Array.from(container.querySelectorAll("button")).find(
+			(button) => button.textContent?.includes("Type latest text"),
+		);
+		expect(changeButton).not.toBeNull();
+		await act(async () => {
+			changeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		// Same note, new cache object with the pre-edit text (as after a save).
+		await act(async () => {
+			root.render(
+				<MarkdownEditorPane
+					relPath="notes/race.md"
+					initialDoc={makeDoc("notes/race.md", "initial text", 1)}
+				/>,
+			);
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(900);
+		});
+
+		expect(invokeMock).toHaveBeenCalledWith("space_write_text", {
+			path: "notes/race.md",
+			text: "latest typed text",
+			base_mtime_ms: 1,
+		});
+	});
+
 	it("opts the main note editor into smart Markdown paste", async () => {
 		await act(async () => {
 			root.render(

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -189,8 +189,9 @@ export function MarkdownEditorPane({
 	}, []);
 	const {
 		error,
-		flushRawMarkdown,
+		flushPendingEdits,
 		handleRawEditorReady,
+		handleRichEditorFlushReady,
 		isDirty,
 		lastSavedMtimeMs,
 		markUserEdit,
@@ -211,7 +212,7 @@ export function MarkdownEditorPane({
 	});
 	const requestEditorMode = useCallback(
 		async (nextMode: NoteInlineEditorMode) => {
-			flushRawMarkdown();
+			flushPendingEdits();
 			if (nextMode !== "plain" && requiresPlainEditorMode(textRef.current)) {
 				const modeLabel = nextMode === "rich" ? "Rich" : "Preview";
 				const { confirm } = await import("@tauri-apps/plugin-dialog");
@@ -227,7 +228,7 @@ export function MarkdownEditorPane({
 			}
 			applyEditorMode(nextMode);
 		},
-		[applyEditorMode, flushRawMarkdown, textRef],
+		[applyEditorMode, flushPendingEdits, textRef],
 	);
 	const {
 		headings: tocHeadings,
@@ -595,6 +596,7 @@ export function MarkdownEditorPane({
 								onFrontmatterCommit={runAutosave}
 								onEditorReady={handleEditorReady}
 								onRawEditorReady={handleRawEditorReady}
+								onFlushPendingEditsReady={handleRichEditorFlushReady}
 								extractToNoteActions={extractToNoteActions}
 							/>
 						)}

--- a/src/components/preview/useMarkdownDocumentSession.ts
+++ b/src/components/preview/useMarkdownDocumentSession.ts
@@ -66,13 +66,28 @@ export function useMarkdownDocumentSession({
 
 	savingRef.current = saving;
 
-	const flushRawMarkdown = useCallback(() => {
+	const richEditorFlushRef = useRef<(() => void) | null>(null);
+
+	/**
+	 * Synchronously pushes any debounced editor edits (rich Markdown sync and
+	 * raw editor changes) into `textRef` so save snapshots and reload guards
+	 * never observe stale text.
+	 */
+	const flushPendingEdits = useCallback(() => {
+		richEditorFlushRef.current?.();
 		rawEditorRef.current?.flushPendingChange();
 	}, []);
 
 	const handleRawEditorReady = useCallback(
 		(editor: RawMarkdownEditorHandle | null) => {
 			rawEditorRef.current = editor;
+		},
+		[],
+	);
+
+	const handleRichEditorFlushReady = useCallback(
+		(flush: (() => void) | null) => {
+			richEditorFlushRef.current = flush;
 		},
 		[],
 	);
@@ -105,15 +120,15 @@ export function useMarkdownDocumentSession({
 	}, []);
 
 	useEffect(() => {
-		// `initialDoc` is a seed for the pane. Autosave also refreshes that cache,
-		// so do not treat the resulting object identity change as a new document.
-		flushRawMarkdown();
-		if (
-			activeRelPathRef.current === relPath &&
-			initialDoc?.text === textRef.current
-		) {
+		// `initialDoc` is only a seed for a newly opened note. Autosave and file
+		// tree refreshes also produce new cache objects for the *same* note; if
+		// those reset the session while the user kept typing, the text typed
+		// since the last save would be rolled back and lost (issue #399). Only a
+		// note identity change may reset the session.
+		if (activeRelPathRef.current === relPath) {
 			return;
 		}
+		flushPendingEdits();
 		const sessionId = documentSessionRef.current + 1;
 		documentSessionRef.current = sessionId;
 		saveRequestTokenRef.current += 1;
@@ -136,16 +151,14 @@ export function useMarkdownDocumentSession({
 		clearPulse();
 		hasUserEditsRef.current = false;
 		setError(initialError);
-		if (activeRelPathRef.current !== relPath) {
-			setEditorMode(resolveEditorModeForNote(cached));
-		}
+		setEditorMode(resolveEditorModeForNote(cached));
 		activeRelPathRef.current = relPath;
 		if (initialDoc) {
 			setPrefetchedNote(relPath, initialDoc);
 		}
 	}, [
 		clearPulse,
-		flushRawMarkdown,
+		flushPendingEdits,
 		initialDoc,
 		initialError,
 		relPath,
@@ -225,7 +238,7 @@ export function useMarkdownDocumentSession({
 
 	const loadDocFromExternalChange = useCallback(async () => {
 		const sessionId = documentSessionRef.current;
-		flushRawMarkdown();
+		flushPendingEdits();
 		if (
 			textRef.current !== savedTextRef.current ||
 			autosaveInFlightRef.current ||
@@ -238,7 +251,7 @@ export function useMarkdownDocumentSession({
 		try {
 			const doc = await invoke("space_read_text", { path: relPath });
 			if (!isCurrentSession(sessionId)) return;
-			flushRawMarkdown();
+			flushPendingEdits();
 			if (
 				textRef.current !== savedTextRef.current ||
 				autosaveInFlightRef.current ||
@@ -264,7 +277,7 @@ export function useMarkdownDocumentSession({
 			if (!isCurrentSession(sessionId)) return;
 			setError(extractErrorMessage(e));
 		}
-	}, [flushRawMarkdown, isCurrentSession, relPath, replaceText]);
+	}, [flushPendingEdits, isCurrentSession, relPath, replaceText]);
 
 	const loadedSpacePathRef = useRef(spacePath);
 
@@ -389,7 +402,7 @@ export function useMarkdownDocumentSession({
 		const sessionId = documentSessionRef.current;
 		const saveToken = saveRequestTokenRef.current + 1;
 		saveRequestTokenRef.current = saveToken;
-		flushRawMarkdown();
+		flushPendingEdits();
 		setSaving(true);
 		try {
 			await persistDoc(relPath, textRef.current, sessionId);
@@ -401,11 +414,11 @@ export function useMarkdownDocumentSession({
 				setSaving(false);
 			}
 		}
-	}, [flushRawMarkdown, isCurrentSession, persistDoc, relPath]);
+	}, [flushPendingEdits, isCurrentSession, persistDoc, relPath]);
 
 	const runAutosave = useCallback(async () => {
 		const sessionId = documentSessionRef.current;
-		flushRawMarkdown();
+		flushPendingEdits();
 		if (autosaveInFlightRef.current) {
 			autosaveQueuedRef.current = true;
 			return false;
@@ -432,7 +445,7 @@ export function useMarkdownDocumentSession({
 			return runAutosave();
 		}
 		return ok;
-	}, [flushRawMarkdown, isCurrentSession, persistDoc, relPath]);
+	}, [flushPendingEdits, isCurrentSession, persistDoc, relPath]);
 
 	const isDirty = text !== savedText;
 
@@ -461,7 +474,7 @@ export function useMarkdownDocumentSession({
 			}
 			externalSyncTimerRef.current = window.setTimeout(() => {
 				externalSyncTimerRef.current = null;
-				flushRawMarkdown();
+				flushPendingEdits();
 				if (
 					textRef.current !== savedTextRef.current ||
 					autosaveInFlightRef.current ||
@@ -473,7 +486,7 @@ export function useMarkdownDocumentSession({
 				void loadDocFromExternalChange();
 			}, EXTERNAL_RELOAD_DEBOUNCE_MS);
 		},
-		[flushRawMarkdown, loadDocFromExternalChange, relPath],
+		[flushPendingEdits, loadDocFromExternalChange, relPath],
 	);
 
 	useTauriEvent("notes:external_changed", handleExternalNoteChanged);
@@ -507,8 +520,9 @@ export function useMarkdownDocumentSession({
 
 	return {
 		error,
-		flushRawMarkdown,
+		flushPendingEdits,
 		handleRawEditorReady,
+		handleRichEditorFlushReady,
 		isDirty,
 		lastSavedMtimeMs,
 		markUserEdit,


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/399


## Description

Prevents the Rich editor from rolling back text typed after an autosave cache refresh, and ensures pending Rich-editor Markdown syncs are flushed before saves, mode switches, and reload checks.

- Summary of changes
  - Reset the Markdown document session only when the note path changes.
  - Flush pending Rich-editor Markdown updates alongside raw-editor changes.
  - Remove the `requestAnimationFrame` hop that could strand syncs in occluded macOS windows.
  - Add regression coverage for a same-note cache refresh while newer text is pending.
- Reasoning
  - Same-note prefetch-cache updates are not a new document and must not overwrite newer local edits.
- Additional context
  - Added the issue postmortem to `docs/architecture/05-editor-markdown-autosave.md`.


## Docs

Added a postmortem covering the failure sequence, root cause, fix, and regression coverage.


## Ready?

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rich editor rolling back the last words you typed after autosave or a cache refresh. We now flush pending edits and only reset the session when the note changes, so no text is lost.

- **Bug Fixes**
  - Reset the Markdown document session only when `relPath` changes; ignore same‑note `initialDoc` refreshes.
  - Add `flushPendingEdits` to also flush the Rich editor’s debounced Markdown sync; used by autosave, mode switches, and reload checks.
  - Remove the `requestAnimationFrame` hop from Markdown sync to avoid stranded updates in occluded macOS windows.
  - Add a regression test and a postmortem in docs.

- **Dependencies**
  - Bump app version to 0.8.9-alpha.3 in `src-tauri/tauri.conf.json`.

<sup>Written for commit a9ae0c9bc9b949f3f73ac108047755a3b42da83b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented recently typed text from being overwritten when note data refreshes during editing.
  - Improved autosave reliability so pending rich-text and raw-text edits are saved before switching modes, reloading, or handling external updates.
  - Prevented lost edits on macOS when background scheduling is delayed.

- **Tests**
  - Added regression coverage confirming newer typed text is preserved during note refreshes.

- **Documentation**
  - Added a postmortem documenting the data-loss scenario, fix, and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->