### PR TITLE
Fix release Codex startup (#403) [Release]

### DIFF
--- a/src-tauri/src/ai_codex/state.rs
+++ b/src-tauri/src/ai_codex/state.rs
@@ -154,11 +154,26 @@ impl CodexState {
 
     fn spawn_process(&self) -> Result<RuntimeProcess, String> {
         let codex_bin = Self::resolve_codex_binary()?;
-        let mut child = Command::new(&codex_bin)
+        let mut command = Command::new(&codex_bin);
+        command
             .args(["app-server", "--listen", "stdio://"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        #[cfg(target_os = "macos")]
+        {
+            let existing_path = std::env::var_os("PATH").unwrap_or_default();
+            let path = std::env::join_paths(
+                [PathBuf::from("/opt/homebrew/bin"), PathBuf::from("/usr/local/bin")]
+                    .into_iter()
+                    .chain(std::env::split_paths(&existing_path)),
+            )
+            .map_err(|error| format!("failed to configure Codex PATH: {error}"))?;
+            command.env("PATH", path);
+        }
+
+        let mut child = command
             .spawn()
             .map_err(|e| {
                 format!(

--- a/src-tauri/src/ai_codex/state.rs
+++ b/src-tauri/src/ai_codex/state.rs
@@ -163,11 +163,15 @@ impl CodexState {
 
         #[cfg(target_os = "macos")]
         {
-            let existing_path = std::env::var_os("PATH").unwrap_or_default();
+            let existing_path = std::env::var_os("PATH").filter(|path| !path.is_empty());
             let path = std::env::join_paths(
                 [PathBuf::from("/opt/homebrew/bin"), PathBuf::from("/usr/local/bin")]
                     .into_iter()
-                    .chain(std::env::split_paths(&existing_path)),
+                    .chain(
+                        existing_path
+                            .iter()
+                            .flat_map(|path| std::env::split_paths(path)),
+                    ),
             )
             .map_err(|error| format!("failed to configure Codex PATH: {error}"))?;
             command.env("PATH", path);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.9-alpha.3",
+	"version": "0.8.9-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Closes 


## Description

Fixes Codex startup in the packaged macOS app.

- Adds standard macOS Node.js locations to the PATH used for the Codex child process.
- The packaged app has a restricted PATH, so the globally installed Codex launcher could not find Node.js and exited immediately.
- Bumps the app version to `0.8.9-alpha.4`.

Verified by starting Codex app-server with the release app's PATH and completing Glyph's initialization request.


## Docs

No user-facing documentation is required. The packaged app now includes the standard macOS Node.js locations when launching Codex.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex startup in the packaged macOS app by adding standard Node.js paths to the launch environment and skipping empty PATH values. Prevents the Codex launcher from exiting when Node isn’t on PATH.

- **Bug Fixes**
  - On macOS, prepend `/opt/homebrew/bin` and `/usr/local/bin` to PATH for the Codex child process; preserve existing PATH when set and ignore empty values.
  - Bumped app version to `0.8.9-alpha.4`.
  - Verified by starting Codex `app-server` and completing Glyph initialization.

<sup>Written for commit 47469f5bfb86c82a15ff653300b0f669594e8df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS support by ensuring required system tool paths are available when launching the app’s AI process.

* **Chores**
  * Updated the application version to 0.8.9-alpha.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->