### PR TITLE
Add copy buttons for code blocks in preview mode

### DIFF
--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -1,0 +1,107 @@
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { i18n } from "../../../i18n";
+
+const FEEDBACK_MS = 1500;
+
+function iconMarkup(copied: boolean): string {
+	return renderToStaticMarkup(
+		createElement(HugeiconsIcon, {
+			icon: copied ? Tick02Icon : Copy01Icon,
+			size: "var(--icon-sm)",
+			strokeWidth: 0.9,
+		}),
+	);
+}
+
+function copyButton(): HTMLButtonElement {
+	const btn = document.createElement("button");
+	btn.type = "button";
+	btn.className = "codeBlockActionBtn codeBlockInlineCopy";
+	let timer: number | null = null;
+
+	const paint = (kind: "idle" | "copied" | "failed") => {
+		const label = i18n.t(
+			kind === "copied"
+				? "editor:codeBlock.copied"
+				: kind === "failed"
+					? "editor:codeBlock.copyFailed"
+					: "editor:codeBlock.copy",
+		);
+		btn.title = label;
+		btn.setAttribute("aria-label", label);
+		btn.innerHTML = iconMarkup(kind === "copied");
+		btn.toggleAttribute("data-copied", kind === "copied");
+		btn.toggleAttribute("data-failed", kind === "failed");
+	};
+	paint("idle");
+
+	btn.addEventListener("mousedown", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+	});
+	btn.addEventListener("click", (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+		const text = btn.closest("pre")?.querySelector("code")?.textContent ?? "";
+		const clipboard = navigator.clipboard;
+		const finish = (ok: boolean) => {
+			if (timer !== null) window.clearTimeout(timer);
+			paint(ok ? "copied" : "failed");
+			timer = window.setTimeout(() => {
+				timer = null;
+				paint("idle");
+			}, FEEDBACK_MS);
+		};
+		if (!clipboard?.writeText) {
+			console.error("Clipboard API is unavailable.");
+			finish(false);
+			return;
+		}
+		void clipboard.writeText(text).then(
+			() => finish(true),
+			(err: unknown) => {
+				console.error("Failed to copy code block contents.", err);
+				finish(false);
+			},
+		);
+	});
+	return btn;
+}
+
+/** Preview/read-only: copy control on each code block (widget on the block). */
+export const CodeBlockCopyControls = Extension.create({
+	name: "codeBlockCopyControls",
+	addProseMirrorPlugins() {
+		const editor = this.editor;
+		return [
+			new Plugin({
+				key: new PluginKey("code-block-copy-controls"),
+				props: {
+					decorations(state) {
+						if (editor.isEditable) return DecorationSet.empty;
+						const decos: Decoration[] = [];
+						state.doc.descendants((node, pos) => {
+							if (node.type.name !== "codeBlock") return;
+							decos.push(
+								Decoration.widget(pos + 1, copyButton, {
+									side: -1,
+									ignoreSelection: true,
+									key: `code-block-copy-${pos}`,
+								}),
+							);
+						});
+						return decos.length
+							? DecorationSet.create(state.doc, decos)
+							: DecorationSet.empty;
+					},
+				},
+			}),
+		];
+	},
+});

--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -1,13 +1,23 @@
 import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { Decoration, DecorationSet } from "@tiptap/pm/view";
+import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { i18n } from "../../../i18n";
 
 const FEEDBACK_MS = 1500;
+
+const pluginKey = new PluginKey<CodeBlockCopyPluginState>(
+	"code-block-copy-controls",
+);
+
+interface CodeBlockCopyPluginState {
+	decorations: DecorationSet;
+	editable: boolean;
+}
 
 function iconMarkup(copied: boolean): string {
 	return renderToStaticMarkup(
@@ -19,7 +29,21 @@ function iconMarkup(copied: boolean): string {
 	);
 }
 
-function copyButton(): HTMLButtonElement {
+function codeBlockTextAtWidget(
+	view: EditorView,
+	getPos: () => number | undefined,
+): string {
+	const pos = getPos();
+	if (typeof pos !== "number") return "";
+	const $pos = view.state.doc.resolve(pos);
+	if ($pos.parent.type.name !== "codeBlock") return "";
+	return $pos.parent.textContent ?? "";
+}
+
+function copyButton(
+	view: EditorView,
+	getPos: () => number | undefined,
+): HTMLButtonElement {
 	const btn = document.createElement("button");
 	btn.type = "button";
 	btn.className = "codeBlockActionBtn codeBlockInlineCopy";
@@ -48,11 +72,12 @@ function copyButton(): HTMLButtonElement {
 	btn.addEventListener("click", (e) => {
 		e.preventDefault();
 		e.stopPropagation();
-		const text = btn.closest("pre")?.querySelector("code")?.textContent ?? "";
+		const text = codeBlockTextAtWidget(view, getPos);
 		const clipboard = navigator.clipboard;
 		const finish = (ok: boolean) => {
 			if (timer !== null) window.clearTimeout(timer);
 			paint(ok ? "copied" : "failed");
+			// Keep success/fail visible briefly, then return the control to idle.
 			timer = window.setTimeout(() => {
 				timer = null;
 				paint("idle");
@@ -74,31 +99,74 @@ function copyButton(): HTMLButtonElement {
 	return btn;
 }
 
+function buildCopyDecorations(doc: ProseMirrorNode): DecorationSet {
+	const decos: Decoration[] = [];
+	doc.descendants((node, pos) => {
+		if (node.type.name !== "codeBlock") return;
+		decos.push(
+			Decoration.widget(
+				pos + 1,
+				(view, getPos) => {
+					const resolvePos =
+						typeof getPos === "function" ? getPos : () => undefined;
+					return copyButton(view, resolvePos);
+				},
+				{
+					side: -1,
+					ignoreSelection: true,
+					key: `code-block-copy-${pos}`,
+				},
+			),
+		);
+		return false;
+	});
+	return decos.length ? DecorationSet.create(doc, decos) : DecorationSet.empty;
+}
+
 /** Preview/read-only: copy control on each code block (widget on the block). */
 export const CodeBlockCopyControls = Extension.create({
 	name: "codeBlockCopyControls",
 	addProseMirrorPlugins() {
 		const editor = this.editor;
+		const getEditable = () => editor.isEditable;
+
 		return [
-			new Plugin({
-				key: new PluginKey("code-block-copy-controls"),
+			new Plugin<CodeBlockCopyPluginState>({
+				key: pluginKey,
+				state: {
+					init: (_config, state) => {
+						const editable = getEditable();
+						return {
+							editable,
+							decorations: editable
+								? DecorationSet.empty
+								: buildCopyDecorations(state.doc),
+						};
+					},
+					apply(transaction, value, _oldState, newState) {
+						const editable = getEditable();
+						if (editable) {
+							if (value.editable) return value;
+							return {
+								editable: true,
+								decorations: DecorationSet.empty,
+							};
+						}
+						if (!value.editable && !transaction.docChanged) {
+							return value;
+						}
+						return {
+							editable: false,
+							decorations: buildCopyDecorations(newState.doc),
+						};
+					},
+				},
 				props: {
 					decorations(state) {
 						if (editor.isEditable) return DecorationSet.empty;
-						const decos: Decoration[] = [];
-						state.doc.descendants((node, pos) => {
-							if (node.type.name !== "codeBlock") return;
-							decos.push(
-								Decoration.widget(pos + 1, copyButton, {
-									side: -1,
-									ignoreSelection: true,
-									key: `code-block-copy-${pos}`,
-								}),
-							);
-						});
-						return decos.length
-							? DecorationSet.create(state.doc, decos)
-							: DecorationSet.empty;
+						return (
+							pluginKey.getState(state)?.decorations ?? DecorationSet.empty
+						);
 					},
 				},
 			}),

--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -163,10 +163,12 @@ export const CodeBlockCopyControls = Extension.create({
 				},
 				props: {
 					decorations(state) {
+						// setEditable does not run plugin apply, so after rich→preview
+						// the cache can still be the empty set from editable mode.
 						if (editor.isEditable) return DecorationSet.empty;
-						return (
-							pluginKey.getState(state)?.decorations ?? DecorationSet.empty
-						);
+						const cached = pluginKey.getState(state);
+						if (cached && !cached.editable) return cached.decorations;
+						return buildCopyDecorations(state.doc);
 					},
 				},
 			}),

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -21,6 +21,7 @@ import {
 	visitChangedNodes,
 	visitNodesInRanges,
 } from "./changedRanges";
+import { CodeBlockCopyControls } from "./codeBlockCopyControls";
 import { SyntaxHighlightedCodeBlock } from "./codeBlockHighlighting";
 import { ColoredText } from "./coloredText";
 import { glyphDetailsExtensions } from "./detailsBlock";
@@ -648,6 +649,7 @@ export function createEditorExtensions(
 		HighlightedText,
 		ColoredText,
 		SyntaxHighlightedCodeBlock,
+		CodeBlockCopyControls,
 		EditorLink,
 		TaskList,
 		TaskItem.configure({ nested: true }),

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "Vorschau ausführen",
 		"copy": "Code kopieren",
 		"copied": "Code kopiert",
+		"copyFailed": "Code konnte nicht kopiert werden",
 		"editCode": "Code bearbeiten",
 		"editMermaid": "Mermaid-Code bearbeiten",
 		"editHtml": "HTML-Code bearbeiten",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -46,6 +46,7 @@
 		"runPreview": "Run preview",
 		"copy": "Copy code",
 		"copied": "Copied code",
+		"copyFailed": "Failed to copy code",
 		"editCode": "Edit code",
 		"editMermaid": "Edit Mermaid code",
 		"editHtml": "Edit HTML code",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "Ejecutar vista previa",
 		"copy": "Copiar código",
 		"copied": "Código copiado",
+		"copyFailed": "No se pudo copiar el código",
 		"editCode": "Editar código",
 		"editMermaid": "Editar código Mermaid",
 		"editHtml": "Editar código HTML",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "Exécuter l’aperçu",
 		"copy": "Copier le code",
 		"copied": "Code copié",
+		"copyFailed": "Échec de la copie du code",
 		"editCode": "Modifier le code",
 		"editMermaid": "Modifier le code Mermaid",
 		"editHtml": "Modifier le code HTML",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "プレビューを実行",
 		"copy": "コードをコピー",
 		"copied": "コードをコピーしました",
+		"copyFailed": "コードのコピーに失敗しました",
 		"editCode": "コードを編集",
 		"editMermaid": "Mermaid コードを編集",
 		"editHtml": "HTML コードを編集",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "미리보기 실행",
 		"copy": "코드 복사",
 		"copied": "코드 복사됨",
+		"copyFailed": "코드 복사 실패",
 		"editCode": "코드 편집",
 		"editMermaid": "Mermaid 코드 편집",
 		"editHtml": "HTML 코드 편집",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -45,6 +45,7 @@
 		"runPreview": "Executar pré-visualização",
 		"copy": "Copiar código",
 		"copied": "Código copiado",
+		"copyFailed": "Falha ao copiar o código",
 		"editCode": "Editar código",
 		"editMermaid": "Editar código Mermaid",
 		"editHtml": "Editar código HTML",

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -692,6 +692,7 @@
 }
 
 .tiptapContentInline pre {
+	position: relative;
 	background: color-mix(in srgb, var(--bg-secondary) 86%, var(--bg-primary));
 	padding: var(--space-6) var(--space-4) var(--space-4);
 	border-radius: var(--radius-lg);

--- a/src/styles/app/26-node-note-overlays.css
+++ b/src/styles/app/26-node-note-overlays.css
@@ -91,7 +91,23 @@
 }
 
 .codeBlockActionBtn[data-copied] {
-	color: var(--success);
+	color: var(--status-success-fg);
+}
+
+.codeBlockActionBtn[data-failed] {
+	color: var(--status-danger-fg);
+}
+
+/* Preview/read-only: decoration widget pinned to the code block itself. */
+.codeBlockInlineCopy {
+	position: absolute;
+	top: 4px;
+	right: 10px;
+	z-index: 15;
+	display: inline-flex;
+	align-items: center;
+	user-select: none;
+	pointer-events: auto;
 }
 
 .mermaidCodeBlockHiddenInPreview {


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/401


## Description

Adds always-available copy controls on code blocks in view/preview mode so readers can copy fenced code without switching to rich edit.

### Summary of changes
- New TipTap extension `CodeBlockCopyControls` places a copy button widget on each code block when the editor is read-only
- Reuses existing code-block action button styles and Hugeicons (`Copy01Icon` / `Tick02Icon`)
- i18n `codeBlock.copyFailed` strings for all editor locales
- Pin buttons to the block via `pre { position: relative }` + `.codeBlockInlineCopy`

### Reasoning
Preview mode cannot use the rich-mode selection chrome (caret/selection overlays). A ProseMirror decoration widget keeps the control on the block itself—no host geometry, scroll listeners, or parallel React overlay system. Hidden mermaid/HTML source blocks already use `display: none`, so their copy controls stay hidden with them.

### Additional context
- Rich-mode selected-block copy is unchanged
- Icon markup is rendered with `HugeiconsIcon` via `renderToStaticMarkup` because widgets are plain DOM, not React trees


## Screenshots

_(Visual: copy icon on each visible code block in preview; brief success/fail feedback on click. Please attach a screen recording if useful.)_


## Docs

- Extension: `src/components/editor/extensions/codeBlockCopyControls.ts`
- Wired in `createEditorExtensions()` next to `SyntaxHighlightedCodeBlock`
- When `editor.isEditable` is true → no decorations
- When false (preview) → one widget per `codeBlock` node at `pos + 1`, CSS absolute top-right on the `pre`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds always-visible copy buttons to code blocks in preview mode. Readers can copy code without switching to edit; edit mode is unchanged.

- **New Features**
  - TipTap extension `CodeBlockCopyControls` adds a per-block copy button in read-only preview.
  - Reuses existing code-block action styles; positions on the `pre` via CSS; button is clickable in preview.
  - Uses `@hugeicons/core-free-icons` with `@hugeicons/react`; shows copied/failed feedback; resets after 1.5s.
  - Adds i18n `codeBlock.copyFailed`; controls stay hidden for Mermaid/HTML source blocks.

- **Bug Fixes**
  - Ensures buttons render after switching between edit and preview; decorations refresh even when `setEditable` doesn’t trigger apply.

<sup>Written for commit 2679b0081dd5d119a523a872370bc35f81d8539a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy button to code blocks in read-only view.
  * Displays success or failure feedback after copying.
  * Added localized copy-failure messages in supported languages.

* **Style**
  * Improved code-block copy button positioning and visual states.
  * Updated success and error colors for clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->