### PR TITLE
Add a global date display format preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,14 @@ Repo extras: internal product and engineering docs live in `docs/`.
 - Use `paths::join_under()` for space paths (prevent traversal). Never log secrets.
 - Use `net.rs` SSRF checks for user-supplied URLs. Version durable documents (`version: 1`).
 - New Tauri commands: implement in `src-tauri/src/`, register in `lib.rs`, add types to `TauriCommands` in `src/lib/tauri.ts`.
+- Wrap blocking work (filesystem walks, SQLite, git subprocesses) in `tauri::async_runtime::spawn_blocking` inside Tauri commands; never block the async runtime.
+- Multi-window: resolve the space per window via `space_state.root_for_window(&window)` in commands; never assume a single global active space.
+- Never call `invoke()` in a loop over paths/notes; use the existing batch commands (`space_read_texts_batch`, `space_read_text_previews_batch`, `task_summaries_for_paths`) or add a batch command.
+- New settings require all of: default value, load-time normalization of legacy/invalid values, `settings:updated` emit, Rust runtime sync when native code consumes it, and a `settingsSearch.ts` entry.
+- Any Rust code path that writes a note must reindex it and emit the change event (`notes:external_changed` / `space:fs_changed`); the SQLite index is derived and must never go stale after a write.
+- All user-facing strings go through the i18n translation layer (menu labels via `set_menu_labels`); no hardcoded UI text.
 - Make sure we don't over-engineer CSS and use default components as much as possible unless explicitly stated.
-- Hard subtraction pass: fix the issue by deleting or narrowing code first. Do not add new abstractions, command entries, shortcuts, files, or wiring unless the existing code cannot support the fix.
-- Make sure we always narrow the code and apply fixes instead of patching the code by adding unnecessary LOCs in places that don't need them.
+- Hard subtraction pass: always attempt the fix by deleting or narrowing existing code first, and only add LOC when the existing code provably cannot support the fix. Never add new abstractions, command entries, shortcuts, files, or wiring as a patch around code that should have been narrowed.
 - NEVER make test files unless specifically requested by users.
 - For TSX files extract hooks/subcomponents when rendering, state, effects, and commands start mixing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Repo extras: internal product and engineering docs live in `docs/`.
 
 ## Backend Overview (`src-tauri/src/`)
 
-- Tauri setup and command registration live in `lib.rs` / `main.rs`; native features are grouped by domain such as `space`, `space_fs`, `notes`, `index`, `database`, `ai_*`, `license`, and `links`.
+- Tauri setup and command registration live in `lib.rs` / `main.rs`; native features are grouped by domain such as `space`, `space_fs`, `notes`, `index`, `databases`, `ai_*` (`ai_rig`, `ai_codex`, `ai_amp`, `ai_claude_code`, `ai_opencode`, `ai_pi`), `git_sync`, `license`, and `external_markdown`.
 - Use `paths::join_under()` for safe space paths, `io_atomic::write_atomic()` for durable writes, and `net.rs` checks for user-supplied URLs.
 
 ## Code Style & Safety

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://discord.gg/cNqrBfFx7D"><strong>Join us on Discord →</strong></a>
 </p>
 
-Offline-first desktop note-taking application. Tauri 2 shell with a React 19 / TypeScript / Vite 8 frontend and a Rust backend. Data lives entirely on-disk in a per-space `.glyph/` directory backed by SQLite and the local filesystem. No cloud sync, no server.
+Offline-first desktop note-taking application. Tauri 2 shell with a React 19 / TypeScript / Vite 8 frontend and a Rust backend. Notes live on-disk as Markdown files with per-space metadata in a `.glyph/` directory; a derived SQLite search index lives in app support and rebuilds from the notes. No cloud sync, no server.
 
 ![Glyph](imageforWebsite.png)
 
@@ -87,7 +87,6 @@ Source is open. Official release binaries include a 7-day trial with Gumroad lic
 
 - Releases: [GitHub Releases](https://github.com/SidhuK/Glyph/releases)
 - Purchase: [Gumroad](https://karatsidhu.gumroad.com/l/sqxfay)
-- Details: [`docs/licensing.md`](docs/licensing.md)
 
 ## Platform support
 

--- a/docs/architecture/04-ipc-and-native-runtime.md
+++ b/docs/architecture/04-ipc-and-native-runtime.md
@@ -70,17 +70,22 @@ If any of those steps are missing, the failure usually appears at runtime. TypeS
 
 The command map covers these groups:
 
-- App and native shell: app info, windows, menus, vibrancy, fonts
+- App and native shell: app info, windows, menus, vibrancy, fonts, clipboard, print
+- App exit: exit listener registration and confirm-exit flow (`app_confirm_exit`, `app_register_exit_listener`)
 - License: bootstrap, activate, clear local
-- Space lifecycle: create, open, close, onboarding
-- Space filesystem: list, read, write, preview, create, rename, duplicate, delete, link resolution
+- Updater: release channel check (`updater_check_release_channel`)
+- Space lifecycle: create, open, close, onboarding, open in new window (`space_open_window`)
+- Space filesystem: list, read, write, preview, batch reads, create, rename, duplicate, delete, link resolution, pasted image saving
+- External markdown: open, read, write, and close markdown files outside the space in dedicated windows (`external_markdown_*`, `open_external_markdown_path`)
+- Note metadata: frontmatter property parse/render, relationships, local connections (`note_*`)
 - Appearance stores: file tree, tags, pinned files
-- Index: rebuild, search, all docs, calendar, tags, people, tasks, backlinks, graph
-- Databases: list, get, create, update, delete, query rows, mutate cells, create rows, preview context
+- Index: rebuild, sync, search (plain, advanced, parse-and-run), all docs, calendar, tags, people, task summaries, backlinks, space connections
+- Databases: list, get, create, update, delete, query rows, mutate cells, create rows, status colors, preview context
 - Git sync: status, config, run, disconnect
-- AI: profiles, secrets, models, chat, context, history, Codex account
+- Git history: commit list and diffs (`git_history_list`, `git_history_diff`)
+- AI: profiles, secrets, models, chat, context, history, provider support, Codex account and rate limits
 
-Keep command names descriptive. Most existing commands use a module prefix: `space_`, `index_`, `databases_`, `ai_`, `codex_`, `git_sync_`.
+Keep command names descriptive. Most existing commands use a module prefix: `space_`, `index_`-style index names, `databases_`, `ai_`, `codex_`, `git_sync_`, `git_history_`, `external_markdown_`.
 
 ## Tauri Builder
 
@@ -102,6 +107,8 @@ Managed state:
 - `ai_codex::state::CodexState`
 - `git_sync::GitSyncState`
 - `space::SpaceState`
+- `app_exit::AppExitState`
+- `external_markdown::ExternalMarkdownState`
 - `MenuState`
 - `QuickNoteShortcutState`
 
@@ -109,7 +116,6 @@ Plugins:
 
 - global shortcut
 - dialog
-- notification
 - opener
 - process
 - store
@@ -134,7 +140,7 @@ This keeps native menus, keyboard shortcuts, and command palette behavior aligne
 - find default bindings
 - convert shortcut strings into native accelerators
 
-`set_menu_shortcuts` lets React push updated shortcut bindings into the native menu after settings load or change.
+`set_menu_shortcuts` lets React push updated shortcut bindings into the native menu after settings load or change. `set_menu_labels` does the same for translated menu labels when the UI language setting changes.
 
 When adding a user-configurable command:
 
@@ -157,16 +163,18 @@ The shell should update this only from active tab state, not from arbitrary file
 
 ## Windows
 
-`src-tauri/src/lib.rs` owns native windows:
+`src-tauri/src/lib.rs` owns native windows. Window labels live in `src/lib/windowLabels.ts`:
 
-- Main window
-- Settings window behavior when present
-- Quick note window
+- Main window (`main`)
+- Per-space windows (`space-` prefix) created through `space_open_window`
+- Quick note window (`quick-note`)
+- External markdown windows (`external-markdown-` prefix)
+- Settings and quick-task windows when present
 
 Close behavior:
 
-- Settings window close requests hide the window.
-- Quick note window close requests hide the window.
+- Settings, quick note, and quick-task window close requests hide the window.
+- External markdown windows emit `external-markdown:close_requested` so the frontend can flush unsaved content before `external_markdown_finish_close`.
 - On macOS, closing the main window hides it instead of exiting the app.
 
 Quick note window helpers:
@@ -189,7 +197,7 @@ The shortcut emits a native action that opens the quick note window. Keep this p
 During setup, Rust:
 
 - refreshes AI provider support metadata in the background
-- sizes and centers the main window to 80 percent of the current monitor
+- restores persisted main window geometry through `window_geometry`, falling back to 80 percent of the current monitor on first launch
 - applies macOS vibrancy when available
 
 Frontend startup then hydrates settings and space state. Do not assume React settings are available in Rust setup unless you pass them through a command later.
@@ -203,14 +211,17 @@ Backend-to-frontend events include:
 - `space:fs_changed`
 - `notes:external_changed`
 - `settings:updated`
+- `index:progress`
 - `ai:chunk`
 - `ai:done`
 - `ai:error`
 - `ai:status`
 - `ai:tool`
 - `ai:profiles-updated`
+- `codex:chunk`, `codex:done`, `codex:error`, `codex:status`, `codex:tool`
 - `git_sync:status`
 - `quick-note:open_note`
+- `external-markdown:close_requested`
 
 Use events for state changes that multiple frontend areas need to react to. Use command return values for direct request/response work.
 

--- a/docs/architecture/07-databases-frontmatter.md
+++ b/docs/architecture/07-databases-frontmatter.md
@@ -10,7 +10,8 @@ Backend:
 
 - `src-tauri/src/databases/types.rs`: database document, view, column, filter, row types
 - `src-tauri/src/databases/store.rs`: `.glyph/databases.json` load/save and default view helpers
-- `src-tauri/src/databases/query.rs`: source selection, filtering, sorting, row hydration
+- `src-tauri/src/databases/query.rs`: source selection, sorting, row hydration
+- `src-tauri/src/databases/filter.rs`: filter operators over hydrated rows
 - `src-tauri/src/databases/commands.rs`: Tauri commands and frontmatter mutations
 - `src-tauri/src/index/properties.rs`: indexed frontmatter property rows
 - `src-tauri/src/notes/frontmatter.rs`: YAML mapping parse/render
@@ -41,6 +42,7 @@ The store shape:
 
 ```rust
 pub struct DatabaseStore {
+    pub version: u32, // currently 1
     pub databases: Vec<DatabaseDefinition>,
     pub status_colors: BTreeMap<String, String>,
 }
@@ -48,7 +50,7 @@ pub struct DatabaseStore {
 
 The store contains collection definitions and view preferences. It does not contain row data. Row data comes from notes and the SQLite index.
 
-There is no store version field and no load-time migration. `load_store()` parses JSON as-is. Unknown JSON fields are ignored by serde.
+`load_store()` parses JSON and then runs `normalize_store_on_load()`, which sets a missing version to 1, normalizes property kinds and schema field defaults, prunes unsupported view layouts, and drops invalid status colors. Unknown JSON fields are ignored by serde.
 
 ## Collections
 
@@ -114,6 +116,7 @@ Users can still change a collection source to `all_notes`, `tag`, or `search` la
 - board lane colors
 - board lane order
 - board card order
+- board card fields
 - timestamps
 
 Unsupported layouts are pruned on `databases_update`. If all views disappear after pruning, the store adds a default board view named `View 1` grouped by `tags`.
@@ -203,7 +206,7 @@ The frontend receives rows with:
 
 ## Filtering
 
-Filters run in Rust over hydrated rows. Supported operators include:
+Filters run in Rust over hydrated rows in `filter.rs`. Supported operators include:
 
 - equals
 - not_equals
@@ -403,7 +406,7 @@ When changing databases:
 
 1. Decide whether the data belongs in note frontmatter or `.glyph/databases.json`.
 2. Update Rust types and TypeScript IPC types together.
-3. Use a hard cutover for store shape changes. Do not add version fields or load-time migration.
+3. Use a hard cutover for store shape changes. Bump the `version` field and normalize on load in `normalize_store_on_load()`; do not keep backward-compatibility shims.
 4. Keep row content derived from Markdown and index rows.
 5. Use `db_store_mutex()` for store writes.
 6. Use atomic writes for store saves and note writes.

--- a/docs/architecture/09-settings-menus-git-sync-native-windows.md
+++ b/docs/architecture/09-settings-menus-git-sync-native-windows.md
@@ -39,17 +39,20 @@ Git sync:
 
 Settings include:
 
-- current and recent spaces
-- theme mode, accent, font families, font sizes
-- auto-update check interval
+- current and recent spaces, restore-last-session behavior
+- theme mode, light/dark theme ids, custom theme colors, accent, corner radius style, translucency
+- font families (UI, editor, mono) and font sizes
+- auto-update check interval and release channel
+- UI language (i18n)
 - AI enabled and assistant mode
 - daily notes folder
 - quick notes folder
 - template folder and daily note template
-- task source
+- attachment folder and attachment storage mode
+- date display format
+- editor settings: default editor mode, focus mode, spell check, editor width, raw Markdown Vim mode, frontmatter visibility, collapsible headings, TOC
+- file tree settings: sort mode, folder counts, non-Markdown file visibility, beautiful tags, people mentions
 - database UI settings
-- editor settings
-- file tree settings
 - shortcut bindings
 - onboarding flags
 
@@ -146,12 +149,13 @@ This lets native menus call the same functions as keyboard shortcuts and command
 
 ## Window Runtime
 
-`lib.rs` owns window setup and close behavior:
+`lib.rs` owns window setup and close behavior. Window labels live in `src/lib/windowLabels.ts` (`main`, `space-` prefix, `quick-note`, `external-markdown-` prefix):
 
-- The main window is centered and sized to 80 percent of the current monitor.
+- Main window geometry persists across launches (`window_geometry`); first launch centers at 80 percent of the current monitor.
+- `space_open_window` opens another space in its own `space-` window, so multiple spaces can be open at once.
+- External markdown files open in dedicated `external-markdown-` windows managed by `external_markdown`.
 - macOS vibrancy applies during setup and can change later through command.
-- Settings window close requests hide the window.
-- Quick note window close requests hide the window.
+- Settings, quick note, and quick-task window close requests hide the window.
 - macOS main window close requests hide the window.
 
 Quick note commands:
@@ -270,15 +274,14 @@ Manual Git operations remain the escape hatch for complex conflicts.
 
 It also starts an interval using `status.interval_minutes`, clamped to at least one minute in the frontend and one to 1,440 minutes in the backend.
 
-## Native Notifications
+## Git History
 
-Rust sends notifications for:
+Beyond sync, the backend exposes read-only Git history commands:
 
-- index rebuild complete
-- AI response ready
-- AI request failed
+- `git_history_list`: commits touching a note path (default limit 30)
+- `git_history_diff`: per-file diff for a selected commit
 
-Git sync status uses app events instead of system notifications.
+Both validate the space-relative path and require the repo at the space root. The frontend uses these for note version history and restore flows.
 
 ## Change Checklist
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.9-alpha.5",
+	"version": "0.8.9-alpha.6",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -21,10 +21,18 @@ import {
 } from "date-fns";
 import { useReducedMotion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
-import { useFileTreeContext, useUILayoutContext } from "../../contexts";
+import {
+	useDateDisplayFormat,
+	useFileTreeContext,
+	useUILayoutContext,
+} from "../../contexts";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { getDailyNotePath } from "../../lib/dailyNotes";
+import {
+	type DateDisplayFormat,
+	formatDisplayDate,
+} from "../../lib/dateDisplayFormat";
 import {
 	ACTIVITY_DOCS_PAGE_SIZE,
 	allDocsListQueryOptions,
@@ -88,12 +96,16 @@ function dateKey(date: Date): string {
 	return format(date, "yyyy-MM-dd");
 }
 
-function dayLabel(date: Date): string {
+function dayLabel(date: Date, dateFormat: DateDisplayFormat): string {
 	const today = startOfDay(new Date());
 	const yesterday = subDays(today, 1);
 	if (isSameDay(date, today)) return "Today";
 	if (isSameDay(date, yesterday)) return "Yesterday";
-	return format(date, isSameYear(date, today) ? "EEEE, MMM d" : "MMM d, yyyy");
+	// Same-year headings omit the year (compact); only complete dates use the preference.
+	if (isSameYear(date, today)) {
+		return format(date, "EEEE, MMM d");
+	}
+	return formatDisplayDate(date, dateFormat);
 }
 
 function monthLabel(date: Date): string {
@@ -513,12 +525,13 @@ function ActivityFeed({
 }
 
 function ActivityDayHeaderRow({ day }: { day: ActivityDay }) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	return (
 		<section className="activityDayGroup activityDayHeaderRow">
 			<div className="activityDayRail" aria-hidden="true" />
 			<header className="activityDayHeader">
 				<div>
-					<h2>{dayLabel(day.date)}</h2>
+					<h2>{dayLabel(day.date, dateDisplayFormat)}</h2>
 				</div>
 				<div className="activityDayCounts">
 					<span>

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -3,7 +3,7 @@ import { Calendar03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { m, useReducedMotion } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { useFileTreeContext } from "../../contexts";
+import { useDateDisplayFormat, useFileTreeContext } from "../../contexts";
 import { useDatabaseBoard } from "../../hooks/database/useDatabaseBoard";
 import { useSentinelLoadMore } from "../../hooks/useLoadMoreTriggers";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
@@ -22,6 +22,7 @@ import {
 	formatDatabaseDateTime,
 } from "../../lib/database/config";
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
+import type { DateDisplayFormat } from "../../lib/dateDisplayFormat";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import {
@@ -159,9 +160,14 @@ function boardCardTextPropertyValues(
 	return values;
 }
 
-function formatCompactBoardDateTime(value: string): string {
+function formatCompactBoardDateTime(
+	value: string,
+	dateFormat: DateDisplayFormat,
+): string {
 	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) return formatDatabaseDateTime(value);
+	if (Number.isNaN(date.getTime())) {
+		return formatDatabaseDateTime(value, dateFormat);
+	}
 	const month = date.toLocaleString("en-US", { month: "short" });
 	const day = date.getDate();
 	const time = date
@@ -207,6 +213,7 @@ export function DatabaseBoard({
 		},
 		[boardCardFields],
 	);
+	const dateDisplayFormat = useDateDisplayFormat();
 	const { beautifulTags, itemAppearance, tagAppearance } = useFileTreeContext();
 	const shouldReduceMotion = useReducedMotion();
 	const {
@@ -577,9 +584,13 @@ export function DatabaseBoard({
 												priorityValues.length - maxVisiblePriorities,
 												0,
 											);
-											const updatedLabel = formatDatabaseDateTime(row.updated);
+											const updatedLabel = formatDatabaseDateTime(
+												row.updated,
+												dateDisplayFormat,
+											);
 											const compactUpdatedLabel = formatCompactBoardDateTime(
 												row.updated,
+												dateDisplayFormat,
 											);
 											const taskSummary =
 												taskSummariesByPath?.[row.note_path] ??

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { useFileTreeContext } from "../../contexts";
+import { useDateDisplayFormat, useFileTreeContext } from "../../contexts";
 import {
 	databaseCellValueFromRow,
 	formatDatabaseDateTime,
@@ -8,6 +8,7 @@ import {
 } from "../../lib/database/config";
 import { databaseValueToneStyleForColor } from "../../lib/database/palette";
 import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
+import { formatDisplayDate } from "../../lib/dateDisplayFormat";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	priorityColorKey,
@@ -1108,6 +1109,7 @@ export function DatabaseCell({
 	onRenameTitle,
 	onSave,
 }: DatabaseCellProps) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const { beautifulTags, itemAppearance, tagAppearance } = useFileTreeContext();
 	const editable = isColumnEditable(column);
 	const cellValue = useMemo(
@@ -1122,8 +1124,10 @@ export function DatabaseCell({
 	const [editing, setEditing] = useState(false);
 	const displayText =
 		cellValue.kind === "datetime"
-			? formatDatabaseDateTime(cellValue.value_text)
-			: (cellValue.value_text ?? "");
+			? formatDatabaseDateTime(cellValue.value_text, dateDisplayFormat)
+			: cellValue.kind === "date" && cellValue.value_text
+				? formatDisplayDate(cellValue.value_text, dateDisplayFormat)
+				: (cellValue.value_text ?? "");
 	const tagIconOverrides = useMemo(
 		() => tagIconOverridesFromAppearance(tagAppearance),
 		[tagAppearance],

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
+import { useDateDisplayFormat } from "../../../contexts";
 import {
 	priorityColorKey,
 	priorityOptionsWithCustomValues,
@@ -64,6 +65,7 @@ export function NotePropertyValueField({
 	onSetTagInputRef,
 	tagInputRef,
 }: NotePropertyValueFieldProps) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const textValue = property.value_text ?? "";
 	const [textDraft, setTextDraft] = useState(textValue);
 	const textInputRef = useRef<HTMLInputElement | null>(null);
@@ -134,7 +136,10 @@ export function NotePropertyValueField({
 			);
 		}
 		if (property.kind === "date") {
-			const formatted = formatPropertyDate(property.value_text ?? "");
+			const formatted = formatPropertyDate(
+				property.value_text ?? "",
+				dateDisplayFormat,
+			);
 			if (!formatted) {
 				return <span className="notePropertyEmptyValue">—</span>;
 			}

--- a/src/components/editor/noteProperties/utils.ts
+++ b/src/components/editor/noteProperties/utils.ts
@@ -1,3 +1,8 @@
+import {
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	type DateDisplayFormat,
+	formatDisplayDate,
+} from "../../../lib/dateDisplayFormat";
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 
 /** Keep in sync with `TAG_SEGMENT_PATTERN` / `INLINE_TAG_PATTERN` in `src-tauri/src/index/tags.rs`. */
@@ -20,15 +25,12 @@ export function tagHueFromName(name: string): number {
 	return Math.abs(hash) % 360;
 }
 
-export function formatPropertyDate(value: string): string {
+export function formatPropertyDate(
+	value: string,
+	format: DateDisplayFormat = DEFAULT_DATE_DISPLAY_FORMAT,
+): string {
 	if (!value) return "";
-	const parsed = new Date(value);
-	if (Number.isNaN(parsed.getTime())) return value;
-	return parsed.toLocaleDateString(undefined, {
-		year: "numeric",
-		month: "long",
-		day: "numeric",
-	});
+	return formatDisplayDate(value, format);
 }
 
 export function emptyProperty(): NoteProperty {

--- a/src/components/licensing/LicenseSettingsCard.tsx
+++ b/src/components/licensing/LicenseSettingsCard.tsx
@@ -1,5 +1,6 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useDateDisplayFormat } from "../../contexts";
 import {
 	activateLicenseKey,
 	clearLocalLicense,
@@ -40,6 +41,7 @@ function statusLabel(status: LicenseStatus): string {
 }
 
 export function LicenseSettingsCard() {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const { status, error, reload } = useLicenseStatus(false);
 	const [licenseKey, setLicenseKey] = useState("");
 	const [actionError, setActionError] = useState("");
@@ -146,7 +148,7 @@ export function LicenseSettingsCard() {
 				<>
 					<SettingsRow label="Activated" interactive={false}>
 						<div className="settingsValue">
-							{formatLicenseDate(status.activated_at_ms)}
+							{formatLicenseDate(status.activated_at_ms, dateDisplayFormat)}
 						</div>
 					</SettingsRow>
 					<SettingsRow label="License key" interactive={false}>

--- a/src/components/preview/GitDiffView.tsx
+++ b/src/components/preview/GitDiffView.tsx
@@ -1,3 +1,9 @@
+import { useDateDisplayFormat } from "../../contexts";
+import {
+	formatDisplayDate,
+	formatLocalClockTime,
+	parseDisplayDateInput,
+} from "../../lib/dateDisplayFormat";
 import type { GitCommitDiff } from "../../lib/tauri";
 
 interface GitDiffViewProps {
@@ -47,20 +53,16 @@ function diffLineDisplay(line: string): DiffLineDisplay {
 	return { kind, marker: "", text: line || " " };
 }
 
-function formatCommitDate(timestampMs: number): string {
-	if (!timestampMs) return "";
-	return new Intl.DateTimeFormat(undefined, {
-		month: "short",
-		day: "numeric",
-		year: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-	}).format(new Date(timestampMs));
-}
-
 export function GitDiffView({ diff, onBack }: GitDiffViewProps) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const lines = diff.diff.length ? diff.diff.trimEnd().split("\n") : [];
-	const dateLabel = formatCommitDate(diff.commit.timestamp_ms);
+	const timestampMs = diff.commit.timestamp_ms;
+	const commitDate = timestampMs ? parseDisplayDateInput(timestampMs) : null;
+	const dateLabel = commitDate
+		? formatDisplayDate(commitDate, dateDisplayFormat, {
+				time: formatLocalClockTime(commitDate),
+			})
+		: "";
 
 	return (
 		<div className="gitDiffView">

--- a/src/components/preview/GitHistorySidebar.tsx
+++ b/src/components/preview/GitHistorySidebar.tsx
@@ -1,5 +1,12 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
+import { useDateDisplayFormat } from "../../contexts";
+import {
+	type DateDisplayFormat,
+	formatDisplayDate,
+	formatLocalClockTime,
+	parseDisplayDateInput,
+} from "../../lib/dateDisplayFormat";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	type GitCommitDiff,
@@ -15,14 +22,16 @@ interface GitHistorySidebarProps {
 	onSelectDiff: (diff: GitCommitDiff) => void;
 }
 
-function formatCommitDate(timestampMs: number): string {
+function formatCommitDate(
+	timestampMs: number,
+	dateFormat: DateDisplayFormat,
+): string {
 	if (!timestampMs) return "";
-	return new Intl.DateTimeFormat(undefined, {
-		month: "short",
-		day: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
-	}).format(new Date(timestampMs));
+	const date = parseDisplayDateInput(timestampMs);
+	if (!date) return "";
+	return formatDisplayDate(date, dateFormat, {
+		time: formatLocalClockTime(date),
+	});
 }
 
 function formatCommitAge(timestampMs: number): string {
@@ -57,6 +66,7 @@ export function GitHistorySidebar({
 	selectedCommitHash = null,
 	onSelectDiff,
 }: GitHistorySidebarProps) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const latestDiffRequestId = useRef(0);
 	useEffect(
 		() => () => {
@@ -145,7 +155,10 @@ export function GitHistorySidebar({
 												) : null}
 												<span
 													className="gitHistoryMeta"
-													title={formatCommitDate(commit.timestamp_ms)}
+													title={formatCommitDate(
+														commit.timestamp_ms,
+														dateDisplayFormat,
+													)}
 												>
 													{isLoading
 														? "Opening…"

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -6,6 +6,13 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { useDateDisplayFormat } from "../../contexts";
+import {
+	type DateDisplayFormat,
+	formatDisplayDate,
+	formatLocalClockTime,
+	parseDisplayDateInput,
+} from "../../lib/dateDisplayFormat";
 import { canShowGitHistory } from "../../lib/gitSyncUi";
 import {
 	type RelationshipGroup,
@@ -69,16 +76,15 @@ interface NotesInfoSidebarProps {
 	onClose: () => void;
 }
 
-function formatMetadataDate(value: string | null | undefined): string {
+function formatMetadataDate(
+	value: string | null | undefined,
+	dateFormat: DateDisplayFormat,
+): string {
 	if (!value) return "—";
-	const parsed = new Date(value);
-	if (Number.isNaN(parsed.getTime())) return value;
-	return parsed.toLocaleString(undefined, {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-		hour: "numeric",
-		minute: "2-digit",
+	const parsed = parseDisplayDateInput(value);
+	if (!parsed) return value;
+	return formatDisplayDate(parsed, dateFormat, {
+		time: formatLocalClockTime(parsed),
 	});
 }
 
@@ -122,6 +128,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 	onSelectGitDiff,
 	onClose,
 }: NotesInfoSidebarProps) {
+	const dateDisplayFormat = useDateDisplayFormat();
 	const [host, setHost] = useState<HTMLElement | null>(null);
 	const [activeTab, setActiveTab] = useState<InfoSidebarTab>("info");
 	const hasGitHistoryTab =
@@ -408,13 +415,17 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 											lastSavedMtimeMs
 												? new Date(lastSavedMtimeMs).toISOString()
 												: (previewContext?.updated ?? null),
+											dateDisplayFormat,
 										)}
 									</span>
 								</div>
 								<div className="markdownEditorInfoRow">
 									<span>Created</span>
 									<span className="markdownEditorInfoValue">
-										{formatMetadataDate(previewContext?.created)}
+										{formatMetadataDate(
+											previewContext?.created,
+											dateDisplayFormat,
+										)}
 									</span>
 								</div>
 								<div className="markdownEditorInfoRow">

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -14,10 +14,23 @@ const { useLicenseStatusMock, useTauriEventMock } = vi.hoisted(() => ({
 vi.mock("../../lib/settings", () => ({
 	isFocusMode: (value: unknown) =>
 		value === "off" || value === "paragraph" || value === "sentence",
+	DATE_DISPLAY_FORMAT_OPTIONS: [
+		{ value: "us", label: "US — 08/23/2026" },
+		{ value: "european", label: "European — 23/08/2026" },
+		{ value: "friendly", label: "Friendly — August 23, 2026" },
+		{ value: "iso", label: "ISO — 2026-08-23" },
+	],
+	DEFAULT_DATE_DISPLAY_FORMAT: "friendly",
+	isDateDisplayFormat: (value: unknown) =>
+		value === "us" ||
+		value === "european" ||
+		value === "friendly" ||
+		value === "iso",
 	loadSettings: vi.fn(() =>
 		Promise.resolve({
 			ui: {
 				language: "en",
+				dateDisplayFormat: "friendly",
 				resumeLastSession: false,
 				showToc: true,
 				showFileTreeFolderCounts: false,
@@ -34,6 +47,7 @@ vi.mock("../../lib/settings", () => ({
 		}),
 	),
 	setLanguage: vi.fn(() => Promise.resolve()),
+	setDateDisplayFormat: vi.fn(() => Promise.resolve()),
 	setResumeLastSession: vi.fn(() => Promise.resolve()),
 	setShowToc: vi.fn(() => Promise.resolve()),
 	setEditorShowFrontmatterInEditor: vi.fn(() => Promise.resolve()),

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -11,9 +11,14 @@ import {
 } from "../../lib/editorMode";
 import { GLYPH_LINKS } from "../../lib/helpMenu";
 import {
+	DATE_DISPLAY_FORMAT_OPTIONS,
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	type DateDisplayFormat,
 	type FocusMode,
+	isDateDisplayFormat,
 	isFocusMode,
 	loadSettings,
+	setDateDisplayFormat,
 	setEditorColorfulHeadings,
 	setEditorDefaultEditorMode,
 	setEditorFocusMode,
@@ -85,6 +90,11 @@ export function GeneralSettingsPane() {
 	const { t } = useTranslation("settings.general");
 	const [error, setError] = useState("");
 	const [language, setLanguageState] = useState<AppLanguage>("en");
+	const dateFormat = useSettingsValue<DateDisplayFormat>(
+		DEFAULT_DATE_DISPLAY_FORMAT,
+		setDateDisplayFormat,
+		setError,
+	);
 	const defaultEditorMode = useSettingsValue<EditorViewMode>(
 		getDefaultEditorViewMode,
 		setEditorDefaultEditorMode,
@@ -146,6 +156,8 @@ export function GeneralSettingsPane() {
 	const setDefaultEditorModeValue = defaultEditorMode.setValue;
 	const setInitialFocusMode = focusMode.setInitialValue;
 	const setFocusModeValue = focusMode.setValue;
+	const setInitialDateFormat = dateFormat.setInitialValue;
+	const setDateFormatValue = dateFormat.setValue;
 
 	useEffect(() => {
 		let cancelled = false;
@@ -154,6 +166,7 @@ export function GeneralSettingsPane() {
 			.then((settings) => {
 				if (cancelled) return;
 				setLanguageState(settings.ui.language);
+				setInitialDateFormat(settings.ui.dateDisplayFormat);
 				setInitialDefaultEditorMode(settings.editor.defaultEditorMode);
 				setInitialFocusMode(settings.editor.focusMode);
 				setResumeLastSessionChecked(settings.ui.resumeLastSession);
@@ -184,6 +197,7 @@ export function GeneralSettingsPane() {
 		setRawMarkdownVimModeChecked,
 		setFolderCountsChecked,
 		setNonMarkdownFilesChecked,
+		setInitialDateFormat,
 		setInitialDefaultEditorMode,
 		setInitialFocusMode,
 	]);
@@ -194,6 +208,9 @@ export function GeneralSettingsPane() {
 			(payload) => {
 				if (payload.ui?.language) {
 					setLanguageState(payload.ui.language);
+				}
+				if (isDateDisplayFormat(payload.ui?.dateDisplayFormat)) {
+					setDateFormatValue(payload.ui.dateDisplayFormat);
 				}
 				if (isEditorViewMode(payload.editor?.defaultEditorMode)) {
 					setDefaultEditorModeValue(payload.editor.defaultEditorMode);
@@ -242,6 +259,7 @@ export function GeneralSettingsPane() {
 				setRawMarkdownVimModeChecked,
 				setFolderCountsChecked,
 				setNonMarkdownFilesChecked,
+				setDateFormatValue,
 				setDefaultEditorModeValue,
 				setFocusModeValue,
 			],
@@ -443,6 +461,36 @@ export function GeneralSettingsPane() {
 							{LANGUAGE_OPTIONS.map((option) => (
 								<option key={option.id} value={option.id}>
 									{option.nativeLabel}
+								</option>
+							))}
+						</SettingsSelect>
+					</SettingsRow>
+				</SettingsSection>
+				<SettingsSection
+					title={t("dateTime.sectionTitle")}
+					description={t("dateTime.sectionDescription")}
+				>
+					<SettingsRow
+						title={t("dateTime.dateFormat.label")}
+						label={t("dateTime.dateFormat.label")}
+						description={t("dateTime.dateFormat.description")}
+						htmlFor="settings-date-format-select"
+						interactive={false}
+					>
+						<SettingsSelect
+							id="settings-date-format-select"
+							aria-label={t("dateTime.dateFormat.ariaLabel")}
+							value={dateFormat.value}
+							disabled={dateFormat.isSaving}
+							onChange={(event) => {
+								const next = event.currentTarget.value;
+								if (!isDateDisplayFormat(next)) return;
+								dateFormat.onChange(next);
+							}}
+						>
+							{DATE_DISPLAY_FORMAT_OPTIONS.map((option) => (
+								<option key={option.value} value={option.value}>
+									{option.label}
 								</option>
 							))}
 						</SettingsSelect>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -30,6 +30,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "general-official-build", tab: "general" },
 	{ id: "general-license-help", tab: "general" },
 	{ id: "general-language", tab: "general" },
+	{ id: "general-date-format", tab: "general" },
 	{ id: "general-resume-last-session", tab: "general" },
 	{ id: "appearance-theme-mode", tab: "appearance" },
 	{ id: "appearance-light-theme", tab: "appearance" },

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -17,6 +17,11 @@ import {
 } from "../components/folio/folioScopes";
 import type { SettingsTab } from "../components/settings/settingsConfig";
 import {
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	type DateDisplayFormat,
+	isDateDisplayFormat,
+} from "../lib/dateDisplayFormat";
+import {
 	type AiAssistantMode,
 	loadSettings,
 	reloadFromDisk,
@@ -64,6 +69,9 @@ interface AISidebarContextValue {
 
 const UILayoutContext = createContext<UILayoutContextValue | null>(null);
 const AISidebarContext = createContext<AISidebarContextValue | null>(null);
+const DateDisplayFormatContext = createContext<DateDisplayFormat>(
+	DEFAULT_DATE_DISPLAY_FORMAT,
+);
 
 type UIState = {
 	sidebarCollapsed: boolean;
@@ -82,6 +90,7 @@ type UIState = {
 	aiEnabled: boolean;
 	aiPanelOpen: boolean;
 	aiAssistantMode: AiAssistantMode;
+	dateDisplayFormat: DateDisplayFormat;
 };
 
 type UIAction =
@@ -99,6 +108,7 @@ type UIAction =
 	| { type: "setAiEnabled"; value: boolean }
 	| { type: "setAiPanelOpen"; value: SetStateAction<boolean> }
 	| { type: "setAiAssistantMode"; value: AiAssistantMode }
+	| { type: "setDateDisplayFormat"; value: DateDisplayFormat }
 	| { type: "openSettings"; tab?: SettingsTab }
 	| { type: "closeSettings" }
 	| { type: "setSettingsTab"; value: SettingsTab }
@@ -112,6 +122,7 @@ type UIAction =
 			dailyNoteTemplatePath: string | null;
 			showToc: boolean;
 			folioMode: boolean;
+			dateDisplayFormat: DateDisplayFormat;
 	  };
 
 const initialUIState: UIState = {
@@ -131,6 +142,7 @@ const initialUIState: UIState = {
 	aiEnabled: true,
 	aiPanelOpen: false,
 	aiAssistantMode: "create",
+	dateDisplayFormat: DEFAULT_DATE_DISPLAY_FORMAT,
 };
 
 function uiReducer(state: UIState, action: UIAction): UIState {
@@ -184,6 +196,8 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 			};
 		case "setAiAssistantMode":
 			return { ...state, aiAssistantMode: action.value };
+		case "setDateDisplayFormat":
+			return { ...state, dateDisplayFormat: action.value };
 		case "openSettings":
 			return {
 				...state,
@@ -217,6 +231,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				dailyNoteTemplatePath: action.dailyNoteTemplatePath,
 				showToc: action.showToc,
 				folioMode: action.folioMode,
+				dateDisplayFormat: action.dateDisplayFormat,
 			};
 		default:
 			return state;
@@ -244,6 +259,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		aiEnabled,
 		aiPanelOpen,
 		aiAssistantMode,
+		dateDisplayFormat,
 	} = state;
 
 	useEffect(() => {
@@ -268,6 +284,12 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		const nextFolioMode = payload.ui?.folioMode;
 		if (typeof nextFolioMode === "boolean") {
 			dispatch({ type: "setFolioMode", value: nextFolioMode });
+		}
+		if (isDateDisplayFormat(payload.ui?.dateDisplayFormat)) {
+			dispatch({
+				type: "setDateDisplayFormat",
+				value: payload.ui.dateDisplayFormat,
+			});
 		}
 		if (payload.dailyNotes && "folder" in payload.dailyNotes) {
 			dispatch({
@@ -304,6 +326,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					dailyNoteTemplatePath: s.templates?.dailyNoteTemplate ?? null,
 					showToc: s.ui.showToc,
 					folioMode: s.ui.folioMode,
+					dateDisplayFormat: s.ui.dateDisplayFormat,
 				});
 			} catch {
 				// best-effort settings hydration
@@ -504,7 +527,9 @@ export function UIProvider({ children }: { children: ReactNode }) {
 	return (
 		<UILayoutContext.Provider value={layoutValue}>
 			<AISidebarContext.Provider value={aiSidebarValue}>
-				{children}
+				<DateDisplayFormatContext.Provider value={dateDisplayFormat}>
+					{children}
+				</DateDisplayFormatContext.Provider>
 			</AISidebarContext.Provider>
 		</UILayoutContext.Provider>
 	);
@@ -522,4 +547,9 @@ export function useAISidebarContext(): AISidebarContextValue {
 	if (!ctx)
 		throw new Error("useAISidebarContext must be used within UIProvider");
 	return ctx;
+}
+
+/** Current global complete-date display format (defaults to Friendly outside provider). */
+export function useDateDisplayFormat(): DateDisplayFormat {
+	return useContext(DateDisplayFormatContext);
 }

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -10,7 +10,11 @@ export { useUpdaterContext } from "./UpdaterContext";
 
 export { useSpace } from "./SpaceContext";
 export { useFileTreeContext } from "./FileTreeContext";
-export { useAISidebarContext, useUILayoutContext } from "./UIContext";
+export {
+	useAISidebarContext,
+	useDateDisplayFormat,
+	useUILayoutContext,
+} from "./UIContext";
 export { useEditorContext, useEditorRegistration } from "./EditorContext";
 export { useGitSyncContext } from "./GitSyncContext";
 

--- a/src/i18n/locales/de/settings.general.json
+++ b/src/i18n/locales/de/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "Sprache",
 		"communityNotice": "Übersetzungen stammen aus der Community und können unvollständig sein. Fragen oder Verbesserungen? <discord>Discord beitreten</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "Datum & Uhrzeit",
+		"sectionDescription": "Lege fest, wie vollständige Daten in Glyph angezeigt werden.",
+		"dateFormat": {
+			"label": "Datumsformat",
+			"description": "Gilt sofort für vollständige Daten in Notizen, Metadaten, Datenbanken und Verlauf.",
+			"ariaLabel": "Datumsformat"
+		}
+	},
 	"startup": {
 		"sectionTitle": "Start",
 		"sectionDescription": "Wähle, was beim Start von Glyph geöffnet wird.",

--- a/src/i18n/locales/de/settings.search.json
+++ b/src/i18n/locales/de/settings.search.json
@@ -106,6 +106,21 @@
 				"translation"
 			]
 		},
+		"general-date-format": {
+			"title": "Datumsformat",
+			"section": "Datum & Uhrzeit",
+			"description": "Lege fest, wie vollständige Daten in Glyph angezeigt werden.",
+			"keywords": [
+				"Datum",
+				"Format",
+				"Kalender",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"Anzeige"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "Vorherige Tabs öffnen",
 			"section": "Start",

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "Language",
 		"communityNotice": "Translations are community-contributed and may be incomplete. Questions or improvements? <discord>Join Discord</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "Date & time",
+		"sectionDescription": "Choose how complete dates appear across Glyph.",
+		"dateFormat": {
+			"label": "Date format",
+			"description": "Applies immediately to complete dates in notes, metadata, databases, and history.",
+			"ariaLabel": "Date format"
+		}
+	},
 	"startup": {
 		"sectionTitle": "Startup",
 		"sectionDescription": "Choose what opens when you start Glyph.",

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -99,6 +99,22 @@
 			"description": "Choose the display language for Glyph.",
 			"keywords": ["locale", "translation", "i18n", "language"]
 		},
+		"general-date-format": {
+			"title": "Date format",
+			"section": "Date & time",
+			"description": "Choose how complete dates are displayed across Glyph.",
+			"keywords": [
+				"date",
+				"format",
+				"calendar",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"locale",
+				"display"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "Open previous tabs",
 			"section": "Startup",

--- a/src/i18n/locales/es/settings.general.json
+++ b/src/i18n/locales/es/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "Idioma",
 		"communityNotice": "Las traducciones son aportadas por la comunidad y pueden estar incompletas. ¿Preguntas o mejoras? <discord>Únete a Discord</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "Fecha y hora",
+		"sectionDescription": "Elige cómo se muestran las fechas completas en Glyph.",
+		"dateFormat": {
+			"label": "Formato de fecha",
+			"description": "Se aplica de inmediato a las fechas completas en notas, metadatos, bases de datos e historial.",
+			"ariaLabel": "Formato de fecha"
+		}
+	},
 	"startup": {
 		"sectionTitle": "Inicio",
 		"sectionDescription": "Elige qué se abre al iniciar Glyph.",

--- a/src/i18n/locales/es/settings.search.json
+++ b/src/i18n/locales/es/settings.search.json
@@ -106,6 +106,21 @@
 				"translation"
 			]
 		},
+		"general-date-format": {
+			"title": "Formato de fecha",
+			"section": "Fecha y hora",
+			"description": "Elige cómo se muestran las fechas completas en Glyph.",
+			"keywords": [
+				"fecha",
+				"formato",
+				"calendario",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"visualización"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "Abrir pestañas anteriores",
 			"section": "Inicio",

--- a/src/i18n/locales/fr/settings.general.json
+++ b/src/i18n/locales/fr/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "Langue",
 		"communityNotice": "Les traductions sont fournies par la communauté et peuvent être incomplètes. Des questions ou des améliorations ? <discord>Rejoindre Discord</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "Date et heure",
+		"sectionDescription": "Choisissez l’affichage des dates complètes dans Glyph.",
+		"dateFormat": {
+			"label": "Format de date",
+			"description": "S’applique immédiatement aux dates complètes dans les notes, métadonnées, bases de données et l’historique.",
+			"ariaLabel": "Format de date"
+		}
+	},
 	"startup": {
 		"sectionTitle": "Démarrage",
 		"sectionDescription": "Choisissez ce qui s’ouvre au démarrage de Glyph.",

--- a/src/i18n/locales/fr/settings.search.json
+++ b/src/i18n/locales/fr/settings.search.json
@@ -106,6 +106,21 @@
 				"translation"
 			]
 		},
+		"general-date-format": {
+			"title": "Format de date",
+			"section": "Date et heure",
+			"description": "Choisissez l’affichage des dates complètes dans Glyph.",
+			"keywords": [
+				"date",
+				"format",
+				"calendrier",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"affichage"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "Ouvrir les onglets précédents",
 			"section": "Démarrage",

--- a/src/i18n/locales/ja/settings.general.json
+++ b/src/i18n/locales/ja/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "言語",
 		"communityNotice": "翻訳はコミュニティによる貢献であり、不完全な場合があります。質問や改善案は <discord>Discord に参加</discord>してください。"
 	},
+	"dateTime": {
+		"sectionTitle": "日付と時刻",
+		"sectionDescription": "Glyph 全体での完全な日付の表示方法を選びます。",
+		"dateFormat": {
+			"label": "日付形式",
+			"description": "ノート、メタデータ、データベース、履歴の完全な日付にすぐ反映されます。",
+			"ariaLabel": "日付形式"
+		}
+	},
 	"startup": {
 		"sectionTitle": "起動",
 		"sectionDescription": "Glyph 起動時に開く内容を選択します。",

--- a/src/i18n/locales/ja/settings.search.json
+++ b/src/i18n/locales/ja/settings.search.json
@@ -99,6 +99,21 @@
 			"description": "Glyph の表示言語を選びます。",
 			"keywords": ["locale", "翻訳", "i18n", "言語", "language", "translation"]
 		},
+		"general-date-format": {
+			"title": "日付形式",
+			"section": "日付と時刻",
+			"description": "Glyph 全体での完全な日付の表示方法を選びます。",
+			"keywords": [
+				"日付",
+				"形式",
+				"カレンダー",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"表示"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "前回のタブを開く",
 			"section": "起動",

--- a/src/i18n/locales/ko/settings.general.json
+++ b/src/i18n/locales/ko/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "언어",
 		"communityNotice": "번역은 커뮤니티 기여이며 불완전할 수 있습니다. 질문이나 개선 사항이 있나요? <discord>Discord 참여</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "날짜 및 시간",
+		"sectionDescription": "Glyph 전체에서 완전한 날짜가 표시되는 방식을 선택합니다.",
+		"dateFormat": {
+			"label": "날짜 형식",
+			"description": "노트, 메타데이터, 데이터베이스, 기록의 완전한 날짜에 즉시 적용됩니다.",
+			"ariaLabel": "날짜 형식"
+		}
+	},
 	"startup": {
 		"sectionTitle": "시작",
 		"sectionDescription": "Glyph를 시작할 때 열 내용을 선택합니다.",

--- a/src/i18n/locales/ko/settings.search.json
+++ b/src/i18n/locales/ko/settings.search.json
@@ -99,6 +99,21 @@
 			"description": "Glyph 표시 언어를 선택합니다.",
 			"keywords": ["locale", "번역", "i18n", "언어", "language", "translation"]
 		},
+		"general-date-format": {
+			"title": "날짜 형식",
+			"section": "날짜 및 시간",
+			"description": "Glyph 전체에서 완전한 날짜가 표시되는 방식을 선택합니다.",
+			"keywords": [
+				"날짜",
+				"형식",
+				"달력",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"표시"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "이전 탭 열기",
 			"section": "시작",

--- a/src/i18n/locales/pt-BR/settings.general.json
+++ b/src/i18n/locales/pt-BR/settings.general.json
@@ -15,6 +15,15 @@
 		"ariaLabel": "Idioma",
 		"communityNotice": "As traduções são contribuições da comunidade e podem estar incompletas. Dúvidas ou melhorias? <discord>Entre no Discord</discord>."
 	},
+	"dateTime": {
+		"sectionTitle": "Data e hora",
+		"sectionDescription": "Escolha como as datas completas aparecem no Glyph.",
+		"dateFormat": {
+			"label": "Formato de data",
+			"description": "Aplica-se imediatamente às datas completas em notas, metadados, bancos de dados e histórico.",
+			"ariaLabel": "Formato de data"
+		}
+	},
 	"startup": {
 		"sectionTitle": "Inicialização",
 		"sectionDescription": "Escolha o que abre ao iniciar o Glyph.",

--- a/src/i18n/locales/pt-BR/settings.search.json
+++ b/src/i18n/locales/pt-BR/settings.search.json
@@ -106,6 +106,21 @@
 				"translation"
 			]
 		},
+		"general-date-format": {
+			"title": "Formato de data",
+			"section": "Data e hora",
+			"description": "Escolha como as datas completas são exibidas no Glyph.",
+			"keywords": [
+				"data",
+				"formato",
+				"calendário",
+				"US",
+				"European",
+				"Friendly",
+				"ISO",
+				"exibição"
+			]
+		},
 		"general-resume-last-session": {
 			"title": "Abrir abas anteriores",
 			"section": "Inicialização",

--- a/src/lib/database/config.ts
+++ b/src/lib/database/config.ts
@@ -1,4 +1,11 @@
 import { parentDir } from "../../utils/path";
+import {
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	type DateDisplayFormat,
+	formatDatabaseClockTime,
+	formatDisplayDate,
+	parseDisplayDateInput,
+} from "../dateDisplayFormat";
 import { defaultDatabaseColumnIconName } from "./columnIcons";
 import type {
 	DatabaseCellValue,
@@ -95,38 +102,14 @@ export function databaseCellValueFromRow(
 	}
 }
 
-function ordinalSuffix(day: number): string {
-	if (day >= 11 && day <= 13) return "th";
-	switch (day % 10) {
-		case 1:
-			return "st";
-		case 2:
-			return "nd";
-		case 3:
-			return "rd";
-		default:
-			return "th";
-	}
-}
-
 export function formatDatabaseDateTime(
 	value: string | null | undefined,
+	format: DateDisplayFormat = DEFAULT_DATE_DISPLAY_FORMAT,
 ): string {
 	if (!value) return "";
-	const date = new Date(value);
-	if (Number.isNaN(date.getTime())) return value;
-
-	const month = date.toLocaleString("en-US", { month: "long" });
-	const day = date.getDate();
-	const year = date.getFullYear();
-	const time = date
-		.toLocaleString("en-US", {
-			hour: "numeric",
-			minute: "2-digit",
-			hour12: true,
-		})
-		.toLowerCase()
-		.replace(" ", " ");
-
-	return `${month} ${day}${ordinalSuffix(day)}, ${year}, ${time}`;
+	const date = parseDisplayDateInput(value);
+	if (!date) return value;
+	return formatDisplayDate(date, format, {
+		time: formatDatabaseClockTime(date),
+	});
 }

--- a/src/lib/dateDisplayFormat.ts
+++ b/src/lib/dateDisplayFormat.ts
@@ -1,0 +1,174 @@
+/**
+ * Global complete-date display preference.
+ * Controls user-facing absolute calendar dates only; storage and compact/relative labels are unchanged.
+ */
+
+export type DateDisplayFormat = "us" | "european" | "friendly" | "iso";
+
+export const DEFAULT_DATE_DISPLAY_FORMAT: DateDisplayFormat = "friendly";
+
+/** Settings option labels with fixed examples for August 23, 2026. */
+export const DATE_DISPLAY_FORMAT_OPTIONS = [
+	{ value: "us", label: "US — 08/23/2026" },
+	{ value: "european", label: "European — 23/08/2026" },
+	{ value: "friendly", label: "Friendly — August 23, 2026" },
+	{ value: "iso", label: "ISO — 2026-08-23" },
+] as const satisfies readonly {
+	value: DateDisplayFormat;
+	label: string;
+}[];
+
+const ENGLISH_MONTHS = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+] as const;
+
+const ENGLISH_WEEKDAYS = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+] as const;
+
+/** Pure calendar-date string: YYYY-MM-DD (no time component). */
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function isDateDisplayFormat(
+	value: unknown,
+): value is DateDisplayFormat {
+	return (
+		value === "us" ||
+		value === "european" ||
+		value === "friendly" ||
+		value === "iso"
+	);
+}
+
+export function normalizeDateDisplayFormat(value: unknown): DateDisplayFormat {
+	return isDateDisplayFormat(value) ? value : DEFAULT_DATE_DISPLAY_FORMAT;
+}
+
+function pad2(value: number): string {
+	return String(value).padStart(2, "0");
+}
+
+/**
+ * Parse a display input into a local calendar Date.
+ * Date-only `YYYY-MM-DD` stays on that calendar day in every time zone.
+ * Timestamps keep normal local conversion of the instant.
+ */
+export function parseDisplayDateInput(
+	value: string | number | Date,
+): Date | null {
+	if (value instanceof Date) {
+		return Number.isNaN(value.getTime()) ? null : value;
+	}
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) return null;
+		const date = new Date(value);
+		return Number.isNaN(date.getTime()) ? null : date;
+	}
+
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+
+	const dateOnly = DATE_ONLY_PATTERN.exec(trimmed);
+	if (dateOnly) {
+		const year = Number(dateOnly[1]);
+		const month = Number(dateOnly[2]);
+		const day = Number(dateOnly[3]);
+		const local = new Date(year, month - 1, day);
+		if (
+			local.getFullYear() !== year ||
+			local.getMonth() !== month - 1 ||
+			local.getDate() !== day
+		) {
+			return null;
+		}
+		return local;
+	}
+
+	const parsed = new Date(trimmed);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** Format only the calendar-date portion for a known-valid Date. */
+function formatCalendarDate(date: Date, format: DateDisplayFormat): string {
+	const year = date.getFullYear();
+	const month = date.getMonth() + 1;
+	const day = date.getDate();
+	switch (format) {
+		case "us":
+			return `${pad2(month)}/${pad2(day)}/${year}`;
+		case "european":
+			return `${pad2(day)}/${pad2(month)}/${year}`;
+		case "iso":
+			return `${year}-${pad2(month)}-${pad2(day)}`;
+		case "friendly":
+			return `${ENGLISH_MONTHS[date.getMonth()]} ${day}, ${year}`;
+	}
+}
+
+export interface FormatDisplayDateOptions {
+	/** Prefix with long English weekday (e.g. "Monday, 08/23/2026"). */
+	weekday?: boolean;
+	/** Already-formatted clock time to append after the date (preserves surface convention). */
+	time?: string;
+}
+
+/**
+ * Format a complete absolute date for display.
+ * On parse failure returns the original string input, or "" for non-string inputs.
+ */
+export function formatDisplayDate(
+	input: string | number | Date,
+	format: DateDisplayFormat,
+	options?: FormatDisplayDateOptions,
+): string {
+	const date = parseDisplayDateInput(input);
+	if (!date) {
+		return typeof input === "string" ? input : "";
+	}
+
+	let out = formatCalendarDate(date, format);
+	if (options?.weekday) {
+		out = `${ENGLISH_WEEKDAYS[date.getDay()]}, ${out}`;
+	}
+	const time = options?.time?.trim();
+	if (time) {
+		out = `${out}, ${time}`;
+	}
+	return out;
+}
+
+/** Locale-default clock (hour + minute) for surfaces that used Intl with undefined locale. */
+export function formatLocalClockTime(date: Date): string {
+	return date.toLocaleString(undefined, {
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+/** en-US 12h lowercase clock used by database date-time labels. */
+export function formatDatabaseClockTime(date: Date): string {
+	return date
+		.toLocaleString("en-US", {
+			hour: "numeric",
+			minute: "2-digit",
+			hour12: true,
+		})
+		.toLowerCase();
+}

--- a/src/lib/dateDisplayFormat.ts
+++ b/src/lib/dateDisplayFormat.ts
@@ -90,7 +90,9 @@ export function parseDisplayDateInput(
 		const year = Number(dateOnly[1]);
 		const month = Number(dateOnly[2]);
 		const day = Number(dateOnly[3]);
+		// Date(year, …) maps 0–99 → 1900–1999; setFullYear keeps 0000–0099 as-is.
 		const local = new Date(year, month - 1, day);
+		local.setFullYear(year);
 		if (
 			local.getFullYear() !== year ||
 			local.getMonth() !== month - 1 ||

--- a/src/lib/license.ts
+++ b/src/lib/license.ts
@@ -1,6 +1,13 @@
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	type DateDisplayFormat,
+	formatDisplayDate,
+	formatLocalClockTime,
+	parseDisplayDateInput,
+} from "./dateDisplayFormat";
+import {
 	type LicenseActivateResult,
 	type LicenseStatus,
 	invoke,
@@ -58,13 +65,16 @@ export function formatTrialRemaining(seconds: number | null): string {
 	return `${days}d ${remHours}h left`;
 }
 
-export function formatLicenseDate(timestampMs: number | null): string {
+export function formatLicenseDate(
+	timestampMs: number | null,
+	format: DateDisplayFormat = DEFAULT_DATE_DISPLAY_FORMAT,
+): string {
 	if (timestampMs == null) return "";
-	try {
-		return new Date(timestampMs).toLocaleString();
-	} catch {
-		return "";
-	}
+	const date = parseDisplayDateInput(timestampMs);
+	if (!date) return "";
+	return formatDisplayDate(date, format, {
+		time: formatLocalClockTime(date),
+	});
 }
 
 export function useLicenseStatus(reloadOnWindowFocus = true): {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -14,6 +14,10 @@ import {
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
 import { type AppLanguage, normalizeAppLanguage } from "../i18n/locales";
 import {
+	type DateDisplayFormat,
+	normalizeDateDisplayFormat,
+} from "./dateDisplayFormat";
+import {
 	getSettingsStore,
 	invalidateSettingsCache,
 	loadSettingsEntries,
@@ -56,6 +60,13 @@ export type {
 } from "./themeColors";
 
 export type { AiAssistantMode } from "./tauri";
+export type { DateDisplayFormat } from "./dateDisplayFormat";
+export {
+	DATE_DISPLAY_FORMAT_OPTIONS,
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	isDateDisplayFormat,
+	normalizeDateDisplayFormat,
+} from "./dateDisplayFormat";
 export type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 export type { AppLanguage } from "../i18n/locales";
 
@@ -419,6 +430,7 @@ async function emitSettingsUpdated(payload: {
 		aiAssistantMode?: AiAssistantMode;
 		aiEnabled?: boolean;
 		language?: AppLanguage;
+		dateDisplayFormat?: DateDisplayFormat;
 	};
 	dailyNotes?: {
 		folder?: string | null;
@@ -499,6 +511,7 @@ interface AppSettings {
 		classicAllNotesByDefault: boolean;
 		resumeLastSession: boolean;
 		aiAssistantMode: AiAssistantMode;
+		dateDisplayFormat: DateDisplayFormat;
 	};
 	dailyNotes: {
 		folder: string | null;
@@ -551,6 +564,7 @@ const KEYS = {
 	recentFiles: "files.recent",
 	aiEnabled: "ui.aiEnabled",
 	language: "ui.language",
+	dateDisplayFormat: "ui.dateDisplayFormat",
 	aiAssistantMode: "ui.aiAssistantMode",
 	theme: "ui.theme",
 	autoUpdateCheckInterval: "ui.autoUpdateCheckInterval",
@@ -876,6 +890,7 @@ export async function loadSettings(
 	);
 	const rawAiEnabled = getSettingValue<boolean | null>(entries, KEYS.aiEnabled);
 	const rawLanguage = getSettingValue(entries, KEYS.language);
+	const rawDateDisplayFormat = getSettingValue(entries, KEYS.dateDisplayFormat);
 	const rawAiAssistantMode = getSettingValue(entries, KEYS.aiAssistantMode);
 	const rawTheme = getSettingValue(entries, KEYS.theme);
 	const rawAutoUpdateCheckInterval = getSettingValue(
@@ -1008,6 +1023,7 @@ export async function loadSettings(
 	const aiEnabled =
 		typeof rawAiEnabled === "boolean" ? rawAiEnabled : DEFAULT_AI_ENABLED;
 	const language = normalizeAppLanguage(rawLanguage);
+	const dateDisplayFormat = normalizeDateDisplayFormat(rawDateDisplayFormat);
 	const aiAssistantMode = asAiAssistantMode(rawAiAssistantMode);
 	const theme = asThemeMode(rawTheme);
 	const autoUpdateCheckInterval = asAutoUpdateCheckInterval(
@@ -1157,6 +1173,7 @@ export async function loadSettings(
 			classicAllNotesByDefault,
 			resumeLastSession,
 			aiAssistantMode,
+			dateDisplayFormat,
 		},
 		dailyNotes: {
 			folder: dailyNotesFolder,
@@ -1313,6 +1330,16 @@ export async function setLanguage(language: AppLanguage): Promise<void> {
 	await store.set(KEYS.language, normalized);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ ui: { language: normalized } });
+}
+
+export async function setDateDisplayFormat(
+	format: DateDisplayFormat,
+): Promise<void> {
+	const store = await getSettingsStore();
+	const next = normalizeDateDisplayFormat(format);
+	await store.set(KEYS.dateDisplayFormat, next);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({ ui: { dateDisplayFormat: next } });
 }
 
 export async function setThemeMode(theme: ThemeMode): Promise<void> {

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -5,6 +5,7 @@ import type {
 	AppLanguage,
 	AttachmentStorageMode,
 	AutoUpdateCheckInterval,
+	DateDisplayFormat,
 	EditorWidthMode,
 	FileTreeSortMode,
 	FocusMode,
@@ -86,6 +87,7 @@ type TauriEventMap = {
 			aiEnabled?: boolean;
 			aiAssistantMode?: "chat" | "create";
 			language?: AppLanguage;
+			dateDisplayFormat?: DateDisplayFormat;
 		};
 		dailyNotes?: {
 			folder?: string | null;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/408


## Description

Adds a global **Date format** preference so complete user-facing absolute dates stay consistent across Glyph and follow the user's preferred convention.

### Summary of changes
- New setting `ui.dateDisplayFormat` with four options: US, European, Friendly (default), ISO
- Settings → General → **Date & time** section with a `SettingsSelect` that shows format examples
- Shared pure formatter in `src/lib/dateDisplayFormat.ts` (date-only `YYYY-MM-DD` stays calendar-local; invalid inputs keep the original value)
- App-wide reactive ownership via `DateDisplayFormatContext` / `useDateDisplayFormat()` on `settings:updated`
- Complete-date surfaces routed through the formatter: note properties, notes info metadata, Git commit dates/tooltips, license activation date, Activity Timeline year-bearing headings, database date/datetime display
- Settings search entry + i18n for all supported locales

### Reasoning
Complete dates were formatted independently (`Intl`, `toLocale*`, fixed English database strings, `date-fns`), so output was inconsistent and users had no control. One global preference plus one formatter removes that duplication without touching stored values, relative labels, or compact calendar UI.

### Additional context
- Friendly always uses English full month names and always includes the year (no ordinals)
- Relative labels (`Today`, `Yesterday`, ages), compact Folio/board labels, calendar furniture, filenames, and source/frontmatter values are intentionally unchanged
- Cross-window updates reuse the existing `settings:updated` emit; no new Tauri commands
- `pnpm check`, `pnpm build`, and related settings tests passed

## Screenshots

Settings → General → Date & time → Date format select with US / European / Friendly / ISO options (examples in labels). Complete dates in note properties, notes info, Git history, databases, and timeline headings update immediately when the preference changes.

## Docs

- Setting key: `ui.dateDisplayFormat`
- Type/union: `"us" | "european" | "friendly" | "iso"`
- Default / invalid: `"friendly"`
- Read in UI: `useDateDisplayFormat()` from `src/contexts`
- Format: `formatDisplayDate(input, format, { weekday?, time? })` from `src/lib/dateDisplayFormat.ts`
- Persist: `setDateDisplayFormat(format)` in `src/lib/settings.ts`

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global date display format so complete dates are consistent across the app and update instantly when changed. Users can choose US, European, Friendly (default), or ISO.

- New Features
  - Added `ui.dateDisplayFormat`; Settings → General → Date & time shows example labels and is searchable.
  - Shared formatter in `src/lib/dateDisplayFormat.ts` (`formatDisplayDate`, `parseDisplayDateInput`, `formatLocalClockTime`, `formatDatabaseClockTime`); date-only `YYYY‑MM‑DD` stays calendar‑local; invalid inputs keep original text; storage and relative/compact labels are unchanged.
  - App‑wide reactive format via `useDateDisplayFormat()`; updates on `settings:updated` across windows.
  - Routed complete‑date surfaces to the formatter: note properties, Notes Info (created/updated with local clock time), Git history and diffs, license activation, database date/datetime cells and board cards, and Activity Timeline day headers.
  - Added i18n strings and settings search entries for all supported locales.

<sup>Written for commit 43414854d9c295645f7ed867f936585ba03af0c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a date format preference in General Settings, with options for US, European, friendly, and ISO styles.
  * Date format preferences can be found through settings search and are available in supported languages.
  * Applied the selected format consistently across activity timelines, databases, notes, licenses, Git history, and metadata.

* **Bug Fixes**
  * Improved handling of invalid and date-only values while displaying dates and times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->