### PR TITLE
Prevent startup session restore from overriding navigation (#410) [Release]

### DIFF
--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -132,6 +132,7 @@ export function useWorkspaceSession({
 			!spacePath ||
 			!settingsLoaded ||
 			resumeLastSession === null ||
+			tabsRevision !== 0 ||
 			restoredSessionSpaceRef.current === spacePath
 		) {
 			return;
@@ -178,6 +179,7 @@ export function useWorkspaceSession({
 		resumeLastSession,
 		settingsLoaded,
 		spacePath,
+		tabsRevision,
 	]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Description

Prevents the asynchronous startup session restore from overriding a file selected by the user while the app is still launching.

- Skip workspace restoration once the live tab state has changed.
- Track `tabsRevision` in the restoration effect so an in-flight restore is cancelled when the user navigates.
- Keep the fix limited to the existing workspace-session guard with no new state or abstractions.

## Docs

No documentation changes were needed. The behavior change is limited to preserving user navigation during startup session restoration.

## Ready?

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the startup session restore from replacing the tab the user selects while the app is launching. The restore effect now bails once tabs change (`tabsRevision !== 0`) and tracks `tabsRevision` so any in‑flight restore is cancelled, scoped to the existing workspace-session guard.

<sup>Written for commit 44f1b658990d79b726a6cfbed78a8c7855b3b569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace session restoration to preserve existing tabs during startup.
  - Saved workspace sessions now restore at the appropriate time when tab state is ready.
  - Prevented restored sessions from unexpectedly replacing current tab changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->