### PR TITLE
Add note and section transclusion

### DIFF
--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -10,6 +10,8 @@ Frontend:
 - `src/components/editor/NoteInlineEditor.tsx`: editor surface, toolbar overlays, frontmatter panel, backlinks, interactions
 - `src/components/editor/hooks/useNoteEditor.ts`: TipTap instance, Markdown conversion, paste handling, image paste
 - `src/components/editor/extensions/index.ts`: extension composition
+- `src/components/editor/extensions/noteTransclusion.ts`: block bridge for standalone note embeds
+- `src/components/editor/transclusions/`: read-only rendering, batch data, and recursion context
 - `src/components/editor/markdown/`: wiki link and Markdown bridge helpers
 - `src/components/editor/hooks/useHydrateInlineImages.ts`: image path hydration
 - `src/components/editor/hooks/useTaskInlineDates.ts`: inline task date editing
@@ -20,6 +22,8 @@ Backend:
 
 - `src-tauri/src/space_fs/read_write/text.rs`: read/write text docs
 - `src-tauri/src/space_fs/read_write/binary.rs`: pasted image persistence
+- `src-tauri/src/space_fs/transclusion.rs`: batch resolution and heading suggestions
+- `src-tauri/src/space_fs/markdown_sections.rs`: fenced-code-aware heading parsing and section extraction
 - `src-tauri/src/index/indexer.rs`: reindex note after write
 - `src-tauri/src/notes/frontmatter.rs`: parse and render frontmatter mappings
 - `src-tauri/src/notes/properties.rs`: property conversion
@@ -106,6 +110,20 @@ Wiki links need bridge logic because TipTap and Markdown need different represen
 Use the bridge helpers rather than ad hoc string replacement when changing wiki-link Markdown behavior.
 
 ## TipTap Extensions
+
+Standalone `![[Note]]` and `![[Note#Heading]]` tokens render as read-only
+transclusion blocks in Rich and Preview modes. Expanded content is never
+serialized into the containing note. The frontend batches visible requests
+through `space_transclusions_batch`; Rust resolves current-space files and
+extracts heading sections. Nested renders carry an ancestor path chain so
+direct and indirect cycles stop at a placeholder.
+
+Wiki-link completion suggests notes and attachments after `[[`, notes and
+images after `![[`, and headings from the resolved note after `#`. With a note
+selected, Right Arrow fills the note target and starts its heading query;
+Enter or Tab still selects the entire note. Heading navigation is queued
+across note opening so `[[Note#Heading]]` scrolls after the target editor has
+mounted and derived its table of contents.
 
 `createEditorExtensions()` composes:
 

--- a/docs/architecture/06-index-search-graph-tasks.md
+++ b/docs/architecture/06-index-search-graph-tasks.md
@@ -55,7 +55,7 @@ Opening or closing a space calls `reset_schema_cache()` so a different space get
 
 `db.rs` sets:
 
-- `INDEX_DB_VERSION = 7`
+- `INDEX_DB_VERSION = 8`
 - `journal_mode = WAL`
 - `journal_size_limit = 1_048_576`
 - `SQLITE_FCNTL_PERSIST_WAL`
@@ -67,6 +67,7 @@ Migrations are hard-coded by `user_version`:
 - version 5: infer status property kinds
 - version 6: infer priority property kinds
 - version 7: add `checklist_total` and `checklist_completed` on `notes`, backfill from markdown files
+- version 8: clear derived link fingerprints so note embeds are reindexed with `kind = embed`
 
 Schema creation still uses `CREATE TABLE IF NOT EXISTS`. Migrations fix existing databases that already have older tables.
 
@@ -97,9 +98,11 @@ Stores outgoing links:
 - `from_id`
 - `to_id`
 - `to_title`
-- `kind`
+- `kind` (`note`, `wikilink`, `file`, or `embed`)
 
 `to_id` is set when the link resolves to a known note or file path. `to_title` stores unresolved wiki titles.
+Markdown transclusions use `embed`. Backlink queries expose that attribution,
+while connection graphs continue to treat the row as a note connection.
 
 ### `note_relationships`
 

--- a/src-tauri/src/index/commands.rs
+++ b/src-tauri/src/index/commands.rs
@@ -622,17 +622,19 @@ pub async fn backlinks(
             .to_string();
         let mut stmt = conn
             .prepare(
-                "SELECT DISTINCT n.id, n.title, n.updated
+                "SELECT n.id, n.title, n.updated,
+                        CASE WHEN MAX(refs.is_embed) = 1 THEN 'embed' ELSE 'link' END
                  FROM notes n
                  JOIN (
-                    SELECT l.from_id
+                    SELECT l.from_id, CASE WHEN l.kind = 'embed' THEN 1 ELSE 0 END AS is_embed
                     FROM links l
                     WHERE l.to_id = ? OR (l.to_title IS NOT NULL AND l.to_title = ?)
                     UNION
-                    SELECT r.from_id
+                    SELECT r.from_id, 0 AS is_embed
                     FROM note_relationships r
                     WHERE r.to_id = ? OR r.to_title = ? OR r.target_title = ?
                  ) refs ON refs.from_id = n.id
+                 GROUP BY n.id, n.title, n.updated
                  ORDER BY n.updated DESC
                  LIMIT 100",
             )
@@ -646,6 +648,7 @@ pub async fn backlinks(
                 id: row.get(0).map_err(|e| e.to_string())?,
                 title: row.get(1).map_err(|e| e.to_string())?,
                 updated: row.get(2).map_err(|e| e.to_string())?,
+                kind: row.get(3).map_err(|e| e.to_string())?,
             });
         }
         Ok(out)

--- a/src-tauri/src/index/db.rs
+++ b/src-tauri/src/index/db.rs
@@ -8,7 +8,7 @@ use std::sync::{Mutex, OnceLock};
 use super::checklists::checklist_counts;
 use super::schema::ensure_schema;
 
-const INDEX_DB_VERSION: i32 = 7;
+const INDEX_DB_VERSION: i32 = 8;
 const WAL_SIZE_LIMIT_BYTES: i64 = 1_048_576;
 
 fn schema_cache() -> &'static Mutex<HashSet<PathBuf>> {
@@ -43,6 +43,14 @@ fn migrate_if_needed(conn: &rusqlite::Connection, space_root: &Path) -> Result<(
 
     if current_version < 7 {
         migrate_checklist_summary_columns(conn, space_root)?;
+    }
+
+    if current_version < 8 {
+        conn.execute("DELETE FROM links", [])
+            .map_err(|error| error.to_string())?;
+        conn.execute("DELETE FROM indexed_files", [])
+            .map_err(|error| error.to_string())?;
+        tracing::info!("Cleared indexed link rows to classify note transclusions");
     }
 
     conn.pragma_update(None, "user_version", INDEX_DB_VERSION)

--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -14,7 +14,7 @@ use super::frontmatter::{
     parse_frontmatter_title_created_updated, preview_from_markdown, split_frontmatter,
 };
 use super::helpers::{path_to_slash_string, sha256_hex, should_skip_entry};
-use super::links::parse_outgoing_links;
+use super::links::{parse_outgoing_embeds, parse_outgoing_links};
 use super::properties::{delete_note_properties, reindex_note_properties};
 use super::relationships::{
     delete_note_relationships, ensure_note_relationships_indexed, insert_note_relationships,
@@ -238,6 +238,7 @@ fn index_note_with_conn(
     reindex_note_relationships(&tx, note_id, markdown)?;
 
     let (to_ids, to_titles) = parse_outgoing_links(note_id, markdown);
+    let (embed_ids, embed_titles) = parse_outgoing_embeds(note_id, markdown);
     let mut inserted = HashSet::<(Option<String>, Option<String>, &'static str)>::new();
 
     for to_id in to_ids {
@@ -250,6 +251,17 @@ fn index_note_with_conn(
             inserted.insert((Some(to_id), None, "note"));
         } else {
             inserted.insert((None, Some(to_title), "wikilink"));
+        }
+    }
+
+    for to_id in embed_ids {
+        inserted.insert((Some(to_id), None, "embed"));
+    }
+    for to_title in embed_titles {
+        if let Some(to_id) = resolve_title_to_id(&tx, &to_title)? {
+            inserted.insert((Some(to_id), None, "embed"));
+        } else {
+            inserted.insert((None, Some(to_title), "embed"));
         }
     }
 
@@ -357,8 +369,13 @@ where
         .map_err(|e| e.to_string())?;
 
     let note_paths = collect_markdown_files(space_root)?;
-    let mut link_data: Vec<(String, HashSet<String>, HashSet<String>)> =
-        Vec::with_capacity(note_paths.len());
+    let mut link_data: Vec<(
+        String,
+        HashSet<String>,
+        HashSet<String>,
+        HashSet<String>,
+        HashSet<String>,
+    )> = Vec::with_capacity(note_paths.len());
     let mut relationship_data = Vec::with_capacity(note_paths.len());
     let count = note_paths.len();
     on_progress(0, count);
@@ -431,7 +448,8 @@ where
             );
         }
         let (to_ids, to_titles) = parse_outgoing_links(rel, &markdown);
-        link_data.push((rel.clone(), to_ids, to_titles));
+        let (embed_ids, embed_titles) = parse_outgoing_embeds(rel, &markdown);
+        link_data.push((rel.clone(), to_ids, to_titles, embed_ids, embed_titles));
         relationship_data.push((rel.clone(), parse_frontmatter_relationships(&markdown)));
         let (modified_ns, size) = file_fingerprint(path)?;
         tx.execute(
@@ -444,7 +462,7 @@ where
         }
     }
 
-    for (rel, to_ids, to_titles) in &link_data {
+    for (rel, to_ids, to_titles, embed_ids, embed_titles) in &link_data {
         let mut inserted = HashSet::<(Option<String>, Option<String>, &'static str)>::new();
         for to_id in to_ids {
             inserted.insert((Some(to_id.clone()), None, link_kind_for_id(to_id)));
@@ -454,6 +472,16 @@ where
                 inserted.insert((Some(to_id), None, "note"));
             } else {
                 inserted.insert((None, Some(to_title.clone()), "wikilink"));
+            }
+        }
+        for to_id in embed_ids {
+            inserted.insert((Some(to_id.clone()), None, "embed"));
+        }
+        for to_title in embed_titles {
+            if let Some(to_id) = resolve_title_to_id(&tx, to_title)? {
+                inserted.insert((Some(to_id), None, "embed"));
+            } else {
+                inserted.insert((None, Some(to_title.clone()), "embed"));
             }
         }
         for (to_id, to_title, kind) in inserted {

--- a/src-tauri/src/index/links.rs
+++ b/src-tauri/src/index/links.rs
@@ -30,6 +30,24 @@ pub fn normalize_rel_path(raw: &str) -> Option<String> {
     }
 }
 
+fn insert_wikilink_target(target: &str, paths: &mut HashSet<String>, titles: &mut HashSet<String>) {
+    if target.is_empty() {
+        return;
+    }
+    if is_file_wikilink_target(target) {
+        let path = if should_append_markdown_extension(target) {
+            format!("{target}.md")
+        } else {
+            target.to_string()
+        };
+        if let Some(path) = normalize_rel_path(&path) {
+            paths.insert(path);
+        }
+    } else {
+        titles.insert(target.to_string());
+    }
+}
+
 pub fn parse_outgoing_links(
     from_rel_path: &str,
     markdown: &str,
@@ -45,26 +63,13 @@ pub fn parse_outgoing_links(
     let mut i = 0;
     let bytes = markdown.as_bytes();
     while i + 4 <= bytes.len() {
-        if bytes[i] == b'[' && bytes[i + 1] == b'[' {
+        if bytes[i] == b'[' && bytes[i + 1] == b'[' && (i == 0 || bytes[i - 1] != b'!') {
             if let Some(end) = markdown[i + 2..].find("]]") {
                 let inner = &markdown[i + 2..i + 2 + end];
                 let inner = inner.trim();
                 let inner = inner.split('|').next().unwrap_or(inner).trim();
                 let inner = inner.split('#').next().unwrap_or(inner).trim();
-                if !inner.is_empty() {
-                    if is_file_wikilink_target(inner) {
-                        let p = if should_append_markdown_extension(inner) {
-                            format!("{inner}.md")
-                        } else {
-                            inner.to_string()
-                        };
-                        if let Some(p) = normalize_rel_path(&p) {
-                            paths.insert(p);
-                        }
-                    } else {
-                        titles.insert(inner.to_string());
-                    }
-                }
+                insert_wikilink_target(inner, &mut paths, &mut titles);
                 i = i + 2 + end + 2;
                 continue;
             }
@@ -119,6 +124,37 @@ pub fn parse_outgoing_links(
     (paths, titles)
 }
 
+pub fn parse_outgoing_embeds(
+    _from_rel_path: &str,
+    markdown: &str,
+) -> (HashSet<String>, HashSet<String>) {
+    let mut paths = HashSet::new();
+    let mut titles = HashSet::new();
+    let bytes = markdown.as_bytes();
+    let mut i = 0;
+    while i + 5 <= bytes.len() {
+        if bytes[i] == b'!' && bytes[i + 1] == b'[' && bytes[i + 2] == b'[' {
+            if let Some(end) = markdown[i + 3..].find("]]") {
+                let inner = markdown[i + 3..i + 3 + end].trim();
+                let target = inner
+                    .split('|')
+                    .next()
+                    .unwrap_or(inner)
+                    .split('#')
+                    .next()
+                    .unwrap_or(inner)
+                    .trim();
+                insert_wikilink_target(target, &mut paths, &mut titles);
+                i += 3 + end + 2;
+                continue;
+            }
+        }
+        i += 1;
+    }
+
+    (paths, titles)
+}
+
 fn is_file_wikilink_target(target: &str) -> bool {
     is_linkable_file_target(target)
         || (target.contains('/') && !utils::has_explicit_file_extension(target))
@@ -134,7 +170,7 @@ fn is_linkable_file_target(target: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_outgoing_links;
+    use super::{parse_outgoing_embeds, parse_outgoing_links};
 
     #[test]
     fn parses_attachment_wikilinks_as_file_paths() {
@@ -145,8 +181,13 @@ mod tests {
 
         assert!(paths.contains("assets/logo.png"));
         assert!(paths.contains("spec.pdf"));
-        assert!(paths.contains("hero.webp"));
+        assert!(!paths.contains("hero.webp"));
         assert!(titles.contains("Project"));
+
+        let (embed_paths, embed_titles) =
+            parse_outgoing_embeds("notes/source.md", "![[hero.webp]]");
+        assert!(embed_paths.contains("hero.webp"));
+        assert!(embed_titles.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/index/types.rs
+++ b/src-tauri/src/index/types.rs
@@ -24,6 +24,7 @@ pub struct BacklinkItem {
     pub id: String,
     pub title: String,
     pub updated: String,
+    pub kind: String,
 }
 
 #[derive(Clone, Serialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1662,6 +1662,8 @@ pub fn run() {
             space_fs::list::space_list_markdown_files,
             space_fs::list::space_list_non_markdown_files,
             space_fs::link_ops::space_resolve_wikilink,
+            space_fs::transclusion::space_suggest_wikilink_headings,
+            space_fs::transclusion::space_transclusions_batch,
             space_fs::link_ops::space_resolve_image_wikilink,
             space_fs::link_ops::space_resolve_markdown_link,
             space_fs::link_ops::space_suggest_links,

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -5,7 +5,7 @@ use tauri::{State, WebviewWindow};
 use crate::{paths, space::SpaceState, utils};
 
 #[derive(Clone)]
-struct FileEntry {
+pub(super) struct FileEntry {
     rel_path: String,
     is_markdown: bool,
 }
@@ -101,7 +101,11 @@ fn relative_path(from_dir: &str, to_path: &str) -> String {
     }
 }
 
-fn list_files(root: &Path, markdown_only: bool, limit: usize) -> Result<Vec<FileEntry>, String> {
+pub(super) fn list_files(
+    root: &Path,
+    markdown_only: bool,
+    limit: usize,
+) -> Result<Vec<FileEntry>, String> {
     let mut out: Vec<FileEntry> = Vec::new();
     let mut stack: Vec<PathBuf> = vec![PathBuf::new()];
     while let Some(rel_dir) = stack.pop() {
@@ -233,7 +237,10 @@ fn resolve_image_wikilink_target(entries: &[FileEntry], target: &str) -> Option<
     choose_unambiguous_match(stem_matches)
 }
 
-fn resolve_standard_wikilink_target(entries: &[FileEntry], target: &str) -> Option<String> {
+pub(super) fn resolve_standard_wikilink_target(
+    entries: &[FileEntry],
+    target: &str,
+) -> Option<String> {
     let raw = target
         .split('#')
         .next()

--- a/src-tauri/src/space_fs/markdown_sections.rs
+++ b/src-tauri/src/space_fs/markdown_sections.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+pub(super) struct MarkdownHeading<'a> {
+    pub depth: usize,
+    pub title: &'a str,
+    pub slug: String,
+    pub offset: usize,
+}
+
+fn atx_heading(line: &str) -> Option<(usize, &str)> {
+    let trimmed = line.trim_start();
+    let depth = trimmed
+        .chars()
+        .take_while(|character| *character == '#')
+        .count();
+    if depth == 0 || depth > 6 || trimmed.as_bytes().get(depth) != Some(&b' ') {
+        return None;
+    }
+    Some((depth, trimmed[depth + 1..].trim_end_matches('#').trim()))
+}
+
+fn fence_marker(line: &str) -> Option<(char, usize)> {
+    let trimmed = line.trim_start();
+    let marker = trimmed.chars().next()?;
+    if marker != '`' && marker != '~' {
+        return None;
+    }
+    let width = trimmed
+        .chars()
+        .take_while(|character| *character == marker)
+        .count();
+    (width >= 3).then_some((marker, width))
+}
+
+fn slugify_heading(title: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+    for character in title.trim().to_lowercase().chars() {
+        if character.is_alphanumeric() || character == '_' {
+            slug.push(character);
+            previous_dash = false;
+        } else if (character.is_whitespace() || character == '-')
+            && !slug.is_empty()
+            && !previous_dash
+        {
+            slug.push('-');
+            previous_dash = true;
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+pub(super) fn markdown_headings(markdown: &str) -> Vec<MarkdownHeading<'_>> {
+    let mut active_fence: Option<(char, usize)> = None;
+    let mut slug_counts = HashMap::<String, usize>::new();
+    let mut headings = Vec::new();
+    let mut offset = 0;
+
+    for line_with_newline in markdown.split_inclusive('\n') {
+        let line = line_with_newline.trim_end_matches(['\r', '\n']);
+        if let Some((marker, width)) = fence_marker(line) {
+            match active_fence {
+                Some((active_marker, active_width))
+                    if marker == active_marker && width >= active_width =>
+                {
+                    active_fence = None;
+                }
+                None => active_fence = Some((marker, width)),
+                _ => {}
+            }
+            offset += line_with_newline.len();
+            continue;
+        }
+        if active_fence.is_none() {
+            if let Some((depth, title)) = atx_heading(line) {
+                let base_slug = slugify_heading(title);
+                let seen = slug_counts.entry(base_slug.clone()).or_default();
+                let slug = if *seen == 0 {
+                    base_slug
+                } else {
+                    format!("{base_slug}-{seen}")
+                };
+                *seen += 1;
+                headings.push(MarkdownHeading {
+                    depth,
+                    title,
+                    slug,
+                    offset,
+                });
+            }
+        }
+        offset += line_with_newline.len();
+    }
+    headings
+}
+
+pub(super) fn extract_heading_section(markdown: &str, anchor: &str) -> Option<String> {
+    let requested = anchor.trim().trim_start_matches('#').to_lowercase();
+    let headings = markdown_headings(markdown);
+    let (index, heading) = headings.iter().enumerate().find(|(_, heading)| {
+        heading.slug == requested || heading.title.trim().eq_ignore_ascii_case(&requested)
+    })?;
+    let end = headings[index + 1..]
+        .iter()
+        .find(|candidate| candidate.depth <= heading.depth)
+        .map_or(markdown.len(), |candidate| candidate.offset);
+    Some(markdown[heading.offset..end].trim_end().to_string())
+}

--- a/src-tauri/src/space_fs/mod.rs
+++ b/src-tauri/src/space_fs/mod.rs
@@ -3,6 +3,8 @@ pub(crate) mod helpers;
 pub mod link_ops;
 pub mod link_rewrite;
 pub mod list;
+mod markdown_sections;
 pub mod read_write;
 pub mod summary;
+pub mod transclusion;
 mod types;

--- a/src-tauri/src/space_fs/transclusion.rs
+++ b/src-tauri/src/space_fs/transclusion.rs
@@ -1,0 +1,191 @@
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::Path};
+use tauri::{State, WebviewWindow};
+
+use crate::{paths, space::SpaceState};
+
+use super::{
+    link_ops::{list_files, resolve_standard_wikilink_target, LinkSuggestionItem},
+    markdown_sections::{extract_heading_section, markdown_headings},
+};
+
+const BATCH_LIMIT: usize = 128;
+const FILE_LIST_LIMIT: usize = 80_000;
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransclusionAnchorKind {
+    None,
+    Heading,
+    Block,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TransclusionRequest {
+    pub key: String,
+    pub target: String,
+    pub anchor_kind: TransclusionAnchorKind,
+    pub anchor: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransclusionErrorKind {
+    Unresolved,
+    MissingHeading,
+    UnsupportedBlock,
+    ReadError,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct TransclusionResult {
+    pub key: String,
+    pub resolved_path: Option<String>,
+    pub markdown: Option<String>,
+    pub mtime_ms: Option<u64>,
+    pub error_kind: Option<TransclusionErrorKind>,
+}
+
+impl TransclusionResult {
+    fn error(
+        key: String,
+        resolved_path: Option<String>,
+        mtime_ms: Option<u64>,
+        error_kind: TransclusionErrorKind,
+    ) -> Self {
+        Self {
+            key,
+            resolved_path,
+            markdown: None,
+            mtime_ms,
+            error_kind: Some(error_kind),
+        }
+    }
+}
+
+fn file_mtime_ms(path: &Path) -> u64 {
+    std::fs::metadata(path)
+        .ok()
+        .and_then(|metadata| metadata.modified().ok())
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or_default()
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_suggest_wikilink_headings(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    target: String,
+    query: String,
+    limit: Option<u32>,
+) -> Result<Vec<LinkSuggestionItem>, String> {
+    let root = state.root_for_window(&window)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let entries = list_files(&root, true, FILE_LIST_LIMIT)?;
+        let Some(resolved_path) = resolve_standard_wikilink_target(&entries, &target) else {
+            return Ok(Vec::new());
+        };
+        let absolute = paths::join_under(&root, Path::new(&resolved_path))?;
+        let markdown = std::fs::read_to_string(absolute).map_err(|error| error.to_string())?;
+        let normalized_query = query.trim().to_lowercase();
+        Ok(markdown_headings(&markdown)
+            .into_iter()
+            .filter(|heading| {
+                !heading.slug.is_empty()
+                    && (normalized_query.is_empty()
+                        || heading.title.to_lowercase().contains(&normalized_query))
+            })
+            .take(limit.unwrap_or(8).clamp(1, 50) as usize)
+            .map(|heading| {
+                let anchor = heading.slug;
+                LinkSuggestionItem {
+                    path: format!("{target}#{anchor}"),
+                    title: heading.title.to_string(),
+                    insert_text: format!("{target}#{anchor}"),
+                }
+            })
+            .collect())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_transclusions_batch(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    requests: Vec<TransclusionRequest>,
+) -> Result<Vec<TransclusionResult>, String> {
+    if requests.len() > BATCH_LIMIT {
+        return Err(format!(
+            "too many transclusion requests (maximum {BATCH_LIMIT})"
+        ));
+    }
+    let root = state.root_for_window(&window)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        let entries = list_files(&root, true, FILE_LIST_LIMIT)?;
+        let mut file_cache = HashMap::<String, (String, u64)>::new();
+        let mut results = Vec::with_capacity(requests.len());
+
+        for request in requests {
+            let Some(resolved_path) = resolve_standard_wikilink_target(&entries, &request.target)
+            else {
+                results.push(TransclusionResult::error(
+                    request.key,
+                    None,
+                    None,
+                    TransclusionErrorKind::Unresolved,
+                ));
+                continue;
+            };
+            let source = if let Some(cached) = file_cache.get(&resolved_path) {
+                cached.clone()
+            } else {
+                let absolute = paths::join_under(&root, Path::new(&resolved_path))?;
+                let mtime_ms = file_mtime_ms(&absolute);
+                match std::fs::read_to_string(&absolute) {
+                    Ok(markdown) => {
+                        file_cache.insert(resolved_path.clone(), (markdown.clone(), mtime_ms));
+                        (markdown, mtime_ms)
+                    }
+                    Err(_) => {
+                        results.push(TransclusionResult::error(
+                            request.key,
+                            Some(resolved_path),
+                            Some(mtime_ms),
+                            TransclusionErrorKind::ReadError,
+                        ));
+                        continue;
+                    }
+                }
+            };
+            let (markdown, error_kind) = match request.anchor_kind {
+                TransclusionAnchorKind::None => (Some(source.0), None),
+                TransclusionAnchorKind::Heading => (
+                    request
+                        .anchor
+                        .as_deref()
+                        .and_then(|anchor| extract_heading_section(&source.0, anchor)),
+                    Some(TransclusionErrorKind::MissingHeading),
+                ),
+                TransclusionAnchorKind::Block => {
+                    (None, Some(TransclusionErrorKind::UnsupportedBlock))
+                }
+            };
+            let error_kind = error_kind.filter(|_| markdown.is_none());
+            results.push(TransclusionResult {
+                key: request.key,
+                resolved_path: Some(resolved_path),
+                markdown,
+                mtime_ms: Some(source.1),
+                error_kind,
+            });
+        }
+        Ok(results)
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}

--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,7 @@
 @import "./styles/app/26-node-note-overlays.css";
 @import "./styles/app/27-editor-math.css";
 @import "./styles/app/30-markdown-editor-pane.css";
+@import "./styles/app/30-note-transclusion.css";
 @import "./styles/app/31-responsive.css";
 @import "./styles/app/32-command-palette.css";
 @import "./styles/app/48-calendar-palette.css";

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -18,6 +18,7 @@ import {
 	type TagClickDetail,
 	WIKI_LINK_CLICK_EVENT,
 	type WikiLinkClickDetail,
+	dispatchInternalAnchorClick,
 } from "../editor/markdown/editorEvents";
 
 interface UseWorkspaceLinkEventsArgs {
@@ -39,21 +40,21 @@ export function useWorkspaceLinkEvents({
 		async (rawTarget: string) => {
 			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
-			if (!normalizedTarget) return;
+			if (!normalizedTarget) return null;
 			if (isPdfPath(normalizedTarget)) {
 				const resolved = await invoke("space_resolve_wikilink", {
 					target: normalizedTarget,
 				});
 				if (resolved) {
 					await openWorkspaceFile(resolved);
-					return;
+					return resolved;
 				}
 				setError(`Could not resolve PDF wikilink: ${rawTarget}`);
-				return;
+				return null;
 			}
 			if (!isMarkdownCreatablePath(normalizedTarget)) {
 				setError(`Only markdown notes are creatable via [[...]]: ${rawTarget}`);
-				return;
+				return null;
 			}
 
 			const resolved = await invoke("space_resolve_wikilink", {
@@ -61,7 +62,7 @@ export function useWorkspaceLinkEvents({
 			});
 			if (resolved) {
 				await openWorkspaceFile(resolved);
-				return;
+				return resolved;
 			}
 
 			const sourceDir = activeMarkdownTabPath
@@ -82,7 +83,7 @@ export function useWorkspaceLinkEvents({
 			});
 			if (createdPath) {
 				await openWorkspaceFile(createdPath);
-				return;
+				return createdPath;
 			}
 
 			setError("");
@@ -91,10 +92,11 @@ export function useWorkspaceLinkEvents({
 			});
 			if (fallbackResolved) {
 				await openWorkspaceFile(fallbackResolved);
-				return;
+				return fallbackResolved;
 			}
 
 			setError(`Could not resolve wikilink: ${rawTarget}`);
+			return null;
 		},
 		[activeMarkdownTabPath, fileTree, openWorkspaceFile, setError],
 	);
@@ -133,7 +135,13 @@ export function useWorkspaceLinkEvents({
 						);
 						return;
 					}
-					await openOrCreateWikiLinkTarget(detail.target);
+					const openedPath = await openOrCreateWikiLinkTarget(detail.target);
+					if (openedPath && detail.anchorKind === "heading" && detail.anchor) {
+						dispatchInternalAnchorClick({
+							anchor: detail.anchor,
+							sourcePath: openedPath,
+						});
+					}
 				} catch (e) {
 					setError(
 						`Failed to open wikilink: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -53,6 +53,7 @@ import { parseWikiLink } from "./markdown/wikiLinkCodec";
 import { loadMathExtensionFactory } from "./math/loadMathExtensions";
 import type { SelectedCodeBlockState } from "./noteEditorOverlayTypes";
 import type { RawMarkdownEditorHandle } from "./raw/types";
+import { TransclusionDataProvider } from "./transclusions/TransclusionContext";
 import type { NoteInlineEditorProps } from "./types";
 
 const EMPTY_ADDITIONAL_EXTENSIONS: AnyExtension[] = [];
@@ -750,15 +751,17 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				) : null}
 				{mode !== "plain" &&
 				(mathExtensionsReady || !markdown.includes("$")) ? (
-					<NoteEditorSurface
-						editor={liveEditor}
-						mode={mode}
-						colorfulHeadings={colorfulHeadings}
-						canEdit={canEdit}
-						hostRef={handleTiptapHostRef}
-						tableControls={tableControls}
-						codeBlock={codeBlockControls}
-					/>
+					<TransclusionDataProvider markdown={markdown} relPath={relPath}>
+						<NoteEditorSurface
+							editor={liveEditor}
+							mode={mode}
+							colorfulHeadings={colorfulHeadings}
+							canEdit={canEdit}
+							hostRef={handleTiptapHostRef}
+							tableControls={tableControls}
+							codeBlock={codeBlockControls}
+						/>
+					</TransclusionDataProvider>
 				) : null}
 			</div>
 			<AnimatePresence>

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -37,6 +37,7 @@ import { MarkdownLinkAutocomplete } from "./markdownLinkAutocomplete";
 import type { MathEditRequest } from "./math/mathOptions";
 import { MermaidPreview } from "./mermaidPreview";
 import { NoteSearch } from "./noteSearch";
+import { NoteTransclusion } from "./noteTransclusion";
 import { PersonAutocomplete } from "./personAutocomplete";
 import { TagAutocomplete } from "./tagAutocomplete";
 import { TagDecorations } from "./tagDecorations";
@@ -673,6 +674,7 @@ export function createEditorExtensions(
 		MarkdownImage.configure({
 			allowBase64: true,
 		}),
+		NoteTransclusion,
 		...glyphDetailsExtensions,
 		...additionalExtensions,
 		HtmlEmbedPreview,

--- a/src/components/editor/extensions/noteTransclusion.ts
+++ b/src/components/editor/extensions/noteTransclusion.ts
@@ -1,0 +1,89 @@
+import { Node, nodeInputRule } from "@tiptap/core";
+import type { MarkdownToken } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { isImageTarget } from "../../../lib/linkSuggestions";
+import {
+	parseWikiLink,
+	wikiLinkAttrsToMarkdown,
+} from "../markdown/wikiLinkCodec";
+import { NoteTransclusionView } from "../transclusions/NoteTransclusionView";
+
+function parseNoteTransclusion(raw: string) {
+	const parsed = parseWikiLink(raw);
+	return parsed?.embed && !isImageTarget(parsed.target) ? parsed : null;
+}
+
+export const NoteTransclusion = Node.create({
+	name: "noteTransclusion",
+	group: "block",
+	atom: true,
+	selectable: true,
+	draggable: false,
+	markdownTokenName: "noteTransclusion",
+	addAttributes() {
+		return {
+			raw: { default: "" },
+			target: { default: "" },
+			alias: { default: null },
+			embed: { default: true },
+			anchorKind: { default: "none" },
+			anchor: { default: null },
+			unresolved: { default: false },
+		};
+	},
+	parseHTML() {
+		return [{ tag: 'div[data-note-transclusion="true"]' }];
+	},
+	renderHTML({ node }) {
+		return [
+			"div",
+			{
+				"data-note-transclusion": "true",
+				"data-target": node.attrs.target,
+			},
+		];
+	},
+	parseMarkdown(token: MarkdownToken, helpers) {
+		const raw = (token.raw ?? "").trim();
+		const parsed = parseNoteTransclusion(raw);
+		if (!parsed) return helpers.createTextNode(raw || token.text || "");
+		return helpers.createNode("noteTransclusion", parsed);
+	},
+	renderMarkdown(node) {
+		return wikiLinkAttrsToMarkdown(node.attrs ?? {});
+	},
+	markdownTokenizer: {
+		name: "noteTransclusion",
+		level: "block",
+		start(src: string) {
+			const match = src.match(/^\s*!\[\[[^\]\n]+\]\]\s*(?:\n|$)/m);
+			return match?.index ?? -1;
+		},
+		tokenize(src: string) {
+			const match = src.match(/^\s*(!\[\[[^\]\n]+\]\])\s*(?:\n|$)/);
+			if (!match) return undefined;
+			const parsed = parseNoteTransclusion(match[1]);
+			if (!parsed) return undefined;
+			return {
+				type: "noteTransclusion",
+				raw: match[0],
+				text: match[1],
+				attributes: parsed,
+			};
+		},
+	},
+	addInputRules() {
+		return [
+			nodeInputRule({
+				find: /^(!\[\[[^\]\n]+\]\])$/,
+				type: this.type,
+				getAttributes: (match) => {
+					return parseNoteTransclusion(match[1]) ?? false;
+				},
+			}),
+		];
+	},
+	addNodeView() {
+		return ReactNodeViewRenderer(NoteTransclusionView);
+	},
+});

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -250,11 +250,11 @@ export const WikiLink = Node.create({
 	addProseMirrorPlugins() {
 		const getSuggestions = async (
 			query: string,
-			includeImagesOnly: boolean,
+			forEmbed: boolean,
 		): Promise<EditorLinkSuggestion[]> => {
 			return suggestWikiLinks({
 				query,
-				embedOnly: includeImagesOnly,
+				forEmbed,
 				limit: this.options.suggestionLimit,
 			});
 		};
@@ -295,23 +295,41 @@ export const WikiLink = Node.create({
 						: `[[${props.insertText}]]`;
 					const parsed = parseWikiLink(raw);
 					if (!parsed) return;
+					if (asEmbed && !isImageTarget(props.path)) {
+						editor
+							.chain()
+							.focus()
+							.deleteRange({ from: replaceFrom, to: range.to })
+							.insertContent([
+								{ type: "noteTransclusion", attrs: parsed },
+								{ type: "paragraph" },
+							])
+							.run();
+						return;
+					}
 					editor
 						.chain()
 						.focus()
-						.deleteRange({
-							from: replaceFrom,
-							to: range.to,
-						})
-						.insertContent({
-							type: "wikiLink",
-							attrs: parsed,
-						})
+						.deleteRange({ from: replaceFrom, to: range.to })
+						.insertContent({ type: "wikiLink", attrs: parsed })
 						.insertContent(" ")
 						.run();
 				},
 				render: () =>
 					createTipTapSuggestionMenu<EditorLinkSuggestion>({
 						menuClassName: "wikiLinkSuggestionMenu",
+						onArrowRight: (item, props) => {
+							if (!/\.md$/i.test(item.path) || item.insertText.includes("#")) {
+								return false;
+							}
+							props.editor
+								.chain()
+								.focus()
+								.deleteRange(props.range)
+								.insertContent(`[[${item.insertText}#`)
+								.run();
+							return true;
+						},
 						renderItem: ({ item, isActive, select }) => {
 							const button = document.createElement("button");
 							button.type = "button";

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -33,6 +33,8 @@ export interface InternalAnchorClickDetail {
 	sourcePath: string;
 }
 
+let pendingInternalAnchor: InternalAnchorClickDetail | null = null;
+
 export function dispatchWikiLinkClick(detail: WikiLinkClickDetail): void {
 	window.dispatchEvent(
 		new CustomEvent<WikiLinkClickDetail>(WIKI_LINK_CLICK_EVENT, { detail }),
@@ -64,9 +66,27 @@ export function dispatchMarkdownLinkClick(
 export function dispatchInternalAnchorClick(
 	detail: InternalAnchorClickDetail,
 ): void {
+	pendingInternalAnchor = detail;
 	window.dispatchEvent(
 		new CustomEvent<InternalAnchorClickDetail>(INTERNAL_ANCHOR_CLICK_EVENT, {
 			detail,
 		}),
 	);
+}
+
+export function consumePendingInternalAnchor(
+	sourcePath: string,
+): InternalAnchorClickDetail | null {
+	if (pendingInternalAnchor?.sourcePath !== sourcePath) return null;
+	const pending = pendingInternalAnchor;
+	pendingInternalAnchor = null;
+	return pending;
+}
+
+export function getPendingInternalAnchor(
+	sourcePath: string,
+): InternalAnchorClickDetail | null {
+	return pendingInternalAnchor?.sourcePath === sourcePath
+		? pendingInternalAnchor
+		: null;
 }

--- a/src/components/editor/raw/extensions.ts
+++ b/src/components/editor/raw/extensions.ts
@@ -49,7 +49,10 @@ import {
 	embeddedLatexCompletionSource,
 	latexSnippetCompletionSource,
 } from "./latexCompletions";
-import { createRawLinkCompletionSource } from "./linkCompletions";
+import {
+	createRawLinkCompletionSource,
+	drillIntoSelectedWikiLink,
+} from "./linkCompletions";
 import {
 	embeddedMathLinter,
 	markdownMathExtension,
@@ -278,6 +281,7 @@ export function createRawMarkdownExtensions(
 			}
 		}),
 		keymap.of([
+			{ key: "ArrowRight", run: drillIntoSelectedWikiLink },
 			...completionKeymap,
 			{ key: "Mod-b", run: wrapSelection("**") },
 			{ key: "Mod-i", run: wrapSelection("*") },

--- a/src/components/editor/raw/linkCompletions.ts
+++ b/src/components/editor/raw/linkCompletions.ts
@@ -3,14 +3,18 @@ import {
 	type CompletionContext,
 	type CompletionResult,
 	pickedCompletion,
+	selectedCompletion,
+	startCompletion,
 } from "@codemirror/autocomplete";
 import type { EditorView } from "@codemirror/view";
 import {
+	type EditorLinkSuggestion,
 	suggestMarkdownLinks,
 	suggestWikiLinks,
 } from "../../../lib/linkSuggestions";
 
 const COMPLETION_LIMIT = 8;
+const wikiLinkTargets = new WeakMap<Completion, EditorLinkSuggestion>();
 
 function completionApply(
 	markdown: string,
@@ -43,13 +47,13 @@ async function wikiLinkCompletions(
 	const query = match.text.slice(asEmbed ? 3 : 2).trim();
 	const results = await suggestWikiLinks({
 		query,
-		embedOnly: asEmbed,
+		forEmbed: asEmbed,
 		limit: COMPLETION_LIMIT,
 	});
 	if (context.aborted) return null;
 	const opening = asEmbed ? "![[" : "[[";
-	const options = results.map(
-		(item): Completion => ({
+	const options = results.map((item): Completion => {
+		const completion: Completion = {
 			label: item.title,
 			detail: item.path,
 			apply: completionApply(
@@ -59,9 +63,30 @@ async function wikiLinkCompletions(
 			),
 			type: asEmbed ? "keyword" : "text",
 			boost: item.title ? 1 : 0,
-		}),
-	);
+		};
+		wikiLinkTargets.set(completion, item);
+		return completion;
+	});
 	return { from: match.from, options, filter: false };
+}
+
+export function drillIntoSelectedWikiLink(view: EditorView): boolean {
+	const completion = selectedCompletion(view.state);
+	const item = completion ? wikiLinkTargets.get(completion) : undefined;
+	if (!item || !/\.md$/i.test(item.path) || item.insertText.includes("#")) {
+		return false;
+	}
+	const cursor = view.state.selection.main.head;
+	const line = view.state.doc.lineAt(cursor);
+	const match = line.text.slice(0, cursor - line.from).match(/!?\[\[[^\]\n]*$/);
+	if (!match) return false;
+	const from = cursor - match[0].length;
+	const opening = match[0].startsWith("![[") ? "![[" : "[[";
+	view.dispatch({
+		changes: { from, to: cursor, insert: `${opening}${item.insertText}#` },
+		selection: { anchor: from + opening.length + item.insertText.length + 1 },
+	});
+	return startCompletion(view);
 }
 
 async function markdownLinkCompletions(

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -22,6 +22,7 @@ interface TipTapSuggestionMenuOptions<T> {
 	lockEditorScroll?: boolean;
 	resetSelectionOnUpdate?: boolean;
 	onEscape?: (view: EditorView) => void;
+	onArrowRight?: (item: T, props: SuggestionProps<T>) => boolean;
 }
 
 function placeMenu(menu: HTMLElement, rect: DOMRect): void {
@@ -48,6 +49,7 @@ export function createTipTapSuggestionMenu<T>({
 	lockEditorScroll = true,
 	resetSelectionOnUpdate = false,
 	onEscape,
+	onArrowRight,
 }: TipTapSuggestionMenuOptions<T>) {
 	let menu: HTMLDivElement | null = null;
 	let selectedIndex = 0;
@@ -144,6 +146,13 @@ export function createTipTapSuggestionMenu<T>({
 				selectedIndex = nextSuggestionIndex(selectedIndex, items.length, -1);
 				updateSelection(items);
 				return true;
+			}
+			if (event.key === "ArrowRight" && current && onArrowRight) {
+				const item = items[selectedIndex] ?? items[0];
+				if (item && onArrowRight(item, current)) {
+					event.preventDefault();
+					return true;
+				}
 			}
 			if (event.key === "Enter" || event.key === "Tab") {
 				event.preventDefault();

--- a/src/components/editor/transclusions/NoteTransclusionView.tsx
+++ b/src/components/editor/transclusions/NoteTransclusionView.tsx
@@ -1,0 +1,120 @@
+import { RefreshIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation } from "@tanstack/react-query";
+import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
+import { Suspense, lazy } from "react";
+import { useTranslation } from "react-i18next";
+import { dispatchWikiLinkClick } from "../markdown/editorEvents";
+import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
+import {
+	TransclusionBranch,
+	transclusionKey,
+	useTransclusion,
+} from "./TransclusionContext";
+
+const NoteInlineEditor = lazy(() =>
+	import("../NoteInlineEditor").then((module) => ({
+		default: module.NoteInlineEditor,
+	})),
+);
+
+const TRANSCLUSION_ERROR_KEYS = {
+	unresolved: "transclusion.unresolved",
+	missing_heading: "transclusion.missingHeading",
+	unsupported_block: "transclusion.unsupportedBlock",
+	read_error: "transclusion.readError",
+} as const;
+
+const ignoreEmbeddedChanges = () => {};
+
+export function NoteTransclusionView({ node }: ReactNodeViewProps) {
+	const attrs: WikiLinkAttrs = {
+		raw: typeof node.attrs.raw === "string" ? node.attrs.raw : "",
+		target: typeof node.attrs.target === "string" ? node.attrs.target : "",
+		alias: typeof node.attrs.alias === "string" ? node.attrs.alias : null,
+		embed: true,
+		anchorKind: node.attrs.anchorKind ?? "none",
+		anchor: typeof node.attrs.anchor === "string" ? node.attrs.anchor : null,
+		unresolved: Boolean(node.attrs.unresolved),
+	};
+	const { t } = useTranslation("editor");
+	const { depthExceeded, isLoading, recursive, refresh, result } =
+		useTransclusion(attrs.target, attrs.anchorKind, attrs.anchor);
+	const refreshMutation = useMutation({
+		mutationFn: () =>
+			refresh(transclusionKey(attrs.target, attrs.anchorKind, attrs.anchor)),
+	});
+	const title = attrs.alias || attrs.target.replace(/\.md$/i, "");
+	const resultError = result?.error_kind
+		? t(TRANSCLUSION_ERROR_KEYS[result.error_kind])
+		: null;
+	const error = depthExceeded
+		? t("transclusion.depthExceeded")
+		: recursive
+			? t("transclusion.recursive")
+			: refreshMutation.isError
+				? t("transclusion.readError")
+				: resultError;
+
+	return (
+		<NodeViewWrapper className="noteTransclusion" contentEditable={false}>
+			<header className="noteTransclusionHeader">
+				<button
+					type="button"
+					className="noteTransclusionTitle"
+					onClick={() => dispatchWikiLinkClick({ ...attrs, embed: false })}
+					title={t("transclusion.openSource")}
+				>
+					{title}
+					{attrs.anchor ? ` · ${attrs.anchor}` : ""}
+				</button>
+				<div className="noteTransclusionActions">
+					<button
+						type="button"
+						onClick={() => refreshMutation.mutate()}
+						disabled={refreshMutation.isPending}
+						title={t("transclusion.refresh")}
+						aria-label={t("transclusion.refresh")}
+					>
+						<HugeiconsIcon icon={RefreshIcon} size="var(--icon-sm)" />
+					</button>
+				</div>
+			</header>
+			<div className="noteTransclusionBody">
+				{isLoading ? (
+					<div className="noteTransclusionMessage">
+						{t("transclusion.loading")}
+					</div>
+				) : error ? (
+					<div className="noteTransclusionMessage is-error">{error}</div>
+				) : result?.markdown !== null &&
+					result?.markdown !== undefined &&
+					result.resolved_path ? (
+					<TransclusionBranch resolvedPath={result.resolved_path}>
+						<Suspense
+							fallback={
+								<div className="noteTransclusionMessage">
+									{t("transclusion.loading")}
+								</div>
+							}
+						>
+							<NoteInlineEditor
+								markdown={result.markdown}
+								relPath={result.resolved_path}
+								mode="preview"
+								interactive={false}
+								deferHeavyFeatures
+								chrome="minimal"
+								onChange={ignoreEmbeddedChanges}
+							/>
+						</Suspense>
+					</TransclusionBranch>
+				) : (
+					<div className="noteTransclusionMessage">
+						{t("transclusion.unavailable")}
+					</div>
+				)}
+			</div>
+		</NodeViewWrapper>
+	);
+}

--- a/src/components/editor/transclusions/NoteTransclusionView.tsx
+++ b/src/components/editor/transclusions/NoteTransclusionView.tsx
@@ -1,16 +1,9 @@
-import { RefreshIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { useMutation } from "@tanstack/react-query";
 import { NodeViewWrapper, type ReactNodeViewProps } from "@tiptap/react";
 import { Suspense, lazy } from "react";
 import { useTranslation } from "react-i18next";
 import { dispatchWikiLinkClick } from "../markdown/editorEvents";
 import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
-import {
-	TransclusionBranch,
-	transclusionKey,
-	useTransclusion,
-} from "./TransclusionContext";
+import { TransclusionBranch, useTransclusion } from "./TransclusionContext";
 
 const NoteInlineEditor = lazy(() =>
 	import("../NoteInlineEditor").then((module) => ({
@@ -38,12 +31,8 @@ export function NoteTransclusionView({ node }: ReactNodeViewProps) {
 		unresolved: Boolean(node.attrs.unresolved),
 	};
 	const { t } = useTranslation("editor");
-	const { depthExceeded, isLoading, recursive, refresh, result } =
+	const { depthExceeded, isLoading, recursive, result } =
 		useTransclusion(attrs.target, attrs.anchorKind, attrs.anchor);
-	const refreshMutation = useMutation({
-		mutationFn: () =>
-			refresh(transclusionKey(attrs.target, attrs.anchorKind, attrs.anchor)),
-	});
 	const title = attrs.alias || attrs.target.replace(/\.md$/i, "");
 	const resultError = result?.error_kind
 		? t(TRANSCLUSION_ERROR_KEYS[result.error_kind])
@@ -52,9 +41,7 @@ export function NoteTransclusionView({ node }: ReactNodeViewProps) {
 		? t("transclusion.depthExceeded")
 		: recursive
 			? t("transclusion.recursive")
-			: refreshMutation.isError
-				? t("transclusion.readError")
-				: resultError;
+			: resultError;
 
 	return (
 		<NodeViewWrapper className="noteTransclusion" contentEditable={false}>
@@ -68,17 +55,6 @@ export function NoteTransclusionView({ node }: ReactNodeViewProps) {
 					{title}
 					{attrs.anchor ? ` · ${attrs.anchor}` : ""}
 				</button>
-				<div className="noteTransclusionActions">
-					<button
-						type="button"
-						onClick={() => refreshMutation.mutate()}
-						disabled={refreshMutation.isPending}
-						title={t("transclusion.refresh")}
-						aria-label={t("transclusion.refresh")}
-					>
-						<HugeiconsIcon icon={RefreshIcon} size="var(--icon-sm)" />
-					</button>
-				</div>
 			</header>
 			<div className="noteTransclusionBody">
 				{isLoading ? (

--- a/src/components/editor/transclusions/TransclusionContext.tsx
+++ b/src/components/editor/transclusions/TransclusionContext.tsx
@@ -1,0 +1,186 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	type ReactNode,
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+} from "react";
+import { isImageTarget } from "../../../lib/linkSuggestions";
+import {
+	type TransclusionRequest,
+	type TransclusionResult,
+	invoke,
+} from "../../../lib/tauri";
+import { useTauriEvent } from "../../../lib/tauriEvents";
+import { findWikiLinkSpans, parseWikiLink } from "../markdown/wikiLinkCodec";
+
+const MAX_TRANSCLUSION_DEPTH = 4;
+const EMPTY_RESULTS = new Map<string, TransclusionResult>();
+const noRefresh = async () => {};
+
+interface TransclusionContextValue {
+	ancestors: readonly string[];
+	depth: number;
+	results: ReadonlyMap<string, TransclusionResult>;
+	isLoading: boolean;
+	refresh: (key: string) => Promise<void>;
+}
+
+const TransclusionContext = createContext<TransclusionContextValue>({
+	ancestors: [],
+	depth: 0,
+	results: EMPTY_RESULTS,
+	isLoading: false,
+	refresh: noRefresh,
+});
+
+export function transclusionKey(
+	target: string,
+	anchorKind: TransclusionRequest["anchor_kind"],
+	anchor: string | null,
+): string {
+	return `${target}\0${anchorKind}\0${anchor ?? ""}`;
+}
+
+function requestsFromMarkdown(markdown: string) {
+	const requests = new Map<string, TransclusionRequest>();
+	for (const span of findWikiLinkSpans(markdown)) {
+		const parsed = parseWikiLink(span.raw);
+		if (!parsed?.embed || isImageTarget(parsed.target)) {
+			continue;
+		}
+		const key = transclusionKey(
+			parsed.target,
+			parsed.anchorKind,
+			parsed.anchor,
+		);
+		requests.set(key, {
+			key,
+			target: parsed.target,
+			anchor_kind: parsed.anchorKind,
+			anchor: parsed.anchor,
+		});
+	}
+	return Array.from(requests.values());
+}
+
+export function TransclusionDataProvider({
+	markdown,
+	relPath,
+	children,
+}: {
+	markdown: string;
+	relPath?: string;
+	children: ReactNode;
+}) {
+	const parent = useContext(TransclusionContext);
+	const queryClient = useQueryClient();
+	const requests = useMemo(() => requestsFromMarkdown(markdown), [markdown]);
+	const requestKey = useMemo(
+		() => requests.map((request) => request.key).sort(),
+		[requests],
+	);
+	const queryKey = useMemo(
+		() => ["note-transclusions", relPath ?? "", requestKey] as const,
+		[relPath, requestKey],
+	);
+	const query = useQuery({
+		queryKey,
+		queryFn: () => invoke("space_transclusions_batch", { requests }),
+		enabled: requests.length > 0,
+		staleTime: Number.POSITIVE_INFINITY,
+	});
+	const refresh = useCallback(
+		async (key: string) => {
+			const request = requests.find((candidate) => candidate.key === key);
+			if (!request) return;
+			const [result] = await invoke("space_transclusions_batch", {
+				requests: [request],
+			});
+			if (!result) return;
+			queryClient.setQueryData<TransclusionResult[]>(
+				queryKey,
+				(current = []) => [
+					...current.filter((item) => item.key !== result.key),
+					result,
+				],
+			);
+		},
+		[queryClient, queryKey, requests],
+	);
+	useTauriEvent("notes:external_changed", (payload) => {
+		if (
+			query.data?.some((result) => result.resolved_path === payload.rel_path)
+		) {
+			void query.refetch();
+		}
+	});
+	const results = useMemo(
+		() => new Map((query.data ?? []).map((result) => [result.key, result])),
+		[query.data],
+	);
+	const ancestors = useMemo(() => {
+		if (!relPath || parent.ancestors.includes(relPath)) return parent.ancestors;
+		return [...parent.ancestors, relPath];
+	}, [parent.ancestors, relPath]);
+	const value = useMemo<TransclusionContextValue>(
+		() => ({
+			ancestors,
+			depth: parent.depth,
+			results,
+			isLoading: query.isLoading,
+			refresh,
+		}),
+		[ancestors, parent.depth, query.isLoading, refresh, results],
+	);
+	return (
+		<TransclusionContext.Provider value={value}>
+			{children}
+		</TransclusionContext.Provider>
+	);
+}
+
+export function TransclusionBranch({
+	resolvedPath,
+	children,
+}: {
+	resolvedPath: string;
+	children: ReactNode;
+}) {
+	const parent = useContext(TransclusionContext);
+	const value = useMemo<TransclusionContextValue>(
+		() => ({
+			...parent,
+			ancestors: [...parent.ancestors, resolvedPath],
+			depth: parent.depth + 1,
+			results: EMPTY_RESULTS,
+		}),
+		[parent, resolvedPath],
+	);
+	return (
+		<TransclusionContext.Provider value={value}>
+			{children}
+		</TransclusionContext.Provider>
+	);
+}
+
+export function useTransclusion(
+	target: string,
+	anchorKind: TransclusionRequest["anchor_kind"],
+	anchor: string | null,
+) {
+	const context = useContext(TransclusionContext);
+	const result = context.results.get(
+		transclusionKey(target, anchorKind, anchor),
+	);
+	const recursive = Boolean(
+		result?.resolved_path && context.ancestors.includes(result.resolved_path),
+	);
+	return {
+		...context,
+		result,
+		recursive,
+		depthExceeded: context.depth >= MAX_TRANSCLUSION_DEPTH,
+	};
+}

--- a/src/components/editor/transclusions/TransclusionContext.tsx
+++ b/src/components/editor/transclusions/TransclusionContext.tsx
@@ -1,8 +1,7 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
 	type ReactNode,
 	createContext,
-	useCallback,
 	useContext,
 	useMemo,
 } from "react";
@@ -17,14 +16,12 @@ import { findWikiLinkSpans, parseWikiLink } from "../markdown/wikiLinkCodec";
 
 const MAX_TRANSCLUSION_DEPTH = 4;
 const EMPTY_RESULTS = new Map<string, TransclusionResult>();
-const noRefresh = async () => {};
 
 interface TransclusionContextValue {
 	ancestors: readonly string[];
 	depth: number;
 	results: ReadonlyMap<string, TransclusionResult>;
 	isLoading: boolean;
-	refresh: (key: string) => Promise<void>;
 }
 
 const TransclusionContext = createContext<TransclusionContextValue>({
@@ -32,7 +29,6 @@ const TransclusionContext = createContext<TransclusionContextValue>({
 	depth: 0,
 	results: EMPTY_RESULTS,
 	isLoading: false,
-	refresh: noRefresh,
 });
 
 export function transclusionKey(
@@ -75,7 +71,6 @@ export function TransclusionDataProvider({
 	children: ReactNode;
 }) {
 	const parent = useContext(TransclusionContext);
-	const queryClient = useQueryClient();
 	const requests = useMemo(() => requestsFromMarkdown(markdown), [markdown]);
 	const requestKey = useMemo(
 		() => requests.map((request) => request.key).sort(),
@@ -91,24 +86,6 @@ export function TransclusionDataProvider({
 		enabled: requests.length > 0,
 		staleTime: Number.POSITIVE_INFINITY,
 	});
-	const refresh = useCallback(
-		async (key: string) => {
-			const request = requests.find((candidate) => candidate.key === key);
-			if (!request) return;
-			const [result] = await invoke("space_transclusions_batch", {
-				requests: [request],
-			});
-			if (!result) return;
-			queryClient.setQueryData<TransclusionResult[]>(
-				queryKey,
-				(current = []) => [
-					...current.filter((item) => item.key !== result.key),
-					result,
-				],
-			);
-		},
-		[queryClient, queryKey, requests],
-	);
 	useTauriEvent("notes:external_changed", (payload) => {
 		if (
 			query.data?.some((result) => result.resolved_path === payload.rel_path)
@@ -130,9 +107,8 @@ export function TransclusionDataProvider({
 			depth: parent.depth,
 			results,
 			isLoading: query.isLoading,
-			refresh,
 		}),
-		[ancestors, parent.depth, query.isLoading, refresh, results],
+		[ancestors, parent.depth, query.isLoading, results],
 	);
 	return (
 		<TransclusionContext.Provider value={value}>

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -77,6 +77,7 @@ interface LinkedNoteItem {
 interface SidebarBacklinkItem {
 	id: string;
 	label: string;
+	kind: "link" | "embed";
 }
 
 const UTF8_ENCODER = new TextEncoder();
@@ -298,6 +299,7 @@ export function MarkdownEditorPane({
 			merged.set(id, {
 				id,
 				label: noteLinkLabel(item.title, id),
+				kind: item.kind,
 			});
 		}
 
@@ -307,6 +309,7 @@ export function MarkdownEditorPane({
 			merged.set(id, {
 				id,
 				label: noteLabelFromPath(id),
+				kind: "link",
 			});
 		}
 

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -6,6 +6,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { useDateDisplayFormat } from "../../contexts";
 import {
 	type DateDisplayFormat,
@@ -39,6 +40,7 @@ type InfoSidebarTab = "info" | "history";
 interface SidebarBacklinkItem {
 	id: string;
 	label: string;
+	kind: "link" | "embed";
 }
 
 interface LinkedNoteItem {
@@ -128,6 +130,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 	onSelectGitDiff,
 	onClose,
 }: NotesInfoSidebarProps) {
+	const { t } = useTranslation("editor");
 	const dateDisplayFormat = useDateDisplayFormat();
 	const [host, setHost] = useState<HTMLElement | null>(null);
 	const [activeTab, setActiveTab] = useState<InfoSidebarTab>("info");
@@ -302,6 +305,11 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 										>
 											<span className="wikiLinkIcon" aria-hidden="true" />
 											<span className="wikiLinkLabel">{item.label}</span>
+											{item.kind === "embed" ? (
+												<span className="markdownEditorInfoLinkKind">
+													{t("transclusion.backlinkLabel")}
+												</span>
+											) : null}
 										</button>
 									))}
 								</div>

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -4,6 +4,8 @@ import type { TOCHeading } from "../editor/hooks/useTableOfContents";
 import {
 	INTERNAL_ANCHOR_CLICK_EVENT,
 	type InternalAnchorClickDetail,
+	consumePendingInternalAnchor,
+	getPendingInternalAnchor,
 } from "../editor/markdown/editorEvents";
 import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
 import { analyzeNoteInfo } from "./noteInfoAnalysis";
@@ -27,16 +29,20 @@ export function useInternalAnchorNavigation({
 	tocHeadingsRef.current = tocHeadings;
 
 	useEffect(() => {
-		const onInternalAnchorClick = (event: Event) => {
-			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
-			if (!detail || detail.sourcePath !== relPath) return;
-
+		const navigate = (detail: InternalAnchorClickDetail) => {
 			const headings =
 				mode === "plain"
 					? analyzeNoteInfo(getPlainText(), getPlainText(), true).headings
 					: tocHeadingsRef.current;
 			const heading = resolveAnchorHeading(headings, detail.anchor);
-			if (heading) selectVisibleHeading(heading);
+			if (!heading) return false;
+			selectVisibleHeading(heading);
+			return true;
+		};
+		const onInternalAnchorClick = (event: Event) => {
+			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
+			if (!detail || detail.sourcePath !== relPath) return;
+			if (navigate(detail)) consumePendingInternalAnchor(relPath);
 		};
 
 		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
@@ -47,4 +53,21 @@ export function useInternalAnchorNavigation({
 			);
 		};
 	}, [getPlainText, mode, relPath, selectVisibleHeading]);
+
+	useEffect(() => {
+		const headings =
+			mode === "plain"
+				? analyzeNoteInfo(getPlainText(), getPlainText(), true).headings
+				: tocHeadings;
+		if (headings.length === 0) return;
+		const pending = getPendingInternalAnchor(relPath);
+		if (!pending) return;
+		const heading = resolveAnchorHeading(headings, pending.anchor);
+		if (!heading) {
+			consumePendingInternalAnchor(relPath);
+			return;
+		}
+		selectVisibleHeading(heading);
+		consumePendingInternalAnchor(relPath);
+	}, [getPlainText, mode, relPath, selectVisibleHeading, tocHeadings]);
 }

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "Quelle öffnen",
-		"refresh": "Aktualisieren",
 		"loading": "Eingebettete Notiz wird geladen…",
 		"unavailable": "Eingebettete Notiz nicht verfügbar",
 		"unresolved": "Quellnotiz nicht gefunden.",

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "Quelle öffnen",
+		"refresh": "Aktualisieren",
+		"loading": "Eingebettete Notiz wird geladen…",
+		"unavailable": "Eingebettete Notiz nicht verfügbar",
+		"unresolved": "Quellnotiz nicht gefunden.",
+		"missingHeading": "Abschnittsüberschrift nicht gefunden.",
+		"unsupportedBlock": "Blockeinbettungen werden noch nicht unterstützt.",
+		"readError": "Die eingebettete Notiz konnte nicht gelesen werden.",
+		"recursive": "Diese Einbettung würde eine rekursive Notizschleife erzeugen.",
+		"depthExceeded": "Diese Einbettung überschreitet die maximale Verschachtelungstiefe.",
+		"backlinkLabel": "Einbettung"
+	},
 	"mode": {
 		"label": "Editormodus",
 		"raw": "Raw",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "Open source",
-		"refresh": "Refresh",
 		"loading": "Loading embedded note…",
 		"unavailable": "Embedded note unavailable",
 		"unresolved": "Source note not found.",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "Open source",
+		"refresh": "Refresh",
+		"loading": "Loading embedded note…",
+		"unavailable": "Embedded note unavailable",
+		"unresolved": "Source note not found.",
+		"missingHeading": "Section heading not found.",
+		"unsupportedBlock": "Block transclusion is not supported yet.",
+		"readError": "The embedded note could not be read.",
+		"recursive": "This embed would create a recursive note loop.",
+		"depthExceeded": "This embed exceeds the maximum nesting depth.",
+		"backlinkLabel": "Embed"
+	},
 	"mode": {
 		"label": "Editor mode",
 		"raw": "Raw",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "Abrir fuente",
-		"refresh": "Actualizar",
 		"loading": "Cargando nota incrustada…",
 		"unavailable": "Nota incrustada no disponible",
 		"unresolved": "No se encontró la nota de origen.",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "Abrir fuente",
+		"refresh": "Actualizar",
+		"loading": "Cargando nota incrustada…",
+		"unavailable": "Nota incrustada no disponible",
+		"unresolved": "No se encontró la nota de origen.",
+		"missingHeading": "No se encontró el encabezado de la sección.",
+		"unsupportedBlock": "La transclusión de bloques aún no está disponible.",
+		"readError": "No se pudo leer la nota incrustada.",
+		"recursive": "Esta incrustación crearía un ciclo recursivo de notas.",
+		"depthExceeded": "Esta incrustación supera la profundidad máxima de anidamiento.",
+		"backlinkLabel": "Incrustación"
+	},
 	"mode": {
 		"label": "Modo del editor",
 		"raw": "Sin formato",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "Ouvrir la source",
+		"refresh": "Actualiser",
+		"loading": "Chargement de la note intégrée…",
+		"unavailable": "Note intégrée indisponible",
+		"unresolved": "Note source introuvable.",
+		"missingHeading": "Titre de section introuvable.",
+		"unsupportedBlock": "La transclusion de blocs n’est pas encore prise en charge.",
+		"readError": "La note intégrée n’a pas pu être lue.",
+		"recursive": "Cette intégration créerait une boucle récursive de notes.",
+		"depthExceeded": "Cette intégration dépasse la profondeur d’imbrication maximale.",
+		"backlinkLabel": "Intégration"
+	},
 	"mode": {
 		"label": "Mode de l’éditeur",
 		"raw": "Brut",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "Ouvrir la source",
-		"refresh": "Actualiser",
 		"loading": "Chargement de la note intégrée…",
 		"unavailable": "Note intégrée indisponible",
 		"unresolved": "Note source introuvable.",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "元のノートを開く",
-		"refresh": "更新",
 		"loading": "埋め込みノートを読み込み中…",
 		"unavailable": "埋め込みノートを利用できません",
 		"unresolved": "元のノートが見つかりません。",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "元のノートを開く",
+		"refresh": "更新",
+		"loading": "埋め込みノートを読み込み中…",
+		"unavailable": "埋め込みノートを利用できません",
+		"unresolved": "元のノートが見つかりません。",
+		"missingHeading": "セクションの見出しが見つかりません。",
+		"unsupportedBlock": "ブロックの埋め込みはまだサポートされていません。",
+		"readError": "埋め込みノートを読み込めませんでした。",
+		"recursive": "この埋め込みはノートの再帰ループを作成します。",
+		"depthExceeded": "この埋め込みは最大ネスト階層を超えています。",
+		"backlinkLabel": "埋め込み"
+	},
 	"mode": {
 		"label": "エディタモード",
 		"raw": "Raw",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "원본 노트 열기",
-		"refresh": "새로 고침",
 		"loading": "임베드된 노트 불러오는 중…",
 		"unavailable": "임베드된 노트를 사용할 수 없음",
 		"unresolved": "원본 노트를 찾을 수 없습니다.",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "원본 노트 열기",
+		"refresh": "새로 고침",
+		"loading": "임베드된 노트 불러오는 중…",
+		"unavailable": "임베드된 노트를 사용할 수 없음",
+		"unresolved": "원본 노트를 찾을 수 없습니다.",
+		"missingHeading": "섹션 제목을 찾을 수 없습니다.",
+		"unsupportedBlock": "블록 트랜스클루전은 아직 지원되지 않습니다.",
+		"readError": "임베드된 노트를 읽을 수 없습니다.",
+		"recursive": "이 임베드는 재귀적인 노트 순환을 만듭니다.",
+		"depthExceeded": "이 임베드는 최대 중첩 깊이를 초과합니다.",
+		"backlinkLabel": "임베드"
+	},
 	"mode": {
 		"label": "편집기 모드",
 		"raw": "Raw",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -1,7 +1,6 @@
 {
 	"transclusion": {
 		"openSource": "Abrir origem",
-		"refresh": "Atualizar",
 		"loading": "Carregando nota incorporada…",
 		"unavailable": "Nota incorporada indisponível",
 		"unresolved": "Nota de origem não encontrada.",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -1,4 +1,17 @@
 {
+	"transclusion": {
+		"openSource": "Abrir origem",
+		"refresh": "Atualizar",
+		"loading": "Carregando nota incorporada…",
+		"unavailable": "Nota incorporada indisponível",
+		"unresolved": "Nota de origem não encontrada.",
+		"missingHeading": "Título da seção não encontrado.",
+		"unsupportedBlock": "A transclusão de blocos ainda não é compatível.",
+		"readError": "Não foi possível ler a nota incorporada.",
+		"recursive": "Esta incorporação criaria um ciclo recursivo de notas.",
+		"depthExceeded": "Esta incorporação excede a profundidade máxima de aninhamento.",
+		"backlinkLabel": "Incorporação"
+	},
 	"mode": {
 		"label": "Modo do editor",
 		"raw": "Bruto",

--- a/src/lib/linkSuggestions.ts
+++ b/src/lib/linkSuggestions.ts
@@ -8,7 +8,7 @@ export interface EditorLinkSuggestion {
 }
 
 interface SuggestWikiLinksOptions {
-	embedOnly?: boolean;
+	forEmbed?: boolean;
 	includeAttachments?: boolean;
 	limit: number;
 	query: string;
@@ -46,27 +46,34 @@ function toEditorSuggestion(item: {
 }
 
 export async function suggestWikiLinks({
-	embedOnly = false,
+	forEmbed = false,
 	includeAttachments = true,
 	limit,
 	query,
 }: SuggestWikiLinksOptions): Promise<EditorLinkSuggestion[]> {
-	const requestLimit = embedOnly ? Math.min(limit * 4, 200) : limit;
+	const hashIndex = query.indexOf("#");
+	if (hashIndex >= 0) {
+		const target = query.slice(0, hashIndex).trim();
+		if (!target) return [];
+		const results = await invoke("space_suggest_wikilink_headings", {
+			target,
+			query: query.slice(hashIndex + 1),
+			limit,
+		});
+		return results.map(toEditorSuggestion);
+	}
 	const results = await invoke("space_suggest_links", {
 		request: {
 			query,
 			markdown_only: true,
-			include_pdf: !embedOnly && includeAttachments,
-			include_images: embedOnly || includeAttachments,
-			strip_markdown_ext: !embedOnly,
+			include_pdf: !forEmbed && includeAttachments,
+			include_images: forEmbed || includeAttachments,
+			strip_markdown_ext: true,
 			relative_to_source: false,
-			limit: requestLimit,
+			limit,
 		},
 	});
-	return results
-		.filter((item) => !embedOnly || isImageTarget(item.path))
-		.slice(0, limit)
-		.map(toEditorSuggestion);
+	return results.map(toEditorSuggestion);
 }
 
 export async function suggestMarkdownLinks({

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -371,6 +371,27 @@ export interface BacklinkItem {
 	id: string;
 	title: string;
 	updated: string;
+	kind: "link" | "embed";
+}
+
+export interface TransclusionRequest {
+	key: string;
+	target: string;
+	anchor_kind: "none" | "heading" | "block";
+	anchor?: string | null;
+}
+
+export interface TransclusionResult {
+	key: string;
+	resolved_path: string | null;
+	markdown: string | null;
+	mtime_ms: number | null;
+	error_kind:
+		| "unresolved"
+		| "missing_heading"
+		| "unsupported_block"
+		| "read_error"
+		| null;
 }
 
 export interface NoteRelationship {
@@ -899,6 +920,14 @@ interface TauriCommands {
 	space_reveal_path: CommandDef<{ path: string }, void>;
 	space_relativize_path: CommandDef<{ abs_path: string }, string>;
 	space_resolve_wikilink: CommandDef<{ target: string }, string | null>;
+	space_suggest_wikilink_headings: CommandDef<
+		{ target: string; query: string; limit?: number | null },
+		{ path: string; title: string; insert_text: string }[]
+	>;
+	space_transclusions_batch: CommandDef<
+		{ requests: TransclusionRequest[] },
+		TransclusionResult[]
+	>;
 	space_resolve_image_wikilink: CommandDef<{ target: string }, string | null>;
 	space_resolve_markdown_link: CommandDef<
 		{ href: string; sourcePath: string },

--- a/src/styles/app/30-note-transclusion.css
+++ b/src/styles/app/30-note-transclusion.css
@@ -1,0 +1,151 @@
+.noteTransclusion {
+	display: block;
+	width: 100%;
+	margin: var(--space-2) 0 var(--space-3);
+}
+
+.noteTransclusionHeader {
+	display: flex;
+	align-items: center;
+	min-height: 30px;
+}
+
+.noteTransclusionTitle {
+	align-self: stretch;
+	min-width: 0;
+	flex: 1;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-tertiary);
+	font-size: var(--text-xs);
+	font-weight: var(--font-medium);
+	line-height: 30px;
+	text-align: left;
+	cursor: pointer;
+	transition: color 120ms ease;
+}
+
+.noteTransclusionTitle:hover,
+.noteTransclusionTitle:focus-visible {
+	color: var(--interactive-accent);
+	outline: none;
+}
+
+.noteTransclusionActions {
+	display: flex;
+}
+
+.noteTransclusionActions button {
+	display: grid;
+	place-items: center;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	color: var(--text-tertiary);
+	cursor: pointer;
+	transition: color 120ms ease, scale 120ms ease;
+}
+
+.noteTransclusionActions button:hover,
+.noteTransclusionActions button:focus-visible {
+	color: var(--text-primary);
+	outline: none;
+}
+
+.noteTransclusionActions button:active {
+	scale: 0.96;
+}
+
+.noteTransclusionActions button:disabled {
+	cursor: progress;
+	opacity: 0.5;
+}
+
+.noteTransclusionBody {
+	max-height: 320px;
+	overflow-x: hidden;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	padding: 0 0 var(--space-1);
+}
+
+.noteTransclusionBody .rfNodeNoteEditor,
+.noteTransclusionBody .rfNodeNoteEditorBody,
+.noteTransclusionBody .tiptapHostInline {
+	flex: none;
+	min-height: 0;
+	padding: 0;
+	background: transparent;
+}
+
+.noteTransclusionBody .rfNodeNoteEditorBody {
+	overflow: visible;
+}
+
+.noteTransclusionBody .tiptapContentInline {
+	max-width: none;
+	margin: 0;
+	padding: 0;
+	font-size: calc(var(--editor-font-size) * 0.88);
+	line-height: 1.55;
+}
+
+.noteTransclusionBody .tiptapContentInline p {
+	margin-bottom: var(--space-2);
+}
+
+.noteTransclusionBody .tiptapContentInline h1,
+.noteTransclusionBody .tiptapContentInline h2,
+.noteTransclusionBody .tiptapContentInline h3,
+.noteTransclusionBody .tiptapContentInline h4,
+.noteTransclusionBody .tiptapContentInline h5,
+.noteTransclusionBody .tiptapContentInline h6 {
+	margin-top: var(--space-3);
+	margin-bottom: var(--space-1);
+}
+
+.noteTransclusionBody
+	.tiptapContentInline
+	> :first-child:is(h1, h2, h3, h4, h5, h6) {
+	margin-top: 0;
+}
+
+.noteTransclusionBody .tiptapContentInline h1 {
+	font-size: calc(var(--editor-font-size) * 1.2);
+}
+
+.noteTransclusionBody .tiptapContentInline h2 {
+	font-size: calc(var(--editor-font-size) * 1.08);
+}
+
+.noteTransclusionBody .tiptapContentInline h3,
+.noteTransclusionBody .tiptapContentInline h4,
+.noteTransclusionBody .tiptapContentInline h5,
+.noteTransclusionBody .tiptapContentInline h6 {
+	font-size: var(--editor-font-size);
+}
+
+.noteTransclusionMessage {
+	padding: var(--space-4);
+	color: var(--text-tertiary);
+	font-size: var(--text-sm);
+	text-wrap: pretty;
+}
+
+.noteTransclusionMessage.is-error {
+	color: var(--status-danger-fg);
+}
+
+.markdownEditorInfoLinkKind {
+	margin-left: var(--space-1);
+	color: var(--text-tertiary);
+	font-size: var(--text-xs);
+	font-weight: var(--font-medium);
+	text-decoration: none;
+}

--- a/src/styles/app/30-note-transclusion.css
+++ b/src/styles/app/30-note-transclusion.css
@@ -2,6 +2,9 @@
 	display: block;
 	width: 100%;
 	margin: var(--space-2) 0 var(--space-3);
+	padding: 0 var(--space-2) var(--space-2);
+	border-radius: var(--radius-md);
+	box-shadow: inset 0 0 0 1px var(--border-light);
 }
 
 .noteTransclusionHeader {
@@ -26,45 +29,11 @@
 	line-height: 30px;
 	text-align: left;
 	cursor: pointer;
-	transition: color 120ms ease;
 }
 
-.noteTransclusionTitle:hover,
 .noteTransclusionTitle:focus-visible {
-	color: var(--interactive-accent);
-	outline: none;
-}
-
-.noteTransclusionActions {
-	display: flex;
-}
-
-.noteTransclusionActions button {
-	display: grid;
-	place-items: center;
-	width: 30px;
-	height: 30px;
-	padding: 0;
-	border: 0;
-	background: transparent;
-	color: var(--text-tertiary);
-	cursor: pointer;
-	transition: color 120ms ease, scale 120ms ease;
-}
-
-.noteTransclusionActions button:hover,
-.noteTransclusionActions button:focus-visible {
-	color: var(--text-primary);
-	outline: none;
-}
-
-.noteTransclusionActions button:active {
-	scale: 0.96;
-}
-
-.noteTransclusionActions button:disabled {
-	cursor: progress;
-	opacity: 0.5;
+	outline: 1px solid var(--border-focus);
+	outline-offset: 1px;
 }
 
 .noteTransclusionBody {


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/411


## Description

Adds read-only note and section transclusion for `![[Note]]` and `![[Note#Heading]]`.

- Summary of changes
  - Renders whole notes and individual sections in Rich and Preview modes using compact, content-sized embeds that scroll only after reaching their height cap.
  - Adds batched Tauri resolution, fenced-code-aware Markdown section parsing, open-source and refresh controls, and clear cycle/depth/error placeholders.
  - Adds note and heading autocomplete in both rich and raw editors. Right Arrow accepts a selected note and drills into its headings.
  - Makes normal `[[Note#Heading]]` links navigate to their heading reliably.
  - Distinguishes embeds from normal links in backlinks and the derived index, and localizes all new user-facing UI.
- Reasoning
  - Enables dashboards, project briefs, meeting packets, and index notes without copying source content.
  - Keeps embeds read-only so save ownership remains clear while retaining portable wiki-embed Markdown.
- Additional context
  - The derived index version is bumped to 8 so existing spaces are reindexed with embed attribution.
  - Block references are not part of this change and render a clear unsupported placeholder.


## Screenshots

No screenshot is attached. Repository instructions prohibit starting the development server; the visual implementation uses natural height for short embeds and caps long embeds at 320px with internal scrolling.


## Docs

Updated:

- `docs/architecture/05-editor-markdown-autosave.md`
- `docs/architecture/06-index-search-graph-tasks.md`

Validated with:

- `pnpm check`
- `pnpm build`
- `cd src-tauri && cargo check`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add read-only note and section embeds using ![[Note]] and ![[Note#Heading]] in Rich and Preview modes, with compact, scroll-capped blocks. Backlinks label embeds, and the index now stores embed attribution for graphs.

- **New Features**
  - Render `![[Note]]` and `![[Note#Heading]]` as read-only blocks with a small header and “open source” action; cycles and deep nests stop with clear messages.
  - Batch resolve via `space_transclusions_batch`, with fenced-code-aware section parsing and heading suggestions from `space_suggest_wikilink_headings`.
  - Autocomplete: type `#` to list headings; Right Arrow drills into headings; `![[...]]` to a note inserts a transclusion block; heading anchors scroll after the target note mounts.

- **Migration**
  - Index DB bumped to 8; link rows and file fingerprints are cleared and spaces reindex to classify embeds as `links.kind = 'embed'`. No manual steps needed.

<sup>Written for commit 9c20fcbc7e754535731687994a6a92cc5fb3774f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

