### PR TITLE
Add pinned collections and saved searches (#413) [Release]

### DIFF
--- a/docs/architecture/07-databases-frontmatter.md
+++ b/docs/architecture/07-databases-frontmatter.md
@@ -61,7 +61,10 @@ Collections are user-created databases. New spaces start with an empty store.
 - `databases: []`
 - `status_colors: {}`
 
-Creating a collection (`databases_create`) requires a folder. The backend rejects an empty folder path. New collections are created with:
+The standard collection dialog creates a folder-backed collection and rejects an
+empty folder path. The same `databases_create` command can also receive an
+explicit source for flows such as saving a search. Folder-backed collections are
+created with:
 
 - `source.kind = "folder"`
 - `source.value` = chosen folder (recursive)
@@ -82,6 +85,7 @@ Users can still change a collection source to `all_notes`, `tag`, or `search` la
 - `name`
 - `icon`
 - `color`
+- `pinned`
 - `source`
 - `new_note`
 - `schema`
@@ -94,6 +98,10 @@ Users can still change a collection source to `all_notes`, `tag`, or `search` la
 - `folder`
 - `tag`
 - `search`
+
+Pinned collections appear alongside pinned notes in the Pinned workspace. Saving a
+search from the command palette creates a pinned collection whose source kind is
+`search` and whose source value is the raw palette query.
 
 `new_note.folder` controls where `databases_create_row` creates a new note.
 

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -642,6 +642,7 @@ pub async fn databases_update(
         }
         let mut next = database.clone();
         next.name = normalized_name;
+        next.pinned = store.databases[index].pinned;
         next.source = normalize_database_source(&root, next.source)?;
         next.new_note.folder = if next.source.kind == "folder" {
             next.source.value.clone()
@@ -653,6 +654,34 @@ pub async fn databases_update(
         store.databases[index] = next.clone();
         save_store(&root, &store)?;
         load_database_document(&root, &next)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn databases_set_pinned(
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    database_id: String,
+    pinned: bool,
+) -> Result<DatabaseDocument, String> {
+    let root = state.root_for_window(&window)?;
+    let db_store_mutex = state.db_store_mutex();
+    tauri::async_runtime::spawn_blocking(move || {
+        let _guard = db_store_mutex
+            .lock()
+            .map_err(|_| "database store mutex poisoned".to_string())?;
+        let mut store = load_store(&root)?;
+        let database = store
+            .databases
+            .iter_mut()
+            .find(|entry| entry.id == database_id)
+            .ok_or_else(|| "database not found".to_string())?;
+        database.pinned = pinned;
+        let database = database.clone();
+        save_store(&root, &store)?;
+        load_database_document(&root, &database)
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -74,6 +74,32 @@ fn normalize_collection_folder(base_dir: &Path, folder: &str) -> Result<String, 
     Ok(normalized)
 }
 
+fn normalize_new_note_folder(base_dir: &Path, folder: &str) -> Result<String, String> {
+    let trimmed = folder.trim().replace('\\', "/");
+    if trimmed.trim_matches('/').is_empty() {
+        return Ok(String::new());
+    }
+    normalize_collection_folder(base_dir, &trimmed)
+}
+
+fn normalize_database_source(
+    base_dir: &Path,
+    mut source: super::types::DatabaseSource,
+) -> Result<super::types::DatabaseSource, String> {
+    match source.kind.as_str() {
+        "all_notes" => source.value.clear(),
+        "folder" => source.value = normalize_collection_folder(base_dir, &source.value)?,
+        "tag" | "search" => {
+            source.value = source.value.trim().to_string();
+            if source.value.is_empty() {
+                return Err(format!("{} source value is required", source.kind));
+            }
+        }
+        other => return Err(format!("unsupported database source kind '{other}'")),
+    }
+    Ok(source)
+}
+
 fn normalize_status_id(status: &str) -> Result<String, String> {
     let normalized = status
         .trim()
@@ -534,7 +560,9 @@ pub async fn databases_create(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
     name: String,
-    folder: String,
+    folder: Option<String>,
+    source: Option<super::types::DatabaseSource>,
+    pinned: Option<bool>,
 ) -> Result<DatabaseDocument, String> {
     let root = state.root_for_window(&window)?;
     let db_store_mutex = state.db_store_mutex();
@@ -543,7 +571,22 @@ pub async fn databases_create(
             .lock()
             .map_err(|_| "database store mutex poisoned".to_string())?;
         let normalized_name = normalize_database_name(&name)?;
-        let normalized_folder = normalize_collection_folder(&root, &folder)?;
+        let source = match source {
+            Some(source) => normalize_database_source(&root, source)?,
+            None => super::types::DatabaseSource {
+                kind: "folder".to_string(),
+                value: normalize_collection_folder(
+                    &root,
+                    folder.as_deref().ok_or_else(|| "folder is required".to_string())?,
+                )?,
+                recursive: true,
+            },
+        };
+        let new_note_folder = if source.kind == "folder" {
+            source.value.clone()
+        } else {
+            String::new()
+        };
         let mut store = load_store(&root)?;
         if database_name_exists(&store.databases, &normalized_name, None) {
             return Err("collection name already exists".to_string());
@@ -554,13 +597,10 @@ pub async fn databases_create(
             name: normalized_name,
             icon: None,
             color: None,
-            source: super::types::DatabaseSource {
-                kind: "folder".to_string(),
-                value: normalized_folder.clone(),
-                recursive: true,
-            },
+            pinned: pinned.unwrap_or(false),
+            source,
             new_note: super::types::DatabaseNewNoteConfig {
-                folder: normalized_folder,
+                folder: new_note_folder,
             },
             schema: Vec::new(),
             views: vec![default_view("View 1")],
@@ -599,10 +639,8 @@ pub async fn databases_update(
         }
         let mut next = database.clone();
         next.name = normalized_name;
-        if next.source.kind == "folder" {
-            next.source.value = normalize_collection_folder(&root, &next.source.value)?;
-        }
-        next.new_note.folder = normalize_collection_folder(&root, &next.new_note.folder)?;
+        next.source = normalize_database_source(&root, next.source)?;
+        next.new_note.folder = normalize_new_note_folder(&root, &next.new_note.folder)?;
         prune_unsupported_database_view_layouts(&mut next);
         next.updated_at = chrono::Utc::now().to_rfc3339();
         store.databases[index] = next.clone();

--- a/src-tauri/src/databases/commands.rs
+++ b/src-tauri/src/databases/commands.rs
@@ -637,10 +637,17 @@ pub async fn databases_update(
         if database_name_exists(&store.databases, &normalized_name, Some(&database.id)) {
             return Err("collection name already exists".to_string());
         }
+        if store.databases[index].updated_at != database.updated_at {
+            return Err("collection changed since it was opened".to_string());
+        }
         let mut next = database.clone();
         next.name = normalized_name;
         next.source = normalize_database_source(&root, next.source)?;
-        next.new_note.folder = normalize_new_note_folder(&root, &next.new_note.folder)?;
+        next.new_note.folder = if next.source.kind == "folder" {
+            next.source.value.clone()
+        } else {
+            normalize_new_note_folder(&root, &next.new_note.folder)?
+        };
         prune_unsupported_database_view_layouts(&mut next);
         next.updated_at = chrono::Utc::now().to_rfc3339();
         store.databases[index] = next.clone();

--- a/src-tauri/src/databases/store.rs
+++ b/src-tauri/src/databases/store.rs
@@ -254,6 +254,8 @@ pub fn list_summaries(store: &DatabaseStore) -> Vec<DatabaseSummary> {
             name: database.name.clone(),
             icon: database.icon.clone(),
             color: database.color.clone(),
+            pinned: database.pinned,
+            source: database.source.clone(),
             view_count: database.views.len() as u32,
         })
         .collect::<Vec<_>>();

--- a/src-tauri/src/databases/types.rs
+++ b/src-tauri/src/databases/types.rs
@@ -134,6 +134,8 @@ pub struct DatabaseDefinition {
     pub icon: Option<String>,
     #[serde(default)]
     pub color: Option<String>,
+    #[serde(default)]
+    pub pinned: bool,
     pub source: DatabaseSource,
     pub new_note: DatabaseNewNoteConfig,
     #[serde(default)]
@@ -174,6 +176,9 @@ pub struct DatabaseSummary {
     pub icon: Option<String>,
     #[serde(default)]
     pub color: Option<String>,
+    #[serde(default)]
+    pub pinned: bool,
+    pub source: DatabaseSource,
     #[serde(default)]
     pub view_count: u32,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1623,6 +1623,7 @@ pub fn run() {
             databases::commands::databases_get,
             databases::commands::databases_create,
             databases::commands::databases_update,
+            databases::commands::databases_set_pinned,
             databases::commands::databases_delete,
             databases::commands::databases_query_rows,
             databases::commands::databases_update_cell,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.9-alpha.6",
+	"version": "0.8.9-alpha.7",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1394,6 +1394,7 @@ export function AppShell() {
 				onOpenDailyNote={requestOpenDailyNote}
 				onOpenActivity={openActivityTab}
 				onPrefetchActivity={prefetchActivityTab}
+				onOpenDatabase={(databaseId) => openDatabasesTab(databaseId)}
 				tabs={tabs}
 				rootEntries={rootEntries}
 				childrenByDir={childrenByDir}

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -107,14 +107,15 @@ export function CommandPalette({
 		activeTab === "commands" ? filtered.length : searchItems.length;
 	const parsedSearch = useMemo(() => parseSearchQuery(query), [query]);
 	const databaseSummaries = useQuery({
-		queryKey: [...navigationQueryKeys.databaseSummaries(), spacePath],
+		queryKey: navigationQueryKeys.databaseSummaries(),
 		queryFn: () => invoke("databases_list"),
 		enabled: open && activeTab === "search" && canSearch,
 	});
 	const saveSearch = useMutation({
 		mutationFn: async (rawQuery: string) => {
 			const trimmed = rawQuery.trim();
-			const summaries = await invoke("databases_list");
+			const summaries = databaseSummaries.data;
+			if (!summaries) throw new Error(t("commandPalette.saveSearchFailed"));
 			const baseName =
 				trimmed.length > 56 ? `${trimmed.slice(0, 53)}…` : trimmed;
 			return invoke("databases_create", {
@@ -334,7 +335,10 @@ export function CommandPalette({
 								className="commandSearchSaveButton"
 								data-saved={isCurrentSearchSaved ? "true" : "false"}
 								disabled={
-									!query.trim() || saveSearch.isPending || isCurrentSearchSaved
+									!query.trim() ||
+									!databaseSummaries.data ||
+									saveSearch.isPending ||
+									isCurrentSearchSaved
 								}
 								onClick={() => saveSearch.mutate(query)}
 								title={t(

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -1,6 +1,17 @@
 import { cn } from "@/lib/utils";
+import { StarIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMutation } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { nextCollectionName } from "../../lib/database/collection";
+import { extractErrorMessage } from "../../lib/errorUtils";
+import {
+	invalidateDatabaseSummariesPrefetch,
+	prefetchDatabaseSummaries,
+} from "../../lib/navigationPrefetch";
+import { invoke } from "../../lib/tauri";
+import { toast } from "../../lib/toast";
 import { Search } from "../Icons";
 import { NotePreviewContent } from "../preview/NotePreviewContent";
 import { NOTE_PREVIEW_OPEN_DELAY_MS } from "../preview/notePreviewShared";
@@ -95,6 +106,32 @@ export function CommandPalette({
 	const itemCount =
 		activeTab === "commands" ? filtered.length : searchItems.length;
 	const parsedSearch = useMemo(() => parseSearchQuery(query), [query]);
+	const saveSearch = useMutation({
+		mutationFn: async (rawQuery: string) => {
+			const trimmed = rawQuery.trim();
+			const summaries = await prefetchDatabaseSummaries();
+			const baseName =
+				trimmed.length > 56 ? `${trimmed.slice(0, 53)}…` : trimmed;
+			return invoke("databases_create", {
+				name: nextCollectionName(summaries, baseName),
+				folder: null,
+				source: { kind: "search", value: trimmed, recursive: false },
+				pinned: true,
+			});
+		},
+		onSuccess: () => {
+			invalidateDatabaseSummariesPrefetch();
+			toast.success(t("commandPalette.searchSaved"));
+		},
+		onError: (cause) => {
+			toast.error(t("commandPalette.saveSearchFailed"), {
+				description: extractErrorMessage(cause),
+			});
+		},
+	});
+	const isCurrentSearchSaved =
+		saveSearch.data?.database.source.kind === "search" &&
+		saveSearch.data.database.source.value === query.trim();
 
 	const switchTab = useCallback(
 		(tab: Tab) => {
@@ -272,17 +309,44 @@ export function CommandPalette({
 						/>
 					</div>
 					{activeTab === "search" ? (
-						<CommandSearchFilters
-							request={parsedSearch.request}
-							onChangeQuery={(nextQuery) =>
-								setState((curr) => ({
-									...curr,
-									query: nextQuery,
-									selectedIndex: 0,
-									selectedId: null,
-								}))
-							}
-						/>
+						<div className="commandSearchActions">
+							<CommandSearchFilters
+								request={parsedSearch.request}
+								onChangeQuery={(nextQuery) =>
+									setState((curr) => ({
+										...curr,
+										query: nextQuery,
+										selectedIndex: 0,
+										selectedId: null,
+									}))
+								}
+							/>
+							<button
+								type="button"
+								className="commandSearchSaveButton"
+								data-saved={isCurrentSearchSaved ? "true" : "false"}
+								disabled={
+									!query.trim() || saveSearch.isPending || isCurrentSearchSaved
+								}
+								onClick={() => saveSearch.mutate(query)}
+								title={t(
+									isCurrentSearchSaved
+										? "commandPalette.searchSaved"
+										: "commandPalette.saveSearch",
+								)}
+								aria-label={t(
+									isCurrentSearchSaved
+										? "commandPalette.searchSaved"
+										: "commandPalette.saveSearch",
+								)}
+							>
+								<HugeiconsIcon
+									icon={StarIcon}
+									size="var(--icon-md)"
+									strokeWidth={0.9}
+								/>
+							</button>
+						</div>
 					) : null}
 				</div>
 

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -1,14 +1,14 @@
 import { cn } from "@/lib/utils";
 import { StarIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { nextCollectionName } from "../../lib/database/collection";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
 	invalidateDatabaseSummariesPrefetch,
-	prefetchDatabaseSummaries,
+	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import { invoke } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
@@ -106,10 +106,15 @@ export function CommandPalette({
 	const itemCount =
 		activeTab === "commands" ? filtered.length : searchItems.length;
 	const parsedSearch = useMemo(() => parseSearchQuery(query), [query]);
+	const databaseSummaries = useQuery({
+		queryKey: [...navigationQueryKeys.databaseSummaries(), spacePath],
+		queryFn: () => invoke("databases_list"),
+		enabled: open && activeTab === "search" && canSearch,
+	});
 	const saveSearch = useMutation({
 		mutationFn: async (rawQuery: string) => {
 			const trimmed = rawQuery.trim();
-			const summaries = await prefetchDatabaseSummaries();
+			const summaries = await invoke("databases_list");
 			const baseName =
 				trimmed.length > 56 ? `${trimmed.slice(0, 53)}…` : trimmed;
 			return invoke("databases_create", {
@@ -129,9 +134,12 @@ export function CommandPalette({
 			});
 		},
 	});
-	const isCurrentSearchSaved =
-		saveSearch.data?.database.source.kind === "search" &&
-		saveSearch.data.database.source.value === query.trim();
+	const normalizedQuery = query.trim();
+	const isCurrentSearchSaved = databaseSummaries.data?.some(
+		(collection) =>
+			collection.source.kind === "search" &&
+			collection.source.value === normalizedQuery,
+	);
 
 	const switchTab = useCallback(
 		(tab: Tab) => {

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -283,6 +283,7 @@ interface MainContentProps {
 	onOpenDailyNote: () => void;
 	onOpenActivity: () => void;
 	onPrefetchActivity: () => void;
+	onOpenDatabase: (databaseId: string) => void;
 	tabs: WorkspaceTab[];
 	rootEntries: FsEntry[];
 	childrenByDir: Record<string, FsEntry[] | undefined>;
@@ -326,6 +327,7 @@ export const MainContent = memo(function MainContent({
 	onOpenDailyNote,
 	onOpenActivity,
 	onPrefetchActivity,
+	onOpenDatabase,
 	tabs,
 	rootEntries,
 	childrenByDir,
@@ -564,7 +566,10 @@ export const MainContent = memo(function MainContent({
 		if (viewerPath === PINNED_DOCS_TAB_ID) {
 			return (
 				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<PinnedDocsPane onOpenFile={onOpenFile} />
+					<PinnedDocsPane
+						onOpenFile={onOpenFile}
+						onOpenDatabase={onOpenDatabase}
+					/>
 				</Suspense>
 			);
 		}
@@ -633,6 +638,7 @@ export const MainContent = memo(function MainContent({
 		onOpenFileInNewTab,
 		onOpenActivity,
 		onPrefetchActivity,
+		onOpenDatabase,
 		databasesOpenRequest,
 		onConsumeDatabasesOpenRequest,
 		viewerPath,

--- a/src/components/app/PinnedCollectionCard.tsx
+++ b/src/components/app/PinnedCollectionCard.tsx
@@ -1,0 +1,71 @@
+import { LibraryIcon, StarIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import type { WorkspaceDatabaseSummary } from "../../lib/tauri";
+
+interface PinnedCollectionCardProps {
+	collection: WorkspaceDatabaseSummary;
+	onOpen: () => void;
+	onUnpin: () => void;
+}
+
+function collectionDescription(
+	collection: WorkspaceDatabaseSummary,
+	t: TFunction<"shell">,
+) {
+	if (collection.source.kind === "search") {
+		return t("pinned.savedSearch");
+	}
+	if (collection.source.kind === "tag") {
+		return t("pinned.tagCollection", {
+			tag: collection.source.value.replace(/^#/, ""),
+		});
+	}
+	if (collection.source.kind === "folder") {
+		return t("pinned.folderCollection", { folder: collection.source.value });
+	}
+	return t("pinned.allNotesCollection");
+}
+
+export function PinnedCollectionCard({
+	collection,
+	onOpen,
+	onUnpin,
+}: PinnedCollectionCardProps) {
+	const { t } = useTranslation("shell");
+	return (
+		<article className="pinnedCollectionCard">
+			<button
+				type="button"
+				className="pinnedCollectionCardOpen"
+				onClick={onOpen}
+			>
+				<span className="pinnedCollectionCardCopy">
+					<span className="pinnedCollectionCardTitle">
+						<HugeiconsIcon
+							icon={LibraryIcon}
+							size="var(--icon-md)"
+							strokeWidth={0.9}
+						/>
+						<strong>{collection.name}</strong>
+					</span>
+					<span>{collectionDescription(collection, t)}</span>
+				</span>
+			</button>
+			<button
+				type="button"
+				className="pinnedCollectionCardToggle"
+				onClick={onUnpin}
+				title={t("collections.unpin")}
+				aria-label={t("collections.unpinNamed", { name: collection.name })}
+			>
+				<HugeiconsIcon
+					icon={StarIcon}
+					size="var(--icon-md)"
+					strokeWidth={0.9}
+				/>
+			</button>
+		</article>
+	);
+}

--- a/src/components/app/PinnedDocsPane.tsx
+++ b/src/components/app/PinnedDocsPane.tsx
@@ -1,15 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useReducedMotion } from "motion/react";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFileTreeContext } from "../../contexts";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
+import { extractErrorMessage } from "../../lib/errorUtils";
+import {
+	invalidateDatabasePrefetch,
+	navigationQueryKeys,
+} from "../../lib/navigationPrefetch";
 import { invoke } from "../../lib/tauri";
+import { toast } from "../../lib/toast";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
 import { springPresets } from "../ui/animations";
 import { AllDocsCard, previewLines, titleFromPath } from "./AllDocsCard";
+import { PinnedCollectionCard } from "./PinnedCollectionCard";
 
 interface PinnedDocsPaneProps {
 	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenDatabase: (databaseId: string) => void;
 }
 
 const PREVIEW_MAX_BYTES = 4096;
@@ -22,6 +31,7 @@ interface PinnedFileData {
 
 export const PinnedDocsPane = memo(function PinnedDocsPane({
 	onOpenFile,
+	onOpenDatabase,
 }: PinnedDocsPaneProps) {
 	const { t } = useTranslation("shell");
 	const { pinnedFiles, itemAppearance } = useFileTreeContext();
@@ -29,6 +39,37 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 	const [selectedPath, setSelectedPath] = useState<string | null>(null);
 	const [fileData, setFileData] = useState<PinnedFileData[]>([]);
 	const [loading, setLoading] = useState(true);
+	const queryClient = useQueryClient();
+	const collectionsQuery = useQuery({
+		queryKey: navigationQueryKeys.databaseSummaries(),
+		queryFn: () => invoke("databases_list"),
+	});
+	const pinnedCollections = useMemo(
+		() =>
+			collectionsQuery.data?.filter((collection) => collection.pinned) ?? [],
+		[collectionsQuery.data],
+	);
+	const unpinCollection = useMutation({
+		mutationFn: async (databaseId: string) => {
+			const document = await invoke("databases_get", {
+				database_id: databaseId,
+			});
+			return invoke("databases_update", {
+				database: { ...document.database, pinned: false },
+			});
+		},
+		onSuccess: (document) => {
+			invalidateDatabasePrefetch(document.database.id);
+			void queryClient.invalidateQueries({
+				queryKey: navigationQueryKeys.databaseSummaries(),
+			});
+		},
+		onError: (cause) => {
+			toast.error(t("collections.unpinFailed"), {
+				description: extractErrorMessage(cause),
+			});
+		},
+	});
 
 	useEffect(() => {
 		let cancelled = false;
@@ -79,26 +120,38 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 		[onOpenFile],
 	);
 
-	if (loading) {
+	if (loading || collectionsQuery.isLoading) {
 		return (
 			<section className="allDocsPane">
 				<header className="allDocsHeader">
 					<h1 className="allDocsTitle">{t("pinned.title")}</h1>
 				</header>
-				<div className="databaseLoadingState">Loading pinned notes...</div>
+				<div className="databaseLoadingState">{t("pinned.loading")}</div>
 			</section>
 		);
 	}
 
-	if (pinnedFiles.length === 0) {
+	if (collectionsQuery.error) {
 		return (
 			<section className="allDocsPane">
 				<header className="allDocsHeader">
 					<h1 className="allDocsTitle">{t("pinned.title")}</h1>
 				</header>
 				<div className="databaseLoadingState">
-					No pinned notes yet. Pin a note from the file tree to get started.
+					{t("pinned.loadFailed")}:{" "}
+					{extractErrorMessage(collectionsQuery.error)}
 				</div>
+			</section>
+		);
+	}
+
+	if (pinnedFiles.length === 0 && pinnedCollections.length === 0) {
+		return (
+			<section className="allDocsPane">
+				<header className="allDocsHeader">
+					<h1 className="allDocsTitle">{t("pinned.title")}</h1>
+				</header>
+				<div className="databaseLoadingState">{t("pinned.empty")}</div>
 			</section>
 		);
 	}
@@ -109,6 +162,24 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 				<h1 className="allDocsTitle">{t("pinned.title")}</h1>
 			</header>
 			<div className="allDocsSections">
+				{pinnedCollections.length > 0 ? (
+					<section className="pinnedCollectionsSection">
+						<h2 className="allDocsSectionTitle">{t("pinned.collections")}</h2>
+						<div className="pinnedCollectionsGrid">
+							{pinnedCollections.map((collection) => (
+								<PinnedCollectionCard
+									key={collection.id}
+									collection={collection}
+									onOpen={() => onOpenDatabase(collection.id)}
+									onUnpin={() => unpinCollection.mutate(collection.id)}
+								/>
+							))}
+						</div>
+					</section>
+				) : null}
+				{fileData.length > 0 ? (
+					<h2 className="allDocsSectionTitle">{t("pinned.notes")}</h2>
+				) : null}
 				<div className="allDocsGrid">
 					{fileData.map((data, index) => {
 						const taskSummary = taskSummariesByPath[data.path] ?? undefined;

--- a/src/components/app/PinnedDocsPane.tsx
+++ b/src/components/app/PinnedDocsPane.tsx
@@ -120,7 +120,7 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 		[onOpenFile],
 	);
 
-	if (loading || collectionsQuery.isLoading) {
+	if (loading || (pinnedFiles.length === 0 && collectionsQuery.isLoading)) {
 		return (
 			<section className="allDocsPane">
 				<header className="allDocsHeader">
@@ -131,21 +131,11 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 		);
 	}
 
-	if (collectionsQuery.error) {
-		return (
-			<section className="allDocsPane">
-				<header className="allDocsHeader">
-					<h1 className="allDocsTitle">{t("pinned.title")}</h1>
-				</header>
-				<div className="databaseLoadingState">
-					{t("pinned.loadFailed")}:{" "}
-					{extractErrorMessage(collectionsQuery.error)}
-				</div>
-			</section>
-		);
-	}
-
-	if (pinnedFiles.length === 0 && pinnedCollections.length === 0) {
+	if (
+		!collectionsQuery.error &&
+		pinnedFiles.length === 0 &&
+		pinnedCollections.length === 0
+	) {
 		return (
 			<section className="allDocsPane">
 				<header className="allDocsHeader">
@@ -162,6 +152,12 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 				<h1 className="allDocsTitle">{t("pinned.title")}</h1>
 			</header>
 			<div className="allDocsSections">
+				{collectionsQuery.error ? (
+					<div className="databaseLoadingState">
+						{t("pinned.loadFailed")}:{" "}
+						{extractErrorMessage(collectionsQuery.error)}
+					</div>
+				) : null}
 				{pinnedCollections.length > 0 ? (
 					<section className="pinnedCollectionsSection">
 						<h2 className="allDocsSectionTitle">{t("pinned.collections")}</h2>

--- a/src/components/app/PinnedDocsPane.tsx
+++ b/src/components/app/PinnedDocsPane.tsx
@@ -50,14 +50,11 @@ export const PinnedDocsPane = memo(function PinnedDocsPane({
 		[collectionsQuery.data],
 	);
 	const unpinCollection = useMutation({
-		mutationFn: async (databaseId: string) => {
-			const document = await invoke("databases_get", {
+		mutationFn: (databaseId: string) =>
+			invoke("databases_set_pinned", {
 				database_id: databaseId,
-			});
-			return invoke("databases_update", {
-				database: { ...document.database, pinned: false },
-			});
-		},
+				pinned: false,
+			}),
 		onSuccess: (document) => {
 			invalidateDatabasePrefetch(document.database.id);
 			void queryClient.invalidateQueries({

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -26,10 +26,11 @@ import {
 import {
 	allDocsCountQueryOptions,
 	formatAllDocsCountLabel,
+	navigationQueryKeys,
 } from "../../lib/navigationPrefetch";
 import { isFileTreeSortMode } from "../../lib/settings";
 import { formatShortcutForPlatform } from "../../lib/shortcuts/platform";
-import type { FsEntry } from "../../lib/tauri";
+import { type FsEntry, invoke } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
@@ -117,7 +118,15 @@ function AllNotesCountBadge() {
 	return <span className="sidebarQuickActionCount">{label}</span>;
 }
 
-function PinnedNotesCountBadge({ count }: { count: number }) {
+function PinnedCountBadge({ noteCount }: { noteCount: number }) {
+	const collectionsQuery = useQuery({
+		queryKey: navigationQueryKeys.databaseSummaries(),
+		queryFn: () => invoke("databases_list"),
+	});
+	const collectionCount =
+		collectionsQuery.data?.filter((collection) => collection.pinned).length ??
+		0;
+	const count = noteCount + collectionCount;
 	if (count === 0) return null;
 	return <span className="sidebarQuickActionCount">{count}</span>;
 }
@@ -406,7 +415,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.pinned")}
 							</span>
-							<PinnedNotesCountBadge count={pinnedFiles.length} />
+							<PinnedCountBadge noteCount={pinnedFiles.length} />
 						</button>
 						<button
 							type="button"

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -17,7 +17,7 @@ interface CollectionTopBarProps {
 		| "nameDraft"
 		| "setNameDraft"
 		| "collectionFolderBreadcrumb"
-		| "saveDatabase"
+		| "setDatabasePinned"
 		| "commitDatabaseRename"
 		| "handleDeleteDatabase"
 	>;
@@ -59,6 +59,7 @@ export function CollectionTopBar({
 	const collectionMenuLabel = doc.document
 		? "Switch collection"
 		: "Select collection";
+	const isPinned = doc.document?.database.pinned ?? false;
 
 	return (
 		<div className="databasesTopBar">
@@ -155,24 +156,15 @@ export function CollectionTopBar({
 						variant="ghost"
 						size="icon-sm"
 						className="databasesTopActionButton databasePinButton"
-						data-pinned={doc.document.database.pinned ? "true" : "false"}
-						onClick={() =>
-							void doc.saveDatabase((database) => ({
-								...database,
-								pinned: !database.pinned,
-							}))
-						}
+						data-pinned={isPinned ? "true" : "false"}
+						onClick={() => void doc.setDatabasePinned(!isPinned)}
 						title={t(
-							doc.document.database.pinned
-								? "collections.unpin"
-								: "collections.pin",
+							isPinned ? "collections.unpin" : "collections.pin",
 						)}
 						aria-label={t(
-							doc.document.database.pinned
-								? "collections.unpin"
-								: "collections.pin",
+							isPinned ? "collections.unpin" : "collections.pin",
 						)}
-						aria-pressed={doc.document.database.pinned}
+						aria-pressed={isPinned}
 					>
 						<HugeiconsIcon
 							icon={StarIcon}

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -1,6 +1,7 @@
-import { LibraryIcon, NoteIcon } from "@hugeicons/core-free-icons";
+import { LibraryIcon, NoteIcon, StarIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import type { UseDatabasesPaneReturn } from "../../hooks/database/useDatabasesPane";
 import { buildCollectionMenuItems } from "../../lib/database/viewMenuItems";
 import { isNativeContextMenuAvailable } from "../../lib/nativeContextMenu";
@@ -16,6 +17,7 @@ interface CollectionTopBarProps {
 		| "nameDraft"
 		| "setNameDraft"
 		| "collectionFolderBreadcrumb"
+		| "saveDatabase"
 		| "commitDatabaseRename"
 		| "handleDeleteDatabase"
 	>;
@@ -36,6 +38,7 @@ export function CollectionTopBar({
 	views,
 	actions,
 }: CollectionTopBarProps) {
+	const { t } = useTranslation("shell");
 	const skipNextBlurCommitRef = useRef(false);
 	const collectionMenuItems = useMemo(
 		() =>
@@ -147,6 +150,36 @@ export function CollectionTopBar({
 
 			{doc.document ? (
 				<div className="databasesTopBarRight">
+					<Button
+						type="button"
+						variant="ghost"
+						size="icon-sm"
+						className="databasesTopActionButton databasePinButton"
+						data-pinned={doc.document.database.pinned ? "true" : "false"}
+						onClick={() =>
+							void doc.saveDatabase((database) => ({
+								...database,
+								pinned: !database.pinned,
+							}))
+						}
+						title={t(
+							doc.document.database.pinned
+								? "collections.unpin"
+								: "collections.pin",
+						)}
+						aria-label={t(
+							doc.document.database.pinned
+								? "collections.unpin"
+								: "collections.pin",
+						)}
+						aria-pressed={doc.document.database.pinned}
+					>
+						<HugeiconsIcon
+							icon={StarIcon}
+							size="var(--icon-md)"
+							strokeWidth={0.9}
+						/>
+					</Button>
 					<Button
 						type="button"
 						variant="ghost"

--- a/src/components/databases/CreateCollectionDialog.tsx
+++ b/src/components/databases/CreateCollectionDialog.tsx
@@ -103,6 +103,8 @@ export function CreateCollectionDialog({
 					name.trim() || folderNameFromPath(normalizedFolder),
 				),
 				folder: normalizedFolder,
+				source: null,
+				pinned: false,
 			});
 			onCreated(created);
 			onOpenChange(false);

--- a/src/hooks/database/useCollectionWorkspace.ts
+++ b/src/hooks/database/useCollectionWorkspace.ts
@@ -300,6 +300,27 @@ export function useCollectionWorkspace({
 		void saveDatabase({ ...document.database, name: nameDraft.trim() });
 	}, [document, nameDraft, saveDatabase]);
 
+	const setDatabasePinned = useCallback(
+		async (pinned: boolean) => {
+			if (!document) return;
+			try {
+				const saved = await invoke("databases_set_pinned", {
+					database_id: document.database.id,
+					pinned,
+				});
+				clearError();
+				documentRef.current = saved;
+				setDocument(saved);
+				setPrefetchedDatabaseDocument(saved.database.id, saved);
+				invalidateDatabaseSummariesPrefetch();
+				await loadSummaries();
+			} catch (cause) {
+				setError(extractErrorMessage(cause));
+			}
+		},
+		[clearError, document, loadSummaries, setError],
+	);
+
 	const handleDeleteDatabase = useCallback(async () => {
 		if (!document) return;
 		const { confirm } = await import("@tauri-apps/plugin-dialog");
@@ -361,6 +382,7 @@ export function useCollectionWorkspace({
 		nameDraft,
 		setNameDraft,
 		saveDatabase,
+		setDatabasePinned,
 		commitDatabaseRename,
 		handleDeleteDatabase,
 		collectionFolderBreadcrumb,

--- a/src/hooks/database/useDatabasesPane.ts
+++ b/src/hooks/database/useDatabasesPane.ts
@@ -95,6 +95,7 @@ export function useDatabasesPane({
 			nameDraft: workspace.nameDraft,
 			setNameDraft: workspace.setNameDraft,
 			saveDatabase: workspace.saveDatabase,
+			setDatabasePinned: workspace.setDatabasePinned,
 			commitDatabaseRename: workspace.commitDatabaseRename,
 			handleDeleteDatabase: workspace.handleDeleteDatabase,
 			collectionFolderBreadcrumb: workspace.collectionFolderBreadcrumb,

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "Erstellt (älteste)"
 	},
 	"pinned": {
-		"title": "Angeheftet"
+		"title": "Angeheftet",
+		"loading": "Angeheftete Elemente werden geladen...",
+		"loadFailed": "Angeheftete Sammlungen konnten nicht geladen werden",
+		"empty": "Noch nichts angeheftet. Hefte eine Notiz oder Sammlung an.",
+		"collections": "Sammlungen",
+		"notes": "Notizen",
+		"savedSearch": "Gespeicherte Suche",
+		"tagCollection": "Tag · #{{tag}}",
+		"folderCollection": "Ordner · {{folder}}",
+		"allNotesCollection": "Alle Notizen"
+	},
+	"collections": {
+		"pin": "Sammlung anheften",
+		"unpin": "Sammlung lösen",
+		"unpinNamed": "{{name}} lösen",
+		"unpinFailed": "Sammlung konnte nicht gelöst werden"
 	},
 	"allNotes": {
 		"title": "Alle Notizen",
@@ -74,6 +89,9 @@
 		"close": "Schließen",
 		"filterTitle": "Titel",
 		"filterTag": "Tag",
+		"saveSearch": "Suche speichern und anheften",
+		"searchSaved": "Suche unter Angeheftet gespeichert",
+		"saveSearchFailed": "Suche konnte nicht gespeichert werden",
 		"searching": "Suche…",
 		"results": "{{count}} Ergebnisse",
 		"recentlyOpened": "Zuletzt geöffnet",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "Created oldest"
 	},
 	"pinned": {
-		"title": "Pinned"
+		"title": "Pinned",
+		"loading": "Loading pinned items...",
+		"loadFailed": "Could not load pinned collections",
+		"empty": "Nothing pinned yet. Pin a note or collection to keep it here.",
+		"collections": "Collections",
+		"notes": "Notes",
+		"savedSearch": "Saved search",
+		"tagCollection": "Tag · #{{tag}}",
+		"folderCollection": "Folder · {{folder}}",
+		"allNotesCollection": "All notes"
+	},
+	"collections": {
+		"pin": "Pin collection",
+		"unpin": "Unpin collection",
+		"unpinNamed": "Unpin {{name}}",
+		"unpinFailed": "Could not unpin collection"
 	},
 	"allNotes": {
 		"title": "All Notes",
@@ -74,6 +89,9 @@
 		"close": "Close",
 		"filterTitle": "Title",
 		"filterTag": "Tag",
+		"saveSearch": "Save and pin search",
+		"searchSaved": "Search saved to Pinned",
+		"saveSearchFailed": "Could not save search",
 		"searching": "Searching...",
 		"results": "{{count}} results",
 		"recentlyOpened": "Recently opened",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "Creadas más antiguas"
 	},
 	"pinned": {
-		"title": "Fijadas"
+		"title": "Fijadas",
+		"loading": "Cargando elementos fijados...",
+		"loadFailed": "No se pudieron cargar las colecciones fijadas",
+		"empty": "Aún no hay nada fijado. Fija una nota o colección para guardarla aquí.",
+		"collections": "Colecciones",
+		"notes": "Notas",
+		"savedSearch": "Búsqueda guardada",
+		"tagCollection": "Etiqueta · #{{tag}}",
+		"folderCollection": "Carpeta · {{folder}}",
+		"allNotesCollection": "Todas las notas"
+	},
+	"collections": {
+		"pin": "Fijar colección",
+		"unpin": "Desfijar colección",
+		"unpinNamed": "Desfijar {{name}}",
+		"unpinFailed": "No se pudo desfijar la colección"
 	},
 	"allNotes": {
 		"title": "Todas las notas",
@@ -74,6 +89,9 @@
 		"close": "Cerrar",
 		"filterTitle": "Título",
 		"filterTag": "Etiqueta",
+		"saveSearch": "Guardar y fijar búsqueda",
+		"searchSaved": "Búsqueda guardada en Fijadas",
+		"saveSearchFailed": "No se pudo guardar la búsqueda",
 		"searching": "Buscando…",
 		"results": "{{count}} resultados",
 		"recentlyOpened": "Abiertas recientemente",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "Créées (plus anciennes)"
 	},
 	"pinned": {
-		"title": "Épinglées"
+		"title": "Épinglées",
+		"loading": "Chargement des éléments épinglés...",
+		"loadFailed": "Impossible de charger les collections épinglées",
+		"empty": "Aucun élément épinglé. Épinglez une note ou une collection pour la conserver ici.",
+		"collections": "Collections",
+		"notes": "Notes",
+		"savedSearch": "Recherche enregistrée",
+		"tagCollection": "Étiquette · #{{tag}}",
+		"folderCollection": "Dossier · {{folder}}",
+		"allNotesCollection": "Toutes les notes"
+	},
+	"collections": {
+		"pin": "Épingler la collection",
+		"unpin": "Désépingler la collection",
+		"unpinNamed": "Désépingler {{name}}",
+		"unpinFailed": "Impossible de désépingler la collection"
 	},
 	"allNotes": {
 		"title": "Toutes les notes",
@@ -74,6 +89,9 @@
 		"close": "Fermer",
 		"filterTitle": "Titre",
 		"filterTag": "Étiquette",
+		"saveSearch": "Enregistrer et épingler la recherche",
+		"searchSaved": "Recherche enregistrée dans Épinglées",
+		"saveSearchFailed": "Impossible d’enregistrer la recherche",
 		"searching": "Recherche…",
 		"results": "{{count}} résultats",
 		"recentlyOpened": "Ouvertes récemment",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "作成日（古い順）"
 	},
 	"pinned": {
-		"title": "ピン留め"
+		"title": "ピン留め",
+		"loading": "ピン留めした項目を読み込み中...",
+		"loadFailed": "ピン留めしたコレクションを読み込めませんでした",
+		"empty": "まだ何もピン留めされていません。ノートまたはコレクションをピン留めしてください。",
+		"collections": "コレクション",
+		"notes": "ノート",
+		"savedSearch": "保存済み検索",
+		"tagCollection": "タグ · #{{tag}}",
+		"folderCollection": "フォルダ · {{folder}}",
+		"allNotesCollection": "すべてのノート"
+	},
+	"collections": {
+		"pin": "コレクションをピン留め",
+		"unpin": "コレクションのピン留めを解除",
+		"unpinNamed": "{{name}}のピン留めを解除",
+		"unpinFailed": "コレクションのピン留めを解除できませんでした"
 	},
 	"allNotes": {
 		"title": "すべてのノート",
@@ -74,6 +89,9 @@
 		"close": "閉じる",
 		"filterTitle": "タイトル",
 		"filterTag": "タグ",
+		"saveSearch": "検索を保存してピン留め",
+		"searchSaved": "検索をピン留めに保存しました",
+		"saveSearchFailed": "検索を保存できませんでした",
 		"searching": "検索中…",
 		"results": "{{count}} 件の結果",
 		"recentlyOpened": "最近開いた項目",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "생성일 (오래된순)"
 	},
 	"pinned": {
-		"title": "고정됨"
+		"title": "고정됨",
+		"loading": "고정된 항목 불러오는 중...",
+		"loadFailed": "고정된 컬렉션을 불러올 수 없습니다",
+		"empty": "아직 고정된 항목이 없습니다. 노트나 컬렉션을 고정해 보세요.",
+		"collections": "컬렉션",
+		"notes": "노트",
+		"savedSearch": "저장된 검색",
+		"tagCollection": "태그 · #{{tag}}",
+		"folderCollection": "폴더 · {{folder}}",
+		"allNotesCollection": "모든 노트"
+	},
+	"collections": {
+		"pin": "컬렉션 고정",
+		"unpin": "컬렉션 고정 해제",
+		"unpinNamed": "{{name}} 고정 해제",
+		"unpinFailed": "컬렉션 고정을 해제할 수 없습니다"
 	},
 	"allNotes": {
 		"title": "모든 노트",
@@ -74,6 +89,9 @@
 		"close": "닫기",
 		"filterTitle": "제목",
 		"filterTag": "태그",
+		"saveSearch": "검색 저장 및 고정",
+		"searchSaved": "검색을 고정됨에 저장했습니다",
+		"saveSearchFailed": "검색을 저장할 수 없습니다",
 		"searching": "검색 중…",
 		"results": "결과 {{count}}개",
 		"recentlyOpened": "최근 열림",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -24,7 +24,22 @@
 		"createdOldest": "Criadas (mais antigas)"
 	},
 	"pinned": {
-		"title": "Fixadas"
+		"title": "Fixadas",
+		"loading": "Carregando itens fixados...",
+		"loadFailed": "Não foi possível carregar as coleções fixadas",
+		"empty": "Nada fixado ainda. Fixe uma nota ou coleção para mantê-la aqui.",
+		"collections": "Coleções",
+		"notes": "Notas",
+		"savedSearch": "Pesquisa salva",
+		"tagCollection": "Tag · #{{tag}}",
+		"folderCollection": "Pasta · {{folder}}",
+		"allNotesCollection": "Todas as notas"
+	},
+	"collections": {
+		"pin": "Fixar coleção",
+		"unpin": "Desafixar coleção",
+		"unpinNamed": "Desafixar {{name}}",
+		"unpinFailed": "Não foi possível desafixar a coleção"
 	},
 	"allNotes": {
 		"title": "Todas as notas",
@@ -74,6 +89,9 @@
 		"close": "Fechar",
 		"filterTitle": "Título",
 		"filterTag": "Tag",
+		"saveSearch": "Salvar e fixar pesquisa",
+		"searchSaved": "Pesquisa salva em Fixadas",
+		"saveSearchFailed": "Não foi possível salvar a pesquisa",
 		"searching": "Buscando…",
 		"results": "{{count}} resultados",
 		"recentlyOpened": "Abertas recentemente",

--- a/src/lib/database/summaries.ts
+++ b/src/lib/database/summaries.ts
@@ -8,6 +8,7 @@ export function shouldReloadSummaries(
 		prev.name !== next.name ||
 		prev.icon !== next.icon ||
 		prev.color !== next.color ||
+		prev.pinned !== next.pinned ||
 		prev.views.length !== next.views.length
 	);
 }

--- a/src/lib/database/summaries.ts
+++ b/src/lib/database/summaries.ts
@@ -9,6 +9,9 @@ export function shouldReloadSummaries(
 		prev.icon !== next.icon ||
 		prev.color !== next.color ||
 		prev.pinned !== next.pinned ||
-		prev.views.length !== next.views.length
+		prev.views.length !== next.views.length ||
+		prev.source.kind !== next.source.kind ||
+		prev.source.value !== next.source.value ||
+		prev.source.recursive !== next.source.recursive
 	);
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -271,6 +271,7 @@ export interface WorkspaceDatabaseDefinition {
 	name: string;
 	icon?: string | null;
 	color?: string | null;
+	pinned: boolean;
 	source: {
 		kind: "all_notes" | "folder" | "tag" | "search";
 		value: string;
@@ -288,6 +289,8 @@ export interface WorkspaceDatabaseSummary {
 	name: string;
 	icon?: string | null;
 	color?: string | null;
+	pinned: boolean;
+	source: DatabaseSource;
 	view_count: number;
 }
 
@@ -930,7 +933,12 @@ interface TauriCommands {
 	databases_list: CommandDef<void, WorkspaceDatabaseSummary[]>;
 	databases_get: CommandDef<{ database_id: string }, WorkspaceDatabaseDocument>;
 	databases_create: CommandDef<
-		{ name: string; folder: string },
+		{
+			name: string;
+			folder?: string | null;
+			source?: DatabaseSource | null;
+			pinned?: boolean | null;
+		},
 		WorkspaceDatabaseDocument
 	>;
 	databases_update: CommandDef<

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -945,6 +945,10 @@ interface TauriCommands {
 		{ database: WorkspaceDatabaseDefinition },
 		WorkspaceDatabaseDocument
 	>;
+	databases_set_pinned: CommandDef<
+		{ database_id: string; pinned: boolean },
+		WorkspaceDatabaseDocument
+	>;
 	databases_delete: CommandDef<{ database_id: string }, void>;
 	databases_query_rows: CommandDef<
 		{

--- a/src/styles/app/15-all-docs.css
+++ b/src/styles/app/15-all-docs.css
@@ -52,6 +52,109 @@
 	gap: 22px;
 }
 
+.pinnedCollectionsSection {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.pinnedCollectionsGrid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	gap: 8px;
+}
+
+.pinnedCollectionCard {
+	position: relative;
+	display: flex;
+	min-width: 0;
+	border-radius: var(--radius-md);
+	background: var(--bg-secondary);
+}
+
+.pinnedCollectionCardOpen {
+	display: flex;
+	flex: 1 1 auto;
+	align-items: flex-start;
+	min-width: 0;
+	min-height: 58px;
+	padding: 8px 48px 8px 10px;
+	border: 0;
+	border-radius: inherit;
+	background: transparent;
+	color: inherit;
+	text-align: left;
+}
+
+.pinnedCollectionCardOpen:focus-visible {
+	outline: none;
+	box-shadow: inset 0 0 0 2px
+		color-mix(in srgb, var(--interactive-accent) 36%, transparent);
+}
+
+.pinnedCollectionCardCopy {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 3px;
+	width: 100%;
+}
+
+.pinnedCollectionCardTitle {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	min-width: 0;
+	color: var(--text-accent);
+}
+
+.pinnedCollectionCardTitle > svg {
+	flex: 0 0 auto;
+	transform: translateY(1px);
+}
+
+.pinnedCollectionCardTitle strong {
+	overflow: hidden;
+	color: var(--text-primary);
+	font-size: var(--text-base);
+	font-weight: var(--font-semibold);
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pinnedCollectionCardCopy > span:last-child {
+	padding-left: calc(var(--icon-md) + 7px);
+	color: var(--text-secondary);
+	font-size: var(--text-xs);
+}
+
+.pinnedCollectionCardToggle {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-accent);
+	transition-property: scale;
+	transition-duration: 120ms;
+}
+
+.pinnedCollectionCardToggle svg path {
+	fill: currentColor;
+}
+
+.pinnedCollectionCardToggle:active {
+	scale: 0.96;
+}
+
 .allDocsSections.is-virtualized {
 	position: relative;
 	display: block;

--- a/src/styles/app/32-command-palette.css
+++ b/src/styles/app/32-command-palette.css
@@ -101,6 +101,51 @@
 	padding: 4px 0 6px;
 }
 
+.commandSearchActions {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.commandSearchSaveButton {
+	display: inline-flex;
+	flex: 0 0 auto;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-tertiary);
+	transition-property: color, background-color, scale;
+	transition-duration: 120ms;
+}
+
+.commandSearchSaveButton:hover:not(:disabled),
+.commandSearchSaveButton:focus-visible:not(:disabled) {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+}
+
+.commandSearchSaveButton:active:not(:disabled) {
+	scale: 0.96;
+}
+
+.commandSearchSaveButton[data-saved="true"] {
+	color: var(--text-accent);
+}
+
+.commandSearchSaveButton[data-saved="true"] svg path {
+	fill: currentColor;
+}
+
+.commandSearchSaveButton:disabled:not([data-saved="true"]) {
+	opacity: 0.42;
+}
+
 .commandSearchFilterBtn {
 	display: inline-flex;
 	align-items: center;

--- a/src/styles/app/37-database-collections.css
+++ b/src/styles/app/37-database-collections.css
@@ -79,6 +79,19 @@
 	color: var(--text-primary);
 }
 
+.databasePinButton {
+	min-width: 40px;
+	min-height: 40px;
+}
+
+.databasePinButton[data-pinned="true"] {
+	color: var(--text-accent);
+}
+
+.databasePinButton[data-pinned="true"] svg path {
+	fill: currentColor;
+}
+
 .databasesTopActionButtonDanger:hover:not(:disabled),
 .databasesTopActionButtonDanger:focus-visible:not(:disabled) {
 	color: var(--text-error);


### PR DESCRIPTION
Pull Request Template

Closes {LINK TO GH ISSUE}


## Description

Adds collections to the pinned section alongside notes and turns command-palette searches into reusable, pinned search collections.

- Summary of changes: adds durable collection pinning, pinned collection cards, a collection pin toggle, and a save-search action in the command palette. Updates translations and database architecture documentation.
- Reasoning: reuses the existing collection source model so saved searches behave like collections without introducing a parallel smart-folder system.
- Additional context: saved searches are created with a search source and pinned immediately for quick access.


## Screenshots

Not included. The repository requires the user to run the development app, so no screenshot session was started during implementation.


## Docs

Updated the database architecture documentation with collection pinning and source-aware creation behavior.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it is really helpful.

- [x] Documented what is new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pinned collections and saved searches so users can keep key databases and queries in the Pinned workspace for quick access. Adds a pin toggle, pinned collection cards, and a command‑palette star to save searches.

- **New Features**
  - Pin/unpin collections from the collection top bar; persisted via `databases_set_pinned`. Pinned workspace shows collection cards with open/unpin actions; sidebar count includes pinned collections.
  - Save and pin the current command‑palette search with a new star button; creates a `search`‑source collection with an auto name and avoids duplicates.
  - Backend/API: `databases_create` accepts optional `source`, optional `folder`, and `pinned`; `DatabaseDefinition` and summaries include `pinned` and full `source`; `databases_update` enforces an `updated_at` check and normalizes source/new‑note folder. Updated docs, i18n, and styles.

- **Migration**
  - If you call `databases_create`: `folder` is now optional. Pass `source` for non‑folder collections; otherwise pass `folder`. `pinned` defaults to `false`.
  - Consume new fields on database documents and summaries: `pinned` (boolean) and `source` (included on summaries).

<sup>Written for commit cfaad38b7d369a7717574dc430e82eb8aabdc2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin collections for quick access from the Pinned workspace.
  * Save command palette searches as pinned collections.
  * View, open, and unpin collections alongside pinned notes.
  * Pin or unpin collections directly from the collection toolbar.
  * Pinned item counts now include collections.

* **Bug Fixes**
  * Improved collection source and folder validation.
  * Updated collection summaries when pin status changes.

* **Documentation**
  * Clarified collection creation, saved searches, pinned collections, and database fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->