### PR TITLE
cleaned UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Run the narrowest permitted verification during development and the full permitt
 
 **Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: Markdown and space metadata in `.glyph/`; derived SQLite index in app support.
 
-Repo extras: internal product and engineering docs live in `docs/`. This is for user only. It is not the source of truth. If you are an AI agent, do not use docs/ folder to understand or work with the code. This is forbidden.  
+Repo extras: internal product and engineering docs live in `docs/`. The docs folder is for human user only. It is not the source of truth. If you are an AI agent, do not use docs/ folder to understand or work with the code. 
 
 ## Frontend Overview (`src/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Run the narrowest permitted verification during development and the full permitt
 
 **Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: Markdown and space metadata in `.glyph/`; derived SQLite index in app support.
 
-Repo extras: internal product and engineering docs live in `docs/`. 
+Repo extras: internal product and engineering docs live in `docs/`. This is for user only. It is not the source of truth. If you are an AI agent, do not use docs/ folder to understand or work with the code. This is forbidden.  
 
 ## Frontend Overview (`src/`)
 

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -855,9 +855,11 @@
 	padding: 6px 7px;
 	border-radius: var(--radius-md);
 	background: color-mix(in srgb, var(--bg-hover) 52%, transparent);
+	text-align: left;
 }
 
 .unlinkedMentionSource {
+	justify-content: flex-start;
 	min-width: 0;
 	padding: 0;
 	border: 0;

--- a/src/styles/app/32-command-palette.css
+++ b/src/styles/app/32-command-palette.css
@@ -15,6 +15,7 @@
 
 .commandPalette[data-search-tab="true"] {
 	width: min(840px, calc(100vw - 48px));
+	height: auto;
 }
 
 .commandPaletteHeader {
@@ -31,18 +32,22 @@
 }
 
 .commandPaletteBody[data-with-preview="true"] {
-	flex-direction: row;
-	flex: 1 1 0;
+	--command-palette-preview-width: min(360px, 42%);
+	position: relative;
+	display: block;
+	flex: 0 1 auto;
 	min-height: 0;
 	overflow: hidden;
 }
 
 .commandPalettePreview {
-	flex: 0 0 min(360px, 42%);
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: var(--command-palette-preview-width);
 	min-width: 0;
 	min-height: 0;
-	max-height: 100%;
-	align-self: stretch;
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -182,10 +187,10 @@
 }
 
 .commandPaletteList[data-with-preview="true"] {
-	flex: 1 1 0;
+	flex: 0 1 auto;
 	min-width: 0;
-	min-height: 0;
-	max-height: 100%;
+	width: calc(100% - var(--command-palette-preview-width));
+	max-height: min(448px, calc(72vh - 112px));
 }
 
 .commandPaletteList::-webkit-scrollbar {
@@ -448,7 +453,7 @@
 	}
 
 	.commandPaletteBody[data-with-preview="true"] {
-		flex-direction: column;
+		--command-palette-preview-width: 0px;
 	}
 
 	.commandPalettePreview {


### PR DESCRIPTION
Minor UI fixes and agents.md edited

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the command palette and markdown editor for better alignment and smoother scrolling. Clarified `AGENTS.md` that `docs/` is user-only and not a source of truth for agents.

- **Bug Fixes**
  - Command palette with preview: preview pane is absolute-positioned; list uses remaining width and has a capped max-height for smoother scrolling.
  - Search tab: auto height; on narrow screens the preview collapses to 0 so the list uses full width.
  - Markdown editor: left-aligned result rows and start-justified unlinked mention sources to fix misalignment.

<sup>Written for commit ce9b673ab92ca1cd5e682e2aa8517bb1dfcddece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a preview pane in the command palette, with improved sizing and positioning.
  * Preview content automatically collapses on smaller screens for a more responsive experience.

* **Bug Fixes**
  * Improved alignment of unlinked mention text and source information for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->