### PR TITLE
Add focused code block previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,7 @@ Agents and reviewers should flag these patterns unless the change includes a cle
 ## Version Control
 
 - Always use native `git` commands (push, pull, fetch, commit, squash, rebase, etc.) and never use the `gh` CLI for these operations.
+
+## Tool Restrictions
+
+- Browser and computer-use tools are completely forbidden. Do not use them under any circumstances.

--- a/src/components/editor/FocusedCodeBlockPreviewDialog.tsx
+++ b/src/components/editor/FocusedCodeBlockPreviewDialog.tsx
@@ -1,0 +1,132 @@
+import type { HtmlEmbedKind } from "@/lib/htmlEmbed";
+import { isHtmlEmbedCodeBlockLanguage } from "@/lib/htmlEmbed";
+import { isMermaidCodeBlockLanguage } from "@/lib/mermaid";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogContent, DialogTitle } from "../ui/shadcn/dialog";
+import { createHtmlEmbedWidget } from "./extensions/htmlEmbed/sandbox";
+import {
+	createMermaidCanvas,
+	createMermaidErrorCanvas,
+} from "./extensions/mermaid/canvas";
+import { renderMermaidCanvasSvg } from "./extensions/mermaid/renderer";
+
+export interface FocusedCodeBlockPreview {
+	pos: number;
+	source: string;
+	language: string | null;
+}
+
+function getPreviewKind(
+	language: string | null,
+): "mermaid" | HtmlEmbedKind | null {
+	if (isMermaidCodeBlockLanguage(language)) return "mermaid";
+	return isHtmlEmbedCodeBlockLanguage(language);
+}
+
+function FocusedMermaidPreview({ source }: { source: string }) {
+	const mountRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const mount = mountRef.current;
+		if (!mount) return;
+		const result = renderMermaidCanvasSvg(source);
+		const canvas = result.ok
+			? createMermaidCanvas({
+					svgHtml: result.svgHtml,
+					editMode: false,
+				})
+			: {
+					element: createMermaidErrorCanvas(result.message),
+					destroy: () => {},
+				};
+		mount.replaceChildren(canvas.element);
+		return () => {
+			canvas.destroy();
+			mount.replaceChildren();
+		};
+	}, [source]);
+
+	return <div ref={mountRef} className="focusedMermaidPreview" />;
+}
+
+function FocusedHtmlPreview({
+	source,
+	kind,
+}: {
+	source: string;
+	kind: HtmlEmbedKind;
+}) {
+	const mountRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const mount = mountRef.current;
+		if (!mount) return;
+		const widget = createHtmlEmbedWidget({
+			source,
+			kind,
+			editable: false,
+			onEditCode: () => {},
+		});
+		mount.replaceChildren(widget.element);
+		return () => {
+			widget.destroy();
+			mount.replaceChildren();
+		};
+	}, [kind, source]);
+
+	return <div ref={mountRef} className="focusedHtmlPreview" />;
+}
+
+export function FocusedCodeBlockPreviewDialog({
+	preview,
+	onClose,
+}: {
+	preview: FocusedCodeBlockPreview | null;
+	onClose: () => void;
+}) {
+	const { t } = useTranslation("editor");
+	const [themeVersion, setThemeVersion] = useState(0);
+	const kind = getPreviewKind(preview?.language ?? null);
+
+	useEffect(() => {
+		if (!preview) return;
+		const root = document.documentElement;
+		const observer = new MutationObserver(() =>
+			setThemeVersion((version) => version + 1),
+		);
+		observer.observe(root, {
+			attributes: true,
+			attributeFilter: ["class", "data-theme"],
+		});
+		return () => observer.disconnect();
+	}, [preview]);
+
+	return (
+		<Dialog open={preview !== null} onOpenChange={(open) => !open && onClose()}>
+			<DialogContent
+				className="focusedCodeBlockPreviewDialog h-[min(780px,calc(100dvh-2rem))] max-w-[calc(100%-2rem)] p-3 sm:max-w-[min(1000px,calc(100%-2rem))]"
+				showCloseButton={false}
+			>
+				<DialogTitle className="sr-only">
+					{t("codeBlock.runPreview")}
+				</DialogTitle>
+				<div className="h-full">
+					{preview && kind === "mermaid" ? (
+						<FocusedMermaidPreview
+							key={`${preview.source}-${themeVersion}`}
+							source={preview.source}
+						/>
+					) : null}
+					{preview && (kind === "html" || kind === "svg") ? (
+						<FocusedHtmlPreview
+							key={`${preview.source}-${themeVersion}`}
+							source={preview.source}
+							kind={kind}
+						/>
+					) : null}
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -20,6 +20,10 @@ import { isMermaidCodeBlockLanguage } from "../../lib/mermaid";
 import { joinYamlFrontmatter } from "../../lib/notePreview";
 import { EditorRibbon } from "./EditorRibbon";
 import { ExtractToNoteDialog } from "./ExtractToNoteDialog";
+import {
+	type FocusedCodeBlockPreview,
+	FocusedCodeBlockPreviewDialog,
+} from "./FocusedCodeBlockPreviewDialog";
 import { NoteEditorSurface } from "./NoteEditorSurface";
 import { NoteFindBar } from "./NoteFindBar";
 import { NoteLinkDialog, type NoteLinkDialogState } from "./NoteLinkDialog";
@@ -30,6 +34,8 @@ import {
 } from "./extensions/codeBlockHighlighting";
 import {
 	CODE_BLOCK_PREVIEW_REFRESH_META,
+	type FocusedCodeBlockPreviewRequest,
+	OPEN_FOCUSED_CODE_BLOCK_PREVIEW,
 	clearCodeBlockPreviews,
 	enableCodeBlockPreviewAt,
 } from "./extensions/codeBlockPreviewPlugin";
@@ -77,6 +83,25 @@ function isPreviewableCodeBlockLanguage(language: string | null): boolean {
 	return (
 		isHtmlEmbedCodeBlockLanguage(language) !== null ||
 		isMermaidCodeBlockLanguage(language)
+	);
+}
+
+function isFocusedCodeBlockPreviewRequest(
+	value: unknown,
+): value is FocusedCodeBlockPreviewRequest {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		!("pos" in value) ||
+		!("source" in value) ||
+		!("language" in value)
+	) {
+		return false;
+	}
+	return (
+		typeof value.pos === "number" &&
+		typeof value.source === "string" &&
+		(value.language === null || typeof value.language === "string")
 	);
 }
 
@@ -250,6 +275,8 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	const selectedCodeBlockRef = useRef<SelectedCodeBlockState | null>(null);
 	const codeBlockCopyResetTimerRef = useRef<number | null>(null);
 	const [codeBlockCopied, setCodeBlockCopied] = useState(false);
+	const [focusedCodeBlockPreview, setFocusedCodeBlockPreview] =
+		useState<FocusedCodeBlockPreview | null>(null);
 	const [linkDialog, setLinkDialog] = useState<NoteLinkDialogState | null>(
 		null,
 	);
@@ -292,6 +319,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			}
 		};
 		if (previousRelPathRef.current !== relPath) {
+			setFocusedCodeBlockPreview(null);
 			if (editor && !editor.isDestroyed) {
 				clearCodeBlockPreviews(editor.view);
 				editor.view.dispatch(
@@ -302,12 +330,45 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 			previousRelPathRef.current = relPath;
 		}
 		return () => {
+			setFocusedCodeBlockPreview(null);
 			blurHostSelection(host);
 			if (editor && !editor.isDestroyed) {
 				clearCodeBlockPreviews(editor.view);
 			}
 		};
 	}, [editor, relPath]);
+
+	useEffect(() => {
+		if (!editor || editor.isDestroyed || mode !== "rich" || !tiptapHostNode) {
+			setFocusedCodeBlockPreview(null);
+			return;
+		}
+		const openFocusedPreview = (event: Event) => {
+			if (!(event instanceof CustomEvent)) return;
+			const request: unknown = event.detail;
+			if (!isFocusedCodeBlockPreviewRequest(request)) return;
+			if (!isPreviewableCodeBlockLanguage(request.language)) return;
+			setFocusedCodeBlockPreview(request);
+		};
+		tiptapHostNode.addEventListener(
+			OPEN_FOCUSED_CODE_BLOCK_PREVIEW,
+			openFocusedPreview,
+		);
+		return () =>
+			tiptapHostNode.removeEventListener(
+				OPEN_FOCUSED_CODE_BLOCK_PREVIEW,
+				openFocusedPreview,
+			);
+	}, [editor, mode, tiptapHostNode]);
+
+	useEffect(() => {
+		if (!focusedCodeBlockPreview || !editor || editor.isDestroyed) return;
+		const closeOnSourceChange = () => setFocusedCodeBlockPreview(null);
+		editor.on("update", closeOnSourceChange);
+		return () => {
+			editor.off("update", closeOnSourceChange);
+		};
+	}, [editor, focusedCodeBlockPreview]);
 
 	useEffect(() => {
 		if (frontmatter === lastFrontmatterRef.current) return;
@@ -669,6 +730,23 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		editor.view.focus();
 	}, [editor, selectedCodeBlock]);
 
+	const returnToFocusedPreview = useCallback(() => {
+		if (!editor || editor.isDestroyed || !focusedCodeBlockPreview) return;
+		const node = editor.state.doc.nodeAt(focusedCodeBlockPreview.pos);
+		setFocusedCodeBlockPreview(null);
+		if (!node || node.type.name !== "codeBlock") return;
+		const afterBlock = Math.min(
+			focusedCodeBlockPreview.pos + node.nodeSize,
+			editor.state.doc.content.size,
+		);
+		editor.view.dispatch(
+			editor.state.tr.setSelection(
+				Selection.near(editor.state.doc.resolve(afterBlock)),
+			),
+		);
+		editor.view.focus();
+	}, [editor, focusedCodeBlockPreview]);
+
 	const selectedCodeBlockCanPreview = useMemo(
 		() => isPreviewableCodeBlockLanguage(selectedCodeBlock?.language ?? null),
 		[selectedCodeBlock?.language],
@@ -807,6 +885,10 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					/>
 				</Suspense>
 			) : null}
+			<FocusedCodeBlockPreviewDialog
+				preview={focusedCodeBlockPreview}
+				onClose={returnToFocusedPreview}
+			/>
 		</div>
 	);
 });

--- a/src/components/editor/extensions/codeBlockPreviewControls.ts
+++ b/src/components/editor/extensions/codeBlockPreviewControls.ts
@@ -3,9 +3,13 @@ export function appendEditCodeControls(
 	{
 		label,
 		onEditCode,
+		openPreviewLabel,
+		onOpenFocusedPreview,
 	}: {
 		label: string;
 		onEditCode: () => void;
+		openPreviewLabel?: string;
+		onOpenFocusedPreview?: () => void;
 	},
 ): void {
 	const controls = document.createElement("div");
@@ -26,6 +30,25 @@ export function appendEditCodeControls(
 		event.stopPropagation();
 		onEditCode();
 	});
+
+	if (openPreviewLabel && onOpenFocusedPreview) {
+		const openButton = document.createElement("button");
+		openButton.type = "button";
+		openButton.className = "codeBlockPreviewEditBtn codeBlockPreviewOpenBtn";
+		openButton.textContent = openPreviewLabel;
+		openButton.title = openPreviewLabel;
+		openButton.setAttribute("aria-label", openPreviewLabel);
+		openButton.addEventListener("mousedown", (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+		});
+		openButton.addEventListener("click", (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			onOpenFocusedPreview();
+		});
+		controls.append(openButton);
+	}
 
 	controls.append(editButton);
 	frame.append(controls);

--- a/src/components/editor/extensions/codeBlockPreviewPlugin.ts
+++ b/src/components/editor/extensions/codeBlockPreviewPlugin.ts
@@ -55,6 +55,15 @@ export interface CodeBlockPreviewWidgetContext {
 	language: string | null;
 	editable: boolean;
 	selectSource: () => void;
+	openFocusedPreview: () => void;
+}
+
+export const OPEN_FOCUSED_CODE_BLOCK_PREVIEW = "glyph:open-code-block-preview";
+
+export interface FocusedCodeBlockPreviewRequest {
+	pos: number;
+	source: string;
+	language: string | null;
 }
 
 export interface CodeBlockPreviewExtensionOptions {
@@ -138,6 +147,22 @@ function buildCodeBlockPreviewDecorations(
 						selectSource: () => {
 							if (!editable) return;
 							selectCodeBlockSource(view, pos, node.nodeSize);
+						},
+						openFocusedPreview: () => {
+							if (!editable) return;
+							view.dom.dispatchEvent(
+								new CustomEvent<FocusedCodeBlockPreviewRequest>(
+									OPEN_FOCUSED_CODE_BLOCK_PREVIEW,
+									{
+										bubbles: true,
+										detail: {
+											pos,
+											source,
+											language,
+										},
+									},
+								),
+							);
 						},
 					}),
 				{

--- a/src/components/editor/extensions/htmlEmbed/sandbox.ts
+++ b/src/components/editor/extensions/htmlEmbed/sandbox.ts
@@ -28,6 +28,10 @@ function buildHtmlEmbedSrcDoc(source: string, kind: HtmlEmbedKind): string {
 	const body = wrapHtmlEmbedBody(source, kind);
 	const escapedCsp = HTML_EMBED_CSP.replace(/"/g, "&quot;");
 	const postMessageOrigin = JSON.stringify(window.location.origin);
+	const textColor =
+		getComputedStyle(document.documentElement)
+			.getPropertyValue("--text-primary")
+			.trim() || "#171717";
 
 	return `<!doctype html>
 <html>
@@ -36,7 +40,7 @@ function buildHtmlEmbedSrcDoc(source: string, kind: HtmlEmbedKind): string {
 <meta http-equiv="Content-Security-Policy" content="${escapedCsp}">
 <style>
   html, body { margin: 0; padding: 0; background: transparent; overflow: hidden; }
-  body { font: 14px system-ui, sans-serif; color: #171717; }
+  body { font: 14px system-ui, sans-serif; color: ${textColor}; }
   main { display: block; }
   main svg { display: block; max-width: 100%; height: auto; }
 </style>
@@ -148,11 +152,13 @@ export function createHtmlEmbedWidget({
 	kind,
 	editable,
 	onEditCode,
+	onOpenFocusedPreview,
 }: {
 	source: string;
 	kind: HtmlEmbedKind;
 	editable: boolean;
 	onEditCode: () => void;
+	onOpenFocusedPreview?: () => void;
 }): { element: HTMLElement; destroy: () => void } {
 	const root = document.createElement("div");
 	root.className = "htmlEmbedWidget";
@@ -211,6 +217,10 @@ export function createHtmlEmbedWidget({
 					? i18n.t("editor:codeBlock.editSvg")
 					: i18n.t("editor:codeBlock.editHtml"),
 			onEditCode,
+			openPreviewLabel: onOpenFocusedPreview
+				? i18n.t("editor:codeBlock.focusedViewer.open")
+				: undefined,
+			onOpenFocusedPreview,
 		});
 	}
 

--- a/src/components/editor/extensions/htmlEmbedPreview.ts
+++ b/src/components/editor/extensions/htmlEmbedPreview.ts
@@ -19,7 +19,13 @@ export const HtmlEmbedPreview = createCodeBlockPreviewExtension({
 	widgetKeyPrefix: "html-embed",
 	matchLanguage: (language) => isHtmlEmbedCodeBlockLanguage(language) !== null,
 	getSource: (node) => stripHtmlEmbedRawSentinel(node.textContent ?? ""),
-	createWidget: ({ source, language, editable, selectSource }) => {
+	createWidget: ({
+		source,
+		language,
+		editable,
+		selectSource,
+		openFocusedPreview,
+	}) => {
 		const kind = isHtmlEmbedCodeBlockLanguage(language);
 		if (!kind) {
 			return document.createElement("div");
@@ -34,6 +40,7 @@ export const HtmlEmbedPreview = createCodeBlockPreviewExtension({
 					kind,
 					editable,
 					onEditCode: selectSource,
+					onOpenFocusedPreview: editable ? openFocusedPreview : undefined,
 				}),
 		});
 	},

--- a/src/components/editor/extensions/mermaid/canvas.ts
+++ b/src/components/editor/extensions/mermaid/canvas.ts
@@ -31,7 +31,8 @@ interface MermaidCanvasState {
 interface MermaidCanvasOptions {
 	svgHtml: string;
 	editMode: boolean;
-	onEditCode: () => void;
+	onEditCode?: () => void;
+	onOpenFocusedPreview?: () => void;
 }
 
 interface MermaidCanvasMount {
@@ -169,10 +170,14 @@ export function createMermaidCanvas(
 
 	viewport.append(stage);
 	frame.append(viewport);
-	if (options.editMode) {
+	if (options.editMode && options.onEditCode) {
 		appendEditCodeControls(frame, {
 			label: i18n.t("editor:codeBlock.editMermaid"),
 			onEditCode: options.onEditCode,
+			openPreviewLabel: options.onOpenFocusedPreview
+				? i18n.t("editor:codeBlock.focusedViewer.open")
+				: undefined,
+			onOpenFocusedPreview: options.onOpenFocusedPreview,
 		});
 	}
 	root.append(frame);
@@ -375,7 +380,7 @@ export function createMermaidCanvas(
 				event.preventDefault();
 				return;
 			case "Enter":
-				options.onEditCode();
+				options.onEditCode?.();
 				event.preventDefault();
 				return;
 			default:

--- a/src/components/editor/extensions/mermaidPreview.ts
+++ b/src/components/editor/extensions/mermaidPreview.ts
@@ -24,10 +24,12 @@ function buildMermaidCanvasWidget({
 	editable,
 	source,
 	selectSource,
+	openFocusedPreview,
 }: {
 	editable: boolean;
 	source: string;
 	selectSource: () => void;
+	openFocusedPreview: () => void;
 }) {
 	const result = renderMermaidCanvasSvg(source);
 	if (!result.ok) {
@@ -39,6 +41,8 @@ function buildMermaidCanvasWidget({
 			appendEditCodeControls(frame, {
 				label: i18n.t("editor:codeBlock.editMermaid"),
 				onEditCode: selectSource,
+				openPreviewLabel: i18n.t("editor:codeBlock.focusedViewer.open"),
+				onOpenFocusedPreview: openFocusedPreview,
 			});
 		}
 		return { element, destroy: () => {} };
@@ -48,6 +52,7 @@ function buildMermaidCanvasWidget({
 		svgHtml: result.svgHtml,
 		editMode: editable,
 		onEditCode: selectSource,
+		onOpenFocusedPreview: editable ? openFocusedPreview : undefined,
 	});
 }
 
@@ -57,7 +62,7 @@ export const MermaidPreview = createCodeBlockPreviewExtension({
 	hiddenClass: "mermaidCodeBlockHiddenInPreview",
 	widgetKeyPrefix: "mermaid-canvas",
 	matchLanguage: (language) => isMermaidCodeBlockLanguage(language),
-	createWidget: ({ source, editable, selectSource }) =>
+	createWidget: ({ source, editable, selectSource, openFocusedPreview }) =>
 		createLazyCodeBlockPreviewWidget({
 			placeholderClassName: "mermaidCanvasWidget mermaidCanvasPlaceholder",
 			frameClassName: "mermaidCanvasFrame",
@@ -66,6 +71,7 @@ export const MermaidPreview = createCodeBlockPreviewExtension({
 					editable,
 					source,
 					selectSource,
+					openFocusedPreview,
 				}),
 		}),
 	destroyWidget: destroyLazyCodeBlockPreviewWidget,

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Mermaid-Code bearbeiten",
 		"editHtml": "HTML-Code bearbeiten",
 		"editSvg": "SVG-Code bearbeiten",
+		"focusedViewer": {
+			"open": "Fokussierte Ansicht öffnen"
+		},
 		"languages": {
 			"plaintext": "Klartext",
 			"bash": "Bash",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -85,6 +85,9 @@
 		"editMermaid": "Edit Mermaid code",
 		"editHtml": "Edit HTML code",
 		"editSvg": "Edit SVG code",
+		"focusedViewer": {
+			"open": "Open focused view"
+		},
 		"languages": {
 			"plaintext": "Plain text",
 			"bash": "Bash",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Editar código Mermaid",
 		"editHtml": "Editar código HTML",
 		"editSvg": "Editar código SVG",
+		"focusedViewer": {
+			"open": "Abrir vista enfocada"
+		},
 		"languages": {
 			"plaintext": "Texto sin formato",
 			"bash": "Bash",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Modifier le code Mermaid",
 		"editHtml": "Modifier le code HTML",
 		"editSvg": "Modifier le code SVG",
+		"focusedViewer": {
+			"open": "Ouvrir la vue ciblée"
+		},
 		"languages": {
 			"plaintext": "Texte brut",
 			"bash": "Bash",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Mermaid コードを編集",
 		"editHtml": "HTML コードを編集",
 		"editSvg": "SVG コードを編集",
+		"focusedViewer": {
+			"open": "フォーカスビューを開く"
+		},
 		"languages": {
 			"plaintext": "プレーンテキスト",
 			"bash": "Bash",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Mermaid 코드 편집",
 		"editHtml": "HTML 코드 편집",
 		"editSvg": "SVG 코드 편집",
+		"focusedViewer": {
+			"open": "집중 보기 열기"
+		},
 		"languages": {
 			"plaintext": "일반 텍스트",
 			"bash": "Bash",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -50,6 +50,9 @@
 		"editMermaid": "Editar código Mermaid",
 		"editHtml": "Editar código HTML",
 		"editSvg": "Editar código SVG",
+		"focusedViewer": {
+			"open": "Abrir visualização focada"
+		},
 		"languages": {
 			"plaintext": "Texto simples",
 			"bash": "Bash",

--- a/src/styles/app/26-node-note-overlays.css
+++ b/src/styles/app/26-node-note-overlays.css
@@ -189,7 +189,8 @@
 .mermaidCanvasWidget:hover .codeBlockPreviewControls,
 .mermaidCanvasWidget:focus-within .codeBlockPreviewControls,
 .htmlEmbedWidget:hover .codeBlockPreviewControls,
-.htmlEmbedWidget:focus-within .codeBlockPreviewControls {
+.htmlEmbedWidget:focus-within .codeBlockPreviewControls,
+.codeBlockPreviewControls:has(.codeBlockPreviewOpenBtn) {
 	opacity: 1;
 	pointer-events: auto;
 }
@@ -274,6 +275,27 @@
 .htmlEmbedWidgetError .htmlEmbedIframe {
 	visibility: hidden;
 }
+
+.focusedMermaidPreview,
+.focusedMermaidPreview > .mermaidCanvasWidget,
+.focusedHtmlPreview {
+	height: 100%;
+}
+
+.focusedMermaidPreview > .mermaidCanvasWidget {
+	margin: 0;
+	content-visibility: visible;
+}
+
+.focusedMermaidPreview .mermaidCanvasFrame {
+	height: 100%;
+}
+
+.focusedHtmlPreview .htmlEmbedWidget {
+	margin: 0;
+	content-visibility: visible;
+}
+
 .editorColorDropdown {
 	--editor-ribbon-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='192' height='48'%3E%3Cfilter id='g' color-interpolation-filters='sRGB'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.035 0.65' numOctaves='1' stitchTiles='stitch' seed='11'/%3E%3CfeColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 .12 .58'/%3E%3C/filter%3E%3Crect width='192' height='48' fill='white' filter='url(%23g)'/%3E%3C/svg%3E");
 


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/365


## Description

A clear and concise description of the PR.

Use this section for review hints, explanations or discussion points/todos.

- Summary of changes
  - Adds an inline open action for Mermaid, HTML, and SVG previews.
  - Reuses the existing Mermaid renderer and sandboxed HTML/SVG iframe in a focused dialog.
  - Closes the focused view when source, note, or editor mode changes.
- Reasoning
  - Gives rendered artifacts more room without adding a second renderer or serialization path.
- Additional context
  - The viewer contains only the artifact and dismisses with Escape or click-outside.


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

Not included; repository instructions prohibit running the development server.


## Docs

No public documentation changes needed. The focused dialog reuses the existing Mermaid canvas and HTML/SVG sandbox contracts.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused preview dialog for Mermaid, HTML, and SVG code blocks so users can see renders full-size and return to the editor at the correct position.

- **New Features**
  - Adds an "Open focused view" control on supported previews.
  - Modal `FocusedCodeBlockPreviewDialog` reuses the Mermaid canvas and sandboxed HTML/SVG renderer.
  - Closes on editor updates, note/mode switches, Escape, or click-outside; restores the caret just after the code block.
  - Theme-aware: watches theme changes and re-renders; HTML embeds inherit the current text color.
  - New i18n strings and styles; triggers via bubbled `glyph:open-code-block-preview` CustomEvent.

- **Docs**
  - Update `AGENTS.md` to forbid browser and computer-use tools.

<sup>Written for commit 85680d4eb4586d36d7466bc709a5f248ee10e20f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a focused viewer for Mermaid and HTML code block previews.
  * Added an “Open focused view” action to editable code block previews.
  * Focused previews now support theme changes and return users to the relevant code block when closed.
* **Style**
  * Improved focused preview layouts and control visibility.
* **Localization**
  * Added focused viewer labels in English, German, Spanish, French, Japanese, Korean, and Brazilian Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->