### PR TITLE
Fix SVG icon design-token sizes and Tauri focus unlisten cleanup

### DIFF
--- a/src/components/AppearancePicker.tsx
+++ b/src/components/AppearancePicker.tsx
@@ -121,8 +121,7 @@ export function AppearancePicker({
 					<div className="commandPaletteHeader">
 						<div className="commandPaletteInputWrapper">
 							<Search
-								size="var(--icon-sm)"
-								className="commandPaletteSearchIcon"
+								className="commandPaletteSearchIcon size-[var(--icon-sm)]"
 								aria-hidden="true"
 							/>
 							<Input
@@ -186,7 +185,7 @@ export function AppearancePicker({
 									>
 										<DatabaseColumnIcon
 											iconName={defaultIconName}
-											size="var(--icon-lg)"
+											className="size-[var(--icon-lg)]"
 										/>
 									</Button>
 								</div>
@@ -213,7 +212,7 @@ export function AppearancePicker({
 											>
 												<DatabaseColumnIcon
 													iconName={option.id}
-													size="var(--icon-lg)"
+													className="size-[var(--icon-lg)]"
 												/>
 											</Button>
 										);
@@ -253,7 +252,7 @@ export function AppearancePicker({
 															>
 																<DatabaseColumnIcon
 																	iconName={option.id}
-																	size="var(--icon-lg)"
+																	className="size-[var(--icon-lg)]"
 																/>
 															</Button>
 														);
@@ -298,7 +297,10 @@ export function AppearancePickerIconTrigger({
 				onClick();
 			}}
 		>
-			<DatabaseColumnIcon iconName={iconName} size="var(--icon-md)" />
+			<DatabaseColumnIcon
+				iconName={iconName}
+				className="size-[var(--icon-md)]"
+			/>
 		</Button>
 	);
 }

--- a/src/components/Icons/NavigationIcons.tsx
+++ b/src/components/Icons/NavigationIcons.tsx
@@ -11,14 +11,20 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
+import { cn } from "../../lib/utils";
 
 export type IconProps = Omit<ComponentProps<typeof HugeiconsIcon>, "icon">;
 
 export function withDefaultIconSize({
-	size = "var(--icon-md)",
+	size,
+	className,
 	...props
 }: IconProps): IconProps {
-	return { size, ...props };
+	return {
+		size,
+		className: cn(size === undefined && "size-[var(--icon-md)]", className),
+		...props,
+	};
 }
 
 export const Search = (props: IconProps) => (

--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -289,8 +289,7 @@ function TagRowIcon({
 	return (
 		<HugeiconsIcon
 			icon={Tag01Icon}
-			className="tagsIcon"
-			size="var(--icon-sm)"
+			className="tagsIcon size-[var(--icon-sm)]"
 			strokeWidth={0.9}
 		/>
 	);

--- a/src/components/ai/AIChatThread.tsx
+++ b/src/components/ai/AIChatThread.tsx
@@ -187,7 +187,7 @@ const AIChatMessageBody = memo(function AIChatMessageBody({
 						className="aiInlineRetryBtn"
 						onClick={() => onRetry(index)}
 					>
-						<RefreshCw size="var(--icon-xs)" />
+						<RefreshCw className="size-[var(--icon-xs)]" />
 						<span>Retry</span>
 					</button>
 				</div>
@@ -203,7 +203,7 @@ const AIChatMessageBody = memo(function AIChatMessageBody({
 						title="Copy response"
 						aria-label="Copy response"
 					>
-						<Files size="var(--icon-sm)" />
+						<Files className="size-[var(--icon-sm)]" />
 					</Button>
 					<Button
 						type="button"
@@ -214,7 +214,7 @@ const AIChatMessageBody = memo(function AIChatMessageBody({
 						title="Save response to file"
 						aria-label="Save response to file"
 					>
-						<Save size="var(--icon-sm)" />
+						<Save className="size-[var(--icon-sm)]" />
 					</Button>
 					<Button
 						type="button"
@@ -226,7 +226,7 @@ const AIChatMessageBody = memo(function AIChatMessageBody({
 						aria-label="Retry response"
 						disabled={chatStatus === "streaming"}
 					>
-						<RefreshCw size="var(--icon-sm)" />
+						<RefreshCw className="size-[var(--icon-sm)]" />
 					</Button>
 				</div>
 			) : null}
@@ -360,7 +360,7 @@ export function AIChatThread({
 											)}
 											aria-hidden
 										>
-											<ChevronDown size="var(--icon-sm)" />
+											<ChevronDown className="size-[var(--icon-sm)]" />
 										</span>
 									</button>
 									{citationsOpen ? (

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -466,7 +466,7 @@ export function AIComposer({
 						className="aiAddPanelClose"
 						onClick={() => setAddPanelOpen(false)}
 					>
-						<X size="var(--icon-xs)" />
+						<X className="size-[var(--icon-xs)]" />
 					</button>
 				</div>
 			) : null}
@@ -483,7 +483,7 @@ export function AIComposer({
 								disabled={isAwaitingResponse}
 							>
 								<span className="aiComposerSuggestionIcon">
-									<File size="var(--icon-sm)" />
+									<File className="size-[var(--icon-sm)]" />
 								</span>
 								<span className="aiComposerSuggestionLabel">
 									{truncateLabel(fileNameFromPath(suggestedFilePath), 28)}
@@ -522,7 +522,7 @@ export function AIComposer({
 								>
 									<HugeiconsIcon
 										icon={AtIcon}
-										size="var(--icon-sm)"
+										className="size-[var(--icon-sm)]"
 										strokeWidth={0.9}
 									/>
 								</Button>
@@ -547,7 +547,7 @@ export function AIComposer({
 							>
 								<HugeiconsIcon
 									icon={StopIcon}
-									size="var(--icon-md)"
+									className="size-[var(--icon-md)]"
 									strokeWidth={0.9}
 								/>
 							</button>
@@ -562,7 +562,10 @@ export function AIComposer({
 								aria-label="Send"
 								title="Send"
 							>
-								<HugeiconsIcon icon={ArrowUp02Icon} size="var(--icon-md)" />
+								<HugeiconsIcon
+									icon={ArrowUp02Icon}
+									className="size-[var(--icon-md)]"
+								/>
 							</Button>
 						)}
 					</div>

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -361,7 +361,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 					>
 						<HugeiconsIcon
 							icon={ChatAdd01Icon}
-							size="var(--icon-sm)"
+							className="size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 					</Button>
@@ -375,7 +375,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 						title="Settings"
 						onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
 					>
-						<SettingsIcon size="var(--icon-sm)" />
+						<SettingsIcon className="size-[var(--icon-sm)]" />
 					</Button>
 					<Button
 						type="button"
@@ -389,7 +389,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 					>
 						<HugeiconsIcon
 							icon={Logout05Icon}
-							size="var(--icon-sm)"
+							className="size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 					</Button>
@@ -446,14 +446,14 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 						aria-label="Scroll to bottom"
 						title="Scroll to latest"
 					>
-						<ChevronDown size="var(--icon-md)" />
+						<ChevronDown className="size-[var(--icon-md)]" />
 					</Button>
 				)}
 				{chat.error ? (
 					<div className="aiPanelError">
 						<span>{chat.error.message}</span>
 						<button type="button" onClick={() => chat.clearError()}>
-							<X size="var(--icon-xs)" />
+							<X className="size-[var(--icon-xs)]" />
 						</button>
 					</div>
 				) : null}
@@ -464,7 +464,7 @@ export function AIPanel({ isOpen, onClose }: AIPanelProps) {
 							type="button"
 							onClick={() => actions.setAssistantActionError("")}
 						>
-							<X size="var(--icon-xs)" />
+							<X className="size-[var(--icon-xs)]" />
 						</button>
 					</div>
 				) : null}

--- a/src/components/ai/AIToolTimeline.tsx
+++ b/src/components/ai/AIToolTimeline.tsx
@@ -231,7 +231,7 @@ function GroupedStepCard({
 					className={cn("aiToolChevron", expanded && "aiToolChevron-open")}
 					aria-hidden
 				>
-					<ChevronDown size="var(--icon-sm)" />
+					<ChevronDown className="size-[var(--icon-sm)]" />
 				</span>
 			</button>
 			{summary ? <div className="aiToolSummary">{summary}</div> : null}
@@ -333,7 +333,7 @@ export function AIToolTimeline({ events, streaming }: AIToolTimelineProps) {
 									)}
 									aria-hidden
 								>
-									<ChevronDown size="var(--icon-sm)" />
+									<ChevronDown className="size-[var(--icon-sm)]" />
 								</span>
 							</button>
 							{summary ? <div className="aiToolSummary">{summary}</div> : null}

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -165,7 +165,7 @@ export function ModelSelector({
 				<span
 					className={`${styles.triggerIcon} ${open ? styles.triggerIconOpen : ""}`}
 				>
-					<ChevronDown size="var(--icon-sm)" />
+					<ChevronDown className="size-[var(--icon-sm)]" />
 				</span>
 			</button>
 
@@ -287,7 +287,7 @@ export function ModelSelector({
 													>
 														<HugeiconsIcon
 															icon={InformationCircleIcon}
-															size="var(--icon-md)"
+															className="size-[var(--icon-md)]"
 															strokeWidth={0.9}
 														/>
 													</button>

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -5,7 +5,7 @@ import {
 	type AiProviderKind,
 	invoke,
 } from "../../../lib/tauri";
-import { listenTauriEvent } from "../../../lib/tauriEvents";
+import { listenTauriEvent, safeUnlisten } from "../../../lib/tauriEvents";
 
 type UIMessagePart = { type: "text"; text: string };
 
@@ -80,7 +80,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 
 	const cleanupListeners = useCallback(() => {
 		for (const stop of stopListenersRef.current) {
-			stop();
+			safeUnlisten(stop);
 		}
 		stopListenersRef.current = [];
 	}, []);

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -650,7 +650,7 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 					<h1 className="activityTimelineTitle">
 						<HugeiconsIcon
 							icon={Archive04Icon}
-							size="var(--icon-2xl)"
+							className="size-[var(--icon-2xl)]"
 							strokeWidth={0.9}
 						/>
 						<span>All Notes</span>

--- a/src/components/app/AllDocsCard.tsx
+++ b/src/components/app/AllDocsCard.tsx
@@ -231,8 +231,7 @@ export function AllDocsCard({
 						<DatabaseNoteAppearanceIcon
 							notePath={notePath}
 							appearance={noteAppearance}
-							className="allDocsCardTitleIcon"
-							size="var(--icon-md)"
+							className="allDocsCardTitleIcon size-[var(--icon-md)]"
 						/>
 						{title}
 					</span>

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1331,7 +1331,7 @@ export function AppShell() {
 									}`
 						}
 					>
-						<LayoutAlignLeft size="var(--icon-md)" />
+						<LayoutAlignLeft className="size-[var(--icon-md)]" />
 					</WindowChromeIconButton>
 					<WindowChromeUpdateButton
 						updateReady={autoUpdater.updateReady}

--- a/src/components/app/CalendarPalette.tsx
+++ b/src/components/app/CalendarPalette.tsx
@@ -330,7 +330,7 @@ export function CalendarPalette({
 											<span className="calendarPaletteNoteIcon">
 												<HugeiconsIcon
 													icon={NoteIcon}
-													size="var(--icon-md)"
+													className="size-[var(--icon-md)]"
 													strokeWidth={0.9}
 												/>
 											</span>
@@ -354,7 +354,7 @@ export function CalendarPalette({
 								>
 									<HugeiconsIcon
 										icon={NoteIcon}
-										size="var(--icon-xl)"
+										className="size-[var(--icon-xl)]"
 										strokeWidth={0.9}
 									/>
 								</span>

--- a/src/components/app/CommandList.tsx
+++ b/src/components/app/CommandList.tsx
@@ -57,9 +57,13 @@ function ResultIcon({ result }: { result: PaletteResult }) {
 							? TableIcon
 							: null;
 	return icon ? (
-		<HugeiconsIcon icon={icon} size="var(--icon-md)" strokeWidth={0.9} />
+		<HugeiconsIcon
+			icon={icon}
+			className="size-[var(--icon-md)]"
+			strokeWidth={0.9}
+		/>
 	) : (
-		<FileText size="var(--icon-md)" />
+		<FileText className="size-[var(--icon-md)]" />
 	);
 }
 

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -545,7 +545,7 @@ export function CommandPalette({
 									>
 										<HugeiconsIcon
 											icon={StarIcon}
-											size="var(--icon-md)"
+											className="size-[var(--icon-md)]"
 											strokeWidth={0.9}
 										/>
 									</button>

--- a/src/components/app/GettingStartedPane.tsx
+++ b/src/components/app/GettingStartedPane.tsx
@@ -126,7 +126,7 @@ function ProgressRing({
 					>
 						<HugeiconsIcon
 							icon={CheckmarkCircle02Icon}
-							size="var(--icon-xl)"
+							className="size-[var(--icon-xl)]"
 							strokeWidth={0.9}
 							color="var(--interactive-accent)"
 						/>
@@ -193,7 +193,7 @@ export function GettingStartedPane({
 						onClick={onDismiss}
 						aria-label="Dismiss getting started"
 					>
-						<X size="var(--icon-md)" />
+						<X className="size-[var(--icon-md)]" />
 					</button>
 				</div>
 			</div>
@@ -225,7 +225,7 @@ export function GettingStartedPane({
 						<div className="starterStepIcon">
 							{(() => {
 								const Icon = steps[currentStep].icon;
-								return <Icon size="var(--icon-2xl)" />;
+								return <Icon className="size-[var(--icon-2xl)]" />;
 							})()}
 						</div>
 						<div>

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -139,7 +139,7 @@ function ContextualEmptyState({
 		if (!onboarding.createdFirstNote) {
 			t.push({
 				key: "note",
-				icon: <FileText size="var(--icon-lg)" />,
+				icon: <FileText className="size-[var(--icon-lg)]" />,
 				text: "Create your first note",
 				action: "New note",
 				onClick: onCreateNote,
@@ -148,7 +148,7 @@ function ContextualEmptyState({
 		if (!onboarding.openedDailyNote && showDailyNoteAction) {
 			t.push({
 				key: "daily",
-				icon: <Calendar size="var(--icon-lg)" />,
+				icon: <Calendar className="size-[var(--icon-lg)]" />,
 				text: "Try a daily note — saved to your daily notes folder",
 				action: "Open daily note",
 				onClick: onOpenDailyNote,

--- a/src/components/app/MainTabsBreadcrumbs.tsx
+++ b/src/components/app/MainTabsBreadcrumbs.tsx
@@ -292,8 +292,7 @@ export function MainTabsBreadcrumbs({
 						<span key="breadcrumb-overflow" className="mainTabsBreadcrumbItem">
 							{displayIndex > 0 ? (
 								<ChevronRight
-									size="var(--icon-xs)"
-									className="mainTabsBreadcrumbSep"
+									className="mainTabsBreadcrumbSep size-[var(--icon-xs)]"
 									aria-hidden="true"
 								/>
 							) : null}
@@ -456,8 +455,7 @@ function BreadcrumbEntryMenu({
 					aria-label={`Browse ${menuTitleForDir(dirPath)}`}
 				>
 					<ChevronRight
-						size="var(--icon-xs)"
-						className="mainTabsBreadcrumbSep"
+						className="mainTabsBreadcrumbSep size-[var(--icon-xs)]"
 						aria-hidden="true"
 					/>
 				</button>

--- a/src/components/app/PinnedCollectionCard.tsx
+++ b/src/components/app/PinnedCollectionCard.tsx
@@ -45,7 +45,7 @@ export function PinnedCollectionCard({
 					<span className="pinnedCollectionCardTitle">
 						<HugeiconsIcon
 							icon={LibraryIcon}
-							size="var(--icon-md)"
+							className="size-[var(--icon-md)]"
 							strokeWidth={0.9}
 						/>
 						<strong>{collection.name}</strong>
@@ -62,7 +62,7 @@ export function PinnedCollectionCard({
 			>
 				<HugeiconsIcon
 					icon={StarIcon}
-					size="var(--icon-md)"
+					className="size-[var(--icon-md)]"
 					strokeWidth={0.9}
 				/>
 			</button>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -380,7 +380,7 @@ export const SidebarContent = memo(function SidebarContent({
 						>
 							<HugeiconsIcon
 								icon={NoteIcon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">
@@ -409,7 +409,7 @@ export const SidebarContent = memo(function SidebarContent({
 						>
 							<HugeiconsIcon
 								icon={StarIcon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">
@@ -437,7 +437,7 @@ export const SidebarContent = memo(function SidebarContent({
 						>
 							<HugeiconsIcon
 								icon={Archive04Icon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">
@@ -465,7 +465,7 @@ export const SidebarContent = memo(function SidebarContent({
 						>
 							<HugeiconsIcon
 								icon={LibraryIcon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">
@@ -489,7 +489,7 @@ export const SidebarContent = memo(function SidebarContent({
 						>
 							<HugeiconsIcon
 								icon={ChartRelationshipIcon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">
@@ -521,9 +521,8 @@ export const SidebarContent = memo(function SidebarContent({
 										<span className="sr-only">{t("sidebar.sortNotes")}</span>
 										<HugeiconsIcon
 											icon={Sorting01Icon}
-											size="var(--icon-sm)"
 											strokeWidth={0.9}
-											className="sidebarStackHeaderSortIcon"
+											className="sidebarStackHeaderSortIcon size-[var(--icon-sm)]"
 											aria-hidden="true"
 										/>
 										<select
@@ -555,7 +554,7 @@ export const SidebarContent = memo(function SidebarContent({
 									>
 										<HugeiconsIcon
 											icon={ExpandParagraphIcon}
-											size="var(--icon-sm)"
+											className="size-[var(--icon-sm)]"
 											strokeWidth={0.9}
 										/>
 									</button>
@@ -568,7 +567,7 @@ export const SidebarContent = memo(function SidebarContent({
 									>
 										<HugeiconsIcon
 											icon={ArrowShrinkIcon}
-											size="var(--icon-sm)"
+											className="size-[var(--icon-sm)]"
 											strokeWidth={0.9}
 										/>
 									</button>

--- a/src/components/app/SidebarHeader.tsx
+++ b/src/components/app/SidebarHeader.tsx
@@ -44,7 +44,7 @@ export function SidebarHeader({
 								: ""
 						}`}
 					>
-						<LayoutAlignLeft size="var(--icon-md)" />
+						<LayoutAlignLeft className="size-[var(--icon-md)]" />
 					</WindowChromeIconButton>
 					<WindowChromeUpdateButton
 						updateReady={autoUpdater.updateReady}

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -57,7 +57,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 					>
 						<HugeiconsIcon
 							icon={ArrowLeft02Icon}
-							size="var(--icon-md)"
+							className="size-[var(--icon-md)]"
 							strokeWidth={0.9}
 						/>
 						<span className="sidebarQuickActionLabel">Back</span>
@@ -65,7 +65,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 				</div>
 
 				<div className="settingsSidebarSearch">
-					<Search size="var(--icon-md)" className="settingsSidebarSearchIcon" />
+					<Search className="settingsSidebarSearchIcon size-[var(--icon-md)]" />
 					<input
 						type="search"
 						className="settingsSidebarSearchInput"
@@ -95,7 +95,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							onClick={clearSettingsSearch}
 							aria-label={tGeneral("nav.clearSearchAriaLabel")}
 						>
-							<X size="var(--icon-sm)" />
+							<X className="size-[var(--icon-sm)]" />
 						</button>
 					) : null}
 				</div>
@@ -197,7 +197,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							Buy official license
 							<HugeiconsIcon
 								icon={ArrowUpRight01Icon}
-								size="var(--icon-sm)"
+								className="size-[var(--icon-sm)]"
 								strokeWidth={1.5}
 							/>
 						</Button>
@@ -220,7 +220,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							Send feedback
 							<HugeiconsIcon
 								icon={ArrowUpRight01Icon}
-								size="var(--icon-sm)"
+								className="size-[var(--icon-sm)]"
 								strokeWidth={1.5}
 							/>
 						</Button>

--- a/src/components/app/TemplatePickerDialog.tsx
+++ b/src/components/app/TemplatePickerDialog.tsx
@@ -94,7 +94,7 @@ export function TemplatePickerDialog({
 						title="Template settings"
 						aria-label="Template settings"
 					>
-						<Settings size="var(--icon-lg)" />
+						<Settings className="size-[var(--icon-lg)]" />
 					</Button>
 					<Button
 						type="button"
@@ -104,7 +104,7 @@ export function TemplatePickerDialog({
 						title="Cancel"
 						aria-label="Cancel"
 					>
-						<X size="var(--icon-lg)" />
+						<X className="size-[var(--icon-lg)]" />
 					</Button>
 				</div>
 			</DialogContent>

--- a/src/components/app/editorCommands.tsx
+++ b/src/components/app/editorCommands.tsx
@@ -54,7 +54,7 @@ export function buildEditorCommands({
 	const headingCommands: Command[] = [
 		{
 			id: "collapse_all_headings",
-			icon: <ChevronUp size="var(--icon-lg)" />,
+			icon: <ChevronUp className="size-[var(--icon-lg)]" />,
 			enabled: enabled && showCollapsibleHeadings,
 			allowInEditable: true,
 			action: () =>
@@ -62,7 +62,7 @@ export function buildEditorCommands({
 		},
 		{
 			id: "expand_all_headings",
-			icon: <ChevronDown size="var(--icon-lg)" />,
+			icon: <ChevronDown className="size-[var(--icon-lg)]" />,
 			enabled: enabled && showCollapsibleHeadings,
 			allowInEditable: true,
 			action: () => dispatchEditorMenuAction({ action: "expand_all_headings" }),
@@ -74,7 +74,7 @@ export function buildEditorCommands({
 		icon: (
 			<HugeiconsIcon
 				icon={command.icon}
-				size="var(--icon-lg)"
+				className="size-[var(--icon-lg)]"
 				strokeWidth={0.9}
 			/>
 		),

--- a/src/components/app/movePickerCommands.tsx
+++ b/src/components/app/movePickerCommands.tsx
@@ -28,7 +28,7 @@ export function buildMovePickerCommands({
 			icon: (
 				<HugeiconsIcon
 					icon={Folder01Icon}
-					size="var(--icon-lg)"
+					className="size-[var(--icon-lg)]"
 					strokeWidth={0.9}
 				/>
 			),
@@ -41,7 +41,7 @@ export function buildMovePickerCommands({
 			icon: (
 				<HugeiconsIcon
 					icon={Folder01Icon}
-					size="var(--icon-lg)"
+					className="size-[var(--icon-lg)]"
 					strokeWidth={0.9}
 				/>
 			),

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -141,7 +141,7 @@ function buildAiCommands({
 			icon: (
 				<HugeiconsIcon
 					icon={AiBrain04Icon}
-					size="var(--icon-lg)"
+					className="size-[var(--icon-lg)]"
 					strokeWidth={0.9}
 				/>
 			),
@@ -154,7 +154,7 @@ function buildAiCommands({
 			icon: (
 				<HugeiconsIcon
 					icon={Link01Icon}
-					size="var(--icon-lg)"
+					className="size-[var(--icon-lg)]"
 					strokeWidth={0.9}
 				/>
 			),
@@ -167,7 +167,7 @@ function buildAiCommands({
 			icon: (
 				<HugeiconsIcon
 					icon={Link01Icon}
-					size="var(--icon-lg)"
+					className="size-[var(--icon-lg)]"
 					strokeWidth={0.9}
 				/>
 			),
@@ -303,7 +303,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={PencilEdit02Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -316,7 +316,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -329,7 +329,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={ColorsIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -342,7 +342,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={CursorInWindowIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -376,7 +376,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={TableIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -388,7 +388,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Folder01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -404,7 +404,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -418,7 +418,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={CalendarAdd01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -439,7 +439,7 @@ export function useAppCommands({
 								? PinOffIcon
 								: PinIcon
 						}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -455,7 +455,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -469,7 +469,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={ChartRelationshipIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -486,7 +486,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -503,7 +503,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -518,7 +518,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Link01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -536,7 +536,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Link01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -553,7 +553,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={MoveIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -570,7 +570,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={ArrowLeft}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -584,7 +584,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={ArrowRight}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -598,7 +598,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={SearchIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -612,7 +612,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Archive04Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -625,7 +625,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={ChartRelationshipIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -637,7 +637,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={LibraryIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -650,7 +650,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Calendar03Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -662,7 +662,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Folder01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -677,7 +677,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={FolderOpenIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -689,7 +689,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={FolderOpenIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -701,7 +701,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={FolderRemoveIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -713,7 +713,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Link01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -731,7 +731,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={SidebarLeftIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -743,7 +743,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={SquareLock02Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -767,7 +767,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Settings01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -779,7 +779,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Settings01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -791,7 +791,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={SquareLock02Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -802,7 +802,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Settings01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -814,7 +814,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={Settings01Icon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -825,7 +825,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),
@@ -837,7 +837,7 @@ export function useAppCommands({
 				icon: (
 					<HugeiconsIcon
 						icon={NoteIcon}
-						size="var(--icon-lg)"
+						className="size-[var(--icon-lg)]"
 						strokeWidth={0.9}
 					/>
 				),

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -2,6 +2,7 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useRef } from "react";
 import { invoke } from "../../lib/tauri";
+import { safeUnlisten } from "../../lib/tauriEvents";
 import { toast } from "../../lib/toast";
 import {
 	type WorkspaceSessionSnapshot,
@@ -241,7 +242,7 @@ export function useWorkspaceSession({
 			})
 			.then((stopListening) => {
 				if (disposed) {
-					stopListening();
+					safeUnlisten(stopListening);
 					return;
 				}
 				unlisten = stopListening;
@@ -255,7 +256,7 @@ export function useWorkspaceSession({
 			});
 		return () => {
 			disposed = true;
-			unlisten?.();
+			safeUnlisten(unlisten);
 		};
 	}, [flushPendingSave]);
 
@@ -277,7 +278,7 @@ export function useWorkspaceSession({
 		})
 			.then(async (stopListening) => {
 				if (disposed) {
-					stopListening();
+					safeUnlisten(stopListening);
 					return;
 				}
 				unlisten = stopListening;
@@ -298,7 +299,7 @@ export function useWorkspaceSession({
 			});
 		return () => {
 			disposed = true;
-			unlisten?.();
+			safeUnlisten(unlisten);
 		};
 	}, [flushPendingSave]);
 

--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -167,8 +167,7 @@ export function SpaceConnectionsView() {
 					<div className="flex items-center gap-2 text-sm text-muted-foreground">
 						<HugeiconsIcon
 							icon={LoaderCircle}
-							className="animate-spin"
-							size="var(--icon-sm)"
+							className="animate-spin size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 						Loading notes and links…
@@ -193,8 +192,7 @@ export function SpaceConnectionsView() {
 					<div className="flex items-center gap-2 text-sm text-muted-foreground">
 						<HugeiconsIcon
 							icon={LoaderCircle}
-							className="animate-spin"
-							size="var(--icon-sm)"
+							className="animate-spin size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 						Arranging connections…
@@ -215,7 +213,7 @@ export function SpaceConnectionsView() {
 						<HugeiconsIcon
 							icon={Refresh01Icon}
 							data-icon="inline-start"
-							size="var(--icon-md)"
+							className="size-[var(--icon-md)]"
 							strokeWidth={0.9}
 						/>
 						Retry

--- a/src/components/connections/connectionsDensity.ts
+++ b/src/components/connections/connectionsDensity.ts
@@ -188,7 +188,8 @@ export function sigmaSettingsForVariant(
 			zoomingRatio: LOCAL_SIGMA.zoomingRatio,
 			minEdgeThickness: 0.52,
 			zIndex: true,
-			allowInvalidContainer: false,
+			// Panels/dialogs can briefly report 0×0 while hidden or mid-layout.
+			allowInvalidContainer: true,
 		};
 	}
 
@@ -211,6 +212,7 @@ export function sigmaSettingsForVariant(
 		zoomingRatio: 1.6,
 		minEdgeThickness: sigmaTier.minEdgeThickness,
 		zIndex: true,
-		allowInvalidContainer: false,
+		// Panels/dialogs can briefly report 0×0 while hidden or mid-layout.
+		allowInvalidContainer: true,
 	};
 }

--- a/src/components/connections/useSigmaConnections.ts
+++ b/src/components/connections/useSigmaConnections.ts
@@ -44,6 +44,10 @@ function isEdgeConnectedToFocus(
 	return source === focusId || target === focusId;
 }
 
+function hasValidContainerSize(container: HTMLElement): boolean {
+	return container.clientWidth > 0 && container.clientHeight > 0;
+}
+
 function fitGraphToViewport(
 	renderer: Sigma<ConnectionsNodeAttributes, ConnectionsEdgeAttributes>,
 ) {
@@ -104,7 +108,7 @@ export function useSigmaConnections({
 
 		const setup = () => {
 			if (disposed) return;
-			if (container.clientWidth <= 0 || container.clientHeight <= 0) {
+			if (!hasValidContainerSize(container)) {
 				fitFrame = window.requestAnimationFrame(setup);
 				return;
 			}
@@ -267,6 +271,9 @@ export function useSigmaConnections({
 			mouseCaptor.on("mouseup", handleMouseUp);
 
 			resizeObserver = new ResizeObserver(() => {
+				// Container can collapse to 0x0 when the panel/dialog is hidden.
+				// Sigma throws if resize() runs against an empty container.
+				if (disposed || !hasValidContainerSize(container)) return;
 				activeRenderer.resize();
 				fitToView();
 			});

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -654,8 +654,7 @@ export function DatabaseBoard({
 																<DatabaseNoteAppearanceIcon
 																	notePath={row.note_path}
 																	appearance={noteAppearance}
-																	className="databaseBoardCardTitleIcon"
-																	size="var(--icon-md)"
+																	className="databaseBoardCardTitleIcon size-[var(--icon-md)]"
 																/>
 																{title}
 															</span>
@@ -667,7 +666,7 @@ export function DatabaseBoard({
 																	>
 																		<HugeiconsIcon
 																			icon={Calendar03Icon}
-																			size="var(--icon-xs)"
+																			className="size-[var(--icon-xs)]"
 																			strokeWidth={1}
 																			aria-hidden="true"
 																		/>
@@ -740,8 +739,7 @@ export function DatabaseBoard({
 																>
 																	<DatabaseColumnIcon
 																		iconName={iconNameForTag(tag)}
-																		className="databaseTagPillIcon"
-																		size="var(--icon-xs)"
+																		className="databaseTagPillIcon size-[var(--icon-xs)]"
 																		strokeWidth={1.2}
 																	/>
 																	{formatDatabaseTagLabel(tag)}
@@ -776,7 +774,10 @@ export function DatabaseBoard({
 											title={`Add note to ${lane.label}`}
 											aria-label={`Add note to ${lane.label}`}
 										>
-											<Plus size="var(--icon-sm)" aria-hidden="true" />
+											<Plus
+												className="size-[var(--icon-sm)]"
+												aria-hidden="true"
+											/>
 											<span>New</span>
 										</button>
 									) : null}
@@ -790,7 +791,7 @@ export function DatabaseBoard({
 									title="Add lane"
 									aria-label="Add board lane"
 								>
-									<Plus size="var(--icon-md)" aria-hidden="true" />
+									<Plus className="size-[var(--icon-md)]" aria-hidden="true" />
 								</button>
 							) : null}
 						</div>

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -165,8 +165,7 @@ export function DatabaseBoardLaneView({
 								? priorityPropertyIconForValue(lane.label)
 								: Tag01Icon
 					}
-					className="databaseBoardLaneTitleIcon"
-					size="var(--icon-sm)"
+					className="databaseBoardLaneTitleIcon size-[var(--icon-sm)]"
 					strokeWidth={1.2}
 					aria-hidden="true"
 				/>

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -89,8 +89,7 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 			{item.kind === "tag" ? (
 				<DatabaseColumnIcon
 					iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
-					className="databaseTagPillIcon"
-					size="var(--icon-xs)"
+					className="databaseTagPillIcon size-[var(--icon-xs)]"
 					strokeWidth={1.2}
 				/>
 			) : null}
@@ -197,8 +196,7 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 						{item.kind === "tag" ? (
 							<DatabaseColumnIcon
 								iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
-								className="databaseTagPillIcon"
-								size="var(--icon-xs)"
+								className="databaseTagPillIcon size-[var(--icon-xs)]"
 								strokeWidth={1.2}
 							/>
 						) : null}
@@ -583,12 +581,11 @@ function DatabaseCellEditor({
 						>
 							<DatabaseColumnIcon
 								iconName={iconNameForTag(value)}
-								className="databaseTagPillIcon"
-								size="var(--icon-xs)"
+								className="databaseTagPillIcon size-[var(--icon-xs)]"
 								strokeWidth={1.2}
 							/>
 							<span>{formatDatabaseTagLabel(value)}</span>
-							<X size="var(--icon-xs)" />
+							<X className="size-[var(--icon-xs)]" />
 						</button>
 					))}
 					<input
@@ -875,7 +872,7 @@ function DatabaseCellEditor({
 							title={`Remove ${value}`}
 						>
 							<span>{value}</span>
-							<X size="var(--icon-xs)" />
+							<X className="size-[var(--icon-xs)]" />
 						</button>
 					))}
 					<input
@@ -1443,8 +1440,7 @@ export function DatabaseCell({
 						<DatabaseNoteAppearanceIcon
 							notePath={row.note_path}
 							appearance={noteAppearance}
-							className="databaseTitleCellIcon"
-							size="var(--icon-md)"
+							className="databaseTitleCellIcon size-[var(--icon-md)]"
 						/>
 						{displayText.trim() ? (
 							<span className="databaseCellText">{displayText}</span>

--- a/src/components/database/DatabaseColumnIcon.tsx
+++ b/src/components/database/DatabaseColumnIcon.tsx
@@ -147,6 +147,7 @@ import {
 	resolveDatabaseColumnIconName,
 } from "../../lib/database/columnIcons";
 import type { DatabaseColumn } from "../../lib/database/types";
+import { cn } from "../../lib/utils";
 
 interface DatabaseColumnIconProps {
 	column?: Pick<DatabaseColumn, "type" | "property_kind" | "icon">;
@@ -312,7 +313,7 @@ function iconDefinition(iconName: string) {
 export function DatabaseColumnIcon({
 	column,
 	iconName,
-	size = "var(--icon-md)",
+	size,
 	strokeWidth,
 	className,
 }: DatabaseColumnIconProps) {
@@ -323,7 +324,7 @@ export function DatabaseColumnIcon({
 			icon={iconDefinition(resolvedIconName)}
 			size={size}
 			strokeWidth={strokeWidth ?? 0.9}
-			className={className}
+			className={cn(size === undefined && "size-[var(--icon-md)]", className)}
 		/>
 	);
 }

--- a/src/components/database/DatabaseFolderPicker.tsx
+++ b/src/components/database/DatabaseFolderPicker.tsx
@@ -96,7 +96,7 @@ export function DatabaseFolderPicker({
 			<span className="databasePickerTriggerIcon">
 				<HugeiconsIcon
 					icon={Folder03Icon}
-					size="var(--icon-md)"
+					className="size-[var(--icon-md)]"
 					strokeWidth={0.9}
 				/>
 			</span>

--- a/src/components/database/DatabaseNoteAppearanceIcon.tsx
+++ b/src/components/database/DatabaseNoteAppearanceIcon.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { databaseValueToneStyleForColor } from "../../lib/database/palette";
 import type { FileTreeAppearance } from "../../lib/tauri";
+import { cn } from "../../lib/utils";
 import { isMarkdownPath } from "../../utils/path";
 import { isEditorTextColor } from "../editor/textColors";
 import { getFileTypeInfo } from "../filetree/fileTypeUtils";
@@ -25,7 +26,7 @@ export function DatabaseNoteAppearanceIcon({
 	notePath,
 	appearance,
 	className,
-	size = "var(--icon-md)",
+	size,
 }: {
 	notePath: string;
 	appearance?: FileTreeAppearance | null;
@@ -33,13 +34,17 @@ export function DatabaseNoteAppearanceIcon({
 	size?: string | number;
 }) {
 	const { Icon, color } = getFileTypeInfo(notePath, isMarkdownPath(notePath));
+	const iconClassName = cn(
+		size === undefined && "size-[var(--icon-md)]",
+		className,
+	);
 
 	if (appearance?.icon) {
 		return (
 			<DatabaseColumnIcon
 				iconName={appearance.icon}
 				size={size}
-				className={className}
+				className={iconClassName}
 			/>
 		);
 	}
@@ -47,7 +52,7 @@ export function DatabaseNoteAppearanceIcon({
 	return (
 		<Icon
 			size={size}
-			className={className}
+			className={iconClassName}
 			style={{ color: `var(--database-note-appearance-color, ${color})` }}
 			aria-hidden="true"
 		/>

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -142,9 +142,9 @@ function SortIndicator({
 	return (
 		<span className="databaseHeaderSortIcon" aria-hidden="true">
 			{activeSort.direction === "desc" ? (
-				<ChevronDown size="var(--icon-sm)" />
+				<ChevronDown className="size-[var(--icon-sm)]" />
 			) : (
-				<ChevronUp size="var(--icon-sm)" />
+				<ChevronUp className="size-[var(--icon-sm)]" />
 			)}
 		</span>
 	);
@@ -412,7 +412,7 @@ export function DatabaseTable({
 													aria-label={`Add note to ${group.label}`}
 												>
 													<Plus
-														size="var(--icon-sm)"
+														className="size-[var(--icon-sm)]"
 														strokeWidth={1.6}
 														aria-hidden="true"
 													/>

--- a/src/components/database/DatabaseTagPicker.tsx
+++ b/src/components/database/DatabaseTagPicker.tsx
@@ -100,7 +100,7 @@ export function DatabaseTagPicker({
 					className="databasePickerTrigger"
 				>
 					<span className="databasePickerTriggerIcon">
-						<Hash size="var(--icon-sm)" />
+						<Hash className="size-[var(--icon-sm)]" />
 					</span>
 					<span className="databasePickerTriggerText">
 						<span className="databasePickerTriggerLabel">{selectedLabel}</span>
@@ -113,14 +113,14 @@ export function DatabaseTagPicker({
 			<PopoverContent className="databasePickerPopover" align="start">
 				<PopoverHeader className="databasePickerHeader">
 					<div className="databasePickerEyebrow">
-						<Tags size="var(--icon-sm)" />
+						<Tags className="size-[var(--icon-sm)]" />
 						<span>Tag Source</span>
 					</div>
 					<PopoverTitle>{label}</PopoverTitle>
 					<PopoverDescription>{description}</PopoverDescription>
 				</PopoverHeader>
 				<div className="databasePickerSearch">
-					<Search size="var(--icon-sm)" />
+					<Search className="size-[var(--icon-sm)]" />
 					<Input
 						value={query}
 						placeholder="Search tags"

--- a/src/components/database/DatabaseToolbar.tsx
+++ b/src/components/database/DatabaseToolbar.tsx
@@ -98,7 +98,7 @@ export function DatabaseToolbar({
 			<div className="databaseToolbarActions">
 				{searchExpanded || searchDraft ? (
 					<label className="databaseToolbarSearch" htmlFor={searchInputId}>
-						<Search size="var(--icon-sm)" aria-hidden="true" />
+						<Search className="size-[var(--icon-sm)]" aria-hidden="true" />
 						<Input
 							ref={searchInputRef}
 							id={searchInputId}
@@ -129,7 +129,7 @@ export function DatabaseToolbar({
 								title="Clear search"
 								aria-label="Clear search"
 							>
-								<X size="var(--icon-sm)" />
+								<X className="size-[var(--icon-sm)]" />
 							</button>
 						) : null}
 					</label>
@@ -146,7 +146,7 @@ export function DatabaseToolbar({
 						title="Search view"
 						aria-label="Search view"
 					>
-						<Search size="var(--icon-sm)" />
+						<Search className="size-[var(--icon-sm)]" />
 					</Button>
 				)}
 				{groupColumns.length > 0 ? (

--- a/src/components/database/DatabaseViewOptionsColumnsPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsColumnsPanel.tsx
@@ -80,7 +80,7 @@ export function ColumnsPanel({
 				className="databaseViewRestoreButton"
 				onClick={onRestoreDefaultColumns}
 			>
-				<RefreshCw size="var(--icon-lg)" aria-hidden="true" />
+				<RefreshCw className="size-[var(--icon-lg)]" aria-hidden="true" />
 				Restore defaults
 			</button>
 		</section>

--- a/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsFiltersPanel.tsx
@@ -219,7 +219,7 @@ function FilterJoiner({ index }: { index: number }) {
 	return (
 		<span className="databaseViewOptionJoiner">
 			{index === 0 ? "Where" : "And"}
-			<ChevronDown size="var(--icon-sm)" aria-hidden="true" />
+			<ChevronDown className="size-[var(--icon-sm)]" aria-hidden="true" />
 		</span>
 	);
 }
@@ -334,7 +334,7 @@ export function FiltersPanel({
 						)
 					}
 				>
-					<Plus size="var(--icon-md)" aria-hidden="true" />
+					<Plus className="size-[var(--icon-md)]" aria-hidden="true" />
 					Add a condition
 				</button>
 			) : (
@@ -360,7 +360,7 @@ export function FiltersPanel({
 								<span className="databaseViewFilterColumn">
 									<DatabaseColumnIcon
 										column={selectedColumn ?? undefined}
-										size="var(--icon-lg)"
+										className="size-[var(--icon-lg)]"
 									/>
 									<select
 										className="databaseViewInlineSelect"
@@ -492,7 +492,7 @@ export function FiltersPanel({
 									title="Remove filter"
 									aria-label="Remove filter"
 								>
-									<Trash2 size="var(--icon-lg)" />
+									<Trash2 className="size-[var(--icon-lg)]" />
 								</button>
 							</div>
 						);
@@ -507,7 +507,7 @@ export function FiltersPanel({
 							)
 						}
 					>
-						<Plus size="var(--icon-md)" aria-hidden="true" />
+						<Plus className="size-[var(--icon-md)]" aria-hidden="true" />
 						Add another condition
 					</button>
 				</div>

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -218,7 +218,7 @@ function OptionMenuRow({
 			<span className="databaseViewOptionsRowIcon">{icon}</span>
 			<span className="databaseViewOptionsRowLabel">{label}</span>
 			{value ? <span className="databaseViewOptionsPill">{value}</span> : null}
-			<ChevronRight size="var(--icon-lg)" aria-hidden="true" />
+			<ChevronRight className="size-[var(--icon-lg)]" aria-hidden="true" />
 		</button>
 	);
 }
@@ -501,7 +501,7 @@ export function DatabaseViewOptionsPopover({
 				>
 					<HugeiconsIcon
 						icon={SlidersVerticalIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={0.9}
 					/>
 				</Button>
@@ -575,7 +575,7 @@ export function DatabaseViewOptionsPopover({
 						<div className="databaseViewPanelError">{configError}</div>
 					) : null}
 					<OptionMenuRow
-						icon={<Search size="var(--icon-lg)" />}
+						icon={<Search className="size-[var(--icon-lg)]" />}
 						label="Source"
 						value={sourceLabel(config)}
 						active={activePanel === "source"}
@@ -586,7 +586,7 @@ export function DatabaseViewOptionsPopover({
 							icon={
 								<HugeiconsIcon
 									icon={GridViewIcon}
-									size="var(--icon-lg)"
+									className="size-[var(--icon-lg)]"
 									strokeWidth={0.9}
 								/>
 							}
@@ -600,7 +600,7 @@ export function DatabaseViewOptionsPopover({
 						icon={
 							<HugeiconsIcon
 								icon={FilterMailIcon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={0.9}
 							/>
 						}
@@ -617,7 +617,7 @@ export function DatabaseViewOptionsPopover({
 						icon={
 							<HugeiconsIcon
 								icon={TextFontIcon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={0.9}
 							/>
 						}
@@ -631,7 +631,7 @@ export function DatabaseViewOptionsPopover({
 							icon={
 								<HugeiconsIcon
 									icon={Cards01Icon}
-									size="var(--icon-lg)"
+									className="size-[var(--icon-lg)]"
 									strokeWidth={0.9}
 								/>
 							}
@@ -646,7 +646,7 @@ export function DatabaseViewOptionsPopover({
 						className="databaseViewRestoreButton"
 						onClick={resetViewOptions}
 					>
-						<RefreshCw size="var(--icon-lg)" aria-hidden="true" />
+						<RefreshCw className="size-[var(--icon-lg)]" aria-hidden="true" />
 						Restore defaults
 					</button>
 				</section>

--- a/src/components/database/DatabaseViewOptionsSortPanel.tsx
+++ b/src/components/database/DatabaseViewOptionsSortPanel.tsx
@@ -118,7 +118,7 @@ export function SortPanel({
 					<span className="databaseViewFilterColumn">
 						<DatabaseColumnIcon
 							column={sortColumn ?? undefined}
-							size="var(--icon-lg)"
+							className="size-[var(--icon-lg)]"
 						/>
 						<select
 							className="databaseViewInlineSelect"
@@ -152,7 +152,7 @@ export function SortPanel({
 					disabled={!sortColumn}
 					onClick={() => setSort({ column_id: sortColumn?.id ?? "title" })}
 				>
-					<Plus size="var(--icon-md)" aria-hidden="true" />
+					<Plus className="size-[var(--icon-md)]" aria-hidden="true" />
 					Add sort
 				</button>
 			)}

--- a/src/components/databases/ActionMenuTrigger.tsx
+++ b/src/components/databases/ActionMenuTrigger.tsx
@@ -20,20 +20,20 @@ import {
 function renderMenuIcon(iconKey: ActionMenuIconKey): ReactNode {
 	switch (iconKey) {
 		case "table":
-			return <Table size="var(--icon-sm)" />;
+			return <Table className="size-[var(--icon-sm)]" />;
 		case "board":
-			return <Kanban size="var(--icon-sm)" />;
+			return <Kanban className="size-[var(--icon-sm)]" />;
 		case "edit":
-			return <Edit size="var(--icon-sm)" />;
+			return <Edit className="size-[var(--icon-sm)]" />;
 		case "trash":
-			return <Trash2 size="var(--icon-sm)" />;
+			return <Trash2 className="size-[var(--icon-sm)]" />;
 		case "plus":
-			return <Plus size="var(--icon-sm)" />;
+			return <Plus className="size-[var(--icon-sm)]" />;
 		case "library":
 			return (
 				<HugeiconsIcon
 					icon={LibraryIcon}
-					size="var(--icon-sm)"
+					className="size-[var(--icon-sm)]"
 					strokeWidth={0.9}
 				/>
 			);

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -109,8 +109,7 @@ export function CollectionTopBar({
 									>
 										{index > 0 ? (
 											<ChevronRight
-												size="var(--icon-xs)"
-												className="databasesCollectionBreadcrumbSep"
+												className="databasesCollectionBreadcrumbSep size-[var(--icon-xs)]"
 												aria-hidden
 											/>
 										) : null}
@@ -139,13 +138,13 @@ export function CollectionTopBar({
 				>
 					<HugeiconsIcon
 						icon={LibraryIcon}
-						size="var(--icon-sm)"
+						className="size-[var(--icon-sm)]"
 						strokeWidth={0.9}
 					/>
 					<span className="databasesCollectionSwitcherLabel">
 						{collectionMenuLabel}
 					</span>
-					<ChevronDown size="var(--icon-sm)" />
+					<ChevronDown className="size-[var(--icon-sm)]" />
 				</ActionMenuTrigger>
 			</div>
 
@@ -164,7 +163,7 @@ export function CollectionTopBar({
 					>
 						<HugeiconsIcon
 							icon={StarIcon}
-							size="var(--icon-md)"
+							className="size-[var(--icon-md)]"
 							strokeWidth={0.9}
 						/>
 					</Button>
@@ -177,7 +176,7 @@ export function CollectionTopBar({
 						title="Delete collection"
 						aria-label="Delete collection"
 					>
-						<Trash2 size="var(--icon-md)" />
+						<Trash2 className="size-[var(--icon-md)]" />
 					</Button>
 					<button
 						type="button"
@@ -187,7 +186,7 @@ export function CollectionTopBar({
 					>
 						<HugeiconsIcon
 							icon={NoteIcon}
-							size="var(--icon-md)"
+							className="size-[var(--icon-md)]"
 							strokeWidth={0.9}
 						/>
 						New Note

--- a/src/components/databases/CreateCollectionDialog.tsx
+++ b/src/components/databases/CreateCollectionDialog.tsx
@@ -43,8 +43,8 @@ const COLLECTION_TIPS = [
 		text: "View them as a table or Kanban board.",
 		icons: (
 			<span className="createCollectionTipIcons" aria-hidden="true">
-				<Table size="var(--icon-sm)" />
-				<Kanban size="var(--icon-sm)" />
+				<Table className="size-[var(--icon-sm)]" />
+				<Kanban className="size-[var(--icon-sm)]" />
 			</span>
 		),
 	},
@@ -127,7 +127,7 @@ export function CreateCollectionDialog({
 					<div className="createCollectionIcon" aria-hidden="true">
 						<HugeiconsIcon
 							icon={LibraryIcon}
-							size="var(--icon-xl)"
+							className="size-[var(--icon-xl)]"
 							strokeWidth={0.9}
 						/>
 					</div>

--- a/src/components/databases/DatabaseViewTabs.tsx
+++ b/src/components/databases/DatabaseViewTabs.tsx
@@ -140,14 +140,12 @@ export function DatabaseViewTabs({
 							) : null}
 							{view.layout === "board" ? (
 								<Kanban
-									size="var(--icon-sm)"
-									className="databasesViewTabIcon"
+									className="databasesViewTabIcon size-[var(--icon-sm)]"
 									aria-hidden
 								/>
 							) : (
 								<Table
-									size="var(--icon-sm)"
-									className="databasesViewTabIcon"
+									className="databasesViewTabIcon size-[var(--icon-sm)]"
 									aria-hidden
 								/>
 							)}
@@ -176,8 +174,7 @@ export function DatabaseViewTabs({
 				>
 					<HugeiconsIcon
 						icon={MoreVerticalIcon}
-						className="databasesViewTabMenuIcon"
-						size="var(--icon-md)"
+						className="databasesViewTabMenuIcon size-[var(--icon-md)]"
 						strokeWidth={0.9}
 						color="currentColor"
 						aria-hidden
@@ -190,7 +187,7 @@ export function DatabaseViewTabs({
 					title="Add view"
 					aria-label="Add view"
 				>
-					<Plus size="var(--icon-sm)" />
+					<Plus className="size-[var(--icon-sm)]" />
 				</button>
 			</div>
 		</div>

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -173,7 +173,7 @@ function DatabasesPaneContent({
 					) : null}
 					<HugeiconsIcon
 						icon={LibraryIcon}
-						size="var(--icon-3xl)"
+						className="size-[var(--icon-3xl)]"
 						strokeWidth={0.9}
 					/>
 					<div className="databasesEmptyTitle">
@@ -207,7 +207,7 @@ function DatabasesPaneContent({
 								className="createCollectionCta"
 								onClick={selection.openCreateCollectionDialog}
 							>
-								<Plus size="var(--icon-sm)" />
+								<Plus className="size-[var(--icon-sm)]" />
 								Create Collection
 							</Button>
 						</>

--- a/src/components/editor/EditorRibbon.tsx
+++ b/src/components/editor/EditorRibbon.tsx
@@ -130,7 +130,7 @@ export const EditorRibbon = memo(function EditorRibbon({
 						>
 							<HugeiconsIcon
 								icon={NoteAddIcon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={0.9}
 							/>
 						</m.button>

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -61,7 +61,7 @@ export function EditorViewModeSwitch({
 						>
 							<HugeiconsIcon
 								icon={item.icon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={isActive ? 1.5 : 1}
 							/>
 						</button>

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -127,7 +127,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						>
 							<HugeiconsIcon
 								icon={PlayIcon}
-								size="var(--icon-sm)"
+								className="size-[var(--icon-sm)]"
 								strokeWidth={0.9}
 							/>
 						</button>
@@ -147,7 +147,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 					>
 						<HugeiconsIcon
 							icon={codeBlock.copied ? Tick02Icon : Copy01Icon}
-							size="var(--icon-sm)"
+							className="size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 					</button>

--- a/src/components/editor/NoteFindBar.tsx
+++ b/src/components/editor/NoteFindBar.tsx
@@ -27,7 +27,7 @@ export function NoteFindBar({
 }: NoteFindBarProps) {
 	return (
 		<div className="noteFindBar nodrag nopan nowheel">
-			<Search size="var(--icon-sm)" className="noteFindIcon" aria-hidden />
+			<Search className="noteFindIcon size-[var(--icon-sm)]" aria-hidden />
 			<Input
 				ref={inputRef}
 				className="noteFindInput"

--- a/src/components/editor/NoteLinkDialog.tsx
+++ b/src/components/editor/NoteLinkDialog.tsx
@@ -150,7 +150,7 @@ export function NoteLinkDialog({
 					</label>
 					<DialogFooter className="editorLinkDialogActions">
 						<Button type="button" variant="ghost" onClick={remove}>
-							<X size="var(--icon-md)" />
+							<X className="size-[var(--icon-md)]" />
 							Remove
 						</Button>
 						<Button type="submit">Apply</Button>

--- a/src/components/editor/NotePropertiesPanel.tsx
+++ b/src/components/editor/NotePropertiesPanel.tsx
@@ -288,7 +288,7 @@ export function NotePropertiesPanel({
 									)
 								}
 							>
-								<Plus size="var(--icon-sm)" />
+								<Plus className="size-[var(--icon-sm)]" />
 								Add property
 							</Button>
 						</div>

--- a/src/components/editor/RibbonColorPopover.tsx
+++ b/src/components/editor/RibbonColorPopover.tsx
@@ -45,7 +45,7 @@ export function RibbonColorPopover({
 				>
 					<HugeiconsIcon
 						icon={PaintBucketIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={0.9}
 					/>
 				</m.button>
@@ -91,7 +91,7 @@ export function RibbonColorPopover({
 						onMouseDown={preventMouseDown}
 						onClick={button.onClear}
 					>
-						<X size="var(--icon-sm)" />
+						<X className="size-[var(--icon-sm)]" />
 					</button>
 				</div>
 			</DropdownMenuContent>

--- a/src/components/editor/RibbonHighlightPopover.tsx
+++ b/src/components/editor/RibbonHighlightPopover.tsx
@@ -45,7 +45,7 @@ export function RibbonHighlightPopover({
 				>
 					<HugeiconsIcon
 						icon={HighlighterIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={0.9}
 					/>
 				</m.button>
@@ -91,7 +91,7 @@ export function RibbonHighlightPopover({
 						onMouseDown={preventMouseDown}
 						onClick={button.onClear}
 					>
-						<X size="var(--icon-sm)" />
+						<X className="size-[var(--icon-sm)]" />
 					</button>
 				</div>
 			</DropdownMenuContent>

--- a/src/components/editor/RibbonLinkPopover.tsx
+++ b/src/components/editor/RibbonLinkPopover.tsx
@@ -108,7 +108,7 @@ export function RibbonLinkPopover({
 					whileTap={canEdit ? { scale: 0.97 } : undefined}
 					transition={springPresets.snappy}
 				>
-					<Link2 size="var(--icon-md)" />
+					<Link2 className="size-[var(--icon-md)]" />
 				</m.button>
 			</PopoverTrigger>
 			<PopoverContent
@@ -143,7 +143,7 @@ export function RibbonLinkPopover({
 				</label>
 				<div className="editorLinkPopoverActions">
 					<Button type="button" variant="ghost" size="sm" onClick={removeLink}>
-						<X size="var(--icon-md)" />
+						<X className="size-[var(--icon-md)]" />
 						Remove
 					</Button>
 					<Button type="button" size="sm" onClick={applyLink}>

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -119,7 +119,7 @@ const TableAxisControl = memo(function TableAxisControl({
 		>
 			<HugeiconsIcon
 				icon={LocationAdd01Icon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		</button>

--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -23,7 +23,7 @@ function iconMarkup(copied: boolean): string {
 	return renderToStaticMarkup(
 		createElement(HugeiconsIcon, {
 			icon: copied ? Tick02Icon : Copy01Icon,
-			size: "var(--icon-sm)",
+			className: "size-[var(--icon-sm)]",
 			strokeWidth: 0.9,
 		}),
 	);

--- a/src/components/editor/noteProperties/NotePropertiesToolbar.tsx
+++ b/src/components/editor/noteProperties/NotePropertiesToolbar.tsx
@@ -92,7 +92,7 @@ export function NotePropertiesToolbar({
 							transition={springPresets.gentle}
 						/>
 					) : null}
-					<List size="var(--icon-md)" className="notePropertiesModePillIcon" />
+					<List className="notePropertiesModePillIcon size-[var(--icon-md)]" />
 				</m.button>
 				<m.button
 					ref={rawButtonRef}
@@ -117,7 +117,7 @@ export function NotePropertiesToolbar({
 							transition={springPresets.gentle}
 						/>
 					) : null}
-					<Code size="var(--icon-md)" className="notePropertiesModePillIcon" />
+					<Code className="notePropertiesModePillIcon size-[var(--icon-md)]" />
 				</m.button>
 			</div>
 		</div>

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -123,7 +123,7 @@ export function NotePropertyRow({
 					onClick={() => onRemove(index)}
 					aria-label={`Remove ${property.key || "property"}`}
 				>
-					<X size="var(--icon-xs)" />
+					<X className="size-[var(--icon-xs)]" />
 				</Button>
 			) : null}
 		</div>

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -340,7 +340,7 @@ export function NotePropertyValueField({
 								aria-label={`Remove ${label}`}
 							>
 								<span>{label}</span>
-								<X size="var(--icon-xs)" />
+								<X className="size-[var(--icon-xs)]" />
 							</button>
 						);
 					})}

--- a/src/components/editor/noteProperties/PropertyKindBadge.tsx
+++ b/src/components/editor/noteProperties/PropertyKindBadge.tsx
@@ -43,7 +43,7 @@ export function PropertyKindBadge({
 					>
 						<HugeiconsIcon
 							icon={icon}
-							size="var(--icon-sm)"
+							className="size-[var(--icon-sm)]"
 							strokeWidth={0.9}
 						/>
 					</Button>
@@ -66,7 +66,7 @@ export function PropertyKindBadge({
 								<span className="notePropertyKindOptionIcon">
 									<HugeiconsIcon
 										icon={PROPERTY_KIND_ICONS[menuKind]}
-										size="var(--icon-sm)"
+										className="size-[var(--icon-sm)]"
 										strokeWidth={0.9}
 									/>
 								</span>
@@ -83,7 +83,11 @@ export function PropertyKindBadge({
 
 	return (
 		<div className="notePropertyKindBadge">
-			<HugeiconsIcon icon={icon} size="var(--icon-sm)" strokeWidth={0.9} />
+			<HugeiconsIcon
+				icon={icon}
+				className="size-[var(--icon-sm)]"
+				strokeWidth={0.9}
+			/>
 		</div>
 	);
 }

--- a/src/components/editor/ribbonButtonConfigs.tsx
+++ b/src/components/editor/ribbonButtonConfigs.tsx
@@ -50,25 +50,25 @@ export function getFormatButtons(
 			title: i18n.t("editor:ribbon.bold"),
 			isActive: () => editor.isActive("bold"),
 			onClick: () => runCommand(() => focusChain().toggleBold().run()),
-			icon: <Bold size="var(--icon-md)" />,
+			icon: <Bold className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.italic"),
 			isActive: () => editor.isActive("italic"),
 			onClick: () => runCommand(() => focusChain().toggleItalic().run()),
-			icon: <Italic size="var(--icon-md)" />,
+			icon: <Italic className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.underline"),
 			isActive: () => editor.isActive("underline"),
 			onClick: () => runCommand(() => focusChain().toggleUnderline().run()),
-			icon: <Underline size="var(--icon-md)" />,
+			icon: <Underline className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.strikethrough"),
 			isActive: () => editor.isActive("strike"),
 			onClick: () => runCommand(() => focusChain().toggleStrike().run()),
-			icon: <Strikethrough size="var(--icon-md)" />,
+			icon: <Strikethrough className="size-[var(--icon-md)]" />,
 		},
 	];
 }
@@ -142,21 +142,21 @@ export function getHeadingButtons(
 			isActive: () => editor.isActive("heading", { level: 1 }),
 			onClick: () =>
 				runCommand(() => focusChain().toggleHeading({ level: 1 }).run()),
-			icon: <Heading1 size="var(--icon-md)" />,
+			icon: <Heading1 className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.heading2"),
 			isActive: () => editor.isActive("heading", { level: 2 }),
 			onClick: () =>
 				runCommand(() => focusChain().toggleHeading({ level: 2 }).run()),
-			icon: <Heading2 size="var(--icon-md)" />,
+			icon: <Heading2 className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.heading3"),
 			isActive: () => editor.isActive("heading", { level: 3 }),
 			onClick: () =>
 				runCommand(() => focusChain().toggleHeading({ level: 3 }).run()),
-			icon: <Heading3 size="var(--icon-md)" />,
+			icon: <Heading3 className="size-[var(--icon-md)]" />,
 		},
 	];
 }
@@ -171,19 +171,19 @@ export function getListButtons(
 			title: i18n.t("editor:ribbon.bulletList"),
 			isActive: () => editor.isActive("bulletList"),
 			onClick: () => runCommand(() => focusChain().toggleBulletList().run()),
-			icon: <List size="var(--icon-md)" />,
+			icon: <List className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.numberedList"),
 			isActive: () => editor.isActive("orderedList"),
 			onClick: () => runCommand(() => focusChain().toggleOrderedList().run()),
-			icon: <ListOrdered size="var(--icon-md)" />,
+			icon: <ListOrdered className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.taskList"),
 			isActive: () => editor.isActive("taskList"),
 			onClick: () => runCommand(() => focusChain().toggleTaskList().run()),
-			icon: <ListChecks size="var(--icon-md)" />,
+			icon: <ListChecks className="size-[var(--icon-md)]" />,
 		},
 	];
 }
@@ -198,13 +198,13 @@ export function getBlockButtons(
 			title: i18n.t("editor:ribbon.quote"),
 			isActive: () => editor.isActive("blockquote"),
 			onClick: () => runCommand(() => focusChain().toggleBlockquote().run()),
-			icon: <Quote size="var(--icon-md)" />,
+			icon: <Quote className="size-[var(--icon-md)]" />,
 		},
 		{
 			title: i18n.t("editor:ribbon.codeBlock"),
 			isActive: () => editor.isActive("codeBlock"),
 			onClick: () => runCommand(() => focusChain().toggleCodeBlock().run()),
-			icon: <Code size="var(--icon-md)" />,
+			icon: <Code className="size-[var(--icon-md)]" />,
 		},
 	];
 }

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -266,15 +266,13 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 							{appearance?.icon ? (
 								<DatabaseColumnIcon
 									iconName={appearance.icon}
-									size="var(--icon-md)"
-									className="fileTreeChevron fileTreeFolderIcon"
+									className="fileTreeChevron fileTreeFolderIcon size-[var(--icon-md)]"
 								/>
 							) : (
 								<HugeiconsIcon
 									icon={isExpanded ? Folder03Icon : Folder01Icon}
-									size="var(--icon-sm)"
 									strokeWidth={0.9}
-									className="fileTreeChevron fileTreeFolderIcon"
+									className="fileTreeChevron fileTreeFolderIcon size-[var(--icon-sm)]"
 								/>
 							)}
 							<span className="fileTreeName">{displayDirName}</span>
@@ -300,7 +298,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 											}
 										}}
 									>
-										<Plus size="var(--icon-sm)" />
+										<Plus className="size-[var(--icon-sm)]" />
 									</span>
 									{/* biome-ignore lint/a11y/useSemanticElements: nested inside button row */}
 									<span
@@ -324,7 +322,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 									>
 										<HugeiconsIcon
 											icon={ArrowRight02Icon}
-											size="var(--icon-sm)"
+											className="size-[var(--icon-sm)]"
 											strokeWidth={0.9}
 										/>
 									</span>

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -376,13 +376,11 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 						{appearance?.icon ? (
 							<DatabaseColumnIcon
 								iconName={appearance.icon}
-								size="var(--icon-md)"
-								className="fileTreeIcon"
+								className="fileTreeIcon size-[var(--icon-md)]"
 							/>
 						) : (
 							<Icon
-								size="var(--icon-md)"
-								className="fileTreeIcon"
+								className="fileTreeIcon size-[var(--icon-md)]"
 								style={{ color: iconColor }}
 								aria-hidden="true"
 							/>
@@ -396,9 +394,8 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 						{isPinned ? (
 							<HugeiconsIcon
 								icon={StarIcon}
-								size="var(--icon-sm)"
 								strokeWidth={0.9}
-								className="fileTreePinIcon"
+								className="fileTreePinIcon size-[var(--icon-sm)]"
 							/>
 						) : null}
 						{taskSummary && taskSummary.total_count > 0 ? (

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -209,8 +209,7 @@ function FolderBreadcrumb({
 						</button>
 						{!isLast ? (
 							<ChevronRight
-								size="var(--icon-xs)"
-								className="fileTreeBreadcrumbSeparator"
+								className="fileTreeBreadcrumbSeparator size-[var(--icon-xs)]"
 								aria-hidden="true"
 							/>
 						) : null}

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -513,13 +513,11 @@ export const FolioNoteListItem = memo(
 		const fileIcon = appearance?.icon ? (
 			<DatabaseColumnIcon
 				iconName={appearance.icon}
-				size="var(--icon-lg)"
-				className="folioNoteFileIcon"
+				className="folioNoteFileIcon size-[var(--icon-lg)]"
 			/>
 		) : (
 			<Icon
-				size="var(--icon-lg)"
-				className="folioNoteFileIcon"
+				className="folioNoteFileIcon size-[var(--icon-lg)]"
 				style={{ color: iconColor }}
 				aria-hidden="true"
 			/>
@@ -554,8 +552,7 @@ export const FolioNoteListItem = memo(
 							>
 								<DatabaseColumnIcon
 									iconName="link"
-									className="folioNoteUrlIcon"
-									size="var(--icon-xs)"
+									className="folioNoteUrlIcon size-[var(--icon-xs)]"
 									strokeWidth={1.2}
 								/>
 								{firstUrlLabel}
@@ -570,8 +567,7 @@ export const FolioNoteListItem = memo(
 								>
 									<DatabaseColumnIcon
 										iconName={iconNameForTag(tag)}
-										className="folioNoteTagIcon"
-										size="var(--icon-xs)"
+										className="folioNoteTagIcon size-[var(--icon-xs)]"
 										strokeWidth={1.2}
 									/>
 									{formatDatabaseTagLabel(tag)}

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -34,7 +34,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 				<label className="folioNotesSearch">
 					<HugeiconsIcon
 						icon={SearchIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={0.9}
 					/>
 					<input
@@ -49,7 +49,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 				<label className="folioNotesSort">
 					<HugeiconsIcon
 						icon={sortIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={1}
 					/>
 					<select

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -564,7 +564,7 @@ export function MarkdownEditorPane({
 						>
 							<HugeiconsIcon
 								icon={AiBrain04Icon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={isAiPanelActive ? 1.5 : 1}
 							/>
 						</button>
@@ -579,7 +579,7 @@ export function MarkdownEditorPane({
 						>
 							<HugeiconsIcon
 								icon={LayoutAlignRightIcon}
-								size="var(--icon-md)"
+								className="size-[var(--icon-md)]"
 								strokeWidth={infoPanelOpen ? 1.5 : 1}
 							/>
 						</button>

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -121,8 +121,11 @@ function UnlinkedMentionsSection({
 							{t("unlinkedMentions.heading", { count: mentions.length })}
 						</span>
 						<ChevronDown
-							className={expanded ? undefined : "is-collapsed"}
-							size="var(--icon-xs)"
+							className={
+								expanded
+									? "size-[var(--icon-xs)]"
+									: "is-collapsed size-[var(--icon-xs)]"
+							}
 							aria-hidden="true"
 						/>
 					</button>
@@ -201,7 +204,7 @@ function UnlinkedMentionsSection({
 									>
 										<HugeiconsIcon
 											icon={Link04Icon}
-											size="var(--icon-sm)"
+											className="size-[var(--icon-sm)]"
 											aria-hidden="true"
 										/>
 									</button>
@@ -320,7 +323,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 					>
 						<HugeiconsIcon
 							icon={BadgeInfoIcon}
-							size="var(--icon-sm)"
+							className="size-[var(--icon-sm)]"
 							strokeWidth={1}
 						/>
 						Info
@@ -336,7 +339,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 						>
 							<HugeiconsIcon
 								icon={GitBranchIcon}
-								size="var(--icon-sm)"
+								className="size-[var(--icon-sm)]"
 								strokeWidth={1}
 							/>
 							Version history
@@ -545,7 +548,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 							<h3 className="markdownEditorInfoSectionLabel markdownEditorInfoSectionLabelSubtle">
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
-									size="var(--icon-sm)"
+									className="size-[var(--icon-sm)]"
 									strokeWidth={1}
 								/>
 								Info

--- a/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
+++ b/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
@@ -226,8 +226,7 @@ function TargetBreadcrumbEntryMenu({
 					aria-label={`Browse ${menuTitleForDir(dirPath)}`}
 				>
 					<ChevronRight
-						size="var(--icon-xs)"
-						className="quickNoteTargetSep"
+						className="quickNoteTargetSep size-[var(--icon-xs)]"
 						aria-hidden="true"
 					/>
 				</button>

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -284,7 +284,7 @@ export function QuickNoteWindow() {
 						title="Today's quick note"
 						onClick={() => chooseTarget(quickNoteTarget(folder))}
 					>
-						<FileText size="var(--icon-md)" aria-hidden="true" />
+						<FileText className="size-[var(--icon-md)]" aria-hidden="true" />
 					</button>
 					<QuickNoteTargetBreadcrumbs
 						selectedTarget={selectedTarget}
@@ -309,7 +309,7 @@ export function QuickNoteWindow() {
 						disabled={saving || !hasText}
 						onClick={() => void save()}
 					>
-						<Save size="var(--icon-lg)" />
+						<Save className="size-[var(--icon-lg)]" />
 						<span className="quickNoteSaveLabel">Save</span>
 						<span className="commandPaletteShortcut" aria-hidden="true">
 							<kbd>

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -135,7 +135,7 @@ export function AboutSettingsPane() {
 						>
 							<HugeiconsIcon
 								icon={GlobeIcon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={1.6}
 							/>
 							Website
@@ -149,7 +149,7 @@ export function AboutSettingsPane() {
 						>
 							<HugeiconsIcon
 								icon={DiscordIcon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={1.6}
 							/>
 							Discord
@@ -163,7 +163,7 @@ export function AboutSettingsPane() {
 						>
 							<HugeiconsIcon
 								icon={File01Icon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={1.6}
 							/>
 							Terms
@@ -177,7 +177,7 @@ export function AboutSettingsPane() {
 						>
 							<HugeiconsIcon
 								icon={Shield01Icon}
-								size="var(--icon-lg)"
+								className="size-[var(--icon-lg)]"
 								strokeWidth={1.6}
 							/>
 							Privacy
@@ -310,7 +310,7 @@ export function AboutSettingsPane() {
 							>
 								<HugeiconsIcon
 									icon={ListViewIcon}
-									size="var(--icon-md)"
+									className="size-[var(--icon-md)]"
 									strokeWidth={1.6}
 								/>
 								View Changelog

--- a/src/components/settings/AppearanceThemeCard.tsx
+++ b/src/components/settings/AppearanceThemeCard.tsx
@@ -114,7 +114,7 @@ function ThemeSelector<T extends string>({
 								open && "is-open",
 							)}
 						>
-							<ChevronDown size="var(--icon-md)" />
+							<ChevronDown className="size-[var(--icon-md)]" />
 						</span>
 					</button>
 				</PopoverTrigger>

--- a/src/components/settings/AppearanceThemeColorField.tsx
+++ b/src/components/settings/AppearanceThemeColorField.tsx
@@ -67,7 +67,7 @@ export function AppearanceThemeColorResetButton({
 		>
 			<HugeiconsIcon
 				icon={ReloadIcon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		</button>

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -70,7 +70,7 @@ function VimModeInfo() {
 				>
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
-						size="var(--icon-md)"
+						className="size-[var(--icon-md)]"
 						strokeWidth={0.9}
 					/>
 				</button>

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -180,7 +180,7 @@ export function GitSettingsPane() {
 							icon={
 								<HugeiconsIcon
 									icon={CheckmarkCircle02Icon}
-									size="var(--icon-md)"
+									className="size-[var(--icon-md)]"
 									strokeWidth={0.9}
 								/>
 							}
@@ -197,7 +197,7 @@ export function GitSettingsPane() {
 							icon={
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
-									size="var(--icon-md)"
+									className="size-[var(--icon-md)]"
 									strokeWidth={0.9}
 								/>
 							}
@@ -214,7 +214,7 @@ export function GitSettingsPane() {
 							icon={
 								<HugeiconsIcon
 									icon={Link01Icon}
-									size="var(--icon-md)"
+									className="size-[var(--icon-md)]"
 									strokeWidth={0.9}
 								/>
 							}
@@ -236,7 +236,7 @@ export function GitSettingsPane() {
 								icon={
 									<HugeiconsIcon
 										icon={GitBranchIcon}
-										size="var(--icon-md)"
+										className="size-[var(--icon-md)]"
 										strokeWidth={0.9}
 									/>
 								}

--- a/src/components/settings/SettingsSelect.tsx
+++ b/src/components/settings/SettingsSelect.tsx
@@ -15,8 +15,7 @@ export function SettingsSelect({
 				{children}
 			</select>
 			<ChevronDown
-				className="settingsSelectChevron"
-				size="var(--icon-sm)"
+				className="settingsSelectChevron size-[var(--icon-sm)]"
 				aria-hidden="true"
 			/>
 		</span>

--- a/src/components/settings/ShortcutsSettingsPane.tsx
+++ b/src/components/settings/ShortcutsSettingsPane.tsx
@@ -275,7 +275,7 @@ export function ShortcutsSettingsPane() {
 												aria-label="Disable shortcut"
 												title="Disable shortcut"
 											>
-												<Trash2 size="var(--icon-md)" />
+												<Trash2 className="size-[var(--icon-md)]" />
 											</Button>
 											<Button
 												type="button"
@@ -289,7 +289,7 @@ export function ShortcutsSettingsPane() {
 											>
 												<HugeiconsIcon
 													icon={ReloadIcon}
-													size="var(--icon-md)"
+													className="size-[var(--icon-md)]"
 													strokeWidth={0.9}
 												/>
 											</Button>

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -353,7 +353,7 @@ export function SpaceSettingsPane() {
 										className="min-w-24 rounded-md border-border bg-background justify-center shadow-none"
 										onClick={handleBrowseFolder}
 									>
-										<FolderOpen size="var(--icon-md)" />
+										<FolderOpen className="size-[var(--icon-md)]" />
 										Browse
 									</Button>
 									{dailyNotesFolder ? (
@@ -366,7 +366,7 @@ export function SpaceSettingsPane() {
 											aria-label="Clear daily notes folder"
 											title="Clear daily notes folder"
 										>
-											<Trash2 size="var(--icon-md)" />
+											<Trash2 className="size-[var(--icon-md)]" />
 										</Button>
 									) : null}
 								</div>
@@ -398,7 +398,7 @@ export function SpaceSettingsPane() {
 										className="min-w-24 rounded-md border-border bg-background justify-center shadow-none"
 										onClick={() => void handleBrowseQuickNotesFolder()}
 									>
-										<FolderOpen size="var(--icon-md)" />
+										<FolderOpen className="size-[var(--icon-md)]" />
 										Browse
 									</Button>
 									<Button
@@ -410,7 +410,7 @@ export function SpaceSettingsPane() {
 										aria-label="Reset quick notes folder"
 										title="Reset quick notes folder"
 									>
-										<Trash2 size="var(--icon-md)" />
+										<Trash2 className="size-[var(--icon-md)]" />
 									</Button>
 								</div>
 							</div>
@@ -465,7 +465,7 @@ export function SpaceSettingsPane() {
 											className="min-w-24 rounded-md border-border bg-background justify-center shadow-none"
 											onClick={handleBrowseAttachmentFolder}
 										>
-											<FolderOpen size="var(--icon-md)" />
+											<FolderOpen className="size-[var(--icon-md)]" />
 											Browse
 										</Button>
 										<Button
@@ -479,7 +479,7 @@ export function SpaceSettingsPane() {
 											aria-label="Reset attachments folder"
 											title="Reset attachments folder"
 										>
-											<Trash2 size="var(--icon-md)" />
+											<Trash2 className="size-[var(--icon-md)]" />
 										</Button>
 									</div>
 								</div>
@@ -519,7 +519,7 @@ export function SpaceSettingsPane() {
 											aria-label="Reset attachment subfolder"
 											title="Reset attachment subfolder"
 										>
-											<Trash2 size="var(--icon-md)" />
+											<Trash2 className="size-[var(--icon-md)]" />
 										</Button>
 									</div>
 								</div>

--- a/src/components/settings/TemplatesSettingsPane.tsx
+++ b/src/components/settings/TemplatesSettingsPane.tsx
@@ -351,7 +351,7 @@ export function TemplateSettingsSections() {
 									className="min-w-24 rounded-md border-border bg-background justify-center shadow-none"
 									onClick={handleBrowseFolder}
 								>
-									<FolderOpen size="var(--icon-md)" />
+									<FolderOpen className="size-[var(--icon-md)]" />
 									Browse
 								</Button>
 								{templatesFolder !== null ? (
@@ -364,7 +364,7 @@ export function TemplateSettingsSections() {
 										aria-label="Clear template folder"
 										title="Clear template folder"
 									>
-										<Trash2 size="var(--icon-md)" />
+										<Trash2 className="size-[var(--icon-md)]" />
 									</Button>
 								) : null}
 							</div>

--- a/src/components/settings/ai/AiCodexAccountSection.tsx
+++ b/src/components/settings/ai/AiCodexAccountSection.tsx
@@ -155,7 +155,7 @@ export function AiCodexAccountSection({
 												<span className="codexRateLimitWindow">
 													<HugeiconsIcon
 														icon={WindowIcon}
-														size="var(--icon-lg)"
+														className="size-[var(--icon-lg)]"
 														strokeWidth={1.6}
 														aria-hidden="true"
 													/>

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -38,7 +38,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		renderIcon: () => (
 			<HugeiconsIcon
 				icon={Settings01Icon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		),
@@ -47,7 +47,11 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		id: "appearance",
 		label: "Appearance",
 		renderIcon: () => (
-			<HugeiconsIcon icon={Sun03Icon} size="var(--icon-md)" strokeWidth={0.9} />
+			<HugeiconsIcon
+				icon={Sun03Icon}
+				className="size-[var(--icon-md)]"
+				strokeWidth={0.9}
+			/>
 		),
 	},
 	{
@@ -56,7 +60,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		renderIcon: () => (
 			<HugeiconsIcon
 				icon={CommandIcon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		),
@@ -67,7 +71,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		renderIcon: () => (
 			<HugeiconsIcon
 				icon={AiBrain04Icon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		),
@@ -75,7 +79,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 	{
 		id: "space",
 		label: "Space",
-		renderIcon: () => <FolderOpen size="var(--icon-md)" />,
+		renderIcon: () => <FolderOpen className="size-[var(--icon-md)]" />,
 	},
 	{
 		id: "git",
@@ -83,7 +87,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		renderIcon: () => (
 			<HugeiconsIcon
 				icon={GitBranchIcon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		),
@@ -94,7 +98,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 		renderIcon: () => (
 			<HugeiconsIcon
 				icon={Archive02Icon}
-				size="var(--icon-md)"
+				className="size-[var(--icon-md)]"
 				strokeWidth={0.9}
 			/>
 		),

--- a/src/components/status/PriorityPropertyPill.tsx
+++ b/src/components/status/PriorityPropertyPill.tsx
@@ -48,8 +48,7 @@ export function PriorityPropertyPill({
 		>
 			<HugeiconsIcon
 				icon={priorityPropertyIconForValue(value)}
-				className="propertyValueTextIcon"
-				size="var(--icon-sm)"
+				className="propertyValueTextIcon size-[var(--icon-sm)]"
 				strokeWidth={1.3}
 			/>
 			<span>{label}</span>

--- a/src/components/status/StatusPropertyPill.tsx
+++ b/src/components/status/StatusPropertyPill.tsx
@@ -64,8 +64,7 @@ export function StatusPropertyPill({
 		>
 			<HugeiconsIcon
 				icon={statusPropertyIconForValue(value)}
-				className="propertyValueTextIcon"
-				size="var(--icon-sm)"
+				className="propertyValueTextIcon size-[var(--icon-sm)]"
 				strokeWidth={1.3}
 			/>
 			<span>{label}</span>

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -67,7 +67,7 @@ function DialogContent({
 					>
 						<HugeiconsIcon
 							icon={Close}
-							size="var(--icon-lg)"
+							className="size-[var(--icon-lg)]"
 							strokeWidth={0.9}
 						/>
 						<span className="sr-only">Close</span>

--- a/src/components/ui/shadcn/dropdown-menu.tsx
+++ b/src/components/ui/shadcn/dropdown-menu.tsx
@@ -94,8 +94,7 @@ function DropdownMenuRadioItem({
 				<DropdownMenuPrimitive.ItemIndicator>
 					<HugeiconsIcon
 						icon={Circle}
-						size="var(--icon-xs)"
-						className="fill-current"
+						className="fill-current size-[var(--icon-xs)]"
 						strokeWidth={0.9}
 					/>
 				</DropdownMenuPrimitive.ItemIndicator>
@@ -166,8 +165,7 @@ function DropdownMenuSubTrigger({
 			<span className="pointer-events-none absolute right-2 flex size-[var(--icon-sm)] items-center justify-center">
 				<HugeiconsIcon
 					icon={ArrowRight01Icon}
-					size="var(--icon-xs)"
-					className="text-muted-foreground"
+					className="text-muted-foreground size-[var(--icon-xs)]"
 					strokeWidth={0.9}
 					aria-hidden="true"
 				/>

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	type Dispatch,
 	type ReactNode,
@@ -29,7 +28,11 @@ import {
 	setFolioMode as saveFolioMode,
 	setShowToc as saveShowToc,
 } from "../lib/settings";
-import { useTauriEvent } from "../lib/tauriEvents";
+import {
+	listenWindowFocusChanged,
+	safeUnlisten,
+	useTauriEvent,
+} from "../lib/tauriEvents";
 import { useSpace } from "./SpaceContext";
 
 interface UILayoutContextValue {
@@ -334,8 +337,8 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		};
 
 		void loadAndApplySettings();
-		const win = getCurrentWindow();
-		const unlisten = win.onFocusChanged(({ payload: focused }) => {
+		let cleanup: (() => void) | null = null;
+		void listenWindowFocusChanged((focused) => {
 			if (!focused || cancelled) return;
 			void (async () => {
 				try {
@@ -346,11 +349,19 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					// best-effort refresh
 				}
 			})();
-		});
+		})
+			.then((unlisten) => {
+				if (cancelled) {
+					safeUnlisten(unlisten);
+					return;
+				}
+				cleanup = unlisten;
+			})
+			.catch(() => {});
 
 		return () => {
 			cancelled = true;
-			unlisten.then((fn) => fn()).catch(() => {});
+			safeUnlisten(cleanup);
 		};
 	}, []);
 

--- a/src/hooks/useDebouncedNoteChange.ts
+++ b/src/hooks/useDebouncedNoteChange.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { listenTauriEvent } from "../lib/tauriEvents";
+import { listenTauriEvent, safeUnlisten } from "../lib/tauriEvents";
 
 interface NoteChangePayload {
 	rel_path: string;
@@ -14,17 +14,6 @@ interface UseDebouncedNoteChangeOptions {
 
 function isMarkdownNote(path: string): boolean {
 	return path.toLowerCase().endsWith(".md");
-}
-
-function runUnlisten(unlisten: () => void): void {
-	try {
-		const result = unlisten() as unknown;
-		void Promise.resolve(result).catch(() => {
-			// Tauri may already have cleaned up the listener during window teardown.
-		});
-	} catch {
-		// Ignore teardown races from Tauri listener cleanup.
-	}
 }
 
 export function useDebouncedNoteChange({
@@ -61,7 +50,7 @@ export function useDebouncedNoteChange({
 		])
 			.then((stops) => {
 				if (cancelled) {
-					for (const stop of stops) runUnlisten(stop);
+					for (const stop of stops) safeUnlisten(stop);
 					return;
 				}
 				unlisteners = stops;
@@ -76,7 +65,7 @@ export function useDebouncedNoteChange({
 				window.clearTimeout(timerRef.current);
 				timerRef.current = null;
 			}
-			for (const stop of unlisteners) runUnlisten(stop);
+			for (const stop of unlisteners) safeUnlisten(stop);
 			unlisteners = [];
 		};
 	}, [enabled, schedule]);

--- a/src/hooks/useShortcutBindings.ts
+++ b/src/hooks/useShortcutBindings.ts
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	type EffectiveShortcutBindings,
@@ -12,7 +11,11 @@ import {
 	type ShortcutActionDefinition,
 	type ShortcutActionId,
 } from "../lib/shortcuts/registry";
-import { useTauriEvent } from "../lib/tauriEvents";
+import {
+	listenWindowFocusChanged,
+	safeUnlisten,
+	useTauriEvent,
+} from "../lib/tauriEvents";
 
 const DEFAULT_EFFECTIVE_BINDINGS = getEffectiveShortcutBindings({});
 const FOCUS_REFRESH_DELAY_MS = 200;
@@ -34,22 +37,30 @@ export function useShortcutBindings() {
 
 	useEffect(() => {
 		let cancelled = false;
+		let cleanup: (() => void) | null = null;
 		let focusRefreshTimeout: ReturnType<typeof setTimeout> | null = null;
 		mountedRef.current = true;
 		void refresh().catch(() => {});
-		const win = getCurrentWindow();
-		const unlistenPromise = win.onFocusChanged(({ payload: focused }) => {
+		void listenWindowFocusChanged((focused) => {
 			if (!focused || cancelled) return;
 			if (focusRefreshTimeout) clearTimeout(focusRefreshTimeout);
 			focusRefreshTimeout = setTimeout(() => {
 				if (!cancelled) void refresh(true).catch(() => {});
 			}, FOCUS_REFRESH_DELAY_MS);
-		});
+		})
+			.then((unlisten) => {
+				if (cancelled) {
+					safeUnlisten(unlisten);
+					return;
+				}
+				cleanup = unlisten;
+			})
+			.catch(() => {});
 		return () => {
 			cancelled = true;
 			mountedRef.current = false;
 			if (focusRefreshTimeout) clearTimeout(focusRefreshTimeout);
-			unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
+			safeUnlisten(cleanup);
 		};
 	}, [refresh]);
 

--- a/src/lib/license.ts
+++ b/src/lib/license.ts
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	DEFAULT_DATE_DISPLAY_FORMAT,
@@ -12,6 +11,7 @@ import {
 	type LicenseStatus,
 	invoke,
 } from "./tauri";
+import { listenWindowFocusChanged, safeUnlisten } from "./tauriEvents";
 
 const LICENSE_UPDATED_EVENT = "glyph:license-updated";
 
@@ -134,13 +134,12 @@ export function useLicenseStatus(reloadOnWindowFocus = true): {
 
 		let disposed = false;
 		try {
-			void getCurrentWindow()
-				.onFocusChanged(({ payload }) => {
-					if (payload) void reload();
-				})
+			void listenWindowFocusChanged((focused) => {
+				if (focused) void reload();
+			})
 				.then((unlisten) => {
 					if (disposed) {
-						unlisten();
+						safeUnlisten(unlisten);
 						return;
 					}
 					focusUnlistenRef.current = unlisten;
@@ -155,7 +154,7 @@ export function useLicenseStatus(reloadOnWindowFocus = true): {
 		return () => {
 			disposed = true;
 			window.removeEventListener("focus", onFocus);
-			focusUnlistenRef.current?.();
+			safeUnlisten(focusUnlistenRef.current);
 			focusUnlistenRef.current = null;
 		};
 	}, [reload, reloadOnWindowFocus]);

--- a/src/lib/settingsStore.ts
+++ b/src/lib/settingsStore.ts
@@ -1,5 +1,6 @@
 import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import { LazyStore } from "@tauri-apps/plugin-store";
+import { safeUnlisten } from "./tauriEvents";
 
 let storeInstance: LazyStore | null = null;
 let storeInitPromise: Promise<void> | null = null;
@@ -8,15 +9,6 @@ let settingsEntriesPromise: Promise<Map<string, unknown>> | null = null;
 let settingsEntriesGeneration = 0;
 let settingsInvalidationUnlisten: UnlistenFn | null = null;
 let settingsInvalidationUnlistenPromise: Promise<UnlistenFn> | null = null;
-
-function runSettingsInvalidationUnlisten(unlisten: UnlistenFn): void {
-	try {
-		const result = unlisten() as unknown;
-		void Promise.resolve(result).catch(() => {});
-	} catch {
-		// Ignore listener cleanup races during Tauri window teardown.
-	}
-}
 
 function ensureSettingsInvalidationListener() {
 	if (settingsInvalidationUnlisten || settingsInvalidationUnlistenPromise)
@@ -46,11 +38,11 @@ export function disposeSettingsInvalidationListener(): void {
 	settingsInvalidationUnlistenPromise = null;
 
 	if (unlisten) {
-		runSettingsInvalidationUnlisten(unlisten);
+		safeUnlisten(unlisten);
 		return;
 	}
 	if (unlistenPromise) {
-		void unlistenPromise.then(runSettingsInvalidationUnlisten).catch(() => {});
+		void unlistenPromise.then(safeUnlisten).catch(() => {});
 	}
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,4 +1,5 @@
-import { listen } from "@tauri-apps/api/event";
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef } from "react";
 import type { EditorViewMode } from "./editorMode";
 import type {
@@ -160,7 +161,15 @@ export async function listenTauriEvent<K extends keyof TauriEventMap>(
 	});
 }
 
-function runUnlisten(unlisten: (() => void) | null): void {
+/**
+ * Safely invoke a Tauri UnlistenFn.
+ *
+ * Unlisten can reject when the listener was already removed (window teardown,
+ * double-cleanup, HMR). Call sites must not leave that rejection unhandled.
+ */
+export function safeUnlisten(
+	unlisten: UnlistenFn | (() => void) | null | undefined,
+): void {
 	if (!unlisten) return;
 
 	try {
@@ -171,6 +180,39 @@ function runUnlisten(unlisten: (() => void) | null): void {
 	} catch {
 		// Ignore teardown races from Tauri listener cleanup.
 	}
+}
+
+/**
+ * Listen for the current window gaining/losing focus.
+ *
+ * Prefer this over `Window.onFocusChanged`. Tauri's helper returns a sync
+ * unlisten that fire-and-forgets two async unlistens, which surfaces as
+ * unhandled rejections (`listeners[eventId].handlerId`) on teardown.
+ */
+export async function listenWindowFocusChanged(
+	handler: (focused: boolean) => void,
+): Promise<UnlistenFn> {
+	const win = getCurrentWindow();
+	const unlistenFocus = await win.listen("tauri://focus", () => {
+		handler(true);
+	});
+	let unlistenBlur: UnlistenFn;
+	try {
+		unlistenBlur = await win.listen("tauri://blur", () => {
+			handler(false);
+		});
+	} catch (error) {
+		safeUnlisten(unlistenFocus);
+		throw error;
+	}
+
+	let didUnlisten = false;
+	return () => {
+		if (didUnlisten) return;
+		didUnlisten = true;
+		safeUnlisten(unlistenFocus);
+		safeUnlisten(unlistenBlur);
+	};
 }
 
 export function useTauriEvent<K extends keyof TauriEventMap>(
@@ -189,7 +231,7 @@ export function useTauriEvent<K extends keyof TauriEventMap>(
 		const cleanup = () => {
 			if (didUnlisten) return;
 			if (unlisten) {
-				runUnlisten(unlisten);
+				safeUnlisten(unlisten);
 				unlisten = null;
 				didUnlisten = true;
 				pendingTeardown = false;
@@ -214,7 +256,7 @@ export function useTauriEvent<K extends keyof TauriEventMap>(
 			}
 			unlisten = stop;
 			if (pendingTeardown && !didUnlisten) {
-				runUnlisten(unlisten);
+				safeUnlisten(unlisten);
 				unlisten = null;
 				didUnlisten = true;
 				pendingTeardown = false;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,7 +34,11 @@ import {
 	reloadFromDisk,
 } from "./lib/settings";
 import { invoke } from "./lib/tauri";
-import { useTauriEvent } from "./lib/tauriEvents";
+import {
+	listenWindowFocusChanged,
+	safeUnlisten,
+	useTauriEvent,
+} from "./lib/tauriEvents";
 import {
 	DEFAULT_UI_THEME_COLOR_OVERRIDES,
 	asThemeColorOverridesPatch,
@@ -121,14 +125,19 @@ function ThemeAndTypographyBridge() {
 
 		let cleanup: (() => void) | null = null;
 		try {
-			const win = getCurrentWindow();
-			void win
-				.onFocusChanged(({ payload: focused }) => {
-					if (!focused || cancelled) return;
-					void applyFromSettings(true);
-				})
+			void listenWindowFocusChanged((focused) => {
+				if (!focused || cancelled) return;
+				void applyFromSettings(true);
+			})
 				.then((unlisten) => {
+					if (cancelled) {
+						safeUnlisten(unlisten);
+						return;
+					}
 					cleanup = unlisten;
+				})
+				.catch(() => {
+					// not running inside tauri window context
 				});
 		} catch {
 			// not running inside tauri window context
@@ -136,7 +145,7 @@ function ThemeAndTypographyBridge() {
 
 		return () => {
 			cancelled = true;
-			cleanup?.();
+			safeUnlisten(cleanup);
 		};
 	}, [setTheme]);
 


### PR DESCRIPTION
## Description

Fixes inconsistent SVG icon sizing across the app and cleans up a Tauri focus-listener teardown crash.

- **Summary of changes**
  - Size icons with CSS design-token utilities (`className="size-[var(--icon-*)]"`) instead of the Hugeicons `size` prop, which does not resolve CSS variables reliably.
  - Update `withDefaultIconSize` to apply the default icon size via className when no explicit size is provided.
  - Sweep UI call sites (sidebar, file tree, editor ribbon, databases, settings, AI panel, etc.) to the same pattern.
  - Add `safeUnlisten` and `listenWindowFocusChanged` so window focus/blur listeners clean up without unhandled rejections during teardown.
  - Route remaining bare unlisten call sites through `safeUnlisten`.

- **Reasoning**
  - Passing `size="var(--icon-md)"` into SVG width/height attributes often fails to honor design tokens, so icons rendered at the wrong size.
  - Tauri’s `Window.onFocusChanged` returns a sync unlisten that fire-and-forgets two async unlistens; when a listener is already gone, that surfaces as `listeners[eventId].handlerId` unhandled promise rejections.

- **Additional context**
  - No linked GitHub issue.
  - Verified with `pnpm check` and `pnpm build`.


## Screenshots

Non-visual behavior fix for Tauri listeners. Icon sizing is a layout consistency change across existing UI chrome (sidebar, tree, ribbon, settings); no new UI surfaces.


## Docs

Icon sizing pattern:

```tsx
// Before — CSS vars often ignored on the size prop
<HugeiconsIcon icon={NoteIcon} size="var(--icon-md)" />

// After — token applied via Tailwind size utility
<HugeiconsIcon icon={NoteIcon} className="size-[var(--icon-md)]" />
```

Window focus listening:

```ts
// Prefer this over getCurrentWindow().onFocusChanged(...)
const unlisten = await listenWindowFocusChanged((focused) => { ... });
// cleanup
safeUnlisten(unlisten);
```


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent SVG icon sizes by switching to CSS design-token classes, replaces Tauri focus listeners with a safe helper, and prevents Sigma resize errors when connections containers are hidden. Icons are now uniform and teardown no longer throws on window close or HMR.

- **Bug Fixes**
  - Icons now read `var(--icon-*)` via CSS classes (e.g., `size-[var(--icon-md)]`) instead of the `size` prop on `@hugeicons/react`, fixing mismatched dimensions.
  - Replaced `Window.onFocusChanged` with `listenWindowFocusChanged` and cleanup via `safeUnlisten`, preventing unhandled promise rejections during listener teardown.
  - Connections graph: skip resize and allow invalid containers when panels/dialogs are hidden or 0×0 to avoid Sigma errors.

- **Refactors**
  - `withDefaultIconSize` and `DatabaseColumnIcon` set default sizes via classes when no `size` is provided.
  - Standardized icon sizing across sidebar, file tree, editor, databases, settings, preview, and AI components.
  - Centralized event teardown with `safeUnlisten`; updated listeners in chat hooks, workspace session, settings store, license, shortcut bindings, UI provider, and theme bridge.

<sup>Written for commit 52456fbebef140ba6793d6d2ce70238c7a9c628e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon sizing consistency across navigation, editors, databases, settings, and dialogs.
  * Prevented connection visualizations from attempting layout calculations when panels are temporarily hidden or have no usable dimensions.
  * Improved reliability when refreshing content after window focus changes.
  * Reduced errors during application shutdown, reloads, and repeated event-listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->