### PR TITLE
Add split editor panes (#429) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.10-alpha.2",
+	"version": "0.8.10-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,7 @@
 @import "./styles/app/15-activity-timeline.css";
 @import "./styles/app/16-main-workspace-layout.css";
 @import "./styles/app/17-main-tabs.css";
+@import "./styles/app/17a-split-editors.css";
 @import "./styles/app/20-main-empty-state.css";
 @import "./styles/app/07-ai-panel.css";
 @import "./styles/app/21-ai-composer-context.css";

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -475,13 +475,13 @@ export function AppShell() {
 			}
 			const existingTab = tabs.find((tab) => tab.target === path);
 			if (existingTab) {
-				setActiveTabId(existingTab.id);
+				await openWorkspaceFile(path);
 				return;
 			}
 			openBlankTab();
 			await openWorkspaceFile(path);
 		},
-		[openBlankTab, openWorkspaceFile, setActiveTabId, tabs],
+		[openBlankTab, openWorkspaceFile, tabs],
 	);
 
 	const openFolioWorkspaceFileInNewTab = useCallback(
@@ -493,13 +493,13 @@ export function AppShell() {
 			}
 			const existingTab = tabs.find((tab) => tab.target === path);
 			if (existingTab) {
-				setActiveTabId(existingTab.id);
+				await openFolioWorkspaceFile(path);
 				return;
 			}
 			openBlankTab();
 			await openFolioWorkspaceFile(path);
 		},
-		[openBlankTab, openFolioWorkspaceFile, setActiveTabId, tabs],
+		[openBlankTab, openFolioWorkspaceFile, tabs],
 	);
 
 	const openQuickNoteWindow = useCallback(() => {
@@ -922,11 +922,12 @@ export function AppShell() {
 				nextDatabasesOpenRequest(current, {
 					databaseId: databaseId ?? null,
 					openCreateDialog: options?.openCreateDialog ?? false,
+					paneId: focusedPaneId,
 				}),
 			);
 			openSpecialTab(DATABASES_TAB_ID);
 		},
-		[openSpecialTab],
+		[focusedPaneId, openSpecialTab],
 	);
 	const openConnectionsView = useCallback(() => {
 		openSpecialTab(SPACE_CONNECTIONS_TAB_ID);

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -343,9 +343,13 @@ export function AppShell() {
 
 	const {
 		tabs,
+		panes,
+		splitLayout,
+		focusedPaneId,
 		activeTabId,
 		activeTabPath,
 		setActiveTabId,
+		focusPane,
 		setDirtyByPath,
 		closeTab,
 		closeAllTabs,
@@ -354,6 +358,12 @@ export function AppShell() {
 		renameTabsForPath,
 		reorderTabs,
 		openBlankTab,
+		openBlankTabInPane,
+		openFileInPane,
+		splitPaneWithFile,
+		splitPaneWithBlank,
+		moveTabToPane,
+		resizeSplit,
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
@@ -362,6 +372,8 @@ export function AppShell() {
 		canGoForward,
 		goBack,
 		goForward,
+		goBackInPane,
+		goForwardInPane,
 		activateNextTab,
 		activatePreviousTab,
 		activateTabByIndex,
@@ -374,6 +386,9 @@ export function AppShell() {
 		resumeLastSession,
 		onboardingNotePath,
 		tabs,
+		panes,
+		splitLayout,
+		focusedPaneId,
 		activeTabPath,
 		tabsRevision,
 		restoreWorkspaceTabs,
@@ -458,14 +473,15 @@ export function AppShell() {
 				await openWorkspaceFile(path);
 				return;
 			}
-			if (tabs.some((tab) => tab.target === path)) {
-				await openWorkspaceFile(path);
+			const existingTab = tabs.find((tab) => tab.target === path);
+			if (existingTab) {
+				setActiveTabId(existingTab.id);
 				return;
 			}
 			openBlankTab();
 			await openWorkspaceFile(path);
 		},
-		[openBlankTab, openWorkspaceFile, tabs],
+		[openBlankTab, openWorkspaceFile, setActiveTabId, tabs],
 	);
 
 	const openFolioWorkspaceFileInNewTab = useCallback(
@@ -475,14 +491,15 @@ export function AppShell() {
 				await openFolioWorkspaceFile(path);
 				return;
 			}
-			if (tabs.some((tab) => tab.target === path)) {
-				await openFolioWorkspaceFile(path);
+			const existingTab = tabs.find((tab) => tab.target === path);
+			if (existingTab) {
+				setActiveTabId(existingTab.id);
 				return;
 			}
 			openBlankTab();
 			await openFolioWorkspaceFile(path);
 		},
-		[openBlankTab, openFolioWorkspaceFile, tabs],
+		[openBlankTab, openFolioWorkspaceFile, setActiveTabId, tabs],
 	);
 
 	const openQuickNoteWindow = useCallback(() => {
@@ -1176,6 +1193,7 @@ export function AppShell() {
 		onOpenSpace,
 		openAllDocsTab,
 		openBlankTab,
+		splitPaneWithBlank,
 		openDatabasesTab,
 		openGettingStarted,
 		openCalendar,
@@ -1399,25 +1417,31 @@ export function AppShell() {
 				onPrefetchActivity={prefetchActivityTab}
 				onOpenDatabase={(databaseId) => openDatabasesTab(databaseId)}
 				tabs={tabs}
+				panes={panes}
+				splitLayout={splitLayout}
+				focusedPaneId={focusedPaneId}
 				rootEntries={rootEntries}
 				childrenByDir={childrenByDir}
 				activeTabId={activeTabId}
 				activeTabPath={activeTabPath}
 				setActiveTabId={setActiveTabId}
+				focusPane={focusPane}
 				setDirtyByPath={setDirtyByPath}
 				closeTab={closeTab}
 				closeTabsForPathRemoval={closeTabsForPathRemoval}
 				renameTabsForPath={renameTabsForPath}
 				reorderTabs={reorderTabs}
-				openBlankTab={openBlankTab}
+				openBlankTabInPane={openBlankTabInPane}
+				openFileInPane={openFileInPane}
+				splitPaneWithFile={splitPaneWithFile}
+				moveTabToPane={moveTabToPane}
+				resizeSplit={resizeSplit}
 				onStartRenamePath={handleStartRenameFromTab}
 				onNavigateBreadcrumbPath={handleNavigateBreadcrumbPath}
 				onLoadBreadcrumbDir={fileTree.loadDir}
 				replaceActiveTabWithBlank={replaceActiveTabWithBlank}
-				canGoBack={canGoBack}
-				canGoForward={canGoForward}
-				onGoBack={goBack}
-				onGoForward={goForward}
+				onGoBackInPane={goBackInPane}
+				onGoForwardInPane={goForwardInPane}
 				showGettingStartedRequest={showGettingStartedRequest}
 				databasesOpenRequest={databasesOpenRequest}
 				onConsumeDatabasesOpenRequest={consumeDatabasesOpenRequest}

--- a/src/components/app/EditorPaneCanvas.tsx
+++ b/src/components/app/EditorPaneCanvas.tsx
@@ -24,6 +24,7 @@ import {
 import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
 import type { FsEntry, GitCommitDiff } from "../../lib/tauri";
+import { isMarkdownPath } from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import type {
 	CreateMarkdownFileOptions,
@@ -115,7 +116,7 @@ export const EditorPaneCanvas = memo(function EditorPaneCanvas({
 	const handlePrefetchTab = useCallback(
 		(target: string | null) => {
 			if (!target) return;
-			if (target.toLowerCase().endsWith(".md")) {
+			if (isMarkdownPath(target)) {
 				prefetchNote(target);
 			} else if (target === ALL_DOCS_TAB_ID) {
 				void loadAllDocsPane();
@@ -291,7 +292,7 @@ function EditorPaneContent({
 			</Suspense>
 		);
 	}
-	if (!viewerPath.toLowerCase().endsWith(".md")) return null;
+	if (!isMarkdownPath(viewerPath)) return null;
 
 	const extractToNoteActions = {
 		createMarkdownFile: createMarkdownFileAtPath,

--- a/src/components/app/EditorPaneCanvas.tsx
+++ b/src/components/app/EditorPaneCanvas.tsx
@@ -1,0 +1,322 @@
+import {
+	type Dispatch,
+	type ReactNode,
+	type SetStateAction,
+	Suspense,
+	lazy,
+	memo,
+	useCallback,
+	useState,
+} from "react";
+import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
+import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
+import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
+import { DATABASES_TAB_ID } from "../../lib/databases";
+import {
+	ACTIVITY_DOCS_PAGE_SIZE,
+	getPrefetchedAllDocs,
+	getPrefetchedDatabaseDocument,
+	getPrefetchedNote,
+	prefetchAllDocs,
+	prefetchDatabasesLanding,
+	prefetchNote,
+} from "../../lib/navigationPrefetch";
+import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
+import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
+import type { FsEntry, GitCommitDiff } from "../../lib/tauri";
+import { onWindowDragMouseDown } from "../../utils/window";
+import type {
+	CreateMarkdownFileOptions,
+	ExtractToNoteActions,
+} from "../editor/types";
+import { NotePane } from "../preview/NotePane";
+import { CanvasPaneAwait } from "./CanvasPaneAwait";
+import { TabBar } from "./TabBar";
+import {
+	loadActivityTimelinePane,
+	loadAllDocsPane,
+	loadDatabasesPane,
+} from "./prefetchablePanes";
+import type { WorkspaceEditorPane } from "./useTabManager";
+
+const PinnedDocsPane = lazy(() =>
+	import("./PinnedDocsPane").then((module) => ({
+		default: module.PinnedDocsPane,
+	})),
+);
+const DatabasesPane = lazy(loadDatabasesPane);
+const AllDocsPane = lazy(loadAllDocsPane);
+const ActivityTimelinePane = lazy(loadActivityTimelinePane);
+const SpaceConnectionsView = lazy(() =>
+	import("../connections/SpaceConnectionsView").then((module) => ({
+		default: module.SpaceConnectionsView,
+	})),
+);
+
+interface EditorPaneCanvasProps {
+	pane: WorkspaceEditorPane;
+	focused: boolean;
+	allowWindowDrag: boolean;
+	rootEntries: FsEntry[];
+	childrenByDir: Record<string, FsEntry[] | undefined>;
+	emptyState: ReactNode;
+	createMarkdownFileAtPath: (
+		options: CreateMarkdownFileOptions,
+	) => Promise<string | null>;
+	onRenameFile: (path: string, nextName: string) => Promise<string | null>;
+	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onOpenActivity: () => void;
+	onPrefetchActivity: () => void;
+	onOpenDatabase: (databaseId: string) => void;
+	onStartRenamePath: (path: string) => void;
+	onNavigateBreadcrumbPath: (dirPath: string) => void;
+	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
+	onSelectTab: (tabId: string) => void;
+	onCloseTab: (tabId: string) => void;
+	onReorderTabs: (fromTabId: string, toTabId: string) => void;
+	onOpenBlankTab: (paneId: string) => void;
+	onGoBack: (paneId: string) => void;
+	onGoForward: (paneId: string) => void;
+	setDirtyByPath: Dispatch<SetStateAction<Record<string, boolean>>>;
+	onInfoSidebarOpenChange: (open: boolean) => void;
+	databasesOpenRequest: DatabasesOpenRequest;
+	onConsumeDatabasesOpenRequest?: () => void;
+}
+
+export const EditorPaneCanvas = memo(function EditorPaneCanvas({
+	pane,
+	focused,
+	allowWindowDrag,
+	rootEntries,
+	childrenByDir,
+	emptyState,
+	createMarkdownFileAtPath,
+	onRenameFile,
+	onOpenFile,
+	onOpenFileInNewTab,
+	onOpenActivity,
+	onPrefetchActivity,
+	onOpenDatabase,
+	onStartRenamePath,
+	onNavigateBreadcrumbPath,
+	onLoadBreadcrumbDir,
+	onSelectTab,
+	onCloseTab,
+	onReorderTabs,
+	onOpenBlankTab,
+	onGoBack,
+	onGoForward,
+	setDirtyByPath,
+	onInfoSidebarOpenChange,
+	databasesOpenRequest,
+	onConsumeDatabasesOpenRequest,
+}: EditorPaneCanvasProps) {
+	const handlePrefetchTab = useCallback(
+		(target: string | null) => {
+			if (!target) return;
+			if (target.toLowerCase().endsWith(".md")) {
+				prefetchNote(target);
+			} else if (target === ALL_DOCS_TAB_ID) {
+				void loadAllDocsPane();
+				void prefetchAllDocs(null);
+			} else if (target === ACTIVITY_TIMELINE_TAB_ID) {
+				void loadActivityTimelinePane();
+				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+			} else if (target === DATABASES_TAB_ID) {
+				void loadDatabasesPane();
+				void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
+			}
+		},
+		[databasesOpenRequest.databaseId],
+	);
+
+	const viewerPath = pane.activeTabPath;
+	const content = viewerPath ? (
+		<EditorPaneContent
+			key={pane.activeTabId}
+			viewerPath={viewerPath}
+			focused={focused}
+			createMarkdownFileAtPath={createMarkdownFileAtPath}
+			onRenameFile={onRenameFile}
+			onOpenFile={onOpenFile}
+			onOpenFileInNewTab={onOpenFileInNewTab}
+			onOpenActivity={onOpenActivity}
+			onPrefetchActivity={onPrefetchActivity}
+			onOpenDatabase={onOpenDatabase}
+			setDirtyByPath={setDirtyByPath}
+			onInfoSidebarOpenChange={onInfoSidebarOpenChange}
+			databasesOpenRequest={databasesOpenRequest}
+			onConsumeDatabasesOpenRequest={onConsumeDatabasesOpenRequest}
+		/>
+	) : null;
+
+	return (
+		<div
+			className="canvasPaneHost"
+			data-space-connections={
+				viewerPath === SPACE_CONNECTIONS_TAB_ID ? "true" : undefined
+			}
+			data-all-docs={
+				viewerPath === ALL_DOCS_TAB_ID ||
+				viewerPath === ACTIVITY_TIMELINE_TAB_ID
+					? "true"
+					: undefined
+			}
+			data-databases={viewerPath === DATABASES_TAB_ID ? "true" : undefined}
+		>
+			{pane.tabs.length > 0 ? (
+				<div className="mainTabBarTransition">
+					<TabBar
+						tabs={pane.tabs}
+						rootEntries={rootEntries}
+						childrenByDir={childrenByDir}
+						activeTabId={pane.activeTabId}
+						activeTabPath={pane.activeTabPath}
+						useWindowBackground={!content}
+						allowWindowDrag={allowWindowDrag}
+						canGoBack={pane.canGoBack}
+						canGoForward={pane.canGoForward}
+						onGoBack={() => onGoBack(pane.id)}
+						onGoForward={() => onGoForward(pane.id)}
+						onOpenBlankTab={() => onOpenBlankTab(pane.id)}
+						onPrefetchTab={handlePrefetchTab}
+						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
+						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
+						onOpenBreadcrumbFile={onOpenFile}
+						onRenameFile={onRenameFile}
+						onSelectTab={onSelectTab}
+						onCloseTab={onCloseTab}
+						onStartRenamePath={onStartRenamePath}
+						onReorder={onReorderTabs}
+					/>
+				</div>
+			) : (
+				<div
+					aria-hidden="true"
+					className="mainTabsEmptyDragRegion"
+					data-tauri-drag-region={allowWindowDrag ? "" : undefined}
+					onMouseDown={allowWindowDrag ? onWindowDragMouseDown : undefined}
+				/>
+			)}
+			{content ?? <div className="mainEmptyState">{emptyState}</div>}
+		</div>
+	);
+});
+
+interface EditorPaneContentProps {
+	viewerPath: string;
+	focused: boolean;
+	createMarkdownFileAtPath: EditorPaneCanvasProps["createMarkdownFileAtPath"];
+	onRenameFile: EditorPaneCanvasProps["onRenameFile"];
+	onOpenFile: EditorPaneCanvasProps["onOpenFile"];
+	onOpenFileInNewTab: EditorPaneCanvasProps["onOpenFileInNewTab"];
+	onOpenActivity: EditorPaneCanvasProps["onOpenActivity"];
+	onPrefetchActivity: EditorPaneCanvasProps["onPrefetchActivity"];
+	onOpenDatabase: EditorPaneCanvasProps["onOpenDatabase"];
+	setDirtyByPath: EditorPaneCanvasProps["setDirtyByPath"];
+	onInfoSidebarOpenChange: EditorPaneCanvasProps["onInfoSidebarOpenChange"];
+	databasesOpenRequest: DatabasesOpenRequest;
+	onConsumeDatabasesOpenRequest?: () => void;
+}
+
+function EditorPaneContent({
+	viewerPath,
+	focused,
+	createMarkdownFileAtPath,
+	onRenameFile,
+	onOpenFile,
+	onOpenFileInNewTab,
+	onOpenActivity,
+	onPrefetchActivity,
+	onOpenDatabase,
+	setDirtyByPath,
+	onInfoSidebarOpenChange,
+	databasesOpenRequest,
+	onConsumeDatabasesOpenRequest,
+}: EditorPaneContentProps) {
+	const [gitDiff, setGitDiff] = useState<GitCommitDiff | null>(null);
+
+	if (viewerPath === ALL_DOCS_TAB_ID) {
+		return (
+			<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+				<AllDocsPane
+					onOpenFile={onOpenFile}
+					onOpenActivity={onOpenActivity}
+					onPrefetchActivity={onPrefetchActivity}
+					initialNotes={getPrefetchedAllDocs(null)}
+				/>
+			</Suspense>
+		);
+	}
+	if (viewerPath === PINNED_DOCS_TAB_ID) {
+		return (
+			<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+				<PinnedDocsPane
+					onOpenFile={onOpenFile}
+					onOpenDatabase={onOpenDatabase}
+				/>
+			</Suspense>
+		);
+	}
+	if (viewerPath === ACTIVITY_TIMELINE_TAB_ID) {
+		return (
+			<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+				<ActivityTimelinePane onOpenFile={onOpenFile} />
+			</Suspense>
+		);
+	}
+	if (viewerPath === DATABASES_TAB_ID) {
+		const initialDatabaseId = databasesOpenRequest.databaseId;
+		return (
+			<Suspense fallback={<CanvasPaneAwait variant="databases" />}>
+				<DatabasesPane
+					onOpenFile={onOpenFile}
+					onRenameNotePath={onRenameFile}
+					databasesOpenRequest={databasesOpenRequest}
+					onConsumeOpenRequest={onConsumeDatabasesOpenRequest}
+					initialDocument={
+						initialDatabaseId
+							? getPrefetchedDatabaseDocument(initialDatabaseId)
+							: null
+					}
+				/>
+			</Suspense>
+		);
+	}
+	if (viewerPath === SPACE_CONNECTIONS_TAB_ID) {
+		return (
+			<Suspense fallback={<CanvasPaneAwait variant="connections" />}>
+				<SpaceConnectionsView />
+			</Suspense>
+		);
+	}
+	if (!viewerPath.toLowerCase().endsWith(".md")) return null;
+
+	const extractToNoteActions = {
+		createMarkdownFile: createMarkdownFileAtPath,
+		openNote: onOpenFile,
+		openNoteInNewTab: onOpenFileInNewTab,
+	} satisfies ExtractToNoteActions;
+
+	return (
+		<NotePane
+			relPath={viewerPath}
+			initialDoc={getPrefetchedNote(viewerPath)}
+			extractToNoteActions={extractToNoteActions}
+			active={focused}
+			onInfoSidebarOpenChange={
+				focused ? onInfoSidebarOpenChange : undefined
+			}
+			gitDiff={gitDiff}
+			onGitDiffChange={setGitDiff}
+			onDirtyChange={(dirty) =>
+				setDirtyByPath((previous) =>
+					previous[viewerPath] === dirty
+						? previous
+						: { ...previous, [viewerPath]: dirty },
+				)
+			}
+		/>
+	);
+}

--- a/src/components/app/EditorPaneCanvas.tsx
+++ b/src/components/app/EditorPaneCanvas.tsx
@@ -305,9 +305,7 @@ function EditorPaneContent({
 			initialDoc={getPrefetchedNote(viewerPath)}
 			extractToNoteActions={extractToNoteActions}
 			active={focused}
-			onInfoSidebarOpenChange={
-				focused ? onInfoSidebarOpenChange : undefined
-			}
+			onInfoSidebarOpenChange={focused ? onInfoSidebarOpenChange : undefined}
 			gitDiff={gitDiff}
 			onGitDiffChange={setGitDiff}
 			onDirtyChange={(dirty) =>

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -74,6 +74,7 @@ import { localizedSettingsTabLabel } from "../settings/settingsSearch";
 import { springPresets } from "../ui/animations";
 import { CanvasPaneAwait } from "./CanvasPaneAwait";
 import { GettingStartedPane } from "./GettingStartedPane";
+import { SplitEditorLayout } from "./SplitEditorLayout";
 import { TabBar } from "./TabBar";
 import { WelcomeScreen } from "./WelcomeScreen";
 import {
@@ -81,7 +82,15 @@ import {
 	loadAllDocsPane,
 	loadDatabasesPane,
 } from "./prefetchablePanes";
-import type { WorkspaceTab } from "./useTabManager";
+import type {
+	SplitEditorDragSource,
+	SplitEditorDropTarget,
+} from "./splitEditorDnd";
+import type { SplitEditorNode } from "./splitEditorModel";
+import type {
+	WorkspaceEditorPane,
+	WorkspaceTab,
+} from "./useTabManager";
 
 const PinnedDocsPane = lazy(() =>
 	import("./PinnedDocsPane").then((module) => ({
@@ -261,6 +270,302 @@ function ContextualEmptyState({
 	);
 }
 
+interface EditorPaneCanvasProps {
+	fileTree: MainContentProps["fileTree"];
+	pane: WorkspaceEditorPane;
+	focused: boolean;
+	allowWindowDrag: boolean;
+	rootEntries: FsEntry[];
+	childrenByDir: Record<string, FsEntry[] | undefined>;
+	onOpenFile: (relPath: string) => Promise<void>;
+	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onOpenActivity: () => void;
+	onPrefetchActivity: () => void;
+	onOpenDatabase: (databaseId: string) => void;
+	onCreateNote: () => void;
+	onOpenCommandPalette: () => void;
+	onOpenDailyNote: () => void;
+	onStartRenamePath: (path: string) => void;
+	onNavigateBreadcrumbPath: (dirPath: string) => void;
+	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
+	onSelectTab: (tabId: string) => void;
+	onCloseTab: (tabId: string) => void;
+	onReorderTabs: (fromTabId: string, toTabId: string) => void;
+	onOpenBlankTab: (paneId: string) => void;
+	onGoBack: (paneId: string) => void;
+	onGoForward: (paneId: string) => void;
+	setDirtyByPath: Dispatch<SetStateAction<Record<string, boolean>>>;
+	onInfoSidebarOpenChange: (open: boolean) => void;
+	onboarding: OnboardingSettings;
+	commandShortcutParts: string[];
+	showDailyNoteAction: boolean;
+	showStarterPane: boolean;
+	onDismissStarter: () => void;
+	databasesOpenRequest: DatabasesOpenRequest;
+	onConsumeDatabasesOpenRequest?: () => void;
+}
+
+const EditorPaneCanvas = memo(function EditorPaneCanvas({
+	fileTree,
+	pane,
+	focused,
+	allowWindowDrag,
+	rootEntries,
+	childrenByDir,
+	onOpenFile,
+	onOpenFileInNewTab,
+	onOpenActivity,
+	onPrefetchActivity,
+	onOpenDatabase,
+	onCreateNote,
+	onOpenCommandPalette,
+	onOpenDailyNote,
+	onStartRenamePath,
+	onNavigateBreadcrumbPath,
+	onLoadBreadcrumbDir,
+	onSelectTab,
+	onCloseTab,
+	onReorderTabs,
+	onOpenBlankTab,
+	onGoBack,
+	onGoForward,
+	setDirtyByPath,
+	onInfoSidebarOpenChange,
+	onboarding,
+	commandShortcutParts,
+	showDailyNoteAction,
+	showStarterPane,
+	onDismissStarter,
+	databasesOpenRequest,
+	onConsumeDatabasesOpenRequest,
+}: EditorPaneCanvasProps) {
+	const [activeGitDiffState, setActiveGitDiffState] =
+		useState<ActiveGitDiffState | null>(null);
+	const viewerPath = pane.activeTabPath;
+	const currentMarkdownPath = viewerPath?.toLowerCase().endsWith(".md")
+		? viewerPath
+		: null;
+	const activeGitDiff =
+		activeGitDiffState?.path === currentMarkdownPath
+			? activeGitDiffState.diff
+			: null;
+
+	useEffect(() => {
+		setActiveGitDiffState(null);
+	}, [viewerPath]);
+
+	const handleGitDiffChange = useCallback(
+		(diff: GitCommitDiff | null) => {
+			setActiveGitDiffState(
+				diff && currentMarkdownPath
+					? { path: currentMarkdownPath, diff }
+					: null,
+			);
+		},
+		[currentMarkdownPath],
+	);
+
+	const handlePrefetchTab = useCallback(
+		(target: string | null) => {
+			if (!target) return;
+			if (target.toLowerCase().endsWith(".md")) {
+				prefetchNote(target);
+				return;
+			}
+			if (target === ALL_DOCS_TAB_ID) {
+				void loadAllDocsPane();
+				void prefetchAllDocs(null);
+				return;
+			}
+			if (target === ACTIVITY_TIMELINE_TAB_ID) {
+				void loadActivityTimelinePane();
+				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
+				return;
+			}
+			if (target === DATABASES_TAB_ID) {
+				void loadDatabasesPane();
+				void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
+			}
+		},
+		[databasesOpenRequest.databaseId],
+	);
+
+	const content = useMemo(() => {
+		if (!viewerPath) return null;
+		if (viewerPath === ALL_DOCS_TAB_ID) {
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+					<AllDocsPane
+						onOpenFile={onOpenFile}
+						onOpenActivity={onOpenActivity}
+						onPrefetchActivity={onPrefetchActivity}
+						initialNotes={getPrefetchedAllDocs(null)}
+					/>
+				</Suspense>
+			);
+		}
+		if (viewerPath === PINNED_DOCS_TAB_ID) {
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+					<PinnedDocsPane
+						onOpenFile={onOpenFile}
+						onOpenDatabase={onOpenDatabase}
+					/>
+				</Suspense>
+			);
+		}
+		if (viewerPath === ACTIVITY_TIMELINE_TAB_ID) {
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
+					<ActivityTimelinePane onOpenFile={onOpenFile} />
+				</Suspense>
+			);
+		}
+		if (viewerPath === DATABASES_TAB_ID) {
+			const initialDatabaseId = databasesOpenRequest.databaseId;
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="databases" />}>
+					<DatabasesPane
+						onOpenFile={onOpenFile}
+						onRenameNotePath={(notePath, nextName) =>
+							fileTree.onRenameDir(notePath, nextName, "file")
+						}
+						databasesOpenRequest={databasesOpenRequest}
+						onConsumeOpenRequest={onConsumeDatabasesOpenRequest}
+						initialDocument={
+							initialDatabaseId
+								? getPrefetchedDatabaseDocument(initialDatabaseId)
+								: null
+						}
+					/>
+				</Suspense>
+			);
+		}
+		if (viewerPath === SPACE_CONNECTIONS_TAB_ID) {
+			return (
+				<Suspense fallback={<CanvasPaneAwait variant="connections" />}>
+					<SpaceConnectionsView />
+				</Suspense>
+			);
+		}
+		if (!viewerPath.toLowerCase().endsWith(".md")) return null;
+		const extractToNoteActions = {
+			createMarkdownFile: fileTree.createMarkdownFileAtPath,
+			openNote: onOpenFile,
+			openNoteInNewTab: onOpenFileInNewTab,
+		} satisfies ExtractToNoteActions;
+		return (
+			<NotePane
+				relPath={viewerPath}
+				initialDoc={getPrefetchedNote(viewerPath)}
+				extractToNoteActions={extractToNoteActions}
+				active={focused}
+				onInfoSidebarOpenChange={
+					focused ? onInfoSidebarOpenChange : undefined
+				}
+				gitDiff={activeGitDiff}
+				onGitDiffChange={handleGitDiffChange}
+				onDirtyChange={(dirty) =>
+					setDirtyByPath((previous) =>
+						previous[viewerPath] === dirty
+							? previous
+							: { ...previous, [viewerPath]: dirty },
+					)
+				}
+			/>
+		);
+	}, [
+		activeGitDiff,
+		databasesOpenRequest,
+		fileTree,
+		focused,
+		handleGitDiffChange,
+		onConsumeDatabasesOpenRequest,
+		onInfoSidebarOpenChange,
+		onOpenActivity,
+		onOpenDatabase,
+		onOpenFile,
+		onOpenFileInNewTab,
+		onPrefetchActivity,
+		setDirtyByPath,
+		viewerPath,
+	]);
+
+	const isSpaceConnectionsTab = viewerPath === SPACE_CONNECTIONS_TAB_ID;
+	const isAllDocsTab = viewerPath === ALL_DOCS_TAB_ID;
+	const isActivityTab = viewerPath === ACTIVITY_TIMELINE_TAB_ID;
+	const isDatabasesTab = viewerPath === DATABASES_TAB_ID;
+
+	return (
+		<div
+			className="canvasPaneHost"
+			data-space-connections={isSpaceConnectionsTab ? "true" : undefined}
+			data-all-docs={isAllDocsTab || isActivityTab ? "true" : undefined}
+			data-databases={isDatabasesTab ? "true" : undefined}
+		>
+			{pane.tabs.length > 0 ? (
+				<div className="mainTabBarTransition">
+					<TabBar
+						tabs={pane.tabs}
+						rootEntries={rootEntries}
+						childrenByDir={childrenByDir}
+						activeTabId={pane.activeTabId}
+						activeTabPath={pane.activeTabPath}
+						useWindowBackground={!content}
+						allowWindowDrag={allowWindowDrag}
+						canGoBack={pane.canGoBack}
+						canGoForward={pane.canGoForward}
+						onGoBack={() => onGoBack(pane.id)}
+						onGoForward={() => onGoForward(pane.id)}
+						onOpenBlankTab={() => onOpenBlankTab(pane.id)}
+						onPrefetchTab={handlePrefetchTab}
+						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
+						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
+						onOpenBreadcrumbFile={onOpenFile}
+						onRenameFile={(path, nextName) =>
+							fileTree.onRenameDir(path, nextName, "file")
+						}
+						onSelectTab={onSelectTab}
+						onCloseTab={onCloseTab}
+						onStartRenamePath={onStartRenamePath}
+						onReorder={onReorderTabs}
+					/>
+				</div>
+			) : (
+				<div
+					aria-hidden="true"
+					className="mainTabsEmptyDragRegion"
+					data-tauri-drag-region={allowWindowDrag ? "" : undefined}
+					onMouseDown={allowWindowDrag ? onWindowDragMouseDown : undefined}
+				/>
+			)}
+			{content ?? (
+				<div className="mainEmptyState">
+					{showStarterPane ? (
+						<GettingStartedPane
+							commandShortcutParts={commandShortcutParts}
+							showDailyNoteAction={showDailyNoteAction}
+							onCreateNote={onCreateNote}
+							onOpenCommandPalette={onOpenCommandPalette}
+							onOpenDailyNote={onOpenDailyNote}
+							onDismiss={onDismissStarter}
+						/>
+					) : (
+						<ContextualEmptyState
+							onboarding={onboarding}
+							commandShortcutParts={commandShortcutParts}
+							showDailyNoteAction={showDailyNoteAction}
+							onCreateNote={onCreateNote}
+							onOpenCommandPalette={onOpenCommandPalette}
+							onOpenDailyNote={onOpenDailyNote}
+						/>
+					)}
+				</div>
+			)}
+		</div>
+	);
+});
+
 interface MainContentProps {
 	fileTree: {
 		createMarkdownFileAtPath: (
@@ -285,6 +590,9 @@ interface MainContentProps {
 	onPrefetchActivity: () => void;
 	onOpenDatabase: (databaseId: string) => void;
 	tabs: WorkspaceTab[];
+	panes: Record<string, WorkspaceEditorPane>;
+	splitLayout: SplitEditorNode;
+	focusedPaneId: string;
 	rootEntries: FsEntry[];
 	childrenByDir: Record<string, FsEntry[] | undefined>;
 	activeTabId: string | null;
@@ -299,15 +607,26 @@ interface MainContentProps {
 		recursive?: boolean,
 	) => void;
 	reorderTabs: (fromTabId: string, toTabId: string) => void;
-	openBlankTab: () => void;
+	openBlankTabInPane: (paneId: string) => void;
+	openFileInPane: (path: string, paneId: string) => boolean;
+	splitPaneWithFile: (
+		paneId: string,
+		edge: Exclude<SplitEditorDropTarget["edge"], "center">,
+		path: string,
+	) => void;
+	moveTabToPane: (
+		tabId: string,
+		paneId: string,
+		edge: SplitEditorDropTarget["edge"],
+	) => void;
+	focusPane: (paneId: string) => void;
+	resizeSplit: (splitId: string, ratio: number) => void;
 	onStartRenamePath: (path: string) => void;
 	onNavigateBreadcrumbPath: (dirPath: string) => void;
 	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
 	replaceActiveTabWithBlank: () => void;
-	canGoBack: boolean;
-	canGoForward: boolean;
-	onGoBack: () => void;
-	onGoForward: () => void;
+	onGoBackInPane: (paneId: string) => void;
+	onGoForwardInPane: (paneId: string) => void;
 	showGettingStartedRequest: number;
 	databasesOpenRequest: DatabasesOpenRequest;
 	onConsumeDatabasesOpenRequest?: () => void;
@@ -329,6 +648,9 @@ export const MainContent = memo(function MainContent({
 	onPrefetchActivity,
 	onOpenDatabase,
 	tabs,
+	panes,
+	splitLayout,
+	focusedPaneId,
 	rootEntries,
 	childrenByDir,
 	activeTabId,
@@ -339,15 +661,18 @@ export const MainContent = memo(function MainContent({
 	closeTabsForPathRemoval,
 	renameTabsForPath,
 	reorderTabs,
-	openBlankTab,
+	openBlankTabInPane,
+	openFileInPane,
+	splitPaneWithFile,
+	moveTabToPane,
+	focusPane,
+	resizeSplit,
 	onStartRenamePath,
 	onNavigateBreadcrumbPath,
 	onLoadBreadcrumbDir,
 	replaceActiveTabWithBlank,
-	canGoBack,
-	canGoForward,
-	onGoBack,
-	onGoForward,
+	onGoBackInPane,
+	onGoForwardInPane,
 	showGettingStartedRequest,
 	databasesOpenRequest,
 	onConsumeDatabasesOpenRequest,
@@ -367,8 +692,6 @@ export const MainContent = memo(function MainContent({
 	const [starterOverrideVisible, setStarterOverrideVisible] = useState(false);
 	const [infoSidebarWidth, setInfoSidebarWidth] = useState(340);
 	const [infoSidebarOpen, setInfoSidebarOpen] = useState(false);
-	const [activeGitDiffState, setActiveGitDiffState] =
-		useState<ActiveGitDiffState | null>(null);
 	const handledShowGettingStartedRequestRef = useRef(0);
 	const handledDailyNoteSetupNoticeRequestRef = useRef(0);
 	const activeTab = useMemo(
@@ -413,31 +736,6 @@ export const MainContent = memo(function MainContent({
 		};
 	}, [closeTabsForPathRemoval, renameTabsForPath]);
 
-	const viewerPath = activeTabPath;
-	const currentMarkdownPath = viewerPath?.toLowerCase().endsWith(".md")
-		? viewerPath
-		: null;
-	const activeGitDiff =
-		activeGitDiffState?.path === currentMarkdownPath
-			? activeGitDiffState.diff
-			: null;
-
-	// biome-ignore lint/correctness/useExhaustiveDependencies: clear the active git diff when the viewer path changes.
-	useEffect(() => {
-		setActiveGitDiffState(null);
-	}, [viewerPath]);
-
-	const handleGitDiffChange = useCallback(
-		(diff: GitCommitDiff | null) => {
-			setActiveGitDiffState(
-				diff && currentMarkdownPath
-					? { path: currentMarkdownPath, diff }
-					: null,
-			);
-		},
-		[currentMarkdownPath],
-	);
-
 	const openCommandPaletteShortcut = getBinding("open-command-palette");
 	const commandShortcutParts = useMemo(
 		() =>
@@ -459,7 +757,6 @@ export const MainContent = memo(function MainContent({
 	const showStarterPane =
 		Boolean(spacePath) &&
 		(showStarterByDefault || (starterOverrideVisible && !activeTabPath));
-	const showTabBar = tabs.length > 0;
 	const aiSidebarVisible = aiEnabled && aiPanelOpen && !infoSidebarOpen;
 	const rightSidebarOpen =
 		Boolean(spacePath) &&
@@ -548,134 +845,6 @@ export const MainContent = memo(function MainContent({
 		[infoSidebarResize, rightSidebarOpen],
 	);
 
-	const content = useMemo(() => {
-		if (!viewerPath) return null;
-		if (viewerPath === ALL_DOCS_TAB_ID) {
-			const initialNotes = getPrefetchedAllDocs(null);
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<AllDocsPane
-						onOpenFile={onOpenFile}
-						onOpenActivity={onOpenActivity}
-						onPrefetchActivity={onPrefetchActivity}
-						initialNotes={initialNotes}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === PINNED_DOCS_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<PinnedDocsPane
-						onOpenFile={onOpenFile}
-						onOpenDatabase={onOpenDatabase}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === ACTIVITY_TIMELINE_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<ActivityTimelinePane onOpenFile={onOpenFile} />
-				</Suspense>
-			);
-		}
-		if (viewerPath === DATABASES_TAB_ID) {
-			const initialDatabaseId = databasesOpenRequest.databaseId;
-			const initialDocument = initialDatabaseId
-				? getPrefetchedDatabaseDocument(initialDatabaseId)
-				: null;
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="databases" />}>
-					<DatabasesPane
-						onOpenFile={onOpenFile}
-						onRenameNotePath={(notePath, nextName) =>
-							fileTree.onRenameDir(notePath, nextName, "file")
-						}
-						databasesOpenRequest={databasesOpenRequest}
-						onConsumeOpenRequest={onConsumeDatabasesOpenRequest}
-						initialDocument={initialDocument}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === SPACE_CONNECTIONS_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="connections" />}>
-					<SpaceConnectionsView />
-				</Suspense>
-			);
-		}
-		if (viewerPath.toLowerCase().endsWith(".md")) {
-			const initialDoc = getPrefetchedNote(viewerPath);
-			const extractToNoteActions = {
-				createMarkdownFile: fileTree.createMarkdownFileAtPath,
-				openNote: onOpenFile,
-				openNoteInNewTab: onOpenFileInNewTab,
-			} satisfies ExtractToNoteActions;
-			return (
-				<NotePane
-					relPath={viewerPath}
-					initialDoc={initialDoc}
-					extractToNoteActions={extractToNoteActions}
-					onInfoSidebarOpenChange={setInfoSidebarOpen}
-					gitDiff={activeGitDiff}
-					onGitDiffChange={handleGitDiffChange}
-					onDirtyChange={(dirty) =>
-						setDirtyByPath((prev) =>
-							prev[viewerPath] === dirty
-								? prev
-								: { ...prev, [viewerPath]: dirty },
-						)
-					}
-				/>
-			);
-		}
-		return null;
-	}, [
-		fileTree,
-		onOpenFile,
-		onOpenFileInNewTab,
-		onOpenActivity,
-		onPrefetchActivity,
-		onOpenDatabase,
-		databasesOpenRequest,
-		onConsumeDatabasesOpenRequest,
-		viewerPath,
-		setDirtyByPath,
-		activeGitDiff,
-		handleGitDiffChange,
-	]);
-
-	const handlePrefetchTab = useCallback(
-		(target: string | null) => {
-			if (!target) return;
-			if (target.toLowerCase().endsWith(".md")) {
-				prefetchNote(target);
-				return;
-			}
-			if (target === ALL_DOCS_TAB_ID) {
-				void loadAllDocsPane();
-				void prefetchAllDocs(null);
-				return;
-			}
-			if (target === ACTIVITY_TIMELINE_TAB_ID) {
-				void loadActivityTimelinePane();
-				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
-				return;
-			}
-			if (target === DATABASES_TAB_ID) {
-				void loadDatabasesPane();
-				void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
-				return;
-			}
-			if (target === SPACE_CONNECTIONS_TAB_ID) {
-				return;
-			}
-		},
-		[databasesOpenRequest.databaseId],
-	);
-
 	const settingsTabContentByTab: Record<SettingsTab, ReactNode> = {
 		general: <GeneralSettingsPane />,
 		appearance: <AppearanceSettingsPane />,
@@ -700,79 +869,112 @@ export const MainContent = memo(function MainContent({
 		activeSettingsTabMeta.id,
 		i18n.language,
 	);
-	const isSpaceConnectionsTab = viewerPath === SPACE_CONNECTIONS_TAB_ID;
-	const isAllDocsTab = viewerPath === ALL_DOCS_TAB_ID;
-	const isActivityTab = viewerPath === ACTIVITY_TIMELINE_TAB_ID;
-	const isDatabasesTab = viewerPath === DATABASES_TAB_ID;
-	const editorCanvas = (
-		<div
-			className="canvasPaneHost"
-			data-space-connections={isSpaceConnectionsTab ? "true" : undefined}
-			data-all-docs={isAllDocsTab || isActivityTab ? "true" : undefined}
-			data-databases={isDatabasesTab ? "true" : undefined}
-		>
-			{showTabBar ? (
-				<div className="mainTabBarTransition">
-					<TabBar
-						tabs={tabs}
-						rootEntries={rootEntries}
-						childrenByDir={childrenByDir}
-						activeTabId={activeTabId}
-						activeTabPath={activeTabPath}
-						useWindowBackground={!content}
-						canGoBack={canGoBack}
-						canGoForward={canGoForward}
-						onGoBack={onGoBack}
-						onGoForward={onGoForward}
-						onOpenBlankTab={openBlankTab}
-						onPrefetchTab={handlePrefetchTab}
-						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
-						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
-						onOpenBreadcrumbFile={onOpenFile}
-						onRenameFile={(path, nextName) =>
-							fileTree.onRenameDir(path, nextName, "file")
-						}
-						onSelectTab={setActiveTabId}
-						onCloseTab={closeTab}
-						onStartRenamePath={onStartRenamePath}
-						onReorder={reorderTabs}
-					/>
-				</div>
-			) : (
-				<div
-					aria-hidden="true"
-					className="mainTabsEmptyDragRegion"
-					data-tauri-drag-region
-					onMouseDown={onWindowDragMouseDown}
+	const handleSplitDrop = useCallback(
+		(source: SplitEditorDragSource, target: SplitEditorDropTarget) => {
+			if (source.kind === "tab") {
+				moveTabToPane(source.tabId, target.paneId, target.edge);
+				return;
+			}
+			const existingTab = tabs.find((tab) => tab.target === source.path);
+			if (existingTab) {
+				moveTabToPane(existingTab.id, target.paneId, target.edge);
+				return;
+			}
+			if (target.edge === "center") {
+				openFileInPane(source.path, target.paneId);
+				return;
+			}
+			splitPaneWithFile(target.paneId, target.edge, source.path);
+		},
+		[moveTabToPane, openFileInPane, splitPaneWithFile, tabs],
+	);
+
+	const renderEditorPane = useCallback(
+		(paneId: string, focused: boolean) => {
+			const pane = panes[paneId];
+			if (!pane) return null;
+			return (
+				<EditorPaneCanvas
+					key={paneId}
+					fileTree={fileTree}
+					pane={pane}
+					focused={focused}
+					allowWindowDrag={Object.keys(panes).length === 1}
+					rootEntries={rootEntries}
+					childrenByDir={childrenByDir}
+					onOpenFile={onOpenFile}
+					onOpenFileInNewTab={onOpenFileInNewTab}
+					onOpenActivity={onOpenActivity}
+					onPrefetchActivity={onPrefetchActivity}
+					onOpenDatabase={onOpenDatabase}
+					onCreateNote={onCreateNote}
+					onOpenCommandPalette={onOpenCommandPalette}
+					onOpenDailyNote={onOpenDailyNote}
+					onStartRenamePath={onStartRenamePath}
+					onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
+					onLoadBreadcrumbDir={onLoadBreadcrumbDir}
+					onSelectTab={setActiveTabId}
+					onCloseTab={closeTab}
+					onReorderTabs={reorderTabs}
+					onOpenBlankTab={openBlankTabInPane}
+					onGoBack={onGoBackInPane}
+					onGoForward={onGoForwardInPane}
+					setDirtyByPath={setDirtyByPath}
+					onInfoSidebarOpenChange={setInfoSidebarOpen}
+					onboarding={onboarding}
+					commandShortcutParts={commandShortcutParts}
+					showDailyNoteAction={Boolean(dailyNotesFolder)}
+					showStarterPane={focused && showStarterPane}
+					onDismissStarter={() => {
+						setStarterOverrideVisible(false);
+						void updateOnboardingSettings({ starterDismissed: true });
+					}}
+					databasesOpenRequest={databasesOpenRequest}
+					onConsumeDatabasesOpenRequest={onConsumeDatabasesOpenRequest}
 				/>
-			)}
-			{content ?? (
-				<div className="mainEmptyState">
-					{showStarterPane ? (
-						<GettingStartedPane
-							commandShortcutParts={commandShortcutParts}
-							showDailyNoteAction={Boolean(dailyNotesFolder)}
-							onCreateNote={onCreateNote}
-							onOpenCommandPalette={onOpenCommandPalette}
-							onOpenDailyNote={onOpenDailyNote}
-							onDismiss={() => {
-								setStarterOverrideVisible(false);
-								void updateOnboardingSettings({ starterDismissed: true });
-							}}
-						/>
-					) : (
-						<ContextualEmptyState
-							onboarding={onboarding}
-							commandShortcutParts={commandShortcutParts}
-							showDailyNoteAction={Boolean(dailyNotesFolder)}
-							onCreateNote={onCreateNote}
-							onOpenCommandPalette={onOpenCommandPalette}
-							onOpenDailyNote={onOpenDailyNote}
-						/>
-					)}
-				</div>
-			)}
-		</div>
+			);
+		},
+		[
+			childrenByDir,
+			closeTab,
+			commandShortcutParts,
+			dailyNotesFolder,
+			databasesOpenRequest,
+			fileTree,
+			onConsumeDatabasesOpenRequest,
+			onLoadBreadcrumbDir,
+			onNavigateBreadcrumbPath,
+			onOpenActivity,
+			onOpenCommandPalette,
+			onOpenDailyNote,
+			onOpenDatabase,
+			onOpenFile,
+			onOpenFileInNewTab,
+			onCreateNote,
+			onGoBackInPane,
+			onGoForwardInPane,
+			onPrefetchActivity,
+			onStartRenamePath,
+			onboarding,
+			openBlankTabInPane,
+			panes,
+			reorderTabs,
+			rootEntries,
+			setActiveTabId,
+			setDirtyByPath,
+			showStarterPane,
+			starterOverrideVisible,
+		],
+	);
+	const editorCanvas = (
+		<SplitEditorLayout
+			layout={splitLayout}
+			focusedPaneId={focusedPaneId}
+			onFocusPane={focusPane}
+			onDrop={handleSplitDrop}
+			onResizeSplit={resizeSplit}
+			renderPane={renderEditorPane}
+		/>
 	);
 	const rightSidebarSurface = (
 		<>

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -21,8 +21,6 @@ import {
 } from "../../contexts";
 import { useResizablePanel } from "../../hooks/useResizablePanel";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
-import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
-import { ALL_DOCS_TAB_ID } from "../../lib/allDocs";
 import {
 	PATH_REMOVED_EVENT,
 	PATH_RENAMED_EVENT,
@@ -31,17 +29,6 @@ import {
 } from "../../lib/appEvents";
 import { APP_TAGLINE } from "../../lib/copy";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
-import { DATABASES_TAB_ID } from "../../lib/databases";
-import {
-	ACTIVITY_DOCS_PAGE_SIZE,
-	getPrefetchedAllDocs,
-	getPrefetchedDatabaseDocument,
-	getPrefetchedNote,
-	prefetchAllDocs,
-	prefetchDatabasesLanding,
-	prefetchNote,
-} from "../../lib/navigationPrefetch";
-import { PINNED_DOCS_TAB_ID } from "../../lib/pinnedDocs";
 import {
 	DEFAULT_ONBOARDING_SETTINGS,
 	type OnboardingSettings,
@@ -49,20 +36,15 @@ import {
 	updateOnboardingSettings,
 } from "../../lib/settings";
 import { formatShortcutPartsForPlatform } from "../../lib/shortcuts/platform";
-import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
-import type { FsEntry, GitCommitDiff } from "../../lib/tauri";
+import type { SplitEditorNode } from "../../lib/splitEditor";
+import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { toast } from "../../lib/toast";
 import { cn } from "../../lib/utils";
-import { onWindowDragMouseDown } from "../../utils/window";
 import { Calendar, FileText } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
-import type {
-	CreateMarkdownFileOptions,
-	ExtractToNoteActions,
-} from "../editor/types";
+import type { CreateMarkdownFileOptions } from "../editor/types";
 import { FolioWorkspace } from "../folio/FolioWorkspace";
-import { NotePane } from "../preview/NotePane";
 import { AboutSettingsPane } from "../settings/AboutSettingsPane";
 import { AiSettingsPane } from "../settings/AiSettingsPane";
 import { AppearanceSettingsPane } from "../settings/AppearanceSettingsPane";
@@ -72,55 +54,28 @@ import { SpaceSettingsPane } from "../settings/SpaceSettingsPane";
 import { SETTINGS_TABS, type SettingsTab } from "../settings/settingsConfig";
 import { localizedSettingsTabLabel } from "../settings/settingsSearch";
 import { springPresets } from "../ui/animations";
-import { CanvasPaneAwait } from "./CanvasPaneAwait";
+import { EditorPaneCanvas } from "./EditorPaneCanvas";
 import { GettingStartedPane } from "./GettingStartedPane";
 import { SplitEditorLayout } from "./SplitEditorLayout";
-import { TabBar } from "./TabBar";
 import { WelcomeScreen } from "./WelcomeScreen";
-import {
-	loadActivityTimelinePane,
-	loadAllDocsPane,
-	loadDatabasesPane,
-} from "./prefetchablePanes";
 import type {
 	SplitEditorDragSource,
 	SplitEditorDropTarget,
 } from "./splitEditorDnd";
-import type { SplitEditorNode } from "./splitEditorModel";
 import type {
 	WorkspaceEditorPane,
 	WorkspaceTab,
 } from "./useTabManager";
 
-const PinnedDocsPane = lazy(() =>
-	import("./PinnedDocsPane").then((module) => ({
-		default: module.PinnedDocsPane,
-	})),
-);
-
-const DatabasesPane = lazy(loadDatabasesPane);
-const AllDocsPane = lazy(loadAllDocsPane);
-const ActivityTimelinePane = lazy(loadActivityTimelinePane);
 const DAILY_NOTES_SETUP_TOAST_ID = "daily-notes-setup";
 const ShortcutsSettingsPane = lazy(() =>
 	import("../settings/ShortcutsSettingsPane").then((module) => ({
 		default: module.ShortcutsSettingsPane,
 	})),
 );
-const SpaceConnectionsView = lazy(() =>
-	import("../connections/SpaceConnectionsView").then((module) => ({
-		default: module.SpaceConnectionsView,
-	})),
-);
-
-interface ActiveGitDiffState {
-	path: string;
-	diff: GitCommitDiff;
-}
-
 interface EmptyTip {
 	key: string;
-	icon: React.ReactNode;
+	icon: ReactNode;
 	text: string;
 	action: string;
 	onClick: () => void;
@@ -269,302 +224,6 @@ function ContextualEmptyState({
 		</div>
 	);
 }
-
-interface EditorPaneCanvasProps {
-	fileTree: MainContentProps["fileTree"];
-	pane: WorkspaceEditorPane;
-	focused: boolean;
-	allowWindowDrag: boolean;
-	rootEntries: FsEntry[];
-	childrenByDir: Record<string, FsEntry[] | undefined>;
-	onOpenFile: (relPath: string) => Promise<void>;
-	onOpenFileInNewTab: (relPath: string) => Promise<void>;
-	onOpenActivity: () => void;
-	onPrefetchActivity: () => void;
-	onOpenDatabase: (databaseId: string) => void;
-	onCreateNote: () => void;
-	onOpenCommandPalette: () => void;
-	onOpenDailyNote: () => void;
-	onStartRenamePath: (path: string) => void;
-	onNavigateBreadcrumbPath: (dirPath: string) => void;
-	onLoadBreadcrumbDir: (dirPath: string) => Promise<void>;
-	onSelectTab: (tabId: string) => void;
-	onCloseTab: (tabId: string) => void;
-	onReorderTabs: (fromTabId: string, toTabId: string) => void;
-	onOpenBlankTab: (paneId: string) => void;
-	onGoBack: (paneId: string) => void;
-	onGoForward: (paneId: string) => void;
-	setDirtyByPath: Dispatch<SetStateAction<Record<string, boolean>>>;
-	onInfoSidebarOpenChange: (open: boolean) => void;
-	onboarding: OnboardingSettings;
-	commandShortcutParts: string[];
-	showDailyNoteAction: boolean;
-	showStarterPane: boolean;
-	onDismissStarter: () => void;
-	databasesOpenRequest: DatabasesOpenRequest;
-	onConsumeDatabasesOpenRequest?: () => void;
-}
-
-const EditorPaneCanvas = memo(function EditorPaneCanvas({
-	fileTree,
-	pane,
-	focused,
-	allowWindowDrag,
-	rootEntries,
-	childrenByDir,
-	onOpenFile,
-	onOpenFileInNewTab,
-	onOpenActivity,
-	onPrefetchActivity,
-	onOpenDatabase,
-	onCreateNote,
-	onOpenCommandPalette,
-	onOpenDailyNote,
-	onStartRenamePath,
-	onNavigateBreadcrumbPath,
-	onLoadBreadcrumbDir,
-	onSelectTab,
-	onCloseTab,
-	onReorderTabs,
-	onOpenBlankTab,
-	onGoBack,
-	onGoForward,
-	setDirtyByPath,
-	onInfoSidebarOpenChange,
-	onboarding,
-	commandShortcutParts,
-	showDailyNoteAction,
-	showStarterPane,
-	onDismissStarter,
-	databasesOpenRequest,
-	onConsumeDatabasesOpenRequest,
-}: EditorPaneCanvasProps) {
-	const [activeGitDiffState, setActiveGitDiffState] =
-		useState<ActiveGitDiffState | null>(null);
-	const viewerPath = pane.activeTabPath;
-	const currentMarkdownPath = viewerPath?.toLowerCase().endsWith(".md")
-		? viewerPath
-		: null;
-	const activeGitDiff =
-		activeGitDiffState?.path === currentMarkdownPath
-			? activeGitDiffState.diff
-			: null;
-
-	useEffect(() => {
-		setActiveGitDiffState(null);
-	}, [viewerPath]);
-
-	const handleGitDiffChange = useCallback(
-		(diff: GitCommitDiff | null) => {
-			setActiveGitDiffState(
-				diff && currentMarkdownPath
-					? { path: currentMarkdownPath, diff }
-					: null,
-			);
-		},
-		[currentMarkdownPath],
-	);
-
-	const handlePrefetchTab = useCallback(
-		(target: string | null) => {
-			if (!target) return;
-			if (target.toLowerCase().endsWith(".md")) {
-				prefetchNote(target);
-				return;
-			}
-			if (target === ALL_DOCS_TAB_ID) {
-				void loadAllDocsPane();
-				void prefetchAllDocs(null);
-				return;
-			}
-			if (target === ACTIVITY_TIMELINE_TAB_ID) {
-				void loadActivityTimelinePane();
-				void prefetchAllDocs(null, ACTIVITY_DOCS_PAGE_SIZE);
-				return;
-			}
-			if (target === DATABASES_TAB_ID) {
-				void loadDatabasesPane();
-				void prefetchDatabasesLanding(databasesOpenRequest.databaseId);
-			}
-		},
-		[databasesOpenRequest.databaseId],
-	);
-
-	const content = useMemo(() => {
-		if (!viewerPath) return null;
-		if (viewerPath === ALL_DOCS_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<AllDocsPane
-						onOpenFile={onOpenFile}
-						onOpenActivity={onOpenActivity}
-						onPrefetchActivity={onPrefetchActivity}
-						initialNotes={getPrefetchedAllDocs(null)}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === PINNED_DOCS_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<PinnedDocsPane
-						onOpenFile={onOpenFile}
-						onOpenDatabase={onOpenDatabase}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === ACTIVITY_TIMELINE_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="all-docs" />}>
-					<ActivityTimelinePane onOpenFile={onOpenFile} />
-				</Suspense>
-			);
-		}
-		if (viewerPath === DATABASES_TAB_ID) {
-			const initialDatabaseId = databasesOpenRequest.databaseId;
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="databases" />}>
-					<DatabasesPane
-						onOpenFile={onOpenFile}
-						onRenameNotePath={(notePath, nextName) =>
-							fileTree.onRenameDir(notePath, nextName, "file")
-						}
-						databasesOpenRequest={databasesOpenRequest}
-						onConsumeOpenRequest={onConsumeDatabasesOpenRequest}
-						initialDocument={
-							initialDatabaseId
-								? getPrefetchedDatabaseDocument(initialDatabaseId)
-								: null
-						}
-					/>
-				</Suspense>
-			);
-		}
-		if (viewerPath === SPACE_CONNECTIONS_TAB_ID) {
-			return (
-				<Suspense fallback={<CanvasPaneAwait variant="connections" />}>
-					<SpaceConnectionsView />
-				</Suspense>
-			);
-		}
-		if (!viewerPath.toLowerCase().endsWith(".md")) return null;
-		const extractToNoteActions = {
-			createMarkdownFile: fileTree.createMarkdownFileAtPath,
-			openNote: onOpenFile,
-			openNoteInNewTab: onOpenFileInNewTab,
-		} satisfies ExtractToNoteActions;
-		return (
-			<NotePane
-				relPath={viewerPath}
-				initialDoc={getPrefetchedNote(viewerPath)}
-				extractToNoteActions={extractToNoteActions}
-				active={focused}
-				onInfoSidebarOpenChange={
-					focused ? onInfoSidebarOpenChange : undefined
-				}
-				gitDiff={activeGitDiff}
-				onGitDiffChange={handleGitDiffChange}
-				onDirtyChange={(dirty) =>
-					setDirtyByPath((previous) =>
-						previous[viewerPath] === dirty
-							? previous
-							: { ...previous, [viewerPath]: dirty },
-					)
-				}
-			/>
-		);
-	}, [
-		activeGitDiff,
-		databasesOpenRequest,
-		fileTree,
-		focused,
-		handleGitDiffChange,
-		onConsumeDatabasesOpenRequest,
-		onInfoSidebarOpenChange,
-		onOpenActivity,
-		onOpenDatabase,
-		onOpenFile,
-		onOpenFileInNewTab,
-		onPrefetchActivity,
-		setDirtyByPath,
-		viewerPath,
-	]);
-
-	const isSpaceConnectionsTab = viewerPath === SPACE_CONNECTIONS_TAB_ID;
-	const isAllDocsTab = viewerPath === ALL_DOCS_TAB_ID;
-	const isActivityTab = viewerPath === ACTIVITY_TIMELINE_TAB_ID;
-	const isDatabasesTab = viewerPath === DATABASES_TAB_ID;
-
-	return (
-		<div
-			className="canvasPaneHost"
-			data-space-connections={isSpaceConnectionsTab ? "true" : undefined}
-			data-all-docs={isAllDocsTab || isActivityTab ? "true" : undefined}
-			data-databases={isDatabasesTab ? "true" : undefined}
-		>
-			{pane.tabs.length > 0 ? (
-				<div className="mainTabBarTransition">
-					<TabBar
-						tabs={pane.tabs}
-						rootEntries={rootEntries}
-						childrenByDir={childrenByDir}
-						activeTabId={pane.activeTabId}
-						activeTabPath={pane.activeTabPath}
-						useWindowBackground={!content}
-						allowWindowDrag={allowWindowDrag}
-						canGoBack={pane.canGoBack}
-						canGoForward={pane.canGoForward}
-						onGoBack={() => onGoBack(pane.id)}
-						onGoForward={() => onGoForward(pane.id)}
-						onOpenBlankTab={() => onOpenBlankTab(pane.id)}
-						onPrefetchTab={handlePrefetchTab}
-						onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
-						onLoadBreadcrumbDir={onLoadBreadcrumbDir}
-						onOpenBreadcrumbFile={onOpenFile}
-						onRenameFile={(path, nextName) =>
-							fileTree.onRenameDir(path, nextName, "file")
-						}
-						onSelectTab={onSelectTab}
-						onCloseTab={onCloseTab}
-						onStartRenamePath={onStartRenamePath}
-						onReorder={onReorderTabs}
-					/>
-				</div>
-			) : (
-				<div
-					aria-hidden="true"
-					className="mainTabsEmptyDragRegion"
-					data-tauri-drag-region={allowWindowDrag ? "" : undefined}
-					onMouseDown={allowWindowDrag ? onWindowDragMouseDown : undefined}
-				/>
-			)}
-			{content ?? (
-				<div className="mainEmptyState">
-					{showStarterPane ? (
-						<GettingStartedPane
-							commandShortcutParts={commandShortcutParts}
-							showDailyNoteAction={showDailyNoteAction}
-							onCreateNote={onCreateNote}
-							onOpenCommandPalette={onOpenCommandPalette}
-							onOpenDailyNote={onOpenDailyNote}
-							onDismiss={onDismissStarter}
-						/>
-					) : (
-						<ContextualEmptyState
-							onboarding={onboarding}
-							commandShortcutParts={commandShortcutParts}
-							showDailyNoteAction={showDailyNoteAction}
-							onCreateNote={onCreateNote}
-							onOpenCommandPalette={onOpenCommandPalette}
-							onOpenDailyNote={onOpenDailyNote}
-						/>
-					)}
-				</div>
-			)}
-		</div>
-	);
-});
 
 interface MainContentProps {
 	fileTree: {
@@ -869,15 +528,19 @@ export const MainContent = memo(function MainContent({
 		activeSettingsTabMeta.id,
 		i18n.language,
 	);
+	const handleRenameFile = useCallback(
+		(path: string, nextName: string) =>
+			fileTree.onRenameDir(path, nextName, "file"),
+		[fileTree.onRenameDir],
+	);
+	const handleDismissStarter = useCallback(() => {
+		setStarterOverrideVisible(false);
+		void updateOnboardingSettings({ starterDismissed: true });
+	}, []);
 	const handleSplitDrop = useCallback(
 		(source: SplitEditorDragSource, target: SplitEditorDropTarget) => {
 			if (source.kind === "tab") {
 				moveTabToPane(source.tabId, target.paneId, target.edge);
-				return;
-			}
-			const existingTab = tabs.find((tab) => tab.target === source.path);
-			if (existingTab) {
-				moveTabToPane(existingTab.id, target.paneId, target.edge);
 				return;
 			}
 			if (target.edge === "center") {
@@ -886,30 +549,49 @@ export const MainContent = memo(function MainContent({
 			}
 			splitPaneWithFile(target.paneId, target.edge, source.path);
 		},
-		[moveTabToPane, openFileInPane, splitPaneWithFile, tabs],
+		[moveTabToPane, openFileInPane, splitPaneWithFile],
 	);
 
 	const renderEditorPane = useCallback(
 		(paneId: string, focused: boolean) => {
 			const pane = panes[paneId];
 			if (!pane) return null;
+			const emptyState =
+				focused && showStarterPane ? (
+					<GettingStartedPane
+						commandShortcutParts={commandShortcutParts}
+						showDailyNoteAction={Boolean(dailyNotesFolder)}
+						onCreateNote={onCreateNote}
+						onOpenCommandPalette={onOpenCommandPalette}
+						onOpenDailyNote={onOpenDailyNote}
+						onDismiss={handleDismissStarter}
+					/>
+				) : (
+					<ContextualEmptyState
+						onboarding={onboarding}
+						commandShortcutParts={commandShortcutParts}
+						showDailyNoteAction={Boolean(dailyNotesFolder)}
+						onCreateNote={onCreateNote}
+						onOpenCommandPalette={onOpenCommandPalette}
+						onOpenDailyNote={onOpenDailyNote}
+					/>
+				);
 			return (
 				<EditorPaneCanvas
 					key={paneId}
-					fileTree={fileTree}
 					pane={pane}
 					focused={focused}
-					allowWindowDrag={Object.keys(panes).length === 1}
+					allowWindowDrag={splitLayout.type === "pane"}
 					rootEntries={rootEntries}
 					childrenByDir={childrenByDir}
+					emptyState={emptyState}
+					createMarkdownFileAtPath={fileTree.createMarkdownFileAtPath}
+					onRenameFile={handleRenameFile}
 					onOpenFile={onOpenFile}
 					onOpenFileInNewTab={onOpenFileInNewTab}
 					onOpenActivity={onOpenActivity}
 					onPrefetchActivity={onPrefetchActivity}
 					onOpenDatabase={onOpenDatabase}
-					onCreateNote={onCreateNote}
-					onOpenCommandPalette={onOpenCommandPalette}
-					onOpenDailyNote={onOpenDailyNote}
 					onStartRenamePath={onStartRenamePath}
 					onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
 					onLoadBreadcrumbDir={onLoadBreadcrumbDir}
@@ -921,14 +603,6 @@ export const MainContent = memo(function MainContent({
 					onGoForward={onGoForwardInPane}
 					setDirtyByPath={setDirtyByPath}
 					onInfoSidebarOpenChange={setInfoSidebarOpen}
-					onboarding={onboarding}
-					commandShortcutParts={commandShortcutParts}
-					showDailyNoteAction={Boolean(dailyNotesFolder)}
-					showStarterPane={focused && showStarterPane}
-					onDismissStarter={() => {
-						setStarterOverrideVisible(false);
-						void updateOnboardingSettings({ starterDismissed: true });
-					}}
 					databasesOpenRequest={databasesOpenRequest}
 					onConsumeDatabasesOpenRequest={onConsumeDatabasesOpenRequest}
 				/>
@@ -941,6 +615,8 @@ export const MainContent = memo(function MainContent({
 			dailyNotesFolder,
 			databasesOpenRequest,
 			fileTree,
+			handleDismissStarter,
+			handleRenameFile,
 			onConsumeDatabasesOpenRequest,
 			onLoadBreadcrumbDir,
 			onNavigateBreadcrumbPath,
@@ -963,7 +639,7 @@ export const MainContent = memo(function MainContent({
 			setActiveTabId,
 			setDirtyByPath,
 			showStarterPane,
-			starterOverrideVisible,
+			splitLayout.type,
 		],
 	);
 	const editorCanvas = (

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -28,7 +28,10 @@ import {
 	type PathRenamedDetail,
 } from "../../lib/appEvents";
 import { APP_TAGLINE } from "../../lib/copy";
-import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
+import {
+	type DatabasesOpenRequest,
+	INITIAL_DATABASES_OPEN_REQUEST,
+} from "../../lib/database/openDatabasesRequest";
 import {
 	DEFAULT_ONBOARDING_SETTINGS,
 	type OnboardingSettings,
@@ -553,6 +556,11 @@ export const MainContent = memo(function MainContent({
 		(paneId: string, focused: boolean) => {
 			const pane = panes[paneId];
 			if (!pane) return null;
+			const handlesDatabasesOpenRequest =
+				databasesOpenRequest.paneId === paneId;
+			const paneDatabasesOpenRequest = handlesDatabasesOpenRequest
+				? databasesOpenRequest
+				: INITIAL_DATABASES_OPEN_REQUEST;
 			const emptyState =
 				focused && showStarterPane ? (
 					<GettingStartedPane
@@ -600,8 +608,12 @@ export const MainContent = memo(function MainContent({
 					onGoForward={onGoForwardInPane}
 					setDirtyByPath={setDirtyByPath}
 					onInfoSidebarOpenChange={setInfoSidebarOpen}
-					databasesOpenRequest={databasesOpenRequest}
-					onConsumeDatabasesOpenRequest={onConsumeDatabasesOpenRequest}
+					databasesOpenRequest={paneDatabasesOpenRequest}
+					onConsumeDatabasesOpenRequest={
+						handlesDatabasesOpenRequest
+							? onConsumeDatabasesOpenRequest
+							: undefined
+					}
 				/>
 			);
 		},

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -62,10 +62,7 @@ import type {
 	SplitEditorDragSource,
 	SplitEditorDropTarget,
 } from "./splitEditorDnd";
-import type {
-	WorkspaceEditorPane,
-	WorkspaceTab,
-} from "./useTabManager";
+import type { WorkspaceEditorPane, WorkspaceTab } from "./useTabManager";
 
 const DAILY_NOTES_SETUP_TOAST_ID = "daily-notes-setup";
 const ShortcutsSettingsPane = lazy(() =>

--- a/src/components/app/SplitEditorLayout.tsx
+++ b/src/components/app/SplitEditorLayout.tsx
@@ -8,21 +8,16 @@ import {
 	useState,
 } from "react";
 import {
-	listenForSplitEditorDragEnd,
-	listenForSplitEditorDragMove,
-	listenForSplitEditorDragStart,
-	splitEditorDropTargetAtPoint,
-} from "./splitEditorDnd";
+	DEFAULT_SPLIT_RATIO,
+	MAX_SPLIT_RATIO,
+	MIN_SPLIT_RATIO,
+	type SplitEditorNode,
+} from "../../lib/splitEditor";
+import { subscribeToSplitEditorDrag } from "./splitEditorDnd";
 import type {
 	SplitEditorDragSource,
 	SplitEditorDropTarget,
 } from "./splitEditorDnd";
-import {
-	DEFAULT_SPLIT_RATIO,
-	MAX_SPLIT_RATIO,
-	MIN_SPLIT_RATIO,
-} from "./splitEditorModel";
-import type { SplitEditorNode } from "./splitEditorModel";
 
 const KEYBOARD_RESIZE_STEP = 0.02;
 const KEYBOARD_RESIZE_LARGE_STEP = 0.05;
@@ -37,8 +32,24 @@ interface DropPreviewBounds {
 }
 
 interface DropPreview {
+	source: SplitEditorDragSource;
 	target: SplitEditorDropTarget;
 	bounds: DropPreviewBounds;
+}
+
+function dropEdgeAtPoint(
+	rect: DOMRect,
+	clientX: number,
+	clientY: number,
+): SplitEditorDropTarget["edge"] {
+	const x = (clientX - rect.left) / rect.width;
+	const y = (clientY - rect.top) / rect.height;
+	const edgeSize = 0.3;
+	if (y < edgeSize) return "top";
+	if (y > 1 - edgeSize) return "bottom";
+	if (x < edgeSize) return "left";
+	if (x > 1 - edgeSize) return "right";
+	return "center";
 }
 
 function splitDropPreviewBounds(
@@ -50,55 +61,30 @@ function splitDropPreviewBounds(
 	const paneTop = paneRect.top - layoutRect.top;
 	const halfWidth = paneRect.width / 2;
 	const halfHeight = paneRect.height / 2;
-	const fullWidth = Math.max(0, paneRect.width - DROP_PREVIEW_INSET * 2);
-	const fullHeight = Math.max(0, paneRect.height - DROP_PREVIEW_INSET * 2);
-	const splitWidth = Math.max(
-		0,
-		halfWidth - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
-	);
-	const splitHeight = Math.max(
-		0,
-		halfHeight - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
-	);
-
-	if (edge === "left") {
-		return {
-			left: paneLeft + DROP_PREVIEW_INSET,
-			top: paneTop + DROP_PREVIEW_INSET,
-			width: splitWidth,
-			height: fullHeight,
-		};
-	}
-	if (edge === "right") {
-		return {
-			left: paneLeft + halfWidth + DROP_PREVIEW_SPLIT_GAP,
-			top: paneTop + DROP_PREVIEW_INSET,
-			width: splitWidth,
-			height: fullHeight,
-		};
-	}
-	if (edge === "top") {
-		return {
-			left: paneLeft + DROP_PREVIEW_INSET,
-			top: paneTop + DROP_PREVIEW_INSET,
-			width: fullWidth,
-			height: splitHeight,
-		};
-	}
-	if (edge === "bottom") {
-		return {
-			left: paneLeft + DROP_PREVIEW_INSET,
-			top: paneTop + halfHeight + DROP_PREVIEW_SPLIT_GAP,
-			width: fullWidth,
-			height: splitHeight,
-		};
-	}
-	return {
+	const bounds = {
 		left: paneLeft + DROP_PREVIEW_INSET,
 		top: paneTop + DROP_PREVIEW_INSET,
-		width: fullWidth,
-		height: fullHeight,
+		width: Math.max(0, paneRect.width - DROP_PREVIEW_INSET * 2),
+		height: Math.max(0, paneRect.height - DROP_PREVIEW_INSET * 2),
 	};
+	if (edge === "left" || edge === "right") {
+		bounds.width = Math.max(
+			0,
+			halfWidth - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
+		);
+		if (edge === "right") {
+			bounds.left = paneLeft + halfWidth + DROP_PREVIEW_SPLIT_GAP;
+		}
+	} else if (edge === "top" || edge === "bottom") {
+		bounds.height = Math.max(
+			0,
+			halfHeight - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
+		);
+		if (edge === "bottom") {
+			bounds.top = paneTop + halfHeight + DROP_PREVIEW_SPLIT_GAP;
+		}
+	}
+	return bounds;
 }
 
 interface SplitEditorLayoutProps {
@@ -121,68 +107,87 @@ export function SplitEditorLayout({
 	onResizeSplit,
 	renderPane,
 }: SplitEditorLayoutProps) {
-	const [dragSource, setDragSource] =
-		useState<SplitEditorDragSource | null>(null);
 	const [dropPreview, setDropPreview] = useState<DropPreview | null>(null);
 	const pointerRef = useRef({ x: 0, y: 0 });
 	const dragSourceRef = useRef<SplitEditorDragSource | null>(null);
+	const dropTargetRef = useRef<SplitEditorDropTarget | null>(null);
 	const layoutRef = useRef<HTMLDivElement | null>(null);
 	const paneElementsRef = useRef(new Map<string, HTMLElement>());
 
 	const updateDropPreview = useCallback((x: number, y: number) => {
 		pointerRef.current = { x, y };
 		if (!dragSourceRef.current) return;
-		const target = splitEditorDropTargetAtPoint(x, y);
 		const layoutElement = layoutRef.current;
-		const paneElement = target
-			? paneElementsRef.current.get(target.paneId)
-			: null;
-		if (!target || !layoutElement || !paneElement) {
+		let paneEntry: [string, HTMLElement] | null = null;
+		for (const entry of paneElementsRef.current) {
+			const rect = entry[1].getBoundingClientRect();
+			if (
+				x >= rect.left &&
+				x <= rect.right &&
+				y >= rect.top &&
+				y <= rect.bottom
+			) {
+				paneEntry = entry;
+				break;
+			}
+		}
+		if (!layoutElement || !paneEntry) {
+			dropTargetRef.current = null;
 			setDropPreview(null);
 			return;
 		}
+		const [paneId, paneElement] = paneEntry;
+		const paneRect = paneElement.getBoundingClientRect();
+		const target = {
+			paneId,
+			edge: dropEdgeAtPoint(paneRect, x, y),
+		};
+		if (
+			dropTargetRef.current?.paneId === target.paneId &&
+			dropTargetRef.current.edge === target.edge
+		) {
+			return;
+		}
+		dropTargetRef.current = target;
 		setDropPreview({
+			source: dragSourceRef.current,
 			target,
 			bounds: splitDropPreviewBounds(
 				layoutElement.getBoundingClientRect(),
-				paneElement.getBoundingClientRect(),
+				paneRect,
 				target.edge,
 			),
 		});
 	}, []);
 
 	useEffect(() => {
-		const stopStart = listenForSplitEditorDragStart((source) => {
-			dragSourceRef.current = source;
-			setDragSource(source);
-			const { x, y } = pointerRef.current;
-			updateDropPreview(x, y);
-		});
-		const stopMove = listenForSplitEditorDragMove((x, y) => {
-			updateDropPreview(x, y);
-		});
-		const stopEnd = listenForSplitEditorDragEnd((source, event) => {
-			const { x, y } = pointerRef.current;
-			const target = splitEditorDropTargetAtPoint(x, y);
+		return subscribeToSplitEditorDrag((event) => {
+			if (event.type === "start") {
+				dragSourceRef.current = event.source;
+				const { x, y } = pointerRef.current;
+				updateDropPreview(x, y);
+				return;
+			}
+			if (event.type === "move") {
+				updateDropPreview(event.x, event.y);
+				return;
+			}
+
+			const target = dropTargetRef.current;
+			const source = event.source;
 			const shouldHandleDrop =
 				source &&
 				target &&
 				(source.kind === "file" ||
 					target.edge !== "center" ||
 					source.paneId !== target.paneId);
-			if (source && target && shouldHandleDrop) {
-				event.preventDefault();
-				onDrop(source, target);
-			}
 			dragSourceRef.current = null;
-			setDragSource(null);
+			dropTargetRef.current = null;
 			setDropPreview(null);
+			if (!source || !target || !shouldHandleDrop) return false;
+			onDrop(source, target);
+			return true;
 		});
-		return () => {
-			stopStart();
-			stopMove();
-			stopEnd();
-		};
 	}, [onDrop, updateDropPreview]);
 
 	const renderNode = useCallback(
@@ -245,9 +250,9 @@ export function SplitEditorLayout({
 	);
 
 	const suppressSamePaneCenterPreview =
-		dragSource?.kind === "tab" &&
+		dropPreview?.source.kind === "tab" &&
 		dropPreview?.target.edge === "center" &&
-		dragSource.paneId === dropPreview.target.paneId;
+		dropPreview.source.paneId === dropPreview.target.paneId;
 
 	return (
 		<div ref={layoutRef} className="splitEditorLayout">
@@ -273,6 +278,7 @@ function SplitDivider({
 	onResize: (ratio: number) => void;
 }) {
 	const [isResizing, setIsResizing] = useState(false);
+	const resizeRef = useRef<{ pointerId: number; rect: DOMRect } | null>(null);
 	const handlePointerDown = useCallback(
 		(event: ReactPointerEvent<HTMLDivElement>) => {
 			const divider = event.currentTarget;
@@ -281,25 +287,32 @@ function SplitDivider({
 			event.preventDefault();
 			setIsResizing(true);
 			divider.setPointerCapture(event.pointerId);
-			const rect = branch.getBoundingClientRect();
-			const handlePointerMove = (moveEvent: PointerEvent) => {
-				const ratio =
-					direction === "horizontal"
-						? (moveEvent.clientX - rect.left) / rect.width
-						: (moveEvent.clientY - rect.top) / rect.height;
-				onResize(ratio);
+			resizeRef.current = {
+				pointerId: event.pointerId,
+				rect: branch.getBoundingClientRect(),
 			};
-			const handlePointerUp = () => {
-				setIsResizing(false);
-				divider.removeEventListener("pointermove", handlePointerMove);
-				divider.removeEventListener("pointerup", handlePointerUp);
-				divider.removeEventListener("pointercancel", handlePointerUp);
-			};
-			divider.addEventListener("pointermove", handlePointerMove);
-			divider.addEventListener("pointerup", handlePointerUp);
-			divider.addEventListener("pointercancel", handlePointerUp);
+		},
+		[],
+	);
+	const handlePointerMove = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			const resize = resizeRef.current;
+			if (!resize || resize.pointerId !== event.pointerId) return;
+			const ratio =
+				direction === "horizontal"
+					? (event.clientX - resize.rect.left) / resize.rect.width
+					: (event.clientY - resize.rect.top) / resize.rect.height;
+			onResize(ratio);
 		},
 		[direction, onResize],
+	);
+	const handlePointerEnd = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			if (resizeRef.current?.pointerId !== event.pointerId) return;
+			resizeRef.current = null;
+			setIsResizing(false);
+		},
+		[],
 	);
 
 	const handleKeyDown = useCallback(
@@ -338,6 +351,9 @@ function SplitDivider({
 			data-direction={direction}
 			data-resizing={isResizing ? "true" : undefined}
 			onPointerDown={handlePointerDown}
+			onPointerMove={handlePointerMove}
+			onPointerUp={handlePointerEnd}
+			onPointerCancel={handlePointerEnd}
 			onDoubleClick={() => onResize(DEFAULT_SPLIT_RATIO)}
 			onKeyDown={handleKeyDown}
 			role="separator"

--- a/src/components/app/SplitEditorLayout.tsx
+++ b/src/components/app/SplitEditorLayout.tsx
@@ -1,7 +1,7 @@
 import {
 	type KeyboardEvent as ReactKeyboardEvent,
-	type PointerEvent as ReactPointerEvent,
 	type ReactNode,
+	type PointerEvent as ReactPointerEvent,
 	useCallback,
 	useEffect,
 	useRef,
@@ -21,21 +21,6 @@ import type {
 
 const KEYBOARD_RESIZE_STEP = 0.02;
 const KEYBOARD_RESIZE_LARGE_STEP = 0.05;
-const DROP_PREVIEW_INSET = 8;
-const DROP_PREVIEW_SPLIT_GAP = 6;
-
-interface DropPreviewBounds {
-	left: number;
-	top: number;
-	width: number;
-	height: number;
-}
-
-interface DropPreview {
-	source: SplitEditorDragSource;
-	target: SplitEditorDropTarget;
-	bounds: DropPreviewBounds;
-}
 
 function dropEdgeAtPoint(
 	rect: DOMRect,
@@ -50,41 +35,6 @@ function dropEdgeAtPoint(
 	if (x < edgeSize) return "left";
 	if (x > 1 - edgeSize) return "right";
 	return "center";
-}
-
-function splitDropPreviewBounds(
-	layoutRect: DOMRect,
-	paneRect: DOMRect,
-	edge: SplitEditorDropTarget["edge"],
-): DropPreviewBounds {
-	const paneLeft = paneRect.left - layoutRect.left;
-	const paneTop = paneRect.top - layoutRect.top;
-	const halfWidth = paneRect.width / 2;
-	const halfHeight = paneRect.height / 2;
-	const bounds = {
-		left: paneLeft + DROP_PREVIEW_INSET,
-		top: paneTop + DROP_PREVIEW_INSET,
-		width: Math.max(0, paneRect.width - DROP_PREVIEW_INSET * 2),
-		height: Math.max(0, paneRect.height - DROP_PREVIEW_INSET * 2),
-	};
-	if (edge === "left" || edge === "right") {
-		bounds.width = Math.max(
-			0,
-			halfWidth - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
-		);
-		if (edge === "right") {
-			bounds.left = paneLeft + halfWidth + DROP_PREVIEW_SPLIT_GAP;
-		}
-	} else if (edge === "top" || edge === "bottom") {
-		bounds.height = Math.max(
-			0,
-			halfHeight - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
-		);
-		if (edge === "bottom") {
-			bounds.top = paneTop + halfHeight + DROP_PREVIEW_SPLIT_GAP;
-		}
-	}
-	return bounds;
 }
 
 interface SplitEditorLayoutProps {
@@ -107,17 +57,14 @@ export function SplitEditorLayout({
 	onResizeSplit,
 	renderPane,
 }: SplitEditorLayoutProps) {
-	const [dropPreview, setDropPreview] = useState<DropPreview | null>(null);
-	const pointerRef = useRef({ x: 0, y: 0 });
+	const [dropPreviewTarget, setDropPreviewTarget] =
+		useState<SplitEditorDropTarget | null>(null);
 	const dragSourceRef = useRef<SplitEditorDragSource | null>(null);
 	const dropTargetRef = useRef<SplitEditorDropTarget | null>(null);
-	const layoutRef = useRef<HTMLDivElement | null>(null);
 	const paneElementsRef = useRef(new Map<string, HTMLElement>());
 
 	const updateDropPreview = useCallback((x: number, y: number) => {
-		pointerRef.current = { x, y };
 		if (!dragSourceRef.current) return;
-		const layoutElement = layoutRef.current;
 		let paneEntry: [string, HTMLElement] | null = null;
 		for (const entry of paneElementsRef.current) {
 			const rect = entry[1].getBoundingClientRect();
@@ -131,9 +78,9 @@ export function SplitEditorLayout({
 				break;
 			}
 		}
-		if (!layoutElement || !paneEntry) {
+		if (!paneEntry) {
 			dropTargetRef.current = null;
-			setDropPreview(null);
+			setDropPreviewTarget(null);
 			return;
 		}
 		const [paneId, paneElement] = paneEntry;
@@ -149,26 +96,19 @@ export function SplitEditorLayout({
 			return;
 		}
 		dropTargetRef.current = target;
-		setDropPreview({
-			source: dragSourceRef.current,
-			target,
-			bounds: splitDropPreviewBounds(
-				layoutElement.getBoundingClientRect(),
-				paneRect,
-				target.edge,
-			),
-		});
+		setDropPreviewTarget(
+			dragSourceRef.current.kind === "tab" &&
+				dragSourceRef.current.paneId === paneId &&
+				target.edge === "center"
+				? null
+				: target,
+		);
 	}, []);
 
 	useEffect(() => {
 		return subscribeToSplitEditorDrag((event) => {
-			if (event.type === "start") {
-				dragSourceRef.current = event.source;
-				const { x, y } = pointerRef.current;
-				updateDropPreview(x, y);
-				return;
-			}
 			if (event.type === "move") {
+				dragSourceRef.current = event.source;
 				updateDropPreview(event.x, event.y);
 				return;
 			}
@@ -183,7 +123,7 @@ export function SplitEditorLayout({
 					source.paneId !== target.paneId);
 			dragSourceRef.current = null;
 			dropTargetRef.current = null;
-			setDropPreview(null);
+			setDropPreviewTarget(null);
 			if (!source || !target || !shouldHandleDrop) return false;
 			onDrop(source, target);
 			return true;
@@ -206,11 +146,17 @@ export function SplitEditorLayout({
 						}}
 						className="splitEditorPane"
 						data-focused={focused ? "true" : undefined}
-						data-split-editor-pane-id={node.paneId}
 						onFocusCapture={() => onFocusPane(node.paneId)}
 						onPointerDownCapture={() => onFocusPane(node.paneId)}
 					>
 						{renderPane(node.paneId, focused)}
+						{dropPreviewTarget?.paneId === node.paneId ? (
+							<div
+								className="splitEditorDropPreview"
+								data-edge={dropPreviewTarget.edge}
+								aria-hidden="true"
+							/>
+						) : null}
 					</section>
 				);
 			}
@@ -241,31 +187,10 @@ export function SplitEditorLayout({
 				</div>
 			);
 		},
-		[
-			focusedPaneId,
-			onFocusPane,
-			onResizeSplit,
-			renderPane,
-		],
+		[focusedPaneId, dropPreviewTarget, onFocusPane, onResizeSplit, renderPane],
 	);
 
-	const suppressSamePaneCenterPreview =
-		dropPreview?.source.kind === "tab" &&
-		dropPreview?.target.edge === "center" &&
-		dropPreview.source.paneId === dropPreview.target.paneId;
-
-	return (
-		<div ref={layoutRef} className="splitEditorLayout">
-			{renderNode(layout)}
-			{dropPreview && !suppressSamePaneCenterPreview ? (
-				<div
-					className="splitEditorDropPreview"
-					aria-hidden="true"
-					style={dropPreview.bounds}
-				/>
-			) : null}
-		</div>
-	);
+	return <div className="splitEditorLayout">{renderNode(layout)}</div>;
 }
 
 function SplitDivider({

--- a/src/components/app/SplitEditorLayout.tsx
+++ b/src/components/app/SplitEditorLayout.tsx
@@ -1,0 +1,351 @@
+import {
+	type KeyboardEvent as ReactKeyboardEvent,
+	type PointerEvent as ReactPointerEvent,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import {
+	listenForSplitEditorDragEnd,
+	listenForSplitEditorDragMove,
+	listenForSplitEditorDragStart,
+	splitEditorDropTargetAtPoint,
+} from "./splitEditorDnd";
+import type {
+	SplitEditorDragSource,
+	SplitEditorDropTarget,
+} from "./splitEditorDnd";
+import {
+	DEFAULT_SPLIT_RATIO,
+	MAX_SPLIT_RATIO,
+	MIN_SPLIT_RATIO,
+} from "./splitEditorModel";
+import type { SplitEditorNode } from "./splitEditorModel";
+
+const KEYBOARD_RESIZE_STEP = 0.02;
+const KEYBOARD_RESIZE_LARGE_STEP = 0.05;
+const DROP_PREVIEW_INSET = 8;
+const DROP_PREVIEW_SPLIT_GAP = 6;
+
+interface DropPreviewBounds {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+interface DropPreview {
+	target: SplitEditorDropTarget;
+	bounds: DropPreviewBounds;
+}
+
+function splitDropPreviewBounds(
+	layoutRect: DOMRect,
+	paneRect: DOMRect,
+	edge: SplitEditorDropTarget["edge"],
+): DropPreviewBounds {
+	const paneLeft = paneRect.left - layoutRect.left;
+	const paneTop = paneRect.top - layoutRect.top;
+	const halfWidth = paneRect.width / 2;
+	const halfHeight = paneRect.height / 2;
+	const fullWidth = Math.max(0, paneRect.width - DROP_PREVIEW_INSET * 2);
+	const fullHeight = Math.max(0, paneRect.height - DROP_PREVIEW_INSET * 2);
+	const splitWidth = Math.max(
+		0,
+		halfWidth - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
+	);
+	const splitHeight = Math.max(
+		0,
+		halfHeight - DROP_PREVIEW_INSET - DROP_PREVIEW_SPLIT_GAP,
+	);
+
+	if (edge === "left") {
+		return {
+			left: paneLeft + DROP_PREVIEW_INSET,
+			top: paneTop + DROP_PREVIEW_INSET,
+			width: splitWidth,
+			height: fullHeight,
+		};
+	}
+	if (edge === "right") {
+		return {
+			left: paneLeft + halfWidth + DROP_PREVIEW_SPLIT_GAP,
+			top: paneTop + DROP_PREVIEW_INSET,
+			width: splitWidth,
+			height: fullHeight,
+		};
+	}
+	if (edge === "top") {
+		return {
+			left: paneLeft + DROP_PREVIEW_INSET,
+			top: paneTop + DROP_PREVIEW_INSET,
+			width: fullWidth,
+			height: splitHeight,
+		};
+	}
+	if (edge === "bottom") {
+		return {
+			left: paneLeft + DROP_PREVIEW_INSET,
+			top: paneTop + halfHeight + DROP_PREVIEW_SPLIT_GAP,
+			width: fullWidth,
+			height: splitHeight,
+		};
+	}
+	return {
+		left: paneLeft + DROP_PREVIEW_INSET,
+		top: paneTop + DROP_PREVIEW_INSET,
+		width: fullWidth,
+		height: fullHeight,
+	};
+}
+
+interface SplitEditorLayoutProps {
+	layout: SplitEditorNode;
+	focusedPaneId: string;
+	onFocusPane: (paneId: string) => void;
+	onDrop: (
+		source: SplitEditorDragSource,
+		target: SplitEditorDropTarget,
+	) => void;
+	onResizeSplit: (splitId: string, ratio: number) => void;
+	renderPane: (paneId: string, focused: boolean) => ReactNode;
+}
+
+export function SplitEditorLayout({
+	layout,
+	focusedPaneId,
+	onFocusPane,
+	onDrop,
+	onResizeSplit,
+	renderPane,
+}: SplitEditorLayoutProps) {
+	const [dragSource, setDragSource] =
+		useState<SplitEditorDragSource | null>(null);
+	const [dropPreview, setDropPreview] = useState<DropPreview | null>(null);
+	const pointerRef = useRef({ x: 0, y: 0 });
+	const dragSourceRef = useRef<SplitEditorDragSource | null>(null);
+	const layoutRef = useRef<HTMLDivElement | null>(null);
+	const paneElementsRef = useRef(new Map<string, HTMLElement>());
+
+	const updateDropPreview = useCallback((x: number, y: number) => {
+		pointerRef.current = { x, y };
+		if (!dragSourceRef.current) return;
+		const target = splitEditorDropTargetAtPoint(x, y);
+		const layoutElement = layoutRef.current;
+		const paneElement = target
+			? paneElementsRef.current.get(target.paneId)
+			: null;
+		if (!target || !layoutElement || !paneElement) {
+			setDropPreview(null);
+			return;
+		}
+		setDropPreview({
+			target,
+			bounds: splitDropPreviewBounds(
+				layoutElement.getBoundingClientRect(),
+				paneElement.getBoundingClientRect(),
+				target.edge,
+			),
+		});
+	}, []);
+
+	useEffect(() => {
+		const stopStart = listenForSplitEditorDragStart((source) => {
+			dragSourceRef.current = source;
+			setDragSource(source);
+			const { x, y } = pointerRef.current;
+			updateDropPreview(x, y);
+		});
+		const stopMove = listenForSplitEditorDragMove((x, y) => {
+			updateDropPreview(x, y);
+		});
+		const stopEnd = listenForSplitEditorDragEnd((source, event) => {
+			const { x, y } = pointerRef.current;
+			const target = splitEditorDropTargetAtPoint(x, y);
+			const shouldHandleDrop =
+				source &&
+				target &&
+				(source.kind === "file" ||
+					target.edge !== "center" ||
+					source.paneId !== target.paneId);
+			if (source && target && shouldHandleDrop) {
+				event.preventDefault();
+				onDrop(source, target);
+			}
+			dragSourceRef.current = null;
+			setDragSource(null);
+			setDropPreview(null);
+		});
+		return () => {
+			stopStart();
+			stopMove();
+			stopEnd();
+		};
+	}, [onDrop, updateDropPreview]);
+
+	const renderNode = useCallback(
+		(node: SplitEditorNode): ReactNode => {
+			if (node.type === "pane") {
+				const focused = node.paneId === focusedPaneId;
+				return (
+					<section
+						key={node.paneId}
+						ref={(element) => {
+							if (element) {
+								paneElementsRef.current.set(node.paneId, element);
+							} else {
+								paneElementsRef.current.delete(node.paneId);
+							}
+						}}
+						className="splitEditorPane"
+						data-focused={focused ? "true" : undefined}
+						data-split-editor-pane-id={node.paneId}
+						onFocusCapture={() => onFocusPane(node.paneId)}
+						onPointerDownCapture={() => onFocusPane(node.paneId)}
+					>
+						{renderPane(node.paneId, focused)}
+					</section>
+				);
+			}
+
+			return (
+				<div
+					key={node.id}
+					className="splitEditorBranch"
+					data-direction={node.direction}
+				>
+					<div
+						className="splitEditorBranchChild"
+						style={{ flexBasis: `${node.ratio * 100}%` }}
+					>
+						{renderNode(node.first)}
+					</div>
+					<SplitDivider
+						direction={node.direction}
+						ratio={node.ratio}
+						onResize={(ratio) => onResizeSplit(node.id, ratio)}
+					/>
+					<div
+						className="splitEditorBranchChild"
+						style={{ flexBasis: `${(1 - node.ratio) * 100}%` }}
+					>
+						{renderNode(node.second)}
+					</div>
+				</div>
+			);
+		},
+		[
+			focusedPaneId,
+			onFocusPane,
+			onResizeSplit,
+			renderPane,
+		],
+	);
+
+	const suppressSamePaneCenterPreview =
+		dragSource?.kind === "tab" &&
+		dropPreview?.target.edge === "center" &&
+		dragSource.paneId === dropPreview.target.paneId;
+
+	return (
+		<div ref={layoutRef} className="splitEditorLayout">
+			{renderNode(layout)}
+			{dropPreview && !suppressSamePaneCenterPreview ? (
+				<div
+					className="splitEditorDropPreview"
+					aria-hidden="true"
+					style={dropPreview.bounds}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+function SplitDivider({
+	direction,
+	ratio,
+	onResize,
+}: {
+	direction: "horizontal" | "vertical";
+	ratio: number;
+	onResize: (ratio: number) => void;
+}) {
+	const [isResizing, setIsResizing] = useState(false);
+	const handlePointerDown = useCallback(
+		(event: ReactPointerEvent<HTMLDivElement>) => {
+			const divider = event.currentTarget;
+			const branch = divider.parentElement;
+			if (!branch) return;
+			event.preventDefault();
+			setIsResizing(true);
+			divider.setPointerCapture(event.pointerId);
+			const rect = branch.getBoundingClientRect();
+			const handlePointerMove = (moveEvent: PointerEvent) => {
+				const ratio =
+					direction === "horizontal"
+						? (moveEvent.clientX - rect.left) / rect.width
+						: (moveEvent.clientY - rect.top) / rect.height;
+				onResize(ratio);
+			};
+			const handlePointerUp = () => {
+				setIsResizing(false);
+				divider.removeEventListener("pointermove", handlePointerMove);
+				divider.removeEventListener("pointerup", handlePointerUp);
+				divider.removeEventListener("pointercancel", handlePointerUp);
+			};
+			divider.addEventListener("pointermove", handlePointerMove);
+			divider.addEventListener("pointerup", handlePointerUp);
+			divider.addEventListener("pointercancel", handlePointerUp);
+		},
+		[direction, onResize],
+	);
+
+	const handleKeyDown = useCallback(
+		(event: ReactKeyboardEvent<HTMLDivElement>) => {
+			const step = event.shiftKey
+				? KEYBOARD_RESIZE_LARGE_STEP
+				: KEYBOARD_RESIZE_STEP;
+			let nextRatio: number | null = null;
+
+			if (
+				(direction === "horizontal" && event.key === "ArrowLeft") ||
+				(direction === "vertical" && event.key === "ArrowUp")
+			) {
+				nextRatio = ratio - step;
+			} else if (
+				(direction === "horizontal" && event.key === "ArrowRight") ||
+				(direction === "vertical" && event.key === "ArrowDown")
+			) {
+				nextRatio = ratio + step;
+			} else if (event.key === "Home") {
+				nextRatio = MIN_SPLIT_RATIO;
+			} else if (event.key === "End") {
+				nextRatio = MAX_SPLIT_RATIO;
+			}
+
+			if (nextRatio === null) return;
+			event.preventDefault();
+			onResize(nextRatio);
+		},
+		[direction, onResize, ratio],
+	);
+
+	return (
+		<div
+			className="splitEditorDivider"
+			data-direction={direction}
+			data-resizing={isResizing ? "true" : undefined}
+			onPointerDown={handlePointerDown}
+			onDoubleClick={() => onResize(DEFAULT_SPLIT_RATIO)}
+			onKeyDown={handleKeyDown}
+			role="separator"
+			aria-orientation={direction === "horizontal" ? "vertical" : "horizontal"}
+			aria-valuemin={MIN_SPLIT_RATIO * 100}
+			aria-valuemax={MAX_SPLIT_RATIO * 100}
+			aria-valuenow={Math.round(ratio * 100)}
+			tabIndex={0}
+		/>
+	);
+}

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -2,6 +2,8 @@ import { PointerActivationConstraints } from "@dnd-kit/dom";
 import {
 	DragDropProvider,
 	type DragEndEvent,
+	type DragMoveEvent,
+	type DragStartEvent,
 	PointerSensor,
 } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
@@ -21,6 +23,12 @@ import { isMarkdownPath } from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { ActiveFileTitle } from "./ActiveFileTitle";
 import { MainTabsBreadcrumbs } from "./MainTabsBreadcrumbs";
+import {
+	cancelSplitEditorDrag,
+	endSplitEditorDrag,
+	moveSplitEditorDrag,
+	startSplitEditorDrag,
+} from "./splitEditorDnd";
 import type { WorkspaceTab } from "./useTabManager";
 
 interface TabBarProps {
@@ -30,6 +38,7 @@ interface TabBarProps {
 	activeTabId: string | null;
 	activeTabPath: string | null;
 	useWindowBackground?: boolean;
+	allowWindowDrag?: boolean;
 	canGoBack: boolean;
 	canGoForward: boolean;
 	onGoBack: () => void;
@@ -73,6 +82,7 @@ export function TabBar({
 	activeTabId,
 	activeTabPath,
 	useWindowBackground = false,
+	allowWindowDrag = true,
 	canGoBack,
 	canGoForward,
 	onGoBack,
@@ -119,7 +129,7 @@ export function TabBar({
 		[compactLabel, stripFileExtension, t],
 	);
 
-	const showTabs = tabs.length > 1;
+	const showTabs = tabs.length > 0;
 	const newTabShortcut = getBinding("new-tab");
 	const activeMarkdownPath =
 		activeTabPath &&
@@ -133,11 +143,26 @@ export function TabBar({
 			window.setTimeout(() => {
 				suppressClickRef.current = false;
 			}, 0);
-			if (event.canceled) return;
-
 			const { source, target } = event.operation;
 			const sourceTabId =
 				typeof source?.data.tabId === "string" ? source.data.tabId : null;
+			const sourcePaneId =
+				typeof source?.data.paneId === "string" ? source.data.paneId : null;
+			if (event.canceled || !sourceTabId || !sourcePaneId) {
+				cancelSplitEditorDrag();
+				return;
+			}
+			const { x, y } = event.operation.position.current;
+			moveSplitEditorDrag(x, y);
+			if (
+				endSplitEditorDrag({
+					kind: "tab",
+					paneId: sourcePaneId,
+					tabId: sourceTabId,
+				})
+			) {
+				return;
+			}
 			const targetTabId =
 				typeof target?.data.tabId === "string" ? target.data.tabId : null;
 			if (!sourceTabId || !targetTabId || sourceTabId === targetTabId) return;
@@ -146,12 +171,28 @@ export function TabBar({
 		},
 		[onReorder],
 	);
+	const handleDragStart = useCallback((event: DragStartEvent) => {
+		const { source } = event.operation;
+		const tabId =
+			typeof source?.data.tabId === "string" ? source.data.tabId : null;
+		const paneId =
+			typeof source?.data.paneId === "string" ? source.data.paneId : null;
+		if (tabId && paneId) {
+			startSplitEditorDrag({ kind: "tab", paneId, tabId });
+			const { x, y } = event.operation.position.current;
+			moveSplitEditorDrag(x, y);
+		}
+	}, []);
+	const handleDragMove = useCallback((event: DragMoveEvent) => {
+		const { x, y } = event.operation.position.current;
+		moveSplitEditorDrag(x, y);
+	}, []);
 
 	return (
 		<div
 			className="mainTabsBarWrap"
-			data-tauri-drag-region
-			onMouseDown={onWindowDragMouseDown}
+			data-tauri-drag-region={allowWindowDrag ? "" : undefined}
+			onMouseDown={allowWindowDrag ? onWindowDragMouseDown : undefined}
 		>
 			<div
 				className="mainTabsBar"
@@ -184,7 +225,11 @@ export function TabBar({
 					onRenameFile={onRenameFile}
 				/>
 				{showTabs ? (
-					<DragDropProvider onDragEnd={handleDragEnd}>
+					<DragDropProvider
+						onDragStart={handleDragStart}
+						onDragMove={handleDragMove}
+						onDragEnd={handleDragEnd}
+					>
 						<div className="mainTabsStrip">
 							<div className="mainTabsStripTabs">
 								{tabs.map((tab, index) => (
@@ -259,7 +304,7 @@ const TabItem = memo(function TabItem({
 		type: MAIN_TAB_DND_TYPE,
 		accept: MAIN_TAB_DND_TYPE,
 		sensors: MAIN_TAB_SENSORS,
-		data: { tabId: tab.id },
+		data: { paneId: tab.paneId, tabId: tab.id },
 		transition: { duration: 160, easing: "ease" },
 	});
 	const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -3,7 +3,6 @@ import {
 	DragDropProvider,
 	type DragEndEvent,
 	type DragMoveEvent,
-	type DragStartEvent,
 	PointerSensor,
 } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
@@ -27,7 +26,6 @@ import {
 	cancelSplitEditorDrag,
 	endSplitEditorDrag,
 	moveSplitEditorDrag,
-	startSplitEditorDrag,
 } from "./splitEditorDnd";
 import type { WorkspaceTab } from "./useTabManager";
 
@@ -153,14 +151,13 @@ export function TabBar({
 				return;
 			}
 			const { x, y } = event.operation.position.current;
-			moveSplitEditorDrag(x, y);
-			if (
-				endSplitEditorDrag({
-					kind: "tab",
-					paneId: sourcePaneId,
-					tabId: sourceTabId,
-				})
-			) {
+			const sourceDrag = {
+				kind: "tab" as const,
+				paneId: sourcePaneId,
+				tabId: sourceTabId,
+			};
+			moveSplitEditorDrag(sourceDrag, x, y);
+			if (endSplitEditorDrag(sourceDrag)) {
 				return;
 			}
 			const targetTabId =
@@ -171,21 +168,16 @@ export function TabBar({
 		},
 		[onReorder],
 	);
-	const handleDragStart = useCallback((event: DragStartEvent) => {
+	const handleDragMove = useCallback((event: DragMoveEvent) => {
 		const { source } = event.operation;
 		const tabId =
 			typeof source?.data.tabId === "string" ? source.data.tabId : null;
 		const paneId =
 			typeof source?.data.paneId === "string" ? source.data.paneId : null;
 		if (tabId && paneId) {
-			startSplitEditorDrag({ kind: "tab", paneId, tabId });
 			const { x, y } = event.operation.position.current;
-			moveSplitEditorDrag(x, y);
+			moveSplitEditorDrag({ kind: "tab", paneId, tabId }, x, y);
 		}
-	}, []);
-	const handleDragMove = useCallback((event: DragMoveEvent) => {
-		const { x, y } = event.operation.position.current;
-		moveSplitEditorDrag(x, y);
 	}, []);
 
 	return (
@@ -226,7 +218,6 @@ export function TabBar({
 				/>
 				{showTabs ? (
 					<DragDropProvider
-						onDragStart={handleDragStart}
 						onDragMove={handleDragMove}
 						onDragEnd={handleDragEnd}
 					>

--- a/src/components/app/splitEditorDnd.ts
+++ b/src/components/app/splitEditorDnd.ts
@@ -1,0 +1,109 @@
+import type { SplitDropEdge } from "./splitEditorModel";
+
+export type SplitEditorDragSource =
+	| { kind: "file"; path: string }
+	| { kind: "tab"; paneId: string; tabId: string };
+
+export interface SplitEditorDropTarget {
+	paneId: string;
+	edge: SplitDropEdge | "center";
+}
+
+const DRAG_START_EVENT = "glyph:split-editor-drag-start";
+const DRAG_MOVE_EVENT = "glyph:split-editor-drag-move";
+const DRAG_END_EVENT = "glyph:split-editor-drag-end";
+
+export function startSplitEditorDrag(source: SplitEditorDragSource): void {
+	window.dispatchEvent(
+		new CustomEvent<SplitEditorDragSource>(DRAG_START_EVENT, {
+			detail: source,
+		}),
+	);
+}
+
+export function moveSplitEditorDrag(x: number, y: number): void {
+	window.dispatchEvent(
+		new CustomEvent<{ x: number; y: number }>(DRAG_MOVE_EVENT, {
+			detail: { x, y },
+		}),
+	);
+}
+
+export function endSplitEditorDrag(source: SplitEditorDragSource): boolean {
+	const event = new CustomEvent<SplitEditorDragSource>(DRAG_END_EVENT, {
+		cancelable: true,
+		detail: source,
+	});
+	return !window.dispatchEvent(event);
+}
+
+export function cancelSplitEditorDrag(): void {
+	window.dispatchEvent(
+		new CustomEvent<SplitEditorDragSource | undefined>(DRAG_END_EVENT, {
+			detail: undefined,
+		}),
+	);
+}
+
+export function listenForSplitEditorDragStart(
+	listener: (source: SplitEditorDragSource) => void,
+): () => void {
+	const handleEvent = (event: Event) => {
+		const detail = (event as CustomEvent<SplitEditorDragSource>).detail;
+		if (detail) listener(detail);
+	};
+	window.addEventListener(DRAG_START_EVENT, handleEvent);
+	return () => window.removeEventListener(DRAG_START_EVENT, handleEvent);
+}
+
+export function listenForSplitEditorDragMove(
+	listener: (x: number, y: number) => void,
+): () => void {
+	const handleEvent = (event: Event) => {
+		const detail = (event as CustomEvent<{ x: number; y: number }>).detail;
+		if (detail) listener(detail.x, detail.y);
+	};
+	window.addEventListener(DRAG_MOVE_EVENT, handleEvent);
+	return () => window.removeEventListener(DRAG_MOVE_EVENT, handleEvent);
+}
+
+export function listenForSplitEditorDragEnd(
+	listener: (
+		source: SplitEditorDragSource | undefined,
+		event: Event,
+	) => void,
+): () => void {
+	const handleEvent = (event: Event) => {
+		listener(
+			(event as CustomEvent<SplitEditorDragSource | undefined>).detail,
+			event,
+		);
+	};
+	window.addEventListener(DRAG_END_EVENT, handleEvent);
+	return () => window.removeEventListener(DRAG_END_EVENT, handleEvent);
+}
+
+export function splitEditorDropTargetAtPoint(
+	clientX: number,
+	clientY: number,
+): SplitEditorDropTarget | null {
+	const element = document
+		.elementsFromPoint(clientX, clientY)
+		.map((candidate) =>
+			candidate.closest<HTMLElement>("[data-split-editor-pane-id]"),
+		)
+		.find((candidate) => candidate !== null);
+	const paneId = element?.dataset.splitEditorPaneId;
+	if (!element || !paneId) return null;
+
+	const rect = element.getBoundingClientRect();
+	const x = (clientX - rect.left) / rect.width;
+	const y = (clientY - rect.top) / rect.height;
+	const edgeSize = 0.3;
+	let edge: SplitEditorDropTarget["edge"] = "center";
+	if (y < edgeSize) edge = "top";
+	else if (y > 1 - edgeSize) edge = "bottom";
+	else if (x < edgeSize) edge = "left";
+	else if (x > 1 - edgeSize) edge = "right";
+	return { paneId, edge };
+}

--- a/src/components/app/splitEditorDnd.ts
+++ b/src/components/app/splitEditorDnd.ts
@@ -1,4 +1,4 @@
-import type { SplitDropEdge } from "./splitEditorModel";
+import type { SplitDropEdge } from "../../lib/splitEditor";
 
 export type SplitEditorDragSource =
 	| { kind: "file"; path: string }
@@ -9,101 +9,42 @@ export interface SplitEditorDropTarget {
 	edge: SplitDropEdge | "center";
 }
 
-const DRAG_START_EVENT = "glyph:split-editor-drag-start";
-const DRAG_MOVE_EVENT = "glyph:split-editor-drag-move";
-const DRAG_END_EVENT = "glyph:split-editor-drag-end";
+type SplitEditorDragEvent =
+	| { type: "start"; source: SplitEditorDragSource }
+	| { type: "move"; x: number; y: number }
+	| { type: "end"; source: SplitEditorDragSource | null };
+
+type SplitEditorDragListener = (event: SplitEditorDragEvent) => boolean | void;
+
+const listeners = new Set<SplitEditorDragListener>();
+
+function publish(event: SplitEditorDragEvent): boolean {
+	let handled = false;
+	for (const listener of listeners) {
+		handled = listener(event) === true || handled;
+	}
+	return handled;
+}
+
+export function subscribeToSplitEditorDrag(
+	listener: SplitEditorDragListener,
+): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
 
 export function startSplitEditorDrag(source: SplitEditorDragSource): void {
-	window.dispatchEvent(
-		new CustomEvent<SplitEditorDragSource>(DRAG_START_EVENT, {
-			detail: source,
-		}),
-	);
+	publish({ type: "start", source });
 }
 
 export function moveSplitEditorDrag(x: number, y: number): void {
-	window.dispatchEvent(
-		new CustomEvent<{ x: number; y: number }>(DRAG_MOVE_EVENT, {
-			detail: { x, y },
-		}),
-	);
+	publish({ type: "move", x, y });
 }
 
 export function endSplitEditorDrag(source: SplitEditorDragSource): boolean {
-	const event = new CustomEvent<SplitEditorDragSource>(DRAG_END_EVENT, {
-		cancelable: true,
-		detail: source,
-	});
-	return !window.dispatchEvent(event);
+	return publish({ type: "end", source });
 }
 
 export function cancelSplitEditorDrag(): void {
-	window.dispatchEvent(
-		new CustomEvent<SplitEditorDragSource | undefined>(DRAG_END_EVENT, {
-			detail: undefined,
-		}),
-	);
-}
-
-export function listenForSplitEditorDragStart(
-	listener: (source: SplitEditorDragSource) => void,
-): () => void {
-	const handleEvent = (event: Event) => {
-		const detail = (event as CustomEvent<SplitEditorDragSource>).detail;
-		if (detail) listener(detail);
-	};
-	window.addEventListener(DRAG_START_EVENT, handleEvent);
-	return () => window.removeEventListener(DRAG_START_EVENT, handleEvent);
-}
-
-export function listenForSplitEditorDragMove(
-	listener: (x: number, y: number) => void,
-): () => void {
-	const handleEvent = (event: Event) => {
-		const detail = (event as CustomEvent<{ x: number; y: number }>).detail;
-		if (detail) listener(detail.x, detail.y);
-	};
-	window.addEventListener(DRAG_MOVE_EVENT, handleEvent);
-	return () => window.removeEventListener(DRAG_MOVE_EVENT, handleEvent);
-}
-
-export function listenForSplitEditorDragEnd(
-	listener: (
-		source: SplitEditorDragSource | undefined,
-		event: Event,
-	) => void,
-): () => void {
-	const handleEvent = (event: Event) => {
-		listener(
-			(event as CustomEvent<SplitEditorDragSource | undefined>).detail,
-			event,
-		);
-	};
-	window.addEventListener(DRAG_END_EVENT, handleEvent);
-	return () => window.removeEventListener(DRAG_END_EVENT, handleEvent);
-}
-
-export function splitEditorDropTargetAtPoint(
-	clientX: number,
-	clientY: number,
-): SplitEditorDropTarget | null {
-	const element = document
-		.elementsFromPoint(clientX, clientY)
-		.map((candidate) =>
-			candidate.closest<HTMLElement>("[data-split-editor-pane-id]"),
-		)
-		.find((candidate) => candidate !== null);
-	const paneId = element?.dataset.splitEditorPaneId;
-	if (!element || !paneId) return null;
-
-	const rect = element.getBoundingClientRect();
-	const x = (clientX - rect.left) / rect.width;
-	const y = (clientY - rect.top) / rect.height;
-	const edgeSize = 0.3;
-	let edge: SplitEditorDropTarget["edge"] = "center";
-	if (y < edgeSize) edge = "top";
-	else if (y > 1 - edgeSize) edge = "bottom";
-	else if (x < edgeSize) edge = "left";
-	else if (x > 1 - edgeSize) edge = "right";
-	return { paneId, edge };
+	publish({ type: "end", source: null });
 }

--- a/src/components/app/splitEditorDnd.ts
+++ b/src/components/app/splitEditorDnd.ts
@@ -10,11 +10,12 @@ export interface SplitEditorDropTarget {
 }
 
 type SplitEditorDragEvent =
-	| { type: "start"; source: SplitEditorDragSource }
-	| { type: "move"; x: number; y: number }
+	| { type: "move"; source: SplitEditorDragSource; x: number; y: number }
 	| { type: "end"; source: SplitEditorDragSource | null };
 
-type SplitEditorDragListener = (event: SplitEditorDragEvent) => boolean | void;
+type SplitEditorDragListener = (
+	event: SplitEditorDragEvent,
+) => boolean | undefined;
 
 const listeners = new Set<SplitEditorDragListener>();
 
@@ -33,12 +34,12 @@ export function subscribeToSplitEditorDrag(
 	return () => listeners.delete(listener);
 }
 
-export function startSplitEditorDrag(source: SplitEditorDragSource): void {
-	publish({ type: "start", source });
-}
-
-export function moveSplitEditorDrag(x: number, y: number): void {
-	publish({ type: "move", x, y });
+export function moveSplitEditorDrag(
+	source: SplitEditorDragSource,
+	x: number,
+	y: number,
+): void {
+	publish({ type: "move", source, x, y });
 }
 
 export function endSplitEditorDrag(source: SplitEditorDragSource): boolean {

--- a/src/components/app/splitEditorModel.ts
+++ b/src/components/app/splitEditorModel.ts
@@ -1,0 +1,102 @@
+export type SplitDirection = "horizontal" | "vertical";
+export type SplitDropEdge = "top" | "right" | "bottom" | "left";
+
+export const MIN_SPLIT_RATIO = 0.1;
+export const MAX_SPLIT_RATIO = 0.9;
+export const DEFAULT_SPLIT_RATIO = 0.5;
+
+export interface SplitEditorPaneNode {
+	type: "pane";
+	paneId: string;
+}
+
+export interface SplitEditorBranchNode {
+	type: "split";
+	id: string;
+	direction: SplitDirection;
+	ratio: number;
+	first: SplitEditorNode;
+	second: SplitEditorNode;
+}
+
+export type SplitEditorNode = SplitEditorPaneNode | SplitEditorBranchNode;
+
+export const PRIMARY_EDITOR_PANE_ID = "editor-pane-primary";
+
+export function createInitialSplitEditorLayout(): SplitEditorPaneNode {
+	return { type: "pane", paneId: PRIMARY_EDITOR_PANE_ID };
+}
+
+export function paneIdsInLayout(node: SplitEditorNode): string[] {
+	if (node.type === "pane") return [node.paneId];
+	return [...paneIdsInLayout(node.first), ...paneIdsInLayout(node.second)];
+}
+
+export function splitEditorPane(
+	node: SplitEditorNode,
+	paneId: string,
+	newPaneId: string,
+	splitId: string,
+	edge: SplitDropEdge,
+): SplitEditorNode {
+	if (node.type === "pane") {
+		if (node.paneId !== paneId) return node;
+		const currentPane: SplitEditorPaneNode = { type: "pane", paneId };
+		const newPane: SplitEditorPaneNode = { type: "pane", paneId: newPaneId };
+		const newPaneFirst = edge === "left" || edge === "top";
+		return {
+			type: "split",
+			id: splitId,
+			direction:
+				edge === "left" || edge === "right" ? "horizontal" : "vertical",
+			ratio: DEFAULT_SPLIT_RATIO,
+			first: newPaneFirst ? newPane : currentPane,
+			second: newPaneFirst ? currentPane : newPane,
+		};
+	}
+
+	const first = splitEditorPane(
+		node.first,
+		paneId,
+		newPaneId,
+		splitId,
+		edge,
+	);
+	if (first !== node.first) return { ...node, first };
+	const second = splitEditorPane(
+		node.second,
+		paneId,
+		newPaneId,
+		splitId,
+		edge,
+	);
+	return second === node.second ? node : { ...node, second };
+}
+
+export function removeEditorPane(
+	node: SplitEditorNode,
+	paneId: string,
+): SplitEditorNode | null {
+	if (node.type === "pane") return node.paneId === paneId ? null : node;
+
+	const first = removeEditorPane(node.first, paneId);
+	const second = removeEditorPane(node.second, paneId);
+	if (!first) return second;
+	if (!second) return first;
+	if (first === node.first && second === node.second) return node;
+	return { ...node, first, second };
+}
+
+export function updateSplitRatio(
+	node: SplitEditorNode,
+	splitId: string,
+	ratio: number,
+): SplitEditorNode {
+	if (node.type === "pane") return node;
+	if (node.id === splitId) return { ...node, ratio };
+	const first = updateSplitRatio(node.first, splitId, ratio);
+	const second = updateSplitRatio(node.second, splitId, ratio);
+	return first === node.first && second === node.second
+		? node
+		: { ...node, first, second };
+}

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -12,6 +12,10 @@ import {
 	FolderOpenIcon,
 	FolderRemoveIcon,
 	InformationCircleIcon,
+	LayoutBottomIcon,
+	LayoutLeftIcon,
+	LayoutRightIcon,
+	LayoutTopIcon,
 	LibraryIcon,
 	Link01Icon,
 	MoveIcon,
@@ -22,10 +26,6 @@ import {
 	SearchIcon,
 	Settings01Icon,
 	SidebarLeftIcon,
-	LayoutBottomIcon,
-	LayoutLeftIcon,
-	LayoutRightIcon,
-	LayoutTopIcon,
 	SquareLock02Icon,
 	TableIcon,
 } from "@hugeicons/core-free-icons";
@@ -48,10 +48,10 @@ import {
 	type ShortcutActionId,
 	isShortcutActionId,
 } from "../../lib/shortcuts/registry";
+import type { SplitDropEdge } from "../../lib/splitEditor";
 import { toast } from "../../lib/toast";
 import { isMarkdownPath, parentDir } from "../../utils/path";
 import type { SettingsTab } from "../settings/settingsConfig";
-import type { SplitDropEdge } from "./splitEditorModel";
 import type { Command } from "./CommandPalette";
 import { buildEditorCommands } from "./editorCommands";
 import { buildMovePickerCommands } from "./movePickerCommands";
@@ -358,54 +358,25 @@ export function useAppCommands({
 				allowInEditable: true,
 				action: openBlankTab,
 			},
-			{
-				id: "split-editor-left",
+			...(
+				[
+					["split-editor-left", LayoutLeftIcon, "left"],
+					["split-editor-right", LayoutRightIcon, "right"],
+					["split-editor-above", LayoutTopIcon, "top"],
+					["split-editor-below", LayoutBottomIcon, "bottom"],
+				] as const
+			).map(([id, icon, edge]) => ({
+				id,
 				icon: (
 					<HugeiconsIcon
-						icon={LayoutLeftIcon}
+						icon={icon}
 						size="var(--icon-lg)"
 						strokeWidth={0.9}
 					/>
 				),
 				enabled: Boolean(spacePath),
-				action: () => splitPaneWithBlank("left"),
-			},
-			{
-				id: "split-editor-right",
-				icon: (
-					<HugeiconsIcon
-						icon={LayoutRightIcon}
-						size="var(--icon-lg)"
-						strokeWidth={0.9}
-					/>
-				),
-				enabled: Boolean(spacePath),
-				action: () => splitPaneWithBlank("right"),
-			},
-			{
-				id: "split-editor-above",
-				icon: (
-					<HugeiconsIcon
-						icon={LayoutTopIcon}
-						size="var(--icon-lg)"
-						strokeWidth={0.9}
-					/>
-				),
-				enabled: Boolean(spacePath),
-				action: () => splitPaneWithBlank("top"),
-			},
-			{
-				id: "split-editor-below",
-				icon: (
-					<HugeiconsIcon
-						icon={LayoutBottomIcon}
-						size="var(--icon-lg)"
-						strokeWidth={0.9}
-					/>
-				),
-				enabled: Boolean(spacePath),
-				action: () => splitPaneWithBlank("bottom"),
-			},
+				action: () => splitPaneWithBlank(edge),
+			})),
 			{
 				id: "close-active-tab",
 				enabled: tabsLength > 0,

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -368,11 +368,7 @@ export function useAppCommands({
 			).map(([id, icon, edge]) => ({
 				id,
 				icon: (
-					<HugeiconsIcon
-						icon={icon}
-						size="var(--icon-lg)"
-						strokeWidth={0.9}
-					/>
+					<HugeiconsIcon icon={icon} size="var(--icon-lg)" strokeWidth={0.9} />
 				),
 				enabled: Boolean(spacePath),
 				action: () => splitPaneWithBlank(edge),

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -22,6 +22,10 @@ import {
 	SearchIcon,
 	Settings01Icon,
 	SidebarLeftIcon,
+	LayoutBottomIcon,
+	LayoutLeftIcon,
+	LayoutRightIcon,
+	LayoutTopIcon,
 	SquareLock02Icon,
 	TableIcon,
 } from "@hugeicons/core-free-icons";
@@ -47,6 +51,7 @@ import {
 import { toast } from "../../lib/toast";
 import { isMarkdownPath, parentDir } from "../../utils/path";
 import type { SettingsTab } from "../settings/settingsConfig";
+import type { SplitDropEdge } from "./splitEditorModel";
 import type { Command } from "./CommandPalette";
 import { buildEditorCommands } from "./editorCommands";
 import { buildMovePickerCommands } from "./movePickerCommands";
@@ -90,6 +95,7 @@ interface UseAppCommandsDeps {
 	onOpenSpace: () => void;
 	openAllDocsTab: () => void;
 	openBlankTab: () => void;
+	splitPaneWithBlank: (edge: SplitDropEdge) => void;
 	openDatabasesTab: (databaseId?: string | null) => void;
 	openGettingStarted: () => void;
 	openCalendar: () => void;
@@ -248,6 +254,7 @@ export function useAppCommands({
 	onOpenSpace,
 	openAllDocsTab,
 	openBlankTab,
+	splitPaneWithBlank,
 	openDatabasesTab,
 	openGettingStarted,
 	openCalendar,
@@ -350,6 +357,54 @@ export function useAppCommands({
 				enabled: Boolean(spacePath),
 				allowInEditable: true,
 				action: openBlankTab,
+			},
+			{
+				id: "split-editor-left",
+				icon: (
+					<HugeiconsIcon
+						icon={LayoutLeftIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: () => splitPaneWithBlank("left"),
+			},
+			{
+				id: "split-editor-right",
+				icon: (
+					<HugeiconsIcon
+						icon={LayoutRightIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: () => splitPaneWithBlank("right"),
+			},
+			{
+				id: "split-editor-above",
+				icon: (
+					<HugeiconsIcon
+						icon={LayoutTopIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: () => splitPaneWithBlank("top"),
+			},
+			{
+				id: "split-editor-below",
+				icon: (
+					<HugeiconsIcon
+						icon={LayoutBottomIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: () => splitPaneWithBlank("bottom"),
 			},
 			{
 				id: "close-active-tab",
@@ -892,6 +947,7 @@ export function useAppCommands({
 		openCalendar,
 		openConnectionsView,
 		openBlankTab,
+		splitPaneWithBlank,
 		openQuickNoteWindow,
 		openWorkspaceFile,
 		showWelcomeNote,

--- a/src/components/app/useSplitEditorTabs.ts
+++ b/src/components/app/useSplitEditorTabs.ts
@@ -20,11 +20,15 @@ import type {
 	WorkspaceTab,
 } from "./useTabManager";
 
-interface SplitEditorTabController {
+interface UseSplitEditorTabsArgs {
+	tabs: WorkspaceTab[];
+	historyByTabId: TabHistoryById;
+	splitLayout: SplitEditorNode;
+	focusedPaneId: string;
+	setSplitLayout: Dispatch<SetStateAction<SplitEditorNode>>;
+	activeTabByPane: Record<string, string | null>;
 	tabsRef: RefObject<WorkspaceTab[]>;
-	focusedPaneIdRef: RefObject<string>;
 	activeTabByPaneRef: RefObject<Record<string, string | null>>;
-	setFocusedPaneId: Dispatch<SetStateAction<string>>;
 	createTab: (
 		kind: WorkspaceTab["kind"],
 		target: string | null,
@@ -37,20 +41,7 @@ interface SplitEditorTabController {
 	setActiveTabId: (tabId: string | null) => void;
 	clearHistoryForTab: (tabId: string) => void;
 	pushNoteHistory: (tabId: string, path: string) => void;
-	stepHistory: (tabId: string, delta: -1 | 1) => string | null;
-	updateActiveTabInPlace: (
-		kind: WorkspaceTab["kind"],
-		target: string | null,
-	) => string;
-}
-
-interface UseSplitEditorTabsArgs {
-	tabs: WorkspaceTab[];
-	historyByTabId: TabHistoryById;
-	splitLayout: SplitEditorNode;
-	setSplitLayout: Dispatch<SetStateAction<SplitEditorNode>>;
-	activeTabByPane: Record<string, string | null>;
-	controller: SplitEditorTabController;
+	navigateTabHistory: (tabId: string, delta: -1 | 1) => void;
 }
 
 function createSplit(
@@ -69,67 +60,33 @@ function createSplit(
 	return { newPaneId, nextLayout };
 }
 
-function reconcilePaneActiveTab(
-	activeTabByPaneRef: RefObject<Record<string, string | null>>,
-	tabs: WorkspaceTab[],
-	paneId: string,
-) {
-	const activeTabId = activeTabByPaneRef.current[paneId];
-	if (
-		activeTabId &&
-		tabs.some((tab) => tab.id === activeTabId && tab.paneId === paneId)
-	) {
-		return;
-	}
-	activeTabByPaneRef.current = {
-		...activeTabByPaneRef.current,
-		[paneId]: tabs.find((tab) => tab.paneId === paneId)?.id ?? null,
-	};
-}
-
 export function useSplitEditorTabs({
 	tabs,
 	historyByTabId,
 	splitLayout,
+	focusedPaneId,
 	setSplitLayout,
 	activeTabByPane,
-	controller,
+	tabsRef,
+	activeTabByPaneRef,
+	createTab,
+	commitTabsChange,
+	setActiveTabId,
+	clearHistoryForTab,
+	pushNoteHistory,
+	navigateTabHistory,
 }: UseSplitEditorTabsArgs) {
-	const {
-		tabsRef,
-		focusedPaneIdRef,
-		activeTabByPaneRef,
-		setFocusedPaneId,
-		createTab,
-		commitTabsChange,
-		setActiveTabId,
-		clearHistoryForTab,
-		pushNoteHistory,
-		stepHistory,
-		updateActiveTabInPlace,
-	} = controller;
-
-	const focusPaneState = useCallback(
-		(paneId: string) => {
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneId(paneId);
-		},
-		[focusedPaneIdRef, setFocusedPaneId],
-	);
-
 	const openBlankTabInPane = useCallback(
 		(paneId: string) => {
-			focusPaneState(paneId);
 			const blankTab = createTab("blank", null, paneId);
 			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
 		},
-		[commitTabsChange, createTab, focusPaneState, tabsRef],
+		[commitTabsChange, createTab, tabsRef],
 	);
 
 	const openFileInPane = useCallback(
 		(path: string, paneId: string) => {
 			if (!isMarkdownPath(path)) return false;
-			focusPaneState(paneId);
 			const existing = tabsRef.current.find(
 				(tab) => tab.paneId === paneId && tab.target === path,
 			);
@@ -162,7 +119,6 @@ export function useSplitEditorTabs({
 			clearHistoryForTab,
 			commitTabsChange,
 			createTab,
-			focusPaneState,
 			pushNoteHistory,
 			tabsRef,
 		],
@@ -175,22 +131,16 @@ export function useSplitEditorTabs({
 			kind: WorkspaceTab["kind"],
 			target: string | null,
 		) => {
-			const { newPaneId, nextLayout } = createSplit(
-				splitLayout,
-				paneId,
-				edge,
-			);
+			const { newPaneId, nextLayout } = createSplit(splitLayout, paneId, edge);
 			if (nextLayout === splitLayout) return;
 			const tab = createTab(kind, target, newPaneId);
 			setSplitLayout(nextLayout);
-			focusPaneState(newPaneId);
 			if (kind === "file" && target) pushNoteHistory(tab.id, target);
 			commitTabsChange([...tabsRef.current, tab], tab.id);
 		},
 		[
 			commitTabsChange,
 			createTab,
-			focusPaneState,
 			pushNoteHistory,
 			setSplitLayout,
 			splitLayout,
@@ -207,22 +157,13 @@ export function useSplitEditorTabs({
 
 	const splitPaneWithBlank = useCallback(
 		(edge: SplitDropEdge) => {
-			splitPaneWithTab(
-				focusedPaneIdRef.current,
-				edge,
-				"blank",
-				null,
-			);
+			splitPaneWithTab(focusedPaneId, edge, "blank", null);
 		},
-		[focusedPaneIdRef, splitPaneWithTab],
+		[focusedPaneId, splitPaneWithTab],
 	);
 
 	const moveTabToPane = useCallback(
-		(
-			tabId: string,
-			targetPaneId: string,
-			edge: SplitDropEdge | "center",
-		) => {
+		(tabId: string, targetPaneId: string, edge: SplitDropEdge | "center") => {
 			const sourceTab = tabsRef.current.find((tab) => tab.id === tabId);
 			if (!sourceTab) return;
 
@@ -251,22 +192,9 @@ export function useSplitEditorTabs({
 					(tab) => tab.paneId === sourceTab.paneId,
 				);
 				if (sourcePaneIsEmpty && paneIdsInLayout(splitLayout).length > 1) {
-					const nextLayout = removeEditorPane(
-						splitLayout,
-						sourceTab.paneId,
-					);
+					const nextLayout = removeEditorPane(splitLayout, sourceTab.paneId);
 					if (nextLayout) setSplitLayout(nextLayout);
-					const nextActiveByPane = { ...activeTabByPaneRef.current };
-					delete nextActiveByPane[sourceTab.paneId];
-					activeTabByPaneRef.current = nextActiveByPane;
-				} else {
-					reconcilePaneActiveTab(
-						activeTabByPaneRef,
-						nextTabs,
-						sourceTab.paneId,
-					);
 				}
-				focusPaneState(targetPaneId);
 				commitTabsChange(nextTabs, tabId);
 				return;
 			}
@@ -288,20 +216,12 @@ export function useSplitEditorTabs({
 				const blankTab = createTab("blank", null, sourceTab.paneId);
 				nextTabs = [...nextTabs, blankTab];
 			}
-			reconcilePaneActiveTab(
-				activeTabByPaneRef,
-				nextTabs,
-				sourceTab.paneId,
-			);
 			setSplitLayout(nextLayout);
-			focusPaneState(newPaneId);
 			commitTabsChange(nextTabs, movedTab.id);
 		},
 		[
-			activeTabByPaneRef,
 			commitTabsChange,
 			createTab,
-			focusPaneState,
 			setActiveTabId,
 			setSplitLayout,
 			splitLayout,
@@ -311,9 +231,7 @@ export function useSplitEditorTabs({
 
 	const resizeSplit = useCallback(
 		(splitId: string, ratio: number) => {
-			setSplitLayout((current) =>
-				updateSplitRatio(current, splitId, ratio),
-			);
+			setSplitLayout((current) => updateSplitRatio(current, splitId, ratio));
 		},
 		[setSplitLayout],
 	);
@@ -322,19 +240,9 @@ export function useSplitEditorTabs({
 		(paneId: string, delta: -1 | 1) => {
 			const tabId = activeTabByPaneRef.current[paneId];
 			if (!tabId) return;
-			focusPaneState(paneId);
-			const path = stepHistory(tabId, delta);
-			if (!path) return;
-			setActiveTabId(tabId);
-			updateActiveTabInPlace("file", path);
+			navigateTabHistory(tabId, delta);
 		},
-		[
-			activeTabByPaneRef,
-			focusPaneState,
-			setActiveTabId,
-			stepHistory,
-			updateActiveTabInPlace,
-		],
+		[activeTabByPaneRef, navigateTabHistory],
 	);
 	const goBackInPane = useCallback(
 		(paneId: string) => navigatePaneHistory(paneId, -1),

--- a/src/components/app/useSplitEditorTabs.ts
+++ b/src/components/app/useSplitEditorTabs.ts
@@ -24,6 +24,7 @@ interface UseSplitEditorTabsArgs {
 	tabs: WorkspaceTab[];
 	historyByTabId: TabHistoryById;
 	splitLayout: SplitEditorNode;
+	splitLayoutRef: RefObject<SplitEditorNode>;
 	focusedPaneId: string;
 	setSplitLayout: Dispatch<SetStateAction<SplitEditorNode>>;
 	activeTabByPane: Record<string, string | null>;
@@ -64,6 +65,7 @@ export function useSplitEditorTabs({
 	tabs,
 	historyByTabId,
 	splitLayout,
+	splitLayoutRef,
 	focusedPaneId,
 	setSplitLayout,
 	activeTabByPane,
@@ -88,7 +90,7 @@ export function useSplitEditorTabs({
 		(path: string, paneId: string) => {
 			if (!isMarkdownPath(path)) return false;
 			const existing = tabsRef.current.find(
-				(tab) => tab.paneId === paneId && tab.target === path,
+				(tab) => tab.kind === "file" && tab.target === path,
 			);
 			if (existing) {
 				commitTabsChange(tabsRef.current, existing.id);
@@ -131,8 +133,13 @@ export function useSplitEditorTabs({
 			kind: WorkspaceTab["kind"],
 			target: string | null,
 		) => {
-			const { newPaneId, nextLayout } = createSplit(splitLayout, paneId, edge);
-			if (nextLayout === splitLayout) return;
+			const currentLayout = splitLayoutRef.current;
+			const { newPaneId, nextLayout } = createSplit(
+				currentLayout,
+				paneId,
+				edge,
+			);
+			if (nextLayout === currentLayout) return;
 			const tab = createTab(kind, target, newPaneId);
 			setSplitLayout(nextLayout);
 			if (kind === "file" && target) pushNoteHistory(tab.id, target);
@@ -143,16 +150,24 @@ export function useSplitEditorTabs({
 			createTab,
 			pushNoteHistory,
 			setSplitLayout,
-			splitLayout,
+			splitLayoutRef,
 			tabsRef,
 		],
 	);
 
 	const splitPaneWithFile = useCallback(
 		(paneId: string, edge: SplitDropEdge, path: string) => {
-			if (isMarkdownPath(path)) splitPaneWithTab(paneId, edge, "file", path);
+			if (!isMarkdownPath(path)) return;
+			const existing = tabsRef.current.find(
+				(tab) => tab.kind === "file" && tab.target === path,
+			);
+			if (existing) {
+				setActiveTabId(existing.id);
+				return;
+			}
+			splitPaneWithTab(paneId, edge, "file", path);
 		},
-		[splitPaneWithTab],
+		[setActiveTabId, splitPaneWithTab, tabsRef],
 	);
 
 	const splitPaneWithBlank = useCallback(
@@ -191,20 +206,22 @@ export function useSplitEditorTabs({
 				const sourcePaneIsEmpty = !nextTabs.some(
 					(tab) => tab.paneId === sourceTab.paneId,
 				);
-				if (sourcePaneIsEmpty && paneIdsInLayout(splitLayout).length > 1) {
-					const nextLayout = removeEditorPane(splitLayout, sourceTab.paneId);
+				const currentLayout = splitLayoutRef.current;
+				if (sourcePaneIsEmpty && paneIdsInLayout(currentLayout).length > 1) {
+					const nextLayout = removeEditorPane(currentLayout, sourceTab.paneId);
 					if (nextLayout) setSplitLayout(nextLayout);
 				}
 				commitTabsChange(nextTabs, tabId);
 				return;
 			}
 
+			const currentLayout = splitLayoutRef.current;
 			const { newPaneId, nextLayout } = createSplit(
-				splitLayout,
+				currentLayout,
 				targetPaneId,
 				edge,
 			);
-			if (nextLayout === splitLayout) return;
+			if (nextLayout === currentLayout) return;
 			const sourcePaneTabs = tabsRef.current.filter(
 				(tab) => tab.paneId === sourceTab.paneId,
 			);
@@ -224,7 +241,7 @@ export function useSplitEditorTabs({
 			createTab,
 			setActiveTabId,
 			setSplitLayout,
-			splitLayout,
+			splitLayoutRef,
 			tabsRef,
 		],
 	);

--- a/src/components/app/useSplitEditorTabs.ts
+++ b/src/components/app/useSplitEditorTabs.ts
@@ -1,0 +1,390 @@
+import {
+	type Dispatch,
+	type RefObject,
+	type SetStateAction,
+	useCallback,
+	useMemo,
+} from "react";
+import {
+	type SplitDropEdge,
+	type SplitEditorNode,
+	paneIdsInLayout,
+	removeEditorPane,
+	splitEditorPane,
+	updateSplitRatio,
+} from "../../lib/splitEditor";
+import { isMarkdownPath } from "../../utils/path";
+import type {
+	TabHistoryById,
+	WorkspaceEditorPane,
+	WorkspaceTab,
+} from "./useTabManager";
+
+interface SplitEditorTabController {
+	tabsRef: RefObject<WorkspaceTab[]>;
+	focusedPaneIdRef: RefObject<string>;
+	activeTabByPaneRef: RefObject<Record<string, string | null>>;
+	setFocusedPaneId: Dispatch<SetStateAction<string>>;
+	createTab: (
+		kind: WorkspaceTab["kind"],
+		target: string | null,
+		paneId?: string,
+	) => WorkspaceTab;
+	commitTabsChange: (
+		nextTabs: WorkspaceTab[],
+		nextActiveTabId: string | null,
+	) => void;
+	setActiveTabId: (tabId: string | null) => void;
+	clearHistoryForTab: (tabId: string) => void;
+	pushNoteHistory: (tabId: string, path: string) => void;
+	stepHistory: (tabId: string, delta: -1 | 1) => string | null;
+	updateActiveTabInPlace: (
+		kind: WorkspaceTab["kind"],
+		target: string | null,
+	) => string;
+}
+
+interface UseSplitEditorTabsArgs {
+	tabs: WorkspaceTab[];
+	historyByTabId: TabHistoryById;
+	splitLayout: SplitEditorNode;
+	setSplitLayout: Dispatch<SetStateAction<SplitEditorNode>>;
+	activeTabByPane: Record<string, string | null>;
+	controller: SplitEditorTabController;
+}
+
+function createSplit(
+	layout: SplitEditorNode,
+	paneId: string,
+	edge: SplitDropEdge,
+) {
+	const newPaneId = `editor-pane-${crypto.randomUUID()}`;
+	const nextLayout = splitEditorPane(
+		layout,
+		paneId,
+		newPaneId,
+		`editor-split-${crypto.randomUUID()}`,
+		edge,
+	);
+	return { newPaneId, nextLayout };
+}
+
+function reconcilePaneActiveTab(
+	activeTabByPaneRef: RefObject<Record<string, string | null>>,
+	tabs: WorkspaceTab[],
+	paneId: string,
+) {
+	const activeTabId = activeTabByPaneRef.current[paneId];
+	if (
+		activeTabId &&
+		tabs.some((tab) => tab.id === activeTabId && tab.paneId === paneId)
+	) {
+		return;
+	}
+	activeTabByPaneRef.current = {
+		...activeTabByPaneRef.current,
+		[paneId]: tabs.find((tab) => tab.paneId === paneId)?.id ?? null,
+	};
+}
+
+export function useSplitEditorTabs({
+	tabs,
+	historyByTabId,
+	splitLayout,
+	setSplitLayout,
+	activeTabByPane,
+	controller,
+}: UseSplitEditorTabsArgs) {
+	const {
+		tabsRef,
+		focusedPaneIdRef,
+		activeTabByPaneRef,
+		setFocusedPaneId,
+		createTab,
+		commitTabsChange,
+		setActiveTabId,
+		clearHistoryForTab,
+		pushNoteHistory,
+		stepHistory,
+		updateActiveTabInPlace,
+	} = controller;
+
+	const focusPaneState = useCallback(
+		(paneId: string) => {
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneId(paneId);
+		},
+		[focusedPaneIdRef, setFocusedPaneId],
+	);
+
+	const openBlankTabInPane = useCallback(
+		(paneId: string) => {
+			focusPaneState(paneId);
+			const blankTab = createTab("blank", null, paneId);
+			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
+		},
+		[commitTabsChange, createTab, focusPaneState, tabsRef],
+	);
+
+	const openFileInPane = useCallback(
+		(path: string, paneId: string) => {
+			if (!isMarkdownPath(path)) return false;
+			focusPaneState(paneId);
+			const existing = tabsRef.current.find(
+				(tab) => tab.paneId === paneId && tab.target === path,
+			);
+			if (existing) {
+				commitTabsChange(tabsRef.current, existing.id);
+				return true;
+			}
+
+			const paneActiveId = activeTabByPaneRef.current[paneId] ?? null;
+			const paneActive = tabsRef.current.find(
+				(tab) => tab.id === paneActiveId && tab.paneId === paneId,
+			);
+			const tab =
+				paneActive?.kind === "blank"
+					? { ...paneActive, kind: "file" as const, target: path }
+					: createTab("file", path, paneId);
+			const nextTabs =
+				paneActive?.kind === "blank"
+					? tabsRef.current.map((candidate) =>
+							candidate.id === tab.id ? tab : candidate,
+						)
+					: [...tabsRef.current, tab];
+			if (paneActive?.kind === "blank") clearHistoryForTab(tab.id);
+			pushNoteHistory(tab.id, path);
+			commitTabsChange(nextTabs, tab.id);
+			return true;
+		},
+		[
+			activeTabByPaneRef,
+			clearHistoryForTab,
+			commitTabsChange,
+			createTab,
+			focusPaneState,
+			pushNoteHistory,
+			tabsRef,
+		],
+	);
+
+	const splitPaneWithTab = useCallback(
+		(
+			paneId: string,
+			edge: SplitDropEdge,
+			kind: WorkspaceTab["kind"],
+			target: string | null,
+		) => {
+			const { newPaneId, nextLayout } = createSplit(
+				splitLayout,
+				paneId,
+				edge,
+			);
+			if (nextLayout === splitLayout) return;
+			const tab = createTab(kind, target, newPaneId);
+			setSplitLayout(nextLayout);
+			focusPaneState(newPaneId);
+			if (kind === "file" && target) pushNoteHistory(tab.id, target);
+			commitTabsChange([...tabsRef.current, tab], tab.id);
+		},
+		[
+			commitTabsChange,
+			createTab,
+			focusPaneState,
+			pushNoteHistory,
+			setSplitLayout,
+			splitLayout,
+			tabsRef,
+		],
+	);
+
+	const splitPaneWithFile = useCallback(
+		(paneId: string, edge: SplitDropEdge, path: string) => {
+			if (isMarkdownPath(path)) splitPaneWithTab(paneId, edge, "file", path);
+		},
+		[splitPaneWithTab],
+	);
+
+	const splitPaneWithBlank = useCallback(
+		(edge: SplitDropEdge) => {
+			splitPaneWithTab(
+				focusedPaneIdRef.current,
+				edge,
+				"blank",
+				null,
+			);
+		},
+		[focusedPaneIdRef, splitPaneWithTab],
+	);
+
+	const moveTabToPane = useCallback(
+		(
+			tabId: string,
+			targetPaneId: string,
+			edge: SplitDropEdge | "center",
+		) => {
+			const sourceTab = tabsRef.current.find((tab) => tab.id === tabId);
+			if (!sourceTab) return;
+
+			if (edge === "center") {
+				if (sourceTab.paneId === targetPaneId) {
+					setActiveTabId(tabId);
+					return;
+				}
+				const existing = sourceTab.target
+					? tabsRef.current.find(
+							(tab) =>
+								tab.paneId === targetPaneId &&
+								tab.target === sourceTab.target &&
+								tab.kind === sourceTab.kind,
+						)
+					: null;
+				if (existing) {
+					setActiveTabId(existing.id);
+					return;
+				}
+
+				const nextTabs = tabsRef.current.map((tab) =>
+					tab.id === tabId ? { ...tab, paneId: targetPaneId } : tab,
+				);
+				const sourcePaneIsEmpty = !nextTabs.some(
+					(tab) => tab.paneId === sourceTab.paneId,
+				);
+				if (sourcePaneIsEmpty && paneIdsInLayout(splitLayout).length > 1) {
+					const nextLayout = removeEditorPane(
+						splitLayout,
+						sourceTab.paneId,
+					);
+					if (nextLayout) setSplitLayout(nextLayout);
+					const nextActiveByPane = { ...activeTabByPaneRef.current };
+					delete nextActiveByPane[sourceTab.paneId];
+					activeTabByPaneRef.current = nextActiveByPane;
+				} else {
+					reconcilePaneActiveTab(
+						activeTabByPaneRef,
+						nextTabs,
+						sourceTab.paneId,
+					);
+				}
+				focusPaneState(targetPaneId);
+				commitTabsChange(nextTabs, tabId);
+				return;
+			}
+
+			const { newPaneId, nextLayout } = createSplit(
+				splitLayout,
+				targetPaneId,
+				edge,
+			);
+			if (nextLayout === splitLayout) return;
+			const sourcePaneTabs = tabsRef.current.filter(
+				(tab) => tab.paneId === sourceTab.paneId,
+			);
+			const movedTab = { ...sourceTab, paneId: newPaneId };
+			let nextTabs = tabsRef.current.map((tab) =>
+				tab.id === tabId ? movedTab : tab,
+			);
+			if (sourcePaneTabs.length === 1) {
+				const blankTab = createTab("blank", null, sourceTab.paneId);
+				nextTabs = [...nextTabs, blankTab];
+			}
+			reconcilePaneActiveTab(
+				activeTabByPaneRef,
+				nextTabs,
+				sourceTab.paneId,
+			);
+			setSplitLayout(nextLayout);
+			focusPaneState(newPaneId);
+			commitTabsChange(nextTabs, movedTab.id);
+		},
+		[
+			activeTabByPaneRef,
+			commitTabsChange,
+			createTab,
+			focusPaneState,
+			setActiveTabId,
+			setSplitLayout,
+			splitLayout,
+			tabsRef,
+		],
+	);
+
+	const resizeSplit = useCallback(
+		(splitId: string, ratio: number) => {
+			setSplitLayout((current) =>
+				updateSplitRatio(current, splitId, ratio),
+			);
+		},
+		[setSplitLayout],
+	);
+
+	const navigatePaneHistory = useCallback(
+		(paneId: string, delta: -1 | 1) => {
+			const tabId = activeTabByPaneRef.current[paneId];
+			if (!tabId) return;
+			focusPaneState(paneId);
+			const path = stepHistory(tabId, delta);
+			if (!path) return;
+			setActiveTabId(tabId);
+			updateActiveTabInPlace("file", path);
+		},
+		[
+			activeTabByPaneRef,
+			focusPaneState,
+			setActiveTabId,
+			stepHistory,
+			updateActiveTabInPlace,
+		],
+	);
+	const goBackInPane = useCallback(
+		(paneId: string) => navigatePaneHistory(paneId, -1),
+		[navigatePaneHistory],
+	);
+	const goForwardInPane = useCallback(
+		(paneId: string) => navigatePaneHistory(paneId, 1),
+		[navigatePaneHistory],
+	);
+
+	const panes = useMemo<Record<string, WorkspaceEditorPane>>(() => {
+		const tabsByPane = new Map<string, WorkspaceTab[]>();
+		for (const tab of tabs) {
+			const paneTabs = tabsByPane.get(tab.paneId);
+			if (paneTabs) paneTabs.push(tab);
+			else tabsByPane.set(tab.paneId, [tab]);
+		}
+
+		const result: Record<string, WorkspaceEditorPane> = {};
+		for (const paneId of paneIdsInLayout(splitLayout)) {
+			const paneTabs = tabsByPane.get(paneId) ?? [];
+			const paneActiveTabId =
+				activeTabByPane[paneId] ?? paneTabs[0]?.id ?? null;
+			const paneActiveTab =
+				paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null;
+			const history = paneActiveTabId
+				? historyByTabId[paneActiveTabId]
+				: undefined;
+			result[paneId] = {
+				id: paneId,
+				tabs: paneTabs,
+				activeTabId: paneActiveTabId,
+				activeTabPath: paneActiveTab?.target ?? null,
+				canGoBack: (history?.index ?? -1) > 0,
+				canGoForward:
+					(history?.index ?? -1) < (history?.entries.length ?? 0) - 1,
+			};
+		}
+		return result;
+	}, [activeTabByPane, historyByTabId, splitLayout, tabs]);
+
+	return {
+		panes,
+		openBlankTabInPane,
+		openFileInPane,
+		splitPaneWithFile,
+		splitPaneWithBlank,
+		moveTabToPane,
+		resizeSplit,
+		goBackInPane,
+		goForwardInPane,
+	};
+}

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -2,11 +2,35 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useRecentFiles } from "../../hooks/useRecentFiles";
 import { isMarkdownPath } from "../../utils/path";
+import {
+	MAX_SPLIT_RATIO,
+	MIN_SPLIT_RATIO,
+	PRIMARY_EDITOR_PANE_ID,
+	createInitialSplitEditorLayout,
+	paneIdsInLayout,
+	removeEditorPane,
+	splitEditorPane,
+	updateSplitRatio,
+} from "./splitEditorModel";
+import type {
+	SplitDropEdge,
+	SplitEditorNode,
+} from "./splitEditorModel";
 
 export interface WorkspaceTab {
 	id: string;
+	paneId: string;
 	kind: "blank" | "file" | "special";
 	target: string | null;
+}
+
+export interface WorkspaceEditorPane {
+	id: string;
+	tabs: WorkspaceTab[];
+	activeTabId: string | null;
+	activeTabPath: string | null;
+	canGoBack: boolean;
+	canGoForward: boolean;
 }
 
 type NoteHistoryEntry = {
@@ -23,6 +47,7 @@ type TabHistoryById = Record<string, TabNoteHistory>;
 interface RestoredWorkspaceTab {
 	kind: "file" | "special";
 	target: string;
+	paneId?: string;
 }
 
 function matchesRemovedPath(
@@ -43,12 +68,25 @@ export function useTabManager(spacePath: string | null) {
 
 	const [tabs, setTabs] = useState<WorkspaceTab[]>([]);
 	const [activeTabId, setActiveTabIdState] = useState<string | null>(null);
+	const [splitLayout, setSplitLayout] = useState<SplitEditorNode>(
+		createInitialSplitEditorLayout,
+	);
+	const [focusedPaneId, setFocusedPaneIdState] = useState(
+		PRIMARY_EDITOR_PANE_ID,
+	);
+	const [activeTabByPane, setActiveTabByPane] = useState<
+		Record<string, string | null>
+	>({ [PRIMARY_EDITOR_PANE_ID]: null });
 	const [dirtyByPath, setDirtyByPath] = useState<Record<string, boolean>>({});
 	const [historyByTabId, setHistoryByTabId] = useState<TabHistoryById>({});
 	const [tabsRevision, setTabsRevision] = useState(0);
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
+	const focusedPaneIdRef = useRef(PRIMARY_EDITOR_PANE_ID);
+	const activeTabByPaneRef = useRef<Record<string, string | null>>({
+		[PRIMARY_EDITOR_PANE_ID]: null,
+	});
 	const historyByTabIdRef = useRef<TabHistoryById>({});
 
 	tabsRef.current = tabs;
@@ -56,8 +94,13 @@ export function useTabManager(spacePath: string | null) {
 	historyByTabIdRef.current = historyByTabId;
 
 	const createTab = useCallback(
-		(kind: WorkspaceTab["kind"], target: string | null): WorkspaceTab => ({
+		(
+			kind: WorkspaceTab["kind"],
+			target: string | null,
+			paneId = focusedPaneIdRef.current,
+		): WorkspaceTab => ({
 			id: `workspace-tab-${++tabIdCounterRef.current}`,
+			paneId,
 			kind,
 			target,
 		}),
@@ -131,8 +174,17 @@ export function useTabManager(spacePath: string | null) {
 			const previousActiveTarget = previousActiveTab?.target ?? null;
 			tabsRef.current = nextTabs;
 			activeTabIdRef.current = nextActiveTabId;
+			const nextActivePaneId =
+				nextTabs.find((tab) => tab.id === nextActiveTabId)?.paneId ??
+				focusedPaneIdRef.current;
+			const nextActiveByPane = {
+				...activeTabByPaneRef.current,
+				[nextActivePaneId]: nextActiveTabId,
+			};
+			activeTabByPaneRef.current = nextActiveByPane;
 			setTabs(nextTabs);
 			setActiveTabIdState(nextActiveTabId);
+			setActiveTabByPane(nextActiveByPane);
 			setTabsRevision((revision) => revision + 1);
 			syncWorkspaceState(nextTabs, nextActiveTabId, previousActiveTarget);
 		},
@@ -141,6 +193,26 @@ export function useTabManager(spacePath: string | null) {
 
 	const setActiveTabId = useCallback(
 		(nextActiveTabId: string | null) => {
+			const paneId = tabsRef.current.find(
+				(tab) => tab.id === nextActiveTabId,
+			)?.paneId;
+			if (paneId) {
+				focusedPaneIdRef.current = paneId;
+				setFocusedPaneIdState(paneId);
+			}
+			commitTabsChange(tabsRef.current, nextActiveTabId);
+		},
+		[commitTabsChange],
+	);
+
+	const focusPane = useCallback(
+		(paneId: string) => {
+			if (focusedPaneIdRef.current === paneId) return;
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneIdState(paneId);
+			const paneTabs = tabsRef.current.filter((tab) => tab.paneId === paneId);
+			const nextActiveTabId =
+				activeTabByPaneRef.current[paneId] ?? paneTabs[0]?.id ?? null;
 			commitTabsChange(tabsRef.current, nextActiveTabId);
 		},
 		[commitTabsChange],
@@ -151,8 +223,13 @@ export function useTabManager(spacePath: string | null) {
 		tabsRef.current = [];
 		activeTabIdRef.current = null;
 		historyByTabIdRef.current = {};
+		focusedPaneIdRef.current = PRIMARY_EDITOR_PANE_ID;
+		activeTabByPaneRef.current = { [PRIMARY_EDITOR_PANE_ID]: null };
 		setTabs([]);
 		setActiveTabIdState(null);
+		setSplitLayout(createInitialSplitEditorLayout());
+		setFocusedPaneIdState(PRIMARY_EDITOR_PANE_ID);
+		setActiveTabByPane({ [PRIMARY_EDITOR_PANE_ID]: null });
 		setDirtyByPath({});
 		setHistoryByTabId({});
 		setTabsRevision(0);
@@ -160,7 +237,10 @@ export function useTabManager(spacePath: string | null) {
 
 	const focusExistingTab = useCallback(
 		(target: string) => {
-			const existing = tabs.find((tab) => tab.target === target);
+			const existing = tabs.find(
+				(tab) =>
+					tab.paneId === focusedPaneIdRef.current && tab.target === target,
+			);
 			if (!existing) return false;
 			setActiveTabId(existing.id);
 			return true;
@@ -373,15 +453,35 @@ export function useTabManager(spacePath: string | null) {
 	);
 
 	const restoreWorkspaceTabs = useCallback(
-		(tabSnapshots: RestoredWorkspaceTab[], activeTabTarget: string | null) => {
+		(
+			tabSnapshots: RestoredWorkspaceTab[],
+			activeTabTarget: string | null,
+			restoredLayout: SplitEditorNode | null,
+			restoredFocusedPaneId: string | null,
+			activeTabTargetByPane: Record<string, string | null>,
+		) => {
+			const nextLayout =
+				restoredLayout ?? createInitialSplitEditorLayout();
+			const layoutPaneIds = new Set(paneIdsInLayout(nextLayout));
+			const fallbackPaneId =
+				paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
 			const seenTargets = new Set<string>();
 			const nextTabs: WorkspaceTab[] = [];
 			const nextHistory: TabHistoryById = {};
 
 			for (const snapshot of tabSnapshots) {
-				if (seenTargets.has(snapshot.target)) continue;
-				seenTargets.add(snapshot.target);
-				const tab = createTab(snapshot.kind, snapshot.target);
+				const paneId =
+					snapshot.paneId && layoutPaneIds.has(snapshot.paneId)
+						? snapshot.paneId
+					: fallbackPaneId;
+				const targetKey = `${paneId}\0${snapshot.target}`;
+				if (seenTargets.has(targetKey)) continue;
+				seenTargets.add(targetKey);
+				const tab = createTab(
+					snapshot.kind,
+					snapshot.target,
+					paneId,
+				);
 				nextTabs.push(tab);
 				if (snapshot.kind === "file" && isMarkdownPath(snapshot.target)) {
 					nextHistory[tab.id] = {
@@ -391,12 +491,32 @@ export function useTabManager(spacePath: string | null) {
 				}
 			}
 
+			const nextActiveByPane: Record<string, string | null> = {};
+			for (const paneId of layoutPaneIds) {
+				const target = activeTabTargetByPane[paneId];
+				nextActiveByPane[paneId] =
+					nextTabs.find(
+						(tab) => tab.paneId === paneId && tab.target === target,
+					)?.id ??
+					nextTabs.find((tab) => tab.paneId === paneId)?.id ??
+					null;
+			}
+			const nextFocusedPaneId =
+				restoredFocusedPaneId && layoutPaneIds.has(restoredFocusedPaneId)
+					? restoredFocusedPaneId
+					: fallbackPaneId;
 			const nextActiveTabId =
+				nextActiveByPane[nextFocusedPaneId] ??
 				nextTabs.find((tab) => tab.target === activeTabTarget)?.id ??
 				nextTabs[0]?.id ??
 				null;
 
 			historyByTabIdRef.current = nextHistory;
+			focusedPaneIdRef.current = nextFocusedPaneId;
+			activeTabByPaneRef.current = nextActiveByPane;
+			setSplitLayout(nextLayout);
+			setFocusedPaneIdState(nextFocusedPaneId);
+			setActiveTabByPane(nextActiveByPane);
 			setHistoryByTabId(nextHistory);
 			setDirtyByPath({});
 			commitTabsChange(nextTabs, nextActiveTabId);
@@ -429,7 +549,66 @@ export function useTabManager(spacePath: string | null) {
 			const nextActiveTabId =
 				activeTabIdRef.current !== tabId
 					? activeTabIdRef.current
-					: (nextTabs[index]?.id ?? nextTabs[index - 1]?.id ?? null);
+					: (nextTabs.find(
+							(tab) =>
+								tab.paneId === removed?.paneId &&
+								currentTabs.indexOf(tab) > index,
+						)?.id ??
+						[...nextTabs]
+							.reverse()
+							.find(
+								(tab) =>
+									tab.paneId === removed?.paneId &&
+									currentTabs.indexOf(tab) < index,
+							)?.id ??
+						null);
+			const removedPaneId = removed?.paneId;
+			if (
+				removedPaneId &&
+				activeTabByPaneRef.current[removedPaneId] === tabId
+			) {
+				const replacementTabId =
+					nextTabs.find(
+						(tab) =>
+							tab.paneId === removedPaneId &&
+							currentTabs.indexOf(tab) > index,
+					)?.id ??
+					[...nextTabs]
+						.reverse()
+						.find(
+							(tab) =>
+								tab.paneId === removedPaneId &&
+								currentTabs.indexOf(tab) < index,
+						)?.id ??
+					null;
+				activeTabByPaneRef.current = {
+					...activeTabByPaneRef.current,
+					[removedPaneId]: replacementTabId,
+				};
+			}
+			const paneIsEmpty =
+				removedPaneId &&
+				!nextTabs.some((tab) => tab.paneId === removedPaneId) &&
+				paneIdsInLayout(splitLayout).length > 1;
+			let committedActiveTabId = nextActiveTabId;
+			if (paneIsEmpty && removedPaneId) {
+				const nextLayout = removeEditorPane(splitLayout, removedPaneId);
+				if (nextLayout) {
+					setSplitLayout(nextLayout);
+					const fallbackPaneId =
+						paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
+					focusedPaneIdRef.current = fallbackPaneId;
+					setFocusedPaneIdState(fallbackPaneId);
+					committedActiveTabId =
+						activeTabByPaneRef.current[fallbackPaneId] ??
+						nextTabs.find((tab) => tab.paneId === fallbackPaneId)?.id ??
+						null;
+				}
+				const nextActiveByPane = { ...activeTabByPaneRef.current };
+				delete nextActiveByPane[removedPaneId];
+				activeTabByPaneRef.current = nextActiveByPane;
+				setActiveTabByPane(nextActiveByPane);
+			}
 			if (removedTarget) {
 				setDirtyByPath((prev) => {
 					if (!(removedTarget in prev)) return prev;
@@ -444,7 +623,7 @@ export function useTabManager(spacePath: string | null) {
 				delete next[tabId];
 				return next;
 			});
-			commitTabsChange(nextTabs, nextActiveTabId);
+			commitTabsChange(nextTabs, committedActiveTabId);
 			setDirtyByPath((prev) => {
 				let changed = false;
 				const next: Record<string, boolean> = {};
@@ -462,10 +641,15 @@ export function useTabManager(spacePath: string | null) {
 				return changed ? next : prev;
 			});
 		},
-		[commitTabsChange, updateHistoryState],
+		[commitTabsChange, splitLayout, updateHistoryState],
 	);
 
 	const closeAllTabs = useCallback(() => {
+		focusedPaneIdRef.current = PRIMARY_EDITOR_PANE_ID;
+		activeTabByPaneRef.current = { [PRIMARY_EDITOR_PANE_ID]: null };
+		setSplitLayout(createInitialSplitEditorLayout());
+		setFocusedPaneIdState(PRIMARY_EDITOR_PANE_ID);
+		setActiveTabByPane({ [PRIMARY_EDITOR_PANE_ID]: null });
 		commitTabsChange([], null);
 		setDirtyByPath({});
 		historyByTabIdRef.current = {};
@@ -650,6 +834,8 @@ export function useTabManager(spacePath: string | null) {
 			const fromIndex = currentTabs.findIndex((tab) => tab.id === fromTabId);
 			const toIndex = currentTabs.findIndex((tab) => tab.id === toTabId);
 			if (fromIndex === -1 || toIndex === -1) return;
+			if (currentTabs[fromIndex]?.paneId !== currentTabs[toIndex]?.paneId)
+				return;
 			const next = [...currentTabs];
 			const [moved] = next.splice(fromIndex, 1);
 			next.splice(toIndex, 0, moved);
@@ -659,27 +845,35 @@ export function useTabManager(spacePath: string | null) {
 	);
 
 	const activateNextTab = useCallback(() => {
-		if (!tabsRef.current.length) return;
+		const paneTabs = tabsRef.current.filter(
+			(tab) => tab.paneId === focusedPaneIdRef.current,
+		);
+		if (!paneTabs.length) return;
 		const currentIndex = activeTabIdRef.current
-			? tabsRef.current.findIndex((tab) => tab.id === activeTabIdRef.current)
+			? paneTabs.findIndex((tab) => tab.id === activeTabIdRef.current)
 			: -1;
-		const nextIndex = (Math.max(currentIndex, -1) + 1) % tabsRef.current.length;
-		setActiveTabId(tabsRef.current[nextIndex]?.id ?? null);
+		const nextIndex = (Math.max(currentIndex, -1) + 1) % paneTabs.length;
+		setActiveTabId(paneTabs[nextIndex]?.id ?? null);
 	}, [setActiveTabId]);
 
 	const activatePreviousTab = useCallback(() => {
-		if (!tabsRef.current.length) return;
+		const paneTabs = tabsRef.current.filter(
+			(tab) => tab.paneId === focusedPaneIdRef.current,
+		);
+		if (!paneTabs.length) return;
 		const currentIndex = activeTabIdRef.current
-			? tabsRef.current.findIndex((tab) => tab.id === activeTabIdRef.current)
+			? paneTabs.findIndex((tab) => tab.id === activeTabIdRef.current)
 			: 0;
 		const nextIndex =
-			(currentIndex - 1 + tabsRef.current.length) % tabsRef.current.length;
-		setActiveTabId(tabsRef.current[nextIndex]?.id ?? null);
+			(currentIndex - 1 + paneTabs.length) % paneTabs.length;
+		setActiveTabId(paneTabs[nextIndex]?.id ?? null);
 	}, [setActiveTabId]);
 
 	const activateTabByIndex = useCallback(
 		(index: number) => {
-			const tab = tabsRef.current[index];
+			const tab = tabsRef.current.filter(
+				(candidate) => candidate.paneId === focusedPaneIdRef.current,
+			)[index];
 			if (!tab) return false;
 			setActiveTabId(tab.id);
 			return true;
@@ -687,12 +881,307 @@ export function useTabManager(spacePath: string | null) {
 		[setActiveTabId],
 	);
 
+	const openBlankTabInPane = useCallback(
+		(paneId: string) => {
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneIdState(paneId);
+			const blankTab = createTab("blank", null, paneId);
+			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
+		},
+		[commitTabsChange, createTab],
+	);
+
+	const openFileInPane = useCallback(
+		(path: string, paneId: string) => {
+			if (!canOpenInMainPane(path)) return false;
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneIdState(paneId);
+			const existing = tabsRef.current.find(
+				(tab) => tab.paneId === paneId && tab.target === path,
+			);
+			if (existing) {
+				commitTabsChange(tabsRef.current, existing.id);
+				return true;
+			}
+			const paneActiveId = activeTabByPaneRef.current[paneId] ?? null;
+			const paneActive = tabsRef.current.find(
+				(tab) => tab.id === paneActiveId && tab.paneId === paneId,
+			);
+			let tab: WorkspaceTab;
+			let nextTabs: WorkspaceTab[];
+			if (paneActive?.kind === "blank") {
+				tab = { ...paneActive, kind: "file", target: path };
+				nextTabs = tabsRef.current.map((candidate) =>
+					candidate.id === tab.id ? tab : candidate,
+				);
+				clearHistoryForTab(tab.id);
+			} else {
+				tab = createTab("file", path, paneId);
+				nextTabs = [...tabsRef.current, tab];
+			}
+			pushNoteHistory(tab.id, path);
+			commitTabsChange(nextTabs, tab.id);
+			return true;
+		},
+		[
+			canOpenInMainPane,
+			clearHistoryForTab,
+			commitTabsChange,
+			createTab,
+			pushNoteHistory,
+		],
+	);
+
+	const splitPaneWithFile = useCallback(
+		(paneId: string, edge: SplitDropEdge, path: string) => {
+			if (!canOpenInMainPane(path)) return;
+			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
+			const nextLayout = splitEditorPane(
+				splitLayout,
+				paneId,
+				newPaneId,
+				`editor-split-${crypto.randomUUID()}`,
+				edge,
+			);
+			if (nextLayout === splitLayout) return;
+			const tab = createTab("file", path, newPaneId);
+			setSplitLayout(nextLayout);
+			focusedPaneIdRef.current = newPaneId;
+			setFocusedPaneIdState(newPaneId);
+			activeTabByPaneRef.current = {
+				...activeTabByPaneRef.current,
+				[newPaneId]: tab.id,
+			};
+			setActiveTabByPane(activeTabByPaneRef.current);
+			pushNoteHistory(tab.id, path);
+			commitTabsChange([...tabsRef.current, tab], tab.id);
+		},
+		[
+			canOpenInMainPane,
+			commitTabsChange,
+			createTab,
+			pushNoteHistory,
+			splitLayout,
+		],
+	);
+
+	const splitPaneWithBlank = useCallback(
+		(edge: SplitDropEdge) => {
+			const paneId = focusedPaneIdRef.current;
+			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
+			const nextLayout = splitEditorPane(
+				splitLayout,
+				paneId,
+				newPaneId,
+				`editor-split-${crypto.randomUUID()}`,
+				edge,
+			);
+			if (nextLayout === splitLayout) return;
+			const blankTab = createTab("blank", null, newPaneId);
+			setSplitLayout(nextLayout);
+			focusedPaneIdRef.current = newPaneId;
+			setFocusedPaneIdState(newPaneId);
+			activeTabByPaneRef.current = {
+				...activeTabByPaneRef.current,
+				[newPaneId]: blankTab.id,
+			};
+			setActiveTabByPane(activeTabByPaneRef.current);
+			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
+		},
+		[commitTabsChange, createTab, splitLayout],
+	);
+
+	const moveTabToPane = useCallback(
+		(
+			tabId: string,
+			targetPaneId: string,
+			edge: SplitDropEdge | "center",
+		) => {
+			const sourceTab = tabsRef.current.find((tab) => tab.id === tabId);
+			if (!sourceTab) return;
+
+			if (edge === "center") {
+				if (sourceTab.paneId === targetPaneId) {
+					setActiveTabId(tabId);
+					return;
+				}
+				const existing = sourceTab.target
+					? tabsRef.current.find(
+							(tab) =>
+								tab.paneId === targetPaneId &&
+								tab.target === sourceTab.target &&
+								tab.kind === sourceTab.kind,
+						)
+					: null;
+				if (existing) {
+					setActiveTabId(existing.id);
+					closeTab(tabId);
+					return;
+				}
+				const nextTabs = tabsRef.current.map((tab) =>
+					tab.id === tabId ? { ...tab, paneId: targetPaneId } : tab,
+				);
+				const sourcePaneIsEmpty = !nextTabs.some(
+					(tab) => tab.paneId === sourceTab.paneId,
+				);
+				if (sourcePaneIsEmpty && paneIdsInLayout(splitLayout).length > 1) {
+					const nextLayout = removeEditorPane(
+						splitLayout,
+						sourceTab.paneId,
+					);
+					if (nextLayout) setSplitLayout(nextLayout);
+					const nextActiveByPane = { ...activeTabByPaneRef.current };
+					delete nextActiveByPane[sourceTab.paneId];
+					activeTabByPaneRef.current = nextActiveByPane;
+				} else if (
+					activeTabByPaneRef.current[sourceTab.paneId] === tabId
+				) {
+					activeTabByPaneRef.current = {
+						...activeTabByPaneRef.current,
+						[sourceTab.paneId]:
+							nextTabs.find(
+								(tab) => tab.paneId === sourceTab.paneId,
+							)?.id ?? null,
+					};
+				}
+				focusedPaneIdRef.current = targetPaneId;
+				setFocusedPaneIdState(targetPaneId);
+				commitTabsChange(nextTabs, tabId);
+				return;
+			}
+
+			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
+			const nextLayout = splitEditorPane(
+				splitLayout,
+				targetPaneId,
+				newPaneId,
+				`editor-split-${crypto.randomUUID()}`,
+				edge,
+			);
+			if (nextLayout === splitLayout) return;
+			const sourcePaneTabs = tabsRef.current.filter(
+				(tab) => tab.paneId === sourceTab.paneId,
+			);
+			let nextTab = sourceTab;
+			let nextTabs: WorkspaceTab[];
+			if (sourcePaneTabs.length === 1) {
+				const blankTab = createTab("blank", null, sourceTab.paneId);
+				nextTab = { ...sourceTab, paneId: newPaneId };
+				nextTabs = [
+					...tabsRef.current.map((tab) =>
+						tab.id === tabId ? nextTab : tab,
+					),
+					blankTab,
+				];
+				activeTabByPaneRef.current = {
+					...activeTabByPaneRef.current,
+					[sourceTab.paneId]: blankTab.id,
+				};
+			} else {
+				nextTab = { ...sourceTab, paneId: newPaneId };
+				nextTabs = tabsRef.current.map((tab) =>
+					tab.id === tabId ? nextTab : tab,
+				);
+				if (activeTabByPaneRef.current[sourceTab.paneId] === tabId) {
+					activeTabByPaneRef.current = {
+						...activeTabByPaneRef.current,
+						[sourceTab.paneId]:
+							nextTabs.find(
+								(tab) => tab.paneId === sourceTab.paneId,
+							)?.id ?? null,
+					};
+				}
+			}
+			setSplitLayout(nextLayout);
+			focusedPaneIdRef.current = newPaneId;
+			setFocusedPaneIdState(newPaneId);
+			commitTabsChange(nextTabs, nextTab.id);
+		},
+		[
+			closeTab,
+			commitTabsChange,
+				createTab,
+				setActiveTabId,
+				splitLayout,
+			],
+		);
+
+	const resizeSplit = useCallback((splitId: string, ratio: number) => {
+		const clampedRatio = Math.min(
+			MAX_SPLIT_RATIO,
+			Math.max(MIN_SPLIT_RATIO, ratio),
+		);
+		setSplitLayout((current) =>
+			updateSplitRatio(current, splitId, clampedRatio),
+		);
+		setTabsRevision((revision) => revision + 1);
+	}, []);
+
+	const goBackInPane = useCallback(
+		(paneId: string) => {
+			const tabId = activeTabByPaneRef.current[paneId];
+			if (!tabId) return;
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneIdState(paneId);
+			activeTabIdRef.current = tabId;
+			const path = stepHistory(tabId, -1);
+			if (!path) return;
+			updateActiveTabInPlace("file", path);
+		},
+		[stepHistory, updateActiveTabInPlace],
+	);
+
+	const goForwardInPane = useCallback(
+		(paneId: string) => {
+			const tabId = activeTabByPaneRef.current[paneId];
+			if (!tabId) return;
+			focusedPaneIdRef.current = paneId;
+			setFocusedPaneIdState(paneId);
+			activeTabIdRef.current = tabId;
+			const path = stepHistory(tabId, 1);
+			if (!path) return;
+			updateActiveTabInPlace("file", path);
+		},
+		[stepHistory, updateActiveTabInPlace],
+	);
+
+	const panes = useMemo<Record<string, WorkspaceEditorPane>>(() => {
+		const result: Record<string, WorkspaceEditorPane> = {};
+		for (const paneId of paneIdsInLayout(splitLayout)) {
+			const paneTabs = tabs.filter((tab) => tab.paneId === paneId);
+			const paneActiveTabId =
+				activeTabByPane[paneId] ?? paneTabs[0]?.id ?? null;
+			const paneActiveTab =
+				paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null;
+			const history = paneActiveTabId
+				? historyByTabId[paneActiveTabId]
+				: undefined;
+			result[paneId] = {
+				id: paneId,
+				tabs: paneTabs,
+				activeTabId: paneActiveTabId,
+				activeTabPath:
+					paneActiveTab?.kind === "blank"
+						? null
+						: (paneActiveTab?.target ?? null),
+				canGoBack: (history?.index ?? -1) > 0,
+				canGoForward:
+					(history?.index ?? -1) < (history?.entries.length ?? 0) - 1,
+			};
+		}
+		return result;
+	}, [activeTabByPane, historyByTabId, splitLayout, tabs]);
+
 	return {
 		tabs,
+		panes,
+		splitLayout,
+		focusedPaneId,
 		activeTab,
 		activeTabId,
 		activeTabPath,
 		setActiveTabId,
+		focusPane,
 		dirtyByPath,
 		setDirtyByPath,
 		closeTab,
@@ -702,6 +1191,12 @@ export function useTabManager(spacePath: string | null) {
 		renameTabsForPath,
 		reorderTabs,
 		openBlankTab,
+		openBlankTabInPane,
+		openFileInPane,
+		splitPaneWithFile,
+		splitPaneWithBlank,
+		moveTabToPane,
+		resizeSplit,
 		replaceActiveTabWithBlank,
 		openFileTab,
 		openSpecialTab,
@@ -710,6 +1205,8 @@ export function useTabManager(spacePath: string | null) {
 		canGoForward,
 		goBack,
 		goForward,
+		goBackInPane,
+		goForwardInPane,
 		activateNextTab,
 		activatePreviousTab,
 		activateTabByIndex,

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -1,21 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useRecentFiles } from "../../hooks/useRecentFiles";
-import { isMarkdownPath } from "../../utils/path";
 import {
-	MAX_SPLIT_RATIO,
-	MIN_SPLIT_RATIO,
 	PRIMARY_EDITOR_PANE_ID,
+	type SplitEditorNode,
 	createInitialSplitEditorLayout,
 	paneIdsInLayout,
 	removeEditorPane,
-	splitEditorPane,
-	updateSplitRatio,
-} from "./splitEditorModel";
-import type {
-	SplitDropEdge,
-	SplitEditorNode,
-} from "./splitEditorModel";
+} from "../../lib/splitEditor";
+import { isMarkdownPath } from "../../utils/path";
+import { useSplitEditorTabs } from "./useSplitEditorTabs";
 
 export interface WorkspaceTab {
 	id: string;
@@ -42,12 +36,12 @@ type TabNoteHistory = {
 	index: number;
 };
 
-type TabHistoryById = Record<string, TabNoteHistory>;
+export type TabHistoryById = Record<string, TabNoteHistory>;
 
 interface RestoredWorkspaceTab {
 	kind: "file" | "special";
 	target: string;
-	paneId?: string;
+	paneId: string;
 }
 
 function matchesRemovedPath(
@@ -58,6 +52,29 @@ function matchesRemovedPath(
 	if (tab.kind !== "file" || !tab.target) return false;
 	if (tab.target === path) return true;
 	return recursive && tab.target.startsWith(`${path}/`);
+}
+
+function nearestTabIdInPane(
+	currentTabs: WorkspaceTab[],
+	nextTabs: WorkspaceTab[],
+	removedIndex: number,
+	paneId: string,
+): string | null {
+	const next = nextTabs.find(
+		(tab) =>
+			tab.paneId === paneId && currentTabs.indexOf(tab) > removedIndex,
+	);
+	if (next) return next.id;
+	for (let index = nextTabs.length - 1; index >= 0; index -= 1) {
+		const tab = nextTabs[index];
+		if (
+			tab?.paneId === paneId &&
+			currentTabs.indexOf(tab) < removedIndex
+		) {
+			return tab.id;
+		}
+	}
+	return null;
 }
 
 export function useTabManager(spacePath: string | null) {
@@ -126,14 +143,17 @@ export function useTabManager(spacePath: string | null) {
 				nextActiveTab?.kind === "file" && nextActiveTab.target
 					? nextActiveTab.target
 					: null;
-			const nextMarkdownTabs = nextTabs
-				.filter(
-					(tab) =>
+			const nextMarkdownTabs = [
+				...new Set(
+					nextTabs.flatMap((tab) =>
 						tab.kind === "file" &&
 						tab.target !== null &&
-						isMarkdownPath(tab.target),
-				)
-				.map((tab) => tab.target as string);
+						isMarkdownPath(tab.target)
+							? [tab.target]
+							: [],
+					),
+				),
+			];
 			const nextActiveMarkdownPath =
 				nextActiveTab?.kind === "file" &&
 				nextActiveTab.target !== null &&
@@ -237,7 +257,7 @@ export function useTabManager(spacePath: string | null) {
 
 	const focusExistingTab = useCallback(
 		(target: string) => {
-			const existing = tabs.find(
+			const existing = tabsRef.current.find(
 				(tab) =>
 					tab.paneId === focusedPaneIdRef.current && tab.target === target,
 			);
@@ -245,7 +265,7 @@ export function useTabManager(spacePath: string | null) {
 			setActiveTabId(existing.id);
 			return true;
 		},
-		[setActiveTabId, tabs],
+		[setActiveTabId],
 	);
 
 	const clearDirtyForTarget = useCallback((target: string | null) => {
@@ -470,9 +490,8 @@ export function useTabManager(spacePath: string | null) {
 			const nextHistory: TabHistoryById = {};
 
 			for (const snapshot of tabSnapshots) {
-				const paneId =
-					snapshot.paneId && layoutPaneIds.has(snapshot.paneId)
-						? snapshot.paneId
+				const paneId = layoutPaneIds.has(snapshot.paneId)
+					? snapshot.paneId
 					: fallbackPaneId;
 				const targetKey = `${paneId}\0${snapshot.target}`;
 				if (seenTargets.has(targetKey)) continue;
@@ -546,41 +565,23 @@ export function useTabManager(spacePath: string | null) {
 			const removed = currentTabs[index];
 			const removedTarget = removed?.kind === "file" ? removed.target : null;
 			const nextTabs = currentTabs.filter((tab) => tab.id !== tabId);
+			const removedPaneId = removed?.paneId;
+			const replacementTabId = removedPaneId
+				? nearestTabIdInPane(
+						currentTabs,
+						nextTabs,
+						index,
+						removedPaneId,
+					)
+				: null;
 			const nextActiveTabId =
 				activeTabIdRef.current !== tabId
 					? activeTabIdRef.current
-					: (nextTabs.find(
-							(tab) =>
-								tab.paneId === removed?.paneId &&
-								currentTabs.indexOf(tab) > index,
-						)?.id ??
-						[...nextTabs]
-							.reverse()
-							.find(
-								(tab) =>
-									tab.paneId === removed?.paneId &&
-									currentTabs.indexOf(tab) < index,
-							)?.id ??
-						null);
-			const removedPaneId = removed?.paneId;
+					: replacementTabId;
 			if (
 				removedPaneId &&
 				activeTabByPaneRef.current[removedPaneId] === tabId
 			) {
-				const replacementTabId =
-					nextTabs.find(
-						(tab) =>
-							tab.paneId === removedPaneId &&
-							currentTabs.indexOf(tab) > index,
-					)?.id ??
-					[...nextTabs]
-						.reverse()
-						.find(
-							(tab) =>
-								tab.paneId === removedPaneId &&
-								currentTabs.indexOf(tab) < index,
-						)?.id ??
-					null;
 				activeTabByPaneRef.current = {
 					...activeTabByPaneRef.current,
 					[removedPaneId]: replacementTabId,
@@ -595,27 +596,27 @@ export function useTabManager(spacePath: string | null) {
 				const nextLayout = removeEditorPane(splitLayout, removedPaneId);
 				if (nextLayout) {
 					setSplitLayout(nextLayout);
-					const fallbackPaneId =
-						paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
-					focusedPaneIdRef.current = fallbackPaneId;
-					setFocusedPaneIdState(fallbackPaneId);
-					committedActiveTabId =
-						activeTabByPaneRef.current[fallbackPaneId] ??
-						nextTabs.find((tab) => tab.paneId === fallbackPaneId)?.id ??
-						null;
+					if (focusedPaneIdRef.current === removedPaneId) {
+						const fallbackPaneId =
+							paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
+						focusedPaneIdRef.current = fallbackPaneId;
+						setFocusedPaneIdState(fallbackPaneId);
+						committedActiveTabId =
+							activeTabByPaneRef.current[fallbackPaneId] ??
+							nextTabs.find((tab) => tab.paneId === fallbackPaneId)?.id ??
+							null;
+					}
 				}
 				const nextActiveByPane = { ...activeTabByPaneRef.current };
 				delete nextActiveByPane[removedPaneId];
 				activeTabByPaneRef.current = nextActiveByPane;
 				setActiveTabByPane(nextActiveByPane);
 			}
-			if (removedTarget) {
-				setDirtyByPath((prev) => {
-					if (!(removedTarget in prev)) return prev;
-					const next = { ...prev };
-					delete next[removedTarget];
-					return next;
-				});
+			if (
+				removedTarget &&
+				!nextTabs.some((tab) => tab.target === removedTarget)
+			) {
+				clearDirtyForTarget(removedTarget);
 			}
 			updateHistoryState((prev) => {
 				if (!(tabId in prev)) return prev;
@@ -624,24 +625,13 @@ export function useTabManager(spacePath: string | null) {
 				return next;
 			});
 			commitTabsChange(nextTabs, committedActiveTabId);
-			setDirtyByPath((prev) => {
-				let changed = false;
-				const next: Record<string, boolean> = {};
-				for (const [tabPath, dirty] of Object.entries(prev)) {
-					if (
-						removedTarget &&
-						(tabPath === removedTarget ||
-							tabPath.startsWith(`${removedTarget}/`))
-					) {
-						changed = true;
-						continue;
-					}
-					next[tabPath] = dirty;
-				}
-				return changed ? next : prev;
-			});
 		},
-		[commitTabsChange, splitLayout, updateHistoryState],
+		[
+			clearDirtyForTarget,
+			commitTabsChange,
+			splitLayout,
+			updateHistoryState,
+		],
 	);
 
 	const closeAllTabs = useCallback(() => {
@@ -881,296 +871,36 @@ export function useTabManager(spacePath: string | null) {
 		[setActiveTabId],
 	);
 
-	const openBlankTabInPane = useCallback(
-		(paneId: string) => {
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneIdState(paneId);
-			const blankTab = createTab("blank", null, paneId);
-			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
-		},
-		[commitTabsChange, createTab],
-	);
-
-	const openFileInPane = useCallback(
-		(path: string, paneId: string) => {
-			if (!canOpenInMainPane(path)) return false;
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneIdState(paneId);
-			const existing = tabsRef.current.find(
-				(tab) => tab.paneId === paneId && tab.target === path,
-			);
-			if (existing) {
-				commitTabsChange(tabsRef.current, existing.id);
-				return true;
-			}
-			const paneActiveId = activeTabByPaneRef.current[paneId] ?? null;
-			const paneActive = tabsRef.current.find(
-				(tab) => tab.id === paneActiveId && tab.paneId === paneId,
-			);
-			let tab: WorkspaceTab;
-			let nextTabs: WorkspaceTab[];
-			if (paneActive?.kind === "blank") {
-				tab = { ...paneActive, kind: "file", target: path };
-				nextTabs = tabsRef.current.map((candidate) =>
-					candidate.id === tab.id ? tab : candidate,
-				);
-				clearHistoryForTab(tab.id);
-			} else {
-				tab = createTab("file", path, paneId);
-				nextTabs = [...tabsRef.current, tab];
-			}
-			pushNoteHistory(tab.id, path);
-			commitTabsChange(nextTabs, tab.id);
-			return true;
-		},
-		[
-			canOpenInMainPane,
+	const {
+		panes,
+		openBlankTabInPane,
+		openFileInPane,
+		splitPaneWithFile,
+		splitPaneWithBlank,
+		moveTabToPane,
+		resizeSplit,
+		goBackInPane,
+		goForwardInPane,
+	} = useSplitEditorTabs({
+		tabs,
+		historyByTabId,
+		splitLayout,
+		setSplitLayout,
+		activeTabByPane,
+		controller: {
+			tabsRef,
+			focusedPaneIdRef,
+			activeTabByPaneRef,
+			setFocusedPaneId: setFocusedPaneIdState,
+			createTab,
+			commitTabsChange,
+			setActiveTabId,
 			clearHistoryForTab,
-			commitTabsChange,
-			createTab,
 			pushNoteHistory,
-		],
-	);
-
-	const splitPaneWithFile = useCallback(
-		(paneId: string, edge: SplitDropEdge, path: string) => {
-			if (!canOpenInMainPane(path)) return;
-			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
-			const nextLayout = splitEditorPane(
-				splitLayout,
-				paneId,
-				newPaneId,
-				`editor-split-${crypto.randomUUID()}`,
-				edge,
-			);
-			if (nextLayout === splitLayout) return;
-			const tab = createTab("file", path, newPaneId);
-			setSplitLayout(nextLayout);
-			focusedPaneIdRef.current = newPaneId;
-			setFocusedPaneIdState(newPaneId);
-			activeTabByPaneRef.current = {
-				...activeTabByPaneRef.current,
-				[newPaneId]: tab.id,
-			};
-			setActiveTabByPane(activeTabByPaneRef.current);
-			pushNoteHistory(tab.id, path);
-			commitTabsChange([...tabsRef.current, tab], tab.id);
+			stepHistory,
+			updateActiveTabInPlace,
 		},
-		[
-			canOpenInMainPane,
-			commitTabsChange,
-			createTab,
-			pushNoteHistory,
-			splitLayout,
-		],
-	);
-
-	const splitPaneWithBlank = useCallback(
-		(edge: SplitDropEdge) => {
-			const paneId = focusedPaneIdRef.current;
-			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
-			const nextLayout = splitEditorPane(
-				splitLayout,
-				paneId,
-				newPaneId,
-				`editor-split-${crypto.randomUUID()}`,
-				edge,
-			);
-			if (nextLayout === splitLayout) return;
-			const blankTab = createTab("blank", null, newPaneId);
-			setSplitLayout(nextLayout);
-			focusedPaneIdRef.current = newPaneId;
-			setFocusedPaneIdState(newPaneId);
-			activeTabByPaneRef.current = {
-				...activeTabByPaneRef.current,
-				[newPaneId]: blankTab.id,
-			};
-			setActiveTabByPane(activeTabByPaneRef.current);
-			commitTabsChange([...tabsRef.current, blankTab], blankTab.id);
-		},
-		[commitTabsChange, createTab, splitLayout],
-	);
-
-	const moveTabToPane = useCallback(
-		(
-			tabId: string,
-			targetPaneId: string,
-			edge: SplitDropEdge | "center",
-		) => {
-			const sourceTab = tabsRef.current.find((tab) => tab.id === tabId);
-			if (!sourceTab) return;
-
-			if (edge === "center") {
-				if (sourceTab.paneId === targetPaneId) {
-					setActiveTabId(tabId);
-					return;
-				}
-				const existing = sourceTab.target
-					? tabsRef.current.find(
-							(tab) =>
-								tab.paneId === targetPaneId &&
-								tab.target === sourceTab.target &&
-								tab.kind === sourceTab.kind,
-						)
-					: null;
-				if (existing) {
-					setActiveTabId(existing.id);
-					closeTab(tabId);
-					return;
-				}
-				const nextTabs = tabsRef.current.map((tab) =>
-					tab.id === tabId ? { ...tab, paneId: targetPaneId } : tab,
-				);
-				const sourcePaneIsEmpty = !nextTabs.some(
-					(tab) => tab.paneId === sourceTab.paneId,
-				);
-				if (sourcePaneIsEmpty && paneIdsInLayout(splitLayout).length > 1) {
-					const nextLayout = removeEditorPane(
-						splitLayout,
-						sourceTab.paneId,
-					);
-					if (nextLayout) setSplitLayout(nextLayout);
-					const nextActiveByPane = { ...activeTabByPaneRef.current };
-					delete nextActiveByPane[sourceTab.paneId];
-					activeTabByPaneRef.current = nextActiveByPane;
-				} else if (
-					activeTabByPaneRef.current[sourceTab.paneId] === tabId
-				) {
-					activeTabByPaneRef.current = {
-						...activeTabByPaneRef.current,
-						[sourceTab.paneId]:
-							nextTabs.find(
-								(tab) => tab.paneId === sourceTab.paneId,
-							)?.id ?? null,
-					};
-				}
-				focusedPaneIdRef.current = targetPaneId;
-				setFocusedPaneIdState(targetPaneId);
-				commitTabsChange(nextTabs, tabId);
-				return;
-			}
-
-			const newPaneId = `editor-pane-${crypto.randomUUID()}`;
-			const nextLayout = splitEditorPane(
-				splitLayout,
-				targetPaneId,
-				newPaneId,
-				`editor-split-${crypto.randomUUID()}`,
-				edge,
-			);
-			if (nextLayout === splitLayout) return;
-			const sourcePaneTabs = tabsRef.current.filter(
-				(tab) => tab.paneId === sourceTab.paneId,
-			);
-			let nextTab = sourceTab;
-			let nextTabs: WorkspaceTab[];
-			if (sourcePaneTabs.length === 1) {
-				const blankTab = createTab("blank", null, sourceTab.paneId);
-				nextTab = { ...sourceTab, paneId: newPaneId };
-				nextTabs = [
-					...tabsRef.current.map((tab) =>
-						tab.id === tabId ? nextTab : tab,
-					),
-					blankTab,
-				];
-				activeTabByPaneRef.current = {
-					...activeTabByPaneRef.current,
-					[sourceTab.paneId]: blankTab.id,
-				};
-			} else {
-				nextTab = { ...sourceTab, paneId: newPaneId };
-				nextTabs = tabsRef.current.map((tab) =>
-					tab.id === tabId ? nextTab : tab,
-				);
-				if (activeTabByPaneRef.current[sourceTab.paneId] === tabId) {
-					activeTabByPaneRef.current = {
-						...activeTabByPaneRef.current,
-						[sourceTab.paneId]:
-							nextTabs.find(
-								(tab) => tab.paneId === sourceTab.paneId,
-							)?.id ?? null,
-					};
-				}
-			}
-			setSplitLayout(nextLayout);
-			focusedPaneIdRef.current = newPaneId;
-			setFocusedPaneIdState(newPaneId);
-			commitTabsChange(nextTabs, nextTab.id);
-		},
-		[
-			closeTab,
-			commitTabsChange,
-				createTab,
-				setActiveTabId,
-				splitLayout,
-			],
-		);
-
-	const resizeSplit = useCallback((splitId: string, ratio: number) => {
-		const clampedRatio = Math.min(
-			MAX_SPLIT_RATIO,
-			Math.max(MIN_SPLIT_RATIO, ratio),
-		);
-		setSplitLayout((current) =>
-			updateSplitRatio(current, splitId, clampedRatio),
-		);
-		setTabsRevision((revision) => revision + 1);
-	}, []);
-
-	const goBackInPane = useCallback(
-		(paneId: string) => {
-			const tabId = activeTabByPaneRef.current[paneId];
-			if (!tabId) return;
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneIdState(paneId);
-			activeTabIdRef.current = tabId;
-			const path = stepHistory(tabId, -1);
-			if (!path) return;
-			updateActiveTabInPlace("file", path);
-		},
-		[stepHistory, updateActiveTabInPlace],
-	);
-
-	const goForwardInPane = useCallback(
-		(paneId: string) => {
-			const tabId = activeTabByPaneRef.current[paneId];
-			if (!tabId) return;
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneIdState(paneId);
-			activeTabIdRef.current = tabId;
-			const path = stepHistory(tabId, 1);
-			if (!path) return;
-			updateActiveTabInPlace("file", path);
-		},
-		[stepHistory, updateActiveTabInPlace],
-	);
-
-	const panes = useMemo<Record<string, WorkspaceEditorPane>>(() => {
-		const result: Record<string, WorkspaceEditorPane> = {};
-		for (const paneId of paneIdsInLayout(splitLayout)) {
-			const paneTabs = tabs.filter((tab) => tab.paneId === paneId);
-			const paneActiveTabId =
-				activeTabByPane[paneId] ?? paneTabs[0]?.id ?? null;
-			const paneActiveTab =
-				paneTabs.find((tab) => tab.id === paneActiveTabId) ?? null;
-			const history = paneActiveTabId
-				? historyByTabId[paneActiveTabId]
-				: undefined;
-			result[paneId] = {
-				id: paneId,
-				tabs: paneTabs,
-				activeTabId: paneActiveTabId,
-				activeTabPath:
-					paneActiveTab?.kind === "blank"
-						? null
-						: (paneActiveTab?.target ?? null),
-				canGoBack: (history?.index ?? -1) > 0,
-				canGoForward:
-					(history?.index ?? -1) < (history?.entries.length ?? 0) - 1,
-			};
-		}
-		return result;
-	}, [activeTabByPane, historyByTabId, splitLayout, tabs]);
+	});
 
 	return {
 		tabs,

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -61,20 +61,20 @@ function nearestTabIdInPane(
 	paneId: string,
 ): string | null {
 	const next = nextTabs.find(
-		(tab) =>
-			tab.paneId === paneId && currentTabs.indexOf(tab) > removedIndex,
+		(tab) => tab.paneId === paneId && currentTabs.indexOf(tab) > removedIndex,
 	);
 	if (next) return next.id;
 	for (let index = nextTabs.length - 1; index >= 0; index -= 1) {
 		const tab = nextTabs[index];
-		if (
-			tab?.paneId === paneId &&
-			currentTabs.indexOf(tab) < removedIndex
-		) {
+		if (tab?.paneId === paneId && currentTabs.indexOf(tab) < removedIndex) {
 			return tab.id;
 		}
 	}
 	return null;
+}
+
+function paneIdForTab(tabs: WorkspaceTab[], tabId: string | null): string {
+	return tabs.find((tab) => tab.id === tabId)?.paneId ?? PRIMARY_EDITOR_PANE_ID;
 }
 
 export function useTabManager(spacePath: string | null) {
@@ -88,9 +88,6 @@ export function useTabManager(spacePath: string | null) {
 	const [splitLayout, setSplitLayout] = useState<SplitEditorNode>(
 		createInitialSplitEditorLayout,
 	);
-	const [focusedPaneId, setFocusedPaneIdState] = useState(
-		PRIMARY_EDITOR_PANE_ID,
-	);
 	const [activeTabByPane, setActiveTabByPane] = useState<
 		Record<string, string | null>
 	>({ [PRIMARY_EDITOR_PANE_ID]: null });
@@ -100,7 +97,6 @@ export function useTabManager(spacePath: string | null) {
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
-	const focusedPaneIdRef = useRef(PRIMARY_EDITOR_PANE_ID);
 	const activeTabByPaneRef = useRef<Record<string, string | null>>({
 		[PRIMARY_EDITOR_PANE_ID]: null,
 	});
@@ -114,7 +110,7 @@ export function useTabManager(spacePath: string | null) {
 		(
 			kind: WorkspaceTab["kind"],
 			target: string | null,
-			paneId = focusedPaneIdRef.current,
+			paneId = paneIdForTab(tabsRef.current, activeTabIdRef.current),
 		): WorkspaceTab => ({
 			id: `workspace-tab-${++tabIdCounterRef.current}`,
 			paneId,
@@ -130,6 +126,7 @@ export function useTabManager(spacePath: string | null) {
 	);
 	const activeTabPath =
 		activeTab && activeTab.kind !== "blank" ? activeTab.target : null;
+	const focusedPaneId = activeTab?.paneId ?? PRIMARY_EDITOR_PANE_ID;
 
 	const syncWorkspaceState = useCallback(
 		(
@@ -196,11 +193,18 @@ export function useTabManager(spacePath: string | null) {
 			activeTabIdRef.current = nextActiveTabId;
 			const nextActivePaneId =
 				nextTabs.find((tab) => tab.id === nextActiveTabId)?.paneId ??
-				focusedPaneIdRef.current;
-			const nextActiveByPane = {
-				...activeTabByPaneRef.current,
-				[nextActivePaneId]: nextActiveTabId,
-			};
+				PRIMARY_EDITOR_PANE_ID;
+			const nextActiveByPane: Record<string, string | null> = {};
+			const nextTabIds = new Set(nextTabs.map((tab) => tab.id));
+			for (const tab of nextTabs) {
+				if (tab.paneId in nextActiveByPane) continue;
+				const currentActiveId = activeTabByPaneRef.current[tab.paneId];
+				nextActiveByPane[tab.paneId] =
+					currentActiveId && nextTabIds.has(currentActiveId)
+						? currentActiveId
+						: tab.id;
+			}
+			nextActiveByPane[nextActivePaneId] = nextActiveTabId;
 			activeTabByPaneRef.current = nextActiveByPane;
 			setTabs(nextTabs);
 			setActiveTabIdState(nextActiveTabId);
@@ -213,13 +217,6 @@ export function useTabManager(spacePath: string | null) {
 
 	const setActiveTabId = useCallback(
 		(nextActiveTabId: string | null) => {
-			const paneId = tabsRef.current.find(
-				(tab) => tab.id === nextActiveTabId,
-			)?.paneId;
-			if (paneId) {
-				focusedPaneIdRef.current = paneId;
-				setFocusedPaneIdState(paneId);
-			}
 			commitTabsChange(tabsRef.current, nextActiveTabId);
 		},
 		[commitTabsChange],
@@ -227,9 +224,8 @@ export function useTabManager(spacePath: string | null) {
 
 	const focusPane = useCallback(
 		(paneId: string) => {
-			if (focusedPaneIdRef.current === paneId) return;
-			focusedPaneIdRef.current = paneId;
-			setFocusedPaneIdState(paneId);
+			if (paneIdForTab(tabsRef.current, activeTabIdRef.current) === paneId)
+				return;
 			const paneTabs = tabsRef.current.filter((tab) => tab.paneId === paneId);
 			const nextActiveTabId =
 				activeTabByPaneRef.current[paneId] ?? paneTabs[0]?.id ?? null;
@@ -243,12 +239,10 @@ export function useTabManager(spacePath: string | null) {
 		tabsRef.current = [];
 		activeTabIdRef.current = null;
 		historyByTabIdRef.current = {};
-		focusedPaneIdRef.current = PRIMARY_EDITOR_PANE_ID;
 		activeTabByPaneRef.current = { [PRIMARY_EDITOR_PANE_ID]: null };
 		setTabs([]);
 		setActiveTabIdState(null);
 		setSplitLayout(createInitialSplitEditorLayout());
-		setFocusedPaneIdState(PRIMARY_EDITOR_PANE_ID);
 		setActiveTabByPane({ [PRIMARY_EDITOR_PANE_ID]: null });
 		setDirtyByPath({});
 		setHistoryByTabId({});
@@ -259,7 +253,9 @@ export function useTabManager(spacePath: string | null) {
 		(target: string) => {
 			const existing = tabsRef.current.find(
 				(tab) =>
-					tab.paneId === focusedPaneIdRef.current && tab.target === target,
+					tab.paneId ===
+						paneIdForTab(tabsRef.current, activeTabIdRef.current) &&
+					tab.target === target,
 			);
 			if (!existing) return false;
 			setActiveTabId(existing.id);
@@ -388,21 +384,25 @@ export function useTabManager(spacePath: string | null) {
 		[updateHistoryState],
 	);
 
+	const navigateTabHistory = useCallback(
+		(tabId: string, delta: -1 | 1) => {
+			const path = stepHistory(tabId, delta);
+			if (!path) return;
+			activeTabIdRef.current = tabId;
+			updateActiveTabInPlace("file", path);
+		},
+		[stepHistory, updateActiveTabInPlace],
+	);
+
 	const goBack = useCallback(() => {
 		const activeId = activeTabIdRef.current;
-		if (!activeId) return;
-		const path = stepHistory(activeId, -1);
-		if (!path) return;
-		updateActiveTabInPlace("file", path);
-	}, [stepHistory, updateActiveTabInPlace]);
+		if (activeId) navigateTabHistory(activeId, -1);
+	}, [navigateTabHistory]);
 
 	const goForward = useCallback(() => {
 		const activeId = activeTabIdRef.current;
-		if (!activeId) return;
-		const path = stepHistory(activeId, 1);
-		if (!path) return;
-		updateActiveTabInPlace("file", path);
-	}, [stepHistory, updateActiveTabInPlace]);
+		if (activeId) navigateTabHistory(activeId, 1);
+	}, [navigateTabHistory]);
 
 	const activeHistory =
 		activeTabId !== null ? (historyByTabId[activeTabId] ?? null) : null;
@@ -480,8 +480,7 @@ export function useTabManager(spacePath: string | null) {
 			restoredFocusedPaneId: string | null,
 			activeTabTargetByPane: Record<string, string | null>,
 		) => {
-			const nextLayout =
-				restoredLayout ?? createInitialSplitEditorLayout();
+			const nextLayout = restoredLayout ?? createInitialSplitEditorLayout();
 			const layoutPaneIds = new Set(paneIdsInLayout(nextLayout));
 			const fallbackPaneId =
 				paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
@@ -496,11 +495,7 @@ export function useTabManager(spacePath: string | null) {
 				const targetKey = `${paneId}\0${snapshot.target}`;
 				if (seenTargets.has(targetKey)) continue;
 				seenTargets.add(targetKey);
-				const tab = createTab(
-					snapshot.kind,
-					snapshot.target,
-					paneId,
-				);
+				const tab = createTab(snapshot.kind, snapshot.target, paneId);
 				nextTabs.push(tab);
 				if (snapshot.kind === "file" && isMarkdownPath(snapshot.target)) {
 					nextHistory[tab.id] = {
@@ -509,14 +504,18 @@ export function useTabManager(spacePath: string | null) {
 					};
 				}
 			}
+			for (const paneId of layoutPaneIds) {
+				if (!nextTabs.some((tab) => tab.paneId === paneId)) {
+					nextTabs.push(createTab("blank", null, paneId));
+				}
+			}
 
 			const nextActiveByPane: Record<string, string | null> = {};
 			for (const paneId of layoutPaneIds) {
 				const target = activeTabTargetByPane[paneId];
 				nextActiveByPane[paneId] =
-					nextTabs.find(
-						(tab) => tab.paneId === paneId && tab.target === target,
-					)?.id ??
+					nextTabs.find((tab) => tab.paneId === paneId && tab.target === target)
+						?.id ??
 					nextTabs.find((tab) => tab.paneId === paneId)?.id ??
 					null;
 			}
@@ -531,10 +530,8 @@ export function useTabManager(spacePath: string | null) {
 				null;
 
 			historyByTabIdRef.current = nextHistory;
-			focusedPaneIdRef.current = nextFocusedPaneId;
 			activeTabByPaneRef.current = nextActiveByPane;
 			setSplitLayout(nextLayout);
-			setFocusedPaneIdState(nextFocusedPaneId);
 			setActiveTabByPane(nextActiveByPane);
 			setHistoryByTabId(nextHistory);
 			setDirtyByPath({});
@@ -564,29 +561,17 @@ export function useTabManager(spacePath: string | null) {
 			if (index === -1) return;
 			const removed = currentTabs[index];
 			const removedTarget = removed?.kind === "file" ? removed.target : null;
+			const removedWasFocused =
+				removed?.paneId === paneIdForTab(currentTabs, activeTabIdRef.current);
 			const nextTabs = currentTabs.filter((tab) => tab.id !== tabId);
 			const removedPaneId = removed?.paneId;
 			const replacementTabId = removedPaneId
-				? nearestTabIdInPane(
-						currentTabs,
-						nextTabs,
-						index,
-						removedPaneId,
-					)
+				? nearestTabIdInPane(currentTabs, nextTabs, index, removedPaneId)
 				: null;
 			const nextActiveTabId =
 				activeTabIdRef.current !== tabId
 					? activeTabIdRef.current
 					: replacementTabId;
-			if (
-				removedPaneId &&
-				activeTabByPaneRef.current[removedPaneId] === tabId
-			) {
-				activeTabByPaneRef.current = {
-					...activeTabByPaneRef.current,
-					[removedPaneId]: replacementTabId,
-				};
-			}
 			const paneIsEmpty =
 				removedPaneId &&
 				!nextTabs.some((tab) => tab.paneId === removedPaneId) &&
@@ -596,21 +581,15 @@ export function useTabManager(spacePath: string | null) {
 				const nextLayout = removeEditorPane(splitLayout, removedPaneId);
 				if (nextLayout) {
 					setSplitLayout(nextLayout);
-					if (focusedPaneIdRef.current === removedPaneId) {
+					if (removedWasFocused) {
 						const fallbackPaneId =
 							paneIdsInLayout(nextLayout)[0] ?? PRIMARY_EDITOR_PANE_ID;
-						focusedPaneIdRef.current = fallbackPaneId;
-						setFocusedPaneIdState(fallbackPaneId);
 						committedActiveTabId =
 							activeTabByPaneRef.current[fallbackPaneId] ??
 							nextTabs.find((tab) => tab.paneId === fallbackPaneId)?.id ??
 							null;
 					}
 				}
-				const nextActiveByPane = { ...activeTabByPaneRef.current };
-				delete nextActiveByPane[removedPaneId];
-				activeTabByPaneRef.current = nextActiveByPane;
-				setActiveTabByPane(nextActiveByPane);
 			}
 			if (
 				removedTarget &&
@@ -626,20 +605,11 @@ export function useTabManager(spacePath: string | null) {
 			});
 			commitTabsChange(nextTabs, committedActiveTabId);
 		},
-		[
-			clearDirtyForTarget,
-			commitTabsChange,
-			splitLayout,
-			updateHistoryState,
-		],
+		[clearDirtyForTarget, commitTabsChange, splitLayout, updateHistoryState],
 	);
 
 	const closeAllTabs = useCallback(() => {
-		focusedPaneIdRef.current = PRIMARY_EDITOR_PANE_ID;
-		activeTabByPaneRef.current = { [PRIMARY_EDITOR_PANE_ID]: null };
 		setSplitLayout(createInitialSplitEditorLayout());
-		setFocusedPaneIdState(PRIMARY_EDITOR_PANE_ID);
-		setActiveTabByPane({ [PRIMARY_EDITOR_PANE_ID]: null });
 		commitTabsChange([], null);
 		setDirtyByPath({});
 		historyByTabIdRef.current = {};
@@ -654,7 +624,7 @@ export function useTabManager(spacePath: string | null) {
 	const closeTabsForPathRemoval = useCallback(
 		(path: string, recursive = false) => {
 			const currentTabs = tabsRef.current;
-			const nextTabs = currentTabs.filter(
+			let nextTabs = currentTabs.filter(
 				(tab) => !matchesRemovedPath(tab, path, recursive),
 			);
 			const tabsRemoved = nextTabs.length < currentTabs.length;
@@ -666,32 +636,28 @@ export function useTabManager(spacePath: string | null) {
 
 			const currentActiveTabId = activeTabIdRef.current;
 			let nextActiveTabId = currentActiveTabId;
+			if (tabsRemoved) {
+				for (const paneId of paneIdsInLayout(splitLayout)) {
+					if (!nextTabs.some((tab) => tab.paneId === paneId)) {
+						nextTabs = [...nextTabs, createTab("blank", null, paneId)];
+					}
+				}
+			}
 			if (tabsRemoved && currentActiveTabId) {
 				const removedIndex = currentTabs.findIndex(
 					(tab) => tab.id === currentActiveTabId,
 				);
 				const removedTab = removedIndex >= 0 ? currentTabs[removedIndex] : null;
 				if (removedTab && matchesRemovedPath(removedTab, path, recursive)) {
-					const survivingTabIds = new Set(nextTabs.map((tab) => tab.id));
-					nextActiveTabId = null;
-					for (
-						let index = removedIndex + 1;
-						index < currentTabs.length;
-						index++
-					) {
-						const candidate = currentTabs[index];
-						if (!survivingTabIds.has(candidate.id)) continue;
-						nextActiveTabId = candidate.id;
-						break;
-					}
-					if (!nextActiveTabId) {
-						for (let index = removedIndex - 1; index >= 0; index--) {
-							const candidate = currentTabs[index];
-							if (!survivingTabIds.has(candidate.id)) continue;
-							nextActiveTabId = candidate.id;
-							break;
-						}
-					}
+					nextActiveTabId =
+						nearestTabIdInPane(
+							currentTabs,
+							nextTabs,
+							removedIndex,
+							removedTab.paneId,
+						) ??
+						nextTabs.find((tab) => tab.paneId === removedTab.paneId)?.id ??
+						null;
 				}
 			}
 			updateHistoryState((prev) => {
@@ -749,7 +715,7 @@ export function useTabManager(spacePath: string | null) {
 				return changed ? next : prev;
 			});
 		},
-		[commitTabsChange, updateHistoryState],
+		[commitTabsChange, createTab, splitLayout, updateHistoryState],
 	);
 
 	const renameTabsForPath = useCallback(
@@ -835,9 +801,8 @@ export function useTabManager(spacePath: string | null) {
 	);
 
 	const activateNextTab = useCallback(() => {
-		const paneTabs = tabsRef.current.filter(
-			(tab) => tab.paneId === focusedPaneIdRef.current,
-		);
+		const paneId = paneIdForTab(tabsRef.current, activeTabIdRef.current);
+		const paneTabs = tabsRef.current.filter((tab) => tab.paneId === paneId);
 		if (!paneTabs.length) return;
 		const currentIndex = activeTabIdRef.current
 			? paneTabs.findIndex((tab) => tab.id === activeTabIdRef.current)
@@ -847,22 +812,21 @@ export function useTabManager(spacePath: string | null) {
 	}, [setActiveTabId]);
 
 	const activatePreviousTab = useCallback(() => {
-		const paneTabs = tabsRef.current.filter(
-			(tab) => tab.paneId === focusedPaneIdRef.current,
-		);
+		const paneId = paneIdForTab(tabsRef.current, activeTabIdRef.current);
+		const paneTabs = tabsRef.current.filter((tab) => tab.paneId === paneId);
 		if (!paneTabs.length) return;
 		const currentIndex = activeTabIdRef.current
 			? paneTabs.findIndex((tab) => tab.id === activeTabIdRef.current)
 			: 0;
-		const nextIndex =
-			(currentIndex - 1 + paneTabs.length) % paneTabs.length;
+		const nextIndex = (currentIndex - 1 + paneTabs.length) % paneTabs.length;
 		setActiveTabId(paneTabs[nextIndex]?.id ?? null);
 	}, [setActiveTabId]);
 
 	const activateTabByIndex = useCallback(
 		(index: number) => {
+			const paneId = paneIdForTab(tabsRef.current, activeTabIdRef.current);
 			const tab = tabsRef.current.filter(
-				(candidate) => candidate.paneId === focusedPaneIdRef.current,
+				(candidate) => candidate.paneId === paneId,
 			)[index];
 			if (!tab) return false;
 			setActiveTabId(tab.id);
@@ -885,21 +849,17 @@ export function useTabManager(spacePath: string | null) {
 		tabs,
 		historyByTabId,
 		splitLayout,
+		focusedPaneId,
 		setSplitLayout,
 		activeTabByPane,
-		controller: {
-			tabsRef,
-			focusedPaneIdRef,
-			activeTabByPaneRef,
-			setFocusedPaneId: setFocusedPaneIdState,
-			createTab,
-			commitTabsChange,
-			setActiveTabId,
-			clearHistoryForTab,
-			pushNoteHistory,
-			stepHistory,
-			updateActiveTabInPlace,
-		},
+		tabsRef,
+		activeTabByPaneRef,
+		createTab,
+		commitTabsChange,
+		setActiveTabId,
+		clearHistoryForTab,
+		pushNoteHistory,
+		navigateTabHistory,
 	});
 
 	return {

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import { useFileTreeContext, useUILayoutContext } from "../../contexts";
 import { useRecentFiles } from "../../hooks/useRecentFiles";
 import {
@@ -85,7 +92,7 @@ export function useTabManager(spacePath: string | null) {
 
 	const [tabs, setTabs] = useState<WorkspaceTab[]>([]);
 	const [activeTabId, setActiveTabIdState] = useState<string | null>(null);
-	const [splitLayout, setSplitLayout] = useState<SplitEditorNode>(
+	const [splitLayout, setSplitLayoutState] = useState<SplitEditorNode>(
 		createInitialSplitEditorLayout,
 	);
 	const [activeTabByPane, setActiveTabByPane] = useState<
@@ -97,6 +104,7 @@ export function useTabManager(spacePath: string | null) {
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
+	const splitLayoutRef = useRef(splitLayout);
 	const activeTabByPaneRef = useRef<Record<string, string | null>>({
 		[PRIMARY_EDITOR_PANE_ID]: null,
 	});
@@ -105,6 +113,16 @@ export function useTabManager(spacePath: string | null) {
 	tabsRef.current = tabs;
 	activeTabIdRef.current = activeTabId;
 	historyByTabIdRef.current = historyByTabId;
+
+	const setSplitLayout = useCallback(
+		(action: SetStateAction<SplitEditorNode>) => {
+			const nextLayout =
+				typeof action === "function" ? action(splitLayoutRef.current) : action;
+			splitLayoutRef.current = nextLayout;
+			setSplitLayoutState(nextLayout);
+		},
+		[],
+	);
 
 	const createTab = useCallback(
 		(
@@ -195,12 +213,16 @@ export function useTabManager(spacePath: string | null) {
 				nextTabs.find((tab) => tab.id === nextActiveTabId)?.paneId ??
 				PRIMARY_EDITOR_PANE_ID;
 			const nextActiveByPane: Record<string, string | null> = {};
-			const nextTabIds = new Set(nextTabs.map((tab) => tab.id));
 			for (const tab of nextTabs) {
 				if (tab.paneId in nextActiveByPane) continue;
 				const currentActiveId = activeTabByPaneRef.current[tab.paneId];
 				nextActiveByPane[tab.paneId] =
-					currentActiveId && nextTabIds.has(currentActiveId)
+					currentActiveId &&
+					nextTabs.some(
+						(candidate) =>
+							candidate.id === currentActiveId &&
+							candidate.paneId === tab.paneId,
+					)
 						? currentActiveId
 						: tab.id;
 			}
@@ -420,7 +442,13 @@ export function useTabManager(spacePath: string | null) {
 	const openFileTab = useCallback(
 		(path: string) => {
 			if (!canOpenInMainPane(path)) return false;
-			if (focusExistingTab(path)) return true;
+			const existing = tabsRef.current.find(
+				(tab) => tab.kind === "file" && tab.target === path,
+			);
+			if (existing) {
+				setActiveTabId(existing.id);
+				return true;
+			}
 
 			const currentActiveId = activeTabIdRef.current;
 			const currentTabs = tabsRef.current;
@@ -445,8 +473,8 @@ export function useTabManager(spacePath: string | null) {
 		[
 			canOpenInMainPane,
 			clearHistoryForTab,
-			focusExistingTab,
 			pushNoteHistory,
+			setActiveTabId,
 			updateActiveTabInPlace,
 		],
 	);
@@ -492,7 +520,10 @@ export function useTabManager(spacePath: string | null) {
 				const paneId = layoutPaneIds.has(snapshot.paneId)
 					? snapshot.paneId
 					: fallbackPaneId;
-				const targetKey = `${paneId}\0${snapshot.target}`;
+				const targetKey =
+					snapshot.kind === "file"
+						? `file\0${snapshot.target}`
+						: `special\0${paneId}\0${snapshot.target}`;
 				if (seenTargets.has(targetKey)) continue;
 				seenTargets.add(targetKey);
 				const tab = createTab(snapshot.kind, snapshot.target, paneId);
@@ -537,7 +568,7 @@ export function useTabManager(spacePath: string | null) {
 			setDirtyByPath({});
 			commitTabsChange(nextTabs, nextActiveTabId);
 		},
-		[commitTabsChange, createTab],
+		[commitTabsChange, createTab, setSplitLayout],
 	);
 
 	const openBlankTab = useCallback(() => {
@@ -572,13 +603,14 @@ export function useTabManager(spacePath: string | null) {
 				activeTabIdRef.current !== tabId
 					? activeTabIdRef.current
 					: replacementTabId;
+			const currentLayout = splitLayoutRef.current;
 			const paneIsEmpty =
 				removedPaneId &&
 				!nextTabs.some((tab) => tab.paneId === removedPaneId) &&
-				paneIdsInLayout(splitLayout).length > 1;
+				paneIdsInLayout(currentLayout).length > 1;
 			let committedActiveTabId = nextActiveTabId;
 			if (paneIsEmpty && removedPaneId) {
-				const nextLayout = removeEditorPane(splitLayout, removedPaneId);
+				const nextLayout = removeEditorPane(currentLayout, removedPaneId);
 				if (nextLayout) {
 					setSplitLayout(nextLayout);
 					if (removedWasFocused) {
@@ -605,7 +637,7 @@ export function useTabManager(spacePath: string | null) {
 			});
 			commitTabsChange(nextTabs, committedActiveTabId);
 		},
-		[clearDirtyForTarget, commitTabsChange, splitLayout, updateHistoryState],
+		[clearDirtyForTarget, commitTabsChange, setSplitLayout, updateHistoryState],
 	);
 
 	const closeAllTabs = useCallback(() => {
@@ -614,7 +646,7 @@ export function useTabManager(spacePath: string | null) {
 		setDirtyByPath({});
 		historyByTabIdRef.current = {};
 		setHistoryByTabId({});
-	}, [commitTabsChange]);
+	}, [commitTabsChange, setSplitLayout]);
 
 	const closeActiveTab = useCallback(() => {
 		if (!activeTabId) return;
@@ -637,7 +669,7 @@ export function useTabManager(spacePath: string | null) {
 			const currentActiveTabId = activeTabIdRef.current;
 			let nextActiveTabId = currentActiveTabId;
 			if (tabsRemoved) {
-				for (const paneId of paneIdsInLayout(splitLayout)) {
+				for (const paneId of paneIdsInLayout(splitLayoutRef.current)) {
 					if (!nextTabs.some((tab) => tab.paneId === paneId)) {
 						nextTabs = [...nextTabs, createTab("blank", null, paneId)];
 					}
@@ -715,7 +747,7 @@ export function useTabManager(spacePath: string | null) {
 				return changed ? next : prev;
 			});
 		},
-		[commitTabsChange, createTab, splitLayout, updateHistoryState],
+		[commitTabsChange, createTab, updateHistoryState],
 	);
 
 	const renameTabsForPath = useCallback(
@@ -849,6 +881,7 @@ export function useTabManager(spacePath: string | null) {
 		tabs,
 		historyByTabId,
 		splitLayout,
+		splitLayoutRef,
 		focusedPaneId,
 		setSplitLayout,
 		activeTabByPane,

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -9,7 +9,7 @@ import {
 	loadWorkspaceSessionSnapshot,
 	saveWorkspaceSessionSnapshot,
 } from "../../lib/workspaceSession";
-import type { SplitEditorNode } from "./splitEditorModel";
+import type { SplitEditorNode } from "../../lib/splitEditor";
 import type { WorkspaceEditorPane, WorkspaceTab } from "./useTabManager";
 
 const WORKSPACE_SESSION_SAVE_DEBOUNCE_MS = 250;
@@ -160,7 +160,7 @@ export function useWorkspaceSession({
 			const snapshot = await loadWorkspaceSessionSnapshot(spacePath);
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
-				!snapshot?.tabs.length
+				!snapshot
 			) {
 				return;
 			}
@@ -169,7 +169,7 @@ export function useWorkspaceSession({
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
 				restorableTabs === null ||
-				!restorableTabs.length
+				(!restorableTabs.length && !snapshot.splitLayout)
 			) {
 				return;
 			}
@@ -182,9 +182,9 @@ export function useWorkspaceSession({
 			restoreWorkspaceTabs(
 				restorableTabs,
 				activeTabTarget,
-				snapshot.splitLayout ?? null,
-				snapshot.focusedPaneId ?? null,
-				snapshot.activeTabTargetByPane ?? {},
+				snapshot.splitLayout,
+				snapshot.focusedPaneId,
+				snapshot.activeTabTargetByPane,
 			);
 			restoredSessionSpaceRef.current = spacePath;
 		})().catch((cause) => {

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -9,7 +9,8 @@ import {
 	loadWorkspaceSessionSnapshot,
 	saveWorkspaceSessionSnapshot,
 } from "../../lib/workspaceSession";
-import type { WorkspaceTab } from "./useTabManager";
+import type { SplitEditorNode } from "./splitEditorModel";
+import type { WorkspaceEditorPane, WorkspaceTab } from "./useTabManager";
 
 const WORKSPACE_SESSION_SAVE_DEBOUNCE_MS = 250;
 
@@ -22,12 +23,16 @@ function buildWorkspaceSessionTabs(
 		if (
 			(tab.kind !== "file" && tab.kind !== "special") ||
 			tab.target === null ||
-			seenTargets.has(tab.target)
+			seenTargets.has(`${tab.paneId}\0${tab.target}`)
 		) {
 			continue;
 		}
-		seenTargets.add(tab.target);
-		snapshotTabs.push({ kind: tab.kind, target: tab.target });
+		seenTargets.add(`${tab.paneId}\0${tab.target}`);
+		snapshotTabs.push({
+			kind: tab.kind,
+			target: tab.target,
+			paneId: tab.paneId,
+		});
 	}
 	return snapshotTabs;
 }
@@ -60,11 +65,17 @@ interface UseWorkspaceSessionArgs {
 	resumeLastSession: boolean | null;
 	onboardingNotePath: string | null;
 	tabs: WorkspaceTab[];
+	panes: Record<string, WorkspaceEditorPane>;
+	splitLayout: SplitEditorNode;
+	focusedPaneId: string;
 	activeTabPath: string | null;
 	tabsRevision: number;
 	restoreWorkspaceTabs: (
 		tabSnapshots: WorkspaceSessionTabSnapshot[],
 		activeTabTarget: string | null,
+		splitLayout: SplitEditorNode | null,
+		focusedPaneId: string | null,
+		activeTabTargetByPane: Record<string, string | null>,
 	) => void;
 }
 
@@ -79,6 +90,9 @@ export function useWorkspaceSession({
 	resumeLastSession,
 	onboardingNotePath,
 	tabs,
+	panes,
+	splitLayout,
+	focusedPaneId,
 	activeTabPath,
 	tabsRevision,
 	restoreWorkspaceTabs,
@@ -165,7 +179,13 @@ export function useWorkspaceSession({
 			)
 				? snapshot.activeTabTarget
 				: null;
-			restoreWorkspaceTabs(restorableTabs, activeTabTarget);
+			restoreWorkspaceTabs(
+				restorableTabs,
+				activeTabTarget,
+				snapshot.splitLayout ?? null,
+				snapshot.focusedPaneId ?? null,
+				snapshot.activeTabTargetByPane ?? {},
+			);
 			restoredSessionSpaceRef.current = spacePath;
 		})().catch((cause) => {
 			console.error("Failed to restore workspace session", cause);
@@ -195,6 +215,9 @@ export function useWorkspaceSession({
 		const snapshotTabs = buildWorkspaceSessionTabs(tabs);
 		const activeTarget =
 			snapshotTabs.find((tab) => tab.target === activeTabPath)?.target ?? null;
+		const activeTabTargetByPane = Object.fromEntries(
+			Object.values(panes).map((pane) => [pane.id, pane.activeTabPath]),
+		);
 		pendingSaveRef.current = {
 			spacePath,
 			snapshot: {
@@ -202,6 +225,9 @@ export function useWorkspaceSession({
 				savedAt: Date.now(),
 				tabs: snapshotTabs,
 				activeTabTarget: activeTarget,
+				activeTabTargetByPane,
+				focusedPaneId,
+				splitLayout,
 			},
 		};
 		clearSaveTimer();
@@ -214,8 +240,11 @@ export function useWorkspaceSession({
 	}, [
 		activeTabPath,
 		clearSaveTimer,
+		focusedPaneId,
 		flushPendingSave,
+		panes,
 		spacePath,
+		splitLayout,
 		tabs,
 		tabsRevision,
 	]);

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useCallback, useEffect, useRef } from "react";
+import type { SplitEditorNode } from "../../lib/splitEditor";
 import { invoke } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
 import {
@@ -9,7 +10,6 @@ import {
 	loadWorkspaceSessionSnapshot,
 	saveWorkspaceSessionSnapshot,
 } from "../../lib/workspaceSession";
-import type { SplitEditorNode } from "../../lib/splitEditor";
 import type { WorkspaceEditorPane, WorkspaceTab } from "./useTabManager";
 
 const WORKSPACE_SESSION_SAVE_DEBOUNCE_MS = 250;
@@ -158,10 +158,7 @@ export function useWorkspaceSession({
 		const requestId = ++restoreSessionRequestIdRef.current;
 		void (async () => {
 			const snapshot = await loadWorkspaceSessionSnapshot(spacePath);
-			if (
-				requestId !== restoreSessionRequestIdRef.current ||
-				!snapshot
-			) {
+			if (requestId !== restoreSessionRequestIdRef.current || !snapshot) {
 				return;
 			}
 

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -1,6 +1,8 @@
 import {
 	DragDropProvider,
 	type DragEndEvent,
+	type DragMoveEvent,
+	type DragStartEvent,
 	useDroppable,
 } from "@dnd-kit/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -50,6 +52,12 @@ import {
 	FILE_TREE_ENTRY_TYPE,
 	FILE_TREE_ROOT_DROP_COLLISION_PRIORITY,
 } from "./fileTreeDnd";
+import {
+	cancelSplitEditorDrag,
+	endSplitEditorDrag,
+	moveSplitEditorDrag,
+	startSplitEditorDrag,
+} from "../app/splitEditorDnd";
 import { useFileTreeCreateFolderScroll } from "./useFileTreeCreateFolderScroll";
 import { useVisibleFilePreviews } from "./useVisibleFilePreviews";
 
@@ -910,8 +918,6 @@ export const FileTreePane = memo(function FileTreePane({
 			window.setTimeout(() => {
 				moveClickSuppressRef.current = false;
 			}, 0);
-			if (event.canceled) return;
-
 			const { source, target } = event.operation;
 			const sourcePath =
 				typeof source?.data.path === "string" ? source.data.path : null;
@@ -919,6 +925,19 @@ export const FileTreePane = memo(function FileTreePane({
 				source?.data.kind === "dir" || source?.data.kind === "file"
 					? source.data.kind
 					: null;
+			if (event.canceled || !sourcePath || !sourceKind) {
+				cancelSplitEditorDrag();
+				return;
+			}
+			const { x, y } = event.operation.position.current;
+			moveSplitEditorDrag(x, y);
+			if (
+				sourceKind === "file" &&
+				endSplitEditorDrag({ kind: "file", path: sourcePath })
+			) {
+				return;
+			}
+			cancelSplitEditorDrag();
 			const targetDirPath =
 				typeof target?.data.targetDirPath === "string"
 					? target.data.targetDirPath
@@ -929,9 +948,27 @@ export const FileTreePane = memo(function FileTreePane({
 		},
 		[onMovePath],
 	);
+	const handleDragStart = useCallback((event: DragStartEvent) => {
+		const { source } = event.operation;
+		const sourcePath =
+			typeof source?.data.path === "string" ? source.data.path : null;
+		if (source?.data.kind === "file" && sourcePath) {
+			startSplitEditorDrag({ kind: "file", path: sourcePath });
+			const { x, y } = event.operation.position.current;
+			moveSplitEditorDrag(x, y);
+		}
+	}, []);
+	const handleDragMove = useCallback((event: DragMoveEvent) => {
+		const { x, y } = event.operation.position.current;
+		moveSplitEditorDrag(x, y);
+	}, []);
 
 	return (
-		<DragDropProvider onDragEnd={handleDragEnd}>
+		<DragDropProvider
+			onDragStart={handleDragStart}
+			onDragMove={handleDragMove}
+			onDragEnd={handleDragEnd}
+		>
 			<m.aside
 				className="fileTreePane"
 				initial={{ y: 10 }}

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -44,6 +44,12 @@ import { isDeleteKey } from "../../utils/keyboard";
 import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
 import { AppearancePicker } from "../AppearancePicker";
 import { ChevronRight } from "../Icons";
+import {
+	cancelSplitEditorDrag,
+	endSplitEditorDrag,
+	moveSplitEditorDrag,
+	startSplitEditorDrag,
+} from "../app/splitEditorDnd";
 import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { springPresets } from "../ui/animations";
 import { FileTreeDirItem } from "./FileTreeDirItem";
@@ -52,12 +58,6 @@ import {
 	FILE_TREE_ENTRY_TYPE,
 	FILE_TREE_ROOT_DROP_COLLISION_PRIORITY,
 } from "./fileTreeDnd";
-import {
-	cancelSplitEditorDrag,
-	endSplitEditorDrag,
-	moveSplitEditorDrag,
-	startSplitEditorDrag,
-} from "../app/splitEditorDnd";
 import { useFileTreeCreateFolderScroll } from "./useFileTreeCreateFolderScroll";
 import { useVisibleFilePreviews } from "./useVisibleFilePreviews";
 
@@ -933,6 +933,7 @@ export const FileTreePane = memo(function FileTreePane({
 			moveSplitEditorDrag(x, y);
 			if (
 				sourceKind === "file" &&
+				isMarkdownPath(sourcePath) &&
 				endSplitEditorDrag({ kind: "file", path: sourcePath })
 			) {
 				return;
@@ -952,13 +953,25 @@ export const FileTreePane = memo(function FileTreePane({
 		const { source } = event.operation;
 		const sourcePath =
 			typeof source?.data.path === "string" ? source.data.path : null;
-		if (source?.data.kind === "file" && sourcePath) {
+		if (
+			source?.data.kind === "file" &&
+			sourcePath &&
+			isMarkdownPath(sourcePath)
+		) {
 			startSplitEditorDrag({ kind: "file", path: sourcePath });
 			const { x, y } = event.operation.position.current;
 			moveSplitEditorDrag(x, y);
 		}
 	}, []);
 	const handleDragMove = useCallback((event: DragMoveEvent) => {
+		const source = event.operation.source;
+		if (
+			source?.data.kind !== "file" ||
+			typeof source.data.path !== "string" ||
+			!isMarkdownPath(source.data.path)
+		) {
+			return;
+		}
 		const { x, y } = event.operation.position.current;
 		moveSplitEditorDrag(x, y);
 	}, []);

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -2,7 +2,6 @@ import {
 	DragDropProvider,
 	type DragEndEvent,
 	type DragMoveEvent,
-	type DragStartEvent,
 	useDroppable,
 } from "@dnd-kit/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -48,7 +47,6 @@ import {
 	cancelSplitEditorDrag,
 	endSplitEditorDrag,
 	moveSplitEditorDrag,
-	startSplitEditorDrag,
 } from "../app/splitEditorDnd";
 import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { springPresets } from "../ui/animations";
@@ -929,14 +927,11 @@ export const FileTreePane = memo(function FileTreePane({
 				cancelSplitEditorDrag();
 				return;
 			}
-			const { x, y } = event.operation.position.current;
-			moveSplitEditorDrag(x, y);
-			if (
-				sourceKind === "file" &&
-				isMarkdownPath(sourcePath) &&
-				endSplitEditorDrag({ kind: "file", path: sourcePath })
-			) {
-				return;
+			if (sourceKind === "file" && isMarkdownPath(sourcePath)) {
+				const { x, y } = event.operation.position.current;
+				const splitDragSource = { kind: "file" as const, path: sourcePath };
+				moveSplitEditorDrag(splitDragSource, x, y);
+				if (endSplitEditorDrag(splitDragSource)) return;
 			}
 			cancelSplitEditorDrag();
 			const targetDirPath =
@@ -949,20 +944,6 @@ export const FileTreePane = memo(function FileTreePane({
 		},
 		[onMovePath],
 	);
-	const handleDragStart = useCallback((event: DragStartEvent) => {
-		const { source } = event.operation;
-		const sourcePath =
-			typeof source?.data.path === "string" ? source.data.path : null;
-		if (
-			source?.data.kind === "file" &&
-			sourcePath &&
-			isMarkdownPath(sourcePath)
-		) {
-			startSplitEditorDrag({ kind: "file", path: sourcePath });
-			const { x, y } = event.operation.position.current;
-			moveSplitEditorDrag(x, y);
-		}
-	}, []);
 	const handleDragMove = useCallback((event: DragMoveEvent) => {
 		const source = event.operation.source;
 		if (
@@ -973,15 +954,11 @@ export const FileTreePane = memo(function FileTreePane({
 			return;
 		}
 		const { x, y } = event.operation.position.current;
-		moveSplitEditorDrag(x, y);
+		moveSplitEditorDrag({ kind: "file", path: source.data.path }, x, y);
 	}, []);
 
 	return (
-		<DragDropProvider
-			onDragStart={handleDragStart}
-			onDragMove={handleDragMove}
-			onDragEnd={handleDragEnd}
-		>
+		<DragDropProvider onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
 			<m.aside
 				className="fileTreePane"
 				initial={{ y: 10 }}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -66,6 +66,7 @@ interface MarkdownEditorPaneProps {
 	initialDoc?: TextFileDoc | null;
 	initialError?: string;
 	extractToNoteActions?: ExtractToNoteActions;
+	active?: boolean;
 }
 
 type LinkedNoteKind = "wiki" | "markdown";
@@ -159,6 +160,7 @@ export function MarkdownEditorPane({
 	initialDoc = null,
 	initialError = "",
 	extractToNoteActions,
+	active = true,
 }: MarkdownEditorPaneProps) {
 	const [infoPanelText, setInfoPanelText] = useState("");
 	const preferredEditorModeRef = useRef<NoteInlineEditorMode | null>(null);
@@ -435,7 +437,11 @@ export function MarkdownEditorPane({
 		}),
 		[isDirty, onSave, relPath, requestEditorMode, textRef],
 	);
-	useEditorRegistration(editorState);
+	useEditorRegistration(editorState, active);
+
+	useEffect(() => {
+		if (!active) setInfoPanelOpen(false);
+	}, [active]);
 
 	useEffect(() => {
 		onDirtyChange?.(isDirty);

--- a/src/components/preview/NotePane.tsx
+++ b/src/components/preview/NotePane.tsx
@@ -10,6 +10,7 @@ interface NotePaneProps {
 	onGitDiffChange?: (diff: GitCommitDiff | null) => void;
 	initialDoc?: TextFileDoc | null;
 	extractToNoteActions?: ExtractToNoteActions;
+	active?: boolean;
 }
 
 export function NotePane({
@@ -20,6 +21,7 @@ export function NotePane({
 	onGitDiffChange,
 	initialDoc = null,
 	extractToNoteActions,
+	active = true,
 }: NotePaneProps) {
 	return (
 		<MarkdownEditorPane
@@ -30,6 +32,7 @@ export function NotePane({
 			gitDiff={gitDiff}
 			onGitDiffChange={onGitDiffChange}
 			extractToNoteActions={extractToNoteActions}
+			active={active}
 		/>
 	);
 }

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -29,10 +29,8 @@ export interface EditorSaveState {
  */
 interface EditorContextValue {
 	/** Register an editor's save state */
-	registerEditor: (state: EditorSaveState) => void;
-	unregisterEditor: (state: EditorSaveState) => void;
-	activateEditor: (state: EditorSaveState) => void;
-	deactivateEditor: (state: EditorSaveState) => void;
+	registerEditor: (state: EditorSaveState) => () => void;
+	activateEditor: (state: EditorSaveState) => () => void;
 	/** Get the current editor's save state */
 	getEditorState: () => EditorSaveState | null;
 	/** Save the current editor if dirty */
@@ -57,20 +55,19 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 
 	const registerEditor = useCallback((state: EditorSaveState) => {
 		registeredEditorsRef.current.add(state);
-	}, []);
-
-	const unregisterEditor = useCallback((state: EditorSaveState) => {
-		registeredEditorsRef.current.delete(state);
-		if (editorStateRef.current === state) {
-			editorStateRef.current = null;
-		}
+		return () => {
+			registeredEditorsRef.current.delete(state);
+			if (editorStateRef.current === state) {
+				editorStateRef.current = null;
+			}
+		};
 	}, []);
 
 	const activateEditor = useCallback((state: EditorSaveState) => {
 		editorStateRef.current = state;
-	}, []);
-	const deactivateEditor = useCallback((state: EditorSaveState) => {
-		if (editorStateRef.current === state) editorStateRef.current = null;
+		return () => {
+			if (editorStateRef.current === state) editorStateRef.current = null;
+		};
 	}, []);
 
 	const getEditorState = useCallback(() => {
@@ -113,9 +110,7 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 		<EditorContext.Provider
 			value={{
 				registerEditor,
-				unregisterEditor,
 				activateEditor,
-				deactivateEditor,
 				getEditorState,
 				saveCurrentEditor,
 				hasUnsavedChanges,
@@ -146,25 +141,15 @@ export function useEditorRegistration(
 	state: EditorSaveState | null,
 	active = true,
 ): void {
-	const {
-		activateEditor,
-		deactivateEditor,
-		registerEditor,
-		unregisterEditor,
-	} =
-		useEditorContext();
+	const { activateEditor, registerEditor } = useEditorContext();
 
 	useEffect(() => {
 		if (!state) return;
-		registerEditor(state);
-		return () => {
-			unregisterEditor(state);
-		};
-	}, [registerEditor, state, unregisterEditor]);
+		return registerEditor(state);
+	}, [registerEditor, state]);
 
 	useEffect(() => {
 		if (!state || !active) return;
-		activateEditor(state);
-		return () => deactivateEditor(state);
-	}, [activateEditor, active, deactivateEditor, state]);
+		return activateEditor(state);
+	}, [activateEditor, active, state]);
 }

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -30,6 +30,8 @@ export interface EditorSaveState {
 interface EditorContextValue {
 	/** Register an editor's save state */
 	registerEditor: (state: EditorSaveState | null) => void;
+	unregisterEditor: (state: EditorSaveState) => void;
+	activateEditor: (state: EditorSaveState) => void;
 	/** Get the current editor's save state */
 	getEditorState: () => EditorSaveState | null;
 	/** Save the current editor if dirty */
@@ -52,6 +54,20 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 	const editorStateRef = useRef<EditorSaveState | null>(null);
 
 	const registerEditor = useCallback((state: EditorSaveState | null) => {
+		if (!state) {
+			editorStateRef.current = null;
+			return;
+		}
+		editorStateRef.current ??= state;
+	}, []);
+
+	const unregisterEditor = useCallback((state: EditorSaveState) => {
+		if (editorStateRef.current === state) {
+			editorStateRef.current = null;
+		}
+	}, []);
+
+	const activateEditor = useCallback((state: EditorSaveState) => {
 		editorStateRef.current = state;
 	}, []);
 
@@ -87,6 +103,8 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 		<EditorContext.Provider
 			value={{
 				registerEditor,
+				unregisterEditor,
+				activateEditor,
 				getEditorState,
 				saveCurrentEditor,
 				hasUnsavedChanges,
@@ -113,13 +131,22 @@ export function useEditorContext(): EditorContextValue {
 /**
  * Hook for editor components to register their save state
  */
-export function useEditorRegistration(state: EditorSaveState | null): void {
-	const { getEditorState, registerEditor } = useEditorContext();
+export function useEditorRegistration(
+	state: EditorSaveState | null,
+	active = true,
+): void {
+	const { activateEditor, registerEditor, unregisterEditor } =
+		useEditorContext();
 
 	useEffect(() => {
+		if (!state) return;
 		registerEditor(state);
 		return () => {
-			if (getEditorState() === state) registerEditor(null);
+			unregisterEditor(state);
 		};
-	}, [getEditorState, registerEditor, state]);
+	}, [registerEditor, state, unregisterEditor]);
+
+	useEffect(() => {
+		if (state && active) activateEditor(state);
+	}, [activateEditor, active, state]);
 }

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -29,9 +29,10 @@ export interface EditorSaveState {
  */
 interface EditorContextValue {
 	/** Register an editor's save state */
-	registerEditor: (state: EditorSaveState | null) => void;
+	registerEditor: (state: EditorSaveState) => void;
 	unregisterEditor: (state: EditorSaveState) => void;
 	activateEditor: (state: EditorSaveState) => void;
+	deactivateEditor: (state: EditorSaveState) => void;
 	/** Get the current editor's save state */
 	getEditorState: () => EditorSaveState | null;
 	/** Save the current editor if dirty */
@@ -52,16 +53,14 @@ const EditorContext = createContext<EditorContextValue | null>(null);
  */
 export function EditorProvider({ children }: { children: ReactNode }) {
 	const editorStateRef = useRef<EditorSaveState | null>(null);
+	const registeredEditorsRef = useRef(new Set<EditorSaveState>());
 
-	const registerEditor = useCallback((state: EditorSaveState | null) => {
-		if (!state) {
-			editorStateRef.current = null;
-			return;
-		}
-		editorStateRef.current ??= state;
+	const registerEditor = useCallback((state: EditorSaveState) => {
+		registeredEditorsRef.current.add(state);
 	}, []);
 
 	const unregisterEditor = useCallback((state: EditorSaveState) => {
+		registeredEditorsRef.current.delete(state);
 		if (editorStateRef.current === state) {
 			editorStateRef.current = null;
 		}
@@ -69,6 +68,9 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 
 	const activateEditor = useCallback((state: EditorSaveState) => {
 		editorStateRef.current = state;
+	}, []);
+	const deactivateEditor = useCallback((state: EditorSaveState) => {
+		if (editorStateRef.current === state) editorStateRef.current = null;
 	}, []);
 
 	const getEditorState = useCallback(() => {
@@ -83,13 +85,21 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 	}, []);
 
 	const hasUnsavedChanges = useCallback(() => {
-		return editorStateRef.current?.isDirty ?? false;
+		for (const editor of registeredEditorsRef.current) {
+			if (editor.isDirty) return true;
+		}
+		return false;
 	}, []);
 
 	const getCurrentMarkdown = useCallback((relPath: string) => {
-		const state = editorStateRef.current;
-		if (!state || state.relPath !== relPath) return null;
-		return state.getMarkdown?.() ?? null;
+		const activeEditor = editorStateRef.current;
+		if (activeEditor?.relPath === relPath) {
+			return activeEditor.getMarkdown?.() ?? null;
+		}
+		for (const editor of registeredEditorsRef.current) {
+			if (editor.relPath === relPath) return editor.getMarkdown?.() ?? null;
+		}
+		return null;
 	}, []);
 
 	const setCurrentEditorMode = useCallback((mode: EditorViewMode) => {
@@ -105,6 +115,7 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 				registerEditor,
 				unregisterEditor,
 				activateEditor,
+				deactivateEditor,
 				getEditorState,
 				saveCurrentEditor,
 				hasUnsavedChanges,
@@ -135,7 +146,12 @@ export function useEditorRegistration(
 	state: EditorSaveState | null,
 	active = true,
 ): void {
-	const { activateEditor, registerEditor, unregisterEditor } =
+	const {
+		activateEditor,
+		deactivateEditor,
+		registerEditor,
+		unregisterEditor,
+	} =
 		useEditorContext();
 
 	useEffect(() => {
@@ -147,6 +163,8 @@ export function useEditorRegistration(
 	}, [registerEditor, state, unregisterEditor]);
 
 	useEffect(() => {
-		if (state && active) activateEditor(state);
-	}, [activateEditor, active, state]);
+		if (!state || !active) return;
+		activateEditor(state);
+		return () => deactivateEditor(state);
+	}, [activateEditor, active, deactivateEditor, state]);
 }

--- a/src/contexts/EditorContext.tsx
+++ b/src/contexts/EditorContext.tsx
@@ -35,6 +35,8 @@ interface EditorContextValue {
 	getEditorState: () => EditorSaveState | null;
 	/** Save the current editor if dirty */
 	saveCurrentEditor: () => Promise<boolean>;
+	/** Save all dirty editors */
+	saveAllEditors: () => Promise<boolean>;
 	/** Check if current editor has unsaved changes */
 	hasUnsavedChanges: () => boolean;
 	/** Get the current editor content as markdown for a specific note */
@@ -81,6 +83,15 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 		return true;
 	}, []);
 
+	const saveAllEditors = useCallback(async () => {
+		const dirtyEditors = [...registeredEditorsRef.current].filter(
+			(editor) => editor.isDirty,
+		);
+		if (dirtyEditors.length === 0) return false;
+		await Promise.all(dirtyEditors.map((editor) => editor.save()));
+		return true;
+	}, []);
+
 	const hasUnsavedChanges = useCallback(() => {
 		for (const editor of registeredEditorsRef.current) {
 			if (editor.isDirty) return true;
@@ -113,6 +124,7 @@ export function EditorProvider({ children }: { children: ReactNode }) {
 				activateEditor,
 				getEditorState,
 				saveCurrentEditor,
+				saveAllEditors,
 				hasUnsavedChanges,
 				getCurrentMarkdown,
 				setCurrentEditorMode,

--- a/src/contexts/GitSyncContext.tsx
+++ b/src/contexts/GitSyncContext.tsx
@@ -18,8 +18,8 @@ const GitSyncContext = createContext<GitSyncController | null>(null);
 
 export function GitSyncProvider({ children }: { children: ReactNode }) {
 	const { spacePath } = useSpace();
-	const { saveCurrentEditor } = useEditorContext();
-	const gitSync = useGitSync({ spacePath, saveCurrentEditor });
+	const { saveAllEditors } = useEditorContext();
+	const gitSync = useGitSync({ spacePath, saveEditors: saveAllEditors });
 	return (
 		<GitSyncContext.Provider value={gitSync}>
 			{children}

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -12,7 +12,7 @@ import { useTauriEvent } from "../lib/tauriEvents";
 
 interface UseGitSyncOptions {
 	spacePath: string | null;
-	saveCurrentEditor: () => Promise<boolean>;
+	saveEditors: () => Promise<boolean>;
 }
 
 interface GitSyncController {
@@ -39,7 +39,7 @@ async function buildRunContext() {
 
 export function useGitSync({
 	spacePath,
-	saveCurrentEditor,
+	saveEditors,
 }: UseGitSyncOptions): GitSyncController {
 	const { openSettings } = useUILayoutContext();
 	const [status, setStatus] = useState<GitSyncStatus | null>(null);
@@ -85,7 +85,7 @@ export function useGitSync({
 	const runSync = useCallback(
 		async (mode: GitSyncRunMode) => {
 			const runSpacePath = activeSpacePathRef.current;
-			await saveCurrentEditor();
+			await saveEditors();
 			const context = await buildRunContext();
 			const nextStatus = await invoke("git_sync_run", {
 				request: { mode, context },
@@ -96,7 +96,7 @@ export function useGitSync({
 			}
 			return nextStatus;
 		},
-		[saveCurrentEditor],
+		[saveEditors],
 	);
 
 	const syncNow = useCallback(async () => runSync("manual"), [runSync]);

--- a/src/i18n/locales/de/commands.json
+++ b/src/i18n/locales/de/commands.json
@@ -382,6 +382,22 @@
 			"label": "Auf X folgen",
 			"description": "Karat Sidhu auf X öffnen."
 		},
+		"split-editor-above": {
+			"label": "Editor oben teilen",
+			"description": "Oberhalb des fokussierten Bereichs einen leeren Editorbereich erstellen."
+		},
+		"split-editor-below": {
+			"label": "Editor unten teilen",
+			"description": "Unterhalb des fokussierten Bereichs einen leeren Editorbereich erstellen."
+		},
+		"split-editor-left": {
+			"label": "Editor links teilen",
+			"description": "Links vom fokussierten Bereich einen leeren Editorbereich erstellen."
+		},
+		"split-editor-right": {
+			"label": "Editor rechts teilen",
+			"description": "Rechts vom fokussierten Bereich einen leeren Editorbereich erstellen."
+		},
 		"strikethrough": {
 			"label": "Durchgestrichen",
 			"description": "Durchgestrichen-Formatierung für die aktuelle Auswahl umschalten."

--- a/src/i18n/locales/en/commands.json
+++ b/src/i18n/locales/en/commands.json
@@ -382,6 +382,22 @@
 			"label": "Follow on X",
 			"description": "Open Karat Sidhu on X."
 		},
+		"split-editor-above": {
+			"label": "Split Editor Above",
+			"description": "Create a blank editor pane above the focused pane."
+		},
+		"split-editor-below": {
+			"label": "Split Editor Below",
+			"description": "Create a blank editor pane below the focused pane."
+		},
+		"split-editor-left": {
+			"label": "Split Editor Left",
+			"description": "Create a blank editor pane to the left of the focused pane."
+		},
+		"split-editor-right": {
+			"label": "Split Editor Right",
+			"description": "Create a blank editor pane to the right of the focused pane."
+		},
 		"strikethrough": {
 			"label": "Strikethrough",
 			"description": "Toggle strikethrough formatting for the current selection."

--- a/src/i18n/locales/es/commands.json
+++ b/src/i18n/locales/es/commands.json
@@ -382,6 +382,22 @@
 			"label": "Seguir en X",
 			"description": "Abrir Karat Sidhu en X."
 		},
+		"split-editor-above": {
+			"label": "Dividir editor arriba",
+			"description": "Crear un panel de editor vacío encima del panel enfocado."
+		},
+		"split-editor-below": {
+			"label": "Dividir editor abajo",
+			"description": "Crear un panel de editor vacío debajo del panel enfocado."
+		},
+		"split-editor-left": {
+			"label": "Dividir editor a la izquierda",
+			"description": "Crear un panel de editor vacío a la izquierda del panel enfocado."
+		},
+		"split-editor-right": {
+			"label": "Dividir editor a la derecha",
+			"description": "Crear un panel de editor vacío a la derecha del panel enfocado."
+		},
 		"strikethrough": {
 			"label": "Tachado",
 			"description": "Alternar tachado en la selección actual."

--- a/src/i18n/locales/fr/commands.json
+++ b/src/i18n/locales/fr/commands.json
@@ -382,6 +382,22 @@
 			"label": "Suivre sur X",
 			"description": "Ouvrir Karat Sidhu sur X."
 		},
+		"split-editor-above": {
+			"label": "Scinder l’éditeur au-dessus",
+			"description": "Créer un volet d’éditeur vide au-dessus du volet actif."
+		},
+		"split-editor-below": {
+			"label": "Scinder l’éditeur en dessous",
+			"description": "Créer un volet d’éditeur vide sous le volet actif."
+		},
+		"split-editor-left": {
+			"label": "Scinder l’éditeur à gauche",
+			"description": "Créer un volet d’éditeur vide à gauche du volet actif."
+		},
+		"split-editor-right": {
+			"label": "Scinder l’éditeur à droite",
+			"description": "Créer un volet d’éditeur vide à droite du volet actif."
+		},
 		"strikethrough": {
 			"label": "Barré",
 			"description": "Activer ou désactiver le barré pour la sélection actuelle."

--- a/src/i18n/locales/ja/commands.json
+++ b/src/i18n/locales/ja/commands.json
@@ -382,6 +382,22 @@
 			"label": "X でフォロー",
 			"description": "X で Karat Sidhu を開きます。"
 		},
+		"split-editor-above": {
+			"label": "エディターを上に分割",
+			"description": "フォーカス中のペインの上に空のエディターペインを作成します。"
+		},
+		"split-editor-below": {
+			"label": "エディターを下に分割",
+			"description": "フォーカス中のペインの下に空のエディターペインを作成します。"
+		},
+		"split-editor-left": {
+			"label": "エディターを左に分割",
+			"description": "フォーカス中のペインの左に空のエディターペインを作成します。"
+		},
+		"split-editor-right": {
+			"label": "エディターを右に分割",
+			"description": "フォーカス中のペインの右に空のエディターペインを作成します。"
+		},
 		"strikethrough": {
 			"label": "取り消し線",
 			"description": "選択範囲の取り消し線を切り替えます。"

--- a/src/i18n/locales/ko/commands.json
+++ b/src/i18n/locales/ko/commands.json
@@ -382,6 +382,22 @@
 			"label": "X에서 팔로우",
 			"description": "X에서 Karat Sidhu를 엽니다."
 		},
+		"split-editor-above": {
+			"label": "편집기를 위로 분할",
+			"description": "포커스된 창 위에 빈 편집기 창을 만듭니다."
+		},
+		"split-editor-below": {
+			"label": "편집기를 아래로 분할",
+			"description": "포커스된 창 아래에 빈 편집기 창을 만듭니다."
+		},
+		"split-editor-left": {
+			"label": "편집기를 왼쪽으로 분할",
+			"description": "포커스된 창 왼쪽에 빈 편집기 창을 만듭니다."
+		},
+		"split-editor-right": {
+			"label": "편집기를 오른쪽으로 분할",
+			"description": "포커스된 창 오른쪽에 빈 편집기 창을 만듭니다."
+		},
 		"strikethrough": {
 			"label": "취소선",
 			"description": "현재 선택 영역의 취소선 서식을 전환합니다."

--- a/src/i18n/locales/pt-BR/commands.json
+++ b/src/i18n/locales/pt-BR/commands.json
@@ -382,6 +382,22 @@
 			"label": "Seguir no X",
 			"description": "Abrir Karat Sidhu no X."
 		},
+		"split-editor-above": {
+			"label": "Dividir editor acima",
+			"description": "Criar um painel de editor vazio acima do painel em foco."
+		},
+		"split-editor-below": {
+			"label": "Dividir editor abaixo",
+			"description": "Criar um painel de editor vazio abaixo do painel em foco."
+		},
+		"split-editor-left": {
+			"label": "Dividir editor à esquerda",
+			"description": "Criar um painel de editor vazio à esquerda do painel em foco."
+		},
+		"split-editor-right": {
+			"label": "Dividir editor à direita",
+			"description": "Criar um painel de editor vazio à direita do painel em foco."
+		},
 		"strikethrough": {
 			"label": "Tachado",
 			"description": "Alternar tachado na seleção atual."

--- a/src/lib/database/openDatabasesRequest.ts
+++ b/src/lib/database/openDatabasesRequest.ts
@@ -1,18 +1,24 @@
 export interface DatabasesOpenRequest {
 	databaseId: string | null;
 	openCreateDialog: boolean;
+	paneId: string | null;
 	nonce: number;
 }
 
 export const INITIAL_DATABASES_OPEN_REQUEST: DatabasesOpenRequest = {
 	databaseId: null,
 	openCreateDialog: false,
+	paneId: null,
 	nonce: 0,
 };
 
 export function nextDatabasesOpenRequest(
 	current: DatabasesOpenRequest,
-	patch: { databaseId?: string | null; openCreateDialog?: boolean },
+	patch: {
+		databaseId?: string | null;
+		openCreateDialog?: boolean;
+		paneId?: string | null;
+	},
 ): DatabasesOpenRequest {
 	const databaseId =
 		patch.databaseId !== undefined ? patch.databaseId : current.databaseId;
@@ -20,17 +26,21 @@ export function nextDatabasesOpenRequest(
 		patch.openCreateDialog !== undefined
 			? patch.openCreateDialog
 			: current.openCreateDialog;
+	const paneId = patch.paneId !== undefined ? patch.paneId : current.paneId;
 	const databaseIdChanged =
 		patch.databaseId !== undefined && patch.databaseId !== current.databaseId;
 	const openCreateDialogChanged =
 		patch.openCreateDialog !== undefined &&
 		patch.openCreateDialog !== current.openCreateDialog;
+	const paneIdChanged =
+		patch.paneId !== undefined && patch.paneId !== current.paneId;
 
 	return {
 		databaseId,
 		openCreateDialog,
+		paneId,
 		nonce:
-			databaseIdChanged || openCreateDialogChanged
+			databaseIdChanged || openCreateDialogChanged || paneIdChanged
 				? current.nonce + 1
 				: current.nonce,
 	};

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -218,20 +218,52 @@ describe("settings workspace session restore", () => {
 			version: 1,
 			savedAt: 123.5,
 			tabs: [
-				{ kind: "file", target: "Notes/A.md" },
-				{ kind: "special", target: "all-docs" },
+				{
+					kind: "file",
+					target: "Notes/A.md",
+					paneId: "editor-pane-primary",
+				},
+				{
+					kind: "special",
+					target: "all-docs",
+					paneId: "editor-pane-primary",
+				},
 			],
 			activeTabTarget: "all-docs",
+			activeTabTargetByPane: {
+				"editor-pane-primary": "all-docs",
+			},
+			focusedPaneId: "editor-pane-primary",
+			splitLayout: {
+				type: "pane",
+				paneId: "editor-pane-primary",
+			},
 		});
 
 		expect(await loadWorkspaceSessionSnapshot("/tmp/space")).toEqual({
 			version: 1,
 			savedAt: 123,
 			tabs: [
-				{ kind: "file", target: "Notes/A.md" },
-				{ kind: "special", target: "all-docs" },
+				{
+					kind: "file",
+					target: "Notes/A.md",
+					paneId: "editor-pane-primary",
+				},
+				{
+					kind: "special",
+					target: "all-docs",
+					paneId: "editor-pane-primary",
+				},
 			],
 			activeTabTarget: "all-docs",
+			activeTabTargetByPane: {
+				"editor-pane-primary": "all-docs",
+			},
+			focusedPaneId: "editor-pane-primary",
+			splitLayout: {
+				type: "pane",
+				paneId: "editor-pane-primary",
+			},
 		});
 	});
 
@@ -260,11 +292,28 @@ describe("settings workspace session restore", () => {
 			version: 1,
 			savedAt: 0,
 			tabs: [
-				{ kind: "file", target: "Notes/A.md" },
-				{ kind: "file", target: "Notes/B.markdown" },
-				{ kind: "special", target: "all-docs" },
+				{
+					kind: "file",
+					target: "Notes/A.md",
+					paneId: "editor-pane-primary",
+				},
+				{
+					kind: "file",
+					target: "Notes/B.markdown",
+					paneId: "editor-pane-primary",
+				},
+				{
+					kind: "special",
+					target: "all-docs",
+					paneId: "editor-pane-primary",
+				},
 			],
 			activeTabTarget: null,
+			activeTabTargetByPane: {
+				"editor-pane-primary": null,
+			},
+			focusedPaneId: null,
+			splitLayout: null,
 		});
 	});
 });

--- a/src/lib/splitEditor.ts
+++ b/src/lib/splitEditor.ts
@@ -81,6 +81,7 @@ export function updateSplitRatio(
 ): SplitEditorNode {
 	if (node.type === "pane") return node;
 	if (node.id === splitId) {
+		if (!Number.isFinite(ratio)) return node;
 		return {
 			...node,
 			ratio: Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio)),

--- a/src/lib/splitEditor.ts
+++ b/src/lib/splitEditor.ts
@@ -4,6 +4,7 @@ export type SplitDropEdge = "top" | "right" | "bottom" | "left";
 export const MIN_SPLIT_RATIO = 0.1;
 export const MAX_SPLIT_RATIO = 0.9;
 export const DEFAULT_SPLIT_RATIO = 0.5;
+export const PRIMARY_EDITOR_PANE_ID = "editor-pane-primary";
 
 export interface SplitEditorPaneNode {
 	type: "pane";
@@ -20,8 +21,6 @@ export interface SplitEditorBranchNode {
 }
 
 export type SplitEditorNode = SplitEditorPaneNode | SplitEditorBranchNode;
-
-export const PRIMARY_EDITOR_PANE_ID = "editor-pane-primary";
 
 export function createInitialSplitEditorLayout(): SplitEditorPaneNode {
 	return { type: "pane", paneId: PRIMARY_EDITOR_PANE_ID };
@@ -93,7 +92,12 @@ export function updateSplitRatio(
 	ratio: number,
 ): SplitEditorNode {
 	if (node.type === "pane") return node;
-	if (node.id === splitId) return { ...node, ratio };
+	if (node.id === splitId) {
+		return {
+			...node,
+			ratio: Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, ratio)),
+		};
+	}
 	const first = updateSplitRatio(node.first, splitId, ratio);
 	const second = updateSplitRatio(node.second, splitId, ratio);
 	return first === node.first && second === node.second

--- a/src/lib/splitEditor.ts
+++ b/src/lib/splitEditor.ts
@@ -54,21 +54,9 @@ export function splitEditorPane(
 		};
 	}
 
-	const first = splitEditorPane(
-		node.first,
-		paneId,
-		newPaneId,
-		splitId,
-		edge,
-	);
+	const first = splitEditorPane(node.first, paneId, newPaneId, splitId, edge);
 	if (first !== node.first) return { ...node, first };
-	const second = splitEditorPane(
-		node.second,
-		paneId,
-		newPaneId,
-		splitId,
-		edge,
-	);
+	const second = splitEditorPane(node.second, paneId, newPaneId, splitId, edge);
 	return second === node.second ? node : { ...node, second };
 }
 

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -1,22 +1,19 @@
-import {
-	paneIdsInLayout,
-	type SplitEditorNode,
-} from "../components/app/splitEditorModel";
 import { isMarkdownPath, normalizeRelPath } from "../utils/path";
 import { getSettingsStore, saveSettingsStore } from "./settingsStore";
+import {
+	MAX_SPLIT_RATIO,
+	MIN_SPLIT_RATIO,
+	PRIMARY_EDITOR_PANE_ID,
+	paneIdsInLayout,
+	type SplitEditorNode,
+} from "./splitEditor";
 
 const WORKSPACE_SESSION_BY_SPACE_KEY = "workspace.sessionBySpace";
 
 export interface WorkspaceSessionTabSnapshot {
 	kind: "file" | "special";
 	target: string;
-	paneId?: string;
-}
-
-interface WorkspaceSessionTabInput {
-	kind: "file" | "special";
-	target: string;
-	paneId?: string;
+	paneId: string;
 }
 
 export interface WorkspaceSessionSnapshot {
@@ -24,23 +21,10 @@ export interface WorkspaceSessionSnapshot {
 	savedAt: number;
 	tabs: WorkspaceSessionTabSnapshot[];
 	activeTabTarget: string | null;
-	activeTabTargetByPane?: Record<string, string | null>;
-	focusedPaneId?: string | null;
-	splitLayout?: SplitEditorNode | null;
+	activeTabTargetByPane: Record<string, string | null>;
+	focusedPaneId: string | null;
+	splitLayout: SplitEditorNode | null;
 }
-
-type WorkspaceSessionSnapshotInput = Omit<
-	WorkspaceSessionSnapshot,
-	| "tabs"
-	| "activeTabTargetByPane"
-	| "focusedPaneId"
-	| "splitLayout"
-> & {
-	tabs: WorkspaceSessionTabInput[];
-	activeTabTargetByPane?: Record<string, string | null>;
-	focusedPaneId?: string | null;
-	splitLayout?: SplitEditorNode | null;
-};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -57,11 +41,7 @@ function normalizeWorkspaceSessionTab(
 	const paneId =
 		typeof value.paneId === "string" && value.paneId.trim()
 			? value.paneId.trim()
-			: "editor-pane-primary";
-	const paneSnapshot =
-		typeof value.paneId === "string" && value.paneId.trim()
-			? { paneId }
-			: {};
+			: PRIMARY_EDITOR_PANE_ID;
 
 	if (value.kind === "file") {
 		const target = normalizeRelPath(value.target);
@@ -69,7 +49,7 @@ function normalizeWorkspaceSessionTab(
 		const key = `${paneId}\0${target}`;
 		if (seenTargets.has(key)) return null;
 		seenTargets.add(key);
-		return { kind: "file", target, ...paneSnapshot };
+		return { kind: "file", target, paneId };
 	}
 
 	const target = value.target.trim();
@@ -77,7 +57,7 @@ function normalizeWorkspaceSessionTab(
 	const key = `${paneId}\0${target}`;
 	if (seenTargets.has(key)) return null;
 	seenTargets.add(key);
-	return { kind: "special", target, ...paneSnapshot };
+	return { kind: "special", target, paneId };
 }
 
 function normalizeSplitEditorNode(
@@ -123,7 +103,7 @@ function normalizeSplitEditorNode(
 		type: "split",
 		id,
 		direction: value.direction,
-		ratio: Math.min(0.8, Math.max(0.2, value.ratio)),
+		ratio: Math.min(MAX_SPLIT_RATIO, Math.max(MIN_SPLIT_RATIO, value.ratio)),
 		first,
 		second,
 	};
@@ -150,23 +130,19 @@ function normalizeWorkspaceSessionSnapshot(
 		new Set(),
 	);
 	const layoutPaneIds = new Set(
-		splitLayout ? paneIdsInLayout(splitLayout) : ["editor-pane-primary"],
+		splitLayout ? paneIdsInLayout(splitLayout) : [PRIMARY_EDITOR_PANE_ID],
 	);
 	const activeTabTargetByPane: Record<string, string | null> = {};
-	if (isRecord(value.activeTabTargetByPane)) {
-		for (const [paneId, target] of Object.entries(
-			value.activeTabTargetByPane,
-		)) {
-			activeTabTargetByPane[paneId] =
-				typeof target === "string" &&
-				tabs.some(
-					(tab) =>
-						(tab.paneId ?? "editor-pane-primary") === paneId &&
-						tab.target === target,
-				)
-					? target
-					: null;
-		}
+	const rawActiveTargets = isRecord(value.activeTabTargetByPane)
+		? value.activeTabTargetByPane
+		: {};
+	for (const paneId of layoutPaneIds) {
+		const target = rawActiveTargets[paneId];
+		activeTabTargetByPane[paneId] =
+			typeof target === "string" &&
+			tabs.some((tab) => tab.paneId === paneId && tab.target === target)
+				? target
+				: null;
 	}
 	const focusedPaneId =
 		typeof value.focusedPaneId === "string" &&
@@ -177,23 +153,14 @@ function normalizeWorkspaceSessionSnapshot(
 		typeof value.savedAt === "number" && Number.isFinite(value.savedAt)
 			? Math.floor(value.savedAt)
 			: 0;
-	const hasSplitEditorState =
-		"splitLayout" in value ||
-		"focusedPaneId" in value ||
-		"activeTabTargetByPane" in value ||
-		value.tabs.some((tab) => isRecord(tab) && "paneId" in tab);
 	return {
 		version: 1,
 		savedAt,
 		tabs,
 		activeTabTarget,
-		...(hasSplitEditorState
-			? {
-					activeTabTargetByPane,
-					focusedPaneId,
-					splitLayout,
-				}
-			: {}),
+		activeTabTargetByPane,
+		focusedPaneId,
+		splitLayout,
 	};
 }
 
@@ -223,21 +190,15 @@ export async function loadWorkspaceSessionSnapshot(
 
 export async function saveWorkspaceSessionSnapshot(
 	spacePath: string,
-	snapshot: WorkspaceSessionSnapshotInput,
+	snapshot: WorkspaceSessionSnapshot,
 ): Promise<void> {
 	const store = await getSettingsStore();
 	const sessionBySpace = normalizeWorkspaceSessionMap(
 		await store.get<unknown>(WORKSPACE_SESSION_BY_SPACE_KEY),
 	);
-	sessionBySpace[spacePath] = normalizeWorkspaceSessionSnapshot(snapshot) ?? {
-		version: 1,
-		savedAt: Date.now(),
-		tabs: [],
-		activeTabTarget: null,
-		activeTabTargetByPane: {},
-		focusedPaneId: null,
-		splitLayout: null,
-	};
+	const normalized = normalizeWorkspaceSessionSnapshot(snapshot);
+	if (!normalized) throw new Error("Invalid workspace session snapshot");
+	sessionBySpace[spacePath] = normalized;
 	await store.set(WORKSPACE_SESSION_BY_SPACE_KEY, sessionBySpace);
 	await saveSettingsStore(store);
 }

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -46,9 +46,11 @@ function normalizeWorkspaceSessionTab(
 	if (value.kind === "file") {
 		const target = normalizeRelPath(value.target);
 		if (!isMarkdownPath(target)) return null;
-		const key = `${paneId}\0${target}`;
-		if (seenTargets.has(key)) return null;
+		const key = `file\0${target}`;
+		const paneKey = `${paneId}\0${target}`;
+		if (seenTargets.has(key) || seenTargets.has(paneKey)) return null;
 		seenTargets.add(key);
+		seenTargets.add(paneKey);
 		return { kind: "file", target, paneId };
 	}
 

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -1,3 +1,7 @@
+import {
+	paneIdsInLayout,
+	type SplitEditorNode,
+} from "../components/app/splitEditorModel";
 import { isMarkdownPath, normalizeRelPath } from "../utils/path";
 import { getSettingsStore, saveSettingsStore } from "./settingsStore";
 
@@ -6,6 +10,13 @@ const WORKSPACE_SESSION_BY_SPACE_KEY = "workspace.sessionBySpace";
 export interface WorkspaceSessionTabSnapshot {
 	kind: "file" | "special";
 	target: string;
+	paneId?: string;
+}
+
+interface WorkspaceSessionTabInput {
+	kind: "file" | "special";
+	target: string;
+	paneId?: string;
 }
 
 export interface WorkspaceSessionSnapshot {
@@ -13,7 +24,23 @@ export interface WorkspaceSessionSnapshot {
 	savedAt: number;
 	tabs: WorkspaceSessionTabSnapshot[];
 	activeTabTarget: string | null;
+	activeTabTargetByPane?: Record<string, string | null>;
+	focusedPaneId?: string | null;
+	splitLayout?: SplitEditorNode | null;
 }
+
+type WorkspaceSessionSnapshotInput = Omit<
+	WorkspaceSessionSnapshot,
+	| "tabs"
+	| "activeTabTargetByPane"
+	| "focusedPaneId"
+	| "splitLayout"
+> & {
+	tabs: WorkspaceSessionTabInput[];
+	activeTabTargetByPane?: Record<string, string | null>;
+	focusedPaneId?: string | null;
+	splitLayout?: SplitEditorNode | null;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -27,19 +54,79 @@ function normalizeWorkspaceSessionTab(
 	if (value.kind !== "file" && value.kind !== "special") return null;
 	if (typeof value.target !== "string") return null;
 
+	const paneId =
+		typeof value.paneId === "string" && value.paneId.trim()
+			? value.paneId.trim()
+			: "editor-pane-primary";
+	const paneSnapshot =
+		typeof value.paneId === "string" && value.paneId.trim()
+			? { paneId }
+			: {};
+
 	if (value.kind === "file") {
 		const target = normalizeRelPath(value.target);
 		if (!isMarkdownPath(target)) return null;
-		if (seenTargets.has(target)) return null;
-		seenTargets.add(target);
-		return { kind: "file", target };
+		const key = `${paneId}\0${target}`;
+		if (seenTargets.has(key)) return null;
+		seenTargets.add(key);
+		return { kind: "file", target, ...paneSnapshot };
 	}
 
 	const target = value.target.trim();
 	if (!target || target.length > 120) return null;
-	if (seenTargets.has(target)) return null;
-	seenTargets.add(target);
-	return { kind: "special", target };
+	const key = `${paneId}\0${target}`;
+	if (seenTargets.has(key)) return null;
+	seenTargets.add(key);
+	return { kind: "special", target, ...paneSnapshot };
+}
+
+function normalizeSplitEditorNode(
+	value: unknown,
+	paneIds: Set<string>,
+	splitIds: Set<string>,
+	depth = 0,
+): SplitEditorNode | null {
+	if (!isRecord(value) || depth > 12) return null;
+	if (value.type === "pane") {
+		if (typeof value.paneId !== "string" || !value.paneId.trim()) return null;
+		const paneId = value.paneId.trim();
+		if (paneIds.has(paneId)) return null;
+		paneIds.add(paneId);
+		return { type: "pane", paneId };
+	}
+	if (
+		value.type !== "split" ||
+		typeof value.id !== "string" ||
+		(value.direction !== "horizontal" && value.direction !== "vertical") ||
+		typeof value.ratio !== "number" ||
+		!Number.isFinite(value.ratio)
+	) {
+		return null;
+	}
+	const id = value.id.trim();
+	if (!id || splitIds.has(id)) return null;
+	splitIds.add(id);
+	const first = normalizeSplitEditorNode(
+		value.first,
+		paneIds,
+		splitIds,
+		depth + 1,
+	);
+	const second = normalizeSplitEditorNode(
+		value.second,
+		paneIds,
+		splitIds,
+		depth + 1,
+	);
+	if (!first || !second) return null;
+	return {
+		type: "split",
+		id,
+		direction: value.direction,
+		ratio: Math.min(0.8, Math.max(0.2, value.ratio)),
+		first,
+		second,
+	};
 }
 
 function normalizeWorkspaceSessionSnapshot(
@@ -57,15 +144,56 @@ function normalizeWorkspaceSessionSnapshot(
 		tabs.some((tab) => tab.target === value.activeTabTarget)
 			? value.activeTabTarget
 			: null;
+	const splitLayout = normalizeSplitEditorNode(
+		value.splitLayout,
+		new Set(),
+		new Set(),
+	);
+	const layoutPaneIds = new Set(
+		splitLayout ? paneIdsInLayout(splitLayout) : ["editor-pane-primary"],
+	);
+	const activeTabTargetByPane: Record<string, string | null> = {};
+	if (isRecord(value.activeTabTargetByPane)) {
+		for (const [paneId, target] of Object.entries(
+			value.activeTabTargetByPane,
+		)) {
+			activeTabTargetByPane[paneId] =
+				typeof target === "string" &&
+				tabs.some(
+					(tab) =>
+						(tab.paneId ?? "editor-pane-primary") === paneId &&
+						tab.target === target,
+				)
+					? target
+					: null;
+		}
+	}
+	const focusedPaneId =
+		typeof value.focusedPaneId === "string" &&
+		layoutPaneIds.has(value.focusedPaneId)
+			? value.focusedPaneId
+			: null;
 	const savedAt =
 		typeof value.savedAt === "number" && Number.isFinite(value.savedAt)
 			? Math.floor(value.savedAt)
 			: 0;
+	const hasSplitEditorState =
+		"splitLayout" in value ||
+		"focusedPaneId" in value ||
+		"activeTabTargetByPane" in value ||
+		value.tabs.some((tab) => isRecord(tab) && "paneId" in tab);
 	return {
 		version: 1,
 		savedAt,
 		tabs,
 		activeTabTarget,
+		...(hasSplitEditorState
+			? {
+					activeTabTargetByPane,
+					focusedPaneId,
+					splitLayout,
+				}
+			: {}),
 	};
 }
 
@@ -95,7 +223,7 @@ export async function loadWorkspaceSessionSnapshot(
 
 export async function saveWorkspaceSessionSnapshot(
 	spacePath: string,
-	snapshot: WorkspaceSessionSnapshot,
+	snapshot: WorkspaceSessionSnapshotInput,
 ): Promise<void> {
 	const store = await getSettingsStore();
 	const sessionBySpace = normalizeWorkspaceSessionMap(
@@ -106,6 +234,9 @@ export async function saveWorkspaceSessionSnapshot(
 		savedAt: Date.now(),
 		tabs: [],
 		activeTabTarget: null,
+		activeTabTargetByPane: {},
+		focusedPaneId: null,
+		splitLayout: null,
 	};
 	await store.set(WORKSPACE_SESSION_BY_SPACE_KEY, sessionBySpace);
 	await saveSettingsStore(store);

--- a/src/lib/workspaceSession.ts
+++ b/src/lib/workspaceSession.ts
@@ -4,8 +4,8 @@ import {
 	MAX_SPLIT_RATIO,
 	MIN_SPLIT_RATIO,
 	PRIMARY_EDITOR_PANE_ID,
-	paneIdsInLayout,
 	type SplitEditorNode,
+	paneIdsInLayout,
 } from "./splitEditor";
 
 const WORKSPACE_SESSION_BY_SPACE_KEY = "workspace.sessionBySpace";

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -1111,6 +1111,46 @@
 			"commandPalette": false,
 			"menuId": "help.x"
 		},
+		"split-editor-above": {
+			"id": "split-editor-above",
+			"label": "Split Editor Above",
+			"description": "Create a blank editor pane above the focused pane.",
+			"category": "tabs",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": true,
+			"commandPalette": true
+		},
+		"split-editor-below": {
+			"id": "split-editor-below",
+			"label": "Split Editor Below",
+			"description": "Create a blank editor pane below the focused pane.",
+			"category": "tabs",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": true,
+			"commandPalette": true
+		},
+		"split-editor-left": {
+			"id": "split-editor-left",
+			"label": "Split Editor Left",
+			"description": "Create a blank editor pane to the left of the focused pane.",
+			"category": "tabs",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": true,
+			"commandPalette": true
+		},
+		"split-editor-right": {
+			"id": "split-editor-right",
+			"label": "Split Editor Right",
+			"description": "Create a blank editor pane to the right of the focused pane.",
+			"category": "tabs",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": true,
+			"commandPalette": true
+		},
 		"strikethrough": {
 			"id": "strikethrough",
 			"label": "Strikethrough",

--- a/src/styles/app/17a-split-editors.css
+++ b/src/styles/app/17a-split-editors.css
@@ -111,13 +111,30 @@
 .splitEditorDropPreview {
 	position: absolute;
 	z-index: 3000;
+	inset: 8px;
 	box-sizing: border-box;
 	pointer-events: none;
 	border-radius: var(--radius-lg);
 	background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
-	box-shadow:
-		inset 0 0 0 2px
-		color-mix(in srgb, var(--interactive-accent) 92%, transparent),
-		0 12px 36px
+	box-shadow: inset 0 0 0 2px
+		color-mix(in srgb, var(--interactive-accent) 92%, transparent), 0 12px 36px
 		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+}
+
+.splitEditorDropPreview[data-edge="left"],
+.splitEditorDropPreview[data-edge="right"] {
+	width: calc(50% - 14px);
+}
+
+.splitEditorDropPreview[data-edge="right"] {
+	left: calc(50% + 6px);
+}
+
+.splitEditorDropPreview[data-edge="top"],
+.splitEditorDropPreview[data-edge="bottom"] {
+	height: calc(50% - 14px);
+}
+
+.splitEditorDropPreview[data-edge="bottom"] {
+	top: calc(50% + 6px);
 }

--- a/src/styles/app/17a-split-editors.css
+++ b/src/styles/app/17a-split-editors.css
@@ -1,0 +1,154 @@
+.splitEditorLayout,
+.splitEditorBranch,
+.splitEditorBranchChild,
+.splitEditorPane {
+	min-width: 0;
+	min-height: 0;
+}
+
+.splitEditorLayout {
+	position: relative;
+	display: flex;
+	flex: 1;
+	overflow: hidden;
+	background: var(--bg-canvas, var(--bg-primary));
+}
+
+.splitEditorBranch {
+	display: flex;
+	flex: 1;
+	overflow: hidden;
+}
+
+.splitEditorBranch[data-direction="vertical"] {
+	flex-direction: column;
+}
+
+.splitEditorBranchChild {
+	display: flex;
+	flex-grow: 1;
+	overflow: hidden;
+}
+
+.splitEditorPane {
+	position: relative;
+	display: flex;
+	flex: 1;
+	overflow: hidden;
+	box-shadow: inset 0 0 0 1px transparent;
+	transition: box-shadow 140ms ease-out;
+}
+
+.splitEditorPane[data-focused="true"] {
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 26%, transparent);
+}
+
+.splitEditorDivider {
+	position: relative;
+	z-index: 4;
+	flex: 0 0 11px;
+	background: transparent;
+	touch-action: none;
+	outline: none;
+}
+
+.splitEditorDivider::before,
+.splitEditorDivider::after {
+	content: "";
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	border-radius: var(--radius-full);
+	transform: translate(-50%, -50%);
+}
+
+.splitEditorDivider::before {
+	background: color-mix(in srgb, var(--border-light) 72%, transparent);
+	transition: background-color 140ms ease-out;
+}
+
+.splitEditorDivider::after {
+	background: color-mix(in srgb, var(--bg-primary) 94%, var(--interactive-accent));
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--border-light) 72%, transparent),
+		0 2px 8px color-mix(in srgb, var(--bg-primary) 42%, transparent);
+	opacity: 0.46;
+	transition:
+		background-color 140ms ease-out,
+		box-shadow 140ms ease-out,
+		opacity 140ms ease-out,
+		transform 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.splitEditorDivider[data-direction="horizontal"] {
+	margin: 0 -5px;
+	cursor: col-resize;
+}
+
+.splitEditorDivider[data-direction="horizontal"]::before {
+	width: 1px;
+	height: 100%;
+}
+
+.splitEditorDivider[data-direction="horizontal"]::after {
+	width: 5px;
+	height: 44px;
+}
+
+.splitEditorDivider[data-direction="vertical"] {
+	margin: -5px 0;
+	cursor: row-resize;
+}
+
+.splitEditorDivider[data-direction="vertical"]::before {
+	width: 100%;
+	height: 1px;
+}
+
+.splitEditorDivider[data-direction="vertical"]::after {
+	width: 44px;
+	height: 5px;
+}
+
+.splitEditorDivider:hover::before,
+.splitEditorDivider[data-resizing="true"]::before,
+.splitEditorDivider:focus-visible::before {
+	background: color-mix(in srgb, var(--interactive-accent) 58%, transparent);
+}
+
+.splitEditorDivider:hover::after,
+.splitEditorDivider[data-resizing="true"]::after,
+.splitEditorDivider:focus-visible::after {
+	background: color-mix(in srgb, var(--bg-primary) 84%, var(--interactive-accent));
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--interactive-accent) 62%, transparent),
+		0 3px 12px color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+	opacity: 1;
+}
+
+.splitEditorDivider[data-direction="horizontal"]:hover::after,
+.splitEditorDivider[data-direction="horizontal"][data-resizing="true"]::after,
+.splitEditorDivider[data-direction="horizontal"]:focus-visible::after {
+	transform: translate(-50%, -50%) scaleX(1.18);
+}
+
+.splitEditorDivider[data-direction="vertical"]:hover::after,
+.splitEditorDivider[data-direction="vertical"][data-resizing="true"]::after,
+.splitEditorDivider[data-direction="vertical"]:focus-visible::after {
+	transform: translate(-50%, -50%) scaleY(1.18);
+}
+
+.splitEditorDropPreview {
+	position: absolute;
+	z-index: 3000;
+	box-sizing: border-box;
+	pointer-events: none;
+	border-radius: var(--radius-lg);
+	background: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+	box-shadow:
+		inset 0 0 0 2px
+		color-mix(in srgb, var(--interactive-accent) 92%, transparent),
+		0 12px 36px
+		color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+}

--- a/src/styles/app/17a-split-editors.css
+++ b/src/styles/app/17a-split-editors.css
@@ -24,17 +24,15 @@
 	flex-direction: column;
 }
 
-.splitEditorBranchChild {
+.splitEditorBranchChild,
+.splitEditorPane {
 	display: flex;
-	flex-grow: 1;
+	flex: 1;
 	overflow: hidden;
 }
 
 .splitEditorPane {
 	position: relative;
-	display: flex;
-	flex: 1;
-	overflow: hidden;
 	box-shadow: inset 0 0 0 1px transparent;
 	transition: box-shadow 140ms ease-out;
 }
@@ -60,25 +58,15 @@
 	left: 50%;
 	top: 50%;
 	border-radius: var(--radius-full);
-	transform: translate(-50%, -50%);
-}
-
-.splitEditorDivider::before {
 	background: color-mix(in srgb, var(--border-light) 72%, transparent);
-	transition: background-color 140ms ease-out;
+	transform: translate(-50%, -50%);
+	transition-property: background-color, box-shadow, opacity;
+	transition-duration: 140ms;
+	transition-timing-function: ease-out;
 }
 
 .splitEditorDivider::after {
-	background: color-mix(in srgb, var(--bg-primary) 94%, var(--interactive-accent));
-	box-shadow:
-		0 0 0 1px color-mix(in srgb, var(--border-light) 72%, transparent),
-		0 2px 8px color-mix(in srgb, var(--bg-primary) 42%, transparent);
 	opacity: 0.46;
-	transition:
-		background-color 140ms ease-out,
-		box-shadow 140ms ease-out,
-		opacity 140ms ease-out,
-		transform 140ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .splitEditorDivider[data-direction="horizontal"] {
@@ -111,32 +99,13 @@
 	height: 5px;
 }
 
-.splitEditorDivider:hover::before,
-.splitEditorDivider[data-resizing="true"]::before,
-.splitEditorDivider:focus-visible::before {
-	background: color-mix(in srgb, var(--interactive-accent) 58%, transparent);
-}
-
 .splitEditorDivider:hover::after,
 .splitEditorDivider[data-resizing="true"]::after,
 .splitEditorDivider:focus-visible::after {
-	background: color-mix(in srgb, var(--bg-primary) 84%, var(--interactive-accent));
-	box-shadow:
-		0 0 0 1px color-mix(in srgb, var(--interactive-accent) 62%, transparent),
-		0 3px 12px color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+	background: var(--interactive-accent);
+	box-shadow: 0 2px 8px
+		color-mix(in srgb, var(--interactive-accent) 24%, transparent);
 	opacity: 1;
-}
-
-.splitEditorDivider[data-direction="horizontal"]:hover::after,
-.splitEditorDivider[data-direction="horizontal"][data-resizing="true"]::after,
-.splitEditorDivider[data-direction="horizontal"]:focus-visible::after {
-	transform: translate(-50%, -50%) scaleX(1.18);
-}
-
-.splitEditorDivider[data-direction="vertical"]:hover::after,
-.splitEditorDivider[data-direction="vertical"][data-resizing="true"]::after,
-.splitEditorDivider[data-direction="vertical"]:focus-visible::after {
-	transform: translate(-50%, -50%) scaleY(1.18);
 }
 
 .splitEditorDropPreview {


### PR DESCRIPTION
Closes 


## Description

Adds multi-pane split editors so you can view and edit multiple notes side-by-side (or stacked) in the same window.

### Summary of changes
- Introduce a binary split layout tree (`splitEditor.ts`) for horizontal/vertical panes with resizable ratios
- Extend tab management so each tab belongs to a pane; support open/move/split/focus across panes
- New UI: `SplitEditorLayout`, `EditorPaneCanvas`, per-pane tab bars, edge-drop DnD for splitting
- Command palette actions: Split Editor Left / Right / Above / Below (localized)
- Persist split layout, focused pane, and per-pane active tabs in workspace session restore
- Multi-editor registration in `EditorContext` so unsaved-state / save work correctly across panes

### Reasoning
Single-pane tabs limit comparing or editing notes together. This brings VS Code–style editor splits into Glyph without a separate window.

### Additional context / review notes
- Branch name typo: `spilt` → meant “split”
- Migration policy: session snapshot fields are extended; legacy sessions without `paneId` / `splitLayout` normalize to a single primary pane
- Hard subtraction pass was applied in the last commit (`fix the subtraction`)
- No linked GitHub issue


## Screenshots

_(Visual feature — screenshots/recording welcome if available.)_


## Docs

**How it works**
- Layout is a tree of `pane` and `split` nodes (`src/lib/splitEditor.ts`)
- Tab manager tracks `panes`, `splitLayout`, `focusedPaneId`
- Commands: `split-editor-left|right|above|below` create a blank pane on that edge
- DnD: drop a tab onto a pane edge to split; move tabs between panes
- Session: `WorkspaceSessionSnapshot` stores `splitLayout`, `focusedPaneId`, `activeTabTargetByPane`, and per-tab `paneId`

**Key files**
- `src/lib/splitEditor.ts` — layout pure helpers
- `src/components/app/useSplitEditorTabs.ts` / `useTabManager.ts` — state
- `src/components/app/SplitEditorLayout.tsx` / `EditorPaneCanvas.tsx` — UI
- `src/lib/workspaceSession.ts` — persistence


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add split editor panes so you can view and edit multiple notes side-by-side or stacked, with drag-to-split and per-pane tabs. Layout, focus, and active tabs are saved and restored on startup.

- **New Features**
  - Horizontal/vertical split layout with resizable dividers.
  - Per-pane tab bars and history; move tabs between panes.
  - Drag-and-drop to split or open: drop files/tabs on pane edges or center (works from tab bar and file tree).
  - Command palette actions: Split Editor Left/Right/Above/Below (localized).
  - Session restore now remembers `splitLayout`, `focusedPaneId`, and active tab per pane.
  - Multi-editor registration routes dirty/save to the active pane and deactivates inactive editors.

- **Refactors**
  - Reworked tab manager to track panes and per-pane history; added pane navigation (`goBackInPane`/`goForwardInPane`) and open/move/split-in-pane helpers.
  - `EditorContext` supports multiple active editors and `saveAllEditors`; `GitSync` saves all dirty editors before syncing.
  - Database open requests now include `paneId` so Databases can open in a specific pane; session save/restore deduplicates tabs per pane.

<sup>Written for commit 053e40e471e1c3497652576ec0058103fa633d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added split-editor panes with flexible layouts, resizing, and drag-and-drop tab/file movement.
  * Added commands to split the editor above, below, left, or right of the focused pane.
  * Workspace sessions now preserve split layouts, focused panes, and pane-specific tabs.
  * Editors now support multiple active instances while accurately tracking unsaved changes.
* **Bug Fixes**
  * Opening a file already present in a tab now focuses the existing tab instead of creating a duplicate.
* **Localization**
  * Added translations for split-editor commands across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->