### PR TITLE
Fix daily note rollover task move errors

### DIFF
--- a/src/components/editor/rollover/DailyNoteRollover.tsx
+++ b/src/components/editor/rollover/DailyNoteRollover.tsx
@@ -237,21 +237,21 @@ export function DailyNoteRollover({
 	const overdue = overdueQuery.data ?? [];
 	const taskActions: RolloverTaskActions = {
 		targets: noteDate === today ? ["tomorrow"] : ["today", "tomorrow"],
-		onMoveCandidate: (index, target) => {
-			const candidateId = noteQuery.data?.[index]?.id;
+		onMoveCandidate: ({ index, total }, target) => {
 			void (async () => {
-				if (!candidateId) {
-					await showMoveError(t("rollover.itemChanged"));
-					return;
-				}
+				// Save first: candidates are parsed from disk, so the index only
+				// lines up once the editor's edits have been persisted.
 				if (!(await onBeforeReview())) {
 					await showMoveError(t("rollover.saveBeforeMove"));
 					return;
 				}
 				const refreshed = await noteQuery.refetch();
-				const candidate = refreshed.data?.find(
-					(item) => item.id === candidateId,
-				);
+				if (refreshed.error) {
+					await showMoveError(t("rollover.moveFailedDescription"));
+					return;
+				}
+				const candidate =
+					refreshed.data?.length === total ? refreshed.data[index] : undefined;
 				if (!candidate) {
 					await showMoveError(t("rollover.itemChanged"));
 					return;

--- a/src/components/editor/rollover/RolloverTaskActions.tsx
+++ b/src/components/editor/rollover/RolloverTaskActions.tsx
@@ -10,15 +10,22 @@ import type { RolloverTaskActions as TaskActions } from "../types";
 
 interface CandidateTask {
 	index: number;
+	total: number;
 	left: number;
 	top: number;
 }
 
 const MOVED_TO_DATE_PATTERN = /\bMoved to\s*\[\[\d{4}-\d{2}-\d{2}\]\]/;
 
+/**
+ * The backend only looks for the marker on the task's own line, so nested
+ * subtasks must be ignored here or the two candidate lists drift apart.
+ */
 function hasMovedMarker(node: ProseMirrorNode): boolean {
+	const ownLine = node.firstChild;
+	if (!ownLine) return false;
 	let markdown = "";
-	node.descendants((child) => {
+	ownLine.descendants((child) => {
 		if (child.isText) {
 			markdown += child.text ?? "";
 		} else if (child.type.name === "wikiLink") {
@@ -32,6 +39,9 @@ function hasMovedMarker(node: ProseMirrorNode): boolean {
 function activeTask(editor: Editor, host: HTMLElement): CandidateTask | null {
 	const positions: number[] = [];
 	editor.state.doc.descendants((node, position) => {
+		// The backend never parses `> - [ ] …` as a task, so blockquoted tasks
+		// must stay out of this list to keep both orderings identical.
+		if (node.type.name === "blockquote") return false;
 		if (node.type.name !== "taskItem") return true;
 		let unfinished = node.attrs.checked !== true;
 		node.descendants((child) => {
@@ -58,7 +68,12 @@ function activeTask(editor: Editor, host: HTMLElement): CandidateTask | null {
 	const element = editor.view.nodeDOM(positions[index]);
 	if (!(element instanceof HTMLElement)) return null;
 	const offset = getOffsetWithinAncestor(element, host);
-	return { index, left: offset.left + element.offsetWidth, top: offset.top };
+	return {
+		index,
+		total: positions.length,
+		left: offset.left + element.offsetWidth,
+		top: offset.top,
+	};
 }
 
 export function RolloverTaskActions({
@@ -105,7 +120,12 @@ export function RolloverTaskActions({
 							: t("rollover.moveTomorrow")
 					}
 					onMouseDown={(event) => event.preventDefault()}
-					onClick={() => actions.onMoveCandidate(active.index, target)}
+					onClick={() =>
+						actions.onMoveCandidate(
+							{ index: active.index, total: active.total },
+							target,
+						)
+					}
 				>
 					<HugeiconsIcon icon={target === "today" ? Sun02Icon : NextWeekIcon} />
 				</Button>

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -7,9 +7,18 @@ export type NoteInlineEditorChrome = "full" | "minimal";
 export type PasteMarkdownBehavior = "plain-text" | "smart-markdown";
 export type RolloverMoveTarget = "today" | "tomorrow";
 
+/** Position of a task within the editor's unfinished-task list. */
+export interface RolloverTaskPosition {
+	index: number;
+	total: number;
+}
+
 export interface RolloverTaskActions {
 	targets: RolloverMoveTarget[];
-	onMoveCandidate: (index: number, target: RolloverMoveTarget) => void;
+	onMoveCandidate: (
+		position: RolloverTaskPosition,
+		target: RolloverMoveTarget,
+	) => void;
 }
 
 export interface CreateMarkdownFileOptions {


### PR DESCRIPTION
Closes 


## Description

Fixes daily-note rollover move failures caused by the editor and backend disagreeing on which unfinished tasks exist (and in what order).

- **Summary of changes**
  - Align the editor's rollover candidate list with backend task parsing: only treat the task's own line as the "Moved to" marker source, and skip blockquoted task items that the backend never parses as tasks.
  - After saving and refetching candidates, match the clicked task by position + list length instead of a stale candidate id.
  - Surface a clear error when the post-save candidate refetch fails.
- **Reasoning**
  Move actions were resolving the wrong item (or none at all) when nested subtask markers or blockquoted tasks made the UI list diverge from the disk-parsed list. Saving first still left id-based lookup fragile; validating `total` against the refreshed list and using the stable index keeps both sides in sync.
- **Additional context**
  Non-visual correctness fix for daily note task rollover (`DailyNoteRollover` / `RolloverTaskActions`). No linked issue.


## Screenshots

N/A — non-visual bug fix.


## Docs

- Rollover move candidates now only scan a task item's own line for `Moved to [[YYYY-MM-DD]]` markers (nested subtasks no longer affect the parent).
- Blockquoted tasks (`> - [ ] …`) are excluded from the editor candidate list, matching backend parsing.
- `onMoveCandidate` now takes `{ index, total }` so a post-save refetch can confirm the list length before applying the move.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes daily note rollover move failures by syncing the editor’s unfinished-task list with backend parsing and resolving the moved item by stable position after save. Prevents moving the wrong task and shows a clear error if the post-save refresh fails.

- **Bug Fixes**
  - Only scan the task’s own line for "Moved to [[YYYY-MM-DD]]"; ignore nested subtasks.
  - Exclude blockquoted tasks from candidates to match backend parsing.
  - Save and refetch before moving; resolve by index + total instead of id, with a clear error if refetch fails.

- **Migration**
  - `RolloverTaskActions.onMoveCandidate` now accepts `{ index, total }` plus the target.

<sup>Written for commit 0319ff9db296b931cf0aa62601d1c78a318018e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily note rollover reliability by detecting when a task list changes before moving an item.
  * Added clearer error handling when rollover data cannot be refreshed or the selected task is no longer available.
  * Prevented nested subtasks and tasks inside blockquotes from being incorrectly identified as rollover candidates.
  * Improved detection of existing “Moved to” markers on tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->