### PR TITLE
Subtle AI composer animations and context attachment cleanup (#432) [Release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@tiptap/starter-kit": "3.27.4",
 		"@tiptap/suggestion": "3.27.4",
 		"beautiful-mermaid": "^1.1.3",
+		"border-beam": "1.3.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"codemirror-lang-latex": "0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       beautiful-mermaid:
         specifier: ^1.1.3
         version: 1.1.3
+      border-beam:
+        specifier: 1.3.0
+        version: 1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2216,6 +2219,12 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  border-beam@1.3.0:
+    resolution: {integrity: sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -4959,6 +4968,11 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  border-beam@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   chai@6.2.2: {}
 

--- a/src-tauri/src/ai_rig/audit.rs
+++ b/src-tauri/src/ai_rig/audit.rs
@@ -85,6 +85,7 @@ fn write_chat_history(params: &AuditLogParams<'_>, response: &str, created_at_ms
         messages.push(AiMessage {
             role: "assistant".to_string(),
             content: response.to_string(),
+            context: None,
         });
     }
     let title = params

--- a/src-tauri/src/ai_rig/types.rs
+++ b/src-tauri/src/ai_rig/types.rs
@@ -78,6 +78,14 @@ pub struct AiProfile {
 pub struct AiMessage {
     pub role: String,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<Vec<AiMessageContextItem>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AiMessageContextItem {
+    pub kind: String,
+    pub label: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/src/components/ai/AIChatThread.tsx
+++ b/src/components/ai/AIChatThread.tsx
@@ -3,7 +3,14 @@ import { m, useReducedMotion } from "motion/react";
 import { Fragment, memo, useMemo, useState } from "react";
 import { type OrbState, ThinkingOrb } from "thinking-orbs";
 import { isMarkdownPath } from "../../utils/path";
-import { ChevronDown, Files, RefreshCw, Save } from "../Icons";
+import {
+	ChevronDown,
+	File,
+	Files,
+	FolderOpen,
+	RefreshCw,
+	Save,
+} from "../Icons";
 import { dispatchMarkdownLinkClick } from "../editor/markdown/editorEvents";
 import { Button } from "../ui/shadcn/button";
 import {
@@ -181,7 +188,26 @@ const AIChatMessageBody = memo(function AIChatMessageBody({
 					<AIMessageMarkdown markdown={text} />
 				)
 			) : (
-				<div className="aiChatContent">{text}</div>
+				<>
+					{msg.context?.length ? (
+						<div className="aiChatContextPills">
+							{msg.context.map((item) => (
+								<span
+									className="aiChatContextPill"
+									key={`${item.kind}:${item.label}`}
+								>
+									{item.kind === "file" ? (
+										<File size="var(--icon-xs)" />
+									) : (
+										<FolderOpen size="var(--icon-xs)" />
+									)}
+									<span>{item.label}</span>
+								</span>
+							))}
+						</div>
+					) : null}
+					<div className="aiChatContent">{text}</div>
+				</>
 			)}
 			{isFailedAssistant ? (
 				<div className="aiInlineError">

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -1,5 +1,6 @@
 import { ArrowUp02Icon, AtIcon, StopIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { BorderBeam } from "border-beam";
 import {
 	type Dispatch,
 	type ClipboardEvent as ReactClipboardEvent,
@@ -11,6 +12,7 @@ import {
 	useMemo,
 	useRef,
 } from "react";
+import { useIsDarkTheme } from "../../hooks/useIsDarkTheme";
 import { APP_TAGLINE } from "../../lib/copy";
 import { normalizeRelPath } from "../../utils/path";
 import { File, X } from "../Icons";
@@ -44,6 +46,7 @@ interface AIComposerProps {
 	input: string;
 	setInput: Dispatch<SetStateAction<string>>;
 	isAwaitingResponse: boolean;
+	isStreamingResponse: boolean;
 	canSend: boolean;
 	onSend: () => void;
 	onStop: () => void;
@@ -229,6 +232,7 @@ export function AIComposer({
 	input,
 	setInput,
 	isAwaitingResponse,
+	isStreamingResponse,
 	canSend,
 	onSend,
 	onStop,
@@ -245,6 +249,11 @@ export function AIComposer({
 	onAddContext,
 	onRemoveContext,
 }: AIComposerProps) {
+	const isDarkTheme = useIsDarkTheme();
+	const hasDraftText = Boolean(input.replace(CHIP_RE, "").trim());
+	const beamSize = isStreamingResponse ? "pulse-inner" : "md";
+	const beamStrength = isStreamingResponse ? 0.3 : hasDraftText ? 0.28 : 0.7;
+
 	const handleInsertMentionTrigger = useCallback(() => {
 		if (isAwaitingResponse) return;
 		setInput((prev) => {
@@ -471,102 +480,114 @@ export function AIComposer({
 				</div>
 			) : null}
 			<div className="aiComposer">
-				<div className="aiComposerInputShell">
-					{showActiveFileSuggestion ? (
-						<div className="aiComposerSuggestionHint" aria-label="Active file">
-							<button
-								type="button"
-								className="aiComposerSuggestionButton"
-								onClick={() => onAddContext("file", suggestedFilePath)}
-								aria-label={`Add ${fileNameFromPath(suggestedFilePath)} to context`}
-								title={`Add ${suggestedFilePath} to context`}
-								disabled={isAwaitingResponse}
+				<BorderBeam
+					className="aiComposerBeam"
+					size={beamSize}
+					colorVariant="colorful"
+					theme={isDarkTheme ? "dark" : "light"}
+					strength={beamStrength}
+					duration={isStreamingResponse ? 3.4 : 5.2}
+				>
+					<div className="aiComposerInputShell">
+						{showActiveFileSuggestion ? (
+							<div
+								className="aiComposerSuggestionHint"
+								aria-label="Active file"
 							>
-								<span className="aiComposerSuggestionIcon">
-									<File size="var(--icon-sm)" />
-								</span>
-								<span className="aiComposerSuggestionLabel">
-									{truncateLabel(fileNameFromPath(suggestedFilePath), 28)}
-								</span>
-							</button>
-						</div>
-					) : null}
-					<div
-						ref={composerInputRef}
-						className="aiComposerInput"
-						contentEditable={!isAwaitingResponse}
-						suppressContentEditableWarning
-						role="textbox"
-						tabIndex={0}
-						aria-multiline="true"
-						aria-label="Message"
-						data-placeholder={activeFilePath ? undefined : APP_TAGLINE}
-						spellCheck
-						onInput={handleInput}
-						onPaste={handlePaste}
-						onClick={handleClick}
-						onKeyDown={handleKeyDown}
-					/>
-					<div className="aiComposerBar">
-						<div className="aiComposerControls">
-							<div className="aiComposerLeftControls">
+								<button
+									type="button"
+									className="aiComposerSuggestionButton"
+									onClick={() => onAddContext("file", suggestedFilePath)}
+									aria-label={`Add ${fileNameFromPath(suggestedFilePath)} to context`}
+									title={`Add ${suggestedFilePath} to context`}
+									disabled={isAwaitingResponse}
+								>
+									<span className="aiComposerSuggestionIcon">
+										<File size="var(--icon-sm)" />
+									</span>
+									<span className="aiComposerSuggestionLabel">
+										{truncateLabel(fileNameFromPath(suggestedFilePath), 28)}
+									</span>
+								</button>
+							</div>
+						) : null}
+						<div
+							ref={composerInputRef}
+							className="aiComposerInput"
+							contentEditable={!isAwaitingResponse}
+							suppressContentEditableWarning
+							role="textbox"
+							tabIndex={0}
+							aria-multiline="true"
+							aria-label="Message"
+							data-placeholder={activeFilePath ? undefined : APP_TAGLINE}
+							spellCheck
+							onInput={handleInput}
+							onPaste={handlePaste}
+							onClick={handleClick}
+							onKeyDown={handleKeyDown}
+						/>
+						<div className="aiComposerBar">
+							<div className="aiComposerControls">
+								<div className="aiComposerLeftControls">
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-sm"
+										className="aiComposerMentionButton"
+										aria-label="Add note with @"
+										title="Add note with @"
+										onClick={handleInsertMentionTrigger}
+										disabled={isAwaitingResponse}
+									>
+										<HugeiconsIcon
+											icon={AtIcon}
+											size="var(--icon-sm)"
+											strokeWidth={0.9}
+										/>
+									</Button>
+								</div>
+								<div className="aiComposerRight">
+									<ModelSelector
+										key={profiles.activeProfileId ?? "no-profile"}
+										profileId={profiles.activeProfileId}
+										value={profiles.activeProfile?.model ?? ""}
+										provider={profiles.activeProfile?.provider ?? null}
+										onChange={(modelId) => void profiles.setModel(modelId)}
+									/>
+								</div>
+							</div>
+							{isAwaitingResponse ? (
+								<button
+									type="button"
+									className="aiComposerStop"
+									onClick={onStop}
+									aria-label="Stop"
+									title="Stop"
+								>
+									<HugeiconsIcon
+										icon={StopIcon}
+										size="var(--icon-md)"
+										strokeWidth={0.9}
+									/>
+								</button>
+							) : (
 								<Button
 									type="button"
 									variant="ghost"
 									size="icon-sm"
-									className="aiComposerMentionButton"
-									aria-label="Add note with @"
-									title="Add note with @"
-									onClick={handleInsertMentionTrigger}
-									disabled={isAwaitingResponse}
+									className="aiComposerSend"
+									disabled={!canSend}
+									onClick={onSend}
+									aria-label="Send"
+									title="Send"
 								>
-									<HugeiconsIcon
-										icon={AtIcon}
-										size="var(--icon-sm)"
-										strokeWidth={0.9}
-									/>
+									<HugeiconsIcon icon={ArrowUp02Icon} size="var(--icon-md)" />
 								</Button>
-							</div>
-							<div className="aiComposerRight">
-								<ModelSelector
-									key={profiles.activeProfileId ?? "no-profile"}
-									profileId={profiles.activeProfileId}
-									value={profiles.activeProfile?.model ?? ""}
-									provider={profiles.activeProfile?.provider ?? null}
-									onChange={(modelId) => void profiles.setModel(modelId)}
-								/>
-							</div>
+							)}
 						</div>
-						{isAwaitingResponse ? (
-							<button
-								type="button"
-								className="aiComposerStop"
-								onClick={onStop}
-								aria-label="Stop"
-								title="Stop"
-							>
-								<HugeiconsIcon
-									icon={StopIcon}
-									size="var(--icon-md)"
-									strokeWidth={0.9}
-								/>
-							</button>
-						) : (
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								className="aiComposerSend"
-								disabled={!canSend}
-								onClick={onSend}
-								aria-label="Send"
-								title="Send"
-							>
-								<HugeiconsIcon icon={ArrowUp02Icon} size="var(--icon-md)" />
-							</Button>
-						)}
 					</div>
-				</div>
+				</BorderBeam>
 			</div>
 		</>
 	);

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -315,19 +315,18 @@ export function AIComposer({
 		return segments;
 	}, [input]);
 
-	const lastInputRef = useRef(input);
 	const isUserInputRef = useRef(false);
 
 	useLayoutEffect(() => {
 		const el = composerInputRef.current;
 		if (!el) return;
-		if (isUserInputRef.current) {
+		const currentInput = domToInput(el);
+		if (isUserInputRef.current && currentInput === input) {
 			isUserInputRef.current = false;
-			lastInputRef.current = input;
 			return;
 		}
-		if (lastInputRef.current === input) return;
-		lastInputRef.current = input;
+		isUserInputRef.current = false;
+		if (currentInput === input) return;
 		const caret = readCaretOffset(el);
 		el.innerHTML = "";
 		for (const seg of renderSegments) {

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -124,7 +124,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 				return false;
 			}
 			void chat.sendMessage(
-				{ text: sanitized },
+				{ text: sanitized, context: built.attachments },
 				{
 					body: {
 						profile_id: profiles.activeProfileId ?? undefined,
@@ -170,7 +170,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 			return;
 		}
 		void chat.sendMessage(
-			{ text: sanitized },
+			{ text: sanitized, context: built.attachments },
 			{
 				body: {
 					profile_id: profiles.activeProfileId ?? undefined,

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -450,6 +450,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 					input={input}
 					setInput={setInput}
 					isAwaitingResponse={toolEvents.isAwaitingResponse}
+					isStreamingResponse={toolEvents.responsePhase === "streaming"}
 					canSend={canSend}
 					onSend={() => void handleSend()}
 					onStop={() => chat.stop()}

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -3,6 +3,7 @@ import { ChatAdd01Icon, Logout05Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAISidebarContext, useUILayoutContext } from "../../contexts";
+import { extractErrorMessage } from "../../lib/errorUtils";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { ChevronDown, Settings as SettingsIcon, X } from "../Icons";
 import { Button } from "../ui/shadcn/button";
@@ -160,6 +161,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 		) {
 			return;
 		}
+		actions.setAssistantActionError("");
 		toolEvents.setResponsePhase("submitted");
 		toolEvents.resetToolState();
 		setInput("");
@@ -167,8 +169,9 @@ export function AIPanel({ onClose }: AIPanelProps) {
 		let built: Awaited<ReturnType<typeof context.ensurePayload>>;
 		try {
 			built = await context.ensurePayload();
-		} catch {
+		} catch (error) {
 			toolEvents.setResponsePhase("idle");
+			actions.setAssistantActionError(extractErrorMessage(error));
 			setInput(text);
 			scheduleResize();
 			return;
@@ -187,6 +190,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 			},
 		);
 	}, [
+		actions,
 		aiAssistantMode,
 		chat,
 		context,

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -118,8 +118,10 @@ export function AIPanel({ onClose }: AIPanelProps) {
 			if (!sanitized || !profiles.activeProfileId) return false;
 			toolEvents.setResponsePhase("submitted");
 			toolEvents.resetToolState();
-			const built = await context.ensurePayload();
-			if (context.payloadError) {
+			let built: Awaited<ReturnType<typeof context.ensurePayload>>;
+			try {
+				built = await context.ensurePayload();
+			} catch {
 				toolEvents.setResponsePhase("idle");
 				return false;
 			}
@@ -162,8 +164,10 @@ export function AIPanel({ onClose }: AIPanelProps) {
 		toolEvents.resetToolState();
 		setInput("");
 		scheduleResize();
-		const built = await context.ensurePayload();
-		if (context.payloadError) {
+		let built: Awaited<ReturnType<typeof context.ensurePayload>>;
+		try {
+			built = await context.ensurePayload();
+		} catch {
 			toolEvents.setResponsePhase("idle");
 			setInput(text);
 			scheduleResize();

--- a/src/components/ai/hooks/useAiToolEvents.ts
+++ b/src/components/ai/hooks/useAiToolEvents.ts
@@ -350,6 +350,7 @@ export function useAiToolEvents({
 		phaseStatusText,
 		activityState,
 		isAwaitingResponse,
+		responsePhase: state.responsePhase,
 		setResponsePhase,
 		resetToolState,
 	};

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type AiAssistantMode,
 	type AiMessage,
+	type AiMessageContextItem,
 	type AiProviderKind,
 	invoke,
 } from "../../../lib/tauri";
@@ -9,10 +10,7 @@ import { listenTauriEvent } from "../../../lib/tauriEvents";
 
 type UIMessagePart = { type: "text"; text: string };
 
-export type UIMessageContextItem = {
-	kind: "file" | "folder";
-	label: string;
-};
+export type UIMessageContextItem = AiMessageContextItem;
 
 export interface UIMessage {
 	id: string;
@@ -58,7 +56,7 @@ function asAiMessages(messages: UIMessage[]): AiMessage[] {
 			.join("")
 			.trim();
 		if (!content) continue;
-		out.push({ role: message.role, content });
+		out.push({ role: message.role, content, context: message.context });
 	}
 	return out;
 }

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -9,13 +9,22 @@ import { listenTauriEvent } from "../../../lib/tauriEvents";
 
 type UIMessagePart = { type: "text"; text: string };
 
+export type UIMessageContextItem = {
+	kind: "file" | "folder";
+	label: string;
+};
+
 export interface UIMessage {
 	id: string;
 	role: "system" | "user" | "assistant";
 	parts: UIMessagePart[];
+	context?: UIMessageContextItem[];
 }
 
-type SendMessageArgs = { text: string };
+type SendMessageArgs = {
+	text: string;
+	context?: UIMessageContextItem[];
+};
 type ChunkPayload = { job_id: string; delta: string };
 type DonePayload = { job_id: string; cancelled: boolean };
 type ErrorPayload = { job_id: string; message: string };
@@ -118,7 +127,10 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	}, [cleanupListeners, clearDoneTimer]);
 
 	const sendMessage = useCallback(
-		async ({ text }: SendMessageArgs, options?: SendMessageOptions) => {
+		async (
+			{ text, context }: SendMessageArgs,
+			options?: SendMessageOptions,
+		) => {
 			const trimmed = text.trim();
 			if (!trimmed) return;
 			const profileId = options?.body?.profile_id?.trim() ?? "";
@@ -138,6 +150,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				id: userId,
 				role: "user",
 				parts: [{ type: "text", text: trimmed }],
+				context,
 			};
 			const assistantMessage: UIMessage = {
 				id: assistantId,

--- a/src/components/ai/useAiContext.ts
+++ b/src/components/ai/useAiContext.ts
@@ -204,17 +204,9 @@ export function useAiContext(contextSearch = "") {
 		},
 	});
 
-	const buildPayload = useCallback(async () => {
-		try {
-			return await buildPayloadMutation.mutateAsync();
-		} catch {
-			return { payload: "", manifest: null, attachments: [] };
-		}
-	}, [buildPayloadMutation]);
-
 	const ensurePayload = useCallback(async () => {
-		return buildPayload();
-	}, [buildPayload]);
+		return buildPayloadMutation.mutateAsync();
+	}, [buildPayloadMutation]);
 
 	return {
 		addContext,

--- a/src/components/ai/useAiContext.ts
+++ b/src/components/ai/useAiContext.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { queryClient } from "../../lib/queryClient";
 import { invoke } from "../../lib/tauri";
@@ -74,6 +74,7 @@ export async function preloadAiContextIndex(): Promise<AiContextIndexData | null
 
 export function useAiContext(contextSearch = "") {
 	const [attachedContext, setAttachedContext] = useState<ContextEntry[]>([]);
+	const attachedContextRef = useRef<ContextEntry[]>([]);
 	const indexQuery = useQuery({
 		queryKey: aiContextIndexQueryKey,
 		queryFn: async () => {
@@ -103,19 +104,27 @@ export function useAiContext(contextSearch = "") {
 		const path = normalizeRelPath(rawPath);
 		if (kind === "file" && !path) return;
 		const label = kind === "folder" ? folderLabel(path) : fileLabel(path);
-		setAttachedContext((prev) => {
-			const key = contextKey(kind, path);
-			if (prev.some((it) => contextKey(it.kind, it.path) === key)) return prev;
-			return [...prev, { kind, path, label }];
-		});
+		const key = contextKey(kind, path);
+		if (
+			attachedContextRef.current.some(
+				(entry) => contextKey(entry.kind, entry.path) === key,
+			)
+		) {
+			return;
+		}
+		const next = [...attachedContextRef.current, { kind, path, label }];
+		attachedContextRef.current = next;
+		setAttachedContext(next);
 	}, []);
 
 	const removeContext = useCallback(
 		(kind: ContextEntryKind, rawPath: string) => {
 			const path = normalizeRelPath(rawPath);
-			setAttachedContext((prev) =>
-				prev.filter((it) => !(it.kind === kind && it.path === path)),
+			const next = attachedContextRef.current.filter(
+				(entry) => !(entry.kind === kind && entry.path === path),
 			);
+			attachedContextRef.current = next;
+			setAttachedContext(next);
 		},
 		[],
 	);
@@ -173,9 +182,10 @@ export function useAiContext(contextSearch = "") {
 
 	const buildPayloadMutation = useMutation({
 		mutationFn: async () => {
+			const attachments = attachedContextRef.current;
 			const built = await invoke("ai_context_build", {
 				request: {
-					attachments: attachedFolders,
+					attachments,
 					char_budget: DEFAULT_CHAR_BUDGET,
 				},
 			});
@@ -190,7 +200,7 @@ export function useAiContext(contextSearch = "") {
 				totalChars: built.manifest.total_chars,
 				estTokens: built.manifest.est_tokens,
 			};
-			return { payload: built.payload, manifest };
+			return { payload: built.payload, manifest, attachments };
 		},
 	});
 
@@ -198,7 +208,7 @@ export function useAiContext(contextSearch = "") {
 		try {
 			return await buildPayloadMutation.mutateAsync();
 		} catch {
-			return { payload: "", manifest: null };
+			return { payload: "", manifest: null, attachments: [] };
 		}
 	}, [buildPayloadMutation]);
 

--- a/src/components/ai/useAiHistory.ts
+++ b/src/components/ai/useAiHistory.ts
@@ -34,6 +34,7 @@ function toUIMessages(
 			id: `${jobId}:${i}`,
 			role: msg.role,
 			parts: [{ type: "text", text: msg.content }],
+			context: msg.context,
 		});
 	}
 	return out;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -703,6 +703,12 @@ export interface AiProfile {
 export interface AiMessage {
 	role: "system" | "user" | "assistant";
 	content: string;
+	context?: AiMessageContextItem[];
+}
+
+export interface AiMessageContextItem {
+	kind: "file" | "folder";
+	label: string;
 }
 
 interface AiChatStartResult {

--- a/src/styles/app/07-ai-panel.css
+++ b/src/styles/app/07-ai-panel.css
@@ -307,6 +307,34 @@
 	overflow-wrap: anywhere;
 }
 
+.aiChatContextPills {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-bottom: 5px;
+}
+
+.aiChatContextPill {
+	display: inline-flex;
+	align-items: center;
+	gap: 3px;
+	max-width: 100%;
+	padding: 2px 6px;
+	border-radius: var(--pill-radius);
+	color: var(--interactive-accent);
+	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+	border: 1px solid
+		color-mix(in srgb, var(--interactive-accent) 20%, transparent);
+	font-size: var(--text-xs);
+	line-height: var(--leading-normal);
+}
+
+.aiChatContextPill span {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .aiAssistantActions {
 	margin-top: 4px;
 	display: flex;

--- a/src/styles/app/21-ai-composer-context.css
+++ b/src/styles/app/21-ai-composer-context.css
@@ -71,14 +71,19 @@
 	background: transparent;
 }
 
+.aiComposerBeam,
 .aiComposerInputShell {
 	position: relative;
-	padding: 0;
-	background: transparent;
+	border-radius: var(--radius-lg);
 }
 
-.aiComposerInputShell:focus-within .aiComposerInput {
-	background: var(--bg-primary);
+.aiComposerBeam {
+	width: 100%;
+}
+
+.aiComposerInputShell {
+	padding: 0;
+	background: transparent;
 }
 
 .aiComposerInput {
@@ -94,8 +99,7 @@
 	background: var(--bg-primary);
 	border-radius: var(--radius-lg);
 	border: 1px solid color-mix(in srgb, var(--border-default) 35%, transparent);
-	transition: border-color var(--transition-fast), background
-		var(--transition-fast);
+	transition: border-color var(--transition-fast);
 	white-space: pre-wrap;
 	word-break: normal;
 	overflow-wrap: anywhere;
@@ -105,10 +109,6 @@
 
 .aiComposerInput:focus {
 	border-color: color-mix(in srgb, var(--border-default) 60%, transparent);
-}
-
-.aiComposerInput::placeholder {
-	color: color-mix(in srgb, var(--text-tertiary) 95%, transparent);
 }
 
 .aiComposerInput:empty::before {


### PR DESCRIPTION
Closes 


## Description

Subtle AI composer motion and a cleaner pass for file/folder context attachments in chat.

- Summary of changes
  - Wrap the AI composer input shell in `border-beam` for a light animated border that responds to draft text and streaming state
  - Pass attached file/folder context through `sendMessage` so user messages keep that metadata
  - Render context pills on user chat messages (file/folder icons + labels)
  - Stabilize context attachment state with a ref so payload builds always use the latest attachments
  - Tighten contentEditable composer sync (drop stale `lastInputRef` comparison)
- Reasoning
  - Give the composer a quieter live feel without heavy motion elsewhere
  - Context chips were easy to lose after send; keeping them on the message makes the thread easier to read
- Additional context
  - Adds `border-beam@1.3.0`
  - Beam strength/size dials down while drafting and pulses more gently while streaming
  - No linked issue for this branch


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- AI composer: `BorderBeam` wraps `.aiComposerInputShell` (`AIComposer.tsx`)
- Streaming phase exposed via `useAiToolEvents` → `responsePhase === "streaming"`
- Context items stored on `UIMessage.context` and shown in `AIChatThread` as `.aiChatContextPill`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a subtle, theme-aware animated border to the composer and persist file/folder context on sent messages and in history. This smooths the composer feel and makes chat context clearer and reliable.

- **New Features**
  - Animated composer border using `border-beam`; theme-aware and adapts to draft text and streaming via `responsePhase`.
  - User messages keep attached context and show pills with file/folder icons and labels.
  - Context persists end-to-end: `sendMessage({ text, context })` → `UIMessage.context` → Tauri `AiMessage.context` → history.

- **Bug Fixes**
  - Surface context payload build errors; block send on failure, preserve input, reset phase, and show the error message.
  - Stabilized attachment state with a ref to avoid stale attachments; simplified contentEditable syncing.

<sup>Written for commit b0b0eed08a0cc9092d2d20163bc70210767180d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching file and folder context to AI chat messages.
  * Displayed attached context as labeled pills in chat messages.
  * Added animated visual feedback around the composer while responses are streaming.
  * Improved composer behavior while editing and streaming responses.
* **Bug Fixes**
  * Improved context attachment handling, including duplicate prevention and reliable message submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->