### PR TITLE
Add colorful heading palette options (#434) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.10-alpha.4",
+	"version": "0.8.10-alpha.5",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../../lib/settings", () => ({
 			editor: {
 				showFrontmatterInEditor: false,
 				colorfulHeadings: false,
+				headingPaletteId: "classy",
 				showCollapsibleHeadings: false,
 				showCollapsibleLists: false,
 				spellCheck: true,
@@ -53,6 +54,7 @@ vi.mock("../../lib/settings", () => ({
 	setShowToc: vi.fn(() => Promise.resolve()),
 	setEditorShowFrontmatterInEditor: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadings: vi.fn(() => Promise.resolve()),
+	setEditorHeadingPaletteId: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleHeadings: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleLists: vi.fn(() => Promise.resolve()),
 	setEditorSpellCheck: vi.fn(() => Promise.resolve()),

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -9,6 +9,11 @@ import {
 	getDefaultEditorViewMode,
 	isEditorViewMode,
 } from "../../lib/editorMode";
+import {
+	DEFAULT_HEADING_PALETTE_ID,
+	type HeadingPaletteId,
+	isHeadingPaletteId,
+} from "../../lib/headingPalettes";
 import { GLYPH_LINKS } from "../../lib/helpMenu";
 import {
 	DATE_DISPLAY_FORMAT_OPTIONS,
@@ -22,6 +27,7 @@ import {
 	setEditorColorfulHeadings,
 	setEditorDefaultEditorMode,
 	setEditorFocusMode,
+	setEditorHeadingPaletteId,
 	setEditorRawMarkdownVimMode,
 	setEditorShowCollapsibleHeadings,
 	setEditorShowCollapsibleLists,
@@ -37,6 +43,7 @@ import { useTauriEvent } from "../../lib/tauriEvents";
 import { LicenseSettingsCard } from "../licensing/LicenseSettingsCard";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
 import { FileTreeSettingsSection } from "./FileTreeSettingsSection";
+import { HeadingPalettePicker } from "./HeadingPalettePicker";
 import {
 	SettingsRow,
 	SettingsSection,
@@ -122,6 +129,11 @@ export function GeneralSettingsPane() {
 		setEditorColorfulHeadings,
 		setError,
 	);
+	const headingPalette = useSettingsValue<HeadingPaletteId>(
+		DEFAULT_HEADING_PALETTE_ID,
+		setEditorHeadingPaletteId,
+		setError,
+	);
 	const collapsibleHeadings = useSettingsBoolean(
 		false,
 		setEditorShowCollapsibleHeadings,
@@ -163,6 +175,8 @@ export function GeneralSettingsPane() {
 	const setDefaultEditorModeValue = defaultEditorMode.setValue;
 	const setInitialFocusMode = focusMode.setInitialValue;
 	const setFocusModeValue = focusMode.setValue;
+	const setInitialHeadingPalette = headingPalette.setInitialValue;
+	const setHeadingPaletteValue = headingPalette.setValue;
 	const setInitialDateFormat = dateFormat.setInitialValue;
 	const setDateFormatValue = dateFormat.setValue;
 
@@ -180,6 +194,7 @@ export function GeneralSettingsPane() {
 				setShowTocChecked(settings.ui.showToc);
 				setShowFrontmatterChecked(settings.editor.showFrontmatterInEditor);
 				setColorfulHeadingsChecked(settings.editor.colorfulHeadings);
+				setInitialHeadingPalette(settings.editor.headingPaletteId);
 				setCollapsibleHeadingsChecked(settings.editor.showCollapsibleHeadings);
 				setCollapsibleListsChecked(settings.editor.showCollapsibleLists);
 				setSpellCheckChecked(settings.editor.spellCheck);
@@ -209,6 +224,7 @@ export function GeneralSettingsPane() {
 		setInitialDateFormat,
 		setInitialDefaultEditorMode,
 		setInitialFocusMode,
+		setInitialHeadingPalette,
 	]);
 
 	useTauriEvent(
@@ -226,6 +242,9 @@ export function GeneralSettingsPane() {
 				}
 				if (isFocusMode(payload.editor?.focusMode)) {
 					setFocusModeValue(payload.editor.focusMode);
+				}
+				if (isHeadingPaletteId(payload.editor?.headingPaletteId)) {
+					setHeadingPaletteValue(payload.editor.headingPaletteId);
 				}
 				applyIfBoolean(
 					payload.ui?.resumeLastSession,
@@ -276,6 +295,7 @@ export function GeneralSettingsPane() {
 				setDateFormatValue,
 				setDefaultEditorModeValue,
 				setFocusModeValue,
+				setHeadingPaletteValue,
 			],
 		),
 	);
@@ -340,13 +360,23 @@ export function GeneralSettingsPane() {
 					<SettingsRow
 						label={t("editor.colorfulHeadings.label")}
 						description={t("editor.colorfulHeadings.description")}
+						interactive={false}
 					>
-						<SettingsToggle
-							checked={colorfulHeadings.checked}
-							disabled={colorfulHeadings.isSaving}
-							ariaLabel={t("editor.colorfulHeadings.ariaLabel")}
-							onCheckedChange={colorfulHeadings.onCheckedChange}
-						/>
+						<div className="colorfulHeadingsControls">
+							{colorfulHeadings.checked ? (
+								<HeadingPalettePicker
+									value={headingPalette.value}
+									disabled={headingPalette.isSaving}
+									onChange={headingPalette.onChange}
+								/>
+							) : null}
+							<SettingsToggle
+								checked={colorfulHeadings.checked}
+								disabled={colorfulHeadings.isSaving}
+								ariaLabel={t("editor.colorfulHeadings.ariaLabel")}
+								onCheckedChange={colorfulHeadings.onCheckedChange}
+							/>
+						</div>
 					</SettingsRow>
 					<SettingsRow
 						label={t("editor.collapsibleHeadings.label")}

--- a/src/components/settings/HeadingPalettePicker.tsx
+++ b/src/components/settings/HeadingPalettePicker.tsx
@@ -1,0 +1,112 @@
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useIsDarkTheme } from "../../hooks/useIsDarkTheme";
+import {
+	HEADING_PALETTE_OPTIONS,
+	type HeadingPaletteId,
+	getHeadingPalette,
+} from "../../lib/headingPalettes";
+import { ChevronDown } from "../Icons";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
+
+function HeadingPalettePreview({ colors }: { colors: readonly string[] }) {
+	return (
+		<span className="headingPalettePreview" aria-hidden="true">
+			{colors.map((color, index) => (
+				<span
+					key={`${index}-${color}`}
+					className="headingPaletteSwatch"
+					style={{ color }}
+				>
+					H{index + 1}
+				</span>
+			))}
+		</span>
+	);
+}
+
+export function HeadingPalettePicker({
+	value,
+	disabled,
+	onChange,
+}: {
+	value: HeadingPaletteId;
+	disabled?: boolean;
+	onChange: (value: HeadingPaletteId) => void;
+}) {
+	const { t } = useTranslation("settings.general");
+	const [open, setOpen] = useState(false);
+	const isDark = useIsDarkTheme();
+	const selected = getHeadingPalette(value);
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					className={cn(
+						"appearanceThemeDropdownTrigger",
+						"headingPaletteTrigger",
+						open && "is-open",
+					)}
+					disabled={disabled}
+					aria-label={t("editor.colorfulHeadings.palette.label")}
+					aria-expanded={open}
+				>
+					<HeadingPalettePreview
+						colors={isDark ? selected.dark : selected.light}
+					/>
+					<span className="appearanceThemeDropdownTitle">
+						{t(`editor.colorfulHeadings.palette.options.${selected.id}`)}
+					</span>
+					<span
+						className={cn("appearanceThemeDropdownChevron", open && "is-open")}
+					>
+						<ChevronDown size="var(--icon-md)" />
+					</span>
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				side="bottom"
+				sideOffset={8}
+				className="appearanceThemeDropdownContent headingPaletteContent"
+			>
+				<div className="appearanceThemeDropdownHeader">
+					<div className="appearanceThemeDropdownHeaderTitle">
+						{t("editor.colorfulHeadings.palette.label")}
+					</div>
+				</div>
+				<div className="appearanceThemeDropdownList">
+					{HEADING_PALETTE_OPTIONS.map((palette) => {
+						const isSelected = palette.id === selected.id;
+						return (
+							<button
+								key={palette.id}
+								type="button"
+								className={cn(
+									"appearanceThemeDropdownOption",
+									"headingPaletteOption",
+									isSelected && "is-selected",
+								)}
+								aria-pressed={isSelected}
+								onClick={() => {
+									onChange(palette.id);
+									setOpen(false);
+								}}
+							>
+								<span className="appearanceThemeDropdownOptionTitle">
+									{t(`editor.colorfulHeadings.palette.options.${palette.id}`)}
+								</span>
+								<HeadingPalettePreview
+									colors={isDark ? palette.dark : palette.light}
+								/>
+							</button>
+						);
+					})}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/src/i18n/locales/de/settings.general.json
+++ b/src/i18n/locales/de/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "Farbige Überschriften",
-			"description": "Beim Bearbeiten von Notizen eingebaute Farben für H1–H6 verwenden.",
-			"ariaLabel": "Farbige Überschriften"
+			"description": "Beim Bearbeiten von Notizen eine ausgewählte Farbpalette für H1–H6 verwenden.",
+			"ariaLabel": "Farbige Überschriften",
+			"palette": {
+				"label": "Überschriftenpalette",
+				"options": {
+					"classy": "Klassisch",
+					"seaside": "Meeresküste",
+					"woodland": "Waldland",
+					"sunset": "Sonnenuntergang",
+					"candy": "Bonbon"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "Einklappbare Überschriften",

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "Colorful headings",
-			"description": "Use distinct built-in colors for H1-H6 while editing notes.",
-			"ariaLabel": "Colorful headings"
+			"description": "Use a selected color palette for H1-H6 while editing notes.",
+			"ariaLabel": "Colorful headings",
+			"palette": {
+				"label": "Heading palette",
+				"options": {
+					"classy": "Classy",
+					"seaside": "Seaside",
+					"woodland": "Woodland",
+					"sunset": "Sunset",
+					"candy": "Candy"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "Collapsible headings",

--- a/src/i18n/locales/es/settings.general.json
+++ b/src/i18n/locales/es/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "Encabezados con color",
-			"description": "Usar colores integrados distintos para H1-H6 al editar notas.",
-			"ariaLabel": "Encabezados con color"
+			"description": "Usar una paleta de colores seleccionada para H1-H6 al editar notas.",
+			"ariaLabel": "Encabezados con color",
+			"palette": {
+				"label": "Paleta de encabezados",
+				"options": {
+					"classy": "Elegante",
+					"seaside": "Costa",
+					"woodland": "Bosque",
+					"sunset": "Atardecer",
+					"candy": "Caramelo"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "Encabezados plegables",

--- a/src/i18n/locales/fr/settings.general.json
+++ b/src/i18n/locales/fr/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "Titres colorés",
-			"description": "Utiliser des couleurs intégrées distinctes pour H1-H6 lors de l’édition des notes.",
-			"ariaLabel": "Titres colorés"
+			"description": "Utiliser une palette sélectionnée pour H1-H6 lors de l’édition des notes.",
+			"ariaLabel": "Titres colorés",
+			"palette": {
+				"label": "Palette des titres",
+				"options": {
+					"classy": "Élégante",
+					"seaside": "Bord de mer",
+					"woodland": "Sous-bois",
+					"sunset": "Coucher de soleil",
+					"candy": "Confiserie"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "Titres repliables",

--- a/src/i18n/locales/ja/settings.general.json
+++ b/src/i18n/locales/ja/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "カラフルな見出し",
-			"description": "ノート編集時に H1〜H6 に組み込みの異なる色を使います。",
-			"ariaLabel": "カラフルな見出し"
+			"description": "ノート編集時に H1〜H6 へ選択したカラーパレットを使います。",
+			"ariaLabel": "カラフルな見出し",
+			"palette": {
+				"label": "見出しパレット",
+				"options": {
+					"classy": "クラッシー",
+					"seaside": "シーサイド",
+					"woodland": "ウッドランド",
+					"sunset": "サンセット",
+					"candy": "キャンディ"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "折りたたみ可能な見出し",

--- a/src/i18n/locales/ko/settings.general.json
+++ b/src/i18n/locales/ko/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "컬러풀 제목",
-			"description": "노트 편집 시 H1-H6에 내장된 서로 다른 색상을 사용합니다.",
-			"ariaLabel": "컬러풀 제목"
+			"description": "노트 편집 시 H1-H6에 선택한 색상 팔레트를 사용합니다.",
+			"ariaLabel": "컬러풀 제목",
+			"palette": {
+				"label": "제목 팔레트",
+				"options": {
+					"classy": "클래시",
+					"seaside": "해변",
+					"woodland": "숲",
+					"sunset": "노을",
+					"candy": "캔디"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "접을 수 있는 제목",

--- a/src/i18n/locales/pt-BR/settings.general.json
+++ b/src/i18n/locales/pt-BR/settings.general.json
@@ -68,8 +68,18 @@
 		},
 		"colorfulHeadings": {
 			"label": "Títulos coloridos",
-			"description": "Usar cores integradas distintas para H1-H6 ao editar notas.",
-			"ariaLabel": "Títulos coloridos"
+			"description": "Usar uma paleta de cores selecionada para H1-H6 ao editar notas.",
+			"ariaLabel": "Títulos coloridos",
+			"palette": {
+				"label": "Paleta dos títulos",
+				"options": {
+					"classy": "Clássica",
+					"seaside": "Litoral",
+					"woodland": "Bosque",
+					"sunset": "Pôr do sol",
+					"candy": "Doce"
+				}
+			}
 		},
 		"collapsibleHeadings": {
 			"label": "Títulos recolhíveis",

--- a/src/lib/headingPalettes.ts
+++ b/src/lib/headingPalettes.ts
@@ -1,0 +1,64 @@
+export const HEADING_PALETTE_OPTIONS = [
+	{
+		id: "classy",
+		light: ["#be3d61", "#a45f12", "#267d4c", "#2a74c9", "#7a57d1", "#9b5b2f"],
+		dark: ["#ed86a2", "#e6a457", "#67c58d", "#72a9e8", "#a891eb", "#d99a6d"],
+	},
+	{
+		id: "seaside",
+		light: ["#006d77", "#147d92", "#3a6f8f", "#9b4f66", "#b4533e", "#6f5a2a"],
+		dark: ["#5dc0c8", "#63b3cc", "#83a6d9", "#e19ab5", "#f0a68d", "#d4ba72"],
+	},
+	{
+		id: "woodland",
+		light: ["#52602f", "#3f6d48", "#7c6a2a", "#a65f24", "#8f4b3e", "#645382"],
+		dark: ["#a9bd72", "#7fba8b", "#d3bd67", "#e5aa66", "#d9907f", "#b6a4d2"],
+	},
+	{
+		id: "sunset",
+		light: ["#c83e4d", "#a96700", "#147a9c", "#16815f", "#6246b5", "#9b3e96"],
+		dark: ["#ff7c8c", "#ffc45b", "#57c7e8", "#4fd5a5", "#a998ff", "#e582d7"],
+	},
+	{
+		id: "candy",
+		light: ["#c2185b", "#9c278b", "#6b2ca6", "#3c3aa1", "#3567c8", "#157b9a"],
+		dark: ["#ff70ad", "#e878d8", "#bd8cf5", "#918cff", "#76a2ff", "#61d3ed"],
+	},
+] as const;
+
+export type HeadingPaletteId = (typeof HEADING_PALETTE_OPTIONS)[number]["id"];
+
+export const DEFAULT_HEADING_PALETTE_ID: HeadingPaletteId = "classy";
+
+export function isHeadingPaletteId(value: unknown): value is HeadingPaletteId {
+	return (
+		typeof value === "string" &&
+		HEADING_PALETTE_OPTIONS.some((palette) => palette.id === value)
+	);
+}
+
+export function asHeadingPaletteId(value: unknown): HeadingPaletteId {
+	return isHeadingPaletteId(value) ? value : DEFAULT_HEADING_PALETTE_ID;
+}
+
+export function getHeadingPalette(
+	id: HeadingPaletteId,
+): (typeof HEADING_PALETTE_OPTIONS)[number] {
+	return (
+		HEADING_PALETTE_OPTIONS.find((palette) => palette.id === id) ??
+		HEADING_PALETTE_OPTIONS[0]
+	);
+}
+
+export function applyEditorHeadingPalette(id: HeadingPaletteId): void {
+	if (typeof document === "undefined") return;
+	const palette = getHeadingPalette(id);
+	for (const mode of ["light", "dark"] as const) {
+		for (const [index, color] of palette[mode].entries()) {
+			document.documentElement.style.setProperty(
+				`--editor-heading-h${index + 1}-color-${mode}`,
+				color,
+			);
+		}
+	}
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -11,6 +11,11 @@ import {
 	isEditorViewMode,
 	setCachedDefaultEditorViewMode,
 } from "./editorMode";
+import {
+	DEFAULT_HEADING_PALETTE_ID,
+	type HeadingPaletteId,
+	asHeadingPaletteId,
+} from "./headingPalettes";
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
 import { type AppLanguage, normalizeAppLanguage } from "../i18n/locales";
 import {
@@ -199,6 +204,7 @@ interface EditorSettings {
 	showCollapsibleLists: boolean;
 	showFrontmatterInEditor: boolean;
 	colorfulHeadings: boolean;
+	headingPaletteId: HeadingPaletteId;
 	beautifulTags: boolean;
 	editorWidthMode: EditorWidthMode;
 	defaultEditorMode: EditorViewMode;
@@ -241,6 +247,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	showCollapsibleLists: false,
 	showFrontmatterInEditor: false,
 	colorfulHeadings: false,
+	headingPaletteId: DEFAULT_HEADING_PALETTE_ID,
 	beautifulTags: false,
 	editorWidthMode: "compact",
 	defaultEditorMode: DEFAULT_EDITOR_VIEW_MODE,
@@ -452,6 +459,7 @@ async function emitSettingsUpdated(payload: {
 		showCollapsibleLists?: boolean;
 		showFrontmatterInEditor?: boolean;
 		colorfulHeadings?: boolean;
+		headingPaletteId?: HeadingPaletteId;
 		beautifulTags?: boolean;
 		editorWidthMode?: EditorWidthMode;
 		defaultEditorMode?: EditorViewMode;
@@ -597,6 +605,7 @@ const KEYS = {
 	editorShowCollapsibleLists: "editor.showCollapsibleLists",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
 	editorColorfulHeadings: "editor.colorfulHeadings",
+	editorHeadingPaletteId: "editor.headingPaletteId",
 	editorBeautifulTags: "editor.beautifulTags",
 	editorEditorWidthMode: "editor.editorWidthMode",
 	editorDefaultEditorMode: "editor.defaultEditorMode",
@@ -963,6 +972,10 @@ export async function loadSettings(
 		entries,
 		KEYS.editorColorfulHeadings,
 	);
+	const rawEditorHeadingPaletteId = getSettingValue(
+		entries,
+		KEYS.editorHeadingPaletteId,
+	);
 	const rawEditorBeautifulTags = getSettingValue<boolean | null>(
 		entries,
 		KEYS.editorBeautifulTags,
@@ -1126,6 +1139,7 @@ export async function loadSettings(
 			typeof rawEditorColorfulHeadings === "boolean"
 				? rawEditorColorfulHeadings
 				: DEFAULT_EDITOR_SETTINGS.colorfulHeadings,
+		headingPaletteId: asHeadingPaletteId(rawEditorHeadingPaletteId),
 		beautifulTags:
 			typeof rawEditorBeautifulTags === "boolean"
 				? rawEditorBeautifulTags
@@ -1576,6 +1590,18 @@ export async function setEditorColorfulHeadings(
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
 		editor: { colorfulHeadings: enabled },
+	});
+}
+
+export async function setEditorHeadingPaletteId(
+	headingPaletteId: HeadingPaletteId,
+): Promise<void> {
+	const store = await getSettingsStore();
+	const next = asHeadingPaletteId(headingPaletteId);
+	await store.set(KEYS.editorHeadingPaletteId, next);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({
+		editor: { headingPaletteId: next },
 	});
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
 import type { EditorViewMode } from "./editorMode";
+import type { HeadingPaletteId } from "./headingPalettes";
 import type {
 	AppLanguage,
 	AttachmentStorageMode,
@@ -107,6 +108,7 @@ type TauriEventMap = {
 			showCollapsibleLists?: boolean;
 			showFrontmatterInEditor?: boolean;
 			colorfulHeadings?: boolean;
+			headingPaletteId?: HeadingPaletteId;
 			beautifulTags?: boolean;
 			editorWidthMode?: EditorWidthMode;
 			defaultEditorMode?: EditorViewMode;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,6 +20,10 @@ import {
 	applyUiThemeSelection,
 	applyUiTypography,
 } from "./lib/appearance";
+import {
+	applyEditorHeadingPalette,
+	isHeadingPaletteId,
+} from "./lib/headingPalettes";
 import type {
 	UiAccent,
 	UiCornerRadiusStyle,
@@ -108,6 +112,7 @@ function ThemeAndTypographyBridge() {
 				setTranslucentApp(settings.ui.translucentApp);
 				setCornerRadiusStyle(settings.ui.cornerRadiusStyle);
 				setThemeColors(settings.ui.themeColors);
+				applyEditorHeadingPalette(settings.editor.headingPaletteId);
 				applyEditorWidthMode(settings.editor.editorWidthMode);
 				void invoke("index_set_people_mentions_as_tags_enabled", {
 					enabled: settings.editor.enablePeopleMentionsAsTags,
@@ -205,6 +210,9 @@ function ThemeAndTypographyBridge() {
 			void invoke("index_set_people_mentions_as_tags_enabled", {
 				enabled: payload.editor.enablePeopleMentionsAsTags,
 			}).catch(() => {});
+		}
+		if (isHeadingPaletteId(payload.editor?.headingPaletteId)) {
+			applyEditorHeadingPalette(payload.editor.headingPaletteId);
 		}
 	});
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -303,12 +303,21 @@
 }
 
 .tiptapHostInline[data-colorful-headings="true"]:not(.is-preview) {
-	--editor-heading-h1-color: #c84d6f;
-	--editor-heading-h2-color: #b86f18;
-	--editor-heading-h3-color: #2d8f58;
-	--editor-heading-h4-color: #2a74c9;
-	--editor-heading-h5-color: #7a57d1;
-	--editor-heading-h6-color: #9b5b2f;
+	--editor-heading-h1-color: var(--editor-heading-h1-color-light, #be3d61);
+	--editor-heading-h2-color: var(--editor-heading-h2-color-light, #a45f12);
+	--editor-heading-h3-color: var(--editor-heading-h3-color-light, #267d4c);
+	--editor-heading-h4-color: var(--editor-heading-h4-color-light, #2a74c9);
+	--editor-heading-h5-color: var(--editor-heading-h5-color-light, #7a57d1);
+	--editor-heading-h6-color: var(--editor-heading-h6-color-light, #9b5b2f);
+}
+
+:root.dark .tiptapHostInline[data-colorful-headings="true"]:not(.is-preview) {
+	--editor-heading-h1-color: var(--editor-heading-h1-color-dark, #ed86a2);
+	--editor-heading-h2-color: var(--editor-heading-h2-color-dark, #e6a457);
+	--editor-heading-h3-color: var(--editor-heading-h3-color-dark, #67c58d);
+	--editor-heading-h4-color: var(--editor-heading-h4-color-dark, #72a9e8);
+	--editor-heading-h5-color: var(--editor-heading-h5-color-dark, #a891eb);
+	--editor-heading-h6-color: var(--editor-heading-h6-color-dark, #d99a6d);
 }
 
 .tiptapHostInline[data-colorful-headings="true"]:not(.is-preview)

--- a/src/styles/app/27-settings-appearance.css
+++ b/src/styles/app/27-settings-appearance.css
@@ -169,9 +169,60 @@
 	scrollbar-gutter: stable;
 }
 
+.colorfulHeadingsControls {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+}
+
+.headingPaletteTrigger {
+	min-width: 286px;
+}
+
+.headingPaletteTrigger:disabled {
+	cursor: not-allowed;
+	opacity: 0.55;
+}
+
+.headingPalettePreview {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+
+.headingPaletteSwatch {
+	font-size: calc(var(--text-base) * 0.66);
+	font-weight: var(--font-semibold);
+	letter-spacing: -0.06em;
+	line-height: 1;
+}
+
+.headingPaletteOption.is-selected::after {
+	order: 1;
+	margin-left: 0;
+}
+
+.headingPaletteContent {
+	width: min(360px, calc(100vw - 24px));
+}
+
+.headingPaletteOption .headingPalettePreview {
+	order: 2;
+	margin-left: auto;
+}
+
 @media (max-width: 680px) {
 	.appearanceThemeDropdownContent {
 		width: min(100vw - 16px, 360px);
+	}
+
+	.colorfulHeadingsControls {
+		flex-wrap: wrap-reverse;
+	}
+
+	.headingPaletteTrigger {
+		min-width: 0;
 	}
 }
 


### PR DESCRIPTION
Closes 


## Description

Adds selectable color palettes for the existing colorful headings editor setting, so users can choose how H1–H6 look instead of a single fixed palette.

- Summary of changes
  - New `headingPaletteId` editor setting with five palettes: Classy, Seaside, Woodland, Sunset, Candy
  - Settings UI: when colorful headings is on, a palette picker appears next to the toggle (preview swatches for H1–H6)
  - CSS variables applied at runtime for light/dark modes; heading colors resolve via those vars
  - i18n strings for all supported locales
  - Version bump to `0.8.10-alpha.5`
- Reasoning
  - Colorful headings were previously a single hard-coded palette. Palette choice makes the feature more useful across themes and personal preference without changing markdown content.
- Additional context
  - Default palette is Classy (closest to the previous colors)
  - Invalid/legacy values normalize via `asHeadingPaletteId`
  - Palette picker only shows when colorful headings is enabled


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- Setting key: `editor.headingPaletteId`
- Palettes defined in `src/lib/headingPalettes.ts`
- Applied via `applyEditorHeadingPalette()` in `ThemeAndTypographyBridge` (`src/main.tsx`)
- CSS: `--editor-heading-h{1-6}-color-{light|dark}` → `--editor-heading-h{1-6}-color` when `data-colorful-headings="true"`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds selectable color palettes for colorful headings in the editor so users can choose how H1–H6 look. Includes a new palette picker in Settings and runtime CSS variables that adapt to light and dark themes.

- **New Features**
  - New `editor.headingPaletteId` with five palettes: Classy (default), Seaside, Woodland, Sunset, Candy.
  - Palette picker appears next to the colorful headings toggle with H1–H6 preview swatches.
  - Palette applied via `applyEditorHeadingPalette()` on load and settings updates; colors set through CSS variables for light/dark.
  - i18n strings added for all locales and tests updated.

<sup>Written for commit b5ff80f194a49dc09ee3bb3f35ae0f87f4120c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable heading color palettes for colorful headings.
  * Added five palette options: Classy, Seaside, Woodland, Sunset, and Candy.
  * Palette selection is saved and applied in both light and dark themes.
  * Improved responsive layout and accessibility for the palette picker.
  * Added localized palette labels and options across supported languages.

* **Chores**
  * Updated the application version to 0.8.10-alpha.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->