### PR TITLE
Add in-app space switcher (#435) [Release]

### DIFF
--- a/src-tauri/src/app_exit.rs
+++ b/src-tauri/src/app_exit.rs
@@ -122,7 +122,7 @@ pub(crate) fn handle_exit_requested(app: &tauri::AppHandle, api: &tauri::ExitReq
     let labels = app
         .webview_windows()
         .into_keys()
-        .filter(|label| super::is_space_host_window_label(label))
+        .filter(|label| super::is_main_window_label(label))
         .filter(|label| !inner.unavailable_windows.contains(label))
         .collect::<HashSet<_>>();
     if labels.is_empty() {
@@ -134,7 +134,7 @@ pub(crate) fn handle_exit_requested(app: &tauri::AppHandle, api: &tauri::ExitReq
     inner.status = AppExitStatus::Waiting(labels.clone());
     drop(inner);
 
-    // The main space host confirms only after its open tabs reach disk.
+    // The main window confirms only after its open tabs reach disk.
     for label in labels.intersection(&registered_windows) {
         if let Err(error) = app.emit_to(label, "app:exit_requested", ()) {
             warn!("Failed to request workspace save from {label}: {error}");

--- a/src-tauri/src/app_exit.rs
+++ b/src-tauri/src/app_exit.rs
@@ -134,7 +134,7 @@ pub(crate) fn handle_exit_requested(app: &tauri::AppHandle, api: &tauri::ExitReq
     inner.status = AppExitStatus::Waiting(labels.clone());
     drop(inner);
 
-    // Every space window confirms only after its open tabs reach disk.
+    // The main space host confirms only after its open tabs reach disk.
     for label in labels.intersection(&registered_windows) {
         if let Err(error) = app.emit_to(label, "app:exit_requested", ()) {
             warn!("Failed to request workspace save from {label}: {error}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -909,7 +909,7 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
 }
 
 fn is_space_host_window_label(label: &str) -> bool {
-    label == "main" || space::commands::is_space_window(label)
+    label == "main"
 }
 
 fn is_auxiliary_persisted_window(label: &str) -> bool {
@@ -1541,18 +1541,6 @@ pub fn run() {
                 }
             }
 
-            if space::commands::is_space_window(window.label()) {
-                if let WindowEvent::Destroyed = event {
-                    let state = window.state::<space::SpaceState>();
-                    match state.remove_window_session(window.label()) {
-                        Ok(()) => {
-                            space::commands::update_close_space_menu(window.app_handle(), &state)
-                        }
-                        Err(error) => warn!("Failed to forget space window session: {error}"),
-                    }
-                }
-            }
-
             if is_space_host_window_label(window.label()) {
                 if let WindowEvent::CloseRequested { .. } = event {
                     prepare_host_window_close(window);
@@ -1701,7 +1689,6 @@ pub fn run() {
             git_sync::commands::git_history_diff,
             space::commands::space_create,
             space::commands::space_open,
-            space::commands::space_open_window,
             space::commands::space_get_current,
             space::commands::space_get_current_info,
             space::commands::space_show_onboarding_note,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,7 +70,9 @@ fn init_tracing() {
 }
 
 fn space_is_open(state: &space::SpaceState) -> bool {
-    !state.session_roots().is_empty()
+    state
+        .root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
+        .is_ok()
 }
 
 fn set_menu_item_enabled<R: tauri::Runtime>(
@@ -908,8 +910,8 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
     Ok(window)
 }
 
-fn is_space_host_window_label(label: &str) -> bool {
-    label == "main"
+fn is_main_window_label(label: &str) -> bool {
+    label == window_geometry::MAIN_WINDOW_LABEL
 }
 
 fn is_auxiliary_persisted_window(label: &str) -> bool {
@@ -924,64 +926,16 @@ fn destroy_auxiliary_persisted_windows(app: &tauri::AppHandle) {
     }
 }
 
-fn prepare_host_window_close(window: &tauri::Window) {
-    if !is_space_host_window_label(window.label()) {
-        return;
-    }
-    let app = window.app_handle();
-    let host_count = app
-        .webview_windows()
-        .into_iter()
-        .filter(|(label, _)| is_space_host_window_label(label))
-        .count();
-    if host_count <= 1 {
-        destroy_auxiliary_persisted_windows(&app);
-    }
-}
-
-fn focused_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
-    app.webview_windows().into_iter().find(|(label, window)| {
-        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
-    })
-}
-
 fn focused_editor_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
     app.webview_windows().into_iter().find(|(label, window)| {
-        (is_space_host_window_label(label)
+        (is_main_window_label(label)
             || label == QUICK_NOTE_WINDOW_LABEL
             || external_markdown::is_external_markdown_window(label))
             && window.is_focused().unwrap_or(false)
     })
 }
 
-fn target_space_host_window(app: &tauri::AppHandle) -> Option<(String, tauri::WebviewWindow)> {
-    focused_space_host_window(app).or_else(|| {
-        let space_state = app.try_state::<space::SpaceState>()?;
-        let current_root = space_state.current_root().ok()?;
-        app.webview_windows().into_iter().find(|(label, _window)| {
-            is_space_host_window_label(label)
-                && space_state
-                    .root_for_window_label(label)
-                    .map(|root| root == current_root)
-                    .unwrap_or(false)
-        })
-    })
-}
-
-fn sync_fallback_space_to_focused_window(app: &tauri::AppHandle) {
-    let Some(space_state) = app.try_state::<space::SpaceState>() else {
-        return;
-    };
-    let focused_root = focused_space_host_window(app)
-        .and_then(|(_label, window)| space_state.root_for_window(&window).ok());
-    let Some(root) = focused_root else {
-        return;
-    };
-    let _ = space_state.set_current_root(root);
-}
-
 fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
-    sync_fallback_space_to_focused_window(app);
     let window = quick_note_window(app)?;
     let _ = window.center();
     window.show().map_err(|error| error.to_string())?;
@@ -1088,7 +1042,7 @@ fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) -> bool {
 
 fn should_exit_after_external_markdown_close(app: &tauri::AppHandle) -> bool {
     !app.webview_windows().keys().any(|label| {
-        external_markdown::is_external_markdown_window(label) || is_space_host_window_label(label)
+        external_markdown::is_external_markdown_window(label) || is_main_window_label(label)
     })
 }
 
@@ -1187,11 +1141,10 @@ fn set_recent_spaces_menu(
     recent_spaces: Vec<String>,
 ) -> Result<(), String> {
     let current_space_path = app.try_state::<space::SpaceState>().and_then(|state| {
-        state.current.lock().ok().and_then(|guard| {
-            guard
-                .as_ref()
-                .map(|path| path.to_string_lossy().to_string())
-        })
+        state
+            .root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
+            .ok()
+            .map(|path| path.to_string_lossy().to_string())
     });
     let filtered: Vec<String> = recent_spaces
         .into_iter()
@@ -1431,44 +1384,32 @@ pub fn run() {
                 let Some(space_state) = app.try_state::<space::SpaceState>() else {
                     return;
                 };
-                let current_path = app
-                    .webview_windows()
-                    .into_iter()
-                    .find(|(label, window)| {
-                        is_space_host_window_label(label) && window.is_focused().unwrap_or(false)
-                    })
-                    .and_then(|(label, _window)| {
-                        space_state
-                            .root_for_window_label(&label)
-                            .ok()
-                            .map(|path| path.to_string_lossy().to_string())
-                    });
+                let current_path = space_state
+                    .root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
+                    .ok()
+                    .map(|path| path.to_string_lossy().to_string());
                 if current_path.as_deref() == Some(path.as_str()) {
                     return;
                 }
-                if let Some((label, _window)) = target_space_host_window(app) {
-                    let _ = app.emit_to(
-                        label,
-                        "menu:open_recent_space",
-                        OpenRecentSpacePayload { path },
-                    );
-                }
+                let _ = app.emit_to(
+                    window_geometry::MAIN_WINDOW_LABEL,
+                    "menu:open_recent_space",
+                    OpenRecentSpacePayload { path },
+                );
             }
             "file.print_note" => {
-                if let Some((label, _window)) = target_space_host_window(app) {
-                    let _ = app.emit_to(
-                        label,
-                        "menu:app_command",
-                        AppCommandPayload {
-                            command_id: "print-note".to_string(),
-                        },
-                    );
-                }
+                let _ = app.emit_to(
+                    window_geometry::MAIN_WINDOW_LABEL,
+                    "menu:app_command",
+                    AppCommandPayload {
+                        command_id: "print-note".to_string(),
+                    },
+                );
             }
             #[cfg(target_os = "macos")]
             "edit.paste_without_formatting" => {
-                // Editor surfaces live in space hosts, quick note, and external markdown
-                // windows — target the focused one rather than only the space host.
+                // Editor surfaces live in the main, quick note, and external markdown
+                // windows, so paste targets whichever one is focused.
                 if let Some((label, _window)) = focused_editor_window(app) {
                     let _ = app.emit_to(
                         label,
@@ -1483,15 +1424,13 @@ pub fn run() {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                if let Some((label, _window)) = target_space_host_window(app) {
-                    let _ = app.emit_to(
-                        label,
-                        "menu:app_command",
-                        AppCommandPayload {
-                            command_id: command.id,
-                        },
-                    );
-                }
+                let _ = app.emit_to(
+                    window_geometry::MAIN_WINDOW_LABEL,
+                    "menu:app_command",
+                    AppCommandPayload {
+                        command_id: command.id,
+                    },
+                );
             }
         })
         .setup(|app| {
@@ -1541,9 +1480,9 @@ pub fn run() {
                 }
             }
 
-            if is_space_host_window_label(window.label()) {
+            if is_main_window_label(window.label()) {
                 if let WindowEvent::CloseRequested { .. } = event {
-                    prepare_host_window_close(window);
+                    destroy_auxiliary_persisted_windows(window.app_handle());
                 }
             }
         })

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -3,7 +3,7 @@ use tauri::State;
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    paths,
+    paths, window_geometry,
 };
 
 use super::helpers::{
@@ -11,14 +11,6 @@ use super::helpers::{
 };
 use super::state::SpaceState;
 use super::watcher::create_notes_watcher;
-
-fn space_window_title(root: &Path) -> String {
-    root.file_name()
-        .and_then(|name| name.to_str())
-        .filter(|name| !name.trim().is_empty())
-        .map(|name| format!("{name} - Glyph"))
-        .unwrap_or_else(|| "Glyph".to_string())
-}
 
 fn install_window_session(
     app: tauri::AppHandle,
@@ -37,7 +29,10 @@ fn install_window_session(
 }
 
 pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState) {
-    let _ = crate::set_space_close_menu_enabled(app, !state.session_roots().is_empty());
+    let enabled = state
+        .root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
+        .is_ok();
+    let _ = crate::set_space_close_menu_enabled(app, enabled);
 }
 
 #[tauri::command]
@@ -63,10 +58,6 @@ pub async fn space_create(
         window.label().to_string(),
         PathBuf::from(&info.root),
     )?;
-    if window.label() == "main" {
-        state.set_current_root(PathBuf::from(&info.root))?;
-        let _ = window.set_title(&space_window_title(Path::new(&info.root)));
-    }
     update_close_space_menu(&app, &state);
     Ok(info)
 }
@@ -93,10 +84,6 @@ pub async fn space_open(
         window.label().to_string(),
         PathBuf::from(&info.root),
     )?;
-    if window.label() == "main" {
-        state.set_current_root(PathBuf::from(&info.root))?;
-        let _ = window.set_title(&space_window_title(Path::new(&info.root)));
-    }
     update_close_space_menu(&app, &state);
     Ok(info)
 }
@@ -150,9 +137,6 @@ pub fn space_close(
     state: State<'_, SpaceState>,
 ) -> Result<(), String> {
     state.remove_window_session(window.label())?;
-    if window.label() == "main" {
-        let _ = window.set_title("Glyph");
-    }
     reset_schema_cache();
     update_close_space_menu(&app, &state);
     Ok(())

--- a/src-tauri/src/space/commands.rs
+++ b/src-tauri/src/space/commands.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
-use tauri::{Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tauri::State;
 
 use crate::{
     index::{self, db::reset_schema_cache},
-    paths, utils, window_geometry,
+    paths,
 };
 
 use super::helpers::{
@@ -11,17 +11,6 @@ use super::helpers::{
 };
 use super::state::SpaceState;
 use super::watcher::create_notes_watcher;
-
-pub(crate) const SPACE_WINDOW_PREFIX: &str = "space-";
-
-pub(crate) fn is_space_window(label: &str) -> bool {
-    label.starts_with(SPACE_WINDOW_PREFIX)
-}
-
-fn space_window_label(root: &Path) -> String {
-    let hash = utils::sha256_hex(root.to_string_lossy().as_bytes());
-    format!("{SPACE_WINDOW_PREFIX}{}", &hash[..16])
-}
 
 fn space_window_title(root: &Path) -> String {
     root.file_name()
@@ -45,12 +34,6 @@ fn install_window_session(
         recent_local_changes.clone(),
     )?;
     state.set_window_session(window_label, root, watcher, recent_local_changes)
-}
-
-fn focus_window(window: &tauri::WebviewWindow) -> Result<(), String> {
-    window.show().map_err(|error| error.to_string())?;
-    window.unminimize().map_err(|error| error.to_string())?;
-    window.set_focus().map_err(|error| error.to_string())
 }
 
 pub(crate) fn update_close_space_menu(app: &tauri::AppHandle, state: &SpaceState) {
@@ -82,6 +65,7 @@ pub async fn space_create(
     )?;
     if window.label() == "main" {
         state.set_current_root(PathBuf::from(&info.root))?;
+        let _ = window.set_title(&space_window_title(Path::new(&info.root)));
     }
     update_close_space_menu(&app, &state);
     Ok(info)
@@ -111,6 +95,7 @@ pub async fn space_open(
     )?;
     if window.label() == "main" {
         state.set_current_root(PathBuf::from(&info.root))?;
+        let _ = window.set_title(&space_window_title(Path::new(&info.root)));
     }
     update_close_space_menu(&app, &state);
     Ok(info)
@@ -165,67 +150,10 @@ pub fn space_close(
     state: State<'_, SpaceState>,
 ) -> Result<(), String> {
     state.remove_window_session(window.label())?;
+    if window.label() == "main" {
+        let _ = window.set_title("Glyph");
+    }
     reset_schema_cache();
     update_close_space_menu(&app, &state);
     Ok(())
-}
-
-#[tauri::command(rename_all = "snake_case")]
-pub async fn space_open_window(
-    app: tauri::AppHandle,
-    state: State<'_, SpaceState>,
-    path: String,
-    create: Option<bool>,
-) -> Result<SpaceInfo, String> {
-    let root = PathBuf::from(path);
-    let should_create = create.unwrap_or(false);
-    let info = tauri::async_runtime::spawn_blocking(move || -> Result<SpaceInfo, String> {
-        if should_create {
-            std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
-        }
-        let root = canonicalize_dir(&root)?;
-        create_or_open_impl(&root)
-    })
-    .await
-    .map_err(|e| e.to_string())??;
-
-    let root = PathBuf::from(&info.root);
-    let label = space_window_label(&root);
-
-    if let Some(window) = app.get_webview_window(&label) {
-        focus_window(&window)?;
-        return Ok(info);
-    }
-
-    install_window_session(app.clone(), &state, label.clone(), root.clone())?;
-
-    let window = match WebviewWindowBuilder::new(
-        &app,
-        &label,
-        WebviewUrl::App(format!("index.html?window={label}").into()),
-    )
-    .title(space_window_title(&root))
-    .inner_size(800.0, 600.0)
-    .min_inner_size(
-        window_geometry::MIN_INNER_WIDTH as f64,
-        window_geometry::MIN_INNER_HEIGHT as f64,
-    )
-    .decorations(true)
-    .title_bar_style(tauri::TitleBarStyle::Overlay)
-    .hidden_title(true)
-    .transparent(true)
-    .shadow(true)
-    .center()
-    .build()
-    {
-        Ok(window) => window,
-        Err(error) => {
-            let _ = state.remove_window_session(&label);
-            return Err(error.to_string());
-        }
-    };
-
-    focus_window(&window)?;
-    update_close_space_menu(&app, &state);
-    Ok(info)
 }

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -5,6 +5,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::window_geometry;
+
 const RECENT_LOCAL_CHANGE_TTL: Duration = Duration::from_secs(2);
 pub(crate) const NO_SPACE_SESSION_FOR_WINDOW: &str = "no space session for window";
 
@@ -72,7 +74,6 @@ impl SpaceSession {
 }
 
 pub struct SpaceState {
-    pub(crate) current: Mutex<Option<PathBuf>>,
     pub(crate) sessions: Mutex<HashMap<String, SpaceSession>>,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
@@ -84,7 +85,6 @@ pub struct SpaceState {
 impl Default for SpaceState {
     fn default() -> Self {
         Self {
-            current: Mutex::new(None),
             sessions: Mutex::new(HashMap::new()),
             db_store_mutex: Arc::new(Mutex::new(())),
             file_tree_appearance_mutex: Arc::new(Mutex::new(())),
@@ -107,14 +107,8 @@ impl SpaceState {
         if let Some(session) = sessions.get(window_label) {
             return Arc::clone(&session.recent_local_changes);
         }
-        let current_root = self.current.lock().ok().and_then(|guard| guard.clone());
-        if let Some(current_root) = current_root {
-            if let Some(session) = sessions
-                .values()
-                .find(|session| session.root == current_root)
-            {
-                return Arc::clone(&session.recent_local_changes);
-            }
+        if let Some(session) = sessions.get(window_geometry::MAIN_WINDOW_LABEL) {
+            return Arc::clone(&session.recent_local_changes);
         }
         Arc::new(Mutex::new(HashMap::new()))
     }
@@ -136,30 +130,11 @@ impl SpaceState {
         Ok(())
     }
 
-    pub(crate) fn set_current_root(&self, root: PathBuf) -> Result<(), String> {
-        let mut current = self
-            .current
-            .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        *current = Some(root);
-        Ok(())
-    }
-
     pub(crate) fn remove_window_session(&self, window_label: &str) -> Result<(), String> {
-        let removed_root = {
-            let mut sessions = self
-                .sessions
-                .lock()
-                .map_err(|_| "space sessions state poisoned".to_string())?;
-            sessions.remove(window_label).map(|session| session.root)
-        };
-        let mut current = self
-            .current
+        self.sessions
             .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        if removed_root.as_ref() == current.as_ref() {
-            *current = None;
-        }
+            .map_err(|_| "space sessions state poisoned".to_string())?
+            .remove(window_label);
         Ok(())
     }
 
@@ -183,22 +158,10 @@ impl SpaceState {
                 if matches!(window.label(), "quick-note" | "quick-task")
                     && is_no_space_session_error(&error) =>
             {
-                self.current_root()
+                self.root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
             }
             Err(error) => Err(error),
         }
-    }
-
-    pub(crate) fn session_roots(&self) -> Vec<PathBuf> {
-        self.sessions
-            .lock()
-            .map(|sessions| {
-                sessions
-                    .values()
-                    .map(|session| session.root.clone())
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default()
     }
 
     pub(crate) fn db_store_mutex(&self) -> Arc<Mutex<()>> {
@@ -219,16 +182,6 @@ impl SpaceState {
 
     pub(crate) fn pinned_files_mutex(&self) -> Arc<Mutex<()>> {
         Arc::clone(&self.pinned_files_mutex)
-    }
-
-    pub fn current_root(&self) -> Result<PathBuf, String> {
-        let guard = self
-            .current
-            .lock()
-            .map_err(|_| "space state poisoned".to_string())?;
-        guard
-            .clone()
-            .ok_or_else(|| "no space open (select or create a space first)".to_string())
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.10-alpha.5",
+	"version": "0.8.10-alpha.6",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -435,18 +435,9 @@ export function AppShell() {
 	);
 
 	const handleCloseSpace = useCallback(async () => {
-		try {
-			// Native space teardown happens only after the open-note snapshot is durable.
-			await flushWorkspaceSession();
-			await closeSpace();
-		} catch (cause) {
-			console.error(
-				"Failed to save workspace session before closing space",
-				cause,
-			);
-			setError("The open tabs could not be saved. Please try again.");
-		}
-	}, [closeSpace, flushWorkspaceSession, setError]);
+		if (!(await prepareForSpaceChange())) return;
+		await closeSpace();
+	}, [closeSpace, prepareForSpaceChange]);
 
 	useEffect(() => {
 		const visible =

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -11,6 +11,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import {
 	useAISidebarContext,
 	useEditorContext,
@@ -111,13 +112,15 @@ function showGitSyncErrorToast(message: string) {
 }
 
 export function AppShell() {
+	const { t } = useTranslation("shell");
 	const space = useSpace();
 	const {
 		spacePath,
+		recentSpaces,
 		setError,
-		onOpenSpace,
-		onOpenSpaceAtPath,
-		onCreateSpace,
+		onOpenSpace: openSpace,
+		onOpenSpaceAtPath: openSpaceAtPath,
+		onCreateSpace: createSpace,
 		closeSpace,
 		onboardingNotePath,
 		consumeOnboardingNotePath,
@@ -161,8 +164,12 @@ export function AppShell() {
 		closeSettings,
 	} = useUILayoutContext();
 	const { aiEnabled, setAiPanelOpen } = useAISidebarContext();
-	const { getCurrentMarkdown, saveCurrentEditor, setCurrentEditorMode } =
-		useEditorContext();
+	const {
+		getCurrentMarkdown,
+		saveCurrentEditor,
+		saveAllEditors,
+		setCurrentEditorMode,
+	} = useEditorContext();
 
 	const [paletteLaunchMode, setPaletteLaunchMode] = useState<
 		"commands" | "search"
@@ -396,6 +403,36 @@ export function AppShell() {
 		tabsRevision,
 		restoreWorkspaceTabs,
 	});
+
+	const prepareForSpaceChange = useCallback(async (): Promise<boolean> => {
+		try {
+			await saveAllEditors();
+			await flushWorkspaceSession();
+			return true;
+		} catch (cause) {
+			console.error("Failed to save the current space before switching", cause);
+			setError(t("workspace.switchSaveFailed"));
+			return false;
+		}
+	}, [flushWorkspaceSession, saveAllEditors, setError, t]);
+
+	const handleOpenSpace = useCallback(async () => {
+		if (spacePath && !(await prepareForSpaceChange())) return;
+		await openSpace();
+	}, [openSpace, prepareForSpaceChange, spacePath]);
+
+	const handleCreateSpace = useCallback(async () => {
+		if (spacePath && !(await prepareForSpaceChange())) return;
+		await createSpace();
+	}, [createSpace, prepareForSpaceChange, spacePath]);
+
+	const handleSelectSpace = useCallback(
+		async (path: string) => {
+			if (path === spacePath || !(await prepareForSpaceChange())) return;
+			await openSpaceAtPath(path);
+		},
+		[openSpaceAtPath, prepareForSpaceChange, spacePath],
+	);
 
 	const handleCloseSpace = useCallback(async () => {
 		try {
@@ -1142,9 +1179,9 @@ export function AppShell() {
 		onSaveNote: handleSaveNoteFromMenu,
 		onPrintNote: handlePrintActiveNote,
 		onCloseTab: () => void handleCloseTabOrWindow(),
-		onOpenSpace,
-		onOpenRecentSpaceAtPath: onOpenSpaceAtPath,
-		onCreateSpace,
+		onOpenSpace: handleOpenSpace,
+		onOpenRecentSpaceAtPath: handleSelectSpace,
+		onCreateSpace: handleCreateSpace,
 		closeSpace: handleCloseSpace,
 		onRevealSpace: handleRevealSpaceFromMenu,
 		onOpenSpaceSettings: handleOpenSpaceSettings,
@@ -1195,8 +1232,8 @@ export function AppShell() {
 		handleRevealSpaceFromMenu,
 		movePickerSourcePath,
 		moveTargetDirs,
-		onCreateSpace,
-		onOpenSpace,
+		onCreateSpace: handleCreateSpace,
+		onOpenSpace: handleOpenSpace,
 		openAllDocsTab,
 		openBlankTab,
 		splitPaneWithBlank,
@@ -1389,6 +1426,10 @@ export function AppShell() {
 				sidebarCollapsed={sidebarCollapsed}
 				onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
 				spacePath={spacePath}
+				recentSpaces={recentSpaces}
+				onSelectSpace={handleSelectSpace}
+				onOpenSpace={handleOpenSpace}
+				onCreateSpace={handleCreateSpace}
 				onOpenAllDocs={openAllDocsTab}
 				onOpenPinnedDocs={openPinnedDocsTab}
 				onOpenConnections={openConnectionsView}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -33,6 +33,10 @@ interface SidebarProps {
 	sidebarCollapsed: boolean;
 	onToggleSidebar: () => void;
 	spacePath: string | null;
+	recentSpaces: string[];
+	onSelectSpace: (path: string) => Promise<void>;
+	onOpenSpace: () => Promise<void>;
+	onCreateSpace: () => Promise<void>;
 	onOpenAllDocs: () => void;
 	onOpenPinnedDocs: () => void;
 	onOpenConnections: () => void;
@@ -67,6 +71,10 @@ export const Sidebar = memo(function Sidebar({
 	sidebarCollapsed,
 	onToggleSidebar,
 	spacePath,
+	recentSpaces,
+	onSelectSpace,
+	onOpenSpace,
+	onCreateSpace,
 	onOpenAllDocs,
 	onOpenPinnedDocs,
 	onOpenConnections,
@@ -148,6 +156,10 @@ export const Sidebar = memo(function Sidebar({
 									onOpenPinnedDocs={onOpenPinnedDocs}
 									onOpenConnections={onOpenConnections}
 									spacePath={spacePath}
+									recentSpaces={recentSpaces}
+									onSelectSpace={onSelectSpace}
+									onOpenSpace={onOpenSpace}
+									onCreateSpace={onCreateSpace}
 									activeTopSection={activeTopSection}
 								/>
 							</>

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -2,9 +2,11 @@ import { cn } from "@/lib/utils";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { memo } from "react";
 import { useUILayoutContext } from "../../contexts";
+import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
 import { SidebarContent } from "./SidebarContent";
 import { SidebarHeader } from "./SidebarHeader";
 import { SidebarSettingsContent } from "./SidebarSettingsContent";
+import { SpaceSwitcher } from "./SpaceSwitcher";
 
 interface SidebarProps {
 	onToggleDir: (dirPath: string) => void;
@@ -156,12 +158,18 @@ export const Sidebar = memo(function Sidebar({
 									onOpenPinnedDocs={onOpenPinnedDocs}
 									onOpenConnections={onOpenConnections}
 									spacePath={spacePath}
-									recentSpaces={recentSpaces}
-									onSelectSpace={onSelectSpace}
-									onOpenSpace={onOpenSpace}
-									onCreateSpace={onCreateSpace}
 									activeTopSection={activeTopSection}
 								/>
+								{spacePath ? (
+									<SpaceSwitcher
+										spacePath={spacePath}
+										recentSpaces={recentSpaces}
+										onSelectSpace={onSelectSpace}
+										onOpenSpace={onOpenSpace}
+										onCreateSpace={onCreateSpace}
+									/>
+								) : null}
+								<LicenseStatusFooter />
 							</>
 						)}
 					</m.div>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -34,8 +34,6 @@ import { type FsEntry, invoke } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
-import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
-import { SpaceSwitcher } from "./SpaceSwitcher";
 
 interface SidebarContentProps {
 	onToggleDir: (dirPath: string) => void;
@@ -69,10 +67,6 @@ interface SidebarContentProps {
 	onOpenPinnedDocs: () => void;
 	onOpenConnections: () => void;
 	spacePath: string | null;
-	recentSpaces: string[];
-	onSelectSpace: (path: string) => Promise<void>;
-	onOpenSpace: () => Promise<void>;
-	onCreateSpace: () => Promise<void>;
 	activeTopSection:
 		| "all-notes"
 		| "connections"
@@ -160,10 +154,6 @@ export const SidebarContent = memo(function SidebarContent({
 	onOpenPinnedDocs,
 	onOpenConnections,
 	spacePath,
-	recentSpaces,
-	onSelectSpace,
-	onOpenSpace,
-	onCreateSpace,
 	activeTopSection,
 }: SidebarContentProps) {
 	const { t } = useTranslation("shell");
@@ -358,15 +348,12 @@ export const SidebarContent = memo(function SidebarContent({
 
 	if (!spacePath) {
 		return (
-			<>
-				<div className="sidebarSection sidebarSectionGrow sidebarEmpty">
-					<div className="sidebarEmptyTitle">No space open</div>
-					<div className="sidebarEmptyHint">
-						Open or create a space to get started.
-					</div>
+			<div className="sidebarSection sidebarSectionGrow sidebarEmpty">
+				<div className="sidebarEmptyTitle">No space open</div>
+				<div className="sidebarEmptyHint">
+					Open or create a space to get started.
 				</div>
-				<LicenseStatusFooter />
-			</>
+			</div>
 		);
 	}
 
@@ -629,14 +616,6 @@ export const SidebarContent = memo(function SidebarContent({
 					</div>
 				</div>
 			</div>
-			<SpaceSwitcher
-				spacePath={spacePath}
-				recentSpaces={recentSpaces}
-				onSelectSpace={onSelectSpace}
-				onOpenSpace={onOpenSpace}
-				onCreateSpace={onCreateSpace}
-			/>
-			<LicenseStatusFooter />
 		</>
 	);
 });

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -35,6 +35,7 @@ import { toast } from "../../lib/toast";
 import { TagsPane } from "../TagsPane";
 import { FileTreePane } from "../filetree";
 import { LicenseStatusFooter } from "../licensing/LicenseStatusFooter";
+import { SpaceSwitcher } from "./SpaceSwitcher";
 
 interface SidebarContentProps {
 	onToggleDir: (dirPath: string) => void;
@@ -68,6 +69,10 @@ interface SidebarContentProps {
 	onOpenPinnedDocs: () => void;
 	onOpenConnections: () => void;
 	spacePath: string | null;
+	recentSpaces: string[];
+	onSelectSpace: (path: string) => Promise<void>;
+	onOpenSpace: () => Promise<void>;
+	onCreateSpace: () => Promise<void>;
 	activeTopSection:
 		| "all-notes"
 		| "connections"
@@ -155,6 +160,10 @@ export const SidebarContent = memo(function SidebarContent({
 	onOpenPinnedDocs,
 	onOpenConnections,
 	spacePath,
+	recentSpaces,
+	onSelectSpace,
+	onOpenSpace,
+	onCreateSpace,
 	activeTopSection,
 }: SidebarContentProps) {
 	const { t } = useTranslation("shell");
@@ -620,6 +629,13 @@ export const SidebarContent = memo(function SidebarContent({
 					</div>
 				</div>
 			</div>
+			<SpaceSwitcher
+				spacePath={spacePath}
+				recentSpaces={recentSpaces}
+				onSelectSpace={onSelectSpace}
+				onOpenSpace={onOpenSpace}
+				onCreateSpace={onCreateSpace}
+			/>
 			<LicenseStatusFooter />
 		</>
 	);

--- a/src/components/app/SpaceSwitcher.tsx
+++ b/src/components/app/SpaceSwitcher.tsx
@@ -4,7 +4,7 @@ import {
 	Tick02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronUp } from "../Icons";
 import {
@@ -54,24 +54,20 @@ export function SpaceSwitcher({
 	onCreateSpace,
 }: SpaceSwitcherProps) {
 	const { t } = useTranslation("shell");
-	const [pendingPath, setPendingPath] = useState<string | null>(null);
+	const [isPending, setIsPending] = useState(false);
 	const current = spacePathParts(spacePath);
-	const spaces = useMemo(
-		() =>
-			[spacePath, ...recentSpaces].filter(
-				(path, index, values) =>
-					path.trim().length > 0 && values.indexOf(path) === index,
-			),
-		[recentSpaces, spacePath],
-	);
+	const spaces = [
+		spacePath,
+		...recentSpaces.filter((path) => path !== spacePath),
+	];
 
-	const run = async (path: string, action: () => Promise<void>) => {
-		if (pendingPath) return;
-		setPendingPath(path);
+	const run = async (action: () => Promise<void>) => {
+		if (isPending) return;
+		setIsPending(true);
 		try {
 			await action();
 		} finally {
-			setPendingPath(null);
+			setIsPending(false);
 		}
 	};
 
@@ -83,7 +79,7 @@ export function SpaceSwitcher({
 						type="button"
 						className="spaceSwitcherTrigger"
 						aria-label={t("sidebar.spaceSwitcher")}
-						disabled={pendingPath !== null}
+						disabled={isPending}
 					>
 						<span className="spaceSwitcherIcon" aria-hidden="true">
 							{spaceMonogram(current.name)}
@@ -119,7 +115,7 @@ export function SpaceSwitcher({
 								aria-current={isCurrent ? "true" : undefined}
 								onSelect={() => {
 									if (isCurrent) return;
-									void run(path, () => onSelectSpace(path));
+									void run(() => onSelectSpace(path));
 								}}
 							>
 								<span
@@ -150,7 +146,7 @@ export function SpaceSwitcher({
 					<DropdownMenuSeparator className="spaceSwitcherMenuSeparator" />
 					<DropdownMenuItem
 						className="spaceSwitcherMenuAction"
-						onSelect={() => void run("open", onOpenSpace)}
+						onSelect={() => void run(onOpenSpace)}
 					>
 						<span className="spaceSwitcherMenuActionIcon" aria-hidden="true">
 							<HugeiconsIcon
@@ -163,7 +159,7 @@ export function SpaceSwitcher({
 					</DropdownMenuItem>
 					<DropdownMenuItem
 						className="spaceSwitcherMenuAction"
-						onSelect={() => void run("create", onCreateSpace)}
+						onSelect={() => void run(onCreateSpace)}
 					>
 						<span className="spaceSwitcherMenuActionIcon" aria-hidden="true">
 							<HugeiconsIcon

--- a/src/components/app/SpaceSwitcher.tsx
+++ b/src/components/app/SpaceSwitcher.tsx
@@ -118,16 +118,11 @@ export function SpaceSwitcher({
 									void run(() => onSelectSpace(path));
 								}}
 							>
-								<span
-									className="spaceSwitcherMenuMonogram"
-									aria-hidden="true"
-								>
+								<span className="spaceSwitcherMenuMonogram" aria-hidden="true">
 									{spaceMonogram(item.name)}
 								</span>
 								<span className="spaceSwitcherMenuItemText">
-									<span className="spaceSwitcherMenuItemName">
-										{item.name}
-									</span>
+									<span className="spaceSwitcherMenuItemName">{item.name}</span>
 									<span className="spaceSwitcherMenuItemPath">
 										{item.parent}
 									</span>

--- a/src/components/app/SpaceSwitcher.tsx
+++ b/src/components/app/SpaceSwitcher.tsx
@@ -1,0 +1,181 @@
+import {
+	Folder01Icon,
+	FolderOpenIcon,
+	Tick02Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronUp } from "../Icons";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
+
+interface SpaceSwitcherProps {
+	spacePath: string;
+	recentSpaces: string[];
+	onSelectSpace: (path: string) => Promise<void>;
+	onOpenSpace: () => Promise<void>;
+	onCreateSpace: () => Promise<void>;
+}
+
+function spacePathParts(path: string): { name: string; parent: string } {
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+	const separatorIndex = normalized.lastIndexOf("/");
+	if (separatorIndex < 0) return { name: normalized, parent: "" };
+	return {
+		name: normalized.slice(separatorIndex + 1) || normalized,
+		parent: normalized.slice(0, separatorIndex) || "/",
+	};
+}
+
+function spaceMonogram(name: string): string {
+	const words = name
+		.trim()
+		.split(/[\s_-]+/)
+		.filter(Boolean);
+	const initials = words
+		.slice(0, 2)
+		.map((word) => word[0]?.toLocaleUpperCase() ?? "")
+		.join("");
+	return initials || "G";
+}
+
+export function SpaceSwitcher({
+	spacePath,
+	recentSpaces,
+	onSelectSpace,
+	onOpenSpace,
+	onCreateSpace,
+}: SpaceSwitcherProps) {
+	const { t } = useTranslation("shell");
+	const [pendingPath, setPendingPath] = useState<string | null>(null);
+	const current = spacePathParts(spacePath);
+	const spaces = useMemo(
+		() =>
+			[spacePath, ...recentSpaces].filter(
+				(path, index, values) =>
+					path.trim().length > 0 && values.indexOf(path) === index,
+			),
+		[recentSpaces, spacePath],
+	);
+
+	const run = async (path: string, action: () => Promise<void>) => {
+		if (pendingPath) return;
+		setPendingPath(path);
+		try {
+			await action();
+		} finally {
+			setPendingPath(null);
+		}
+	};
+
+	return (
+		<div className="spaceSwitcher">
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						type="button"
+						className="spaceSwitcherTrigger"
+						aria-label={t("sidebar.spaceSwitcher")}
+						disabled={pendingPath !== null}
+					>
+						<span className="spaceSwitcherIcon" aria-hidden="true">
+							{spaceMonogram(current.name)}
+						</span>
+						<span className="spaceSwitcherText">
+							<span className="spaceSwitcherName">{current.name}</span>
+							<span className="spaceSwitcherPath">{current.parent}</span>
+						</span>
+						<ChevronUp
+							className="spaceSwitcherChevron"
+							size="var(--icon-sm)"
+							aria-hidden="true"
+						/>
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent
+					className="spaceSwitcherMenu"
+					side="top"
+					align="start"
+					sideOffset={3}
+				>
+					<DropdownMenuLabel className="spaceSwitcherMenuLabel">
+						{t("sidebar.spaces")}
+					</DropdownMenuLabel>
+					{spaces.map((path) => {
+						const item = spacePathParts(path);
+						const isCurrent = path === spacePath;
+						return (
+							<DropdownMenuItem
+								key={path}
+								className="spaceSwitcherMenuItem"
+								data-current={isCurrent ? "true" : undefined}
+								aria-current={isCurrent ? "true" : undefined}
+								onSelect={() => {
+									if (isCurrent) return;
+									void run(path, () => onSelectSpace(path));
+								}}
+							>
+								<span
+									className="spaceSwitcherMenuMonogram"
+									aria-hidden="true"
+								>
+									{spaceMonogram(item.name)}
+								</span>
+								<span className="spaceSwitcherMenuItemText">
+									<span className="spaceSwitcherMenuItemName">
+										{item.name}
+									</span>
+									<span className="spaceSwitcherMenuItemPath">
+										{item.parent}
+									</span>
+								</span>
+								{isCurrent ? (
+									<HugeiconsIcon
+										icon={Tick02Icon}
+										className="spaceSwitcherMenuCheck"
+										size="var(--icon-sm)"
+										strokeWidth={1.2}
+									/>
+								) : null}
+							</DropdownMenuItem>
+						);
+					})}
+					<DropdownMenuSeparator className="spaceSwitcherMenuSeparator" />
+					<DropdownMenuItem
+						className="spaceSwitcherMenuAction"
+						onSelect={() => void run("open", onOpenSpace)}
+					>
+						<span className="spaceSwitcherMenuActionIcon" aria-hidden="true">
+							<HugeiconsIcon
+								icon={FolderOpenIcon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+						</span>
+						{t("sidebar.openAnotherSpace")}
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						className="spaceSwitcherMenuAction"
+						onSelect={() => void run("create", onCreateSpace)}
+					>
+						<span className="spaceSwitcherMenuActionIcon" aria-hidden="true">
+							<HugeiconsIcon
+								icon={Folder01Icon}
+								size="var(--icon-md)"
+								strokeWidth={0.9}
+							/>
+						</span>
+						{t("sidebar.createSpace")}
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
 	type ReactNode,
 	createContext,
@@ -20,15 +19,6 @@ import {
 } from "../lib/settings";
 import { type AppInfo, invoke } from "../lib/tauri";
 import { toast } from "../lib/toast";
-import { SPACE_WINDOW_PREFIX } from "../lib/windowLabels";
-
-function isSpaceWindow(): boolean {
-	try {
-		return getCurrentWindow().label.startsWith(SPACE_WINDOW_PREFIX);
-	} catch {
-		return false;
-	}
-}
 
 interface SpaceContextValue {
 	info: AppInfo | null;
@@ -172,7 +162,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 							currentWindowSpaceInfo.onboarding_note_path ?? null,
 						);
 					}
-				} else if (settings.currentSpacePath && !isSpaceWindow()) {
+				} else if (settings.currentSpacePath) {
 					try {
 						const spaceInfo = await invoke("space_open", {
 							path: settings.currentSpacePath,
@@ -239,16 +229,17 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			if (isOpeningSpaceRef.current) return;
 			isOpeningSpaceRef.current = true;
 			try {
-				const sessionSpacePath = await invoke("space_get_current");
-				const spaceInfo = sessionSpacePath
-					? await invoke("space_open_window", {
-							path,
-							create: mode === "create",
-						})
-					: mode === "create"
+				if (path === currentSpacePathRef.current) return;
+				const spaceInfo =
+					mode === "create"
 						? await invoke("space_create", { path })
 						: await invoke("space_open", { path });
-				await setCurrentSpacePath(spaceInfo.root);
+				clearAiPanelCaches();
+				clearInlineImageHydrationCache();
+				invalidateNavigationPrefetch();
+				setSpacePath(spaceInfo.root);
+				setSpaceSchemaVersion(spaceInfo.schema_version);
+				setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
 				setRecentSpaces((prev) =>
 					normalizeRecentSpaces(
 						[spaceInfo.root, ...prev.filter((p) => p !== spaceInfo.root)],
@@ -257,11 +248,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				);
 				void updateOnboardingSettings({ launcherSeen: true });
 				setLastSpacePath(spaceInfo.root);
-				if (!sessionSpacePath) {
-					setSpacePath(spaceInfo.root);
-					setSpaceSchemaVersion(spaceInfo.schema_version);
-					setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
-				}
+				await setCurrentSpacePath(spaceInfo.root);
 			} catch (err) {
 				setError(extractErrorMessage(err));
 			} finally {

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -212,9 +212,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				invalidateNavigationPrefetch();
 				setSpacePath(spaceInfo.root);
 				setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
-				setRecentSpaces((prev) =>
-					normalizeRecentSpaces(prev, spaceInfo.root),
-				);
+				setRecentSpaces((prev) => normalizeRecentSpaces(prev, spaceInfo.root));
 				void updateOnboardingSettings({ launcherSeen: true });
 				await setCurrentSpacePath(spaceInfo.root);
 			} catch (err) {

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -17,15 +17,12 @@ import {
 	setCurrentSpacePath,
 	updateOnboardingSettings,
 } from "../lib/settings";
-import { type AppInfo, invoke } from "../lib/tauri";
+import { invoke } from "../lib/tauri";
 import { toast } from "../lib/toast";
 
 interface SpaceContextValue {
-	info: AppInfo | null;
 	setError: (error: string) => void;
 	spacePath: string | null;
-	lastSpacePath: string | null;
-	spaceSchemaVersion: number | null;
 	onboardingNotePath: string | null;
 	recentSpaces: string[];
 	isIndexing: boolean;
@@ -35,7 +32,6 @@ interface SpaceContextValue {
 	startIndexSync: () => Promise<void>;
 	onOpenSpace: () => Promise<void>;
 	onOpenSpaceAtPath: (path: string) => Promise<void>;
-	onContinueLastSpace: () => Promise<void>;
 	onCreateSpace: () => Promise<void>;
 	closeSpace: () => Promise<void>;
 }
@@ -60,28 +56,24 @@ function normalizeRecentSpaces(
 	return out.slice(0, 20);
 }
 
-function recentSpacesForMenu(
-	recentSpaces: string[],
-	currentSpacePath: string | null,
-): string[] {
-	return recentSpaces
-		.map((path) => path.trim())
-		.filter((path) => path && path !== currentSpacePath)
-		.slice(0, 20);
-}
-
 // Space-level errors surface as top toasts; there is no persistent error state.
 function setError(message: string) {
 	if (message) toast.error(message, { id: "glyph-space-error" });
 }
 
+async function selectSpaceFolder(): Promise<string | null> {
+	const { open } = await import("@tauri-apps/plugin-dialog");
+	const selection = await open({
+		title: "Select a space folder",
+		directory: true,
+		multiple: false,
+	});
+	if (!selection) return null;
+	return Array.isArray(selection) ? (selection[0] ?? null) : selection;
+}
+
 export function SpaceProvider({ children }: { children: ReactNode }) {
-	const [info, setInfo] = useState<AppInfo | null>(null);
 	const [spacePath, setSpacePath] = useState<string | null>(null);
-	const [lastSpacePath, setLastSpacePath] = useState<string | null>(null);
-	const [spaceSchemaVersion, setSpaceSchemaVersion] = useState<number | null>(
-		null,
-	);
 	const [onboardingNotePath, setOnboardingNotePath] = useState<string | null>(
 		null,
 	);
@@ -108,22 +100,9 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	}, []);
 
 	useEffect(() => {
-		let cancelled = false;
-		(async () => {
-			try {
-				const appInfo = await invoke("app_info");
-				if (!cancelled) setInfo(appInfo);
-			} catch (err) {
-				if (!cancelled) setError(extractErrorMessage(err));
-			}
-		})();
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
-	useEffect(() => {
-		syncRecentSpacesMenu(recentSpacesForMenu(recentSpaces, spacePath));
+		syncRecentSpacesMenu(
+			recentSpaces.filter((path) => path !== spacePath).slice(0, 20),
+		);
 	}, [recentSpaces, spacePath, syncRecentSpacesMenu]);
 
 	useEffect(() => {
@@ -137,9 +116,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 						settings.recentSpaces,
 						settings.currentSpacePath ?? null,
 					),
-				);
-				setLastSpacePath(
-					settings.currentSpacePath ?? settings.recentSpaces[0] ?? null,
 				);
 				try {
 					await invoke("index_set_people_mentions_as_tags_enabled", {
@@ -156,8 +132,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				if (currentWindowSpaceInfo) {
 					if (!cancelled) {
 						setSpacePath(currentWindowSpaceInfo.root);
-						setLastSpacePath(currentWindowSpaceInfo.root);
-						setSpaceSchemaVersion(currentWindowSpaceInfo.schema_version);
 						setOnboardingNotePath(
 							currentWindowSpaceInfo.onboarding_note_path ?? null,
 						);
@@ -169,7 +143,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 						});
 						if (!cancelled) {
 							setSpacePath(spaceInfo.root);
-							setSpaceSchemaVersion(spaceInfo.schema_version);
 							setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
 						}
 					} catch {}
@@ -238,16 +211,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				clearInlineImageHydrationCache();
 				invalidateNavigationPrefetch();
 				setSpacePath(spaceInfo.root);
-				setSpaceSchemaVersion(spaceInfo.schema_version);
 				setOnboardingNotePath(spaceInfo.onboarding_note_path ?? null);
 				setRecentSpaces((prev) =>
-					normalizeRecentSpaces(
-						[spaceInfo.root, ...prev.filter((p) => p !== spaceInfo.root)],
-						spaceInfo.root,
-					),
+					normalizeRecentSpaces(prev, spaceInfo.root),
 				);
 				void updateOnboardingSettings({ launcherSeen: true });
-				setLastSpacePath(spaceInfo.root);
 				await setCurrentSpacePath(spaceInfo.root);
 			} catch (err) {
 				setError(extractErrorMessage(err));
@@ -265,7 +233,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			clearInlineImageHydrationCache();
 			invalidateNavigationPrefetch();
 			setSpacePath(null);
-			setSpaceSchemaVersion(null);
 			setOnboardingNotePath(null);
 		} catch (err) {
 			setError(extractErrorMessage(err));
@@ -277,14 +244,7 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	}, []);
 
 	const onOpenSpace = useCallback(async () => {
-		const { open } = await import("@tauri-apps/plugin-dialog");
-		const selection = await open({
-			title: "Select a space folder",
-			directory: true,
-			multiple: false,
-		});
-		if (!selection) return;
-		const path = Array.isArray(selection) ? selection[0] : selection;
+		const path = await selectSpaceFolder();
 		if (path) await applySpaceSelection(path, "open");
 	}, [applySpaceSelection]);
 
@@ -293,29 +253,15 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 		[applySpaceSelection],
 	);
 
-	const onContinueLastSpace = useCallback(async () => {
-		if (lastSpacePath) await applySpaceSelection(lastSpacePath, "open");
-	}, [lastSpacePath, applySpaceSelection]);
-
 	const onCreateSpace = useCallback(async () => {
-		const { open } = await import("@tauri-apps/plugin-dialog");
-		const selection = await open({
-			title: "Select a space folder",
-			directory: true,
-			multiple: false,
-		});
-		if (!selection) return;
-		const path = Array.isArray(selection) ? selection[0] : selection;
+		const path = await selectSpaceFolder();
 		if (path) await applySpaceSelection(path, "create");
 	}, [applySpaceSelection]);
 
 	const value = useMemo<SpaceContextValue>(
 		() => ({
-			info,
 			setError,
 			spacePath,
-			lastSpacePath,
-			spaceSchemaVersion,
 			onboardingNotePath,
 			recentSpaces,
 			isIndexing,
@@ -325,15 +271,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			startIndexSync,
 			onOpenSpace,
 			onOpenSpaceAtPath,
-			onContinueLastSpace,
 			onCreateSpace,
 			closeSpace,
 		}),
 		[
-			info,
 			spacePath,
-			lastSpacePath,
-			spaceSchemaVersion,
 			onboardingNotePath,
 			recentSpaces,
 			isIndexing,
@@ -343,7 +285,6 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 			startIndexSync,
 			onOpenSpace,
 			onOpenSpaceAtPath,
-			onContinueLastSpace,
 			onCreateSpace,
 			closeSpace,
 		],

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "Notizen sortieren",
 		"sort": "Sortieren",
 		"expandAllFolders": "Alle Ordner ausklappen",
-		"collapseAllFolders": "Alle Ordner einklappen"
+		"collapseAllFolders": "Alle Ordner einklappen",
+		"spaceSwitcher": "Space wechseln",
+		"spaces": "Spaces",
+		"openAnotherSpace": "Anderen Space öffnen…",
+		"createSpace": "Space erstellen…"
 	},
 	"sort": {
 		"nameAsc": "Name A-Z",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "Sort notes",
 		"sort": "Sort",
 		"expandAllFolders": "Expand all folders",
-		"collapseAllFolders": "Collapse all folders"
+		"collapseAllFolders": "Collapse all folders",
+		"spaceSwitcher": "Switch space",
+		"spaces": "Spaces",
+		"openAnotherSpace": "Open another space…",
+		"createSpace": "Create a space…"
 	},
 	"sort": {
 		"nameAsc": "Name A-Z",
@@ -127,7 +131,8 @@
 	},
 	"workspace": {
 		"openSpace": "Open space",
-		"openAnotherSpace": "Open another space"
+		"openAnotherSpace": "Open another space",
+		"switchSaveFailed": "The current space could not be saved. Please try again."
 	},
 	"ai": {
 		"toolFailed": "{{tool}} failed"

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "Ordenar notas",
 		"sort": "Ordenar",
 		"expandAllFolders": "Expandir todas las carpetas",
-		"collapseAllFolders": "Contraer todas las carpetas"
+		"collapseAllFolders": "Contraer todas las carpetas",
+		"spaceSwitcher": "Cambiar espacio",
+		"spaces": "Espacios",
+		"openAnotherSpace": "Abrir otro espacio…",
+		"createSpace": "Crear un espacio…"
 	},
 	"sort": {
 		"nameAsc": "Nombre A-Z",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "Trier les notes",
 		"sort": "Trier",
 		"expandAllFolders": "Développer tous les dossiers",
-		"collapseAllFolders": "Réduire tous les dossiers"
+		"collapseAllFolders": "Réduire tous les dossiers",
+		"spaceSwitcher": "Changer d’espace",
+		"spaces": "Espaces",
+		"openAnotherSpace": "Ouvrir un autre espace…",
+		"createSpace": "Créer un espace…"
 	},
 	"sort": {
 		"nameAsc": "Nom A-Z",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "ノートを並べ替え",
 		"sort": "並べ替え",
 		"expandAllFolders": "すべてのフォルダを展開",
-		"collapseAllFolders": "すべてのフォルダを折りたたむ"
+		"collapseAllFolders": "すべてのフォルダを折りたたむ",
+		"spaceSwitcher": "スペースを切り替え",
+		"spaces": "スペース",
+		"openAnotherSpace": "別のスペースを開く…",
+		"createSpace": "スペースを作成…"
 	},
 	"sort": {
 		"nameAsc": "名前 A-Z",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "노트 정렬",
 		"sort": "정렬",
 		"expandAllFolders": "모든 폴더 펼치기",
-		"collapseAllFolders": "모든 폴더 접기"
+		"collapseAllFolders": "모든 폴더 접기",
+		"spaceSwitcher": "스페이스 전환",
+		"spaces": "스페이스",
+		"openAnotherSpace": "다른 스페이스 열기…",
+		"createSpace": "스페이스 만들기…"
 	},
 	"sort": {
 		"nameAsc": "이름 A-Z",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -13,7 +13,11 @@
 		"sortNotes": "Ordenar notas",
 		"sort": "Ordenar",
 		"expandAllFolders": "Expandir todas as pastas",
-		"collapseAllFolders": "Recolher todas as pastas"
+		"collapseAllFolders": "Recolher todas as pastas",
+		"spaceSwitcher": "Alternar espaço",
+		"spaces": "Espaços",
+		"openAnotherSpace": "Abrir outro espaço…",
+		"createSpace": "Criar um espaço…"
 	},
 	"sort": {
 		"nameAsc": "Nome A-Z",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -859,10 +859,6 @@ interface TauriCommands {
 	license_clear_local: CommandDef<void, LicenseActivateResult>;
 	space_create: CommandDef<{ path: string }, SpaceInfo>;
 	space_open: CommandDef<{ path: string }, SpaceInfo>;
-	space_open_window: CommandDef<
-		{ path: string; create?: boolean | null },
-		SpaceInfo
-	>;
 	space_get_current: CommandDef<void, string | null>;
 	space_get_current_info: CommandDef<void, SpaceInfo | null>;
 	space_show_onboarding_note: CommandDef<void, string>;

--- a/src/lib/windowLabels.ts
+++ b/src/lib/windowLabels.ts
@@ -1,4 +1,3 @@
 export const MAIN_WINDOW_LABEL = "main";
-export const SPACE_WINDOW_PREFIX = "space-";
 export const QUICK_NOTE_WINDOW_LABEL = "quick-note";
 export const EXTERNAL_MARKDOWN_WINDOW_PREFIX = "external-markdown-";

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -148,6 +148,222 @@
 	line-height: 1;
 }
 
+.spaceSwitcher {
+	flex-shrink: 0;
+	padding: 4px 8px 8px;
+	-webkit-app-region: no-drag;
+}
+
+.spaceSwitcherTrigger {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	min-width: 0;
+	min-height: 44px;
+	padding: 5px 7px;
+	border: 1px solid transparent;
+	border-radius: calc(var(--radius-lg) + 2px);
+	background: transparent;
+	color: var(--text-primary);
+	text-align: left;
+	cursor: pointer;
+	transition: background var(--transition-fast), border-color
+		var(--transition-fast);
+}
+
+.spaceSwitcherTrigger:hover,
+.spaceSwitcherTrigger:focus-visible,
+.spaceSwitcherTrigger[data-state="open"] {
+	background: var(--bg-hover);
+	border-color: var(--border-light);
+}
+
+.spaceSwitcherTrigger:focus-visible {
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	outline-offset: 2px;
+}
+
+.spaceSwitcherTrigger:disabled {
+	opacity: 0.65;
+	cursor: default;
+}
+
+.spaceSwitcherIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 32px;
+	width: 32px;
+	height: 32px;
+	border: 1px solid
+		color-mix(in srgb, var(--interactive-accent) 82%, white);
+	border-radius: 10px;
+	background: var(--interactive-accent);
+	box-shadow: inset 0 1px 0 color-mix(in srgb, white 20%, transparent);
+	color: var(--text-inverse);
+	font-size: calc(var(--text-base) * 0.86);
+	font-weight: var(--font-semibold);
+	letter-spacing: -0.02em;
+	line-height: 1;
+}
+
+.spaceSwitcherText,
+.spaceSwitcherMenuItemText {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.spaceSwitcherName,
+.spaceSwitcherMenuItemName {
+	overflow: hidden;
+	color: var(--text-primary);
+	font-size: var(--text-sm);
+	font-weight: var(--font-semibold);
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.spaceSwitcherPath,
+.spaceSwitcherMenuItemPath {
+	overflow: hidden;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.78);
+	line-height: 1.25;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.spaceSwitcherChevron {
+	flex: 0 0 auto;
+	color: var(--text-tertiary);
+	transition: transform var(--transition-fast);
+}
+
+.spaceSwitcherTrigger[data-state="open"] .spaceSwitcherChevron {
+	transform: rotate(180deg);
+}
+
+.spaceSwitcherMenu {
+	width: var(--radix-dropdown-menu-trigger-width);
+	min-width: 220px;
+	max-width: min(360px, calc(100vw - 16px));
+	max-height: min(
+		420px,
+		var(--radix-dropdown-menu-content-available-height)
+	);
+	padding: 6px;
+	border-color: color-mix(
+		in srgb,
+		var(--border-light) 82%,
+		var(--text-primary)
+	);
+	border-radius: calc(var(--radius-lg) + 3px);
+	background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+	box-shadow: 0 14px 34px
+		color-mix(in srgb, var(--text-primary) 18%, transparent), inset 0 1px 0
+		color-mix(in srgb, white 10%, transparent);
+	backdrop-filter: blur(18px) saturate(1.15);
+	-webkit-backdrop-filter: blur(18px) saturate(1.15);
+}
+
+.spaceSwitcherMenuLabel {
+	padding: 4px 8px 6px;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.72);
+	font-weight: var(--font-semibold);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.spaceSwitcherMenuItem {
+	gap: 8px;
+	min-height: 38px;
+	padding: 5px 7px;
+	border-radius: var(--radius-8);
+	cursor: pointer;
+}
+
+.spaceSwitcherMenuItem[data-current="true"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 10%,
+		var(--bg-hover)
+	);
+}
+
+.spaceSwitcherMenuMonogram {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 27px;
+	width: 27px;
+	height: 27px;
+	border: 1px solid var(--border-light);
+	border-radius: 8px;
+	background: var(--bg-secondary);
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.76);
+	font-weight: var(--font-semibold);
+	letter-spacing: -0.02em;
+	line-height: 1;
+}
+
+.spaceSwitcherMenuItem[data-current="true"] .spaceSwitcherMenuMonogram {
+	border-color: color-mix(in srgb, var(--interactive-accent) 82%, white);
+	background: var(--interactive-accent);
+	color: var(--text-inverse);
+}
+
+.spaceSwitcherMenuSeparator {
+	margin: 5px 2px;
+}
+
+.spaceSwitcherMenuAction {
+	gap: 8px;
+	min-height: 34px;
+	padding: 3px 7px;
+	border-radius: var(--radius-8);
+	color: var(--text-secondary);
+	font-size: var(--text-sm);
+	cursor: pointer;
+}
+
+.spaceSwitcherMenuActionIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 27px;
+	width: 27px;
+	height: 27px;
+	color: var(--text-tertiary);
+}
+
+.spaceSwitcherMenuActionIcon svg {
+	width: var(--icon-md);
+	height: var(--icon-md);
+}
+
+.spaceSwitcherMenuAction:hover,
+.spaceSwitcherMenuAction:focus {
+	color: var(--text-primary);
+}
+
+.spaceSwitcherMenuAction:hover .spaceSwitcherMenuActionIcon,
+.spaceSwitcherMenuAction:focus .spaceSwitcherMenuActionIcon {
+	color: var(--text-secondary);
+}
+
+.spaceSwitcherMenuCheck {
+	flex: 0 0 auto;
+	margin-left: auto;
+	color: var(--interactive-accent) !important;
+}
+
 .sidebarQuickActionBtn[data-kind="new-note"] {
 	background: var(--interactive-accent);
 	color: var(--text-inverse);

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -197,8 +197,7 @@
 	flex: 0 0 32px;
 	width: 32px;
 	height: 32px;
-	border: 1px solid
-		color-mix(in srgb, var(--interactive-accent) 82%, white);
+	border: 1px solid color-mix(in srgb, var(--interactive-accent) 82%, white);
 	border-radius: 10px;
 	background: var(--interactive-accent);
 	box-shadow: inset 0 1px 0 color-mix(in srgb, white 20%, transparent);
@@ -252,16 +251,9 @@
 	width: var(--radix-dropdown-menu-trigger-width);
 	min-width: 220px;
 	max-width: min(360px, calc(100vw - 16px));
-	max-height: min(
-		420px,
-		var(--radix-dropdown-menu-content-available-height)
-	);
+	max-height: min(420px, var(--radix-dropdown-menu-content-available-height));
 	padding: 6px;
-	border-color: color-mix(
-		in srgb,
-		var(--border-light) 82%,
-		var(--text-primary)
-	);
+	border-color: color-mix(in srgb, var(--border-light) 82%, var(--text-primary));
 	border-radius: calc(var(--radius-lg) + 3px);
 	background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
 	box-shadow: 0 14px 34px
@@ -289,11 +281,7 @@
 }
 
 .spaceSwitcherMenuItem[data-current="true"] {
-	background: color-mix(
-		in srgb,
-		var(--interactive-accent) 10%,
-		var(--bg-hover)
-	);
+	background: color-mix(in srgb, var(--interactive-accent) 10%, var(--bg-hover));
 }
 
 .spaceSwitcherMenuMonogram {


### PR DESCRIPTION
Closes 


## Description

Adds an in-app space switcher in the sidebar so users can switch between recent spaces (and open/create spaces) without multi-window space hosts.

Use this section for review hints, explanations or discussion points/todos.

- Summary of changes
  - New `SpaceSwitcher` UI in the sidebar (dropdown of recent spaces, open another, create space)
  - Before switching/opening/creating a space, save all open editors and flush the workspace session
  - Remove multi-window space host path: drop `space_open_window`, per-space window labels, and related routing/exit/menu targeting
  - Narrow space state and `SpaceContext` to a single main-window session model
  - i18n strings for the switcher across locales; sidebar CSS for the new control
  - Version bump to `0.8.10-alpha.6`
- Reasoning
  - Space switching should happen inside the main window instead of spawning separate space windows
  - Subtraction pass removes multi-host complexity that the switcher makes unnecessary
- Additional context
  - No corresponding GitHub issue
  - Visual change is the footer-area space switcher + license footer placement in the sidebar


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- Sidebar: `SpaceSwitcher` lists the current space + recent spaces, with monogram labels and open/create actions
- Switch path: `AppShell.prepareForSpaceChange` → `saveAllEditors` + `flushWorkspaceSession`, then open/create/select
- Backend: space session is tied to the main window label; menu/exit events target main only
- Removed command: `space_open_window` (and frontend `SPACE_WINDOW_PREFIX` / related tauri types)


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an in‑app space switcher in the sidebar to let users switch spaces inside the main window. Space actions now run in the `main` window with a save‑before‑switch flow for safety.

- **New Features**
  - New `SpaceSwitcher` in the sidebar: shows current and recent spaces, with “open another” and “create” actions.
  - Before switching/opening/creating/closing a space, save all editors and flush the workspace; show a localized error toast on failure.
  - Added i18n strings (including `workspace.switchSaveFailed`) and sidebar styles; version bumped to `0.8.10-alpha.6`.

- **Refactors**
  - Removed multi‑window space hosts: dropped `space_open_window`, per‑space window labels, and related routing/exit/menu targeting; all space actions are bound to the `main` window.
  - Menu events (open recent space, app commands, print) now emit to `main`; paste still targets the focused editor window.
  - Simplified session state: `SpaceState` no longer tracks a global “current” root; `SpaceContext` drops `lastSpacePath`, `spaceSchemaVersion`, and `onContinueLastSpace`.

<sup>Written for commit 25b3cd89d8f95ae0a8836c637acc9539fcc3059b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app space switcher to the sidebar
> - Adds a [SpaceSwitcher](https://github.com/SidhuK/Glyph/pull/435/files#diff-bd5e040d291ad69fceb53b2b66fa2993938f275953fdeaa702f3ef0396f6326d) dropdown in the sidebar that lets users switch to recent spaces, open another space, or create a new space, without opening a new window.
> - Before switching, [AppShell](https://github.com/SidhuK/Glyph/pull/435/files#diff-477852990e593378558fb04daea6895ce1e01057aa65bc0cb05795f64e3c10ed) saves all open editors and flushes workspace state; if this fails, the switch is aborted and a localized error is shown.
> - [SpaceContext](https://github.com/SidhuK/Glyph/pull/435/files#diff-64db60e85f0884da0d67a553fb2804eaa42125ca896b8997efb2fcb19ef25b07) now performs all space operations in the current window — the `space_open_window` command and multi-window space hosting are removed.
> - The Tauri backend consolidates space session tracking around the main window label, removing the global `current` root and the `SPACE_WINDOW_PREFIX` concept.
> - Behavioral Change: opening or switching spaces no longer spawns a new window; all space operations happen in the existing main window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25b3cd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sidebar space switcher for selecting, opening, and creating spaces.
  * Added recent-space navigation with current-space indicators.
  * Added licensing information to the sidebar.
  * Added localized labels and messages for space management.

* **Bug Fixes**
  * Improved save and workspace synchronization before switching spaces.
  * Added a localized error message when saving fails during a space switch.
  * Improved window coordination and cleanup when closing the main window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->