### PR TITLE
Add native file and folder import into spaces (#441) [Release]

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -437,6 +437,14 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         true,
         Some("CmdOrCtrl+Shift+M"),
     )?;
+    let import_files = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "file.import_files",
+        space_open,
+        None,
+    )?;
+    let import_folder = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "file.import_folder",
+        space_open,
+        None,
+    )?;
     let open_daily_note = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "file.open_daily_note",
         true,
         Some("CmdOrCtrl+Shift+D"),
@@ -628,6 +636,9 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
             &new_note,
             &create_from_template,
             &open_daily_note,
+            &PredefinedMenuItem::separator(app)?,
+            &import_files,
+            &import_folder,
             &PredefinedMenuItem::separator(app)?,
             &save_note,
             &print_note,
@@ -1607,6 +1618,7 @@ pub fn run() {
             space_fs::read_write::preview::space_read_text_previews_batch,
             space_fs::read_write::preview::space_read_binary_preview,
             space_fs::read_write::binary::space_save_pasted_image,
+            space_fs::read_write::import::space_import_paths,
             space_fs::read_write::text::space_write_text,
             space_fs::read_write::text::space_link_unlinked_mentions,
             space_fs::read_write::text::space_open_or_create_text,

--- a/src-tauri/src/space_fs/read_write/import.rs
+++ b/src-tauri/src/space_fs/read_write/import.rs
@@ -1,0 +1,321 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+use tauri::{Emitter, State, WebviewWindow};
+
+use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
+use crate::{index, io_atomic, paths, space::SpaceState, utils};
+
+use super::super::helpers::deny_hidden_rel_path;
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportConflictPolicy {
+    KeepBoth,
+    Replace,
+    Skip,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SpaceImportResult {
+    Conflicts {
+        conflict_count: usize,
+    },
+    Imported {
+        imported_count: usize,
+        markdown_paths: Vec<String>,
+    },
+}
+
+#[derive(Clone, Serialize)]
+struct NoteChangeEvent {
+    space_path: String,
+    rel_path: String,
+    removed: bool,
+}
+
+struct ImportRoot {
+    source_abs: PathBuf,
+    destination_rel: PathBuf,
+}
+
+fn path_key(path: &Path) -> String {
+    utils::to_slash(path).to_lowercase()
+}
+
+fn source_file_name(path: &Path) -> Result<PathBuf, String> {
+    path.file_name()
+        .map(PathBuf::from)
+        .ok_or_else(|| "import source has no file name".to_string())
+}
+
+fn validate_source(source: &Path, target_abs: &Path) -> Result<PathBuf, String> {
+    if !source.is_absolute() {
+        return Err("import source path must be absolute".to_string());
+    }
+    let source_metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if source_metadata.file_type().is_symlink() {
+        return Err("symbolic links cannot be imported".to_string());
+    }
+    let canonical = source.canonicalize().map_err(|error| error.to_string())?;
+    let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| error.to_string())?;
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err("import source must be a file or folder".to_string());
+    }
+    if metadata.is_dir() && target_abs.starts_with(&canonical) {
+        return Err("a folder cannot be imported into itself".to_string());
+    }
+    Ok(canonical)
+}
+
+fn plan_import(
+    root: &Path,
+    source_paths: &[String],
+    target_dir: &str,
+) -> Result<Vec<ImportRoot>, String> {
+    if source_paths.is_empty() {
+        return Err("at least one import source is required".to_string());
+    }
+
+    let target_rel = PathBuf::from(target_dir);
+    deny_hidden_rel_path(&target_rel)?;
+    let target_abs = paths::join_under(root, &target_rel)?;
+    if !target_abs.is_dir() {
+        return Err("import destination must be an existing folder".to_string());
+    }
+    let canonical_target = target_abs
+        .canonicalize()
+        .map_err(|error| error.to_string())?;
+
+    source_paths
+        .iter()
+        .map(|source_path| {
+            let source_abs = validate_source(Path::new(source_path), &canonical_target)?;
+            let destination_rel = target_rel.join(source_file_name(&source_abs)?);
+            deny_hidden_rel_path(&destination_rel)?;
+            Ok(ImportRoot {
+                source_abs,
+                destination_rel,
+            })
+        })
+        .collect()
+}
+
+fn count_conflicts(root: &Path, imports: &[ImportRoot]) -> Result<usize, String> {
+    let mut reserved = HashSet::new();
+    let mut conflict_count = 0;
+    for import in imports {
+        let key = path_key(&import.destination_rel);
+        let destination_abs = paths::join_under(root, &import.destination_rel)?;
+        if destination_abs.exists() || !reserved.insert(key) {
+            conflict_count += 1;
+        }
+    }
+    Ok(conflict_count)
+}
+
+fn next_available_path(
+    root: &Path,
+    requested: &Path,
+    reserved: &HashSet<String>,
+    preserve_extension: bool,
+) -> Result<PathBuf, String> {
+    let parent = requested.parent().unwrap_or_else(|| Path::new(""));
+    let file_name = requested
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "import destination has no valid file name".to_string())?;
+    let (stem, extension) = if preserve_extension {
+        super::super::filename::split_stem_extension(file_name)
+    } else {
+        (file_name, "")
+    };
+    let base = if stem.is_empty() { file_name } else { stem };
+
+    let mut suffix = 2;
+    loop {
+        let candidate = parent.join(format!("{base} {suffix}{extension}"));
+        let candidate_abs = paths::join_under(root, &candidate)?;
+        if !candidate_abs.exists() && !reserved.contains(&path_key(&candidate)) {
+            return Ok(candidate);
+        }
+        suffix += 1;
+    }
+}
+
+fn should_skip_source_entry(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn copy_source(
+    root: &Path,
+    source: &Path,
+    destination_rel: &Path,
+    recent_local_changes: &RecentLocalChanges,
+    imported_count: &mut usize,
+    markdown_paths: &mut Vec<String>,
+) -> Result<(), String> {
+    deny_hidden_rel_path(destination_rel)?;
+    let metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "symbolic links cannot be imported: {}",
+            source.display()
+        ));
+    }
+
+    let destination_abs = paths::join_under(root, destination_rel)?;
+    if metadata.is_dir() {
+        if destination_abs.exists() && !destination_abs.is_dir() {
+            return Err(format!(
+                "a file blocks the import destination: {}",
+                utils::to_slash(destination_rel)
+            ));
+        }
+        std::fs::create_dir_all(&destination_abs).map_err(|error| error.to_string())?;
+        for entry in std::fs::read_dir(source).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            let child_source = entry.path();
+            if should_skip_source_entry(&child_source) {
+                continue;
+            }
+            copy_source(
+                root,
+                &child_source,
+                &destination_rel.join(entry.file_name()),
+                recent_local_changes,
+                imported_count,
+                markdown_paths,
+            )?;
+        }
+        return Ok(());
+    }
+
+    if !metadata.is_file() {
+        return Err(format!("unsupported import source: {}", source.display()));
+    }
+    if destination_abs.is_dir() {
+        return Err(format!(
+            "a folder blocks the import destination: {}",
+            utils::to_slash(destination_rel)
+        ));
+    }
+
+    io_atomic::copy_atomic(source, &destination_abs).map_err(|error| error.to_string())?;
+    let rel_path = utils::to_slash(destination_rel);
+    *imported_count += 1;
+    if !utils::is_markdown_path(destination_rel) {
+        return Ok(());
+    }
+
+    mark_recent_local_change(recent_local_changes, &rel_path);
+    match std::fs::read_to_string(&destination_abs) {
+        Ok(markdown) => {
+            if let Err(error) = index::index_note(root, &rel_path, &markdown) {
+                tracing::warn!(
+                    note_id = %rel_path,
+                    error = %error,
+                    "failed to index imported markdown note"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                note_id = %rel_path,
+                error = %error,
+                "failed to read imported markdown note for indexing"
+            );
+        }
+    }
+    markdown_paths.push(rel_path);
+    Ok(())
+}
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn space_import_paths(
+    app: tauri::AppHandle,
+    window: WebviewWindow,
+    state: State<'_, SpaceState>,
+    source_paths: Vec<String>,
+    target_dir: String,
+    conflict_policy: Option<ImportConflictPolicy>,
+) -> Result<SpaceImportResult, String> {
+    let root = state.root_for_window(&window)?;
+    let recent_local_changes = state.recent_local_changes_for_window(window.label());
+    let note_mutation_mutex = state.note_mutation_mutex();
+    let root_for_import = root.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let _guard = note_mutation_mutex
+            .lock()
+            .map_err(|_| "note mutation mutex poisoned".to_string())?;
+        let imports = plan_import(&root_for_import, &source_paths, &target_dir)?;
+        let conflict_count = count_conflicts(&root_for_import, &imports)?;
+        if conflict_count > 0 && conflict_policy.is_none() {
+            return Ok(SpaceImportResult::Conflicts { conflict_count });
+        }
+
+        let policy = conflict_policy.unwrap_or(ImportConflictPolicy::KeepBoth);
+        let mut reserved = HashSet::new();
+        let mut imported_count = 0;
+        let mut markdown_paths = Vec::new();
+
+        for import in imports {
+            let requested_key = path_key(&import.destination_rel);
+            let requested_abs = paths::join_under(&root_for_import, &import.destination_rel)?;
+            let has_conflict = requested_abs.exists() || reserved.contains(&requested_key);
+            let destination_rel = if !has_conflict {
+                import.destination_rel
+            } else {
+                match policy {
+                    ImportConflictPolicy::KeepBoth => next_available_path(
+                        &root_for_import,
+                        &import.destination_rel,
+                        &reserved,
+                        import.source_abs.is_file(),
+                    )?,
+                    ImportConflictPolicy::Replace => import.destination_rel,
+                    ImportConflictPolicy::Skip => continue,
+                }
+            };
+            reserved.insert(path_key(&destination_rel));
+            copy_source(
+                &root_for_import,
+                &import.source_abs,
+                &destination_rel,
+                &recent_local_changes,
+                &mut imported_count,
+                &mut markdown_paths,
+            )?;
+        }
+
+        Ok::<_, String>(SpaceImportResult::Imported {
+            imported_count,
+            markdown_paths,
+        })
+    })
+    .await
+    .map_err(|error| error.to_string())??;
+
+    if let SpaceImportResult::Imported { markdown_paths, .. } = &result {
+        let window_label = window.label().to_string();
+        let space_path = root.to_string_lossy().to_string();
+        for rel_path in markdown_paths {
+            let _ = app.emit_to(
+                &window_label,
+                "notes:external_changed",
+                NoteChangeEvent {
+                    space_path: space_path.clone(),
+                    rel_path: rel_path.clone(),
+                    removed: false,
+                },
+            );
+        }
+    }
+
+    Ok(result)
+}

--- a/src-tauri/src/space_fs/read_write/import.rs
+++ b/src-tauri/src/space_fs/read_write/import.rs
@@ -9,6 +9,7 @@ use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
 use crate::{index, io_atomic, paths, space::SpaceState, utils};
 
 use super::super::helpers::deny_hidden_rel_path;
+use super::paths::remove_markdown_notes_from_index;
 
 #[derive(Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -52,14 +53,40 @@ fn source_file_name(path: &Path) -> Result<PathBuf, String> {
         .ok_or_else(|| "import source has no file name".to_string())
 }
 
+fn ensure_within_space(canonical_root: &Path, abs: &Path) -> Result<(), String> {
+    let canonical = if abs.exists() {
+        abs.canonicalize().map_err(|error| error.to_string())?
+    } else {
+        let parent = abs
+            .parent()
+            .ok_or_else(|| "import destination has no parent directory".to_string())?;
+        let file_name = abs
+            .file_name()
+            .ok_or_else(|| "import destination has no file name".to_string())?;
+        parent
+            .canonicalize()
+            .map_err(|error| error.to_string())?
+            .join(file_name)
+    };
+    if !canonical.starts_with(canonical_root) {
+        return Err("import destination is outside the space".to_string());
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path, label: &str) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!("{label} cannot be a symbolic link: {}", path.display()));
+    }
+    Ok(())
+}
+
 fn validate_source(source: &Path, target_abs: &Path) -> Result<PathBuf, String> {
     if !source.is_absolute() {
         return Err("import source path must be absolute".to_string());
     }
-    let source_metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
-    if source_metadata.file_type().is_symlink() {
-        return Err("symbolic links cannot be imported".to_string());
-    }
+    reject_symlink(source, "import source")?;
     let canonical = source.canonicalize().map_err(|error| error.to_string())?;
     let metadata = std::fs::symlink_metadata(&canonical).map_err(|error| error.to_string())?;
     if !metadata.is_file() && !metadata.is_dir() {
@@ -71,11 +98,36 @@ fn validate_source(source: &Path, target_abs: &Path) -> Result<PathBuf, String> 
     Ok(canonical)
 }
 
+fn validate_source_tree(source: &Path) -> Result<(), String> {
+    let metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "symbolic links cannot be imported: {}",
+            source.display()
+        ));
+    }
+    if metadata.is_dir() {
+        for entry in std::fs::read_dir(source).map_err(|error| error.to_string())? {
+            let entry = entry.map_err(|error| error.to_string())?;
+            let child = entry.path();
+            if should_skip_source_entry(&child) {
+                continue;
+            }
+            validate_source_tree(&child)?;
+        }
+        return Ok(());
+    }
+    if metadata.is_file() {
+        return Ok(());
+    }
+    Err(format!("unsupported import source: {}", source.display()))
+}
+
 fn plan_import(
     root: &Path,
     source_paths: &[String],
     target_dir: &str,
-) -> Result<Vec<ImportRoot>, String> {
+) -> Result<(PathBuf, Vec<ImportRoot>), String> {
     if source_paths.is_empty() {
         return Err("at least one import source is required".to_string());
     }
@@ -83,17 +135,25 @@ fn plan_import(
     let target_rel = PathBuf::from(target_dir);
     deny_hidden_rel_path(&target_rel)?;
     let target_abs = paths::join_under(root, &target_rel)?;
-    if !target_abs.is_dir() {
+    reject_symlink(&target_abs, "import destination")?;
+    let target_metadata =
+        std::fs::symlink_metadata(&target_abs).map_err(|error| error.to_string())?;
+    if !target_metadata.is_dir() {
         return Err("import destination must be an existing folder".to_string());
     }
+    let canonical_root = root.canonicalize().map_err(|error| error.to_string())?;
     let canonical_target = target_abs
         .canonicalize()
         .map_err(|error| error.to_string())?;
+    if !canonical_target.starts_with(&canonical_root) {
+        return Err("import destination is outside the space".to_string());
+    }
 
-    source_paths
+    let imports = source_paths
         .iter()
         .map(|source_path| {
             let source_abs = validate_source(Path::new(source_path), &canonical_target)?;
+            validate_source_tree(&source_abs)?;
             let destination_rel = target_rel.join(source_file_name(&source_abs)?);
             deny_hidden_rel_path(&destination_rel)?;
             Ok(ImportRoot {
@@ -101,7 +161,8 @@ fn plan_import(
                 destination_rel,
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok((canonical_root, imports))
 }
 
 fn count_conflicts(root: &Path, imports: &[ImportRoot]) -> Result<usize, String> {
@@ -152,8 +213,38 @@ fn should_skip_source_entry(path: &Path) -> bool {
         .is_some_and(|name| name.starts_with('.'))
 }
 
+fn remove_destination_for_replace(
+    root: &Path,
+    destination_rel: &Path,
+    recent_local_changes: &RecentLocalChanges,
+) -> Result<(), String> {
+    let destination_abs = paths::join_under(root, destination_rel)?;
+    if !destination_abs.exists() {
+        return Ok(());
+    }
+    reject_symlink(&destination_abs, "import destination")?;
+    let metadata =
+        std::fs::symlink_metadata(&destination_abs).map_err(|error| error.to_string())?;
+    let is_dir = metadata.is_dir();
+    let rel_path = utils::to_slash(destination_rel);
+    remove_markdown_notes_from_index(
+        root,
+        &rel_path,
+        &destination_abs,
+        recent_local_changes,
+        is_dir,
+    );
+    if is_dir {
+        std::fs::remove_dir_all(&destination_abs).map_err(|error| error.to_string())?;
+    } else {
+        std::fs::remove_file(&destination_abs).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
 fn copy_source(
     root: &Path,
+    canonical_root: &Path,
     source: &Path,
     destination_rel: &Path,
     recent_local_changes: &RecentLocalChanges,
@@ -170,6 +261,11 @@ fn copy_source(
     }
 
     let destination_abs = paths::join_under(root, destination_rel)?;
+    if destination_abs.exists() {
+        reject_symlink(&destination_abs, "import destination")?;
+    }
+    ensure_within_space(canonical_root, &destination_abs)?;
+
     if metadata.is_dir() {
         if destination_abs.exists() && !destination_abs.is_dir() {
             return Err(format!(
@@ -178,6 +274,7 @@ fn copy_source(
             ));
         }
         std::fs::create_dir_all(&destination_abs).map_err(|error| error.to_string())?;
+        ensure_within_space(canonical_root, &destination_abs)?;
         for entry in std::fs::read_dir(source).map_err(|error| error.to_string())? {
             let entry = entry.map_err(|error| error.to_string())?;
             let child_source = entry.path();
@@ -186,6 +283,7 @@ fn copy_source(
             }
             copy_source(
                 root,
+                canonical_root,
                 &child_source,
                 &destination_rel.join(entry.file_name()),
                 recent_local_changes,
@@ -253,7 +351,8 @@ pub async fn space_import_paths(
         let _guard = note_mutation_mutex
             .lock()
             .map_err(|_| "note mutation mutex poisoned".to_string())?;
-        let imports = plan_import(&root_for_import, &source_paths, &target_dir)?;
+        let (canonical_root, imports) =
+            plan_import(&root_for_import, &source_paths, &target_dir)?;
         let conflict_count = count_conflicts(&root_for_import, &imports)?;
         if conflict_count > 0 && conflict_policy.is_none() {
             return Ok(SpaceImportResult::Conflicts { conflict_count });
@@ -278,13 +377,23 @@ pub async fn space_import_paths(
                         &reserved,
                         import.source_abs.is_file(),
                     )?,
-                    ImportConflictPolicy::Replace => import.destination_rel,
+                    ImportConflictPolicy::Replace => {
+                        if requested_abs.exists() {
+                            remove_destination_for_replace(
+                                &root_for_import,
+                                &import.destination_rel,
+                                &recent_local_changes,
+                            )?;
+                        }
+                        import.destination_rel
+                    }
                     ImportConflictPolicy::Skip => continue,
                 }
             };
             reserved.insert(path_key(&destination_rel));
             copy_source(
                 &root_for_import,
+                &canonical_root,
                 &import.source_abs,
                 &destination_rel,
                 &recent_local_changes,

--- a/src-tauri/src/space_fs/read_write/import.rs
+++ b/src-tauri/src/space_fs/read_write/import.rs
@@ -9,7 +9,6 @@ use crate::space::state::{mark_recent_local_change, RecentLocalChanges};
 use crate::{index, io_atomic, paths, space::SpaceState, utils};
 
 use super::super::helpers::deny_hidden_rel_path;
-use super::paths::remove_markdown_notes_from_index;
 
 #[derive(Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -94,6 +93,20 @@ fn validate_source(source: &Path, target_abs: &Path) -> Result<PathBuf, String> 
     }
     if metadata.is_dir() && target_abs.starts_with(&canonical) {
         return Err("a folder cannot be imported into itself".to_string());
+    }
+    // Reject file→same-path imports; Replace would delete the source first.
+    if metadata.is_file() {
+        if let Some(name) = canonical.file_name() {
+            let planned = target_abs.join(name);
+            let same_path = planned == canonical
+                || planned
+                    .canonicalize()
+                    .map(|dest| dest == canonical)
+                    .unwrap_or(false);
+            if same_path {
+                return Err("a file cannot be imported onto itself".to_string());
+            }
+        }
     }
     Ok(canonical)
 }
@@ -213,33 +226,140 @@ fn should_skip_source_entry(path: &Path) -> bool {
         .is_some_and(|name| name.starts_with('.'))
 }
 
-fn remove_destination_for_replace(
+/// Move an existing destination aside so a replacement can be written. Caller
+/// must `commit` (delete backup) or `rollback` (restore) afterward.
+fn move_destination_aside(root: &Path, destination_rel: &Path) -> Result<PathBuf, String> {
+    let destination_abs = paths::join_under(root, destination_rel)?;
+    reject_symlink(&destination_abs, "import destination")?;
+    let parent = destination_abs
+        .parent()
+        .ok_or_else(|| "import destination has no parent directory".to_string())?;
+    let file_name = destination_abs
+        .file_name()
+        .ok_or_else(|| "import destination has no file name".to_string())?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let backup_abs = parent.join(format!(
+        ".{}.replace-backup.{}.{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        now_ms
+    ));
+    std::fs::rename(&destination_abs, &backup_abs).map_err(|error| error.to_string())?;
+    Ok(backup_abs)
+}
+
+fn remove_path_best_effort(path: &Path) {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+    if metadata.is_dir() {
+        let _ = std::fs::remove_dir_all(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Drop index rows under `destination_rel` whose files no longer exist on disk.
+fn purge_missing_indexed_notes(
     root: &Path,
     destination_rel: &Path,
     recent_local_changes: &RecentLocalChanges,
-) -> Result<(), String> {
-    let destination_abs = paths::join_under(root, destination_rel)?;
-    if !destination_abs.exists() {
-        return Ok(());
-    }
-    reject_symlink(&destination_abs, "import destination")?;
-    let metadata =
-        std::fs::symlink_metadata(&destination_abs).map_err(|error| error.to_string())?;
-    let is_dir = metadata.is_dir();
+) {
     let rel_path = utils::to_slash(destination_rel);
-    remove_markdown_notes_from_index(
-        root,
-        &rel_path,
-        &destination_abs,
-        recent_local_changes,
-        is_dir,
-    );
-    if is_dir {
-        std::fs::remove_dir_all(&destination_abs).map_err(|error| error.to_string())?;
-    } else {
-        std::fs::remove_file(&destination_abs).map_err(|error| error.to_string())?;
+    let Ok(conn) = index::open_db(root) else {
+        return;
+    };
+    let Ok(mut stmt) = conn.prepare("SELECT id FROM notes WHERE id = ? OR id LIKE ?") else {
+        return;
+    };
+    let pattern = format!("{rel_path}/%");
+    let Ok(rows) = stmt.query_map([rel_path.as_str(), pattern.as_str()], |row| {
+        row.get::<_, String>(0)
+    }) else {
+        return;
+    };
+    for note_id in rows.filter_map(|row| row.ok()) {
+        let abs = root.join(&note_id);
+        if abs.exists() {
+            continue;
+        }
+        mark_recent_local_change(recent_local_changes, &note_id);
+        let _ = index::remove_note(root, &note_id);
     }
-    Ok(())
+}
+
+fn reindex_markdown_tree(
+    root: &Path,
+    destination_rel: &Path,
+    recent_local_changes: &RecentLocalChanges,
+) {
+    let Ok(destination_abs) = paths::join_under(root, destination_rel) else {
+        return;
+    };
+    let Ok(metadata) = std::fs::symlink_metadata(&destination_abs) else {
+        return;
+    };
+    if metadata.is_dir() {
+        let Ok(entries) = std::fs::read_dir(&destination_abs) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_str().is_some_and(|n| n.starts_with('.')) {
+                continue;
+            }
+            reindex_markdown_tree(
+                root,
+                &destination_rel.join(name),
+                recent_local_changes,
+            );
+        }
+        return;
+    }
+    if !utils::is_markdown_path(destination_rel) {
+        return;
+    }
+    let rel_path = utils::to_slash(destination_rel);
+    let Ok(markdown) = std::fs::read_to_string(&destination_abs) else {
+        return;
+    };
+    if index::index_note(root, &rel_path, &markdown).is_ok() {
+        mark_recent_local_change(recent_local_changes, &rel_path);
+    }
+}
+
+fn finalize_replace_backup(
+    root: &Path,
+    destination_rel: &Path,
+    destination_abs: &Path,
+    backup_abs: PathBuf,
+    recent_local_changes: &RecentLocalChanges,
+    copy_result: Result<(), String>,
+) -> Result<(), String> {
+    match copy_result {
+        Ok(()) => {
+            remove_path_best_effort(&backup_abs);
+            purge_missing_indexed_notes(root, destination_rel, recent_local_changes);
+            Ok(())
+        }
+        Err(error) => {
+            if destination_abs.exists() {
+                remove_path_best_effort(destination_abs);
+            }
+            if let Err(restore_error) = std::fs::rename(&backup_abs, destination_abs) {
+                return Err(format!(
+                    "{error}; also failed to restore original: {restore_error}"
+                ));
+            }
+            // Partial copy may have reindexed paths; restore on-disk content to the index.
+            purge_missing_indexed_notes(root, destination_rel, recent_local_changes);
+            reindex_markdown_tree(root, destination_rel, recent_local_changes);
+            Err(error)
+        }
+    }
 }
 
 fn copy_source(
@@ -311,7 +431,7 @@ fn copy_source(
         return Ok(());
     }
 
-    mark_recent_local_change(recent_local_changes, &rel_path);
+    // Only suppress the watcher after a successful index (same as text writes).
     match std::fs::read_to_string(&destination_abs) {
         Ok(markdown) => {
             if let Err(error) = index::index_note(root, &rel_path, &markdown) {
@@ -320,6 +440,8 @@ fn copy_source(
                     error = %error,
                     "failed to index imported markdown note"
                 );
+            } else {
+                mark_recent_local_change(recent_local_changes, &rel_path);
             }
         }
         Err(error) => {
@@ -366,7 +488,12 @@ pub async fn space_import_paths(
         for import in imports {
             let requested_key = path_key(&import.destination_rel);
             let requested_abs = paths::join_under(&root_for_import, &import.destination_rel)?;
-            let has_conflict = requested_abs.exists() || reserved.contains(&requested_key);
+            let claimed_in_batch = reserved.contains(&requested_key);
+            let exists_on_disk = requested_abs.exists();
+            let has_conflict = exists_on_disk || claimed_in_batch;
+
+            // Within-batch basename collisions must not clobber an earlier import
+            // from this same command — even under Replace.
             let destination_rel = if !has_conflict {
                 import.destination_rel
             } else {
@@ -377,21 +504,42 @@ pub async fn space_import_paths(
                         &reserved,
                         import.source_abs.is_file(),
                     )?,
-                    ImportConflictPolicy::Replace => {
-                        if requested_abs.exists() {
-                            remove_destination_for_replace(
-                                &root_for_import,
-                                &import.destination_rel,
-                                &recent_local_changes,
-                            )?;
-                        }
-                        import.destination_rel
-                    }
+                    ImportConflictPolicy::Replace if claimed_in_batch => next_available_path(
+                        &root_for_import,
+                        &import.destination_rel,
+                        &reserved,
+                        import.source_abs.is_file(),
+                    )?,
+                    ImportConflictPolicy::Replace => import.destination_rel,
                     ImportConflictPolicy::Skip => continue,
                 }
             };
+
+            // File→file: leave dest in place; copy_atomic renames over it.
+            // Dir / type-mismatch: move aside, copy, then commit or restore.
+            let replace_backup = if matches!(policy, ImportConflictPolicy::Replace)
+                && !claimed_in_batch
+                && exists_on_disk
+            {
+                let dest_meta = std::fs::symlink_metadata(&requested_abs)
+                    .map_err(|error| error.to_string())?;
+                let source_meta = std::fs::symlink_metadata(&import.source_abs)
+                    .map_err(|error| error.to_string())?;
+                if dest_meta.is_dir() || source_meta.is_dir() {
+                    Some(move_destination_aside(
+                        &root_for_import,
+                        &destination_rel,
+                    )?)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
             reserved.insert(path_key(&destination_rel));
-            copy_source(
+            let destination_abs = paths::join_under(&root_for_import, &destination_rel)?;
+            let copy_result = copy_source(
                 &root_for_import,
                 &canonical_root,
                 &import.source_abs,
@@ -399,7 +547,19 @@ pub async fn space_import_paths(
                 &recent_local_changes,
                 &mut imported_count,
                 &mut markdown_paths,
-            )?;
+            );
+            if let Some(backup_abs) = replace_backup {
+                finalize_replace_backup(
+                    &root_for_import,
+                    &destination_rel,
+                    &destination_abs,
+                    backup_abs,
+                    &recent_local_changes,
+                    copy_result,
+                )?;
+            } else {
+                copy_result?;
+            }
         }
 
         Ok::<_, String>(SpaceImportResult::Imported {

--- a/src-tauri/src/space_fs/read_write/mod.rs
+++ b/src-tauri/src/space_fs/read_write/mod.rs
@@ -1,4 +1,5 @@
 pub mod binary;
+pub mod import;
 pub mod pasted_image;
 pub mod paths;
 pub mod preview;

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -175,7 +175,7 @@ fn duplicate_file_under_root(
     }
 }
 
-fn remove_markdown_notes_from_index(
+pub(crate) fn remove_markdown_notes_from_index(
     root: &Path,
     rel_path: &str,
     abs_path: &Path,

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../contexts";
 import { useCommandShortcuts } from "../../hooks/useCommandShortcuts";
 import { useDailyNote } from "../../hooks/useDailyNote";
+import { useFileImport } from "../../hooks/useFileImport";
 import { useFileTree } from "../../hooks/useFileTree";
 import { useMenuListeners } from "../../hooks/useMenuListeners";
 import { useResizablePanel } from "../../hooks/useResizablePanel";
@@ -456,6 +457,18 @@ export function AppShell() {
 		},
 		[fileTree, openFileTab, setActiveDirPath],
 	);
+	const { importFilesInto, importFolderInto, importPathsInto } = useFileImport({
+		loadDir: fileTree.loadDir,
+		openWorkspaceFile,
+	});
+	const selectedImportDir =
+		activeDirPath ?? (activeFilePath ? parentDir(activeFilePath) : "");
+	const handleImportFilesFromMenu = useCallback(() => {
+		void importFilesInto(selectedImportDir);
+	}, [importFilesInto, selectedImportDir]);
+	const handleImportFolderFromMenu = useCallback(() => {
+		void importFolderInto(selectedImportDir);
+	}, [importFolderInto, selectedImportDir]);
 
 	useEffect(() => {
 		if (!spacePath || !onboardingNotePath) return;
@@ -1165,6 +1178,8 @@ export function AppShell() {
 	useMenuListeners({
 		onNewNote: handleNewNoteFromMenu,
 		onCreateFromTemplate: handleCreateFromTemplateFromMenu,
+		onImportFiles: handleImportFilesFromMenu,
+		onImportFolder: handleImportFolderFromMenu,
 		onOpenDailyNote: handleOpenDailyNoteFromMenu,
 		onSaveNote: handleSaveNoteFromMenu,
 		onPrintNote: handlePrintActiveNote,
@@ -1215,6 +1230,8 @@ export function AppShell() {
 		goForward,
 		handleCopyOpenNoteAsMarkdown,
 		handleCreateFromTemplateFromMenu,
+		handleImportFilesFromMenu,
+		handleImportFolderFromMenu,
 		handleDuplicateActiveMarkdown,
 		handleGitSyncFailure,
 		handleOpenAiSettings,
@@ -1399,6 +1416,9 @@ export function AppShell() {
 				onNewNote={() => void createNoteInSelectedFolder()}
 				onNewFileInDir={(p) => void fileTree.onNewFileInDir(p)}
 				onCreateFromTemplateInDir={(p) => void openTemplatePicker(p)}
+				onImportFilesInDir={importFilesInto}
+				onImportFolderInDir={importFolderInto}
+				onImportPathsInDir={importPathsInto}
 				onRequestCreateFolder={(dirPath) =>
 					fileTree.requestCreateFolder(dirPath)
 				}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -17,6 +17,9 @@ interface SidebarProps {
 	onNewNote: () => void;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
+	onImportFilesInDir: (dirPath: string) => void;
+	onImportFolderInDir: (dirPath: string) => void;
+	onImportPathsInDir: (paths: string[], dirPath: string) => void;
 	onRequestCreateFolder: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onRenameDir: (
@@ -59,6 +62,9 @@ export const Sidebar = memo(function Sidebar({
 	onNewNote,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
+	onImportFilesInDir,
+	onImportFolderInDir,
+	onImportPathsInDir,
 	onRequestCreateFolder,
 	onDuplicateFile,
 	onRenameDir,
@@ -135,6 +141,9 @@ export const Sidebar = memo(function Sidebar({
 									onNewNote={onNewNote}
 									onNewFileInDir={onNewFileInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+									onImportFilesInDir={onImportFilesInDir}
+									onImportFolderInDir={onImportFolderInDir}
+									onImportPathsInDir={onImportPathsInDir}
 									onRequestCreateFolder={onRequestCreateFolder}
 									onDuplicateFile={onDuplicateFile}
 									onRenameDir={onRenameDir}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -45,6 +45,9 @@ interface SidebarContentProps {
 	onNewNote: () => void;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
+	onImportFilesInDir: (dirPath: string) => void;
+	onImportFolderInDir: (dirPath: string) => void;
+	onImportPathsInDir: (paths: string[], dirPath: string) => void;
 	onRequestCreateFolder: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onRenameDir: (
@@ -140,6 +143,9 @@ export const SidebarContent = memo(function SidebarContent({
 	onNewNote,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
+	onImportFilesInDir,
+	onImportFolderInDir,
+	onImportPathsInDir,
 	onRequestCreateFolder,
 	onDuplicateFile,
 	onRenameDir,
@@ -586,6 +592,9 @@ export const SidebarContent = memo(function SidebarContent({
 									onPrefetchFile={onPrefetchFile}
 									onNewFileInDir={onNewFileInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+									onImportFilesInDir={onImportFilesInDir}
+									onImportFolderInDir={onImportFolderInDir}
+									onImportPathsInDir={onImportPathsInDir}
 									onRequestCreateFolder={onRequestCreateFolder}
 									onDuplicateFile={onDuplicateFile}
 									onDeletePath={onDeletePath}

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -8,7 +8,9 @@ import {
 	ChartRelationshipIcon,
 	ColorsIcon,
 	CursorInWindowIcon,
+	FileImportIcon,
 	Folder01Icon,
+	FolderImportIcon,
 	FolderOpenIcon,
 	FolderRemoveIcon,
 	InformationCircleIcon,
@@ -86,6 +88,8 @@ interface UseAppCommandsDeps {
 	goForward: () => void;
 	handleCopyOpenNoteAsMarkdown: () => Promise<void>;
 	handleCreateFromTemplateFromMenu: () => void;
+	handleImportFilesFromMenu: () => void;
+	handleImportFolderFromMenu: () => void;
 	handleDuplicateActiveMarkdown: () => Promise<void>;
 	handleGitSyncFailure: (cause: unknown) => void;
 	handleOpenAiSettings: () => void;
@@ -249,6 +253,8 @@ export function useAppCommands({
 	goForward,
 	handleCopyOpenNoteAsMarkdown,
 	handleCreateFromTemplateFromMenu,
+	handleImportFilesFromMenu,
+	handleImportFolderFromMenu,
 	handleDuplicateActiveMarkdown,
 	handleGitSyncFailure,
 	handleOpenAiSettings,
@@ -352,6 +358,30 @@ export function useAppCommands({
 				shortcut: { meta: true, shift: true, key: "m" },
 				enabled: Boolean(spacePath),
 				action: handleCreateFromTemplateFromMenu,
+			},
+			{
+				id: "import-files",
+				icon: (
+					<HugeiconsIcon
+						icon={FileImportIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: handleImportFilesFromMenu,
+			},
+			{
+				id: "import-folder",
+				icon: (
+					<HugeiconsIcon
+						icon={FolderImportIcon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
+				enabled: Boolean(spacePath),
+				action: handleImportFolderFromMenu,
 			},
 			{
 				id: "new-tab",
@@ -913,6 +943,8 @@ export function useAppCommands({
 		handleGitSyncFailure,
 		handleCopyOpenNoteAsMarkdown,
 		handleDuplicateActiveMarkdown,
+		handleImportFilesFromMenu,
+		handleImportFolderFromMenu,
 		handleOpenAiSettings,
 		handleOpenSpaceSettings,
 		handleRevealSpaceFromMenu,

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -106,6 +106,8 @@ interface FileTreeDirItemProps {
 	onCancelRename: () => void;
 	onNewFileInDir: (dirPath: string) => unknown;
 	onCreateFromTemplateInDir: (dirPath: string) => unknown;
+	onImportFilesInDir: (dirPath: string) => unknown;
+	onImportFolderInDir: (dirPath: string) => unknown;
 	onRequestCreateFolder: (dirPath: string) => unknown;
 	onDeletePath: (path: string, kind: "dir" | "file") => void;
 	onEnterDir?: (dirPath: string) => void;
@@ -131,6 +133,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	onCancelRename,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
+	onImportFilesInDir,
+	onImportFolderInDir,
 	onRequestCreateFolder,
 	onDeletePath,
 	onEnterDir,
@@ -189,6 +193,14 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					label: t("fileTree.addFolder"),
 					action: () => void onRequestCreateFolder(entry.rel_path),
 				},
+				{
+					label: t("fileTree.importFilesHere"),
+					action: () => void onImportFilesInDir(entry.rel_path),
+				},
+				{
+					label: t("fileTree.importFolderHere"),
+					action: () => void onImportFolderInDir(entry.rel_path),
+				},
 				{ type: "separator" },
 				...buildPathCopyMenuItems(spacePath, entry.rel_path),
 				{ type: "separator" },
@@ -211,6 +223,8 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 			onOpenAppearancePicker,
 			onCreateFromTemplateInDir,
 			onDeletePath,
+			onImportFilesInDir,
+			onImportFolderInDir,
 			onNewFileInDir,
 			onRequestCreateFolder,
 			onStartRename,

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -123,6 +123,14 @@ vi.mock("../../lib/tauri", () => ({
 	invoke: invokeMock,
 }));
 
+vi.mock("@tauri-apps/api/window", () => ({
+	getCurrentWindow: () => ({
+		label: "main",
+		onDragDropEvent: vi.fn().mockResolvedValue(vi.fn()),
+		scaleFactor: vi.fn().mockResolvedValue(1),
+	}),
+}));
+
 (
 	globalThis as typeof globalThis & {
 		IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -214,6 +222,9 @@ describe("FileTreePane", () => {
 						onCommitFileRename={vi.fn()}
 						onCommitDirRename={vi.fn()}
 						onMovePath={vi.fn()}
+						onImportFilesInDir={vi.fn()}
+						onImportFolderInDir={vi.fn()}
+						onImportPathsInDir={vi.fn()}
 						pinnedFiles={["notes/alpha.md", "docs/beta.md"]}
 						onTogglePinnedFile={vi.fn()}
 					/>
@@ -262,6 +273,9 @@ describe("FileTreePane", () => {
 						onCommitFileRename={vi.fn()}
 						onCommitDirRename={vi.fn()}
 						onMovePath={vi.fn()}
+						onImportFilesInDir={vi.fn()}
+						onImportFolderInDir={vi.fn()}
+						onImportPathsInDir={vi.fn()}
 						pinnedFiles={[]}
 						onTogglePinnedFile={vi.fn()}
 					/>
@@ -317,6 +331,9 @@ describe("FileTreePane", () => {
 						onCommitFileRename={vi.fn()}
 						onCommitDirRename={vi.fn()}
 						onMovePath={vi.fn()}
+						onImportFilesInDir={vi.fn()}
+						onImportFolderInDir={vi.fn()}
+						onImportPathsInDir={vi.fn()}
 						pinnedFiles={[]}
 						onTogglePinnedFile={vi.fn()}
 					/>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -5,11 +5,13 @@ import {
 	useDroppable,
 } from "@dnd-kit/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { m } from "motion/react";
 import {
 	type CSSProperties,
 	type KeyboardEvent,
+	type MouseEvent,
 	type MutableRefObject,
 	type ReactNode,
 	memo,
@@ -19,6 +21,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useFileTreeContext, useSpace } from "../../contexts";
 import { toast } from "../../lib/toast";
 
@@ -30,6 +33,7 @@ import {
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
+import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { type FileTreeSortMode, loadSettings } from "../../lib/settings";
 import type {
 	DirChildSummary,
@@ -72,6 +76,9 @@ interface FileTreePaneProps {
 	onPrefetchFile?: (filePath: string) => void;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
+	onImportFilesInDir: (dirPath: string) => void;
+	onImportFolderInDir: (dirPath: string) => void;
+	onImportPathsInDir: (paths: string[], dirPath: string) => void;
 	onRequestCreateFolder: (dirPath: string) => Promise<string | null>;
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onDeletePath: (path: string, kind: "dir" | "file") => Promise<boolean>;
@@ -242,6 +249,8 @@ interface TreeEntriesProps {
 	onPrefetchFile?: (filePath: string) => void;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
+	onImportFilesInDir: (dirPath: string) => void;
+	onImportFolderInDir: (dirPath: string) => void;
 	onRequestCreateFolder: (dirPath: string) => void;
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onDeletePath: (path: string, kind: "dir" | "file") => Promise<void>;
@@ -326,6 +335,8 @@ function TreeEntries({
 	onPrefetchFile,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
+	onImportFilesInDir,
+	onImportFolderInDir,
 	onRequestCreateFolder,
 	onDuplicateFile,
 	onDeletePath,
@@ -489,6 +500,8 @@ function TreeEntries({
 							onSelectDir={onSelectDir}
 							onNewFileInDir={onNewFileInDir}
 							onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+							onImportFilesInDir={onImportFilesInDir}
+							onImportFolderInDir={onImportFolderInDir}
 							onRequestCreateFolder={onRequestCreateFolder}
 							onDeletePath={onDeletePath}
 							appearance={itemAppearance[entry.rel_path] ?? null}
@@ -559,6 +572,9 @@ export const FileTreePane = memo(function FileTreePane({
 	onPrefetchFile,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
+	onImportFilesInDir,
+	onImportFolderInDir,
+	onImportPathsInDir,
 	onRequestCreateFolder,
 	onDuplicateFile,
 	onDeletePath,
@@ -572,6 +588,7 @@ export const FileTreePane = memo(function FileTreePane({
 	onTogglePinnedFile,
 	children,
 }: FileTreePaneProps) {
+	const { t } = useTranslation("shell");
 	const {
 		itemAppearance,
 		setItemAppearance,
@@ -596,9 +613,12 @@ export const FileTreePane = memo(function FileTreePane({
 	const [appearancePickerTarget, setAppearancePickerTarget] =
 		useState<AppearancePickerTarget | null>(null);
 	const moveClickSuppressRef = useRef(false);
+	const paneRef = useRef<HTMLElement | null>(null);
+	const focusedDirPathRef = useRef(focusedDirPath);
 	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
 	const itemAppearanceRef = useRef(itemAppearance);
+	focusedDirPathRef.current = focusedDirPath;
 	useEffect(() => {
 		itemAppearanceRef.current = itemAppearance;
 	}, [itemAppearance]);
@@ -956,14 +976,94 @@ export const FileTreePane = memo(function FileTreePane({
 		const { x, y } = event.operation.position.current;
 		moveSplitEditorDrag({ kind: "file", path: source.data.path }, x, y);
 	}, []);
+	const handlePaneContextMenu = useCallback(
+		(event: MouseEvent<HTMLElement>) => {
+			if (
+				!(event.target instanceof Element) ||
+				event.target.closest("[data-file-tree-path][data-file-tree-kind]")
+			) {
+				return;
+			}
+			const targetDir = focusedDirPath ?? "";
+			void showNativeContextMenu(event, [
+				{
+					label: t("fileTree.importFilesHere"),
+					action: () => onImportFilesInDir(targetDir),
+				},
+				{
+					label: t("fileTree.importFolderHere"),
+					action: () => onImportFolderInDir(targetDir),
+				},
+			]).catch((error: unknown) => {
+				console.error("Failed to show file tree context menu", error);
+			});
+		},
+		[focusedDirPath, onImportFilesInDir, onImportFolderInDir, t],
+	);
+
+	useEffect(() => {
+		const currentWindow = getCurrentWindow();
+		let unlisten: (() => void) | undefined;
+		let disposed = false;
+		void currentWindow
+			.onDragDropEvent(async ({ payload }) => {
+				if (payload.type !== "drop" || payload.paths.length === 0) return;
+				const pane = paneRef.current;
+				if (!pane) return;
+				const scaleFactor = await currentWindow.scaleFactor();
+				const position = payload.position.toLogical(scaleFactor);
+				const bounds = pane.getBoundingClientRect();
+				if (
+					position.x < bounds.left ||
+					position.x > bounds.right ||
+					position.y < bounds.top ||
+					position.y > bounds.bottom
+				) {
+					return;
+				}
+
+				const hit = document.elementFromPoint(position.x, position.y);
+				const row =
+					hit instanceof Element
+						? hit.closest<HTMLElement>(
+								"[data-file-tree-path][data-file-tree-kind]",
+							)
+						: null;
+				const rowPath =
+					row && pane.contains(row) ? row.dataset.fileTreePath : undefined;
+				const targetDir =
+					rowPath && row?.dataset.fileTreeKind === "dir"
+						? rowPath
+						: rowPath
+							? parentDir(rowPath)
+							: (focusedDirPathRef.current ?? "");
+				await onImportPathsInDir(payload.paths, targetDir);
+			})
+			.then((stopListening) => {
+				if (disposed) {
+					stopListening();
+					return;
+				}
+				unlisten = stopListening;
+			})
+			.catch((error: unknown) => {
+				console.error("Failed to listen for imported file drops", error);
+			});
+		return () => {
+			disposed = true;
+			unlisten?.();
+		};
+	}, [onImportPathsInDir]);
 
 	return (
 		<DragDropProvider onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
 			<m.aside
+				ref={paneRef}
 				className="fileTreePane"
 				initial={{ y: 10 }}
 				animate={{ y: 0 }}
 				transition={springTransition}
+				onContextMenu={handlePaneContextMenu}
 				onKeyDown={handleTreeKeyDown}
 			>
 				<AppearancePicker
@@ -1014,6 +1114,8 @@ export const FileTreePane = memo(function FileTreePane({
 								onPrefetchFile={onPrefetchFile}
 								onNewFileInDir={onNewFileInDir}
 								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+								onImportFilesInDir={onImportFilesInDir}
+								onImportFolderInDir={onImportFolderInDir}
 								onRequestCreateFolder={handleRequestCreateFolder}
 								onDuplicateFile={handleDuplicateFile}
 								onDeletePath={handleDeletePath}
@@ -1062,6 +1164,8 @@ export const FileTreePane = memo(function FileTreePane({
 							onPrefetchFile={onPrefetchFile}
 							onNewFileInDir={onNewFileInDir}
 							onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+							onImportFilesInDir={onImportFilesInDir}
+							onImportFolderInDir={onImportFolderInDir}
 							onRequestCreateFolder={handleRequestCreateFolder}
 							onDuplicateFile={handleDuplicateFile}
 							onDeletePath={handleDeletePath}

--- a/src/hooks/useFileImport.ts
+++ b/src/hooks/useFileImport.ts
@@ -1,0 +1,153 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { extractErrorMessage } from "../lib/errorUtils";
+import {
+	type ImportConflictPolicy,
+	type SpaceImportResult,
+	invoke,
+} from "../lib/tauri";
+import { toast } from "../lib/toast";
+
+interface UseFileImportOptions {
+	loadDir: (dirPath: string, force?: boolean) => Promise<void>;
+	openWorkspaceFile: (path: string) => Promise<void>;
+}
+
+function policyForDialogResult(result: string): ImportConflictPolicy | null {
+	switch (result) {
+		case "Yes":
+			return "keep_both";
+		case "No":
+			return "replace";
+		case "Cancel":
+			return "skip";
+		default:
+			return null;
+	}
+}
+
+export function useFileImport({
+	loadDir,
+	openWorkspaceFile,
+}: UseFileImportOptions) {
+	const { t } = useTranslation("shell");
+
+	const showImportError = useCallback(
+		async (error: unknown) => {
+			const { message } = await import("@tauri-apps/plugin-dialog");
+			await message(extractErrorMessage(error), {
+				title: t("import.errorTitle"),
+				kind: "error",
+				buttons: "Ok",
+			});
+		},
+		[t],
+	);
+
+	const resolveConflicts = useCallback(
+		async (
+			result: Extract<SpaceImportResult, { status: "conflicts" }>,
+		): Promise<ImportConflictPolicy | null> => {
+			const { message } = await import("@tauri-apps/plugin-dialog");
+			const dialogResult = await message(
+				t("import.conflictMessage", { count: result.conflict_count }),
+				{
+					title: t("import.conflictTitle"),
+					kind: "warning",
+					buttons: {
+						yes: t("import.keepBoth"),
+						no: t("import.replace"),
+						cancel: t("import.skip"),
+					},
+				},
+			);
+			return policyForDialogResult(dialogResult);
+		},
+		[t],
+	);
+
+	const importPathsInto = useCallback(
+		async (sourcePaths: string[], targetDir: string) => {
+			if (sourcePaths.length === 0) return;
+			try {
+				let result = await invoke("space_import_paths", {
+					source_paths: sourcePaths,
+					target_dir: targetDir,
+					conflict_policy: null,
+				});
+				if (result.status === "conflicts") {
+					const conflictPolicy = await resolveConflicts(result);
+					if (!conflictPolicy) return;
+					result = await invoke("space_import_paths", {
+						source_paths: sourcePaths,
+						target_dir: targetDir,
+						conflict_policy: conflictPolicy,
+					});
+				}
+				if (result.status !== "imported") return;
+
+				await loadDir(targetDir, true);
+				if (result.imported_count === 0) {
+					toast.info(t("import.noneImported"));
+				} else {
+					toast.success(t("import.success", { count: result.imported_count }));
+				}
+				if (result.markdown_paths.length === 1) {
+					const markdownPath = result.markdown_paths[0];
+					if (markdownPath) await openWorkspaceFile(markdownPath);
+				}
+			} catch (error) {
+				await showImportError(error);
+			}
+		},
+		[loadDir, openWorkspaceFile, resolveConflicts, showImportError, t],
+	);
+
+	const importFilesInto = useCallback(
+		async (targetDir: string) => {
+			try {
+				const { open } = await import("@tauri-apps/plugin-dialog");
+				const selected = await open({
+					title: t("import.filesTitle"),
+					multiple: true,
+					directory: false,
+					filters: [
+						{
+							name: t("import.markdownFilter"),
+							extensions: ["md", "markdown"],
+						},
+					],
+				});
+				if (!selected) return;
+				await importPathsInto(selected, targetDir);
+			} catch (error) {
+				await showImportError(error);
+			}
+		},
+		[importPathsInto, showImportError, t],
+	);
+
+	const importFolderInto = useCallback(
+		async (targetDir: string) => {
+			try {
+				const { open } = await import("@tauri-apps/plugin-dialog");
+				const selected = await open({
+					title: t("import.folderTitle"),
+					multiple: false,
+					directory: true,
+				});
+				if (!selected) return;
+				await importPathsInto([selected], targetDir);
+			} catch (error) {
+				await showImportError(error);
+			}
+		},
+		[importPathsInto, showImportError, t],
+	);
+
+	return {
+		importFilesInto,
+		importFolderInto,
+		importPathsInto,
+	};
+}

--- a/src/hooks/useFileImport.ts
+++ b/src/hooks/useFileImport.ts
@@ -13,17 +13,16 @@ interface UseFileImportOptions {
 	openWorkspaceFile: (path: string) => Promise<void>;
 }
 
-function policyForDialogResult(result: string): ImportConflictPolicy | null {
-	switch (result) {
-		case "Yes":
-			return "keep_both";
-		case "No":
-			return "replace";
-		case "Cancel":
-			return "skip";
-		default:
-			return null;
-	}
+function policyForDialogResult(
+	result: string,
+	keepBoth: string,
+	replace: string,
+	skip: string,
+): ImportConflictPolicy | null {
+	if (result === keepBoth || result === "Yes") return "keep_both";
+	if (result === replace || result === "No") return "replace";
+	if (result === skip || result === "Cancel") return "skip";
+	return null;
 }
 
 export function useFileImport({
@@ -49,19 +48,22 @@ export function useFileImport({
 			result: Extract<SpaceImportResult, { status: "conflicts" }>,
 		): Promise<ImportConflictPolicy | null> => {
 			const { message } = await import("@tauri-apps/plugin-dialog");
+			const keepBoth = t("import.keepBoth");
+			const replace = t("import.replace");
+			const skip = t("import.skip");
 			const dialogResult = await message(
 				t("import.conflictMessage", { count: result.conflict_count }),
 				{
 					title: t("import.conflictTitle"),
 					kind: "warning",
 					buttons: {
-						yes: t("import.keepBoth"),
-						no: t("import.replace"),
-						cancel: t("import.skip"),
+						yes: keepBoth,
+						no: replace,
+						cancel: skip,
 					},
 				},
 			);
-			return policyForDialogResult(dialogResult);
+			return policyForDialogResult(dialogResult, keepBoth, replace, skip);
 		},
 		[t],
 	);
@@ -69,8 +71,10 @@ export function useFileImport({
 	const importPathsInto = useCallback(
 		async (sourcePaths: string[], targetDir: string) => {
 			if (sourcePaths.length === 0) return;
+
+			let result: SpaceImportResult;
 			try {
-				let result = await invoke("space_import_paths", {
+				result = await invoke("space_import_paths", {
 					source_paths: sourcePaths,
 					target_dir: targetDir,
 					conflict_policy: null,
@@ -84,20 +88,27 @@ export function useFileImport({
 						conflict_policy: conflictPolicy,
 					});
 				}
-				if (result.status !== "imported") return;
+			} catch (error) {
+				await showImportError(error);
+				return;
+			}
 
+			if (result.status !== "imported") return;
+
+			if (result.imported_count === 0) {
+				toast.info(t("import.noneImported"));
+			} else {
+				toast.success(t("import.success", { count: result.imported_count }));
+			}
+
+			try {
 				await loadDir(targetDir, true);
-				if (result.imported_count === 0) {
-					toast.info(t("import.noneImported"));
-				} else {
-					toast.success(t("import.success", { count: result.imported_count }));
-				}
 				if (result.markdown_paths.length === 1) {
 					const markdownPath = result.markdown_paths[0];
 					if (markdownPath) await openWorkspaceFile(markdownPath);
 				}
 			} catch (error) {
-				await showImportError(error);
+				toast.error(extractErrorMessage(error));
 			}
 		},
 		[loadDir, openWorkspaceFile, resolveConflicts, showImportError, t],

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -7,6 +7,8 @@ import { useTauriEvent } from "../lib/tauriEvents";
 interface UseMenuListenersProps {
 	onNewNote: () => void;
 	onCreateFromTemplate: () => void;
+	onImportFiles: () => void;
+	onImportFolder: () => void;
 	onOpenDailyNote: () => void;
 	onSaveNote: () => void;
 	onPrintNote: () => void;
@@ -31,6 +33,8 @@ interface UseMenuListenersProps {
 export function useMenuListeners({
 	onNewNote,
 	onCreateFromTemplate,
+	onImportFiles,
+	onImportFolder,
 	onOpenDailyNote,
 	onSaveNote,
 	onPrintNote,
@@ -72,6 +76,8 @@ export function useMenuListeners({
 			void dispatchAppCommand(payload.command_id, {
 				"new-note": onNewNote,
 				"create-from-template": onCreateFromTemplate,
+				"import-files": onImportFiles,
+				"import-folder": onImportFolder,
 				"open-daily-note": onOpenDailyNote,
 				"save-note": onSaveNote,
 				"print-note": onPrintNote,
@@ -156,6 +162,8 @@ export function useMenuListeners({
 			onCreateSpace,
 			onEditorAction,
 			onGitSyncNow,
+			onImportFiles,
+			onImportFolder,
 			onNewNote,
 			onOpenAiSettings,
 			onOpenDailyNote,

--- a/src/i18n/locales/en/commands.json
+++ b/src/i18n/locales/en/commands.json
@@ -222,6 +222,14 @@
 			"label": "Highlight: Yellow",
 			"description": "Apply yellow text highlight."
 		},
+		"import-files": {
+			"label": "Import Files…",
+			"description": "Copy Markdown files into the current folder."
+		},
+		"import-folder": {
+			"label": "Import Folder…",
+			"description": "Copy a folder into the current folder."
+		},
 		"italic": {
 			"label": "Italic",
 			"description": "Toggle italic formatting for the current selection."

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -72,8 +72,25 @@
 		"addFile": "Add file",
 		"createFromTemplate": "Create from template",
 		"addFolder": "Add folder",
+		"importFilesHere": "Import Files Here…",
+		"importFolderHere": "Import Folder Here…",
 		"deleteFile": "Delete file",
 		"deleteFolder": "Delete folder"
+	},
+	"import": {
+		"filesTitle": "Import Files",
+		"folderTitle": "Import Folder",
+		"markdownFilter": "Markdown files",
+		"conflictTitle": "Items Already Exist",
+		"conflictMessage_one": "1 item already exists in this folder. Apply the selected action to this conflict.",
+		"conflictMessage_other": "{{count}} items already exist in this folder. Apply the selected action to all conflicts.",
+		"keepBoth": "Keep Both",
+		"replace": "Replace",
+		"skip": "Skip",
+		"errorTitle": "Import Failed",
+		"success_one": "Imported 1 file.",
+		"success_other": "Imported {{count}} files.",
+		"noneImported": "No files were imported."
 	},
 	"commandPalette": {
 		"title": "Command Palette",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -64,6 +64,19 @@ interface TextFileWriteResult {
 	mtime_ms: number;
 }
 
+export type ImportConflictPolicy = "keep_both" | "replace" | "skip";
+
+export type SpaceImportResult =
+	| {
+			status: "conflicts";
+			conflict_count: number;
+	  }
+	| {
+			status: "imported";
+			imported_count: number;
+			markdown_paths: string[];
+	  };
+
 interface ExternalMarkdownDoc {
 	path: string;
 	text: string;
@@ -945,6 +958,14 @@ interface TauriCommands {
 			original_filename?: string | null;
 		},
 		SavedPastedImage
+	>;
+	space_import_paths: CommandDef<
+		{
+			source_paths: string[];
+			target_dir: string;
+			conflict_policy?: ImportConflictPolicy | null;
+		},
+		SpaceImportResult
 	>;
 	space_write_text: CommandDef<
 		{ path: string; text: string; base_mtime_ms?: number | null },

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -636,6 +636,28 @@
 			"commandPalette": true,
 			"menuId": "editor.highlight_yellow"
 		},
+		"import-files": {
+			"id": "import-files",
+			"label": "Import Files…",
+			"description": "Copy Markdown files into the current folder.",
+			"category": "file",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": true,
+			"menuId": "file.import_files"
+		},
+		"import-folder": {
+			"id": "import-folder",
+			"label": "Import Folder…",
+			"description": "Copy a folder into the current folder.",
+			"category": "file",
+			"context": "space",
+			"defaultBinding": null,
+			"allowInEditable": false,
+			"commandPalette": true,
+			"menuId": "file.import_folder"
+		},
 		"italic": {
 			"id": "italic",
 			"label": "Italic",

--- a/src/styles/app/03-app-shell.css
+++ b/src/styles/app/03-app-shell.css
@@ -2,7 +2,8 @@
    APP SHELL - Main Layout with floating panels
    ───────────────────────────────────────────────────────────────────────────── */
 .appShell {
-	--window-control-toggle-offset: 90px;
+	--window-control-toggle-offset: 78px;
+	--window-control-toggle-top: calc((var(--header-height) + 6px) / 2);
 	--collapsed-sidebar-top-reserve: calc(
 		var(--window-control-toggle-offset) +
 		38px
@@ -246,7 +247,7 @@ body:has(.indexingNotice) [data-sileo-viewport][data-position="top-center"] {
 
 .sidebarCollapsedToggle {
 	position: absolute;
-	top: calc((var(--header-height) + 6px) / 2);
+	top: var(--window-control-toggle-top);
 	left: var(--window-control-toggle-offset);
 	transform: translateY(-50%);
 	z-index: 3;

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -71,9 +71,9 @@
 	align-items: center;
 	gap: 6px;
 	position: absolute;
-	top: 14px;
-	right: 8px;
-	transform: none;
+	top: var(--window-control-toggle-top);
+	left: var(--window-control-toggle-offset);
+	transform: translateY(-50%);
 	z-index: 30;
 }
 


### PR DESCRIPTION
Closes 


## Description

Adds native import of external files and folders into a Glyph space, so users can bring Markdown content in without manual copy outside the app.

### Summary of changes
- New Rust command `space_import_paths` copies files/folders into a target directory under the space, with conflict policies (`keep_both`, `replace`, `skip`)
- Frontend hook `useFileImport` drives dialogs, conflict resolution, refresh, and opening imported Markdown
- Entry points: File menu, command palette, file-tree folder context menus, empty pane context menu, and drag-and-drop onto the file tree
- i18n strings and command manifest entries for import actions

### Reasoning
Users need a first-class way to import existing notes and folders into a space. Centralizing import in the backend keeps path safety, conflict handling, and index updates consistent across menu, palette, and drag-drop flows.

### Additional context
- Import destination defaults to the active/focused folder (or parent of the active file)
- After a successful import, the target directory is reloaded and imported Markdown files can be opened
- Imported notes are reindexed and filesystem change events are emitted so the SQLite index stays current
- Symlinks are rejected; folders cannot be imported into themselves

## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- **Command:** `space_import_paths` — args: `source_paths`, `target_dir`, optional `conflict_policy`
- **Result:** `{ status: "conflicts", conflict_count }` or `{ status: "imported", imported_count, markdown_paths }`
- **UI entry points:** `file.import_files` / `file.import_folder` menu items, `import-files` / `import-folder` command palette IDs, file tree “Import Files Here…” / “Import Folder Here…”
- **Hook:** `src/hooks/useFileImport.ts` (`importFilesInto`, `importFolderInto`, `importPathsInto`)


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native import for files and folders into a space, with conflict handling, indexing, and drag‑and‑drop. Users can import Markdown and folders into the current folder from menus, context menus, and the file tree.

- **New Features**
  - Backend: `space_import_paths` adds preflight conflict counts and policies (`keep_both`, `replace`, `skip`); keeps destinations inside the space, rejects symlinks, skips dotfiles, prevents importing a folder into itself and a file onto itself, indexes imported Markdown, and emits change events.
  - Frontend: `useFileImport` drives file/folder pickers, conflict resolution, folder reload, and auto‑opens a single imported Markdown when applicable.
  - Entry points: File menu (`file.import_files`, `file.import_folder`), command palette (`import-files`, `import-folder`), file‑tree folder context menus (“Import Files Here…”, “Import Folder Here…”), empty pane context menu, and drag‑and‑drop onto the file tree.

- **Bug Fixes**
  - Conflict dialog now honors the chosen policy; `replace` is atomic for files, moves directories aside with rollback on failure, and never merges.
  - Within‑batch basename collisions never overwrite earlier imports (even under `replace`).
  - Safety checks keep imports within the space, validate sources before copying, and prevent self‑imports.
  - Post‑import folder reload failures no longer appear as copy failures.
  - Sidebar: cleaned up window‑control toggle positioning.

<sup>Written for commit 94f88faf269034944478b818763dae3ef1f94574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native file and folder import into spaces via menu, context menu, and drag-and-drop
> - Adds a new `space_import_paths` Tauri command ([import.rs](https://github.com/SidhuK/Glyph/pull/441/files#diff-0faa6fb96c1ebd75e56f6e75f137fca905b2570572596dc2c12cba0ccff73385)) that copies files/folders into the space, indexes imported markdown notes, and emits `notes:external_changed` events.
> - Adds 'Import Files…' and 'Import Folder…' entries to the File menu, the command palette, and folder context menus in the file tree.
> - Implements drag-and-drop in [FileTreePane.tsx](https://github.com/SidhuK/Glyph/pull/441/files#diff-131490b72392f147fa6a9bc361ada159c4605876713d86d25e4cc50665c868e2) using Tauri window drag-drop events; dropped items are imported into the hovered or focused directory.
> - The [useFileImport](https://github.com/SidhuK/Glyph/pull/441/files#diff-b6b7a68856518e418935100e469e106e13e0d6d7a49dd30ba7059b4f3d00edd5) hook manages the full import workflow: native file dialogs, conflict resolution (keep both / replace / skip), result toasts, directory refresh, and auto-opening a single imported markdown file.
> - Conflict detection returns a count before applying changes; if conflicts exist and no policy is provided, the user is prompted to choose a resolution strategy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94f88fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to import Markdown files or folders into the current workspace folder.
  * Added “Import Files…” and “Import Folder…” commands to the File menu and command palette.
  * Added directory context-menu actions for importing content.
  * Added drag-and-drop importing into folders.
  * Added conflict handling options: keep both, replace, or skip.
  * Imported Markdown files are refreshed and indexed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->