### PR TITLE
Add toggle for rich editor heading prefixes

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.11",
+	"version": "0.8.12-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -20,6 +20,7 @@ interface NoteEditorSurfaceProps {
 	editor: Editor | null;
 	mode: "rich" | "preview" | "plain";
 	colorfulHeadings: boolean;
+	showHeadingPrefixes: boolean;
 	canEdit: boolean;
 	hostRef: (node: HTMLDivElement | null) => void;
 	hostNode: HTMLDivElement | null;
@@ -43,6 +44,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 	editor,
 	mode,
 	colorfulHeadings,
+	showHeadingPrefixes,
 	canEdit,
 	hostRef,
 	hostNode,
@@ -68,6 +70,9 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 			className={hostClassName}
 			data-colorful-headings={
 				mode === "rich" && colorfulHeadings ? "true" : undefined
+			}
+			data-heading-prefixes={
+				mode === "rich" && showHeadingPrefixes ? "true" : undefined
 			}
 		>
 			<EditorContent editor={editor} />

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -277,6 +277,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		lastEmittedMarkdownRef,
 		colorfulHeadings,
 		showFrontmatterInEditor,
+		showHeadingPrefixes,
 	} = useNoteEditor({
 		additionalExtensions: mergedAdditionalExtensions,
 		markdown,
@@ -928,6 +929,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 						editor={liveEditor}
 						mode={mode}
 						colorfulHeadings={colorfulHeadings}
+						showHeadingPrefixes={showHeadingPrefixes}
 						canEdit={canEdit}
 						hostRef={handleTiptapHostRef}
 						hostNode={tiptapHostNode}

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -347,6 +347,7 @@ export function useNoteEditor({
 		showCollapsibleHeadings,
 		showCollapsibleLists,
 		showFrontmatterInEditor,
+		showHeadingPrefixes,
 	} = useNoteEditorSettings();
 	const spellCheckEnabled = useEditorSpellCheck();
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null);
@@ -811,6 +812,7 @@ export function useNoteEditor({
 		frontmatter,
 		colorfulHeadings,
 		showFrontmatterInEditor,
+		showHeadingPrefixes,
 		frontmatterRef,
 		lastAppliedBodyRef,
 		lastEmittedMarkdownRef,

--- a/src/components/editor/hooks/useNoteEditorSettings.ts
+++ b/src/components/editor/hooks/useNoteEditorSettings.ts
@@ -12,6 +12,7 @@ export function useNoteEditorSettings() {
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
 	const [showCollapsibleLists, setShowCollapsibleLists] = useState(false);
 	const [showFrontmatterInEditor, setShowFrontmatterInEditor] = useState(false);
+	const [showHeadingPrefixes, setShowHeadingPrefixes] = useState(true);
 	const [colorfulHeadings, setColorfulHeadings] = useState(false);
 	const [peopleMentionsEnabled, setPeopleMentionsEnabled] = useState(false);
 	const [focusMode, setFocusMode] = useState<FocusMode>("off");
@@ -28,6 +29,7 @@ export function useNoteEditorSettings() {
 				setShowFrontmatterInEditor(
 					settings.editor.showFrontmatterInEditor === true,
 				);
+				setShowHeadingPrefixes(settings.editor.showHeadingPrefixes);
 				setColorfulHeadings(settings.editor.colorfulHeadings);
 				setPeopleMentionsEnabled(settings.editor.enablePeopleMentionsAsTags);
 				setFocusMode(settings.editor.focusMode);
@@ -40,6 +42,7 @@ export function useNoteEditorSettings() {
 				setShowCollapsibleHeadings(false);
 				setShowCollapsibleLists(false);
 				setShowFrontmatterInEditor(false);
+				setShowHeadingPrefixes(true);
 				setColorfulHeadings(false);
 				setPeopleMentionsEnabled(false);
 				setFocusMode("off");
@@ -60,6 +63,9 @@ export function useNoteEditorSettings() {
 		}
 		if (typeof payload.editor?.showFrontmatterInEditor === "boolean") {
 			setShowFrontmatterInEditor(payload.editor.showFrontmatterInEditor);
+		}
+		if (typeof payload.editor?.showHeadingPrefixes === "boolean") {
+			setShowHeadingPrefixes(payload.editor.showHeadingPrefixes);
 		}
 		if (typeof payload.editor?.colorfulHeadings === "boolean") {
 			setColorfulHeadings(payload.editor.colorfulHeadings);
@@ -87,5 +93,6 @@ export function useNoteEditorSettings() {
 		showCollapsibleHeadings,
 		showCollapsibleLists,
 		showFrontmatterInEditor,
+		showHeadingPrefixes,
 	};
 }

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -38,6 +38,7 @@ vi.mock("../../lib/settings", () => ({
 			},
 			editor: {
 				showFrontmatterInEditor: false,
+				showHeadingPrefixes: true,
 				colorfulHeadings: false,
 				headingPaletteId: "classy",
 				showCollapsibleHeadings: false,
@@ -53,6 +54,7 @@ vi.mock("../../lib/settings", () => ({
 	setResumeLastSession: vi.fn(() => Promise.resolve()),
 	setShowToc: vi.fn(() => Promise.resolve()),
 	setEditorShowFrontmatterInEditor: vi.fn(() => Promise.resolve()),
+	setEditorShowHeadingPrefixes: vi.fn(() => Promise.resolve()),
 	setEditorColorfulHeadings: vi.fn(() => Promise.resolve()),
 	setEditorHeadingPaletteId: vi.fn(() => Promise.resolve()),
 	setEditorShowCollapsibleHeadings: vi.fn(() => Promise.resolve()),

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -32,6 +32,7 @@ import {
 	setEditorShowCollapsibleHeadings,
 	setEditorShowCollapsibleLists,
 	setEditorShowFrontmatterInEditor,
+	setEditorShowHeadingPrefixes,
 	setEditorSpellCheck,
 	setLanguage,
 	setResumeLastSession,
@@ -129,6 +130,11 @@ export function GeneralSettingsPane() {
 		setEditorColorfulHeadings,
 		setError,
 	);
+	const headingPrefixes = useSettingsBoolean(
+		true,
+		setEditorShowHeadingPrefixes,
+		setError,
+	);
 	const headingPalette = useSettingsValue<HeadingPaletteId>(
 		DEFAULT_HEADING_PALETTE_ID,
 		setEditorHeadingPaletteId,
@@ -165,6 +171,7 @@ export function GeneralSettingsPane() {
 	const setShowTocChecked = showToc.setChecked;
 	const setShowFrontmatterChecked = showFrontmatter.setChecked;
 	const setColorfulHeadingsChecked = colorfulHeadings.setChecked;
+	const setHeadingPrefixesChecked = headingPrefixes.setChecked;
 	const setCollapsibleHeadingsChecked = collapsibleHeadings.setChecked;
 	const setCollapsibleListsChecked = collapsibleLists.setChecked;
 	const setSpellCheckChecked = spellCheck.setChecked;
@@ -194,6 +201,7 @@ export function GeneralSettingsPane() {
 				setShowTocChecked(settings.ui.showToc);
 				setShowFrontmatterChecked(settings.editor.showFrontmatterInEditor);
 				setColorfulHeadingsChecked(settings.editor.colorfulHeadings);
+				setHeadingPrefixesChecked(settings.editor.showHeadingPrefixes);
 				setInitialHeadingPalette(settings.editor.headingPaletteId);
 				setCollapsibleHeadingsChecked(settings.editor.showCollapsibleHeadings);
 				setCollapsibleListsChecked(settings.editor.showCollapsibleLists);
@@ -215,6 +223,7 @@ export function GeneralSettingsPane() {
 		setShowTocChecked,
 		setShowFrontmatterChecked,
 		setColorfulHeadingsChecked,
+		setHeadingPrefixesChecked,
 		setCollapsibleHeadingsChecked,
 		setCollapsibleListsChecked,
 		setSpellCheckChecked,
@@ -260,6 +269,10 @@ export function GeneralSettingsPane() {
 					setColorfulHeadingsChecked,
 				);
 				applyIfBoolean(
+					payload.editor?.showHeadingPrefixes,
+					setHeadingPrefixesChecked,
+				);
+				applyIfBoolean(
 					payload.editor?.showCollapsibleHeadings,
 					setCollapsibleHeadingsChecked,
 				);
@@ -286,6 +299,7 @@ export function GeneralSettingsPane() {
 				setShowTocChecked,
 				setShowFrontmatterChecked,
 				setColorfulHeadingsChecked,
+				setHeadingPrefixesChecked,
 				setCollapsibleHeadingsChecked,
 				setCollapsibleListsChecked,
 				setSpellCheckChecked,
@@ -355,6 +369,17 @@ export function GeneralSettingsPane() {
 							disabled={showFrontmatter.isSaving}
 							ariaLabel={t("editor.showFrontmatter.ariaLabel")}
 							onCheckedChange={showFrontmatter.onCheckedChange}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label={t("editor.headingPrefixes.label")}
+						description={t("editor.headingPrefixes.description")}
+					>
+						<SettingsToggle
+							checked={headingPrefixes.checked}
+							disabled={headingPrefixes.isSaving}
+							ariaLabel={t("editor.headingPrefixes.ariaLabel")}
+							onCheckedChange={headingPrefixes.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -85,6 +85,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "general-editor-table-of-contents", tab: "general" },
 	{ id: "space-search-index-people-tags", tab: "space" },
 	{ id: "general-editor-frontmatter", tab: "general" },
+	{ id: "general-editor-heading-prefixes", tab: "general" },
 	{ id: "general-editor-colorful-headings", tab: "general" },
 	{ id: "appearance-editor-presentation-beautiful-tags", tab: "appearance" },
 	{ id: "appearance-editor-presentation-width", tab: "appearance" },

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -66,6 +66,11 @@
 			"description": "Display YAML frontmatter at the top of notes while editing. Turning this off keeps frontmatter available to indexing and databases.",
 			"ariaLabel": "Show frontmatter in editor"
 		},
+		"headingPrefixes": {
+			"label": "Heading prefixes",
+			"description": "Show H1-H6 labels beside headings in the rich text editor.",
+			"ariaLabel": "Show heading prefixes"
+		},
 		"colorfulHeadings": {
 			"label": "Colorful headings",
 			"description": "Use a selected color palette for H1-H6 while editing notes.",

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -415,6 +415,11 @@
 			"section": "Editor",
 			"keywords": ["properties", "yaml", "metadata"]
 		},
+		"general-editor-heading-prefixes": {
+			"title": "Heading prefixes",
+			"section": "Editor",
+			"keywords": ["heading", "h1", "h2", "h3", "label"]
+		},
 		"general-editor-colorful-headings": {
 			"title": "Colorful headings",
 			"section": "Editor",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -203,6 +203,7 @@ interface EditorSettings {
 	showCollapsibleHeadings: boolean;
 	showCollapsibleLists: boolean;
 	showFrontmatterInEditor: boolean;
+	showHeadingPrefixes: boolean;
 	colorfulHeadings: boolean;
 	headingPaletteId: HeadingPaletteId;
 	beautifulTags: boolean;
@@ -246,6 +247,7 @@ const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
 	showCollapsibleHeadings: false,
 	showCollapsibleLists: false,
 	showFrontmatterInEditor: false,
+	showHeadingPrefixes: true,
 	colorfulHeadings: false,
 	headingPaletteId: DEFAULT_HEADING_PALETTE_ID,
 	beautifulTags: false,
@@ -458,6 +460,7 @@ async function emitSettingsUpdated(payload: {
 		showCollapsibleHeadings?: boolean;
 		showCollapsibleLists?: boolean;
 		showFrontmatterInEditor?: boolean;
+		showHeadingPrefixes?: boolean;
 		colorfulHeadings?: boolean;
 		headingPaletteId?: HeadingPaletteId;
 		beautifulTags?: boolean;
@@ -604,6 +607,7 @@ const KEYS = {
 	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
 	editorShowCollapsibleLists: "editor.showCollapsibleLists",
 	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
+	editorShowHeadingPrefixes: "editor.showHeadingPrefixes",
 	editorColorfulHeadings: "editor.colorfulHeadings",
 	editorHeadingPaletteId: "editor.headingPaletteId",
 	editorBeautifulTags: "editor.beautifulTags",
@@ -968,6 +972,10 @@ export async function loadSettings(
 		entries,
 		KEYS.editorShowFrontmatterInEditor,
 	);
+	const rawEditorShowHeadingPrefixes = getSettingValue<boolean | null>(
+		entries,
+		KEYS.editorShowHeadingPrefixes,
+	);
 	const rawEditorColorfulHeadings = getSettingValue<boolean | null>(
 		entries,
 		KEYS.editorColorfulHeadings,
@@ -1135,6 +1143,10 @@ export async function loadSettings(
 			typeof rawEditorShowFrontmatterInEditor === "boolean"
 				? rawEditorShowFrontmatterInEditor
 				: DEFAULT_EDITOR_SETTINGS.showFrontmatterInEditor,
+		showHeadingPrefixes:
+			typeof rawEditorShowHeadingPrefixes === "boolean"
+				? rawEditorShowHeadingPrefixes
+				: DEFAULT_EDITOR_SETTINGS.showHeadingPrefixes,
 		colorfulHeadings:
 			typeof rawEditorColorfulHeadings === "boolean"
 				? rawEditorColorfulHeadings
@@ -1590,6 +1602,17 @@ export async function setEditorColorfulHeadings(
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
 		editor: { colorfulHeadings: enabled },
+	});
+}
+
+export async function setEditorShowHeadingPrefixes(
+	enabled: boolean,
+): Promise<void> {
+	const store = await getSettingsStore();
+	await store.set(KEYS.editorShowHeadingPrefixes, enabled);
+	await saveSettingsStore(store);
+	void emitSettingsUpdated({
+		editor: { showHeadingPrefixes: enabled },
 	});
 }
 

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -107,6 +107,7 @@ type TauriEventMap = {
 			showCollapsibleHeadings?: boolean;
 			showCollapsibleLists?: boolean;
 			showFrontmatterInEditor?: boolean;
+			showHeadingPrefixes?: boolean;
 			colorfulHeadings?: boolean;
 			headingPaletteId?: HeadingPaletteId;
 			beautifulTags?: boolean;

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -364,7 +364,8 @@
 	--heading-rail-gap: 6px;
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline {
 	position: relative;
 	padding-left: calc(
 		var(--editor-readable-content-gutter-compact) +
@@ -374,25 +375,50 @@
 	);
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline::before {
 	content: none;
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h1,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h2,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h3,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h4,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h5,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h6 {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h1,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h2,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h3,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h4,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h5,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h6 {
 	position: relative;
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h1::before,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h2::before,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h3::before,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h4::before,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h5::before,
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h6::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h1::before,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h2::before,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h3::before,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h4::before,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h5::before,
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h6::before {
 	display: inline-block;
 	width: var(--heading-level-rail-width);
 	margin-left: calc(
@@ -409,27 +435,39 @@
 	pointer-events: none;
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h1::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h1::before {
 	content: "H1";
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h2::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h2::before {
 	content: "H2";
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h3::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h3::before {
 	content: "H3";
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h4::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h4::before {
 	content: "H4";
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h5::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h5::before {
 	content: "H5";
 }
 
-.tiptapHostInline:not(.is-preview) .tiptapContentInline h6::before {
+.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
+	.tiptapContentInline
+	h6::before {
 	content: "H6";
 }
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -364,8 +364,7 @@
 	--heading-rail-gap: 6px;
 }
 
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline {
+.tiptapHostInline:not(.is-preview) .tiptapContentInline {
 	position: relative;
 	padding-left: calc(
 		var(--editor-readable-content-gutter-compact) +
@@ -375,29 +374,16 @@
 	);
 }
 
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline::before {
+.tiptapHostInline:not(.is-preview) .tiptapContentInline::before {
 	content: none;
 }
 
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h1,
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h2,
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h3,
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h4,
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h5,
-.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)
-	.tiptapContentInline
-	h6 {
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h1,
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h2,
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h3,
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h4,
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h5,
+.tiptapHostInline:not(.is-preview) .tiptapContentInline h6 {
 	position: relative;
 }
 


### PR DESCRIPTION
Closes 


## Description

Adds a General settings toggle so users can show or hide H1–H6 labels beside headings in the rich text editor. Prefixes remain on by default; turning them off removes the side rail labels and related editor gutter spacing.

- Summary of changes
  - New `editor.showHeadingPrefixes` setting (default `true`) with load normalization and `settings:updated` emit
  - Settings UI row + settings search entry and i18n strings
  - Editor surface drives display via `data-heading-prefixes`; CSS only renders H1–H6 prefixes when enabled
  - Wired through note editor settings/hooks and General settings pane tests
  - Version bump to `0.8.12-alpha.1`
- Reasoning
  - Heading prefixes help level orientation while editing, but some users prefer a cleaner canvas without the rail labels
- Additional context
  - Visual-only in rich edit mode; preview/plain modes are unaffected
  - No linked GitHub issue

## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

- Setting key: `editor.showHeadingPrefixes`
- Setter: `setEditorShowHeadingPrefixes`
- DOM attribute on editor host: `data-heading-prefixes="true"` when enabled in rich mode
- CSS gated under `.tiptapHostInline[data-heading-prefixes="true"]:not(.is-preview)`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a General settings toggle to show or hide H1–H6 prefixes beside headings in the rich text editor. Enabled by default; turning it off removes the rail labels and gutter spacing in rich mode only.

- **New Features**
  - New setting `editor.showHeadingPrefixes` (default `true`) with persistence and `settings:updated` payload via `setEditorShowHeadingPrefixes`.
  - General settings toggle with search entry and i18n; settings pane and editor hooks wired to update live; tests updated.
  - Rich editor sets `data-heading-prefixes`; CSS shows the H1–H6 rail only when enabled; preview/plain modes unchanged.
  - Version bumped to `0.8.12-alpha.1`.

<sup>Written for commit 6160a1d217a7bd44f4d80dc6503caf360d5ca22a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user-facing toggle to show or hide heading prefixes in the rich editor
> - Adds a new `showHeadingPrefixes` boolean setting (default `true`) to `EditorSettings`, persisted via a new `setEditorShowHeadingPrefixes` function in [settings.ts](https://github.com/SidhuK/Glyph/pull/443/files#diff-b5f5521c9795e314efdf6293ad3afda789a1402bbf5e2a304e20efa8134d2a15).
> - Exposes the toggle in General Settings under the Editor section, wired through `useNoteEditorSettings` → `useNoteEditor` → `NoteInlineEditor` → `NoteEditorSurface`.
> - CSS heading prefix rules (`H1`–`H6` `::before`) in [25-node-note-content.css](https://github.com/SidhuK/Glyph/pull/443/files#diff-8d0c6428ee16e21fc61cac15bf164d48c6d118a3ac53d0dd0f3334daa14c49ef) are now gated on `data-heading-prefixes="true"` on the editor host element.
> - Behavioral Change: heading prefixes previously appeared for all non-preview rich editor instances; they now require the setting to be enabled (defaults to `true`, so existing users are unaffected).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6160a1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an editor setting to show or hide H1–H6 heading prefixes while editing notes.
  * Heading prefixes are enabled by default and can be managed from General Settings.
  * Added settings search support for the new option.
* **Bug Fixes**
  * Heading prefix spacing and labels now appear only when the setting is enabled.
* **Chores**
  * Updated the application version to 0.8.12-alpha.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->