### PR TITLE
Fix daily note rollover panic when moving tasks (#444) [Release]

### DIFF
--- a/src-tauri/src/daily_note_rollover/markdown.rs
+++ b/src-tauri/src/daily_note_rollover/markdown.rs
@@ -29,6 +29,9 @@ struct Fence {
     length: usize,
 }
 
+/// Byte length of the checkbox prefix (`- [ ] ` / `- [x] `) after indent.
+const CHECKBOX_PREFIX_LEN: usize = 6;
+
 fn task_line(line: &str) -> Option<(usize, bool, bool, String, Option<String>)> {
     let indent = line
         .chars()
@@ -36,7 +39,7 @@ fn task_line(line: &str) -> Option<(usize, bool, bool, String, Option<String>)> 
         .count();
     let rest = &line[indent..];
     let bytes = rest.as_bytes();
-    if bytes.len() < 6
+    if bytes.len() < CHECKBOX_PREFIX_LEN
         || !matches!(bytes[0], b'-' | b'*' | b'+')
         || bytes[1] != b' '
         || bytes[2] != b'['
@@ -46,6 +49,10 @@ fn task_line(line: &str) -> Option<(usize, bool, bool, String, Option<String>)> 
     {
         return None;
     }
+    // Markers include a leading space (e.g. ` ***Moved from*** [[`). When the
+    // task has no body text, that leading space is the same byte as the
+    // required space after `]`, so find() returns an index before
+    // CHECKBOX_PREFIX_LEN — clamp so we never slice with begin > end.
     let marker_start = [
         MOVED_TO_MARKER_PREFIX,
         MOVED_FROM_MARKER_PREFIX,
@@ -55,8 +62,9 @@ fn task_line(line: &str) -> Option<(usize, bool, bool, String, Option<String>)> 
     .into_iter()
     .filter_map(|marker| rest.find(marker))
     .min()
-    .unwrap_or(rest.len());
-    let text = rest[6..marker_start].trim().to_string();
+    .unwrap_or(rest.len())
+    .max(CHECKBOX_PREFIX_LEN);
+    let text = rest[CHECKBOX_PREFIX_LEN..marker_start].trim().to_string();
     let original_date = marker_date(rest, MOVED_FROM_MARKER_PREFIX)
         .or_else(|| marker_date(rest, LEGACY_MOVED_FROM_MARKER_PREFIX))
         .map(str::to_string);


### PR DESCRIPTION
## Description

Fixes a Rust panic in daily note task rollover that made Today/Tomorrow moves fail with "Could not move items. The notes changed or could not be saved."

After a task had been moved into a daily note (especially empty-body tasks, or lines that only retained a `***Moved from***` marker), any later rollover parse of that note could crash the backend worker:

```
begin > end (6 > 5) when slicing `- [x] ***Moved from*** [[2026-07-27]]`
```

- **Summary of changes:** In `task_line`, clamp the moved-to/from marker index so text extraction never slices with `begin > end` when the marker’s leading space is the same byte as the required space after `]`.
- **Reasoning:** Move markers are defined as ` ***Moved from*** [[date]]` (leading space). For a checkbox with no body text, that space is index 5 while content starts at index 6, so `rest[6..marker_start]` panicked. Clamping to `CHECKBOX_PREFIX_LEN` treats those lines as empty text and keeps original-date extraction working.
- **Additional context:** No linked issue. Verified with `pnpm check`, `pnpm build`, and `cargo check`.

## Docs

Rollover markers always include a leading space (` ***Moved from*** [[…]]` / ` ***Moved to*** [[…]]`). When parsing checkbox lines, content starts after the 6-byte prefix (`- [ ] ` / `- [x] `). If a marker sits flush against the checkbox, treat the body as empty instead of slicing past the marker start.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic in daily note rollover when moving tasks with no body text by clamping the move-marker index during checkbox parsing. Moves between Today/Tomorrow no longer fail and the worker no longer crashes.

- **Bug Fixes**
  - Clamp move-marker index to >= `CHECKBOX_PREFIX_LEN` when parsing checkbox lines to prevent begin > end slicing on lines like `- [x] ***Moved from*** [[date]]`.
  - Treat marker-only tasks as empty text while still extracting the original date; introduce and use `CHECKBOX_PREFIX_LEN` (6).

<sup>Written for commit f7856188d71304623e471cd368dbd2de466bbf00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix panic in daily note rollover `task_line` when a marker immediately follows the checkbox
> When a task line had a marker but no body text, `task_line` in [markdown.rs](https://github.com/SidhuK/Glyph/pull/444/files#diff-0bad030ec57f7cf255a6deb81125e98ad74a12d8f419dc9e9cf4d04b22c83f74) would compute an invalid slice range and panic. The fix clamps `marker_start` to at least `CHECKBOX_PREFIX_LEN` (6 bytes) so the slice is always valid, returning empty task text instead of panicking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f785618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed daily note task parsing when a task has no body text and includes a moved marker.
  * Prevented malformed task text extraction and potential slicing errors in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->