### PR TITLE
Improve database board and list drag-and-drop polish (#445) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.12-alpha.1",
+	"version": "0.8.12-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -776,8 +776,13 @@ export function DatabaseBoard({
 											title={`Add note to ${lane.label}`}
 											aria-label={`Add note to ${lane.label}`}
 										>
-											<Plus size="var(--icon-sm)" aria-hidden="true" />
-											<span>New</span>
+											<span
+												className="databaseBoardAddCardIcon"
+												aria-hidden="true"
+											>
+												<Plus size="var(--icon-sm)" strokeWidth={1.8} />
+											</span>
+											<span className="databaseBoardAddCardLabel">New</span>
 										</button>
 									) : null}
 								</DatabaseBoardLaneView>

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -252,7 +252,7 @@ export function DatabaseBoardLaneView({
 				<div className="databaseBoardLaneHeaderActions">
 					<span
 						className="databaseBoardLaneCount"
-						aria-label={`${lane.cardCount} ${lane.cardCount === 1 ? "card" : "cards"}`}
+						aria-label={`${lane.cardCount} cards`}
 					>
 						{lane.cardCount}
 					</span>

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -250,6 +250,12 @@ export function DatabaseBoardLaneView({
 					<div className="databaseBoardLaneTitleGroup">{laneTitleContent}</div>
 				)}
 				<div className="databaseBoardLaneHeaderActions">
+					<span
+						className="databaseBoardLaneCount"
+						aria-label={`${lane.cardCount} ${lane.cardCount === 1 ? "card" : "cards"}`}
+					>
+						{lane.cardCount}
+					</span>
 					<button
 						type="button"
 						className="databaseBoardLaneHandle"

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -557,6 +557,7 @@ export function DatabaseTable({
 										key={virtualRow.key}
 										groupId={group.id}
 										label={group.label}
+										rowCount={group.rowCount}
 										visibleColumnCount={visibleColumnCount}
 										style={{
 											height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
@@ -596,6 +597,12 @@ export function DatabaseTable({
 										className="databaseGroupCell"
 									>
 										<span className="databaseGroupLabel">{group.label}</span>
+										<span
+											className="databaseGroupCount"
+											aria-label={`${group.rowCount} ${group.rowCount === 1 ? "note" : "notes"}`}
+										>
+											{group.rowCount}
+										</span>
 									</td>
 								</tr>
 							);

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -11,8 +11,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
 import {
 	type DatabaseRowGroup,
+	boardCreateValue,
 	boardDropValue,
-	boardRowHasLane,
 	createDatabaseRowGroups,
 	moveBoardCardToLane,
 } from "../../lib/database/board";
@@ -140,6 +140,26 @@ function orderDatabaseRowGroups(
 	});
 }
 
+function databaseGroupDropValue(
+	row: DatabaseRow,
+	column: DatabaseColumn,
+	targetGroupId: string,
+	sourceGroupId?: string | null,
+) {
+	const value = boardDropValue(row, column, targetGroupId, sourceGroupId);
+	const targetValue = boardCreateValue(column, targetGroupId)?.value_list[0];
+	if (!targetValue) return value;
+	return {
+		...value,
+		value_list: [
+			targetValue,
+			...value.value_list.filter(
+				(entry) => entry !== targetValue && entry !== sourceGroupId,
+			),
+		],
+	};
+}
+
 function createDatabaseDisplayItems(
 	displayRows: Row<DatabaseRow>[],
 	rowGroups: DatabaseRowGroup[],
@@ -215,17 +235,15 @@ export function DatabaseTable({
 }: DatabaseTableProps) {
 	const [resizingColumnId, setResizingColumnId] = useState<string | null>(null);
 	const [moveError, setMoveError] = useState("");
-	const [localCardOrder, setLocalCardOrder] =
-		useState<Record<string, string[]>>(cardOrderByGroup);
+	const [optimisticCardOrder, setOptimisticCardOrder] = useState<Record<
+		string,
+		string[]
+	> | null>(null);
 	const tableContainerRef = useRef<HTMLDivElement>(null);
 	const suppressClickRef = useRef(false);
-	const displayedCardOrderRef = useRef(cardOrderByGroup);
-
-	useEffect(() => {
-		if (displayedCardOrderRef.current === cardOrderByGroup) return;
-		displayedCardOrderRef.current = cardOrderByGroup;
-		setLocalCardOrder(cardOrderByGroup);
-	}, [cardOrderByGroup]);
+	const displayedCardOrder = optimisticCardOrder ?? cardOrderByGroup;
+	const displayedCardOrderRef = useRef(displayedCardOrder);
+	displayedCardOrderRef.current = displayedCardOrder;
 
 	const safeLaneColors = useMemo<Record<string, EditorTextColor>>(() => {
 		const next: Record<string, EditorTextColor> = {};
@@ -338,9 +356,24 @@ export function DatabaseTable({
 		[rows, groupColumn],
 	);
 	const rowGroups = useMemo(
-		() => orderDatabaseRowGroups(rawRowGroups, localCardOrder),
-		[localCardOrder, rawRowGroups],
+		() =>
+			activeSort
+				? rawRowGroups
+				: orderDatabaseRowGroups(rawRowGroups, displayedCardOrder),
+		[activeSort, displayedCardOrder, rawRowGroups],
 	);
+	const laneRowsById = useMemo(
+		() =>
+			Object.fromEntries(
+				rowGroups.map((group) => [
+					group.id,
+					group.rows.map((entry) => entry.note_path),
+				]),
+			),
+		[rowGroups],
+	);
+	const laneRowsByIdRef = useRef(laneRowsById);
+	laneRowsByIdRef.current = laneRowsById;
 	const displayRows = table.getRowModel().rows;
 	const visibleColumnCount = table.getVisibleLeafColumns().length || 1;
 	const hasGroups = groupColumn != null && rowGroups.length > 0;
@@ -377,14 +410,27 @@ export function DatabaseTable({
 	}, [activeResizingColumnId, commitColumnResize, resizingColumnId]);
 
 	const commitCardOrder = useCallback(
-		(nextOrder: Record<string, string[]>) => {
-			setLocalCardOrder(nextOrder);
+		async (nextOrder: Record<string, string[]>) => {
 			displayedCardOrderRef.current = nextOrder;
-			if (groupColumn && onCardOrderChange) {
-				void onCardOrderChange(groupColumn.id, nextOrder);
+			laneRowsByIdRef.current = nextOrder;
+			setOptimisticCardOrder(nextOrder);
+			if (!groupColumn || !onCardOrderChange) return;
+			try {
+				await onCardOrderChange(groupColumn.id, nextOrder);
+				setOptimisticCardOrder((current) =>
+					current === nextOrder ? null : current,
+				);
+			} catch (error) {
+				if (displayedCardOrderRef.current === nextOrder) {
+					displayedCardOrderRef.current = cardOrderByGroup;
+					setOptimisticCardOrder((current) =>
+						current === nextOrder ? null : current,
+					);
+				}
+				throw error;
 			}
 		},
-		[groupColumn, onCardOrderChange],
+		[cardOrderByGroup, groupColumn, onCardOrderChange],
 	);
 
 	const handleGroupDrop = useCallback(
@@ -398,58 +444,51 @@ export function DatabaseTable({
 			const row = rows.find((entry) => entry.note_path === notePath);
 			if (!row) return;
 
-			const laneRowsById = Object.fromEntries(
-				rowGroups.map((group) => [
-					group.id,
-					group.rows.map((entry) => entry.note_path),
-				]),
-			);
-
-			const applyOrder = () => {
+			const applyOrder = async () => {
 				const nextOrder = moveBoardCardToLane(
-					localCardOrder,
-					laneRowsById,
+					displayedCardOrderRef.current,
+					laneRowsByIdRef.current,
 					notePath,
 					targetGroupId,
 					targetNotePath,
 					sourceGroupId,
 				);
-				commitCardOrder(nextOrder);
+				await commitCardOrder(nextOrder);
 			};
-
-			if (targetGroupId === sourceGroupId) {
-				if (targetNotePath && targetNotePath !== notePath) {
-					applyOrder();
-				} else if (!targetNotePath) {
-					const targetGroup = rowGroups.find(
-						(group) => group.id === targetGroupId,
-					);
-					const lastRow = targetGroup?.rows[targetGroup.rows.length - 1];
-					if (lastRow?.note_path !== notePath) {
-						applyOrder();
-					}
-				}
-				return;
-			}
-
-			if (boardRowHasLane(row, groupColumn, targetGroupId)) {
-				applyOrder();
-				return;
-			}
 
 			try {
 				setMoveError("");
+				if (targetGroupId === sourceGroupId) {
+					if (targetNotePath && targetNotePath !== notePath) {
+						await applyOrder();
+					} else if (!targetNotePath) {
+						const targetGroup = rowGroups.find(
+							(group) => group.id === targetGroupId,
+						);
+						const lastRow = targetGroup?.rows[targetGroup.rows.length - 1];
+						if (lastRow?.note_path !== notePath) {
+							await applyOrder();
+						}
+					}
+					return;
+				}
+
 				await onSaveCell(
 					row.note_path,
 					groupColumn,
-					boardDropValue(row, groupColumn, targetGroupId, sourceGroupId),
+					databaseGroupDropValue(
+						row,
+						groupColumn,
+						targetGroupId,
+						sourceGroupId,
+					),
 				);
-				applyOrder();
+				await applyOrder();
 			} catch (error) {
 				setMoveError(extractErrorMessage(error));
 			}
 		},
-		[commitCardOrder, groupColumn, localCardOrder, onSaveCell, rowGroups, rows],
+		[commitCardOrder, groupColumn, onSaveCell, rowGroups, rows],
 	);
 
 	const handleDragEnd = useCallback(
@@ -583,7 +622,7 @@ export function DatabaseTable({
 								{flexRender(cell.column.columnDef.cell, cell.getContext())}
 							</TableCell>
 						));
-						if (hasGroups && groupId) {
+						if (hasGroups && groupId && !activeSort) {
 							return (
 								<DatabaseTableDraggableRow
 									key={virtualRow.key}
@@ -641,7 +680,7 @@ export function DatabaseTable({
 			className={`databaseTableShell${activeResizingColumnId ? " is-resizing" : ""}`}
 		>
 			{moveError ? <div className="databaseBoardError">{moveError}</div> : null}
-			{hasGroups ? (
+			{hasGroups && !activeSort ? (
 				<DragDropProvider onDragEnd={handleDragEnd}>
 					{tableBody}
 				</DragDropProvider>

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -1,3 +1,4 @@
+import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
 import {
 	type ColumnDef,
 	type Row,
@@ -8,13 +9,20 @@ import {
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualLoadMore } from "../../hooks/useLoadMoreTriggers";
-import { createDatabaseRowGroups } from "../../lib/database/board";
+import {
+	type DatabaseRowGroup,
+	boardDropValue,
+	boardRowHasLane,
+	createDatabaseRowGroups,
+	moveBoardCardToLane,
+} from "../../lib/database/board";
 import { databaseCellValueFromRow } from "../../lib/database/config";
 import type {
 	DatabaseColumn,
 	DatabaseRow,
 	DatabaseSort,
 } from "../../lib/database/types";
+import { extractErrorMessage } from "../../lib/errorUtils";
 import { ChevronDown, ChevronUp, Plus } from "../Icons";
 import { type EditorTextColor, isEditorTextColor } from "../editor/textColors";
 import {
@@ -27,6 +35,10 @@ import {
 } from "../ui/shadcn/table";
 import { DatabaseCell } from "./DatabaseCell";
 import { DatabaseColumnIconPicker } from "./DatabaseColumnIconPicker";
+import {
+	DatabaseTableDraggableRow,
+	DatabaseTableGroupHeader,
+} from "./DatabaseTableViews";
 
 interface DatabaseTableProps {
 	rows: DatabaseRow[];
@@ -34,6 +46,11 @@ interface DatabaseTableProps {
 	selectedRowPath: string | null;
 	activeSort: DatabaseSort | null;
 	groupColumn?: DatabaseColumn | null;
+	cardOrderByGroup?: Record<string, string[]>;
+	onCardOrderChange?: (
+		groupColumnId: string,
+		cardOrder: Record<string, string[]>,
+	) => void | Promise<void>;
 	onSelectRow: (notePath: string) => void;
 	onOpenRow: (notePath: string) => void;
 	onCreateRow?: (
@@ -62,20 +79,21 @@ interface DatabaseTableProps {
 }
 
 const EMPTY_LANE_COLORS: Record<string, string> = {};
+const EMPTY_CARD_ORDER: Record<string, string[]> = {};
 const DATABASE_TABLE_ROW_HEIGHT = 38;
 const DATABASE_TABLE_GROUP_ROW_HEIGHT = 34;
 
-type DatabaseTableGroup = ReturnType<typeof createDatabaseRowGroups>[number];
 type DatabaseDisplayItem =
 	| {
 			id: string;
 			kind: "group";
-			group: DatabaseTableGroup;
+			group: DatabaseRowGroup;
 	  }
 	| {
 			id: string;
 			kind: "row";
 			row: Row<DatabaseRow>;
+			groupId: string | null;
 	  };
 
 function uniqueOptionValues(values: string[]): string[] {
@@ -102,9 +120,29 @@ function uniqueOptionValues(values: string[]): string[] {
 		.map((entry) => entry.value);
 }
 
+function orderDatabaseRowGroups(
+	groups: DatabaseRowGroup[],
+	cardOrderByLane: Record<string, string[]>,
+): DatabaseRowGroup[] {
+	return groups.map((group) => {
+		const rowByPath = new Map(group.rows.map((row) => [row.note_path, row]));
+		const orderedRows = (cardOrderByLane[group.id] ?? [])
+			.map((notePath) => rowByPath.get(notePath))
+			.filter((row): row is DatabaseRow => row != null);
+		const orderedPathSet = new Set(orderedRows.map((row) => row.note_path));
+		return {
+			...group,
+			rows: [
+				...orderedRows,
+				...group.rows.filter((row) => !orderedPathSet.has(row.note_path)),
+			],
+		};
+	});
+}
+
 function createDatabaseDisplayItems(
 	displayRows: Row<DatabaseRow>[],
-	rowGroups: DatabaseTableGroup[],
+	rowGroups: DatabaseRowGroup[],
 	hasGroups: boolean,
 ): DatabaseDisplayItem[] {
 	if (!hasGroups) {
@@ -112,6 +150,7 @@ function createDatabaseDisplayItems(
 			id: row.id,
 			kind: "row",
 			row,
+			groupId: null,
 		}));
 	}
 	const rowsByPath = new Map(
@@ -130,6 +169,7 @@ function createDatabaseDisplayItems(
 				id: `${group.id}:${row.id}`,
 				kind: "row" as const,
 				row,
+				groupId: group.id,
 			})),
 	]);
 }
@@ -156,6 +196,8 @@ export function DatabaseTable({
 	selectedRowPath,
 	activeSort,
 	groupColumn = null,
+	cardOrderByGroup = EMPTY_CARD_ORDER,
+	onCardOrderChange,
 	onSelectRow,
 	onOpenRow,
 	onCreateRow,
@@ -172,7 +214,19 @@ export function DatabaseTable({
 	onLoadMoreRows,
 }: DatabaseTableProps) {
 	const [resizingColumnId, setResizingColumnId] = useState<string | null>(null);
+	const [moveError, setMoveError] = useState("");
+	const [localCardOrder, setLocalCardOrder] =
+		useState<Record<string, string[]>>(cardOrderByGroup);
 	const tableContainerRef = useRef<HTMLDivElement>(null);
+	const suppressClickRef = useRef(false);
+	const displayedCardOrderRef = useRef(cardOrderByGroup);
+
+	useEffect(() => {
+		if (displayedCardOrderRef.current === cardOrderByGroup) return;
+		displayedCardOrderRef.current = cardOrderByGroup;
+		setLocalCardOrder(cardOrderByGroup);
+	}, [cardOrderByGroup]);
+
 	const safeLaneColors = useMemo<Record<string, EditorTextColor>>(() => {
 		const next: Record<string, EditorTextColor> = {};
 		for (const [laneId, color] of Object.entries(laneColors)) {
@@ -279,9 +333,13 @@ export function DatabaseTable({
 
 	const resizingInfo = table.getState().columnSizingInfo;
 	const activeResizingColumnId = resizingInfo.isResizingColumn;
-	const rowGroups = useMemo(
+	const rawRowGroups = useMemo(
 		() => createDatabaseRowGroups(rows, groupColumn),
 		[rows, groupColumn],
+	);
+	const rowGroups = useMemo(
+		() => orderDatabaseRowGroups(rawRowGroups, localCardOrder),
+		[localCardOrder, rawRowGroups],
 	);
 	const displayRows = table.getRowModel().rows;
 	const visibleColumnCount = table.getVisibleLeafColumns().length || 1;
@@ -318,156 +376,308 @@ export function DatabaseTable({
 		setResizingColumnId(null);
 	}, [activeResizingColumnId, commitColumnResize, resizingColumnId]);
 
+	const commitCardOrder = useCallback(
+		(nextOrder: Record<string, string[]>) => {
+			setLocalCardOrder(nextOrder);
+			displayedCardOrderRef.current = nextOrder;
+			if (groupColumn && onCardOrderChange) {
+				void onCardOrderChange(groupColumn.id, nextOrder);
+			}
+		},
+		[groupColumn, onCardOrderChange],
+	);
+
+	const handleGroupDrop = useCallback(
+		async (
+			notePath: string | null,
+			targetGroupId: string,
+			sourceGroupId?: string | null,
+			targetNotePath?: string | null,
+		) => {
+			if (!notePath || !groupColumn) return;
+			const row = rows.find((entry) => entry.note_path === notePath);
+			if (!row) return;
+
+			const laneRowsById = Object.fromEntries(
+				rowGroups.map((group) => [
+					group.id,
+					group.rows.map((entry) => entry.note_path),
+				]),
+			);
+
+			const applyOrder = () => {
+				const nextOrder = moveBoardCardToLane(
+					localCardOrder,
+					laneRowsById,
+					notePath,
+					targetGroupId,
+					targetNotePath,
+					sourceGroupId,
+				);
+				commitCardOrder(nextOrder);
+			};
+
+			if (targetGroupId === sourceGroupId) {
+				if (targetNotePath && targetNotePath !== notePath) {
+					applyOrder();
+				} else if (!targetNotePath) {
+					const targetGroup = rowGroups.find(
+						(group) => group.id === targetGroupId,
+					);
+					const lastRow = targetGroup?.rows[targetGroup.rows.length - 1];
+					if (lastRow?.note_path !== notePath) {
+						applyOrder();
+					}
+				}
+				return;
+			}
+
+			if (boardRowHasLane(row, groupColumn, targetGroupId)) {
+				applyOrder();
+				return;
+			}
+
+			try {
+				setMoveError("");
+				await onSaveCell(
+					row.note_path,
+					groupColumn,
+					boardDropValue(row, groupColumn, targetGroupId, sourceGroupId),
+				);
+				applyOrder();
+			} catch (error) {
+				setMoveError(extractErrorMessage(error));
+			}
+		},
+		[commitCardOrder, groupColumn, localCardOrder, onSaveCell, rowGroups, rows],
+	);
+
+	const handleDragEnd = useCallback(
+		(event: DragEndEvent) => {
+			suppressClickRef.current = true;
+			window.setTimeout(() => {
+				suppressClickRef.current = false;
+			}, 0);
+			if (event.canceled) return;
+
+			const { source, target } = event.operation;
+			const notePath =
+				typeof source?.data.notePath === "string" ? source.data.notePath : null;
+			const targetGroupId =
+				typeof target?.data.laneId === "string"
+					? target.data.laneId
+					: typeof target?.data.groupId === "string"
+						? target.data.groupId
+						: null;
+			const targetNotePath =
+				typeof target?.data.notePath === "string" ? target.data.notePath : null;
+			const sourceGroupId =
+				typeof source?.data.sourceLaneId === "string"
+					? source.data.sourceLaneId
+					: typeof source?.data.sourceGroupId === "string"
+						? source.data.sourceGroupId
+						: null;
+			if (!targetGroupId) return;
+
+			void handleGroupDrop(
+				notePath,
+				targetGroupId,
+				sourceGroupId,
+				targetNotePath,
+			);
+		},
+		[handleGroupDrop],
+	);
+
+	const tableBody = (
+		<Table className="databaseTable is-virtualized">
+			<TableHeader>
+				{table.getHeaderGroups().map((headerGroup) => (
+					<TableRow key={headerGroup.id} className="databaseHeaderRow">
+						{headerGroup.headers.map((header) => (
+							<TableHead
+								key={header.id}
+								style={{
+									width: header.getSize(),
+									minWidth: header.getSize(),
+								}}
+								className="databaseHeadCell"
+								aria-sort={
+									activeSort?.column_id === header.column.id
+										? activeSort.direction === "desc"
+											? "descending"
+											: "ascending"
+										: "none"
+								}
+							>
+								{header.isPlaceholder
+									? null
+									: flexRender(
+											header.column.columnDef.header,
+											header.getContext(),
+										)}
+								<div
+									className={`databaseColumnResizeHandle${header.column.getIsResizing() ? " is-resizing" : ""}`}
+									onMouseDown={(event) => {
+										event.preventDefault();
+										event.stopPropagation();
+										setResizingColumnId(header.column.id);
+										header.getResizeHandler()(event);
+									}}
+									onTouchStart={(event) => {
+										event.preventDefault();
+										event.stopPropagation();
+										setResizingColumnId(header.column.id);
+										header.getResizeHandler()(event);
+									}}
+								/>
+							</TableHead>
+						))}
+					</TableRow>
+				))}
+			</TableHeader>
+			<TableBody
+				style={{
+					height:
+						displayItems.length > 0
+							? `${rowVirtualizer.getTotalSize()}px`
+							: undefined,
+				}}
+			>
+				{displayItems.length > 0 ? (
+					virtualItems.map((virtualRow) => {
+						const item = displayItems[virtualRow.index];
+						if (!item) return null;
+						const transform = `translateY(${virtualRow.start}px)`;
+						if (item.kind === "group") {
+							const { group } = item;
+							if (hasGroups) {
+								return (
+									<DatabaseTableGroupHeader
+										key={virtualRow.key}
+										groupId={group.id}
+										label={group.label}
+										visibleColumnCount={visibleColumnCount}
+										style={{
+											height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
+											transform,
+										}}
+										canCreateInGroup={canCreateInGroup}
+										onCreateInGroup={
+											groupColumn
+												? () => {
+														void onCreateRow?.({
+															column: groupColumn,
+															laneId: group.id,
+														});
+													}
+												: undefined
+										}
+									>
+										<Plus
+											size="var(--icon-sm)"
+											strokeWidth={1.6}
+											aria-hidden="true"
+										/>
+									</DatabaseTableGroupHeader>
+								);
+							}
+							return (
+								<tr
+									key={virtualRow.key}
+									className="databaseGroupHeaderRow"
+									style={{
+										height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
+										transform,
+									}}
+								>
+									<td
+										colSpan={visibleColumnCount}
+										className="databaseGroupCell"
+									>
+										<span className="databaseGroupLabel">{group.label}</span>
+									</td>
+								</tr>
+							);
+						}
+						const { row, groupId } = item;
+						const cells = row.getVisibleCells().map((cell) => (
+							<TableCell
+								key={cell.id}
+								style={{
+									width: cell.column.getSize(),
+									minWidth: cell.column.getSize(),
+								}}
+								className="databaseBodyCell"
+							>
+								{flexRender(cell.column.columnDef.cell, cell.getContext())}
+							</TableCell>
+						));
+						if (hasGroups && groupId) {
+							return (
+								<DatabaseTableDraggableRow
+									key={virtualRow.key}
+									row={row.original}
+									groupId={groupId}
+									selected={row.original.note_path === selectedRowPath}
+									style={{
+										height: `${DATABASE_TABLE_ROW_HEIGHT}px`,
+										transform,
+									}}
+									suppressClickRef={suppressClickRef}
+									onSelectRow={onSelectRow}
+									onOpenRow={onOpenRow}
+								>
+									{cells}
+								</DatabaseTableDraggableRow>
+							);
+						}
+						return (
+							<TableRow
+								key={virtualRow.key}
+								data-state={
+									row.original.note_path === selectedRowPath
+										? "selected"
+										: undefined
+								}
+								className="databaseRow"
+								style={{
+									height: `${DATABASE_TABLE_ROW_HEIGHT}px`,
+									transform,
+								}}
+								onClick={() => onSelectRow(row.original.note_path)}
+							>
+								{cells}
+							</TableRow>
+						);
+					})
+				) : (
+					<TableRow>
+						<TableCell
+							colSpan={visibleColumnCount}
+							className="databaseEmptyCell"
+						>
+							No matching notes
+						</TableCell>
+					</TableRow>
+				)}
+			</TableBody>
+		</Table>
+	);
+
 	return (
 		<div
 			ref={tableContainerRef}
 			className={`databaseTableShell${activeResizingColumnId ? " is-resizing" : ""}`}
 		>
-			<Table className="databaseTable is-virtualized">
-				<TableHeader>
-					{table.getHeaderGroups().map((headerGroup) => (
-						<TableRow key={headerGroup.id} className="databaseHeaderRow">
-							{headerGroup.headers.map((header) => (
-								<TableHead
-									key={header.id}
-									style={{
-										width: header.getSize(),
-										minWidth: header.getSize(),
-									}}
-									className="databaseHeadCell"
-									aria-sort={
-										activeSort?.column_id === header.column.id
-											? activeSort.direction === "desc"
-												? "descending"
-												: "ascending"
-											: "none"
-									}
-								>
-									{header.isPlaceholder
-										? null
-										: flexRender(
-												header.column.columnDef.header,
-												header.getContext(),
-											)}
-									<div
-										className={`databaseColumnResizeHandle${header.column.getIsResizing() ? " is-resizing" : ""}`}
-										onMouseDown={(event) => {
-											event.preventDefault();
-											event.stopPropagation();
-											setResizingColumnId(header.column.id);
-											header.getResizeHandler()(event);
-										}}
-										onTouchStart={(event) => {
-											event.preventDefault();
-											event.stopPropagation();
-											setResizingColumnId(header.column.id);
-											header.getResizeHandler()(event);
-										}}
-									/>
-								</TableHead>
-							))}
-						</TableRow>
-					))}
-				</TableHeader>
-				<TableBody
-					style={{
-						height:
-							displayItems.length > 0
-								? `${rowVirtualizer.getTotalSize()}px`
-								: undefined,
-					}}
-				>
-					{displayItems.length > 0 ? (
-						virtualItems.map((virtualRow) => {
-							const item = displayItems[virtualRow.index];
-							if (!item) return null;
-							const transform = `translateY(${virtualRow.start}px)`;
-							if (item.kind === "group") {
-								const { group } = item;
-								return (
-									<tr
-										key={virtualRow.key}
-										className="databaseGroupHeaderRow"
-										style={{
-											height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
-											transform,
-										}}
-									>
-										<td
-											colSpan={visibleColumnCount}
-											className="databaseGroupCell"
-										>
-											<span className="databaseGroupLabel">{group.label}</span>
-											{canCreateInGroup && groupColumn ? (
-												<button
-													type="button"
-													className="databaseGroupAddButton"
-													onClick={() => {
-														void onCreateRow?.({
-															column: groupColumn,
-															laneId: group.id,
-														});
-													}}
-													title={`Add note to ${group.label}`}
-													aria-label={`Add note to ${group.label}`}
-												>
-													<Plus
-														size="var(--icon-sm)"
-														strokeWidth={1.6}
-														aria-hidden="true"
-													/>
-												</button>
-											) : null}
-										</td>
-									</tr>
-								);
-							}
-							const { row } = item;
-							return (
-								<TableRow
-									key={virtualRow.key}
-									data-state={
-										row.original.note_path === selectedRowPath
-											? "selected"
-											: undefined
-									}
-									className="databaseRow"
-									style={{
-										height: `${DATABASE_TABLE_ROW_HEIGHT}px`,
-										transform,
-									}}
-									onClick={() => onSelectRow(row.original.note_path)}
-								>
-									{row.getVisibleCells().map((cell) => (
-										<TableCell
-											key={cell.id}
-											style={{
-												width: cell.column.getSize(),
-												minWidth: cell.column.getSize(),
-											}}
-											className="databaseBodyCell"
-										>
-											{flexRender(
-												cell.column.columnDef.cell,
-												cell.getContext(),
-											)}
-										</TableCell>
-									))}
-								</TableRow>
-							);
-						})
-					) : (
-						<TableRow>
-							<TableCell
-								colSpan={visibleColumnCount}
-								className="databaseEmptyCell"
-							>
-								No matching notes
-							</TableCell>
-						</TableRow>
-					)}
-				</TableBody>
-			</Table>
+			{moveError ? <div className="databaseBoardError">{moveError}</div> : null}
+			{hasGroups ? (
+				<DragDropProvider onDragEnd={handleDragEnd}>
+					{tableBody}
+				</DragDropProvider>
+			) : (
+				tableBody
+			)}
 		</div>
 	);
 }

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -23,7 +23,7 @@ import type {
 	DatabaseSort,
 } from "../../lib/database/types";
 import { extractErrorMessage } from "../../lib/errorUtils";
-import { ChevronDown, ChevronUp, Plus } from "../Icons";
+import { ChevronDown, ChevronUp } from "../Icons";
 import { type EditorTextColor, isEditorTextColor } from "../editor/textColors";
 import {
 	Table,
@@ -464,19 +464,13 @@ export function DatabaseTable({
 			const notePath =
 				typeof source?.data.notePath === "string" ? source.data.notePath : null;
 			const targetGroupId =
-				typeof target?.data.laneId === "string"
-					? target.data.laneId
-					: typeof target?.data.groupId === "string"
-						? target.data.groupId
-						: null;
+				typeof target?.data.laneId === "string" ? target.data.laneId : null;
 			const targetNotePath =
 				typeof target?.data.notePath === "string" ? target.data.notePath : null;
 			const sourceGroupId =
 				typeof source?.data.sourceLaneId === "string"
 					? source.data.sourceLaneId
-					: typeof source?.data.sourceGroupId === "string"
-						? source.data.sourceGroupId
-						: null;
+					: null;
 			if (!targetGroupId) return;
 
 			void handleGroupDrop(
@@ -551,60 +545,29 @@ export function DatabaseTable({
 						const transform = `translateY(${virtualRow.start}px)`;
 						if (item.kind === "group") {
 							const { group } = item;
-							if (hasGroups) {
-								return (
-									<DatabaseTableGroupHeader
-										key={virtualRow.key}
-										groupId={group.id}
-										label={group.label}
-										rowCount={group.rowCount}
-										visibleColumnCount={visibleColumnCount}
-										style={{
-											height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
-											transform,
-										}}
-										canCreateInGroup={canCreateInGroup}
-										onCreateInGroup={
-											groupColumn
-												? () => {
-														void onCreateRow?.({
-															column: groupColumn,
-															laneId: group.id,
-														});
-													}
-												: undefined
-										}
-									>
-										<Plus
-											size="var(--icon-sm)"
-											strokeWidth={1.6}
-											aria-hidden="true"
-										/>
-									</DatabaseTableGroupHeader>
-								);
-							}
 							return (
-								<tr
+								<DatabaseTableGroupHeader
 									key={virtualRow.key}
-									className="databaseGroupHeaderRow"
+									groupId={group.id}
+									label={group.label}
+									rowCount={group.rowCount}
+									visibleColumnCount={visibleColumnCount}
 									style={{
 										height: `${DATABASE_TABLE_GROUP_ROW_HEIGHT}px`,
 										transform,
 									}}
-								>
-									<td
-										colSpan={visibleColumnCount}
-										className="databaseGroupCell"
-									>
-										<span className="databaseGroupLabel">{group.label}</span>
-										<span
-											className="databaseGroupCount"
-											aria-label={`${group.rowCount} ${group.rowCount === 1 ? "note" : "notes"}`}
-										>
-											{group.rowCount}
-										</span>
-									</td>
-								</tr>
+									canCreateInGroup={canCreateInGroup}
+									onCreateInGroup={
+										groupColumn
+											? () => {
+													void onCreateRow?.({
+														column: groupColumn,
+														laneId: group.id,
+													});
+												}
+											: undefined
+									}
+								/>
 							);
 						}
 						const { row, groupId } = item;

--- a/src/components/database/DatabaseTableViews.tsx
+++ b/src/components/database/DatabaseTableViews.tsx
@@ -1,0 +1,190 @@
+import { PointerActivationConstraints } from "@dnd-kit/dom";
+import {
+	KeyboardSensor,
+	PointerSensor,
+	useDraggable,
+	useDroppable,
+} from "@dnd-kit/react";
+import {
+	type CSSProperties,
+	type MouseEvent,
+	type MutableRefObject,
+	type ReactNode,
+	useCallback,
+} from "react";
+import type { DatabaseRow } from "../../lib/database/types";
+
+const DATABASE_TABLE_ROW_SENSORS = [
+	PointerSensor.configure({
+		activationConstraints: [
+			new PointerActivationConstraints.Distance({ value: 6 }),
+		],
+	}),
+	KeyboardSensor,
+];
+
+function tableRowDragId(notePath: string, groupId: string): string {
+	return `${groupId}:${notePath}`;
+}
+
+interface DatabaseTableGroupHeaderProps {
+	groupId: string;
+	label: string;
+	visibleColumnCount: number;
+	style: CSSProperties;
+	canCreateInGroup: boolean;
+	onCreateInGroup?: () => void;
+	children?: ReactNode;
+}
+
+export function DatabaseTableGroupHeader({
+	groupId,
+	label,
+	visibleColumnCount,
+	style,
+	canCreateInGroup,
+	onCreateInGroup,
+	children,
+}: DatabaseTableGroupHeaderProps) {
+	const { ref, isDropTarget } = useDroppable({
+		id: `group:${groupId}`,
+		data: { groupId, laneId: groupId },
+		accept: "database-table-row",
+	});
+
+	return (
+		<tr
+			ref={ref}
+			className="databaseGroupHeaderRow"
+			data-drop-target={isDropTarget ? "true" : undefined}
+			style={style}
+		>
+			<td colSpan={visibleColumnCount} className="databaseGroupCell">
+				<span className="databaseGroupLabel">{label}</span>
+				{canCreateInGroup && onCreateInGroup ? (
+					<button
+						type="button"
+						className="databaseGroupAddButton"
+						onClick={onCreateInGroup}
+						title={`Add note to ${label}`}
+						aria-label={`Add note to ${label}`}
+					>
+						{children}
+					</button>
+				) : null}
+			</td>
+		</tr>
+	);
+}
+
+interface DatabaseTableDraggableRowProps {
+	row: DatabaseRow;
+	groupId: string;
+	selected: boolean;
+	style: CSSProperties;
+	suppressClickRef: MutableRefObject<boolean>;
+	onSelectRow: (notePath: string) => void;
+	onOpenRow: (notePath: string) => void;
+	children: ReactNode;
+}
+
+export function DatabaseTableDraggableRow({
+	row,
+	groupId,
+	selected,
+	style,
+	suppressClickRef,
+	onSelectRow,
+	onOpenRow,
+	children,
+}: DatabaseTableDraggableRowProps) {
+	const dragId = tableRowDragId(row.note_path, groupId);
+	const { ref: droppableRef, isDropTarget } = useDroppable({
+		id: `row:${dragId}`,
+		data: {
+			groupId,
+			laneId: groupId,
+			notePath: row.note_path,
+		},
+		accept: "database-table-row",
+	});
+	const { ref, handleRef, isDragging } = useDraggable({
+		id: dragId,
+		type: "database-table-row",
+		sensors: DATABASE_TABLE_ROW_SENSORS,
+		data: {
+			notePath: row.note_path,
+			sourceLaneId: groupId,
+			sourceGroupId: groupId,
+		},
+	});
+	const setRowRef = useCallback(
+		(element: HTMLTableRowElement | null) => {
+			droppableRef(element);
+			ref(element);
+			handleRef(element);
+		},
+		[droppableRef, handleRef, ref],
+	);
+
+	const handleClick = useCallback(
+		(event: MouseEvent<HTMLTableRowElement>) => {
+			if (suppressClickRef.current) return;
+			// Avoid stealing clicks from interactive cell controls.
+			const target = event.target;
+			if (
+				target instanceof Element &&
+				target.closest(
+					"button, a, input, textarea, select, [contenteditable='true'], [role='button'], [role='menuitem'], [role='option']",
+				)
+			) {
+				return;
+			}
+			onSelectRow(row.note_path);
+		},
+		[onSelectRow, row.note_path, suppressClickRef],
+	);
+
+	const handleDoubleClick = useCallback(
+		(event: MouseEvent<HTMLTableRowElement>) => {
+			if (suppressClickRef.current) return;
+			const target = event.target;
+			if (
+				target instanceof Element &&
+				target.closest(
+					"button, a, input, textarea, select, [contenteditable='true'], [role='button'], [role='menuitem'], [role='option']",
+				)
+			) {
+				return;
+			}
+			onOpenRow(row.note_path);
+		},
+		[onOpenRow, row.note_path, suppressClickRef],
+	);
+
+	return (
+		<tr
+			ref={setRowRef}
+			data-slot="table-row"
+			data-state={selected ? "selected" : undefined}
+			data-dragging={isDragging ? "true" : undefined}
+			data-drop-target={isDropTarget ? "true" : undefined}
+			className="databaseRow"
+			style={style}
+			tabIndex={0}
+			onClick={handleClick}
+			onDoubleClick={handleDoubleClick}
+			onKeyDown={(event) => {
+				if (event.key === "Enter") {
+					event.preventDefault();
+					onOpenRow(row.note_path);
+				} else if (event.key === " ") {
+					event.preventDefault();
+					onSelectRow(row.note_path);
+				}
+			}}
+		>
+			{children}
+		</tr>
+	);
+}

--- a/src/components/database/DatabaseTableViews.tsx
+++ b/src/components/database/DatabaseTableViews.tsx
@@ -30,6 +30,7 @@ function tableRowDragId(notePath: string, groupId: string): string {
 interface DatabaseTableGroupHeaderProps {
 	groupId: string;
 	label: string;
+	rowCount: number;
 	visibleColumnCount: number;
 	style: CSSProperties;
 	canCreateInGroup: boolean;
@@ -40,6 +41,7 @@ interface DatabaseTableGroupHeaderProps {
 export function DatabaseTableGroupHeader({
 	groupId,
 	label,
+	rowCount,
 	visibleColumnCount,
 	style,
 	canCreateInGroup,
@@ -61,6 +63,12 @@ export function DatabaseTableGroupHeader({
 		>
 			<td colSpan={visibleColumnCount} className="databaseGroupCell">
 				<span className="databaseGroupLabel">{label}</span>
+				<span
+					className="databaseGroupCount"
+					aria-label={`${rowCount} ${rowCount === 1 ? "note" : "notes"}`}
+				>
+					{rowCount}
+				</span>
 				{canCreateInGroup && onCreateInGroup ? (
 					<button
 						type="button"

--- a/src/components/database/DatabaseTableViews.tsx
+++ b/src/components/database/DatabaseTableViews.tsx
@@ -13,6 +13,7 @@ import {
 	useCallback,
 } from "react";
 import type { DatabaseRow } from "../../lib/database/types";
+import { Plus } from "../Icons";
 
 const DATABASE_TABLE_ROW_SENSORS = [
 	PointerSensor.configure({
@@ -23,8 +24,14 @@ const DATABASE_TABLE_ROW_SENSORS = [
 	KeyboardSensor,
 ];
 
-function tableRowDragId(notePath: string, groupId: string): string {
-	return `${groupId}:${notePath}`;
+const INTERACTIVE_CELL_SELECTOR =
+	"button, a, input, textarea, select, [contenteditable='true'], [role='button'], [role='menuitem'], [role='option']";
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+	return (
+		target instanceof Element &&
+		Boolean(target.closest(INTERACTIVE_CELL_SELECTOR))
+	);
 }
 
 interface DatabaseTableGroupHeaderProps {
@@ -35,7 +42,6 @@ interface DatabaseTableGroupHeaderProps {
 	style: CSSProperties;
 	canCreateInGroup: boolean;
 	onCreateInGroup?: () => void;
-	children?: ReactNode;
 }
 
 export function DatabaseTableGroupHeader({
@@ -46,11 +52,10 @@ export function DatabaseTableGroupHeader({
 	style,
 	canCreateInGroup,
 	onCreateInGroup,
-	children,
 }: DatabaseTableGroupHeaderProps) {
 	const { ref, isDropTarget } = useDroppable({
 		id: `group:${groupId}`,
-		data: { groupId, laneId: groupId },
+		data: { laneId: groupId },
 		accept: "database-table-row",
 	});
 
@@ -63,10 +68,7 @@ export function DatabaseTableGroupHeader({
 		>
 			<td colSpan={visibleColumnCount} className="databaseGroupCell">
 				<span className="databaseGroupLabel">{label}</span>
-				<span
-					className="databaseGroupCount"
-					aria-label={`${rowCount} ${rowCount === 1 ? "note" : "notes"}`}
-				>
+				<span className="databaseGroupCount" aria-label={`${rowCount} notes`}>
 					{rowCount}
 				</span>
 				{canCreateInGroup && onCreateInGroup ? (
@@ -77,7 +79,7 @@ export function DatabaseTableGroupHeader({
 						title={`Add note to ${label}`}
 						aria-label={`Add note to ${label}`}
 					>
-						{children}
+						<Plus size="var(--icon-sm)" strokeWidth={1.6} aria-hidden="true" />
 					</button>
 				) : null}
 			</td>
@@ -106,25 +108,17 @@ export function DatabaseTableDraggableRow({
 	onOpenRow,
 	children,
 }: DatabaseTableDraggableRowProps) {
-	const dragId = tableRowDragId(row.note_path, groupId);
+	const dragId = `${groupId}:${row.note_path}`;
 	const { ref: droppableRef, isDropTarget } = useDroppable({
 		id: `row:${dragId}`,
-		data: {
-			groupId,
-			laneId: groupId,
-			notePath: row.note_path,
-		},
+		data: { laneId: groupId, notePath: row.note_path },
 		accept: "database-table-row",
 	});
 	const { ref, handleRef, isDragging } = useDraggable({
 		id: dragId,
 		type: "database-table-row",
 		sensors: DATABASE_TABLE_ROW_SENSORS,
-		data: {
-			notePath: row.note_path,
-			sourceLaneId: groupId,
-			sourceGroupId: groupId,
-		},
+		data: { notePath: row.note_path, sourceLaneId: groupId },
 	});
 	const setRowRef = useCallback(
 		(element: HTMLTableRowElement | null) => {
@@ -137,17 +131,7 @@ export function DatabaseTableDraggableRow({
 
 	const handleClick = useCallback(
 		(event: MouseEvent<HTMLTableRowElement>) => {
-			if (suppressClickRef.current) return;
-			// Avoid stealing clicks from interactive cell controls.
-			const target = event.target;
-			if (
-				target instanceof Element &&
-				target.closest(
-					"button, a, input, textarea, select, [contenteditable='true'], [role='button'], [role='menuitem'], [role='option']",
-				)
-			) {
-				return;
-			}
+			if (suppressClickRef.current || isInteractiveTarget(event.target)) return;
 			onSelectRow(row.note_path);
 		},
 		[onSelectRow, row.note_path, suppressClickRef],
@@ -155,16 +139,7 @@ export function DatabaseTableDraggableRow({
 
 	const handleDoubleClick = useCallback(
 		(event: MouseEvent<HTMLTableRowElement>) => {
-			if (suppressClickRef.current) return;
-			const target = event.target;
-			if (
-				target instanceof Element &&
-				target.closest(
-					"button, a, input, textarea, select, [contenteditable='true'], [role='button'], [role='menuitem'], [role='option']",
-				)
-			) {
-				return;
-			}
+			if (suppressClickRef.current || isInteractiveTarget(event.target)) return;
 			onOpenRow(row.note_path);
 		},
 		[onOpenRow, row.note_path, suppressClickRef],

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -154,9 +154,9 @@ function DatabasesPaneContent({
 							groupColumn={views.activeGroupColumn}
 							cardOrderByGroup={
 								views.activeGroupColumn
-									? (activeCollection.config.view.board_card_order?.[
+									? activeCollection.config.view.board_card_order?.[
 											views.activeGroupColumn.id
-										] ?? {})
+										]
 									: undefined
 							}
 							onCardOrderChange={views.boardHandlers?.onCardOrderChange}

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -159,7 +159,7 @@ function DatabasesPaneContent({
 										]
 									: undefined
 							}
-							onCardOrderChange={views.boardHandlers?.onCardOrderChange}
+							onCardOrderChange={views.persistCardOrder}
 							onSelectRow={rows.setSelectedRowPath}
 							onOpenRow={(notePath) => void onOpenFile(notePath)}
 							onCreateRow={actions.handleCreateRow}

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -152,6 +152,14 @@ function DatabasesPaneContent({
 							selectedRowPath={rows.selectedRowPath}
 							activeSort={activeCollection.config.sorts[0] ?? null}
 							groupColumn={views.activeGroupColumn}
+							cardOrderByGroup={
+								views.activeGroupColumn
+									? (activeCollection.config.view.board_card_order?.[
+											views.activeGroupColumn.id
+										] ?? {})
+									: undefined
+							}
+							onCardOrderChange={views.boardHandlers?.onCardOrderChange}
 							onSelectRow={rows.setSelectedRowPath}
 							onOpenRow={(notePath) => void onOpenFile(notePath)}
 							onCreateRow={actions.handleCreateRow}

--- a/src/hooks/database/useViewConfigMutations.ts
+++ b/src/hooks/database/useViewConfigMutations.ts
@@ -82,9 +82,9 @@ export function useViewConfigMutations({
 		[patchActiveConfig],
 	);
 
-	const handleCardOrderChange = useCallback(
+	const persistCardOrder = useCallback(
 		(groupColumnId: string, cardOrder: Record<string, string[]>) => {
-			patchActiveConfig((config) =>
+			return handleSaveConfig((config) =>
 				patchBoardMapField(
 					config,
 					"board_card_order",
@@ -93,7 +93,14 @@ export function useViewConfigMutations({
 				),
 			);
 		},
-		[patchActiveConfig],
+		[handleSaveConfig],
+	);
+
+	const handleCardOrderChange = useCallback(
+		(groupColumnId: string, cardOrder: Record<string, string[]>) => {
+			void persistCardOrder(groupColumnId, cardOrder).catch(() => undefined);
+		},
+		[persistCardOrder],
 	);
 
 	const handleLaneColorChange = useCallback(
@@ -206,6 +213,7 @@ export function useViewConfigMutations({
 		handleSaveConfig,
 		patchActiveView,
 		boardHandlers,
+		persistCardOrder,
 		handleResizeColumn,
 		handleChangeColumnIcon,
 		handleToggleSort,

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -138,7 +138,6 @@
 	text-align: right;
 }
 
-.databaseBoardLaneTitleButton,
 .databaseBoardLaneHandle,
 .databaseBoardCard {
 	transition: background-color 140ms ease, border-color 140ms ease, box-shadow
@@ -219,6 +218,7 @@
 	color: inherit;
 	white-space: nowrap;
 	background: transparent;
+	transition: background-color 140ms ease;
 }
 
 .databaseBoardLaneTitleButton:hover {
@@ -239,23 +239,52 @@
 	appearance: none;
 	display: flex;
 	align-items: center;
-	justify-content: center;
-	gap: 6px;
-	min-height: 30px;
+	justify-content: flex-start;
+	gap: 7px;
+	min-height: 32px;
 	width: 100%;
-	border: 1px dashed color-mix(in srgb, var(--database-tone) 20%, transparent);
+	padding: 0 10px;
+	border: 1px solid transparent;
 	border-radius: var(--database-radius-md);
-	background: transparent;
+	background: color-mix(in srgb, var(--bg-primary) 48%, transparent);
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.86);
 	font-weight: var(--font-medium);
+	letter-spacing: -0.01em;
 	cursor: pointer;
+	transition: background-color 140ms ease, border-color 140ms ease, color 140ms
+		ease;
+}
+
+.databaseBoardAddCardIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--database-tone) 12%, transparent);
+	color: color-mix(in srgb, var(--database-tone) 55%, var(--text-secondary));
+	flex: 0 0 auto;
+}
+
+.databaseBoardAddCardLabel {
+	line-height: 1;
 }
 
 .databaseBoardAddCardButton:hover {
-	border-color: color-mix(in srgb, var(--database-tone) 36%, transparent);
-	background: color-mix(in srgb, var(--database-tone) 7%, var(--bg-primary));
+	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-primary));
+	border-color: color-mix(in srgb, var(--database-tone) 16%, transparent);
 	color: var(--text-primary);
+}
+
+.databaseBoardAddCardButton:hover .databaseBoardAddCardIcon {
+	background: color-mix(in srgb, var(--database-tone) 18%, transparent);
+	color: color-mix(in srgb, var(--database-tone) 72%, var(--text-primary));
+}
+
+.databaseBoardAddCardButton:active {
+	background: color-mix(in srgb, var(--database-tone) 12%, var(--bg-primary));
 }
 
 .databaseBoardCard {
@@ -287,39 +316,26 @@
 
 .databaseBoardCard:hover {
 	border-color: color-mix(in srgb, var(--border-default) 72%, transparent);
-	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 5%, transparent),
-		0 4px 12px color-mix(in srgb, var(--text-primary) 6%, transparent);
+	box-shadow: 0 4px 14px color-mix(in srgb, var(--text-primary) 8%, transparent);
 }
 
-/* Floating drag feedback: slight tilt, accent ring, soft lift (matches board mock).
-   Exclude placeholders — dnd-kit may mirror `data-dragging` onto the stand-in. */
 .databaseBoardCard[data-dragging="true"]:not([data-dnd-placeholder]),
 .databaseBoardCard[data-dnd-dragging]:not([data-dnd-placeholder]) {
-	opacity: 1;
 	overflow: visible;
 	cursor: grabbing;
 	border-color: color-mix(in srgb, var(--interactive-accent) 72%, transparent);
 	box-shadow: 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 2px 4px
-		color-mix(in srgb, var(--text-primary) 6%, transparent), 0 10px 24px
-		color-mix(in srgb, var(--text-primary) 12%, transparent), 0 18px 40px
-		color-mix(in srgb, var(--text-primary) 8%, transparent);
-	/* Composes with dnd-kit's `translate` (independent transform properties) */
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 12px 28px
+		color-mix(in srgb, var(--text-primary) 14%, transparent);
 	rotate: 3deg;
 }
 
-/* Space-reserving ghost left behind while the real card is lifted.
-   dnd-kit injects `visibility: hidden` for placeholders; override so the
-   board keeps a faint stand-in like the product mock. */
 .databaseBoardCard[data-dnd-placeholder] {
 	visibility: visible !important;
 	opacity: 0.34;
 	pointer-events: none;
-	filter: grayscale(0.05);
 	box-shadow: none;
 	border-color: color-mix(in srgb, var(--border-default) 55%, transparent);
-	rotate: none;
-	cursor: default;
 }
 
 .databaseBoardCard[data-drop-target="true"] {
@@ -339,8 +355,7 @@
 }
 
 .dark .databaseBoardCard:hover {
-	box-shadow: 0 1px 2px color-mix(in srgb, black 18%, transparent), 0 6px 16px
-		color-mix(in srgb, black 16%, transparent);
+	box-shadow: 0 6px 16px color-mix(in srgb, black 18%, transparent);
 }
 
 .dark .databaseBoardCard[data-state="selected"] {
@@ -358,9 +373,6 @@
 		var(--bg-primary)
 	);
 	border-color: color-mix(in srgb, var(--interactive-accent) 42%, transparent);
-	box-shadow: 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 12%, transparent), 0 1px 2px
-		color-mix(in srgb, var(--text-primary) 4%, transparent);
 }
 
 .databaseBoardCardTitle {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -249,13 +249,46 @@
 	-webkit-user-drag: none;
 }
 
-.databaseBoardCard[data-dragging="true"] {
-	opacity: 0.7;
-	border-color: color-mix(in srgb, var(--interactive-accent) 38%, transparent);
+/* Floating drag feedback: slight tilt, accent ring, soft lift (matches board mock).
+   Exclude placeholders — dnd-kit may mirror `data-dragging` onto the stand-in. */
+.databaseBoardCard[data-dragging="true"]:not([data-dnd-placeholder]),
+.databaseBoardCard[data-dnd-dragging]:not([data-dnd-placeholder]) {
+	opacity: 1;
+	overflow: visible;
+	cursor: grabbing;
+	border-color: color-mix(in srgb, var(--interactive-accent) 72%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 2px 4px
+		color-mix(in srgb, var(--text-primary) 6%, transparent), 0 10px 24px
+		color-mix(in srgb, var(--text-primary) 12%, transparent), 0 18px 40px
+		color-mix(in srgb, var(--text-primary) 8%, transparent);
+	/* Composes with dnd-kit's `translate` (independent transform properties) */
+	rotate: 3deg;
+}
+
+/* Space-reserving ghost left behind while the real card is lifted.
+   dnd-kit injects `visibility: hidden` for placeholders; override so the
+   board keeps a faint stand-in like the product mock. */
+.databaseBoardCard[data-dnd-placeholder] {
+	visibility: visible !important;
+	opacity: 0.34;
+	pointer-events: none;
+	filter: grayscale(0.05);
+	box-shadow: none;
+	border-color: color-mix(in srgb, var(--border-default) 55%, transparent);
+	rotate: none;
+	cursor: default;
 }
 
 .databaseBoardCard[data-drop-target="true"] {
 	border-color: color-mix(in srgb, var(--interactive-accent) 50%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.databaseBoardCard[data-dragging="true"]:not([data-dnd-placeholder]),
+	.databaseBoardCard[data-dnd-dragging]:not([data-dnd-placeholder]) {
+		rotate: none;
+	}
 }
 
 .dark .databaseBoardCard {

--- a/src/styles/app/41-database-board.css
+++ b/src/styles/app/41-database-board.css
@@ -5,7 +5,7 @@
 	min-height: 0;
 	position: relative;
 	overflow: auto;
-	padding: 0 18px 18px;
+	padding: 4px 18px 18px;
 }
 
 .databaseTableShell [data-slot="table-container"] {
@@ -57,9 +57,9 @@
 .databaseBoardScroller {
 	display: grid;
 	grid-auto-flow: column;
-	grid-auto-columns: minmax(240px, 290px);
+	grid-auto-columns: minmax(248px, 300px);
 	width: max-content;
-	gap: 18px;
+	gap: 14px;
 	min-height: min-content;
 	height: auto;
 	align-items: start;
@@ -74,17 +74,18 @@
 	min-height: 0;
 	height: auto;
 	border-radius: var(--database-radius-lg);
-	border: none;
-	background: color-mix(in srgb, var(--database-tone) 6%, var(--bg-secondary));
+	border: 1px solid color-mix(in srgb, var(--border-light) 55%, transparent);
+	background: color-mix(in srgb, var(--database-tone) 5%, var(--bg-secondary));
 	box-shadow: none;
 }
 
 .databaseBoardLane[data-show-column-color="false"] {
-	background: transparent;
+	background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary));
+	border-color: color-mix(in srgb, var(--border-light) 48%, transparent);
 }
 
 .databaseBoardLane[data-show-column-color="true"][data-workflow-state="done"] {
-	background: color-mix(in srgb, var(--database-tone) 5%, var(--bg-secondary));
+	background: color-mix(in srgb, var(--database-tone) 4%, var(--bg-secondary));
 }
 
 .databaseBoardLane[data-workflow-state="archived"] {
@@ -92,17 +93,22 @@
 }
 
 .databaseBoardLane[data-show-column-color="true"][data-workflow-state="archived"] {
-	background: color-mix(in srgb, var(--text-tertiary) 7%, var(--bg-secondary));
+	background: color-mix(in srgb, var(--text-tertiary) 6%, var(--bg-secondary));
 }
 
 .databaseBoardLane[data-active="true"] {
-	background: color-mix(in srgb, var(--database-tone) 9%, var(--bg-secondary));
-	outline: 1px solid color-mix(in srgb, var(--database-tone) 24%, transparent);
+	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-secondary));
+	border-color: color-mix(in srgb, var(--database-tone) 28%, transparent);
+	outline: none;
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--database-tone) 16%, transparent);
 }
 
 .databaseBoardLane[data-show-column-color="false"][data-active="true"] {
-	background: var(--bg-hover);
-	outline-color: color-mix(in srgb, var(--border-default) 70%, transparent);
+	background: color-mix(in srgb, var(--bg-hover) 80%, var(--bg-primary));
+	border-color: color-mix(in srgb, var(--border-default) 70%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--border-default) 28%, transparent);
 }
 
 .databaseBoardLaneHeader {
@@ -110,7 +116,7 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--space-2);
-	padding: 12px 14px 8px;
+	padding: 11px 12px 8px;
 	border-bottom: none;
 }
 
@@ -118,31 +124,51 @@
 .databaseBoardColorRibbon {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: 6px;
+}
+
+.databaseBoardLaneCount {
+	flex: 0 0 auto;
+	min-width: 1.25em;
+	font-size: calc(var(--text-base) * 0.78);
+	font-weight: var(--font-medium);
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+	color: var(--text-tertiary);
+	text-align: right;
 }
 
 .databaseBoardLaneTitleButton,
 .databaseBoardLaneHandle,
 .databaseBoardCard {
-	transition: none;
+	transition: background-color 140ms ease, border-color 140ms ease, box-shadow
+		140ms ease;
 }
 
 .databaseBoardLaneHandle {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
-	height: 24px;
+	width: 22px;
+	height: 22px;
 	padding: 0;
-	border: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+	border: 1px solid transparent;
 	border-radius: 999px;
-	background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+	background: transparent;
 	color: var(--text-tertiary);
 	cursor: context-menu;
+	opacity: 0.55;
+}
+
+.databaseBoardLaneHandle:hover:not(:disabled) {
+	opacity: 1;
+	background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
+	border-color: color-mix(in srgb, var(--border-light) 70%, transparent);
+	color: var(--text-secondary);
 }
 
 .databaseBoardLaneHandle:disabled {
-	opacity: 0.42;
+	opacity: 0.28;
 	cursor: not-allowed;
 }
 
@@ -156,30 +182,35 @@
 }
 
 .databaseBoardLaneTitle {
-	font-size: calc(var(--text-base) * 0.8);
+	font-size: calc(var(--text-base) * 0.88);
 	font-weight: var(--font-semibold);
-	color: color-mix(in srgb, var(--database-tone) 78%, var(--text-primary));
-	letter-spacing: 0.045em;
-	text-transform: uppercase;
-	line-height: 1;
+	color: color-mix(in srgb, var(--database-tone) 42%, var(--text-primary));
+	letter-spacing: -0.01em;
+	text-transform: none;
+	line-height: 1.15;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .databaseBoardLaneTitleIcon {
 	flex: 0 0 auto;
 	color: var(--database-tone);
+	opacity: 0.92;
 }
 
 .databaseBoardLaneTitleButton {
 	display: inline-flex;
 	align-items: center;
 	justify-content: flex-start;
-	gap: 6px;
+	gap: 7px;
 	width: auto;
 	height: auto;
 	min-height: 0;
 	max-width: 100%;
-	padding: 3px 10px 3px 8px;
-	border-radius: var(--radius-8);
+	padding: 3px 6px 3px 4px;
+	margin-left: -4px;
+	border-radius: var(--radius-6);
 	border: none;
 	cursor: pointer;
 	font-size: inherit;
@@ -187,15 +218,19 @@
 	line-height: 1;
 	color: inherit;
 	white-space: nowrap;
-	background: color-mix(in srgb, var(--database-tone) 88%, var(--bg-primary));
+	background: transparent;
+}
+
+.databaseBoardLaneTitleButton:hover {
+	background: color-mix(in srgb, var(--database-tone) 10%, transparent);
 }
 
 .databaseBoardLaneBody {
 	display: flex;
 	flex: 0 0 auto;
 	flex-direction: column;
-	gap: 12px;
-	padding: 8px 12px 12px;
+	gap: 8px;
+	padding: 4px 10px 12px;
 	min-height: auto;
 	overflow: visible;
 }
@@ -206,20 +241,20 @@
 	align-items: center;
 	justify-content: center;
 	gap: 6px;
-	min-height: 32px;
+	min-height: 30px;
 	width: 100%;
-	border: 1px dashed color-mix(in srgb, var(--database-tone) 24%, transparent);
+	border: 1px dashed color-mix(in srgb, var(--database-tone) 20%, transparent);
 	border-radius: var(--database-radius-md);
-	background: color-mix(in srgb, var(--bg-primary) 52%, transparent);
+	background: transparent;
 	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.9);
+	font-size: calc(var(--text-base) * 0.86);
 	font-weight: var(--font-medium);
 	cursor: pointer;
 }
 
 .databaseBoardAddCardButton:hover {
-	border-color: color-mix(in srgb, var(--database-tone) 38%, transparent);
-	background: color-mix(in srgb, var(--database-tone) 8%, var(--bg-primary));
+	border-color: color-mix(in srgb, var(--database-tone) 36%, transparent);
+	background: color-mix(in srgb, var(--database-tone) 7%, var(--bg-primary));
 	color: var(--text-primary);
 }
 
@@ -232,10 +267,11 @@
 	min-width: 0;
 	height: auto;
 	gap: 8px;
-	padding: 12px;
-	border: 1px solid color-mix(in srgb, var(--border-default) 68%, transparent);
+	padding: 11px 12px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 52%, transparent);
 	border-radius: var(--database-radius-md);
-	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
+	background: var(--bg-primary);
+	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 4%, transparent);
 	color: inherit;
 	cursor: pointer;
 	font: inherit;
@@ -247,6 +283,12 @@
 	user-select: none;
 	-webkit-user-select: none;
 	-webkit-user-drag: none;
+}
+
+.databaseBoardCard:hover {
+	border-color: color-mix(in srgb, var(--border-default) 72%, transparent);
+	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 5%, transparent),
+		0 4px 12px color-mix(in srgb, var(--text-primary) 6%, transparent);
 }
 
 /* Floating drag feedback: slight tilt, accent ring, soft lift (matches board mock).
@@ -292,13 +334,19 @@
 }
 
 .dark .databaseBoardCard {
-	background: color-mix(in srgb, var(--bg-primary) 84%, var(--bg-secondary));
+	background: color-mix(in srgb, var(--bg-primary) 90%, var(--bg-secondary));
+	box-shadow: 0 1px 2px color-mix(in srgb, black 18%, transparent);
+}
+
+.dark .databaseBoardCard:hover {
+	box-shadow: 0 1px 2px color-mix(in srgb, black 18%, transparent), 0 6px 16px
+		color-mix(in srgb, black 16%, transparent);
 }
 
 .dark .databaseBoardCard[data-state="selected"] {
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 7%,
+		var(--interactive-accent) 8%,
 		var(--bg-tertiary)
 	);
 }
@@ -306,18 +354,22 @@
 .databaseBoardCard[data-state="selected"] {
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 7%,
+		var(--interactive-accent) 6%,
 		var(--bg-primary)
 	);
-	border-color: color-mix(in srgb, var(--interactive-accent) 46%, transparent);
+	border-color: color-mix(in srgb, var(--interactive-accent) 42%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 12%, transparent), 0 1px 2px
+		color-mix(in srgb, var(--text-primary) 4%, transparent);
 }
 
 .databaseBoardCardTitle {
 	flex: 1 1 auto;
 	min-width: 0;
-	font-size: calc(var(--text-base) * 1.1);
+	font-size: calc(var(--text-base) * 1.02);
 	font-weight: var(--font-semibold);
-	line-height: 1.24;
+	line-height: 1.28;
+	letter-spacing: -0.01em;
 	color: var(--database-note-appearance-color, var(--text-primary));
 	overflow: hidden;
 	display: -webkit-box;
@@ -407,12 +459,12 @@
 
 .databaseBoardCardStatus.propertyValueText {
 	flex: 0 0 auto;
-	min-height: 24px;
-	padding: 0 8px;
-	border: 1px solid color-mix(in srgb, var(--border-default) 76%, transparent);
+	min-height: 22px;
+	padding: 0 7px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 58%, transparent);
 	border-radius: var(--pill-radius);
-	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
-	font-size: calc(var(--text-base) * 0.8);
+	background: color-mix(in srgb, var(--bg-secondary) 40%, var(--bg-primary));
+	font-size: calc(var(--text-base) * 0.76);
 	font-weight: var(--font-medium);
 	line-height: 1.2;
 }
@@ -431,15 +483,15 @@
 	gap: 3px;
 	max-width: 100%;
 	flex: 0 0 auto;
-	min-height: 24px;
-	padding: 0 8px;
-	border: 1px solid color-mix(in srgb, var(--border-default) 76%, transparent);
+	min-height: 22px;
+	padding: 0 7px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 58%, transparent);
 	border-radius: var(--pill-radius);
-	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
-	font-size: calc(var(--text-base) * 0.8);
+	background: color-mix(in srgb, var(--bg-secondary) 40%, var(--bg-primary));
+	font-size: calc(var(--text-base) * 0.76);
 	font-weight: var(--font-medium);
 	line-height: 1.2;
-	color: color-mix(in srgb, var(--database-tone) 58%, var(--text-primary));
+	color: color-mix(in srgb, var(--database-tone) 50%, var(--text-primary));
 	box-shadow: none;
 	white-space: nowrap;
 }
@@ -468,8 +520,14 @@
 	flex: 0 1 auto;
 	display: inline-flex;
 	align-items: center;
-	gap: 3px;
-	font-size: calc(var(--text-base) * 0.8);
+	gap: 4px;
+	min-height: 22px;
+	padding: 0 7px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 48%, transparent);
+	border-radius: var(--pill-radius);
+	background: color-mix(in srgb, var(--bg-secondary) 45%, var(--bg-primary));
+	font-size: calc(var(--text-base) * 0.76);
+	font-weight: var(--font-medium);
 	line-height: 1.2;
 	color: var(--text-tertiary);
 	overflow: hidden;

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -458,6 +458,7 @@
 	transition: background-color 120ms ease;
 	user-select: none;
 	-webkit-user-select: none;
+	background: var(--bg-primary);
 }
 
 .databaseRow:has(.databaseTagSuggestions),
@@ -466,19 +467,19 @@
 }
 
 .databaseRow:hover {
-	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+	background: color-mix(in srgb, var(--bg-hover) 55%, var(--bg-primary));
 }
 
 .databaseRow[data-state="selected"] {
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 8%,
+		var(--interactive-accent) 7%,
 		var(--bg-primary)
 	);
 }
 
 .databaseRow[data-state="selected"]:hover {
-	background: color-mix(in srgb, var(--interactive-accent) 12%, var(--bg-hover));
+	background: color-mix(in srgb, var(--interactive-accent) 11%, var(--bg-hover));
 }
 
 /* Floating list-row drag feedback: slight tilt + soft lift (list mock) */
@@ -486,7 +487,7 @@
 .databaseRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
 	opacity: 1;
 	cursor: grabbing;
-	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
+	background: var(--bg-primary);
 	border-color: color-mix(in srgb, var(--interactive-accent) 55%, transparent);
 	box-shadow: 0 0 0 1px
 		color-mix(in srgb, var(--interactive-accent) 22%, transparent), 0 2px 6px
@@ -499,11 +500,11 @@
 .databaseRow[data-drop-target="true"] {
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 10%,
+		var(--interactive-accent) 9%,
 		var(--bg-primary)
 	);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 34%, transparent);
+		color-mix(in srgb, var(--interactive-accent) 30%, transparent);
 }
 
 /* Faint stand-in left in the group while the row is lifted */
@@ -519,17 +520,17 @@
 .databaseGroupHeaderRow {
 	position: relative;
 	z-index: 0;
-	background: var(--bg-primary);
+	background: transparent;
 }
 
 .databaseGroupHeaderRow[data-drop-target="true"] .databaseGroupCell {
 	background: color-mix(
 		in srgb,
-		var(--interactive-accent) 12%,
-		var(--bg-primary)
+		var(--interactive-accent) 10%,
+		var(--bg-secondary)
 	);
 	box-shadow: inset 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+		color-mix(in srgb, var(--interactive-accent) 24%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -541,12 +542,13 @@
 
 .databaseGroupCell {
 	display: flex;
-	align-items: baseline;
-	gap: 6px;
+	align-items: center;
+	gap: 8px;
 	min-height: 34px;
-	padding: 10px 14px 6px;
-	background: color-mix(in srgb, var(--bg-secondary) 20%, var(--bg-primary));
+	padding: 8px 14px;
+	background: color-mix(in srgb, var(--bg-secondary) 55%, var(--bg-primary));
 	color: var(--text-secondary);
+	border-radius: var(--database-radius-md);
 }
 
 .databaseGroupAddButton {
@@ -555,16 +557,16 @@
 	align-items: center;
 	justify-content: center;
 	flex: 0 0 auto;
-	margin-left: auto;
-	width: 20px;
-	height: 20px;
+	width: 22px;
+	height: 22px;
 	border: none;
-	border-radius: var(--radius-sm);
+	border-radius: 999px;
 	background: transparent;
 	color: var(--text-tertiary);
 	cursor: pointer;
+	opacity: 0.7;
 	transition: color var(--transition-fast), background-color
-		var(--transition-fast);
+		var(--transition-fast), opacity var(--transition-fast);
 }
 
 .databaseGroupAddButton svg {
@@ -574,14 +576,14 @@
 }
 
 .databaseGroupAddButton:hover {
-	background: var(--bg-hover);
+	background: color-mix(in srgb, var(--bg-primary) 80%, transparent);
 	color: var(--text-primary);
+	opacity: 1;
 }
 
 .databaseTable .databaseGroupCell {
-	border-top: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
-	border-bottom: 1px solid
-		color-mix(in srgb, var(--border-light) 52%, transparent);
+	border-top: none;
+	border-bottom: none;
 }
 
 .databaseGroupLabel {
@@ -589,12 +591,29 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	color: var(--text-secondary);
-	font-size: var(--text-xs);
+	color: var(--text-primary);
+	font-size: calc(var(--text-base) * 0.88);
 	font-weight: var(--font-semibold);
-	letter-spacing: 0.02em;
-	line-height: 1.15;
+	letter-spacing: -0.01em;
+	line-height: 1.2;
 	text-transform: none;
+}
+
+.databaseGroupCount {
+	flex: 0 0 auto;
+	margin-left: auto;
+	min-width: 1.25em;
+	font-size: calc(var(--text-base) * 0.78);
+	font-weight: var(--font-medium);
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+	color: var(--text-tertiary);
+	text-align: right;
+}
+
+/* Soften row dividers so grouped lists feel more card-like */
+.databaseTable .databaseBodyCell {
+	border-top-color: color-mix(in srgb, var(--border-light) 36%, transparent);
 }
 
 .databaseLoadingState,
@@ -702,9 +721,9 @@
 }
 
 .databaseBoardLaneTitleGroup {
-	display: flex;
+	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	gap: 7px;
 	min-width: 0;
 	padding: 0;
 	border-radius: 0;
@@ -712,23 +731,23 @@
 }
 
 .databaseBoardLaneDot {
-	width: 13px;
-	height: 13px;
-	border-radius: 999px;
-	background: transparent;
-	border: 2px solid color-mix(in srgb, white 93%, var(--database-tone));
-	box-shadow: inset 0 0 0 1.5px
-		color-mix(in srgb, var(--database-tone) 78%, white);
 	flex: 0 0 auto;
-	opacity: 1;
+	width: 8px;
+	height: 8px;
+	border-radius: 999px;
+	background: var(--database-tone);
+	border: none;
+	box-shadow: none;
+	opacity: 0.9;
 }
 
 .databaseBoardLaneEmptyCard {
-	padding: 18px 12px;
-	border: 1px dashed color-mix(in srgb, var(--border-light) 72%, transparent);
-	border-radius: var(--radius-md);
-	background: color-mix(in srgb, var(--bg-primary) 72%, transparent);
-	font-size: var(--text-xs);
+	padding: 16px 12px;
+	border: 1px dashed color-mix(in srgb, var(--border-light) 62%, transparent);
+	border-radius: var(--database-radius-md);
+	background: color-mix(in srgb, var(--bg-primary) 55%, transparent);
+	font-size: calc(var(--text-base) * 0.82);
+	line-height: 1.35;
 	color: var(--text-tertiary);
 	text-align: center;
 }

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -482,18 +482,13 @@
 	background: color-mix(in srgb, var(--interactive-accent) 11%, var(--bg-hover));
 }
 
-/* Floating list-row drag feedback: slight tilt + soft lift (list mock) */
 .databaseRow[data-dragging="true"]:not([data-dnd-placeholder]),
 .databaseRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
-	opacity: 1;
 	cursor: grabbing;
 	background: var(--bg-primary);
-	border-color: color-mix(in srgb, var(--interactive-accent) 55%, transparent);
 	box-shadow: 0 0 0 1px
-		color-mix(in srgb, var(--interactive-accent) 22%, transparent), 0 2px 6px
-		color-mix(in srgb, var(--text-primary) 8%, transparent), 0 14px 32px
+		color-mix(in srgb, var(--interactive-accent) 22%, transparent), 0 12px 28px
 		color-mix(in srgb, var(--text-primary) 14%, transparent);
-	/* Composes with dnd-kit's `translate` (independent transform properties) */
 	rotate: 2.5deg;
 }
 
@@ -507,14 +502,11 @@
 		color-mix(in srgb, var(--interactive-accent) 30%, transparent);
 }
 
-/* Faint stand-in left in the group while the row is lifted */
 .databaseRow[data-dnd-placeholder] {
 	visibility: visible !important;
 	opacity: 0.3;
 	pointer-events: none;
 	box-shadow: none;
-	rotate: none;
-	cursor: default;
 }
 
 .databaseGroupHeaderRow {
@@ -611,7 +603,6 @@
 	text-align: right;
 }
 
-/* Soften row dividers so grouped lists feel more card-like */
 .databaseTable .databaseBodyCell {
 	border-top-color: color-mix(in srgb, var(--border-light) 36%, transparent);
 }

--- a/src/styles/app/47-database-table-dialogs.css
+++ b/src/styles/app/47-database-table-dialogs.css
@@ -456,6 +456,8 @@
 	z-index: 0;
 	cursor: default;
 	transition: background-color 120ms ease;
+	user-select: none;
+	-webkit-user-select: none;
 }
 
 .databaseRow:has(.databaseTagSuggestions),
@@ -479,10 +481,62 @@
 	background: color-mix(in srgb, var(--interactive-accent) 12%, var(--bg-hover));
 }
 
+/* Floating list-row drag feedback: slight tilt + soft lift (list mock) */
+.databaseRow[data-dragging="true"]:not([data-dnd-placeholder]),
+.databaseRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
+	opacity: 1;
+	cursor: grabbing;
+	background: color-mix(in srgb, var(--bg-primary) 96%, var(--bg-secondary));
+	border-color: color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 22%, transparent), 0 2px 6px
+		color-mix(in srgb, var(--text-primary) 8%, transparent), 0 14px 32px
+		color-mix(in srgb, var(--text-primary) 14%, transparent);
+	/* Composes with dnd-kit's `translate` (independent transform properties) */
+	rotate: 2.5deg;
+}
+
+.databaseRow[data-drop-target="true"] {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 10%,
+		var(--bg-primary)
+	);
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 34%, transparent);
+}
+
+/* Faint stand-in left in the group while the row is lifted */
+.databaseRow[data-dnd-placeholder] {
+	visibility: visible !important;
+	opacity: 0.3;
+	pointer-events: none;
+	box-shadow: none;
+	rotate: none;
+	cursor: default;
+}
+
 .databaseGroupHeaderRow {
 	position: relative;
 	z-index: 0;
 	background: var(--bg-primary);
+}
+
+.databaseGroupHeaderRow[data-drop-target="true"] .databaseGroupCell {
+	background: color-mix(
+		in srgb,
+		var(--interactive-accent) 12%,
+		var(--bg-primary)
+	);
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.databaseRow[data-dragging="true"]:not([data-dnd-placeholder]),
+	.databaseRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
+		rotate: none;
+	}
 }
 
 .databaseGroupCell {


### PR DESCRIPTION
Closes 


## Description

Polishes database Kanban and List (table) drag-and-drop so cards/rows feel closer to the product mock: slight tilt while dragging, soft lift shadows, faint placeholders, and quieter board/list chrome. Grouped list view can also reorder within groups and move rows across groups (persisting card order and updating the group property).

Review notes / summary:

- **Drag feedback** — Board cards and grouped table rows tilt, elevate, and leave a ghost stand-in; reduced-motion skips the tilt.
- **List DnD** — Grouped table rows are draggable between/within groups via dnd-kit; order saved through `board_card_order`; cross-group drops update the group cell value.
- **UI polish** — Softer lane/card surfaces, lane and group counts, refined headers/pills, improved Kanban “New” control (left-aligned + tone chip).
- **Subtraction pass** — Dropped dead branches, duplicate drag data keys, unstable empty-order object, and noisy CSS.

Reasoning: Existing board DnD worked but felt flat; list had no row DnD. Visual and interaction polish makes boards feel intentional without a redesign.

Additional context: `pnpm check`, `pnpm test` (331), `pnpm build`, and `cargo check` all passed.


## Screenshots

Visual changes (board + list while dragging):

- Dragged **board card**: ~3° tilt, accent ring, soft shadow, faint placeholder in the source lane.
- Dragged **list row**: ~2.5° tilt, elevated shadow, group headers/count chrome, calmer row dividers.
- Kanban **New** button: soft solid control with left-aligned label and small + chip.


## Docs

- Board drag styles: `src/styles/app/41-database-board.css` (`data-dragging` / `data-dnd-dragging` / placeholder).
- List drag styles: `src/styles/app/47-database-table-dialogs.css`.
- Table DnD views: `src/components/database/DatabaseTableViews.tsx` (`DatabaseTableDraggableRow`, `DatabaseTableGroupHeader`).
- Table wiring + order persistence: `DatabaseTable.tsx` + `DatabasesPane` `cardOrderByGroup` / `onCardOrderChange`.
- Card order storage reuses view `board_card_order` keyed by group column id.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished Kanban and grouped List drag-and-drop: better drag feedback and calmer UI, plus keyboard-friendly row DnD in grouped lists with order persistence and cross‑group moves that update the group field.

- **New Features**
  - Grouped List DnD using `@dnd-kit/react`/`@dnd-kit/dom`: drag within/across groups with pointer and keyboard; order persisted via `board_card_order` with optimistic updates and rollback; cross‑group drops update the group column; inline error shown on failure and clicks are suppressed briefly after drag.
  - Drag feedback: slight tilt, soft lift shadows, ghost placeholders, and drop‑target highlights for cards and rows; respects reduced motion.
  - Board/List UI: lane and group count badges, refined headers/pills, calmer surfaces, improved Kanban “New” button with icon chip.

- **Refactors**
  - Introduced `DatabaseTableViews` (`DatabaseTableDraggableRow`, `DatabaseTableGroupHeader`) and wired per‑group card order via `cardOrderByGroup` and `views.persistCardOrder` in `DatabasesPane`.
  - Removed dead branches, duplicate drag data keys, and noisy CSS; stabilized order handling.

<sup>Written for commit 119b05ec01b99dce3efac4c315c15ac5780a4b78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-and-drop reordering to grouped database table and board views
> - Grouped database table rows are now draggable within and across groups; dropping a row between groups updates the group field value via `onSaveCell` and persists order via `onCardOrderChange`.
> - Adds `DatabaseTableGroupHeader` and `DatabaseTableDraggableRow` components in [DatabaseTableViews.tsx](https://github.com/SidhuK/Glyph/pull/445/files#diff-3f8c49e6fdf95e3e9e138bad0d368cf86828ebad2b8c917c6efe52e7430f89ce) to handle droppable group headers and draggable rows with pointer/keyboard sensor support.
> - Optimistic ordering is applied immediately on drop and reverted with an error banner on failure.
> - Board lane headers now show a card count, and the 'Add note' button is restyled with a new icon and label.
> - Visual drag-and-drop states (rotation, shadows, drop-target highlights) are added in [41-database-board.css](https://github.com/SidhuK/Glyph/pull/445/files#diff-9550dfcf5469bfd4907fe6bfed86fea1b8eefbbd905eb9449c28bf6225827207) and [47-database-table-dialogs.css](https://github.com/SidhuK/Glyph/pull/445/files#diff-31f46ff76f48555b1d19692566468cc3ad018bf627d023c20e011bae79cf07f8).
> - Risk: clicks are suppressed briefly after a drag completes to prevent accidental row opens; row item IDs in grouped mode now use `groupId:rowId` format, which may affect any code that parses item IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 119b05e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorder cards within grouped database tables using drag and drop.
  * Added card counts to database board lane headers.
  * Added grouped table interactions for selecting, opening, and moving rows.
* **Accessibility**
  * Improved screen-reader labels and keyboard interactions for database controls and rows.
* **Style**
  * Refreshed database board and table visuals, including lane states, cards, group headers, drag states, hover effects, spacing, and dark-mode styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->