### PR TITLE
Batch repeated filesystem, indexing, and UI work

### DIFF
--- a/src-tauri/src/index/indexer.rs
+++ b/src-tauri/src/index/indexer.rs
@@ -141,7 +141,7 @@ pub fn index_note(space_root: &Path, note_id: &str, markdown: &str) -> Result<()
     index_note_with_conn(&conn, note_id, markdown, &file_path)
 }
 
-fn index_note_with_conn(
+pub(crate) fn index_note_with_conn(
     conn: &rusqlite::Connection,
     note_id: &str,
     markdown: &str,
@@ -303,6 +303,13 @@ fn refresh_indexed_timestamps_if_needed(
 
 pub fn remove_note(space_root: &Path, note_id: &str) -> Result<(), String> {
     let conn = open_db(space_root)?;
+    remove_note_with_conn(&conn, note_id)
+}
+
+pub(crate) fn remove_note_with_conn(
+    conn: &rusqlite::Connection,
+    note_id: &str,
+) -> Result<(), String> {
     let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM notes WHERE id = ?", [note_id])
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/index/mod.rs
+++ b/src-tauri/src/index/mod.rs
@@ -22,3 +22,4 @@ pub(crate) use indexer::people_mentions_as_tags_test_lock;
 pub use indexer::{
     index_note, people_mentions_as_tags_enabled, remove_note, set_people_mentions_as_tags_enabled,
 };
+pub(crate) use indexer::{index_note_with_conn, remove_note_with_conn};

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -17,6 +17,7 @@ struct ExternalChangeEvent {
 }
 
 const DEBOUNCE_MS: u64 = 100;
+const INDEX_OPEN_RETRY_MS: u64 = 1_000;
 
 pub fn create_notes_watcher(
     app: tauri::AppHandle,
@@ -32,9 +33,14 @@ pub fn create_notes_watcher(
     let index_space_path = root.to_string_lossy().to_string();
     std::thread::spawn(move || {
         let debounce = std::time::Duration::from_millis(DEBOUNCE_MS);
-        while let Ok(first) = idx_rx.recv() {
-            let mut pending = HashMap::new();
-            pending.insert(first.0, first.1);
+        let mut pending = HashMap::new();
+        loop {
+            if pending.is_empty() {
+                let Ok((rel, remove)) = idx_rx.recv() else {
+                    return;
+                };
+                pending.insert(rel, remove);
+            }
 
             let deadline = std::time::Instant::now() + debounce;
             loop {
@@ -47,19 +53,20 @@ pub fn create_notes_watcher(
                         pending.insert(rel, remove);
                     }
                     Err(std_mpsc::RecvTimeoutError::Timeout) => break,
-                    Err(std_mpsc::RecvTimeoutError::Disconnected) => return,
+                    Err(std_mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             }
 
-            let mut events = Vec::new();
             let conn = match index::open_db(&root_idx) {
                 Ok(conn) => conn,
                 Err(error) => {
                     tracing::warn!(%error, "could not open note index for watcher batch");
+                    std::thread::sleep(std::time::Duration::from_millis(INDEX_OPEN_RETRY_MS));
                     continue;
                 }
             };
-            for (rel_s, is_remove) in pending {
+            let mut events = Vec::new();
+            for (rel_s, is_remove) in std::mem::take(&mut pending) {
                 let result = if is_remove {
                     index::remove_note_with_conn(&conn, &rel_s)
                 } else {

--- a/src-tauri/src/space/watcher.rs
+++ b/src-tauri/src/space/watcher.rs
@@ -52,16 +52,23 @@ pub fn create_notes_watcher(
             }
 
             let mut events = Vec::new();
+            let conn = match index::open_db(&root_idx) {
+                Ok(conn) => conn,
+                Err(error) => {
+                    tracing::warn!(%error, "could not open note index for watcher batch");
+                    continue;
+                }
+            };
             for (rel_s, is_remove) in pending {
                 let result = if is_remove {
-                    index::remove_note(&root_idx, &rel_s)
+                    index::remove_note_with_conn(&conn, &rel_s)
                 } else {
                     let abs = match paths::join_under(&root_idx, Path::new(&rel_s)) {
                         Ok(abs) => abs,
                         Err(_) => continue,
                     };
                     if let Ok(markdown) = std::fs::read_to_string(&abs) {
-                        index::index_note(&root_idx, &rel_s, &markdown)
+                        index::index_note_with_conn(&conn, &rel_s, &markdown, &abs)
                     } else {
                         continue;
                     }

--- a/src-tauri/src/space_fs/list.rs
+++ b/src-tauri/src/space_fs/list.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::VecDeque,
+    path::{Path, PathBuf},
+};
 use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState, utils};
@@ -243,15 +246,34 @@ pub async fn space_list_dir(
         deny_hidden_rel_path(&start_rel)?;
         let start_abs = paths::join_under(&root, &start_rel)?;
         let mut entries: Vec<FsEntry> = Vec::new();
-        let mut stack = vec![(start_rel, start_abs)];
-        while let Some((rel, abs)) = stack.pop() {
-            for entry in std::fs::read_dir(&abs).map_err(|e| e.to_string())? {
-                let entry = entry.map_err(|e| e.to_string())?;
+        let mut queue = VecDeque::from([(start_rel, start_abs)]);
+        let mut is_start = true;
+        while let Some((rel, abs)) = queue.pop_front() {
+            let dir_entries = match std::fs::read_dir(&abs) {
+                Ok(entries) => entries,
+                Err(error) if is_start => return Err(error.to_string()),
+                Err(_) => continue,
+            };
+            is_start = false;
+            for entry in dir_entries {
+                let Ok(entry) = entry else {
+                    continue;
+                };
                 let name = entry.file_name().to_string_lossy().to_string();
                 if should_hide(&name) {
                     continue;
                 }
-                let meta = entry.metadata().map_err(|e| e.to_string())?;
+                if recursive {
+                    let Ok(file_type) = entry.file_type() else {
+                        continue;
+                    };
+                    if file_type.is_symlink() {
+                        continue;
+                    }
+                }
+                let Ok(meta) = entry.metadata() else {
+                    continue;
+                };
                 let kind = if meta.is_dir() {
                     "dir"
                 } else if meta.is_file() {
@@ -261,7 +283,7 @@ pub async fn space_list_dir(
                 };
                 let rel_path = rel.join(&name);
                 if recursive && kind == "dir" {
-                    stack.push((rel_path.clone(), entry.path()));
+                    queue.push_back((rel_path.clone(), entry.path()));
                 }
                 if directories_only && kind != "dir" {
                     continue;

--- a/src-tauri/src/space_fs/list.rs
+++ b/src-tauri/src/space_fs/list.rs
@@ -218,53 +218,83 @@ pub async fn space_list_non_markdown_files(
     .map_err(|e| e.to_string())?
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "snake_case")]
 pub async fn space_list_dir(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
     dir: Option<String>,
+    recursive: Option<bool>,
+    directories_only: Option<bool>,
+    limit: Option<u32>,
 ) -> Result<Vec<FsEntry>, String> {
     let root = state.root_for_window(&window)?;
     let dir = dir.unwrap_or_default();
+    let recursive = recursive.unwrap_or(false);
+    let directories_only = directories_only.unwrap_or(false);
+    let limit = limit
+        .map(|value| value.clamp(1, 50_000) as usize)
+        .unwrap_or(if recursive { 5_000 } else { usize::MAX });
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<FsEntry>, String> {
-        let rel = if dir.trim().is_empty() {
+        let start_rel = if dir.trim().is_empty() {
             PathBuf::new()
         } else {
             PathBuf::from(&dir)
         };
-        deny_hidden_rel_path(&rel)?;
-        let abs = paths::join_under(&root, &rel)?;
+        deny_hidden_rel_path(&start_rel)?;
+        let start_abs = paths::join_under(&root, &start_rel)?;
         let mut entries: Vec<FsEntry> = Vec::new();
-        for entry in std::fs::read_dir(&abs).map_err(|e| e.to_string())? {
-            let entry = entry.map_err(|e| e.to_string())?;
-            let name_os = entry.file_name();
-            let name = name_os.to_string_lossy().to_string();
-            if should_hide(&name) {
-                continue;
+        let mut stack = vec![(start_rel, start_abs)];
+        while let Some((rel, abs)) = stack.pop() {
+            for entry in std::fs::read_dir(&abs).map_err(|e| e.to_string())? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                let name = entry.file_name().to_string_lossy().to_string();
+                if should_hide(&name) {
+                    continue;
+                }
+                let meta = entry.metadata().map_err(|e| e.to_string())?;
+                let kind = if meta.is_dir() {
+                    "dir"
+                } else if meta.is_file() {
+                    "file"
+                } else {
+                    continue;
+                };
+                let rel_path = rel.join(&name);
+                if recursive && kind == "dir" {
+                    stack.push((rel_path.clone(), entry.path()));
+                }
+                if directories_only && kind != "dir" {
+                    continue;
+                }
+                let is_markdown = utils::is_markdown_path(&rel_path);
+                let (created, updated) = metadata_timestamps(&meta);
+                entries.push(FsEntry {
+                    name,
+                    rel_path: rel_path.to_string_lossy().to_string(),
+                    kind: kind.to_string(),
+                    is_markdown,
+                    created,
+                    updated,
+                });
+                if entries.len() >= limit {
+                    break;
+                }
             }
-            let meta = entry.metadata().map_err(|e| e.to_string())?;
-            let kind = if meta.is_dir() {
-                "dir"
-            } else if meta.is_file() {
-                "file"
-            } else {
-                continue;
-            };
-            let rel_path = rel.join(&name);
-            let is_markdown = utils::is_markdown_path(&rel_path);
-            let (created, updated) = metadata_timestamps(&meta);
-            entries.push(FsEntry {
-                name,
-                rel_path: rel_path.to_string_lossy().to_string(),
-                kind: kind.to_string(),
-                is_markdown,
-                created,
-                updated,
-            });
+            if !recursive || entries.len() >= limit {
+                break;
+            }
         }
 
-        entries
-            .sort_by_cached_key(|e| (if e.kind == "dir" { 0u8 } else { 1 }, e.name.to_lowercase()));
+        entries.sort_by_cached_key(|entry| {
+            (
+                if entry.kind == "dir" { 0u8 } else { 1 },
+                if recursive {
+                    entry.rel_path.to_lowercase()
+                } else {
+                    entry.name.to_lowercase()
+                },
+            )
+        });
 
         Ok(entries)
     })

--- a/src-tauri/src/space_fs/summary.rs
+++ b/src-tauri/src/space_fs/summary.rs
@@ -1,161 +1,146 @@
-use std::{cmp::Reverse, collections::BinaryHeap, ffi::OsStr, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState};
 
-use super::helpers::{deny_hidden_rel_path, file_mtime_ms, should_hide};
-use super::types::{DirChildSummary, RecentMarkdown};
+use super::helpers::{deny_hidden_rel_path, should_hide};
+use super::types::DirChildSummary;
+
+const MAX_SCAN_FILES: usize = 200_000;
+const MAX_SUMMARY_PARENTS: usize = 5_000;
+
+struct SummaryAccumulator {
+    summary: DirChildSummary,
+    scanned_files: usize,
+}
+
+impl SummaryAccumulator {
+    fn new(dir_rel_path: &Path, name: String) -> Self {
+        Self {
+            summary: DirChildSummary {
+                dir_rel_path: dir_rel_path.to_string_lossy().to_string(),
+                name,
+                total_files_recursive: 0,
+                total_markdown_recursive: 0,
+                truncated: false,
+            },
+            scanned_files: 0,
+        }
+    }
+
+    fn record_file(&mut self, rel_path: &Path) {
+        if self.summary.truncated {
+            return;
+        }
+
+        self.summary.total_files_recursive = self.summary.total_files_recursive.saturating_add(1);
+        self.scanned_files += 1;
+        if self.scanned_files >= MAX_SCAN_FILES {
+            self.summary.truncated = true;
+            return;
+        }
+        if rel_path.extension() != Some(OsStr::new("md")) {
+            return;
+        }
+
+        self.summary.total_markdown_recursive =
+            self.summary.total_markdown_recursive.saturating_add(1);
+    }
+}
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn space_dir_children_summary(
     window: WebviewWindow,
     state: State<'_, SpaceState>,
-    dir: Option<String>,
-    preview_limit: Option<u32>,
+    dirs: Vec<String>,
 ) -> Result<Vec<DirChildSummary>, String> {
-    const MAX_PREVIEW_LIMIT: usize = 20;
-    const MAX_SCAN_FILES: usize = 200_000;
-
     let root = state.root_for_window(&window)?;
-    let dir = dir.unwrap_or_default();
-    let limit = preview_limit
-        .unwrap_or(5)
-        .max(1)
-        .min(MAX_PREVIEW_LIMIT as u32) as usize;
 
     tauri::async_runtime::spawn_blocking(move || -> Result<Vec<DirChildSummary>, String> {
-        let start_rel = if dir.trim().is_empty() {
-            PathBuf::new()
-        } else {
-            PathBuf::from(&dir)
-        };
-        deny_hidden_rel_path(&start_rel)?;
-        let start_abs = paths::join_under(&root, &start_rel)?;
-        if !start_abs.exists() {
-            return Ok(Vec::new());
+        if dirs.len() > MAX_SUMMARY_PARENTS {
+            return Err(format!(
+                "Too many folder summary parents (maximum {MAX_SUMMARY_PARENTS})"
+            ));
         }
 
-        let mut out: Vec<DirChildSummary> = Vec::new();
-
-        let entries = std::fs::read_dir(&start_abs).map_err(|e| e.to_string())?;
-        for entry in entries {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
+        let mut requested_parents = HashSet::new();
+        for dir in dirs {
+            let rel = if dir.trim().is_empty() {
+                PathBuf::new()
+            } else {
+                PathBuf::from(dir)
             };
-            let name = entry.file_name().to_string_lossy().to_string();
-            if should_hide(&name) {
-                continue;
-            }
-            let meta = match entry.metadata() {
-                Ok(m) => m,
-                Err(_) => continue,
-            };
-            if !meta.is_dir() {
-                continue;
-            }
-
-            let child_rel = start_rel.join(&name);
-            deny_hidden_rel_path(&child_rel)?;
-
-            let mut total_files: u32 = 0;
-            let mut total_markdown: u32 = 0;
-            let mut truncated = false;
-            let mut scanned_files: usize = 0;
-
-            let mut heap: BinaryHeap<Reverse<(u64, String, String)>> = BinaryHeap::new();
-
-            let mut stack: Vec<PathBuf> = vec![child_rel.clone()];
-            while let Some(rel_dir) = stack.pop() {
-                let abs_dir = match paths::join_under(&root, &rel_dir) {
-                    Ok(p) => p,
-                    Err(_) => continue,
-                };
-                let dir_entries = match std::fs::read_dir(&abs_dir) {
-                    Ok(e) => e,
-                    Err(_) => continue,
-                };
-
-                for e in dir_entries {
-                    let e = match e {
-                        Ok(x) => x,
-                        Err(_) => continue,
-                    };
-                    let child_name = e.file_name().to_string_lossy().to_string();
-                    if should_hide(&child_name) {
-                        continue;
-                    }
-                    let m = match e.metadata() {
-                        Ok(m) => m,
-                        Err(_) => continue,
-                    };
-                    let child_rel2 = rel_dir.join(&child_name);
-
-                    if m.is_dir() {
-                        stack.push(child_rel2);
-                        continue;
-                    }
-                    if !m.is_file() {
-                        continue;
-                    }
-
-                    total_files = total_files.saturating_add(1);
-                    scanned_files += 1;
-                    if scanned_files >= MAX_SCAN_FILES {
-                        truncated = true;
-                        break;
-                    }
-
-                    if child_rel2.extension() == Some(OsStr::new("md")) {
-                        total_markdown = total_markdown.saturating_add(1);
-                        let abs_file = match paths::join_under(&root, &child_rel2) {
-                            Ok(p) => p,
-                            Err(_) => continue,
-                        };
-                        let mtime = file_mtime_ms(&abs_file);
-                        let rel_s = child_rel2.to_string_lossy().to_string();
-                        let item = (mtime, rel_s, child_name);
-                        if heap.len() < limit {
-                            heap.push(Reverse(item));
-                        } else if let Some(Reverse((min_mtime, _, _))) = heap.peek() {
-                            if mtime > *min_mtime {
-                                let _ = heap.pop();
-                                heap.push(Reverse(item));
-                            }
-                        }
-                    }
-                }
-
-                if truncated {
-                    break;
-                }
-            }
-
-            let mut recent: Vec<RecentMarkdown> = heap
-                .into_iter()
-                .map(|Reverse((mtime_ms, rel_path, file_name))| RecentMarkdown {
-                    rel_path,
-                    name: file_name,
-                    mtime_ms,
-                })
-                .collect();
-            recent.sort_by(|a, b| {
-                b.mtime_ms
-                    .cmp(&a.mtime_ms)
-                    .then_with(|| a.rel_path.to_lowercase().cmp(&b.rel_path.to_lowercase()))
-            });
-
-            out.push(DirChildSummary {
-                dir_rel_path: child_rel.to_string_lossy().to_string(),
-                name,
-                total_files_recursive: total_files,
-                total_markdown_recursive: total_markdown,
-                recent_markdown: recent,
-                truncated,
-            });
+            deny_hidden_rel_path(&rel)?;
+            requested_parents.insert(rel);
         }
 
-        out.sort_by_cached_key(|e| e.name.to_lowercase());
+        let traversal_roots: Vec<PathBuf> = requested_parents
+            .iter()
+            .filter(|path| {
+                !path
+                    .ancestors()
+                    .skip(1)
+                    .any(|ancestor| requested_parents.contains(ancestor))
+            })
+            .cloned()
+            .collect();
+        let mut summaries = HashMap::new();
+        let mut stack = traversal_roots;
+        while let Some(rel_dir) = stack.pop() {
+            let abs_dir = match paths::join_under(&root, &rel_dir) {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+            let entries = match std::fs::read_dir(abs_dir) {
+                Ok(entries) => entries,
+                Err(_) => continue,
+            };
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(_) => continue,
+                };
+                let name = entry.file_name().to_string_lossy().to_string();
+                if should_hide(&name) {
+                    continue;
+                }
+                let metadata = match entry.metadata() {
+                    Ok(metadata) => metadata,
+                    Err(_) => continue,
+                };
+                let child_rel = rel_dir.join(&name);
+                if metadata.is_dir() {
+                    if requested_parents.contains(&rel_dir) {
+                        summaries
+                            .entry(child_rel.clone())
+                            .or_insert_with(|| SummaryAccumulator::new(&child_rel, name));
+                    }
+                    stack.push(child_rel);
+                    continue;
+                }
+                if !metadata.is_file() {
+                    continue;
+                }
+
+                let mut ancestor = child_rel.parent();
+                while let Some(dir) = ancestor {
+                    if let Some(summary) = summaries.get_mut(dir) {
+                        summary.record_file(&child_rel);
+                    }
+                    ancestor = dir.parent();
+                }
+            }
+        }
+
+        let mut out: Vec<DirChildSummary> = summaries
+            .into_values()
+            .map(|accumulator| accumulator.summary)
+            .collect();
+        out.sort_by_cached_key(|summary| summary.dir_rel_path.to_lowercase());
         Ok(out)
     })
     .await

--- a/src-tauri/src/space_fs/summary.rs
+++ b/src-tauri/src/space_fs/summary.rs
@@ -1,21 +1,19 @@
 use std::{
-    collections::{HashMap, HashSet},
-    ffi::OsStr,
+    collections::{HashMap, HashSet, VecDeque},
     path::{Path, PathBuf},
 };
 use tauri::{State, WebviewWindow};
 
-use crate::{paths, space::SpaceState};
+use crate::{paths, space::SpaceState, utils};
 
 use super::helpers::{deny_hidden_rel_path, should_hide};
 use super::types::DirChildSummary;
 
-const MAX_SCAN_FILES: usize = 200_000;
+const MAX_SCAN_ENTRIES: usize = 200_000;
 const MAX_SUMMARY_PARENTS: usize = 5_000;
 
 struct SummaryAccumulator {
     summary: DirChildSummary,
-    scanned_files: usize,
 }
 
 impl SummaryAccumulator {
@@ -28,27 +26,15 @@ impl SummaryAccumulator {
                 total_markdown_recursive: 0,
                 truncated: false,
             },
-            scanned_files: 0,
         }
     }
 
     fn record_file(&mut self, rel_path: &Path) {
-        if self.summary.truncated {
-            return;
-        }
-
         self.summary.total_files_recursive = self.summary.total_files_recursive.saturating_add(1);
-        self.scanned_files += 1;
-        if self.scanned_files >= MAX_SCAN_FILES {
-            self.summary.truncated = true;
-            return;
+        if utils::is_markdown_path(rel_path) {
+            self.summary.total_markdown_recursive =
+                self.summary.total_markdown_recursive.saturating_add(1);
         }
-        if rel_path.extension() != Some(OsStr::new("md")) {
-            return;
-        }
-
-        self.summary.total_markdown_recursive =
-            self.summary.total_markdown_recursive.saturating_add(1);
     }
 }
 
@@ -89,8 +75,10 @@ pub async fn space_dir_children_summary(
             .cloned()
             .collect();
         let mut summaries = HashMap::new();
-        let mut stack = traversal_roots;
-        while let Some(rel_dir) = stack.pop() {
+        let mut queue = VecDeque::from(traversal_roots);
+        let mut scanned_entries = 0;
+        let mut truncated = false;
+        'traversal: while let Some(rel_dir) = queue.pop_front() {
             let abs_dir = match paths::join_under(&root, &rel_dir) {
                 Ok(path) => path,
                 Err(_) => continue,
@@ -100,12 +88,23 @@ pub async fn space_dir_children_summary(
                 Err(_) => continue,
             };
             for entry in entries {
+                if scanned_entries >= MAX_SCAN_ENTRIES {
+                    truncated = true;
+                    break 'traversal;
+                }
+                scanned_entries += 1;
                 let entry = match entry {
                     Ok(entry) => entry,
                     Err(_) => continue,
                 };
                 let name = entry.file_name().to_string_lossy().to_string();
                 if should_hide(&name) {
+                    continue;
+                }
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if file_type.is_symlink() {
                     continue;
                 }
                 let metadata = match entry.metadata() {
@@ -119,7 +118,7 @@ pub async fn space_dir_children_summary(
                             .entry(child_rel.clone())
                             .or_insert_with(|| SummaryAccumulator::new(&child_rel, name));
                     }
-                    stack.push(child_rel);
+                    queue.push_back(child_rel);
                     continue;
                 }
                 if !metadata.is_file() {
@@ -133,6 +132,11 @@ pub async fn space_dir_children_summary(
                     }
                     ancestor = dir.parent();
                 }
+            }
+        }
+        if truncated {
+            for accumulator in summaries.values_mut() {
+                accumulator.summary.truncated = true;
             }
         }
 

--- a/src-tauri/src/space_fs/types.rs
+++ b/src-tauri/src/space_fs/types.rs
@@ -36,20 +36,12 @@ pub struct OpenOrCreateTextResult {
     pub mtime_ms: u64,
 }
 
-#[derive(Serialize, Clone)]
-pub struct RecentMarkdown {
-    pub rel_path: String,
-    pub name: String,
-    pub mtime_ms: u64,
-}
-
 #[derive(Serialize)]
 pub struct DirChildSummary {
     pub dir_rel_path: String,
     pub name: String,
     pub total_files_recursive: u32,
     pub total_markdown_recursive: u32,
-    pub recent_markdown: Vec<RecentMarkdown>,
     pub truncated: bool,
 }
 

--- a/src/components/ai/hooks/useAiToolEvents.ts
+++ b/src/components/ai/hooks/useAiToolEvents.ts
@@ -209,6 +209,8 @@ export function useAiToolEvents({
 	const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
 	const activeToolJobIdRef = useRef<string | null>(null);
 	const slowStartTimerRef = useRef<number | null>(null);
+	const pendingChunkRef = useRef("");
+	const chunkFrameRef = useRef<number | null>(null);
 
 	const clearSlowStartTimer = useCallback(() => {
 		if (slowStartTimerRef.current == null) return;
@@ -216,15 +218,35 @@ export function useAiToolEvents({
 		slowStartTimerRef.current = null;
 	}, []);
 
+	const clearPendingChunk = useCallback(() => {
+		if (chunkFrameRef.current !== null) {
+			window.cancelAnimationFrame(chunkFrameRef.current);
+		}
+		chunkFrameRef.current = null;
+		pendingChunkRef.current = "";
+	}, []);
+
+	const flushPendingChunk = useCallback(() => {
+		const delta = pendingChunkRef.current;
+		clearPendingChunk();
+		if (!delta) return;
+		dispatch({
+			type: "record-chunk",
+			delta,
+			at: Date.now(),
+		});
+	}, [clearPendingChunk]);
+
 	const isAwaitingResponse =
 		chatStatus === "submitted" || chatStatus === "streaming";
 
 	useEffect(() => {
 		if (isChatMode || chatStatus !== "streaming") {
+			flushPendingChunk();
 			activeToolJobIdRef.current = null;
 		}
 		dispatch({ type: "sync-context", chatStatus, isChatMode });
-	}, [chatStatus, isChatMode]);
+	}, [chatStatus, flushPendingChunk, isChatMode]);
 
 	useTauriEvent("ai:tool", (payload) => {
 		if (isChatMode) return;
@@ -270,11 +292,10 @@ export function useAiToolEvents({
 			activeToolJobIdRef.current = payload.job_id;
 		}
 		if (!payload.delta) return;
-		dispatch({
-			type: "record-chunk",
-			delta: payload.delta,
-			at: Date.now(),
-		});
+		pendingChunkRef.current += payload.delta;
+		if (chunkFrameRef.current === null) {
+			chunkFrameRef.current = window.requestAnimationFrame(flushPendingChunk);
+		}
 	});
 
 	const phaseStatusText = useMemo(() => {
@@ -323,15 +344,17 @@ export function useAiToolEvents({
 	useEffect(
 		() => () => {
 			clearSlowStartTimer();
+			clearPendingChunk();
 		},
-		[clearSlowStartTimer],
+		[clearPendingChunk, clearSlowStartTimer],
 	);
 
 	const resetToolState = useCallback(() => {
 		clearSlowStartTimer();
+		clearPendingChunk();
 		dispatch({ type: "reset-tool-state" });
 		activeToolJobIdRef.current = null;
-	}, [clearSlowStartTimer]);
+	}, [clearPendingChunk, clearSlowStartTimer]);
 
 	const setResponsePhase = useCallback((responsePhase: ResponsePhase) => {
 		dispatch({ type: "set-response-phase", responsePhase });
@@ -339,9 +362,10 @@ export function useAiToolEvents({
 
 	const setActivityTimeline = useCallback(
 		(activityTimeline: AIActivityTimelineEvent[]) => {
+			clearPendingChunk();
 			dispatch({ type: "set-activity-timeline", activityTimeline });
 		},
-		[],
+		[clearPendingChunk],
 	);
 
 	return {

--- a/src/components/ai/hooks/useAiToolEvents.ts
+++ b/src/components/ai/hooks/useAiToolEvents.ts
@@ -259,6 +259,7 @@ export function useAiToolEvents({
 		if (!activeToolJobIdRef.current) {
 			activeToolJobIdRef.current = payload.job_id;
 		}
+		flushPendingChunk();
 		const tool = payload.tool?.trim() || "tool";
 		const phase: ToolPhase =
 			payload.phase === "call" ||

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -72,15 +72,15 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	const awaitingStartRef = useRef(false);
 	const stopListenersRef = useRef<Array<() => void>>([]);
 	const doneTimerRef = useRef<number | null>(null);
+	const flushStreamingRef = useRef<(() => void) | null>(null);
 	const onComplete = options.onComplete;
 
 	const updateMessages = useCallback(
 		(next: UIMessage[] | ((prev: UIMessage[]) => UIMessage[])) => {
-			setMessages((prev) => {
-				const resolved = typeof next === "function" ? next(prev) : next;
-				messagesRef.current = resolved;
-				return resolved;
-			});
+			const resolved =
+				typeof next === "function" ? next(messagesRef.current) : next;
+			messagesRef.current = resolved;
+			setMessages(resolved);
 		},
 		[],
 	);
@@ -99,6 +99,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	}, []);
 
 	const completeActiveJob = useCallback(() => {
+		flushStreamingRef.current?.();
+		flushStreamingRef.current = null;
 		clearDoneTimer();
 		activeJobIdRef.current = null;
 		awaitingStartRef.current = false;
@@ -117,6 +119,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 		if (jobId) {
 			void invoke("ai_chat_cancel", { job_id: jobId }).catch(() => {});
 		}
+		flushStreamingRef.current?.();
+		flushStreamingRef.current = null;
 		clearDoneTimer();
 		activeJobIdRef.current = null;
 		awaitingStartRef.current = false;
@@ -179,31 +183,52 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				const pendingChunks: ChunkPayload[] = [];
 				let pendingDone: DonePayload | null = null;
 				let pendingError: ErrorPayload | null = null;
+				let pendingDelta = "";
+				let chunkFrame: number | null = null;
+				let streamingStarted = false;
 				const shouldBufferEvent = (jobId: string) =>
 					awaitingStartRef.current && !activeJobIdRef.current && !!jobId;
 				const isActiveJob = (jobId: string) => jobId === activeJobIdRef.current;
-				const handleChunk = (payload: ChunkPayload) => {
-					if (!isActiveJob(payload.job_id)) return;
-					clearDoneTimer();
-					setStatus("streaming");
+				const flushChunks = () => {
+					if (chunkFrame !== null) {
+						window.cancelAnimationFrame(chunkFrame);
+						chunkFrame = null;
+					}
+					if (!pendingDelta) return;
+					const delta = pendingDelta;
+					pendingDelta = "";
 					updateMessages((prev) =>
-						prev.map((m) => {
-							if (m.id !== assistantId) return m;
-							const first = m.parts[0];
+						prev.map((message) => {
+							if (message.id !== assistantId) return message;
+							const first = message.parts[0];
 							return {
-								...m,
+								...message,
 								parts: [
 									{
 										type: "text",
-										text: `${first?.text ?? ""}${payload.delta}`,
+										text: `${first?.text ?? ""}${delta}`,
 									},
 								],
 							};
 						}),
 					);
 				};
+				flushStreamingRef.current = flushChunks;
+				const handleChunk = (payload: ChunkPayload) => {
+					if (!isActiveJob(payload.job_id)) return;
+					clearDoneTimer();
+					if (!streamingStarted) {
+						streamingStarted = true;
+						setStatus("streaming");
+					}
+					pendingDelta += payload.delta;
+					if (chunkFrame === null) {
+						chunkFrame = window.requestAnimationFrame(flushChunks);
+					}
+				};
 				const handleDone = (payload: DonePayload) => {
 					if (!isActiveJob(payload.job_id)) return;
+					flushChunks();
 					awaitingStartRef.current = false;
 					clearDoneTimer();
 					doneTimerRef.current = window.setTimeout(() => {
@@ -213,6 +238,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				};
 				const handleError = (payload: ErrorPayload) => {
 					if (!isActiveJob(payload.job_id)) return;
+					flushChunks();
+					flushStreamingRef.current = null;
 					clearDoneTimer();
 					activeJobIdRef.current = null;
 					awaitingStartRef.current = false;
@@ -245,7 +272,18 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					handleError(payload);
 				});
 
-				stopListenersRef.current = [onChunk, onDone, onError];
+				stopListenersRef.current = [
+					onChunk,
+					onDone,
+					onError,
+					() => {
+						if (chunkFrame !== null) {
+							window.cancelAnimationFrame(chunkFrame);
+							chunkFrame = null;
+						}
+						pendingDelta = "";
+					},
+				];
 
 				const { job_id: jobId } = await invoke("ai_chat_start", {
 					request: {
@@ -270,6 +308,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					handleDone(pendingDone);
 				}
 			} catch (err) {
+				flushStreamingRef.current = null;
 				clearDoneTimer();
 				activeJobIdRef.current = null;
 				awaitingStartRef.current = false;

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -47,7 +47,7 @@ import {
 	invalidateAllDocsPrefetch,
 	invalidateDatabaseRowsPrefetch,
 	invalidatePrefetchedNote,
-	invalidateTaskSummariesPrefetchForNote,
+	invalidateTaskSummariesPrefetchForNotes,
 	prefetchAllDocs,
 	prefetchDatabasesLanding,
 	prefetchNote,
@@ -103,6 +103,8 @@ const LazyCommandPalette = lazy(loadCommandPalette);
 const SIDEBAR_MIN_WIDTH = 220;
 const SIDEBAR_MAX_WIDTH = 600;
 const SIDEBAR_AUTO_COLLAPSE_WIDTH = 760;
+const FILE_TREE_REFRESH_BATCH_MS = 150;
+const NOTE_INVALIDATION_BATCH_MS = 50;
 const GIT_SYNC_ERROR_TOAST_ID = "glyph-git-sync-error";
 
 function showGitSyncErrorToast(message: string) {
@@ -718,6 +720,8 @@ export function AppShell() {
 
 	const fsRefreshQueueRef = useRef<Set<string>>(new Set());
 	const fsRefreshTimerRef = useRef<number | null>(null);
+	const noteInvalidationQueueRef = useRef<Map<string, boolean>>(new Map());
+	const noteInvalidationTimerRef = useRef<number | null>(null);
 	const moveTargetDirsRequestIdRef = useRef(0);
 
 	const openPalette = useCallback(
@@ -740,23 +744,18 @@ export function AppShell() {
 		const requestId = ++moveTargetDirsRequestIdRef.current;
 		setMoveTargetDirs([]);
 		try {
-			const out: string[] = [];
-			const seen = new Set<string>([""]);
-			const queue: string[] = [""];
-			while (queue.length > 0 && out.length < 5000) {
-				const dir = queue.shift() ?? "";
-				const entries = await invoke("space_list_dir", dir ? { dir } : {});
-				for (const entry of entries) {
-					if (entry.kind !== "dir" || seen.has(entry.rel_path)) continue;
-					seen.add(entry.rel_path);
-					out.push(entry.rel_path);
-					queue.push(entry.rel_path);
-				}
-			}
+			const entries = await invoke("space_list_dir", {
+				recursive: true,
+				directories_only: true,
+				limit: 5000,
+			});
 			if (moveTargetDirsRequestIdRef.current !== requestId) return;
 			const fromDir = parentDir(sourcePath);
 			setMoveTargetDirs(
-				out.filter((d) => d !== fromDir).sort((a, b) => a.localeCompare(b)),
+				entries
+					.map((entry) => entry.rel_path)
+					.filter((dir) => dir !== fromDir)
+					.sort((left, right) => left.localeCompare(right)),
 			);
 		} catch {
 			if (moveTargetDirsRequestIdRef.current === requestId) {
@@ -897,7 +896,7 @@ export function AppShell() {
 					if (expandedDirs.has(rel)) dirs.add(rel);
 				}
 				for (const dir of dirs) void fileTree.loadDir(dir, true);
-			}, 150);
+			}, FILE_TREE_REFRESH_BATCH_MS);
 		},
 		[expandedDirs, fileTree.loadDir, spacePath],
 	);
@@ -905,20 +904,29 @@ export function AppShell() {
 	useTauriEvent("space:fs_changed", handleSpaceFsChanged);
 	useTauriEvent("notes:external_changed", (payload) => {
 		const relPath = normalizeRelPath(payload.rel_path);
-		invalidateCalendarPrefetch();
-		invalidateAllDocsPrefetch();
-		invalidateDatabaseRowsPrefetch();
-		if (relPath) {
-			void invalidateTaskSummariesPrefetchForNote(relPath, {
-				removed: payload.removed,
-			});
-			invalidatePrefetchedNote(relPath);
-		}
+		if (!relPath) return;
+		noteInvalidationQueueRef.current.set(relPath, payload.removed);
+		if (noteInvalidationTimerRef.current !== null) return;
+		noteInvalidationTimerRef.current = window.setTimeout(() => {
+			noteInvalidationTimerRef.current = null;
+			const changes = new Map(noteInvalidationQueueRef.current);
+			noteInvalidationQueueRef.current.clear();
+			if (changes.size === 0) return;
+			invalidateCalendarPrefetch();
+			invalidateAllDocsPrefetch();
+			invalidateDatabaseRowsPrefetch();
+			void invalidateTaskSummariesPrefetchForNotes(changes);
+			for (const path of changes.keys()) {
+				invalidatePrefetchedNote(path);
+			}
+		}, NOTE_INVALIDATION_BATCH_MS);
 	});
 	useEffect(
 		() => () => {
 			if (fsRefreshTimerRef.current !== null)
 				window.clearTimeout(fsRefreshTimerRef.current);
+			if (noteInvalidationTimerRef.current !== null)
+				window.clearTimeout(noteInvalidationTimerRef.current);
 		},
 		[],
 	);

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -36,7 +36,6 @@ import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { type FileTreeSortMode, loadSettings } from "../../lib/settings";
 import type {
-	DirChildSummary,
 	FileTreeAppearance,
 	FsEntry,
 	NoteTaskSummary,
@@ -704,38 +703,26 @@ export const FileTreePane = memo(function FileTreePane({
 		}
 
 		let cancelled = false;
-		const summaryRequests: Array<Promise<DirChildSummary[]>> =
-			summaryParentDirs.map((dirPath) =>
-				invoke("space_dir_children_summary", dirPath ? { dir: dirPath } : {}),
-			);
-
-		void Promise.allSettled(summaryRequests).then((results) => {
-			if (cancelled) return;
-			const nextCounts: Record<string, number> = {};
-			let hasSuccessfulResult = false;
-
-			for (const result of results) {
-				if (result.status !== "fulfilled") {
-					console.warn(
-						"Failed to load folder file counts for part of the tree",
-						result.reason,
-					);
-					continue;
-				}
-				hasSuccessfulResult = true;
-				for (const summary of result.value) {
+		void invoke("space_dir_children_summary", {
+			dirs: summaryParentDirs,
+		})
+			.then((summaries) => {
+				if (cancelled) return;
+				const nextCounts: Record<string, number> = {};
+				for (const summary of summaries) {
 					nextCounts[summary.dir_rel_path] = showNonMarkdownFiles
 						? summary.total_files_recursive
 						: summary.total_markdown_recursive;
 				}
-			}
-
-			if (!hasSuccessfulResult) return;
-			setFolderFileCounts((prev) => ({
-				...prev,
-				...nextCounts,
-			}));
-		});
+				setFolderFileCounts((prev) => ({
+					...prev,
+					...nextCounts,
+				}));
+			})
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				console.warn("Failed to load folder file counts", error);
+			});
 
 		return () => {
 			cancelled = true;

--- a/src/lib/navigationPrefetch.ts
+++ b/src/lib/navigationPrefetch.ts
@@ -631,30 +631,52 @@ function taskSummariesEqual(left: NoteTaskSummary, right: NoteTaskSummary) {
 	);
 }
 
-export async function invalidateTaskSummariesPrefetchForNote(
-	path: string,
-	options: { removed?: boolean } = {},
+export async function invalidateTaskSummariesPrefetchForNotes(
+	changes: ReadonlyMap<string, boolean>,
 ) {
-	const normalizedPath = normalizeAllDocsPath(path);
-	if (!normalizedPath) return;
-
-	const cachedSummary = cachedTaskSummaryForPath(normalizedPath);
-	if (options.removed) {
-		if (cachedSummary) invalidateTaskSummariesPrefetch();
-		return;
+	const paths: string[] = [];
+	for (const [path, removed] of changes) {
+		const normalizedPath = normalizeAllDocsPath(path);
+		if (!normalizedPath) continue;
+		const cachedSummary = cachedTaskSummaryForPath(normalizedPath);
+		if (removed) {
+			if (cachedSummary) {
+				invalidateTaskSummariesPrefetch();
+				return;
+			}
+			continue;
+		}
+		paths.push(normalizedPath);
 	}
+	if (paths.length === 0) return;
 
-	try {
-		const doc = await invoke("space_read_text", { path: normalizedPath });
-		const nextSummary = summarizeChecklistsFromMarkdown(doc.text);
-		const shouldInvalidate = cachedSummary
-			? !taskSummariesEqual(cachedSummary, nextSummary)
-			: nextSummary.total_count > 0;
-		if (shouldInvalidate) {
+	const docs = await invoke("space_read_texts_batch", { paths }).catch(
+		() => null,
+	);
+	if (!docs) {
+		if (paths.some((path) => cachedTaskSummaryForPath(path))) {
 			invalidateTaskSummariesPrefetch();
 		}
-	} catch {
-		if (cachedSummary) invalidateTaskSummariesPrefetch();
+		return;
+	}
+	for (const doc of docs) {
+		const cachedSummary = cachedTaskSummaryForPath(doc.rel_path);
+		if (doc.error || doc.text === null) {
+			if (cachedSummary) {
+				invalidateTaskSummariesPrefetch();
+				return;
+			}
+			continue;
+		}
+		const nextSummary = summarizeChecklistsFromMarkdown(doc.text);
+		if (
+			cachedSummary
+				? !taskSummariesEqual(cachedSummary, nextSummary)
+				: nextSummary.total_count > 0
+		) {
+			invalidateTaskSummariesPrefetch();
+			return;
+		}
 	}
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -879,7 +879,15 @@ interface TauriCommands {
 	app_confirm_exit: CommandDef<void, void>;
 	app_register_exit_listener: CommandDef<void, void>;
 	app_report_exit_listener_failure: CommandDef<void, void>;
-	space_list_dir: CommandDef<{ dir?: string | null }, FsEntry[]>;
+	space_list_dir: CommandDef<
+		{
+			dir?: string | null;
+			recursive?: boolean | null;
+			directories_only?: boolean | null;
+			limit?: number | null;
+		},
+		FsEntry[]
+	>;
 	file_tree_appearance_list: CommandDef<
 		void,
 		Record<string, FileTreeAppearance>
@@ -918,10 +926,7 @@ interface TauriCommands {
 		{ dir?: string | null; limit?: number | null },
 		FsEntryList
 	>;
-	space_dir_children_summary: CommandDef<
-		{ dir?: string | null; preview_limit?: number | null },
-		DirChildSummary[]
-	>;
+	space_dir_children_summary: CommandDef<{ dirs: string[] }, DirChildSummary[]>;
 	space_read_text: CommandDef<{ path: string }, TextFileDoc>;
 	space_read_texts_batch: CommandDef<{ paths: string[] }, TextFileDocBatch[]>;
 	daily_note_rollover_candidates: CommandDef<


### PR DESCRIPTION
Pull Request Template

Closes https://github.com/SidhuK/Glyph/issues/438


## Description

Batch repeated filesystem, indexing, cache, and UI work so bursts of related operations do less duplicate work without changing visible behavior.

Use this section for review hints, explanations or discussion points/todos.

- Summary of changes
  - Replaced the move-target IPC loop with one bounded recursive directory request.
  - Calculates requested folder counts in one traversal and removes unused recent-note summary work.
  - Reuses one SQLite connection for each watcher batch.
  - Deduplicates note-change invalidations and batches task-summary reads.
  - Coalesces streamed AI text and activity updates once per animation frame.
- Reasoning
  - These paths previously repeated IPC calls, filesystem scans, database setup, cache invalidations, or React renders for work that naturally arrives in batches.
- Additional context
  - Existing limits and final synchronous AI flushes are preserved.
  - This PR has no visual changes.
  - Validation: `pnpm check`, `pnpm build`, and `cargo check`.


## Docs

Internal performance change; typed IPC definitions were updated alongside the Rust commands. No user-facing documentation is required.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches filesystem scans, index updates, and UI streaming so bursts of related work do less duplicate work. No visual changes; faster under load.

- **Refactors**
  - `space_list_dir` now supports `recursive`, `directories_only`, and `limit` for one-pass folder discovery; file-tree move targets use a single recursive call.
  - `space_dir_children_summary` accepts `dirs` and computes child counts in one traversal; removed recent-note summaries.
  - Notes watcher opens one SQLite connection per batch using `index_note_with_conn`/`remove_note_with_conn`; retries if the DB fails to open.
  - Coalesces streamed tool/chat deltas per animation frame and batches file-tree refresh and note invalidations.
  - Task summaries invalidation is batched; reads with `space_read_texts_batch` and early-exits on first detected change.

- **Migration**
  - Update Tauri types: `space_dir_children_summary({ dirs: string[] })`; `DirChildSummary.recent_markdown` removed.
  - Use optional `space_list_dir` params (`recursive`, `directories_only`, `limit`) where recursive directory discovery is needed.
  - Replace `invalidateTaskSummariesPrefetchForNote` with `invalidateTaskSummariesPrefetchForNotes(Map<path, removed>)`.

<sup>Written for commit 0d645eaac312c25b2882933011fc7f57ba1d45e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch filesystem, indexing, and UI work to reduce redundant operations
> - File watcher in [watcher.rs](https://github.com/SidhuK/Glyph/pull/446/files#diff-2fececae1054b8d6ffe2b647fd67fa90202b76ba30af7e853b44efa9629337f1) now opens a single SQLite connection per debounced batch, retrying on failure with a 1s delay, using new `index_note_with_conn` and `remove_note_with_conn` functions
> - `space_list_dir` in [list.rs](https://github.com/SidhuK/Glyph/pull/446/files#diff-00f104e4b05e2c3ced5d50e99198a01472f9ba5d70af77f1605cce25a23d7636) now supports recursive traversal, directories-only filtering, and a result limit; [AppShell.tsx](https://github.com/SidhuK/Glyph/pull/446/files#diff-477852990e593378558fb04daea6895ce1e01057aa65bc0cb05795f64e3c10ed) uses a single recursive call to load file tree move targets instead of iterative UI-driven breadth-first fetches
> - `space_dir_children_summary` in [summary.rs](https://github.com/SidhuK/Glyph/pull/446/files#diff-feffffb93ae34fb4634732004b57150eb80360ee19b74150de8ca4be3f7217cf) now accepts multiple parent dirs in one call and returns recursive file/markdown counts with a global scan limit; [FileTreePane.tsx](https://github.com/SidhuK/Glyph/pull/446/files#diff-131490b72392f147fa6a9bc361ada159c4605876713d86d25e4cc50665c868e2) uses this to load all folder counts in one request
> - External note change events in [AppShell.tsx](https://github.com/SidhuK/Glyph/pull/446/files#diff-477852990e593378558fb04daea6895ce1e01057aa65bc0cb05795f64e3c10ed) are debounced and batched before invalidating caches; task summary invalidation in [navigationPrefetch.ts](https://github.com/SidhuK/Glyph/pull/446/files#diff-6fd495cd1ad895ac1b6f09b289c0335c652009aa8751ac902782eeb3fbeb0d38) operates on batches with early exit
> - AI streaming in [useRigChat.ts](https://github.com/SidhuK/Glyph/pull/446/files#diff-f5400186ee544909e70cc86401fe2ca4afdbe028dfc16cf9f1a925f964ef7786) and [useAiToolEvents.ts](https://github.com/SidhuK/Glyph/pull/446/files#diff-5259265f99630745f9ed34172bf382d616fe5e8d8406da2a92ec0aa236cf6c54) now coalesces updates per animation frame, flushing on completion or phase change
> - Behavioral Change: `DirChildSummary` no longer returns recent markdown entries; callers consuming that field will see it removed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d645ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory browsing now supports recursive listing, directory-only filtering, and result limits.
  * Folder summaries can be generated for multiple directories at once, including total and Markdown file counts.

* **Improvements**
  * AI responses stream more smoothly with fewer visible update interruptions.
  * File tree refreshes and external note updates are more efficient and responsive.
  * Directory summaries no longer include recent Markdown file previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->