### PR TITLE
Make AI note references openable (#448) [Release]

### DIFF
--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -16,6 +16,8 @@ use crate::net;
 
 pub use crate::utils::now_ms;
 
+const NOTE_LINK_PREAMBLE: &str = "When referring to an existing note, format its name as a Markdown link whose destination is the note's exact space-relative path: [Displayed note title](folder/note-name.md). Only link a note when its exact path is present in the provided context or was returned by a tool. Never guess or invent note paths. Do not use [[wikilinks]] in responses.";
+
 pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
     match provider {
         AiProviderKind::Openai => "https://api.openai.com/v1",
@@ -125,7 +127,8 @@ pub fn split_system_and_messages(
     mut messages: Vec<AiMessage>,
     context: Option<String>,
 ) -> (String, Vec<AiMessage>) {
-    let mut sys = String::new();
+    let mut sys = String::from(NOTE_LINK_PREAMBLE);
+    sys.push('\n');
     if let Some(ctx) = context {
         if !ctx.trim().is_empty() {
             sys.push_str("Context (user-approved):\n");

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -16,7 +16,7 @@ use crate::net;
 
 pub use crate::utils::now_ms;
 
-const NOTE_LINK_PREAMBLE: &str = "When referring to an existing note, format its name as a Markdown link whose destination is the note's exact space-relative path: [Displayed note title](folder/note-name.md). Only link a note when its exact path is present in the provided context or was returned by a tool. Never guess or invent note paths. Do not use [[wikilinks]] in responses.";
+const NOTE_LINK_PREAMBLE: &str = "When referring to an existing note, format its name as a Markdown link whose destination begins with / and uses the note's exact space-root-relative path: [Displayed note title](/folder/note-name.md). Reserve ./ for source-relative links, and never use ambiguous bare relative paths. Only link a note when its exact path is present in the provided context or was returned by a tool. Never guess or invent note paths. Do not use [[wikilinks]] in responses.";
 
 pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
     match provider {

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -4,6 +4,8 @@ use tauri::{State, WebviewWindow};
 
 use crate::{paths, space::SpaceState, utils};
 
+use super::link_rewrite::percent_decode_utf8;
+
 #[derive(Clone)]
 struct FileEntry {
     rel_path: String,
@@ -352,15 +354,19 @@ pub async fn space_resolve_markdown_link(
     let root = state.root_for_window(&window)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entries = list_files(&root, false, 80_000)?;
-        let raw = href
+        let encoded_raw = href
             .split('#')
             .next()
             .unwrap_or("")
             .trim()
             .replace('\\', "/");
-        if raw.is_empty() || raw.starts_with("http://") || raw.starts_with("https://") {
+        if encoded_raw.is_empty()
+            || encoded_raw.starts_with("http://")
+            || encoded_raw.starts_with("https://")
+        {
             return Ok(None);
         }
+        let raw = percent_decode_utf8(&encoded_raw).unwrap_or(encoded_raw);
         let source_dir = parent_dir(&source_path);
         let normalized_raw = raw.trim_start_matches("./");
         let mut candidates = Vec::<String>::new();

--- a/src-tauri/src/space_fs/link_ops.rs
+++ b/src-tauri/src/space_fs/link_ops.rs
@@ -360,13 +360,10 @@ pub async fn space_resolve_markdown_link(
             .unwrap_or("")
             .trim()
             .replace('\\', "/");
-        if encoded_raw.is_empty()
-            || encoded_raw.starts_with("http://")
-            || encoded_raw.starts_with("https://")
-        {
+        let raw = percent_decode_utf8(&encoded_raw).unwrap_or(encoded_raw);
+        if raw.is_empty() || raw.starts_with("http://") || raw.starts_with("https://") {
             return Ok(None);
         }
-        let raw = percent_decode_utf8(&encoded_raw).unwrap_or(encoded_raw);
         let source_dir = parent_dir(&source_path);
         let normalized_raw = raw.trim_start_matches("./");
         let mut candidates = Vec::<String>::new();

--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -298,7 +298,7 @@ fn rewrite_markdown_target_path(
     None
 }
 
-fn percent_decode_utf8(value: &str) -> Option<String> {
+pub(super) fn percent_decode_utf8(value: &str) -> Option<String> {
     if !value.as_bytes().contains(&b'%') {
         return None;
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.12-alpha.2",
+	"version": "0.8.12-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Closes 


## Description

Makes note references in AI responses open seamlessly inside Glyph.

- Summary of changes
  - Instructs AI providers to format known notes as Markdown links using exact space-relative paths.
  - Decodes percent-encoded local Markdown paths before resolving them, so filenames containing spaces open correctly.
  - Bumps the Tauri application version to `0.8.12-alpha.3`.
- Reasoning
  - AI responses could mention notes without producing an openable link.
  - Markdown renderers encode spaces as `%20`, while the workspace resolver previously compared the encoded path directly with the filesystem path.
- Additional context
  - Links are emitted only when the model knows an exact path from approved context or tool output; the prompt explicitly forbids guessing paths.
  - Existing external URL handling is unchanged.


## Docs

AI note references should use standard Markdown links:

```md
[Displayed note title](folder/note-name.md)
```

The destination must be an exact space-relative path. AI responses should not use `[[wikilinks]]`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make note references in chat responses clickable so they open inside Glyph. Adds a system-prompt preamble to format known notes as root-relative Markdown links and decodes percent-encoded paths; bumps app version to `0.8.12-alpha.3`.

- **New Features**
  - Adds a system prompt preamble that formats existing notes as Markdown links starting with `/` using exact space-root-relative paths; forbids wikilinks, ambiguous bare relative paths, and guessed paths.

- **Bug Fixes**
  - The Markdown link resolver percent-decodes hrefs before matching, so filenames with spaces open correctly.

<sup>Written for commit a8cdb16c7b0b0ef00bae48fb7470e8fe4b502b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make AI-generated note references openable as Markdown links
> - Injects a `NOTE_LINK_PREAMBLE` into the system prompt in [`helpers.rs`](https://github.com/SidhuK/Glyph/pull/448/files#diff-84680861f69e0a0828315d0ea12a0aea905e4206199a41f188f4efd61055c389) that instructs the LLM to format note references as absolute space-root-relative Markdown links, forbidding wikilinks and relative paths.
> - Updates [`space_resolve_markdown_link`](https://github.com/SidhuK/Glyph/pull/448/files#diff-9008974479c7f1cddb474346ca25c1b42249a621006cd71cd9c4516882c5d73a) to percent-decode hrefs before resolution, so AI-generated links with encoded characters can be opened.
> - Exposes `percent_decode_utf8` as `pub(super)` in [`link_rewrite.rs`](https://github.com/SidhuK/Glyph/pull/448/files#diff-cfb26bc5a1d6111bf9d740c4895a82ede6282538e1870d3d96386c21060fafa1) so `link_ops.rs` can reuse it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8cdb16.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of percent-encoded Markdown note links, including graceful fallback for invalid encoding.
  - Improved assistant guidance for formatting links to existing notes, helping produce more accurate links.

- **Chores**
  - Updated the application version to 0.8.12-alpha.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->