### PR TITLE
Fix shared drag-and-drop handling (#449) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.12-alpha.3",
+	"version": "0.8.12-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import "./App.css";
+import { DragDropProvider } from "@dnd-kit/react";
 import { LazyMotion, domAnimation } from "motion/react";
 import { AppShell } from "./components/app/AppShell";
 import { LicenseGate } from "./components/licensing/LicenseGate";
@@ -9,7 +10,9 @@ function App() {
 		<LazyMotion features={domAnimation}>
 			<AppProviders>
 				<LicenseGate>
-					<AppShell />
+					<DragDropProvider>
+						<AppShell />
+					</DragDropProvider>
 				</LicenseGate>
 			</AppProviders>
 		</LazyMotion>

--- a/src/components/app/EditorPaneCanvas.tsx
+++ b/src/components/app/EditorPaneCanvas.tsx
@@ -171,6 +171,7 @@ export const EditorPaneCanvas = memo(function EditorPaneCanvas({
 			{pane.tabs.length > 0 ? (
 				<div className="mainTabBarTransition">
 					<TabBar
+						paneId={pane.id}
 						tabs={pane.tabs}
 						rootEntries={rootEntries}
 						childrenByDir={childrenByDir}

--- a/src/components/app/SplitEditorLayout.tsx
+++ b/src/components/app/SplitEditorLayout.tsx
@@ -1,9 +1,15 @@
 import {
+	type DragEndEvent,
+	type DragMoveEvent,
+	useDragDropMonitor,
+	useDroppable,
+} from "@dnd-kit/react";
+import {
 	type KeyboardEvent as ReactKeyboardEvent,
 	type ReactNode,
 	type PointerEvent as ReactPointerEvent,
 	useCallback,
-	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -13,7 +19,11 @@ import {
 	MIN_SPLIT_RATIO,
 	type SplitEditorNode,
 } from "../../lib/splitEditor";
-import { subscribeToSplitEditorDrag } from "./splitEditorDnd";
+import {
+	resolveSplitDragSource,
+	splitPaneDroppable,
+	splitPaneIdOf,
+} from "./splitEditorDnd";
 import type {
 	SplitEditorDragSource,
 	SplitEditorDropTarget,
@@ -57,107 +67,71 @@ export function SplitEditorLayout({
 	onResizeSplit,
 	renderPane,
 }: SplitEditorLayoutProps) {
-	const [dropPreviewTarget, setDropPreviewTarget] =
-		useState<SplitEditorDropTarget | null>(null);
-	const dragSourceRef = useRef<SplitEditorDragSource | null>(null);
-	const dropTargetRef = useRef<SplitEditorDropTarget | null>(null);
-	const paneElementsRef = useRef(new Map<string, HTMLElement>());
+	const [dropPreview, setDropPreview] = useState<SplitEditorDropTarget | null>(
+		null,
+	);
+	// Mirrors the preview so drag end reads the resolved target without
+	// depending on when React last re-rendered.
+	const dropPreviewRef = useRef<SplitEditorDropTarget | null>(null);
 
-	const updateDropPreview = useCallback((x: number, y: number) => {
-		if (!dragSourceRef.current) return;
-		let paneEntry: [string, HTMLElement] | null = null;
-		for (const entry of paneElementsRef.current) {
-			const rect = entry[1].getBoundingClientRect();
-			if (
-				x >= rect.left &&
-				x <= rect.right &&
-				y >= rect.top &&
-				y <= rect.bottom
-			) {
-				paneEntry = entry;
-				break;
-			}
-		}
-		if (!paneEntry) {
-			dropTargetRef.current = null;
-			setDropPreviewTarget(null);
+	const setPreview = useCallback((next: SplitEditorDropTarget | null) => {
+		const current = dropPreviewRef.current;
+		if (current?.paneId === next?.paneId && current?.edge === next?.edge) {
 			return;
 		}
-		const [paneId, paneElement] = paneEntry;
-		const paneRect = paneElement.getBoundingClientRect();
-		const target = {
-			paneId,
-			edge: dropEdgeAtPoint(paneRect, x, y),
-		};
-		if (
-			dropTargetRef.current?.paneId === target.paneId &&
-			dropTargetRef.current.edge === target.edge
-		) {
-			return;
-		}
-		dropTargetRef.current = target;
-		setDropPreviewTarget(
-			dragSourceRef.current.kind === "tab" &&
-				dragSourceRef.current.paneId === paneId &&
-				target.edge === "center"
-				? null
-				: target,
-		);
+		dropPreviewRef.current = next;
+		setDropPreview(next);
 	}, []);
 
-	useEffect(() => {
-		return subscribeToSplitEditorDrag((event) => {
-			if (event.type === "move") {
-				dragSourceRef.current = event.source;
-				updateDropPreview(event.x, event.y);
-				return;
-			}
-
-			const target = dropTargetRef.current;
-			const source = event.source;
-			const shouldHandleDrop =
-				source &&
-				target &&
-				(source.kind === "file" ||
-					target.edge !== "center" ||
-					source.paneId !== target.paneId);
-			dragSourceRef.current = null;
-			dropTargetRef.current = null;
-			setDropPreviewTarget(null);
-			if (!source || !target || !shouldHandleDrop) return false;
-			onDrop(source, target);
-			return true;
-		});
-	}, [onDrop, updateDropPreview]);
+	const dragDropHandlers = useMemo(
+		() => ({
+			onDragMove(event: DragMoveEvent) {
+				const source = resolveSplitDragSource(event.operation.source?.data);
+				const target = event.operation.target;
+				const paneId = splitPaneIdOf(target?.data);
+				const element = target?.element;
+				if (!source || !paneId || !element) {
+					setPreview(null);
+					return;
+				}
+				const { x, y } = event.operation.position.current;
+				const edge = dropEdgeAtPoint(element.getBoundingClientRect(), x, y);
+				// Dropping a tab back into the centre of its own pane is a no-op.
+				const isSelfDrop =
+					source.kind === "tab" &&
+					source.paneId === paneId &&
+					edge === "center";
+				setPreview(isSelfDrop ? null : { paneId, edge });
+			},
+			onDragEnd(event: DragEndEvent) {
+				const target = dropPreviewRef.current;
+				setPreview(null);
+				if (event.canceled || !target) return;
+				const source = resolveSplitDragSource(event.operation.source?.data);
+				if (!source) return;
+				onDrop(source, target);
+			},
+		}),
+		[onDrop, setPreview],
+	);
+	useDragDropMonitor(dragDropHandlers);
 
 	const renderNode = useCallback(
 		(node: SplitEditorNode): ReactNode => {
 			if (node.type === "pane") {
 				const focused = node.paneId === focusedPaneId;
 				return (
-					<section
+					<SplitEditorPaneSection
 						key={node.paneId}
-						ref={(element) => {
-							if (element) {
-								paneElementsRef.current.set(node.paneId, element);
-							} else {
-								paneElementsRef.current.delete(node.paneId);
-							}
-						}}
-						className="splitEditorPane"
-						data-focused={focused ? "true" : undefined}
-						onFocusCapture={() => onFocusPane(node.paneId)}
-						onPointerDownCapture={() => onFocusPane(node.paneId)}
+						paneId={node.paneId}
+						focused={focused}
+						dropEdge={
+							dropPreview?.paneId === node.paneId ? dropPreview.edge : null
+						}
+						onFocusPane={onFocusPane}
 					>
 						{renderPane(node.paneId, focused)}
-						{dropPreviewTarget?.paneId === node.paneId ? (
-							<div
-								className="splitEditorDropPreview"
-								data-edge={dropPreviewTarget.edge}
-								aria-hidden="true"
-							/>
-						) : null}
-					</section>
+					</SplitEditorPaneSection>
 				);
 			}
 
@@ -187,10 +161,45 @@ export function SplitEditorLayout({
 				</div>
 			);
 		},
-		[focusedPaneId, dropPreviewTarget, onFocusPane, onResizeSplit, renderPane],
+		[focusedPaneId, dropPreview, onFocusPane, onResizeSplit, renderPane],
 	);
 
 	return <div className="splitEditorLayout">{renderNode(layout)}</div>;
+}
+
+function SplitEditorPaneSection({
+	paneId,
+	focused,
+	dropEdge,
+	onFocusPane,
+	children,
+}: {
+	paneId: string;
+	focused: boolean;
+	dropEdge: SplitEditorDropTarget["edge"] | null;
+	onFocusPane: (paneId: string) => void;
+	children: ReactNode;
+}) {
+	const { ref } = useDroppable(splitPaneDroppable(paneId));
+
+	return (
+		<section
+			ref={ref}
+			className="splitEditorPane"
+			data-focused={focused ? "true" : undefined}
+			onFocusCapture={() => onFocusPane(paneId)}
+			onPointerDownCapture={() => onFocusPane(paneId)}
+		>
+			{children}
+			{dropEdge ? (
+				<div
+					className="splitEditorDropPreview"
+					data-edge={dropEdge}
+					aria-hidden="true"
+				/>
+			) : null}
+		</section>
+	);
 }
 
 function SplitDivider({

--- a/src/components/app/SplitEditorLayout.tsx
+++ b/src/components/app/SplitEditorLayout.tsx
@@ -70,17 +70,13 @@ export function SplitEditorLayout({
 	const [dropPreview, setDropPreview] = useState<SplitEditorDropTarget | null>(
 		null,
 	);
-	// Mirrors the preview so drag end reads the resolved target without
-	// depending on when React last re-rendered.
-	const dropPreviewRef = useRef<SplitEditorDropTarget | null>(null);
-
 	const setPreview = useCallback((next: SplitEditorDropTarget | null) => {
-		const current = dropPreviewRef.current;
-		if (current?.paneId === next?.paneId && current?.edge === next?.edge) {
-			return;
-		}
-		dropPreviewRef.current = next;
-		setDropPreview(next);
+		setDropPreview((current) => {
+			if (current?.paneId === next?.paneId && current?.edge === next?.edge) {
+				return current;
+			}
+			return next;
+		});
 	}, []);
 
 	const dragDropHandlers = useMemo(
@@ -104,12 +100,23 @@ export function SplitEditorLayout({
 				setPreview(isSelfDrop ? null : { paneId, edge });
 			},
 			onDragEnd(event: DragEndEvent) {
-				const target = dropPreviewRef.current;
 				setPreview(null);
-				if (event.canceled || !target) return;
+				if (event.canceled) return;
 				const source = resolveSplitDragSource(event.operation.source?.data);
-				if (!source) return;
-				onDrop(source, target);
+				const target = event.operation.target;
+				const paneId = splitPaneIdOf(target?.data);
+				const element = target?.element;
+				if (!source || !paneId || !element) return;
+
+				const { x, y } = event.operation.position.current;
+				const edge = dropEdgeAtPoint(element.getBoundingClientRect(), x, y);
+				const isSelfDrop =
+					source.kind === "tab" &&
+					source.paneId === paneId &&
+					edge === "center";
+				if (isSelfDrop) return;
+
+				onDrop(source, { paneId, edge });
 			},
 		}),
 		[onDrop, setPreview],

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -1,14 +1,14 @@
+import type { Draggable } from "@dnd-kit/dom";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import {
-	DragDropProvider,
 	type DragEndEvent,
-	type DragMoveEvent,
 	PointerSensor,
+	useDragDropMonitor,
 } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { Cancel01Icon, PinIcon, PinOffIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { memo, useCallback, useRef } from "react";
+import { memo, useCallback, useMemo, useRef } from "react";
 import type { MouseEvent, MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
@@ -24,14 +24,11 @@ import { isMarkdownPath } from "../../utils/path";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { ActiveFileTitle } from "./ActiveFileTitle";
 import { MainTabsBreadcrumbs } from "./MainTabsBreadcrumbs";
-import {
-	cancelSplitEditorDrag,
-	endSplitEditorDrag,
-	moveSplitEditorDrag,
-} from "./splitEditorDnd";
+import { MAIN_TAB_DND_TYPE } from "./splitEditorDnd";
 import type { WorkspaceTab } from "./useTabManager";
 
 interface TabBarProps {
+	paneId: string;
 	tabs: WorkspaceTab[];
 	rootEntries: FsEntry[];
 	childrenByDir: Record<string, FsEntry[] | undefined>;
@@ -56,8 +53,6 @@ interface TabBarProps {
 	onReorder: (fromTabId: string, toTabId: string) => void;
 }
 
-const MAIN_TAB_DND_TYPE = "main-tab";
-const MAIN_TAB_DND_GROUP = "main-tabs";
 const MAIN_TAB_SENSORS = [
 	PointerSensor.configure({
 		activationConstraints: [
@@ -65,6 +60,7 @@ const MAIN_TAB_SENSORS = [
 		],
 	}),
 ];
+const DRAG_CLICK_SUPPRESSION_DELAY_MS = 0;
 
 function isPathSpecial(path: string): boolean {
 	return (
@@ -77,6 +73,7 @@ function isPathSpecial(path: string): boolean {
 }
 
 export function TabBar({
+	paneId,
 	tabs,
 	rootEntries,
 	childrenByDir,
@@ -139,50 +136,38 @@ export function TabBar({
 		isMarkdownPath(activeTabPath)
 			? activeTabPath
 			: null;
-	const handleDragEnd = useCallback(
-		(event: DragEndEvent) => {
-			suppressClickRef.current = true;
-			window.setTimeout(() => {
-				suppressClickRef.current = false;
-			}, 0);
-			const { source, target } = event.operation;
-			const sourceTabId =
-				typeof source?.data.tabId === "string" ? source.data.tabId : null;
-			const sourcePaneId =
-				typeof source?.data.paneId === "string" ? source.data.paneId : null;
-			if (event.canceled || !sourceTabId || !sourcePaneId) {
-				cancelSplitEditorDrag();
-				return;
-			}
-			const { x, y } = event.operation.position.current;
-			const sourceDrag = {
-				kind: "tab" as const,
-				paneId: sourcePaneId,
-				tabId: sourceTabId,
-			};
-			moveSplitEditorDrag(sourceDrag, x, y);
-			if (endSplitEditorDrag(sourceDrag)) {
-				return;
-			}
-			const targetTabId =
-				typeof target?.data.tabId === "string" ? target.data.tabId : null;
-			if (!sourceTabId || !targetTabId || sourceTabId === targetTabId) return;
+	// Reorder only when one of this pane's tabs is dropped onto another tab in
+	// the same pane. Drops onto the editor body resolve to a pane droppable
+	// instead, which SplitEditorLayout handles.
+	const dragDropHandlers = useMemo(
+		() => ({
+			onDragEnd(event: DragEndEvent) {
+				const { source, target } = event.operation;
+				const sourceTabId =
+					typeof source?.data.tabId === "string" ? source.data.tabId : null;
+				const sourcePaneId =
+					typeof source?.data.paneId === "string" ? source.data.paneId : null;
+				if (!sourceTabId || sourcePaneId !== paneId) return;
 
-			onReorder(sourceTabId, targetTabId);
-		},
-		[onReorder],
+				suppressClickRef.current = true;
+				window.setTimeout(() => {
+					suppressClickRef.current = false;
+				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
+				if (event.canceled) return;
+
+				const targetTabId =
+					typeof target?.data.tabId === "string" ? target.data.tabId : null;
+				const targetPaneId =
+					typeof target?.data.paneId === "string" ? target.data.paneId : null;
+				if (!targetTabId || targetPaneId !== paneId) return;
+				if (targetTabId === sourceTabId) return;
+
+				onReorder(sourceTabId, targetTabId);
+			},
+		}),
+		[onReorder, paneId],
 	);
-	const handleDragMove = useCallback((event: DragMoveEvent) => {
-		const { source } = event.operation;
-		const tabId =
-			typeof source?.data.tabId === "string" ? source.data.tabId : null;
-		const paneId =
-			typeof source?.data.paneId === "string" ? source.data.paneId : null;
-		if (tabId && paneId) {
-			const { x, y } = event.operation.position.current;
-			moveSplitEditorDrag({ kind: "tab", paneId, tabId }, x, y);
-		}
-	}, []);
+	useDragDropMonitor(dragDropHandlers);
 
 	return (
 		<div
@@ -221,43 +206,39 @@ export function TabBar({
 					onRenameFile={onRenameFile}
 				/>
 				{showTabs ? (
-					<DragDropProvider
-						onDragMove={handleDragMove}
-						onDragEnd={handleDragEnd}
-					>
-						<div className="mainTabsStrip">
-							<div className="mainTabsStripTabs">
-								{tabs.map((tab, index) => (
-									<TabItem
-										key={tab.id}
-										tab={tab}
-										index={index}
-										label={tabLabel(tab)}
-										isActive={tab.id === activeTabId}
-										suppressClickRef={suppressClickRef}
-										onPrefetchTab={onPrefetchTab}
-										onSelectTab={onSelectTab}
-										onCloseTab={onCloseTab}
-										onToggleTabPinned={onToggleTabPinned}
-										onStartRenamePath={onStartRenamePath}
-									/>
-								))}
-							</div>
-							<button
-								type="button"
-								className="mainTabAdd"
-								onClick={onOpenBlankTab}
-								title={`Open blank tab${
-									newTabShortcut
-										? ` (${formatShortcutForPlatform(newTabShortcut)})`
-										: ""
-								}`}
-								aria-label="Open blank tab"
-							>
-								+
-							</button>
+					<div className="mainTabsStrip">
+						<div className="mainTabsStripTabs">
+							{tabs.map((tab, index) => (
+								<TabItem
+									key={tab.id}
+									paneId={paneId}
+									tab={tab}
+									index={index}
+									label={tabLabel(tab)}
+									isActive={tab.id === activeTabId}
+									suppressClickRef={suppressClickRef}
+									onPrefetchTab={onPrefetchTab}
+									onSelectTab={onSelectTab}
+									onCloseTab={onCloseTab}
+									onToggleTabPinned={onToggleTabPinned}
+									onStartRenamePath={onStartRenamePath}
+								/>
+							))}
 						</div>
-					</DragDropProvider>
+						<button
+							type="button"
+							className="mainTabAdd"
+							onClick={onOpenBlankTab}
+							title={`Open blank tab${
+								newTabShortcut
+									? ` (${formatShortcutForPlatform(newTabShortcut)})`
+									: ""
+							}`}
+							aria-label="Open blank tab"
+						>
+							+
+						</button>
+					</div>
 				) : null}
 			</div>
 			<MainTabsBreadcrumbs
@@ -273,6 +254,7 @@ export function TabBar({
 }
 
 const TabItem = memo(function TabItem({
+	paneId,
 	tab,
 	index,
 	label,
@@ -284,6 +266,7 @@ const TabItem = memo(function TabItem({
 	onToggleTabPinned,
 	onStartRenamePath,
 }: {
+	paneId: string;
 	tab: WorkspaceTab;
 	index: number;
 	label: string;
@@ -296,14 +279,21 @@ const TabItem = memo(function TabItem({
 	onStartRenamePath: (path: string) => void;
 }) {
 	const { t } = useTranslation("shell");
+	// Only accept tabs from this pane, so a tab dragged in from another pane
+	// falls through to the pane droppable and moves panes instead of sorting.
+	const acceptSamePaneTab = useCallback(
+		(source: Draggable) => source.data?.paneId === paneId,
+		[paneId],
+	);
 	const { ref, handleRef, isDragging, isDropTarget } = useSortable({
 		id: tab.id,
 		index,
-		group: MAIN_TAB_DND_GROUP,
+		// Per-pane group: a single shared group would collide indices across panes.
+		group: `main-tabs:${paneId}`,
 		type: MAIN_TAB_DND_TYPE,
-		accept: MAIN_TAB_DND_TYPE,
+		accept: acceptSamePaneTab,
 		sensors: MAIN_TAB_SENSORS,
-		data: { paneId: tab.paneId, tabId: tab.id },
+		data: { paneId, tabId: tab.id },
 		transition: { duration: 160, easing: "ease" },
 	});
 	const { cancelHoverPrefetch, hoverPrefetchProps } = useHoverPrefetch(() => {

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -1,4 +1,3 @@
-import type { Draggable } from "@dnd-kit/dom";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import {
 	type DragEndEvent,
@@ -60,8 +59,6 @@ const MAIN_TAB_SENSORS = [
 		],
 	}),
 ];
-const DRAG_CLICK_SUPPRESSION_DELAY_MS = 0;
-
 function isPathSpecial(path: string): boolean {
 	return (
 		path === ALL_DOCS_TAB_ID ||
@@ -150,9 +147,6 @@ export function TabBar({
 				if (!sourceTabId || sourcePaneId !== paneId) return;
 
 				suppressClickRef.current = true;
-				window.setTimeout(() => {
-					suppressClickRef.current = false;
-				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
 				if (event.canceled) return;
 
 				const targetTabId =
@@ -281,17 +275,13 @@ const TabItem = memo(function TabItem({
 	const { t } = useTranslation("shell");
 	// Only accept tabs from this pane, so a tab dragged in from another pane
 	// falls through to the pane droppable and moves panes instead of sorting.
-	const acceptSamePaneTab = useCallback(
-		(source: Draggable) => source.data?.paneId === paneId,
-		[paneId],
-	);
 	const { ref, handleRef, isDragging, isDropTarget } = useSortable({
 		id: tab.id,
 		index,
 		// Per-pane group: a single shared group would collide indices across panes.
 		group: `main-tabs:${paneId}`,
 		type: MAIN_TAB_DND_TYPE,
-		accept: acceptSamePaneTab,
+		accept: (source) => source.data?.paneId === paneId,
 		sensors: MAIN_TAB_SENSORS,
 		data: { paneId, tabId: tab.id },
 		transition: { duration: 160, easing: "ease" },
@@ -301,7 +291,10 @@ const TabItem = memo(function TabItem({
 	});
 	const handleSelect = useCallback(() => {
 		cancelHoverPrefetch();
-		if (suppressClickRef.current) return;
+		if (suppressClickRef.current) {
+			suppressClickRef.current = false;
+			return;
+		}
 		onSelectTab(tab.id);
 	}, [cancelHoverPrefetch, onSelectTab, suppressClickRef, tab.id]);
 	const handleClose = useCallback(

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -7,7 +7,7 @@ import {
 import { useSortable } from "@dnd-kit/react/sortable";
 import { Cancel01Icon, PinIcon, PinOffIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { memo, useCallback, useMemo, useRef } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import type { MouseEvent, MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
@@ -59,6 +59,8 @@ const MAIN_TAB_SENSORS = [
 		],
 	}),
 ];
+const DRAG_CLICK_SUPPRESSION_DELAY_MS = 100;
+
 function isPathSpecial(path: string): boolean {
 	return (
 		path === ALL_DOCS_TAB_ID ||
@@ -97,6 +99,16 @@ export function TabBar({
 	const { t } = useTranslation("shell");
 	const { getBinding } = useShortcutBindings();
 	const suppressClickRef = useRef(false);
+	const suppressClickResetTimerRef = useRef<ReturnType<
+		typeof window.setTimeout
+	> | null>(null);
+	useEffect(() => {
+		return () => {
+			if (suppressClickResetTimerRef.current !== null) {
+				window.clearTimeout(suppressClickResetTimerRef.current);
+			}
+		};
+	}, []);
 	const stripFileExtension = useCallback((name: string) => {
 		if (!name || name.startsWith(".")) return name;
 		const withoutExt = name.replace(/\.[^./]+$/, "");
@@ -147,6 +159,15 @@ export function TabBar({
 				if (!sourceTabId || sourcePaneId !== paneId) return;
 
 				suppressClickRef.current = true;
+				if (suppressClickResetTimerRef.current !== null) {
+					window.clearTimeout(suppressClickResetTimerRef.current);
+				}
+				// The click handler clears this sooner when a post-drag click arrives;
+				// the fallback handles canceled and non-tab drops with no click event.
+				suppressClickResetTimerRef.current = window.setTimeout(() => {
+					suppressClickRef.current = false;
+					suppressClickResetTimerRef.current = null;
+				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
 				if (event.canceled) return;
 
 				const targetTabId =

--- a/src/components/app/splitEditorDnd.ts
+++ b/src/components/app/splitEditorDnd.ts
@@ -1,4 +1,16 @@
 import type { SplitDropEdge } from "../../lib/splitEditor";
+import { isMarkdownPath } from "../../utils/path";
+import { FILE_TREE_ENTRY_TYPE } from "../filetree/fileTreeDnd";
+
+/** Draggable type for editor tabs, shared so pane droppables can accept them. */
+export const MAIN_TAB_DND_TYPE = "main-tab";
+
+/**
+ * Matches `CollisionPriority.Lowest` in @dnd-kit/abstract. Panes span the whole
+ * editor area, so they must only win a collision when no tab strip or file tree
+ * row is under the pointer.
+ */
+const SPLIT_PANE_COLLISION_PRIORITY = 0;
 
 export type SplitEditorDragSource =
 	| { kind: "file"; path: string }
@@ -9,43 +21,42 @@ export interface SplitEditorDropTarget {
 	edge: SplitDropEdge | "center";
 }
 
-type SplitEditorDragEvent =
-	| { type: "move"; source: SplitEditorDragSource; x: number; y: number }
-	| { type: "end"; source: SplitEditorDragSource | null };
+/** Droppable config for an editor pane. */
+export function splitPaneDroppable(paneId: string) {
+	return {
+		id: `split-pane:${paneId}`,
+		data: { splitPaneId: paneId },
+		accept: [MAIN_TAB_DND_TYPE, FILE_TREE_ENTRY_TYPE],
+		collisionPriority: SPLIT_PANE_COLLISION_PRIORITY,
+	};
+}
 
-type SplitEditorDragListener = (
-	event: SplitEditorDragEvent,
-) => boolean | undefined;
+/**
+ * Pane id for a drop target, or null when the target is not a pane. Tab
+ * sortables also carry a `paneId`, so panes are keyed separately to keep the
+ * two apart.
+ */
+export function splitPaneIdOf(
+	data: Record<string, unknown> | undefined,
+): string | null {
+	const paneId = data?.splitPaneId;
+	return typeof paneId === "string" ? paneId : null;
+}
 
-const listeners = new Set<SplitEditorDragListener>();
-
-function publish(event: SplitEditorDragEvent): boolean {
-	let handled = false;
-	for (const listener of listeners) {
-		handled = listener(event) === true || handled;
+/**
+ * The single place that decides what may be dropped into an editor pane.
+ * Returns null for anything else, including folders and non-markdown files.
+ */
+export function resolveSplitDragSource(
+	data: Record<string, unknown> | undefined,
+): SplitEditorDragSource | null {
+	if (!data) return null;
+	const { tabId, paneId, path, kind } = data;
+	if (typeof tabId === "string" && typeof paneId === "string") {
+		return { kind: "tab", paneId, tabId };
 	}
-	return handled;
-}
-
-export function subscribeToSplitEditorDrag(
-	listener: SplitEditorDragListener,
-): () => void {
-	listeners.add(listener);
-	return () => listeners.delete(listener);
-}
-
-export function moveSplitEditorDrag(
-	source: SplitEditorDragSource,
-	x: number,
-	y: number,
-): void {
-	publish({ type: "move", source, x, y });
-}
-
-export function endSplitEditorDrag(source: SplitEditorDragSource): boolean {
-	return publish({ type: "end", source });
-}
-
-export function cancelSplitEditorDrag(): void {
-	publish({ type: "end", source: null });
+	if (kind === "file" && typeof path === "string" && isMarkdownPath(path)) {
+		return { kind: "file", path };
+	}
+	return null;
 }

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -258,7 +258,10 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 							type="button"
 							className="fileTreeRow"
 							onClick={() => {
-								if (onMoveClickSuppressRef.current) return;
+								if (onMoveClickSuppressRef.current) {
+									onMoveClickSuppressRef.current = false;
+									return;
+								}
 								onSelectDir(entry.rel_path);
 								onToggleDir(entry.rel_path);
 							}}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -352,7 +352,10 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 						}
 						onClick={() => {
 							cancelHoverPrefetch();
-							if (onMoveClickSuppressRef.current) return;
+							if (onMoveClickSuppressRef.current) {
+								onMoveClickSuppressRef.current = false;
+								return;
+							}
 							onOpenFile(entry.rel_path);
 						}}
 						onContextMenu={handleContextMenu}

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -1,7 +1,6 @@
 import {
-	DragDropProvider,
 	type DragEndEvent,
-	type DragMoveEvent,
+	useDragDropMonitor,
 	useDroppable,
 } from "@dnd-kit/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
@@ -46,11 +45,6 @@ import { isDeleteKey } from "../../utils/keyboard";
 import { isMarkdownPath, normalizeRelPath, parentDir } from "../../utils/path";
 import { AppearancePicker } from "../AppearancePicker";
 import { ChevronRight } from "../Icons";
-import {
-	cancelSplitEditorDrag,
-	endSplitEditorDrag,
-	moveSplitEditorDrag,
-} from "../app/splitEditorDnd";
 import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { springPresets } from "../ui/animations";
 import { FileTreeDirItem } from "./FileTreeDirItem";
@@ -99,6 +93,7 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const FILE_TREE_ROW_ESTIMATE = 32;
 const FILE_TREE_PREVIEW_ROW_ESTIMATE = 52;
+const DRAG_CLICK_SUPPRESSION_DELAY_MS = 0;
 
 interface AppearancePickerTarget {
 	entry: FsEntry;
@@ -917,52 +912,38 @@ export const FileTreePane = memo(function FileTreePane({
 		void onLoadDir(focusedDirPath);
 	}, [focusedDirPath, focusedEntries, onLoadDir]);
 
-	const handleDragEnd = useCallback(
-		(event: DragEndEvent) => {
-			moveClickSuppressRef.current = true;
-			window.setTimeout(() => {
-				moveClickSuppressRef.current = false;
-			}, 0);
-			const { source, target } = event.operation;
-			const sourcePath =
-				typeof source?.data.path === "string" ? source.data.path : null;
-			const sourceKind =
-				source?.data.kind === "dir" || source?.data.kind === "file"
-					? source.data.kind
-					: null;
-			if (event.canceled || !sourcePath || !sourceKind) {
-				cancelSplitEditorDrag();
-				return;
-			}
-			if (sourceKind === "file" && isMarkdownPath(sourcePath)) {
-				const { x, y } = event.operation.position.current;
-				const splitDragSource = { kind: "file" as const, path: sourcePath };
-				moveSplitEditorDrag(splitDragSource, x, y);
-				if (endSplitEditorDrag(splitDragSource)) return;
-			}
-			cancelSplitEditorDrag();
-			const targetDirPath =
-				typeof target?.data.targetDirPath === "string"
-					? target.data.targetDirPath
-					: null;
-			if (!sourcePath || !sourceKind || targetDirPath == null) return;
+	// Move only when a tree entry lands on a tree drop target. Drops onto an
+	// editor pane resolve to a pane droppable, which SplitEditorLayout handles.
+	const dragDropHandlers = useMemo(
+		() => ({
+			onDragEnd(event: DragEndEvent) {
+				const { source, target } = event.operation;
+				const sourcePath =
+					typeof source?.data.path === "string" ? source.data.path : null;
+				const sourceKind =
+					source?.data.kind === "dir" || source?.data.kind === "file"
+						? source.data.kind
+						: null;
+				if (!sourcePath || !sourceKind) return;
 
-			void onMovePath(sourcePath, targetDirPath, sourceKind);
-		},
+				moveClickSuppressRef.current = true;
+				window.setTimeout(() => {
+					moveClickSuppressRef.current = false;
+				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
+				if (event.canceled) return;
+
+				const targetDirPath =
+					typeof target?.data.targetDirPath === "string"
+						? target.data.targetDirPath
+						: null;
+				if (targetDirPath == null) return;
+
+				void onMovePath(sourcePath, targetDirPath, sourceKind);
+			},
+		}),
 		[onMovePath],
 	);
-	const handleDragMove = useCallback((event: DragMoveEvent) => {
-		const source = event.operation.source;
-		if (
-			source?.data.kind !== "file" ||
-			typeof source.data.path !== "string" ||
-			!isMarkdownPath(source.data.path)
-		) {
-			return;
-		}
-		const { x, y } = event.operation.position.current;
-		moveSplitEditorDrag({ kind: "file", path: source.data.path }, x, y);
-	}, []);
+	useDragDropMonitor(dragDropHandlers);
 	const handlePaneContextMenu = useCallback(
 		(event: MouseEvent<HTMLElement>) => {
 			if (
@@ -1043,101 +1024,50 @@ export const FileTreePane = memo(function FileTreePane({
 	}, [onImportPathsInDir]);
 
 	return (
-		<DragDropProvider onDragMove={handleDragMove} onDragEnd={handleDragEnd}>
-			<m.aside
-				ref={paneRef}
-				className="fileTreePane"
-				initial={{ y: 10 }}
-				animate={{ y: 0 }}
-				transition={springTransition}
-				onContextMenu={handlePaneContextMenu}
-				onKeyDown={handleTreeKeyDown}
-			>
-				<AppearancePicker
-					title="Choose file tree appearance"
-					open={appearancePickerTarget !== null}
-					onOpenChange={(open) => {
-						if (!open) setAppearancePickerTarget(null);
-					}}
-					iconValue={appearancePickerIcon}
-					defaultIconName={appearancePickerDefaultIcon}
-					showDefaultIcon
-					onIconChange={(icon) => {
-						updatePickerAppearance({
-							icon,
-						});
-					}}
-					showColors
-					colorValue={appearancePickerColor}
-					colorOptions={EDITOR_TEXT_COLORS}
-					onColorChange={(color) => {
-						updatePickerAppearance({
-							color,
-						});
-					}}
-				/>
-				{!hasLoadedFileVisibility ? null : focusedDirPath ? (
-					<FileTreeRootDrop targetDirPath={focusedDirPath}>
-						<FolderBreadcrumb
-							spacePath={spacePath}
-							dirPath={focusedDirPath}
-							onNavigate={handleEnterDir}
-							onExit={handleExitFocusedDir}
-						/>
-						{hasVisibleFocusedEntries ===
-						null ? null : hasVisibleFocusedEntries ? (
-							<TreeEntries
-								entries={focusedEntries ?? []}
-								parentDepth={-1}
-								childrenByDir={childrenByDir}
-								expandedDirs={expandedDirs}
-								activeFilePath={activeFilePath}
-								activeDirPath={activeDirPath}
-								renamingPath={renamingPath}
-								onToggleDir={onToggleDir}
-								onEnterDir={handleEnterDir}
-								onSelectDir={onSelectDir}
-								onOpenFile={onOpenFile}
-								onPrefetchFile={onPrefetchFile}
-								onNewFileInDir={onNewFileInDir}
-								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-								onImportFilesInDir={onImportFilesInDir}
-								onImportFolderInDir={onImportFolderInDir}
-								onRequestCreateFolder={handleRequestCreateFolder}
-								onDuplicateFile={handleDuplicateFile}
-								onDeletePath={handleDeletePath}
-								onStartRename={onStartRename}
-								onCommitDirRename={onCommitDirRename}
-								onCommitFileRename={onCommitFileRename}
-								onCancelRename={onCancelRename}
-								itemAppearance={itemAppearance}
-								folderFileCounts={folderFileCounts}
-								showFolderFileCounts={showFolderFileCounts}
-								showNonMarkdownFiles={showNonMarkdownFilesSetting}
-								onOpenAppearancePicker={handleOpenAppearancePicker}
-								pinnedFiles={pinnedFiles}
-								onTogglePinnedFile={onTogglePinnedFile}
-								onMoveClickSuppressRef={moveClickSuppressRef}
-								taskSummariesByPath={taskSummariesByPath}
-								showFilePreviews
-								filePreviewsByPath={filePreviewsByPath}
-								onVisiblePreviewPathsChange={handleVisiblePreviewPathsChange}
-								sortMode={sortMode}
-							/>
-						) : (
-							<m.div
-								className="fileTreeEmpty"
-								initial={{ opacity: 0 }}
-								animate={{ opacity: 1 }}
-							>
-								No files found.
-							</m.div>
-						)}
-					</FileTreeRootDrop>
-				) : hasVisibleRootEntries ? (
-					<FileTreeRootDrop>
+		<m.aside
+			ref={paneRef}
+			className="fileTreePane"
+			initial={{ y: 10 }}
+			animate={{ y: 0 }}
+			transition={springTransition}
+			onContextMenu={handlePaneContextMenu}
+			onKeyDown={handleTreeKeyDown}
+		>
+			<AppearancePicker
+				title="Choose file tree appearance"
+				open={appearancePickerTarget !== null}
+				onOpenChange={(open) => {
+					if (!open) setAppearancePickerTarget(null);
+				}}
+				iconValue={appearancePickerIcon}
+				defaultIconName={appearancePickerDefaultIcon}
+				showDefaultIcon
+				onIconChange={(icon) => {
+					updatePickerAppearance({
+						icon,
+					});
+				}}
+				showColors
+				colorValue={appearancePickerColor}
+				colorOptions={EDITOR_TEXT_COLORS}
+				onColorChange={(color) => {
+					updatePickerAppearance({
+						color,
+					});
+				}}
+			/>
+			{!hasLoadedFileVisibility ? null : focusedDirPath ? (
+				<FileTreeRootDrop targetDirPath={focusedDirPath}>
+					<FolderBreadcrumb
+						spacePath={spacePath}
+						dirPath={focusedDirPath}
+						onNavigate={handleEnterDir}
+						onExit={handleExitFocusedDir}
+					/>
+					{hasVisibleFocusedEntries ===
+					null ? null : hasVisibleFocusedEntries ? (
 						<TreeEntries
-							entries={rootEntries}
+							entries={focusedEntries ?? []}
 							parentDepth={-1}
 							childrenByDir={childrenByDir}
 							expandedDirs={expandedDirs}
@@ -1169,21 +1099,70 @@ export const FileTreePane = memo(function FileTreePane({
 							onTogglePinnedFile={onTogglePinnedFile}
 							onMoveClickSuppressRef={moveClickSuppressRef}
 							taskSummariesByPath={taskSummariesByPath}
+							showFilePreviews
+							filePreviewsByPath={filePreviewsByPath}
+							onVisiblePreviewPathsChange={handleVisiblePreviewPathsChange}
 							sortMode={sortMode}
 						/>
-					</FileTreeRootDrop>
-				) : (
-					<m.div
-						className="fileTreeEmpty"
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						transition={{ delay: 0.2 }}
-					>
-						No files found.
-					</m.div>
-				)}
-				{children}
-			</m.aside>
-		</DragDropProvider>
+					) : (
+						<m.div
+							className="fileTreeEmpty"
+							initial={{ opacity: 0 }}
+							animate={{ opacity: 1 }}
+						>
+							No files found.
+						</m.div>
+					)}
+				</FileTreeRootDrop>
+			) : hasVisibleRootEntries ? (
+				<FileTreeRootDrop>
+					<TreeEntries
+						entries={rootEntries}
+						parentDepth={-1}
+						childrenByDir={childrenByDir}
+						expandedDirs={expandedDirs}
+						activeFilePath={activeFilePath}
+						activeDirPath={activeDirPath}
+						renamingPath={renamingPath}
+						onToggleDir={onToggleDir}
+						onEnterDir={handleEnterDir}
+						onSelectDir={onSelectDir}
+						onOpenFile={onOpenFile}
+						onPrefetchFile={onPrefetchFile}
+						onNewFileInDir={onNewFileInDir}
+						onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+						onImportFilesInDir={onImportFilesInDir}
+						onImportFolderInDir={onImportFolderInDir}
+						onRequestCreateFolder={handleRequestCreateFolder}
+						onDuplicateFile={handleDuplicateFile}
+						onDeletePath={handleDeletePath}
+						onStartRename={onStartRename}
+						onCommitDirRename={onCommitDirRename}
+						onCommitFileRename={onCommitFileRename}
+						onCancelRename={onCancelRename}
+						itemAppearance={itemAppearance}
+						folderFileCounts={folderFileCounts}
+						showFolderFileCounts={showFolderFileCounts}
+						showNonMarkdownFiles={showNonMarkdownFilesSetting}
+						onOpenAppearancePicker={handleOpenAppearancePicker}
+						pinnedFiles={pinnedFiles}
+						onTogglePinnedFile={onTogglePinnedFile}
+						onMoveClickSuppressRef={moveClickSuppressRef}
+						taskSummariesByPath={taskSummariesByPath}
+						sortMode={sortMode}
+					/>
+				</FileTreeRootDrop>
+			) : (
+				<m.div
+					className="fileTreeEmpty"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{ delay: 0.2 }}
+				>
+					No files found.
+				</m.div>
+			)}
+			{children}
+		</m.aside>
 	);
 });

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -93,8 +93,6 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const FILE_TREE_ROW_ESTIMATE = 32;
 const FILE_TREE_PREVIEW_ROW_ESTIMATE = 52;
-const DRAG_CLICK_SUPPRESSION_DELAY_MS = 0;
-
 interface AppearancePickerTarget {
 	entry: FsEntry;
 }
@@ -927,9 +925,6 @@ export const FileTreePane = memo(function FileTreePane({
 				if (!sourcePath || !sourceKind) return;
 
 				moveClickSuppressRef.current = true;
-				window.setTimeout(() => {
-					moveClickSuppressRef.current = false;
-				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
 				if (event.canceled) return;
 
 				const targetDirPath =

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -93,6 +93,8 @@ interface FileTreePaneProps {
 const springTransition = springPresets.bouncy;
 const FILE_TREE_ROW_ESTIMATE = 32;
 const FILE_TREE_PREVIEW_ROW_ESTIMATE = 52;
+const DRAG_CLICK_SUPPRESSION_DELAY_MS = 100;
+
 interface AppearancePickerTarget {
 	entry: FsEntry;
 }
@@ -605,12 +607,22 @@ export const FileTreePane = memo(function FileTreePane({
 	const [appearancePickerTarget, setAppearancePickerTarget] =
 		useState<AppearancePickerTarget | null>(null);
 	const moveClickSuppressRef = useRef(false);
+	const moveClickSuppressResetTimerRef = useRef<ReturnType<
+		typeof window.setTimeout
+	> | null>(null);
 	const paneRef = useRef<HTMLElement | null>(null);
 	const focusedDirPathRef = useRef(focusedDirPath);
 	const settingsVersionRef = useRef(0);
 	const previousSpacePathRef = useRef(spacePath);
 	const itemAppearanceRef = useRef(itemAppearance);
 	focusedDirPathRef.current = focusedDirPath;
+	useEffect(() => {
+		return () => {
+			if (moveClickSuppressResetTimerRef.current !== null) {
+				window.clearTimeout(moveClickSuppressResetTimerRef.current);
+			}
+		};
+	}, []);
 	useEffect(() => {
 		itemAppearanceRef.current = itemAppearance;
 	}, [itemAppearance]);
@@ -925,6 +937,15 @@ export const FileTreePane = memo(function FileTreePane({
 				if (!sourcePath || !sourceKind) return;
 
 				moveClickSuppressRef.current = true;
+				if (moveClickSuppressResetTimerRef.current !== null) {
+					window.clearTimeout(moveClickSuppressResetTimerRef.current);
+				}
+				// The row click clears this sooner when a post-drag click arrives;
+				// the fallback handles canceled and non-tree drops with no click event.
+				moveClickSuppressResetTimerRef.current = window.setTimeout(() => {
+					moveClickSuppressRef.current = false;
+					moveClickSuppressResetTimerRef.current = null;
+				}, DRAG_CLICK_SUPPRESSION_DELAY_MS);
 				if (event.canceled) return;
 
 				const targetDirPath =

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -395,9 +395,52 @@
 	min-width: 0;
 }
 
-.mainTabWrap[data-dragging="true"] {
+.mainTabWrap[data-dragging="true"]:not([data-dnd-placeholder]),
+.mainTabWrap[data-dnd-dragging]:not([data-dnd-placeholder]) {
 	z-index: 2;
-	opacity: 0.82;
+	cursor: grabbing;
+	rotate: 2deg;
+}
+
+/* Chrome lives on the inner pill, so the lift is painted there. Specificity
+   must clear .mainTab.is-active, and the :active/zoom transforms are
+   neutralized so they don't fight the drag. */
+.mainTabWrap[data-dragging="true"]:not([data-dnd-placeholder]) .mainTab,
+.mainTabWrap[data-dnd-dragging]:not([data-dnd-placeholder]) .mainTab {
+	background: var(--bg-primary);
+	border-color: color-mix(in srgb, var(--interactive-accent) 72%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 12px 28px
+		color-mix(in srgb, var(--text-primary) 14%, transparent);
+	color: var(--text-primary);
+	transform: none;
+	animation: none;
+}
+
+.mainTabWrap[data-dnd-placeholder] {
+	visibility: visible !important;
+	opacity: 0.34;
+	pointer-events: none;
+}
+
+.mainTabWrap[data-dnd-placeholder] .mainTab {
+	box-shadow: none;
+	animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.mainTabWrap[data-dragging="true"]:not([data-dnd-placeholder]),
+	.mainTabWrap[data-dnd-dragging]:not([data-dnd-placeholder]) {
+		rotate: none;
+	}
+}
+
+.dark .mainTabWrap[data-dragging="true"]:not([data-dnd-placeholder]) .mainTab,
+.dark .mainTabWrap[data-dnd-dragging]:not([data-dnd-placeholder]) .mainTab {
+	background: color-mix(in srgb, var(--bg-primary) 90%, var(--bg-secondary));
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 12px 28px
+		color-mix(in srgb, black 30%, transparent);
 }
 
 .mainTabWrap[data-drop-target="true"] .mainTab {

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -230,9 +230,51 @@
 
 /* hierarchy connector lines intentionally removed */
 
-.fileTreeRow[data-dragging="true"] {
-	opacity: 0.62;
-	cursor: pointer;
+/* Dragged row is promoted to the top layer as a popover, where dnd-kit reverts
+   button background/border to UA defaults — both must be set explicitly.
+   Scoped through .fileTreeRowShell to outrank the row hover/active background,
+   which the row keeps while it holds pointer capture during a drag. */
+.fileTreeRowShell
+	> .fileTreeRow[data-dragging="true"]:not([data-dnd-placeholder]),
+.fileTreeRowShell
+	> .fileTreeRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
+	overflow: visible;
+	cursor: grabbing;
+	background: var(--bg-primary);
+	border-color: color-mix(in srgb, var(--interactive-accent) 72%, transparent);
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 12px 28px
+		color-mix(in srgb, var(--text-primary) 14%, transparent);
+	rotate: 2deg;
+}
+
+.fileTreeRow[data-dnd-placeholder] {
+	visibility: visible !important;
+	opacity: 0.34;
+	pointer-events: none;
+	box-shadow: none;
+	border-color: color-mix(in srgb, var(--border-default) 55%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.fileTreeRowShell
+		> .fileTreeRow[data-dragging="true"]:not([data-dnd-placeholder]),
+	.fileTreeRowShell
+		> .fileTreeRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
+		rotate: none;
+	}
+}
+
+.dark
+	.fileTreeRowShell
+	> .fileTreeRow[data-dragging="true"]:not([data-dnd-placeholder]),
+.dark
+	.fileTreeRowShell
+	> .fileTreeRow[data-dnd-dragging]:not([data-dnd-placeholder]) {
+	background: color-mix(in srgb, var(--bg-primary) 90%, var(--bg-secondary));
+	box-shadow: 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 28%, transparent), 0 12px 28px
+		color-mix(in srgb, black 30%, transparent);
 }
 
 .fileTreeRow[data-drop-target="true"] {


### PR DESCRIPTION
Closes N/A


## Description

This PR fixes the file tree crash and consolidates file, tab, and editor-pane dragging under one shared drag-and-drop provider.

- Summary of changes
  - Replaced the old cross-component drag event wiring with shared `dnd-kit` drop targets and monitors.
  - Kept tab reordering scoped to the current pane.
  - Removed stale drag handlers and added the missing provider/monitor wiring.
- Reasoning
  - The file tree was calling `useDragDropMonitor` without the required import/provider wiring, causing a runtime `ReferenceError`.
  - A shared provider gives file tree, tabs, and split panes one consistent drag operation.
- Additional context
  - Monitor subscriptions are memoized so drag listeners are not recreated on every render.


## Screenshots

No screenshots; this is a behavior and code-infrastructure change.


## Docs

No additional documentation is needed for this internal drag-and-drop change.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies drag-and-drop across the file tree, tabs, and editor panes with a single app-level `@dnd-kit/react` provider and pane droppables. Fixes the file tree crash, makes pane drops consistent, scopes tab reordering per pane, and improves drag/placeholder visuals.

- **Bug Fixes**
  - Added `DragDropProvider` at the app root to resolve the `useDragDropMonitor` runtime error in the file tree.
  - Ignored self-drops by a tab into the center of its own pane; only markdown files can be dropped onto panes.
  - Reset post-drag click suppression with a short timer on tabs and file tree rows so only the next click is skipped.

- **Refactors**
  - Removed the custom drag bus; `SplitEditorLayout` and `TabBar` now use `useDragDropMonitor` and pane `useDroppable` targets.
  - Centralized pane drop logic via `splitPaneDroppable`, `splitPaneIdOf`, and `resolveSplitDragSource`; pane droppables use the lowest collision priority so tab strips and tree rows win under the pointer.
  - Scoped tab sorting per pane (`group: main-tabs:<paneId>`) and accept tabs only from the same pane; added clearer drag and placeholder visuals with dark theme and reduced-motion support.

<sup>Written for commit d82c82e9beb0001f7927dfb08e03a87a6ee28b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix shared drag-and-drop handling by migrating to dnd-kit across tabs, file tree, and editor panes
> - Replaces the custom drag event bus in [splitEditorDnd.ts](https://github.com/SidhuK/Glyph/pull/449/files#diff-c9294645a57e8981d53c068ce3823fbd80b117738a0bebf5f83dac46874e8427) with dnd-kit droppables and monitors, giving each editor pane an explicit drop target with collision priority.
> - Wraps `<AppShell />` with a top-level `<DragDropProvider>` in [App.tsx](https://github.com/SidhuK/Glyph/pull/449/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2) so all components share a single DnD context instead of multiple local providers.
> - Tab reordering in [TabBar.tsx](https://github.com/SidhuK/Glyph/pull/449/files#diff-b2692f8a4b81da4f7ec1a5aeecd2570ea499a4421c6ffcb24ecea8cfbf1e3a75) is now scoped per-pane via a group name; post-drag clicks are suppressed briefly to prevent accidental tab activation.
> - File tree drops in [FileTreePane.tsx](https://github.com/SidhuK/Glyph/pull/449/files#diff-131490b72392f147fa6a9bc361ada159c4605876713d86d25e4cc50665c868e2) now only trigger a move when dropped on a tree target; markdown file drops onto editor panes are handled by the pane droppable in [SplitEditorLayout.tsx](https://github.com/SidhuK/Glyph/pull/449/files#diff-02423ef19054c888bafef3c161def256a8e8ca93ea2da5fe480b2b9f90f640d2).
> - Drag visuals for tabs and file tree rows are updated to use dnd-kit data attributes with dark mode and reduced-motion support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d82c82e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved drag-and-drop interactions for editor tabs, split panes, and file-tree items.
  - Added support for dragging markdown files into valid editor panes.
  - Enabled tab reordering within the current pane.

- **Style**
  - Added clearer dragged-item previews, placeholders, shadows, and visual feedback.
  - Added dark-theme and reduced-motion support for drag interactions.

- **Bug Fixes**
  - Prevented invalid drops and self-drops from triggering unintended actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->