### PR TITLE
readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,56 @@
 </p>
 
 <p align="center">
-  <strong>Join the Glyph community</strong><br />
-  Share feedback, ask questions, and help shape what comes next.
+  <strong>Offline-first notes for macOS</strong><br />
+  Keep your Markdown files close, search them quickly, and work without a server.
 </p>
 
 <p align="center">
-  <a href="https://discord.gg/cNqrBfFx7D"><strong>Join us on Discord →</strong></a>
+  <a href="https://github.com/SidhuK/Glyph/actions/workflows/pr-checks.yml">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/ci/SidhuK/Glyph.svg?workflow=PR%20Checks&amp;branch=main&amp;variant=secondary&amp;theme=slate&amp;mode=dark" />
+      <img alt="CI status" src="https://shieldcn.dev/github/ci/SidhuK/Glyph.svg?workflow=PR%20Checks&amp;branch=main&amp;variant=secondary&amp;theme=slate&amp;mode=light" />
+    </picture>
+  </a>
+  <a href="https://github.com/SidhuK/Glyph/releases">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/release/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=dark" />
+      <img alt="Latest release" src="https://shieldcn.dev/github/release/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=light" />
+    </picture>
+  </a>
+  <a href="https://github.com/SidhuK/Glyph/blob/main/LICENSE">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/license/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=dark" />
+      <img alt="License" src="https://shieldcn.dev/github/license/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=light" />
+    </picture>
+  </a>
+  <a href="https://github.com/SidhuK/Glyph/stargazers">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/stars/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=dark" />
+      <img alt="GitHub stars" src="https://shieldcn.dev/github/stars/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=light" />
+    </picture>
+  </a>
+  <a href="https://github.com/SidhuK/Glyph/commits/main">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/github/last-commit/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=dark" />
+      <img alt="Last commit" src="https://shieldcn.dev/github/last-commit/SidhuK/Glyph.svg?variant=secondary&amp;theme=slate&amp;mode=light" />
+    </picture>
+  </a>
 </p>
 
-Offline-first desktop note-taking application. Tauri 2 shell with a React 19 / TypeScript / Vite 8 frontend and a Rust backend. Notes live on-disk as Markdown files with per-space metadata in a `.glyph/` directory; a derived SQLite search index lives in app support and rebuilds from the notes. No cloud sync, no server.
+<p align="center">
+  <a href="https://discord.gg/cNqrBfFx7D"><strong>Join the Glyph community →</strong></a>
+</p>
+
+Glyph is an offline-first desktop note-taking application. It combines a Tauri 2 shell with a React 19 / TypeScript / Vite 8 frontend and a Rust backend. Notes live on disk as Markdown files with per-space metadata in a `.glyph/` directory; a derived SQLite search index lives in app support and rebuilds from the notes. No cloud sync. No server.
 
 ![Glyph](imageforWebsite.png)
+
+## Highlights
+
+- **Markdown files first** — your notes remain readable, portable files on disk.
+- **Local search** — a derived SQLite index keeps navigation fast without sending notes anywhere.
+- **Focused desktop workspace** — a macOS-first Tauri app with a rich editor, spaces, tasks, databases, and optional AI tools.
 
 ## Prerequisites
 
@@ -63,13 +102,13 @@ cd src-tauri && cargo clippy           # lint
 pnpm check && pnpm build && cd src-tauri && cargo check
 ```
 
-## Key dependencies
+## Built with
 
-**Frontend:** React 19, TipTap 3, Tailwind 4, Radix UI (via shadcn/ui), Motion 12, TanStack Table, cmdk, Zod 4, date-fns, Mermaid 11, highlight.js/lowlight, react-resizable-panels, Sonner, react-hook-form
+- **Frontend:** React 19, TipTap 3, TypeScript, Vite 8, Tailwind 4, Radix UI (via shadcn/ui), Motion 12, TanStack Table, cmdk, Zod 4, date-fns, Mermaid 11, highlight.js/lowlight, react-resizable-panels, Sonner, react-hook-form
 
-**Backend:** Tauri 2 (`macos-private-api`), rig-core 0.24, rusqlite 0.31 (bundled), notify 6, reqwest 0.12 (rustls), tokio, serde/serde_json/serde_yaml, chrono, uuid, sha2, window-vibrancy, core-text (macOS)
+- **Backend:** Tauri 2 (`macos-private-api`), Rust, rig-core 0.24, rusqlite 0.31 (bundled), notify 6, reqwest 0.12 (rustls), tokio, serde/serde_json/serde_yaml, chrono, uuid, sha2, window-vibrancy, core-text (macOS)
 
-**Tooling:** Vite 8, TypeScript 5.8, Biome, Vitest 4, Tauri CLI 2
+- **Tooling:** Biome, Vitest 4, Tauri CLI 2, pnpm 10
 
 ## Conventions
 
@@ -83,10 +122,14 @@ pnpm check && pnpm build && cd src-tauri && cargo check
 
 ## Licensing
 
-Source is open. Official release binaries include a 7-day trial with Gumroad license activation.
+Glyph's source is available under the [GNU Affero General Public License v3.0](LICENSE). Official release binaries include a 7-day trial with Gumroad license activation.
 
 - Releases: [GitHub Releases](https://github.com/SidhuK/Glyph/releases)
 - Purchase: [Gumroad](https://karatsidhu.gumroad.com/l/sqxfay)
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development setup, project conventions, and pull request guidance.
 
 ## Platform support
 


### PR DESCRIPTION
## Summary

Describe the change and why it exists.

## Related Issues

Closes #

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes `README.md` to clarify Glyph’s positioning and improve discoverability. Adds status badges and a Highlights section, updates the tech stack/tooling lists, specifies AGPL-3.0 licensing, and links to the contributing guide.

<sup>Written for commit 070b2fca1b4fd023adacc421474f5ef6a49b4cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README with badges, highlights section, and revised stack documentation
> - Adds a centered badge strip (CI, release, license, stars, last-commit) using shields.io with light/dark variants
> - Replaces the "Key dependencies" section with a "Built with" section, reorganizing Vite, TypeScript, Rust, Biome, Vitest 4, Tauri CLI 2, and pnpm 10 into categorized bullet lists
> - Adds a "Highlights" section covering Markdown-first storage, local SQLite search, and desktop workspace focus
> - Adds a "Contributing" section pointing to [CONTRIBUTING.md](https://github.com/SidhuK/Glyph/pull/458/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) and updates the Licensing section to explicitly reference AGPLv3
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 070b2fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->