### PR TITLE
Polish Quick Note and external markdown floating editors (#459) [Release]

### DIFF
--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -286,7 +286,7 @@ pub async fn external_markdown_write(
 }
 
 #[tauri::command]
-pub fn external_markdown_reveal(
+pub async fn external_markdown_reveal(
     window: tauri::WebviewWindow,
     state: State<'_, ExternalMarkdownState>,
 ) -> Result<(), String> {
@@ -297,7 +297,11 @@ pub fn external_markdown_reveal(
         .get(window.label())
         .map(|entry| PathBuf::from(&entry.abs_path))
         .ok_or_else(|| "external markdown file is not registered for this window".to_string())?;
-    crate::space_fs::read_write::paths::reveal_file_manager_path(&path)
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::space_fs::read_write::paths::reveal_file_manager_path(&path)
+    })
+    .await
+    .map_err(|error| error.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/external_markdown.rs
+++ b/src-tauri/src/external_markdown.rs
@@ -286,6 +286,21 @@ pub async fn external_markdown_write(
 }
 
 #[tauri::command]
+pub fn external_markdown_reveal(
+    window: tauri::WebviewWindow,
+    state: State<'_, ExternalMarkdownState>,
+) -> Result<(), String> {
+    let path = state
+        .paths_by_window
+        .lock()
+        .map_err(|_| "failed to lock external markdown state".to_string())?
+        .get(window.label())
+        .map(|entry| PathBuf::from(&entry.abs_path))
+        .ok_or_else(|| "external markdown file is not registered for this window".to_string())?;
+    crate::space_fs::read_write::paths::reveal_file_manager_path(&path)
+}
+
+#[tauri::command]
 pub fn external_markdown_finish_close(window: tauri::WebviewWindow) -> Result<(), String> {
     if !is_external_markdown_window(window.label()) {
         return Err("window is not an external markdown window".to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -901,7 +901,9 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
         WebviewUrl::App(format!("index.html?window={QUICK_NOTE_WINDOW_LABEL}").into()),
     )
     .title("Quick Note")
-    .inner_size(680.0, 440.0)
+    // Starts compact; the webview grows the window to fit what is typed.
+    .inner_size(680.0, 240.0)
+    .min_inner_size(420.0, 180.0)
     .resizable(true)
     .decorations(true)
     .title_bar_style(TitleBarStyle::Overlay)
@@ -916,10 +918,32 @@ fn quick_note_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, Str
     .build()
     .map_err(|error| error.to_string())?;
 
+    // Match the floating card's CSS radius so vibrancy doesn't leave square
+    // frosted corners with desktop leaking through the rounded clip.
     #[cfg(target_os = "macos")]
-    apply_main_window_vibrancy(&window, None)?;
+    apply_quick_note_vibrancy(&window)?;
 
     Ok(window)
+}
+
+/// Corner radius for the Quick Note floating card (CSS + macOS vibrancy).
+const QUICK_NOTE_CORNER_RADIUS: f64 = 20.0;
+
+#[cfg(target_os = "macos")]
+fn apply_quick_note_vibrancy(window: &tauri::WebviewWindow) -> Result<(), String> {
+    clear_main_window_vibrancy(window)?;
+    apply_vibrancy(
+        window,
+        NSVisualEffectMaterial::HudWindow,
+        None,
+        Some(QUICK_NOTE_CORNER_RADIUS),
+    )
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn apply_quick_note_vibrancy(_window: &tauri::WebviewWindow) -> Result<(), String> {
+    Ok(())
 }
 
 fn is_main_window_label(label: &str) -> bool {
@@ -948,8 +972,8 @@ fn focused_editor_window(app: &tauri::AppHandle) -> Option<(String, tauri::Webvi
 }
 
 fn show_quick_note_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
+    // Deliberately not re-centered: the panel stays where the user parked it.
     let window = quick_note_window(app)?;
-    let _ = window.center();
     window.show().map_err(|error| error.to_string())?;
     window.unminimize().map_err(|error| error.to_string())?;
     window.set_focus().map_err(|error| error.to_string())
@@ -1341,30 +1365,45 @@ fn clear_main_window_vibrancy(_window: &tauri::WebviewWindow) -> Result<(), Stri
 #[tauri::command(rename_all = "snake_case")]
 fn set_window_vibrancy_theme(window: tauri::WebviewWindow, theme: String) -> Result<(), String> {
     let normalized = theme.trim().to_ascii_lowercase();
+    let is_quick_note = window.label() == QUICK_NOTE_WINDOW_LABEL;
+    let apply = |theme: Option<&str>| -> Result<(), String> {
+        if is_quick_note {
+            // Keep the floating card's larger corner radius when theme re-applies.
+            apply_quick_note_vibrancy(&window)
+        } else {
+            apply_main_window_vibrancy(&window, theme)
+        }
+    };
     match normalized.as_str() {
         "dark" => {
             window
                 .set_theme(Some(Theme::Dark))
                 .map_err(|error| error.to_string())?;
-            apply_main_window_vibrancy(&window, Some("dark"))
+            apply(Some("dark"))
         }
         "light" => {
             window
                 .set_theme(Some(Theme::Light))
                 .map_err(|error| error.to_string())?;
-            apply_main_window_vibrancy(&window, Some("light"))
+            apply(Some("light"))
         }
         "system-dark" => {
             window.set_theme(None).map_err(|error| error.to_string())?;
-            apply_main_window_vibrancy(&window, Some("dark"))
+            apply(Some("dark"))
         }
         "system-light" => {
             window.set_theme(None).map_err(|error| error.to_string())?;
-            apply_main_window_vibrancy(&window, Some("light"))
+            apply(Some("light"))
         }
         "none" | "" => {
             window.set_theme(None).map_err(|error| error.to_string())?;
-            clear_main_window_vibrancy(&window)
+            if is_quick_note {
+                // Quick Note is always a frosted floating card, even when the
+                // main window turns vibrancy off.
+                apply_quick_note_vibrancy(&window)
+            } else {
+                clear_main_window_vibrancy(&window)
+            }
         }
         _ => Err(format!("unknown vibrancy theme: {normalized}")),
     }
@@ -1532,6 +1571,7 @@ pub fn run() {
             external_markdown::external_markdown_window_rel_path,
             external_markdown::external_markdown_read,
             external_markdown::external_markdown_write,
+            external_markdown::external_markdown_reveal,
             external_markdown::external_markdown_finish_close,
             external_link_preview::external_link_preview,
             print::print_write_html,

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -155,9 +155,11 @@ impl SpaceState {
         match self.root_for_window_label(window.label()) {
             Ok(root) => Ok(root),
             Err(error)
-                if matches!(window.label(), "quick-note" | "quick-task")
-                    && is_no_space_session_error(&error) =>
+                if is_no_space_session_error(&error)
+                    && shares_main_space_session(window.label()) =>
             {
+                // Auxiliary editor windows (quick note, external markdown, …)
+                // inherit the main window's active space rather than owning one.
                 self.root_for_window_label(window_geometry::MAIN_WINDOW_LABEL)
             }
             Err(error) => Err(error),
@@ -187,4 +189,10 @@ impl SpaceState {
 
 pub(crate) fn is_no_space_session_error(error: &str) -> bool {
     error.starts_with(NO_SPACE_SESSION_FOR_WINDOW)
+}
+
+/// Windows that edit notes against the main space without a private session.
+fn shares_main_space_session(window_label: &str) -> bool {
+    matches!(window_label, "quick-note" | "quick-task")
+        || window_label.starts_with("external-markdown-")
 }

--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -281,7 +281,7 @@ pub async fn space_resolve_abs_path(
 }
 
 #[cfg(target_os = "macos")]
-fn reveal_file_manager_path(abs: &Path) -> Result<(), String> {
+pub(crate) fn reveal_file_manager_path(abs: &Path) -> Result<(), String> {
     let status = std::process::Command::new("open")
         .arg("-R")
         .arg(abs)
@@ -295,7 +295,7 @@ fn reveal_file_manager_path(abs: &Path) -> Result<(), String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn reveal_file_manager_path(_abs: &Path) -> Result<(), String> {
+pub(crate) fn reveal_file_manager_path(_abs: &Path) -> Result<(), String> {
     Err("revealing paths in Finder is only available on macOS".to_string())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.12-alpha.5",
+	"version": "0.8.12-alpha.6",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -554,11 +554,11 @@ export function AppShell() {
 		});
 	}, [setError]);
 
-	useTauriEvent("quick-note:open_note", (payload) => {
+	useTauriEvent("app:open_note", (payload) => {
 		void openWorkspaceFile(payload.path).catch((cause) => {
-			console.error("Failed to open quick note", cause);
+			console.error("Failed to open note requested by another window", cause);
 			const message = cause instanceof Error ? cause.message : String(cause);
-			toast.error("Could not open quick note", { description: message });
+			toast.error("Could not open note", { description: message });
 		});
 	});
 

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -883,11 +883,11 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 				.filter(Boolean)
 				.join(" ")}
 			onKeyDownCapture={
-				showEditorChrome ? noteFind.handleEditorKeyDownCapture : undefined
+				canEdit ? noteFind.handleEditorKeyDownCapture : undefined
 			}
 		>
 			<div className="rfNodeNoteEditorBody nodrag nopan nowheel">
-				{showEditorChrome && noteFind.findOpen ? (
+				{canEdit && noteFind.findOpen ? (
 					<NoteFindBar
 						countLabel={noteFind.findCountLabel}
 						inputRef={noteFind.findInputRef}

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -370,9 +370,13 @@ export function useNoteEditor({
 		listCollapseLoadVersionRef.current += 1;
 		listCollapseSaveRef.current = listCollapseSaveRef.current.then(() =>
 			invoke("list_collapse_state_set", { path, branches }).catch((error) => {
+				const message = error instanceof Error ? error.message : String(error);
+				// Auxiliary windows without a private space session inherit main;
+				// if even that is unavailable, collapse is session-only — no toast.
+				if (message.startsWith("no space session for window")) return;
 				console.error("Failed to save list collapse state", error);
 				toast.error(i18n.t("editor:listCollapse.saveFailed"), {
-					description: error instanceof Error ? error.message : String(error),
+					description: message,
 				});
 			}),
 		);
@@ -799,9 +803,12 @@ export function useNoteEditor({
 				if (cancelled || loadVersion !== listCollapseLoadVersionRef.current) {
 					return;
 				}
+				const message = error instanceof Error ? error.message : String(error);
+				// No space session means collapse state simply isn't available here.
+				if (message.startsWith("no space session for window")) return;
 				console.error("Failed to load list collapse state", error);
 				toast.error(i18n.t("editor:listCollapse.loadFailed"), {
-					description: error instanceof Error ? error.message : String(error),
+					description: message,
 				});
 			});
 		return () => {

--- a/src/components/editor/hooks/useNoteFind.ts
+++ b/src/components/editor/hooks/useNoteFind.ts
@@ -45,6 +45,23 @@ function selectedTextForQuery(text: string): string {
 	return normalized;
 }
 
+/**
+ * The editor is embedded in surfaces that scroll at different levels (the note
+ * body, the external markdown window, the quick note panel), so the scroll host
+ * is resolved from the DOM instead of assuming one container.
+ */
+function scrollHostFor(
+	element: Element | null | undefined,
+): HTMLElement | null {
+	let current = element?.parentElement ?? null;
+	while (current) {
+		const overflowY = window.getComputedStyle(current).overflowY;
+		if (overflowY === "auto" || overflowY === "scroll") return current;
+		current = current.parentElement;
+	}
+	return null;
+}
+
 function centerElementInScrollHost(element: Element, scrollHost: HTMLElement) {
 	const elementRect = element.getBoundingClientRect();
 	const hostRect = scrollHost.getBoundingClientRect();
@@ -57,9 +74,7 @@ function centerElementInScrollHost(element: Element, scrollHost: HTMLElement) {
 }
 
 function centerEditorPosition(editor: Editor, pos: number) {
-	const scrollHost = editor.view.dom.closest(
-		".rfNodeNoteEditorBody",
-	) as HTMLElement | null;
+	const scrollHost = scrollHostFor(editor.view.dom);
 	if (!scrollHost) return;
 
 	try {
@@ -125,9 +140,7 @@ export function useNoteFind({
 				const activeMatch = tiptapHostRef.current?.querySelector(
 					".noteSearchMatchActive",
 				);
-				const scrollHost = tiptapHostRef.current?.closest(
-					".rfNodeNoteEditorBody",
-				) as HTMLElement | null;
+				const scrollHost = scrollHostFor(tiptapHostRef.current);
 				if (activeMatch && scrollHost) {
 					centerElementInScrollHost(activeMatch, scrollHost);
 				}
@@ -287,9 +300,7 @@ export function useNoteFind({
 		if (!findOpen || !findQuery || !findMatches.length) return;
 		if (mode === "plain") return;
 		const frame = requestAnimationFrame(() => {
-			const scrollHost = tiptapHostRef.current?.closest(
-				".rfNodeNoteEditorBody",
-			) as HTMLElement | null;
+			const scrollHost = scrollHostFor(tiptapHostRef.current);
 			const activeMatch = tiptapHostRef.current?.querySelector(
 				".noteSearchMatchActive",
 			);

--- a/src/components/external-markdown/ExternalMarkdownHeader.tsx
+++ b/src/components/external-markdown/ExternalMarkdownHeader.tsx
@@ -1,0 +1,67 @@
+import type { EditorViewMode } from "../../lib/editorMode";
+import { FolderOpen } from "../Icons";
+import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
+
+interface ExternalMarkdownHeaderProps {
+	title: string;
+	folderLabel: string;
+	isInsideSpace: boolean;
+	mode: EditorViewMode;
+	onModeChange: (mode: EditorViewMode) => void;
+	onReveal: () => void;
+	onOpenInGlyph: () => void;
+}
+
+export function ExternalMarkdownHeader({
+	title,
+	folderLabel,
+	isInsideSpace,
+	mode,
+	onModeChange,
+	onReveal,
+	onOpenInGlyph,
+}: ExternalMarkdownHeaderProps) {
+	return (
+		<div className="externalMarkdownOverlayChrome">
+			<div
+				className="externalMarkdownDragRegion"
+				data-tauri-drag-region
+				aria-hidden="true"
+			/>
+			<div className="externalMarkdownTitleBlock">
+				<h1 className="externalMarkdownTitle">{title}</h1>
+				<div className="externalMarkdownMetaRow">
+					{folderLabel ? (
+						<button
+							type="button"
+							className="externalMarkdownMetaButton"
+							title="Reveal in Finder"
+							onClick={onReveal}
+						>
+							<FolderOpen size="var(--icon-xs)" aria-hidden="true" />
+							<span className="externalMarkdownMetaLabel">{folderLabel}</span>
+						</button>
+					) : null}
+					{isInsideSpace ? null : (
+						<span className="externalMarkdownBadge">Outside your space</span>
+					)}
+				</div>
+			</div>
+			<div className="externalMarkdownHeaderActions">
+				{isInsideSpace ? (
+					<button
+						type="button"
+						className="externalMarkdownHeaderButton"
+						title="Save and open this note in the main window"
+						onClick={onOpenInGlyph}
+					>
+						Open in Glyph
+					</button>
+				) : null}
+				<div className="externalMarkdownModeSwitch">
+					<EditorViewModeSwitch mode={mode} onModeChange={onModeChange} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/external-markdown/ExternalMarkdownStatusBar.tsx
+++ b/src/components/external-markdown/ExternalMarkdownStatusBar.tsx
@@ -1,0 +1,51 @@
+import { X } from "../Icons";
+
+interface ExternalMarkdownStatusBarProps {
+	wordCount: number;
+	error: string;
+	saveStatus: string | null;
+	saveState: "loading" | "saving" | "edited" | "saved" | undefined;
+	onDismissError: () => void;
+}
+
+export function ExternalMarkdownStatusBar({
+	wordCount,
+	error,
+	saveStatus,
+	saveState,
+	onDismissError,
+}: ExternalMarkdownStatusBarProps) {
+	return (
+		<footer
+			className="externalMarkdownStatusBar"
+			data-error={error ? "true" : undefined}
+		>
+			{error ? (
+				<>
+					<span className="externalMarkdownStatusError">{error}</span>
+					<button
+						type="button"
+						className="externalMarkdownStatusDismiss"
+						aria-label="Dismiss error"
+						onClick={onDismissError}
+					>
+						<X size="var(--icon-xs)" aria-hidden="true" />
+					</button>
+				</>
+			) : (
+				<>
+					<span className="externalMarkdownStatusCounts">
+						{wordCount === 1 ? "1 word" : `${wordCount.toLocaleString()} words`}
+					</span>
+					<span
+						className="externalMarkdownSaveStatus"
+						data-state={saveState}
+						aria-live="polite"
+					>
+						{saveStatus ?? ""}
+					</span>
+				</>
+			)}
+		</footer>
+	);
+}

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -1,5 +1,6 @@
+import { emitTo } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useEditorSaveIndicator } from "../../hooks/useEditorSaveIndicator";
 import { dispatchEditorMenuAction } from "../../lib/appEvents";
 import {
@@ -10,13 +11,17 @@ import { extractErrorMessage } from "../../lib/errorUtils";
 import { loadSettings } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
+import { countWords } from "../../lib/textStats";
 import {
 	displayFolderFromPath,
 	displayNameFromPath,
 	normalizeRelPath,
+	parentDir,
 } from "../../utils/path";
-import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
+import { ExternalMarkdownHeader } from "./ExternalMarkdownHeader";
+import { ExternalMarkdownStatusBar } from "./ExternalMarkdownStatusBar";
+import { useDimChromeWhileTyping } from "./useDimChromeWhileTyping";
 
 const AUTOSAVE_DELAY_MS = 700;
 
@@ -24,6 +29,15 @@ function fallbackRelPathFromAbs(absPath: string): string {
 	const normalized = normalizeRelPath(absPath);
 	const parts = normalized.split("/").filter(Boolean);
 	return parts[parts.length - 1] ?? normalized;
+}
+
+function folderLabelFromAbs(absPath: string): string {
+	const normalized = absPath.replace(/\\/g, "/");
+	const parent = parentDir(normalized);
+	if (!parent) return "";
+	const parts = parent.split("/").filter(Boolean);
+	if (parts.length <= 2) return parts.join(" / ");
+	return parts.slice(-2).join(" / ");
 }
 
 async function resolveRelPath(absPath: string): Promise<string> {
@@ -43,6 +57,7 @@ async function resolveRelPath(absPath: string): Promise<string> {
 
 export function ExternalMarkdownWindow() {
 	const [relPath, setRelPath] = useState("");
+	const [absPath, setAbsPath] = useState("");
 	const [title, setTitle] = useState("Markdown File");
 	const [text, setText] = useState("");
 	const [savedText, setSavedText] = useState("");
@@ -51,10 +66,12 @@ export function ExternalMarkdownWindow() {
 	const textRef = useRef("");
 	const savedTextRef = useRef("");
 	const absPathRef = useRef("");
+	const relPathRef = useRef("");
 	const mtimeRef = useRef<number | null>(null);
 	const saveTokenRef = useRef(0);
 	const autosaveTimerRef = useRef<number | null>(null);
 	const mountedRef = useRef(true);
+	const chromeDimmed = useDimChromeWhileTyping();
 	const {
 		setSaving,
 		setLoading,
@@ -64,13 +81,16 @@ export function ExternalMarkdownWindow() {
 		resolveState,
 	} = useEditorSaveIndicator();
 
-	const folderLabel = useMemo(
-		() => (relPath ? displayFolderFromPath(relPath) : ""),
-		[relPath],
-	);
+	const isInsideSpace = Boolean(relPath);
+	const folderLabel = relPath
+		? displayFolderFromPath(relPath)
+		: absPath
+			? folderLabelFromAbs(absPath)
+			: "";
 	const isDirty = text !== savedText;
 	const visibleSaveStatus = resolveLabel({ isDirty, idleLabel: null });
 	const saveStatusState = resolveState({ isDirty });
+	const wordCount = countWords(text);
 
 	const saveNow = useCallback(async (): Promise<boolean> => {
 		const currentPath = absPathRef.current;
@@ -121,6 +141,20 @@ export function ExternalMarkdownWindow() {
 		await invoke("external_markdown_finish_close").catch(() => {});
 	}, [saveNow]);
 
+	const handleReveal = useCallback(() => {
+		void invoke("external_markdown_reveal").catch((cause) => {
+			setError(extractErrorMessage(cause));
+		});
+	}, []);
+
+	const handleOpenInGlyph = useCallback(async () => {
+		const path = relPathRef.current;
+		if (!path) return;
+		const saved = await saveNow();
+		if (!saved && textRef.current !== savedTextRef.current) return;
+		void emitTo("main", "app:open_note", { path }).catch(() => {});
+	}, [saveNow]);
+
 	useTauriEvent("menu:app_command", (payload) => {
 		if (payload.command_id === "close-active-tab") {
 			void closeWindow();
@@ -152,28 +186,29 @@ export function ExternalMarkdownWindow() {
 		void (async () => {
 			const settingsPromise = loadSettings().catch(() => null);
 			try {
-				const absPath = await invoke("external_markdown_window_path");
+				const nextAbsPath = await invoke("external_markdown_window_path");
 				if (cancelled) return;
-				absPathRef.current = absPath;
+				absPathRef.current = nextAbsPath;
+				setAbsPath(nextAbsPath);
 
-				const nextRelPath = await resolveRelPath(absPath);
+				const nextRelPath = await resolveRelPath(nextAbsPath);
 				if (cancelled) return;
 
 				const nextTitle = displayNameFromPath(
-					nextRelPath || fallbackRelPathFromAbs(absPath),
+					nextRelPath || fallbackRelPathFromAbs(nextAbsPath),
 				);
+				relPathRef.current = nextRelPath;
 				setRelPath(nextRelPath);
 				setTitle(nextTitle);
 				await getCurrentWindow().setTitle(`${nextTitle} - Glyph`);
 
 				const doc = await invoke("external_markdown_read", {
-					path: absPath,
+					path: nextAbsPath,
 				});
 				if (cancelled) return;
 
 				const settings = await settingsPromise;
 				if (cancelled) return;
-				// Keep the built-in default when settings are unavailable.
 				if (settings) {
 					setMode(settings.editor.defaultEditorMode);
 				}
@@ -215,53 +250,45 @@ export function ExternalMarkdownWindow() {
 	);
 
 	return (
-		<div className="externalMarkdownWindow">
-			<div className="externalMarkdownOverlayChrome">
-				<div
-					className="externalMarkdownDragRegion"
-					data-tauri-drag-region
-					aria-hidden="true"
-				/>
-				<div className="externalMarkdownTitleBlock">
-					<h1 className="externalMarkdownTitle">{title}</h1>
-					{folderLabel ? (
-						<p className="externalMarkdownMeta">{folderLabel}</p>
-					) : null}
-				</div>
-			</div>
-
-			{error ? <div className="externalMarkdownError">{error}</div> : null}
+		<div
+			className="externalMarkdownWindow"
+			data-chrome-dimmed={chromeDimmed ? "true" : "false"}
+		>
+			<ExternalMarkdownHeader
+				title={title}
+				folderLabel={folderLabel}
+				isInsideSpace={isInsideSpace}
+				mode={mode}
+				onModeChange={setMode}
+				onReveal={handleReveal}
+				onOpenInGlyph={() => void handleOpenInGlyph()}
+			/>
 
 			<main className="externalMarkdownBody">
-				<div className="externalMarkdownEditorPane">
-					<div className="externalMarkdownFloatActions">
-						{visibleSaveStatus ? (
-							<span
-								className="externalMarkdownSaveStatus"
-								data-state={saveStatusState}
-								aria-live="polite"
-							>
-								{visibleSaveStatus}
-							</span>
-						) : null}
-						<div className="markdownEditorToolbar">
-							<EditorViewModeSwitch mode={mode} onModeChange={setMode} />
-						</div>
-					</div>
-					<div className="externalMarkdownEditorShell">
-						<NoteInlineEditor
-							markdown={text}
-							relPath={relPath}
-							mode={mode}
-							chrome="minimal"
-							deferHeavyFeatures
-							pasteMarkdownBehavior="smart-markdown"
-							onChange={handleChange}
-							onFrontmatterCommit={saveNow}
-						/>
-					</div>
+				<div className="externalMarkdownEditorShell">
+					<NoteInlineEditor
+						markdown={text}
+						// Only real space-relative paths; inventing one from the abs
+						// path makes space-scoped features (list collapse, etc.) fire
+						// against the wrong note or toast when no session exists.
+						relPath={relPath}
+						mode={mode}
+						chrome="minimal"
+						deferHeavyFeatures
+						pasteMarkdownBehavior="smart-markdown"
+						onChange={handleChange}
+						onFrontmatterCommit={saveNow}
+					/>
 				</div>
 			</main>
+
+			<ExternalMarkdownStatusBar
+				wordCount={wordCount}
+				error={error}
+				saveStatus={visibleSaveStatus}
+				saveState={saveStatusState}
+				onDismissError={() => setError("")}
+			/>
 		</div>
 	);
 }

--- a/src/components/external-markdown/ExternalMarkdownWindow.tsx
+++ b/src/components/external-markdown/ExternalMarkdownWindow.tsx
@@ -152,7 +152,9 @@ export function ExternalMarkdownWindow() {
 		if (!path) return;
 		const saved = await saveNow();
 		if (!saved && textRef.current !== savedTextRef.current) return;
-		void emitTo("main", "app:open_note", { path }).catch(() => {});
+		void emitTo("main", "app:open_note", { path }).catch((cause) => {
+			setError(extractErrorMessage(cause));
+		});
 	}, [saveNow]);
 
 	useTauriEvent("menu:app_command", (payload) => {

--- a/src/components/external-markdown/useDimChromeWhileTyping.ts
+++ b/src/components/external-markdown/useDimChromeWhileTyping.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+
+const DIM_AFTER_MS = 1000;
+
+function isTypingKey(event: KeyboardEvent): boolean {
+	if (event.metaKey || event.ctrlKey || event.altKey) return false;
+	return (
+		event.key.length === 1 ||
+		event.key === "Enter" ||
+		event.key === "Backspace" ||
+		event.key === "Delete" ||
+		event.key === "Tab"
+	);
+}
+
+/**
+ * Fades window chrome out of the way while writing and brings it back on the
+ * next mouse move or Escape. Keyboard and pointer are external systems, so the
+ * listeners live in an effect.
+ */
+export function useDimChromeWhileTyping(): boolean {
+	const [dimmed, setDimmed] = useState(false);
+
+	useEffect(() => {
+		let dimTimer: number | null = null;
+
+		const clearDimTimer = () => {
+			if (dimTimer !== null) {
+				window.clearTimeout(dimTimer);
+				dimTimer = null;
+			}
+		};
+
+		const scheduleDim = () => {
+			if (dimTimer !== null) return;
+			dimTimer = window.setTimeout(() => {
+				dimTimer = null;
+				setDimmed(true);
+			}, DIM_AFTER_MS);
+		};
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") {
+				clearDimTimer();
+				setDimmed(false);
+				return;
+			}
+			if (!isTypingKey(event)) return;
+			scheduleDim();
+		};
+
+		const restore = () => {
+			clearDimTimer();
+			setDimmed((current) => (current ? false : current));
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		window.addEventListener("mousemove", restore);
+		window.addEventListener("blur", restore);
+		return () => {
+			clearDimTimer();
+			window.removeEventListener("keydown", handleKeyDown);
+			window.removeEventListener("mousemove", restore);
+			window.removeEventListener("blur", restore);
+		};
+	}, []);
+
+	return dimmed;
+}

--- a/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
+++ b/src/components/quick-note/QuickNoteTargetBreadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type FsEntry, invoke } from "../../lib/tauri";
-import { parentDir } from "../../utils/path";
-import { ChevronRight } from "../Icons";
+import { ChevronDown, ChevronRight } from "../Icons";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -19,13 +18,11 @@ export interface QuickNoteTarget {
 	value: string;
 	path: string;
 	label: string;
-	detail: string;
 }
 
 interface BreadcrumbPart {
 	label: string;
 	path: string;
-	kind: "folder" | "file";
 }
 
 interface QuickNoteTargetBreadcrumbsProps {
@@ -46,10 +43,6 @@ function stripFileExtension(name: string) {
 function savedLabel(path: string) {
 	const name = path.split("/").filter(Boolean).pop() ?? path;
 	return name.toLowerCase().endsWith(".md") ? name.slice(0, -3) : name;
-}
-
-function targetDetail(path: string) {
-	return parentDir(path) || "Space root";
 }
 
 function sortTargetEntries(entries: FsEntry[]) {
@@ -73,7 +66,7 @@ function breadcrumbPartsForTarget(
 	todayQuickNotePath: string,
 ): BreadcrumbPart[] {
 	return [
-		{ label: "Space", path: "", kind: "folder" },
+		{ label: "Space", path: "" },
 		...path
 			.split("/")
 			.filter(Boolean)
@@ -88,11 +81,7 @@ function breadcrumbPartsForTarget(
 				) {
 					label = "Today's quick note";
 				}
-				return {
-					label,
-					path: segmentPath,
-					kind: isFile ? "file" : "folder",
-				};
+				return { label, path: segmentPath };
 			}),
 	];
 }
@@ -102,7 +91,6 @@ function fileTarget(path: string): QuickNoteTarget {
 		value: path,
 		path,
 		label: savedLabel(path),
-		detail: targetDetail(path),
 	};
 }
 
@@ -111,7 +99,6 @@ function todayQuickNoteTarget(todayQuickNotePath: string): QuickNoteTarget {
 		value: QUICK_NOTE_TARGET_VALUE,
 		path: todayQuickNotePath,
 		label: "Today's quick note",
-		detail: targetDetail(todayQuickNotePath),
 	};
 }
 
@@ -189,6 +176,9 @@ function TargetBreadcrumbEntryMenu({
 	dirPath,
 	entries,
 	loading,
+	label,
+	showSeparator,
+	isCurrent,
 	quickNotesFolder,
 	todayQuickNotePath,
 	selectedTargetValue,
@@ -201,6 +191,9 @@ function TargetBreadcrumbEntryMenu({
 	dirPath: string;
 	entries: FsEntry[];
 	loading: boolean;
+	label: string;
+	showSeparator: boolean;
+	isCurrent: boolean;
 	quickNotesFolder: string;
 	todayQuickNotePath: string;
 	selectedTargetValue: string;
@@ -222,19 +215,31 @@ function TargetBreadcrumbEntryMenu({
 			<DropdownMenuTrigger asChild>
 				<button
 					type="button"
-					className="quickNoteTargetSepButton"
-					aria-label={`Browse ${menuTitleForDir(dirPath)}`}
+					className="quickNoteTargetButton"
+					aria-label={`Change destination — browse ${menuTitleForDir(dirPath)}`}
+					aria-current={isCurrent ? "page" : undefined}
+					data-current={isCurrent ? "true" : undefined}
 				>
-					<ChevronRight
-						size="var(--icon-xs)"
-						className="quickNoteTargetSep"
-						aria-hidden="true"
-					/>
+					{showSeparator ? (
+						<ChevronRight
+							size="var(--icon-xs)"
+							className="quickNoteTargetSep"
+							aria-hidden="true"
+						/>
+					) : null}
+					<span className="quickNoteTargetLabel">{label}</span>
+					{isCurrent ? (
+						<ChevronDown
+							size="var(--icon-xs)"
+							className="quickNoteTargetCaret"
+							aria-hidden="true"
+						/>
+					) : null}
 				</button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent
 				align="start"
-				side="top"
+				side="bottom"
 				className="quickNoteTargetMenu"
 			>
 				<DropdownMenuLabel className="quickNoteTargetMenuLabel">
@@ -338,7 +343,6 @@ export function QuickNoteTargetBreadcrumbs({
 	return (
 		<nav
 			className="quickNoteTargetBreadcrumb"
-			data-open="true"
 			aria-label="Quick note destination"
 		>
 			{breadcrumbParts.map((part, index) => {
@@ -349,36 +353,25 @@ export function QuickNoteTargetBreadcrumbs({
 				const menuKey = `${index}:${menuDirPath || ROOT_PATH_KEY}`;
 
 				return (
-					<span
+					<TargetBreadcrumbEntryMenu
 						key={part.path || ROOT_PATH_KEY}
-						className="quickNoteTargetItem"
-						data-current={isCurrent ? "true" : undefined}
-					>
-						{index > 0 ? (
-							<TargetBreadcrumbEntryMenu
-								open={openMenuKey === menuKey}
-								dirPath={menuDirPath}
-								entries={menuItems}
-								loading={menuEntries === undefined}
-								quickNotesFolder={quickNotesFolder}
-								todayQuickNotePath={todayQuickNotePath}
-								selectedTargetValue={selectedTarget.value}
-								onOpenChange={(open) => {
-									setOpenMenuKey(open ? menuKey : null);
-								}}
-								onLoadDir={loadDir}
-								onSelectTarget={handleSelectTarget}
-								childrenByDir={childrenByDir}
-							/>
-						) : null}
-						<span
-							className="quickNoteTargetButton"
-							aria-current={isCurrent ? "page" : undefined}
-							title={part.path || "Space"}
-						>
-							<span className="quickNoteTargetLabel">{part.label}</span>
-						</span>
-					</span>
+						open={openMenuKey === menuKey}
+						dirPath={menuDirPath}
+						entries={menuItems}
+						loading={menuEntries === undefined}
+						label={part.label}
+						showSeparator={index > 0}
+						isCurrent={isCurrent}
+						quickNotesFolder={quickNotesFolder}
+						todayQuickNotePath={todayQuickNotePath}
+						selectedTargetValue={selectedTarget.value}
+						onOpenChange={(open) => {
+							setOpenMenuKey(open ? menuKey : null);
+						}}
+						onLoadDir={loadDir}
+						onSelectTarget={handleSelectTarget}
+						childrenByDir={childrenByDir}
+					/>
 				);
 			})}
 		</nav>

--- a/src/components/quick-note/QuickNoteTargetSummary.tsx
+++ b/src/components/quick-note/QuickNoteTargetSummary.tsx
@@ -1,0 +1,41 @@
+import { useQuery } from "@tanstack/react-query";
+import { isMissingFileError } from "../../lib/fsErrors";
+import { invoke } from "../../lib/tauri";
+import { countWords } from "../../lib/textStats";
+
+export const QUICK_NOTE_TARGET_SUMMARY_KEY = "quick-note-target-summary";
+
+interface TargetSummary {
+	exists: boolean;
+	words: number;
+}
+
+async function readTargetSummary(path: string): Promise<TargetSummary> {
+	try {
+		const doc = await invoke("space_read_text", { path });
+		return { exists: true, words: countWords(doc.text) };
+	} catch (cause) {
+		if (isMissingFileError(cause)) return { exists: false, words: 0 };
+		throw cause;
+	}
+}
+
+function summaryLabel(summary: TargetSummary): string {
+	if (!summary.exists) return "New note";
+	if (summary.words === 0) return "Appending to an empty note";
+	return `Appending · ${summary.words.toLocaleString()} words`;
+}
+
+/** Tells the user what the next save will do before they start typing. */
+export function QuickNoteTargetSummary({ path }: { path: string }) {
+	const summary = useQuery({
+		queryKey: [QUICK_NOTE_TARGET_SUMMARY_KEY, path],
+		queryFn: () => readTargetSummary(path),
+		enabled: Boolean(path),
+	});
+
+	if (!summary.data) return null;
+	return (
+		<span className="quickNoteTargetSummary">{summaryLabel(summary.data)}</span>
+	);
+}

--- a/src/components/quick-note/QuickNoteWindow.test.tsx
+++ b/src/components/quick-note/QuickNoteWindow.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QuickNoteWindow } from "./QuickNoteWindow";
 
 const {
-	emitMock,
+	emitToMock,
 	invokeMock,
 	loadSettingsMock,
 	editorReadyCallbackRef,
@@ -40,7 +41,7 @@ const {
 	};
 
 	return {
-		emitMock: vi.fn(() => Promise.resolve()),
+		emitToMock: vi.fn(() => Promise.resolve()),
 		invokeMock: vi.fn(),
 		loadSettingsMock: vi.fn(() =>
 			Promise.resolve({
@@ -77,12 +78,11 @@ const {
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock("@tauri-apps/api/event", () => ({
-	emit: emitMock,
+	emitTo: emitToMock,
 }));
 
 vi.mock("../../lib/settings", () => ({
 	loadSettings: loadSettingsMock,
-	reloadFromDisk: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("../../lib/tauri", () => ({
@@ -151,9 +151,22 @@ vi.mock("./QuickNoteTargetBreadcrumbs", () => ({
 	QuickNoteTargetBreadcrumbs: () => null,
 }));
 
+vi.mock("./QuickNoteTargetSummary", () => ({
+	QUICK_NOTE_TARGET_SUMMARY_KEY: "quick-note-target-summary",
+	QuickNoteTargetSummary: () => null,
+}));
+
+vi.mock("./useQuickNoteWindowFrame", () => ({
+	useQuickNoteWindowFrame: () => ({ windowFocused: true }),
+}));
+
 vi.mock("../Icons", () => ({
 	FileText: () => null,
 	Save: () => null,
+}));
+
+vi.mock("@hugeicons/react", () => ({
+	HugeiconsIcon: () => null,
 }));
 
 describe("QuickNoteWindow", () => {
@@ -171,7 +184,7 @@ describe("QuickNoteWindow", () => {
 				__quickNoteAdditionalExtensionsChanged?: boolean;
 			}
 		).__quickNoteAdditionalExtensionsChanged = false;
-		emitMock.mockClear();
+		emitToMock.mockClear();
 		invokeMock.mockReset();
 		loadSettingsMock.mockClear();
 		invokeMock.mockImplementation((command: string) => {
@@ -193,8 +206,15 @@ describe("QuickNoteWindow", () => {
 	});
 
 	async function renderWindow() {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
 		await act(async () => {
-			root.render(<QuickNoteWindow />);
+			root.render(
+				<QueryClientProvider client={queryClient}>
+					<QuickNoteWindow />
+				</QueryClientProvider>,
+			);
 		});
 		await act(async () => {
 			editorReadyCallbackRef.current?.(mockEditor, null);
@@ -282,8 +302,9 @@ describe("QuickNoteWindow", () => {
 		expect(mockEditor.commands.setContent).toHaveBeenCalledWith("", {
 			contentType: "markdown",
 		});
-		expect(emitMock).toHaveBeenCalledWith(
-			"quick-note:open_note",
+		expect(emitToMock).toHaveBeenCalledWith(
+			"main",
+			"app:open_note",
 			expect.objectContaining({ path: expect.stringContaining("Quick Note") }),
 		);
 	});

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -1,12 +1,16 @@
-import { emit } from "@tauri-apps/api/event";
+import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useQueryClient } from "@tanstack/react-query";
+import { emitTo } from "@tauri-apps/api/event";
 import type { Editor } from "@tiptap/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { dispatchEditorMenuAction } from "../../lib/appEvents";
 import { isMissingFileError } from "../../lib/fsErrors";
-import { loadSettings, reloadFromDisk } from "../../lib/settings";
+import { loadSettings } from "../../lib/settings";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
-import { basename, parentDir } from "../../utils/path";
+import { countWords } from "../../lib/textStats";
+import { basename } from "../../utils/path";
 import { FileText, Save } from "../Icons";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { createEditorShortcutsExtension } from "../editor/extensions/editorShortcuts";
@@ -15,8 +19,15 @@ import {
 	type QuickNoteTarget,
 	QuickNoteTargetBreadcrumbs,
 } from "./QuickNoteTargetBreadcrumbs";
+import {
+	QUICK_NOTE_TARGET_SUMMARY_KEY,
+	QuickNoteTargetSummary,
+} from "./QuickNoteTargetSummary";
+import { useQuickNoteWindowFrame } from "./useQuickNoteWindowFrame";
 
 const QUICK_NOTE_PLACEHOLDER = "Write a quick note or press / for commands";
+const SAVE_CONFIRMATION_MS = 1600;
+const REFOCUS_DELAY_MS = 20;
 
 function pad(value: number): string {
 	return value.toString().padStart(2, "0");
@@ -39,11 +50,6 @@ function appendMarkdown(existing: string, entry: string): string {
 	const trimmedExisting = existing.trimEnd();
 	if (!trimmedExisting) return `${entry}\n`;
 	return `${trimmedExisting}\n\n${entry}\n`;
-}
-
-async function appendQuickNote(folder: string, text: string): Promise<string> {
-	const path = quickNotePath(folder);
-	return appendQuickNoteToPath(path, text);
 }
 
 async function appendQuickNoteToPath(
@@ -80,7 +86,6 @@ function quickNoteTarget(folder: string): QuickNoteTarget {
 		value: QUICK_NOTE_TARGET_VALUE,
 		path,
 		label: "Today's quick note",
-		detail: parentDir(path) || "Space root",
 	};
 }
 
@@ -102,9 +107,15 @@ export function QuickNoteWindow() {
 	const [folder, setFolder] = useState("Quick Notes");
 	const [draft, setDraft] = useState("");
 	const [hasText, setHasText] = useState(false);
-	const [status, setStatus] = useState("");
+	const [error, setError] = useState("");
+	const [confirmation, setConfirmation] = useState("");
 	const [saving, setSaving] = useState(false);
 	const [targetValue, setTargetValue] = useState(QUICK_NOTE_TARGET_VALUE);
+	const [editorAreaElement, setEditorAreaElement] =
+		useState<HTMLDivElement | null>(null);
+	const [contentElement, setContentElement] = useState<HTMLElement | null>(
+		null,
+	);
 	const editorRef = useRef<Editor | null>(null);
 	const unsubscribeRef = useRef<(() => void) | null>(null);
 	const shortcutsRef = useRef({
@@ -113,8 +124,13 @@ export function QuickNoteWindow() {
 		},
 		onSave: () => {},
 	});
-	const statusTimerRef = useRef<number | null>(null);
+	const confirmationTimerRef = useRef<number | null>(null);
 	const focusTimerRef = useRef<number | null>(null);
+	const queryClient = useQueryClient();
+	const { windowFocused } = useQuickNoteWindowFrame({
+		editorAreaElement,
+		contentElement,
+	});
 
 	const todayQuickNotePath = useMemo(() => quickNotePath(folder), [folder]);
 	const selectedTarget = useMemo((): QuickNoteTarget => {
@@ -125,7 +141,6 @@ export function QuickNoteWindow() {
 			value: targetValue,
 			path: targetValue,
 			label: savedLabel(targetValue),
-			detail: parentDir(targetValue) || "Space root",
 		};
 	}, [folder, targetValue]);
 	const isMac =
@@ -133,6 +148,8 @@ export function QuickNoteWindow() {
 		navigator.userAgent.includes("Mac");
 	const shortcutLabel = isMac ? "⌘+Enter" : "Ctrl+Enter";
 	const shortcutModifierLabel = isMac ? "⌘" : "Ctrl";
+	const wordCount = countWords(draft);
+	const charCount = draft.trim().length;
 
 	const readDraft = useCallback(
 		() => editorRef.current?.getMarkdown().trim() ?? "",
@@ -141,28 +158,24 @@ export function QuickNoteWindow() {
 
 	const chooseTarget = useCallback((target: QuickNoteTarget) => {
 		setTargetValue(target.value);
-		window.setTimeout(() => focusEditor(editorRef.current), 20);
-	}, []);
-
-	const refreshSettings = useCallback(async (withReload = false) => {
-		if (withReload) await reloadFromDisk();
-		const settings = await loadSettings();
-		const nextFolder = settings.quickNotes.folder;
-		setFolder(nextFolder);
-		return nextFolder;
+		window.setTimeout(() => focusEditor(editorRef.current), REFOCUS_DELAY_MS);
 	}, []);
 
 	useEffect(() => {
-		void refreshSettings().catch((cause) => {
-			console.error("Failed to load quick note settings", cause);
-		});
-	}, [refreshSettings]);
+		void loadSettings()
+			.then((settings) => {
+				setFolder(settings.quickNotes.folder);
+			})
+			.catch((cause) => {
+				console.error("Failed to load quick note settings", cause);
+			});
+	}, []);
 
 	useEffect(() => {
 		return () => {
 			unsubscribeRef.current?.();
-			if (statusTimerRef.current !== null) {
-				window.clearTimeout(statusTimerRef.current);
+			if (confirmationTimerRef.current !== null) {
+				window.clearTimeout(confirmationTimerRef.current);
 			}
 			if (focusTimerRef.current !== null) {
 				window.clearTimeout(focusTimerRef.current);
@@ -185,34 +198,49 @@ export function QuickNoteWindow() {
 		const text = readDraft();
 		if (!text || saving) return;
 		setSaving(true);
-		setStatus("");
+		setError("");
 		try {
-			const path =
+			const path = await appendQuickNoteToPath(
 				selectedTarget.value === QUICK_NOTE_TARGET_VALUE
-					? await appendQuickNote(folder, text)
-					: await appendQuickNoteToPath(selectedTarget.path, text);
+					? quickNotePath(folder)
+					: selectedTarget.path,
+				text,
+			);
 			clearDraft(editorRef.current);
 			setDraft("");
 			setHasText(false);
-			setStatus(`Saved ${savedLabel(path)}`);
-			void emit("quick-note:open_note", { path }).catch(() => {});
-			if (statusTimerRef.current !== null) {
-				window.clearTimeout(statusTimerRef.current);
+			setConfirmation(savedLabel(path));
+			void emitTo("main", "app:open_note", { path }).catch(() => {});
+			void queryClient.invalidateQueries({
+				queryKey: [QUICK_NOTE_TARGET_SUMMARY_KEY],
+			});
+			if (confirmationTimerRef.current !== null) {
+				window.clearTimeout(confirmationTimerRef.current);
 			}
 			if (focusTimerRef.current !== null) {
 				window.clearTimeout(focusTimerRef.current);
 			}
-			statusTimerRef.current = window.setTimeout(() => setStatus(""), 1600);
+			confirmationTimerRef.current = window.setTimeout(
+				() => setConfirmation(""),
+				SAVE_CONFIRMATION_MS,
+			);
 			focusTimerRef.current = window.setTimeout(
 				() => focusEditor(editorRef.current),
-				20,
+				REFOCUS_DELAY_MS,
 			);
 		} catch (cause) {
-			setStatus(cause instanceof Error ? cause.message : String(cause));
+			setError(cause instanceof Error ? cause.message : String(cause));
 		} finally {
 			setSaving(false);
 		}
-	}, [folder, readDraft, saving, selectedTarget.path, selectedTarget.value]);
+	}, [
+		folder,
+		queryClient,
+		readDraft,
+		saving,
+		selectedTarget.path,
+		selectedTarget.value,
+	]);
 
 	shortcutsRef.current = {
 		onEscape: () => {
@@ -232,50 +260,42 @@ export function QuickNoteWindow() {
 		[shortcutExtension],
 	);
 
-	const handleEditorReady = useCallback((editor: Editor | null) => {
-		unsubscribeRef.current?.();
-		unsubscribeRef.current = null;
-		editorRef.current = editor;
-		if (!editor) {
-			setHasText(false);
-			return;
-		}
-		focusEditor(editor);
-		const syncHasText = () => {
-			const nextHasText = editorHasText(editor);
-			setHasText((current) =>
-				current === nextHasText ? current : nextHasText,
-			);
-		};
-		syncHasText();
-		editor.on("update", syncHasText);
-		unsubscribeRef.current = () => {
-			editor.off("update", syncHasText);
-		};
-	}, []);
+	const handleEditorReady = useCallback(
+		(editor: Editor | null, contentRoot: HTMLElement | null) => {
+			unsubscribeRef.current?.();
+			unsubscribeRef.current = null;
+			editorRef.current = editor;
+			setContentElement(contentRoot);
+			if (!editor) {
+				setHasText(false);
+				return;
+			}
+			focusEditor(editor);
+			const syncHasText = () => {
+				const nextHasText = editorHasText(editor);
+				setHasText((current) =>
+					current === nextHasText ? current : nextHasText,
+				);
+			};
+			syncHasText();
+			editor.on("update", syncHasText);
+			unsubscribeRef.current = () => {
+				editor.off("update", syncHasText);
+			};
+		},
+		[],
+	);
 
 	const handleDraftChange = useCallback((nextMarkdown: string) => {
 		setDraft(nextMarkdown);
 	}, []);
 
 	return (
-		<div className="quickNoteRoot">
-			<div className="quickNoteDragHandle" data-tauri-drag-region />
-			<div className="quickNoteEditorArea">
-				<NoteInlineEditor
-					markdown={draft}
-					relPath={selectedTarget.path}
-					mode="rich"
-					chrome="minimal"
-					deferHeavyFeatures
-					additionalExtensions={editorAdditionalExtensions}
-					placeholder={QUICK_NOTE_PLACEHOLDER}
-					pasteMarkdownBehavior="smart-markdown"
-					onChange={handleDraftChange}
-					onEditorReady={handleEditorReady}
-				/>
-			</div>
-			<div className="quickNoteEditorChrome">
+		<div
+			className="quickNoteRoot"
+			data-window-focused={windowFocused ? "true" : "false"}
+		>
+			<header className="quickNoteHeader" data-tauri-drag-region>
 				<div className="quickNoteTargetGroup">
 					<button
 						type="button"
@@ -293,37 +313,79 @@ export function QuickNoteWindow() {
 						onSelectTarget={chooseTarget}
 					/>
 				</div>
-				<div className="quickNoteActionGroup">
-					<div className="quickNoteStatus" aria-live="polite">
-						{status}
-					</div>
-					<button
-						type="button"
-						className="quickNoteSaveButton"
-						aria-label={saving ? "Saving quick note" : "Save quick note"}
-						title={
-							saving
-								? "Saving quick note"
-								: `Save quick note (${shortcutLabel})`
-						}
-						disabled={saving || !hasText}
-						onClick={() => void save()}
-					>
-						<Save size="var(--icon-lg)" />
-						<span className="quickNoteSaveLabel">Save</span>
-						<span className="commandPaletteShortcut" aria-hidden="true">
-							<kbd>
-								<span className="commandPaletteShortcutCombo">
-									<span className="commandPaletteShortcutPart">
-										{shortcutModifierLabel}
-									</span>
-									<span className="commandPaletteShortcutPart">↵</span>
-								</span>
-							</kbd>
-						</span>
-					</button>
-				</div>
+				<QuickNoteTargetSummary path={selectedTarget.path} />
+			</header>
+			<div className="quickNoteEditorArea" ref={setEditorAreaElement}>
+				<NoteInlineEditor
+					markdown={draft}
+					relPath={selectedTarget.path}
+					mode="rich"
+					chrome="minimal"
+					deferHeavyFeatures
+					additionalExtensions={editorAdditionalExtensions}
+					placeholder={QUICK_NOTE_PLACEHOLDER}
+					pasteMarkdownBehavior="smart-markdown"
+					onChange={handleDraftChange}
+					onEditorReady={handleEditorReady}
+				/>
 			</div>
+			<footer className="quickNoteFooter">
+				<div className="quickNoteFooterStatus" aria-live="polite">
+					{error ? (
+						<span className="quickNoteFooterError">{error}</span>
+					) : hasText ? (
+						<span>
+							{wordCount === 1 ? "1 word" : `${wordCount} words`}
+							{" · "}
+							{charCount === 1 ? "1 character" : `${charCount} characters`}
+						</span>
+					) : (
+						<span className="quickNoteFooterHint">
+							{shortcutLabel} to save · Esc to dismiss
+						</span>
+					)}
+				</div>
+				<button
+					type="button"
+					className="quickNoteSaveButton"
+					data-state={confirmation ? "saved" : undefined}
+					aria-label={saving ? "Saving quick note" : "Save quick note"}
+					title={
+						saving ? "Saving quick note" : `Save quick note (${shortcutLabel})`
+					}
+					disabled={saving || (!hasText && !confirmation)}
+					onClick={() => void save()}
+				>
+					{confirmation ? (
+						<>
+							<HugeiconsIcon
+								icon={CheckmarkCircle02Icon}
+								size="var(--icon-lg)"
+								strokeWidth={1.6}
+								aria-hidden="true"
+							/>
+							<span className="quickNoteSaveLabel">
+								Saved to {confirmation}
+							</span>
+						</>
+					) : (
+						<>
+							<Save size="var(--icon-lg)" />
+							<span className="quickNoteSaveLabel">Save</span>
+							<span className="commandPaletteShortcut" aria-hidden="true">
+								<kbd>
+									<span className="commandPaletteShortcutCombo">
+										<span className="commandPaletteShortcutPart">
+											{shortcutModifierLabel}
+										</span>
+										<span className="commandPaletteShortcutPart">↵</span>
+									</span>
+								</kbd>
+							</span>
+						</>
+					)}
+				</button>
+			</footer>
 		</div>
 	);
 }

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -158,7 +158,14 @@ export function QuickNoteWindow() {
 
 	const chooseTarget = useCallback((target: QuickNoteTarget) => {
 		setTargetValue(target.value);
-		window.setTimeout(() => focusEditor(editorRef.current), REFOCUS_DELAY_MS);
+		setConfirmation("");
+		if (focusTimerRef.current !== null) {
+			window.clearTimeout(focusTimerRef.current);
+		}
+		focusTimerRef.current = window.setTimeout(
+			() => focusEditor(editorRef.current),
+			REFOCUS_DELAY_MS,
+		);
 	}, []);
 
 	useEffect(() => {
@@ -288,6 +295,11 @@ export function QuickNoteWindow() {
 
 	const handleDraftChange = useCallback((nextMarkdown: string) => {
 		setDraft(nextMarkdown);
+		// Only clear on real input — empty updates after save must not wipe
+		// the "Saved to …" confirmation.
+		if (nextMarkdown.trim()) {
+			setConfirmation("");
+		}
 	}, []);
 
 	return (

--- a/src/components/quick-note/useQuickNoteWindowFrame.ts
+++ b/src/components/quick-note/useQuickNoteWindowFrame.ts
@@ -1,0 +1,156 @@
+import {
+	LogicalSize,
+	PhysicalPosition,
+	getCurrentWindow,
+} from "@tauri-apps/api/window";
+import { useEffect, useRef, useState } from "react";
+
+const FRAME_STORAGE_KEY = "glyph.quickNote.frame";
+const MIN_WINDOW_HEIGHT = 210;
+const MAX_WINDOW_HEIGHT = 620;
+/** Rounding and OS chrome make exact height matches unreliable. */
+const HEIGHT_MATCH_TOLERANCE_PX = 3;
+
+interface StoredFrame {
+	x: number;
+	y: number;
+	width?: number;
+	height?: number;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function readStoredFrame(): StoredFrame | null {
+	try {
+		const raw = window.localStorage.getItem(FRAME_STORAGE_KEY);
+		if (!raw) return null;
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object") return null;
+		const frame: Record<string, unknown> = { ...parsed };
+		if (!isFiniteNumber(frame.x) || !isFiniteNumber(frame.y)) return null;
+		return {
+			x: frame.x,
+			y: frame.y,
+			width: isFiniteNumber(frame.width) ? frame.width : undefined,
+			height: isFiniteNumber(frame.height) ? frame.height : undefined,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredFrame(frame: StoredFrame) {
+	try {
+		window.localStorage.setItem(FRAME_STORAGE_KEY, JSON.stringify(frame));
+	} catch {
+		// A full or disabled store only costs us the remembered position.
+	}
+}
+
+function clampWindowHeight(height: number): number {
+	const screenLimit = Math.round(window.screen.availHeight * 0.7);
+	const maxHeight = Math.max(
+		MIN_WINDOW_HEIGHT,
+		Math.min(MAX_WINDOW_HEIGHT, screenLimit),
+	);
+	return Math.round(Math.min(maxHeight, Math.max(MIN_WINDOW_HEIGHT, height)));
+}
+
+interface QuickNoteWindowFrameOptions {
+	/** Scroll host whose natural height drives the window height. */
+	editorAreaElement: HTMLElement | null;
+	/** Editor content root; changes here are what make the area grow. */
+	contentElement: HTMLElement | null;
+}
+
+/**
+ * Keeps the floating panel where the user left it and sized to its content.
+ * The OS window is an external system, so all of this lives in effects.
+ */
+export function useQuickNoteWindowFrame({
+	editorAreaElement,
+	contentElement,
+}: QuickNoteWindowFrameOptions) {
+	const [windowFocused, setWindowFocused] = useState(true);
+	const storedFrameRef = useRef<StoredFrame | null>(null);
+	const manualSizeRef = useRef(false);
+	const autoHeightRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		const appWindow = getCurrentWindow();
+		const stored = readStoredFrame();
+		storedFrameRef.current = stored;
+		if (!stored) return;
+		manualSizeRef.current = stored.width !== undefined;
+		void appWindow.setPosition(new PhysicalPosition(stored.x, stored.y));
+		if (stored.width !== undefined && stored.height !== undefined) {
+			void appWindow.setSize(new LogicalSize(stored.width, stored.height));
+		}
+	}, []);
+
+	useEffect(() => {
+		const appWindow = getCurrentWindow();
+		const unlistenPromises = [
+			appWindow.onMoved(({ payload }) => {
+				storedFrameRef.current = {
+					...storedFrameRef.current,
+					x: payload.x,
+					y: payload.y,
+				};
+				writeStoredFrame(storedFrameRef.current);
+			}),
+			appWindow.onResized(() => {
+				const autoHeight = autoHeightRef.current;
+				const isAutoResize =
+					autoHeight !== null &&
+					Math.abs(window.innerHeight - autoHeight) <=
+						HEIGHT_MATCH_TOLERANCE_PX;
+				if (isAutoResize) return;
+				manualSizeRef.current = true;
+				const previous = storedFrameRef.current ?? { x: 0, y: 0 };
+				storedFrameRef.current = {
+					...previous,
+					width: window.innerWidth,
+					height: window.innerHeight,
+				};
+				writeStoredFrame(storedFrameRef.current);
+			}),
+			appWindow.onFocusChanged(({ payload }) => setWindowFocused(payload)),
+		];
+
+		return () => {
+			for (const pending of unlistenPromises) {
+				void pending.then((unlisten) => unlisten()).catch(() => {});
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!editorAreaElement || !contentElement) return;
+		const appWindow = getCurrentWindow();
+
+		const fitWindowToContent = () => {
+			if (manualSizeRef.current) return;
+			const chromeHeight = window.innerHeight - editorAreaElement.clientHeight;
+			const nextHeight = clampWindowHeight(
+				chromeHeight + editorAreaElement.scrollHeight,
+			);
+			if (
+				Math.abs(nextHeight - window.innerHeight) <= HEIGHT_MATCH_TOLERANCE_PX
+			) {
+				return;
+			}
+			autoHeightRef.current = nextHeight;
+			void appWindow.setSize(new LogicalSize(window.innerWidth, nextHeight));
+		};
+
+		const observer = new ResizeObserver(fitWindowToContent);
+		observer.observe(contentElement);
+		fitWindowToContent();
+		return () => observer.disconnect();
+	}, [contentElement, editorAreaElement]);
+
+	return { windowFocused };
+}

--- a/src/components/quick-note/useQuickNoteWindowFrame.ts
+++ b/src/components/quick-note/useQuickNoteWindowFrame.ts
@@ -109,13 +109,28 @@ export function useQuickNoteWindowFrame({
 						HEIGHT_MATCH_TOLERANCE_PX;
 				if (isAutoResize) return;
 				manualSizeRef.current = true;
-				const previous = storedFrameRef.current ?? { x: 0, y: 0 };
-				storedFrameRef.current = {
-					...previous,
-					width: window.innerWidth,
-					height: window.innerHeight,
-				};
-				writeStoredFrame(storedFrameRef.current);
+				void (async () => {
+					let x = storedFrameRef.current?.x;
+					let y = storedFrameRef.current?.y;
+					// Never invent (0, 0) — that pins the next launch to the
+					// desktop origin when the user resizes before moving.
+					if (!isFiniteNumber(x) || !isFiniteNumber(y)) {
+						try {
+							const position = await appWindow.outerPosition();
+							x = position.x;
+							y = position.y;
+						} catch {
+							return;
+						}
+					}
+					storedFrameRef.current = {
+						x,
+						y,
+						width: window.innerWidth,
+						height: window.innerHeight,
+					};
+					writeStoredFrame(storedFrameRef.current);
+				})();
 			}),
 			appWindow.onFocusChanged(({ payload }) => setWindowFocused(payload)),
 		];
@@ -134,8 +149,10 @@ export function useQuickNoteWindowFrame({
 		const fitWindowToContent = () => {
 			if (manualSizeRef.current) return;
 			const chromeHeight = window.innerHeight - editorAreaElement.clientHeight;
+			// Measure content, not the scroll host — scrollHeight of a host that
+			// already fits content equals clientHeight, so the window never shrinks.
 			const nextHeight = clampWindowHeight(
-				chromeHeight + editorAreaElement.scrollHeight,
+				chromeHeight + contentElement.scrollHeight,
 			);
 			if (
 				Math.abs(nextHeight - window.innerHeight) <= HEIGHT_MATCH_TOLERANCE_PX

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -875,6 +875,7 @@ interface TauriCommands {
 		{ path: string; text: string; base_mtime_ms?: number | null },
 		ExternalMarkdownWriteResult
 	>;
+	external_markdown_reveal: CommandDef<void, void>;
 	external_markdown_finish_close: CommandDef<void, void>;
 	print_write_html: CommandDef<{ file_stem: string; html: string }, string>;
 	license_bootstrap_status: CommandDef<void, LicenseStatus>;

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -20,7 +20,7 @@ import type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 type TauriEventMap = {
 	"menu:app_command": { command_id: string };
 	"menu:open_recent_space": { path: string };
-	"quick-note:open_note": { path: string };
+	"app:open_note": { path: string };
 	"external-markdown:close_requested": undefined;
 	"git_sync:status": import("./tauri").GitSyncStatus;
 	"ai:chunk": { job_id: string; delta: string };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { ThemeProvider } from "next-themes";
 import { useTheme } from "next-themes";
@@ -24,6 +25,7 @@ import {
 	applyEditorHeadingPalette,
 	isHeadingPaletteId,
 } from "./lib/headingPalettes";
+import { queryClient } from "./lib/queryClient";
 import type {
 	UiAccent,
 	UiCornerRadiusStyle,
@@ -344,7 +346,9 @@ void initI18n()
 						<LanguageBridge />
 						<ThemeAndTypographyBridge />
 						{isQuickNoteWindow ? (
-							<QuickNoteWindow />
+							<QueryClientProvider client={queryClient}>
+								<QuickNoteWindow />
+							</QueryClientProvider>
 						) : isExternalMarkdownWindow ? (
 							<ExternalMarkdownWindow />
 						) : (

--- a/src/styles/app/46-quick-note.css
+++ b/src/styles/app/46-quick-note.css
@@ -1,86 +1,67 @@
+/*
+ * Floating card lives in a transparent OS window. Radius must match the
+ * vibrancy clip in Rust (QUICK_NOTE_CORNER_RADIUS = 20). Avoid CSS box-shadow:
+ * it gets clipped by the rectangular webview and makes corners look broken.
+ */
 .quickNoteRoot {
+	--quick-note-radius: 20px;
+
 	position: relative;
 	display: flex;
 	flex-direction: column;
+	width: 100%;
 	height: 100%;
 	color: var(--text-primary);
-	background: color-mix(in srgb, var(--bg-primary) 88%, transparent);
-	border: 1px solid color-mix(in srgb, var(--border-default) 62%, transparent);
-	border-radius: var(--radius-24);
-	box-shadow: 0 24px 64px color-mix(in srgb, black 24%, transparent);
+	background: color-mix(in srgb, var(--bg-primary) 94%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border-default) 55%, transparent);
+	border-radius: var(--quick-note-radius);
 	overflow: hidden;
+	transition: border-color var(--transition-fast);
 }
 
-.quickNoteDragHandle {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	height: 18px;
-	z-index: 3;
+.quickNoteRoot[data-window-focused="true"] {
+	border-color: color-mix(
+		in srgb,
+		var(--interactive-accent) 34%,
+		var(--border-default)
+	);
+	/* Soft inner ring — stays inside the clip, unlike an outer box-shadow. */
+	box-shadow: inset 0 0 0 1px
+		color-mix(in srgb, var(--interactive-accent) 16%, transparent);
 }
 
-.quickNoteEditorArea {
-	flex: 1;
-	min-height: 0;
-	padding-top: 18px;
-	overflow: hidden;
-	-webkit-app-region: no-drag;
-}
-
-.quickNoteEditorArea .rfNodeNoteEditor {
-	height: 100%;
-	border: 0;
-	border-radius: 0;
-	background: transparent;
-	overflow: hidden;
-}
-
-.quickNoteEditorArea .rfNodeNoteEditor:focus-within {
-	border-color: transparent;
+.quickNoteRoot[data-window-focused="false"] {
+	border-color: color-mix(in srgb, var(--border-default) 34%, transparent);
 	box-shadow: none;
 }
 
-.quickNoteEditorArea .rfNodeNoteEditorBody {
-	padding: 10px 24px 72px;
-	background: transparent;
-}
-
-.quickNoteEditorArea .tiptapHostInline,
-.quickNoteEditorArea .tiptapContentInline {
-	min-height: 100%;
-}
-
-.quickNoteEditorArea .tiptapContentInline {
-	padding-bottom: 8px;
-}
-
-.quickNoteEditorChrome {
-	position: absolute;
-	left: 24px;
-	right: 20px;
-	bottom: 18px;
+/* Left padding clears the macOS traffic lights in the overlay title bar. */
+.quickNoteHeader {
+	flex: 0 0 auto;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 16px;
-	pointer-events: none;
-	z-index: 4;
-}
-
-.quickNoteTargetGroup,
-.quickNoteActionGroup {
-	display: inline-flex;
-	align-items: center;
-	min-width: 0;
-	gap: 8px;
+	gap: 12px;
+	min-height: 38px;
+	/* Keep chrome clear of the top corner curves. */
+	padding: 8px 16px 0 78px;
+	color: var(--text-tertiary);
 }
 
 .quickNoteTargetGroup {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
 	flex: 1 1 auto;
-	max-width: min(560px, calc(100% - 142px));
-	color: var(--text-tertiary);
-	pointer-events: auto;
+	min-width: 0;
+}
+
+.quickNoteTargetSummary {
+	flex: 0 0 auto;
+	color: var(--text-quaternary);
+	font-size: calc(var(--text-base) * 0.78);
+	font-weight: var(--font-medium);
+	white-space: nowrap;
 }
 
 .quickNoteTargetResetButton {
@@ -111,83 +92,54 @@
 	align-items: center;
 	gap: 0;
 	min-width: 0;
-	flex: 1 1 auto;
-	min-height: 28px;
-	max-height: 28px;
+	flex: 0 1 auto;
+	min-height: 26px;
 	margin: 0;
-	padding: 0;
-	opacity: 1;
-	max-width: 100%;
-	width: auto;
-	justify-content: flex-start;
+	padding: 1px 2px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 42%, transparent);
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--bg-primary) 42%, transparent);
 	overflow-x: auto;
 	overflow-y: hidden;
 	scrollbar-width: none;
+	transition: background var(--transition-fast), border-color
+		var(--transition-fast);
+}
+
+.quickNoteTargetBreadcrumb:hover {
+	border-color: color-mix(in srgb, var(--border-default) 62%, transparent);
+	background: color-mix(in srgb, var(--bg-hover) 48%, transparent);
 }
 
 .quickNoteTargetBreadcrumb::-webkit-scrollbar {
 	display: none;
 }
 
-.quickNoteTargetItem {
-	display: inline-flex;
-	align-items: center;
-	gap: 4px;
-	min-width: 0;
+.quickNoteTargetSep,
+.quickNoteTargetCaret {
 	flex-shrink: 0;
+	color: var(--text-quaternary);
+	opacity: 0.74;
+	transition: color var(--transition-fast), opacity var(--transition-fast);
 }
 
 .quickNoteTargetSep {
-	width: var(--icon-xs);
-	height: var(--icon-xs);
-	color: var(--text-quaternary);
-	opacity: 0.74;
-	flex-shrink: 0;
-	margin: 0;
-	transition: color var(--transition-fast), transform var(--transition-fast),
-		opacity var(--transition-fast);
+	margin-right: 2px;
 }
 
-.quickNoteTargetSepButton {
-	width: 20px;
-	height: 22px;
-	flex: 0 0 auto;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 0;
-	border: 1px solid transparent;
-	border-radius: var(--radius-md);
-	background: transparent;
-	color: var(--text-quaternary);
-	cursor: pointer;
-	transition: color var(--transition-fast);
-}
-
-.quickNoteTargetSepButton:hover,
-.quickNoteTargetSepButton:focus-visible,
-.quickNoteTargetSepButton[data-state="open"] {
-	color: var(--text-primary);
-	outline: none;
-}
-
-.quickNoteTargetSepButton:hover .quickNoteTargetSep,
-.quickNoteTargetSepButton:focus-visible .quickNoteTargetSep,
-.quickNoteTargetSepButton[data-state="open"] .quickNoteTargetSep {
-	color: currentcolor;
-	opacity: 1;
-	transform: translateX(1px);
+.quickNoteTargetCaret {
+	margin-left: 1px;
 }
 
 .quickNoteTargetButton {
 	position: relative;
 	display: inline-flex;
 	align-items: center;
-	gap: 5px;
-	max-width: min(34vw, 180px);
-	height: 22px;
+	gap: 3px;
+	max-width: min(34vw, 190px);
+	height: 24px;
 	min-width: 0;
-	padding: 0 7px;
+	padding: 0 6px;
 	border: 1px solid transparent;
 	border-radius: var(--radius-md);
 	background: transparent;
@@ -196,12 +148,27 @@
 	font-weight: var(--font-medium);
 	line-height: 1;
 	white-space: nowrap;
-	cursor: default;
-	transition: color var(--transition-fast);
+	cursor: pointer;
+	flex: 0 0 auto;
+	transition: background var(--transition-fast), color var(--transition-fast);
 }
 
-.quickNoteTargetButton[aria-current="page"] {
+.quickNoteTargetButton[data-current="true"] {
 	color: var(--text-primary);
+}
+
+.quickNoteTargetButton:hover,
+.quickNoteTargetButton:focus-visible,
+.quickNoteTargetButton[data-state="open"] {
+	background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.quickNoteTargetButton:hover .quickNoteTargetCaret,
+.quickNoteTargetButton[data-state="open"] .quickNoteTargetCaret {
+	color: currentcolor;
+	opacity: 1;
 }
 
 .quickNoteTargetLabel,
@@ -261,12 +228,69 @@
 	line-height: 1.3;
 }
 
-.quickNoteActionGroup {
+/* The editor area is the only flexible row, so the window can size to it. */
+.quickNoteEditorArea {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	-webkit-app-region: no-drag;
+}
+
+.quickNoteEditorArea .rfNodeNoteEditor {
+	height: auto;
+	border: 0;
+	border-radius: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+.quickNoteEditorArea .rfNodeNoteEditor:focus-within {
+	border-color: transparent;
+	box-shadow: none;
+}
+
+.quickNoteEditorArea .rfNodeNoteEditorBody {
 	flex: 0 0 auto;
-	justify-content: flex-end;
+	overflow: visible;
+	padding: 4px 24px 12px;
+	background: transparent;
+}
+
+.quickNoteEditorArea .tiptapHostInline {
+	min-height: 60px;
+}
+
+.quickNoteFooter {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	/* Extra bottom/side inset so status + save sit inside the 20px curve. */
+	padding: 6px 18px 14px 20px;
+}
+
+.quickNoteFooterStatus {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.8);
+	font-variant-numeric: tabular-nums;
+}
+
+.quickNoteFooterHint {
+	color: var(--text-quaternary);
+}
+
+.quickNoteFooterError {
+	color: var(--status-danger-fg);
 }
 
 .quickNoteSaveButton {
+	flex: 0 0 auto;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -278,7 +302,6 @@
 	background: var(--interactive-accent);
 	color: var(--text-inverse);
 	cursor: pointer;
-	pointer-events: auto;
 	box-shadow: 0 10px 28px color-mix(in srgb, black 12%, transparent);
 	transition: background var(--transition-fast), color var(--transition-fast);
 }
@@ -299,12 +322,22 @@
 	pointer-events: none;
 }
 
+.quickNoteSaveButton[data-state="saved"] {
+	background: color-mix(in srgb, var(--status-success-fg) 88%, black);
+	opacity: 1;
+	max-width: 260px;
+}
+
 .quickNoteSaveButton > svg {
 	flex: 0 0 auto;
 	color: currentcolor;
 }
 
 .quickNoteSaveLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 	font-size: var(--text-sm);
 	font-weight: var(--font-medium);
 	line-height: 1;
@@ -322,14 +355,4 @@
 	border-color: currentcolor;
 	color: currentcolor;
 	box-shadow: none;
-}
-
-.quickNoteStatus {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	color: var(--text-tertiary);
-	font-size: calc(var(--text-base) * 0.9);
-	pointer-events: none;
 }

--- a/src/styles/app/47-external-markdown.css
+++ b/src/styles/app/47-external-markdown.css
@@ -1,5 +1,12 @@
 .externalMarkdownWindow {
 	--external-markdown-chrome-height: 56px;
+	--external-markdown-status-height: 28px;
+	--external-markdown-editor-min-height: calc(
+		100vh -
+		var(--external-markdown-chrome-height) -
+		var(--external-markdown-status-height) -
+		24px
+	);
 
 	position: relative;
 	display: flex;
@@ -29,18 +36,30 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	z-index: 4;
+	z-index: 6;
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
+	gap: 12px;
 	min-height: var(--external-markdown-chrome-height);
-	padding: 8px 16px 10px 82px;
+	padding: 10px 16px 10px 82px;
 	background: linear-gradient(
 		to bottom,
 		color-mix(in srgb, var(--bg-canvas, var(--bg-primary)) 96%, transparent) 0%,
-		color-mix(in srgb, var(--bg-canvas, var(--bg-primary)) 84%, transparent) 72%,
+		color-mix(in srgb, var(--bg-canvas, var(--bg-primary)) 70%, transparent) 62%,
 		transparent 100%
 	);
 	pointer-events: none;
+	transition: opacity 220ms ease;
+}
+
+.externalMarkdownWindow[data-chrome-dimmed="true"]
+	.externalMarkdownOverlayChrome {
+	opacity: 0.18;
+}
+
+.externalMarkdownWindow[data-chrome-dimmed="true"]
+	.externalMarkdownOverlayChrome:hover {
+	opacity: 1;
 }
 
 .externalMarkdownTitleBlock {
@@ -48,9 +67,7 @@
 	z-index: 1;
 	min-width: 0;
 	flex: 1 1 auto;
-	max-width: calc(100% - 112px);
-	padding-top: 2px;
-	padding-right: 12px;
+	padding-right: 8px;
 	pointer-events: none;
 }
 
@@ -60,20 +77,139 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: calc(var(--text-base) * 0.9);
-	font-weight: var(--font-medium);
-	line-height: 1.35;
-	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 1.05);
+	font-weight: var(--font-semibold);
+	line-height: 1.3;
+	letter-spacing: -0.01em;
+	color: var(--text-primary);
 }
 
-.externalMarkdownMeta {
-	margin: 2px 0 0;
+.externalMarkdownMetaRow {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+	margin-top: 2px;
+	pointer-events: auto;
+	-webkit-app-region: no-drag;
+}
+
+.externalMarkdownMetaButton {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	min-width: 0;
+	max-width: 100%;
+	margin: 0;
+	padding: 1px 4px 1px 2px;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text-tertiary);
+	font: inherit;
+	font-size: calc(var(--text-base) * 0.78);
+	line-height: 1.35;
+	cursor: pointer;
+	transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.externalMarkdownMetaButton:hover,
+.externalMarkdownMetaButton:focus-visible {
+	background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.externalMarkdownMetaLabel {
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: calc(var(--text-base) * 0.76);
-	line-height: 1.35;
-	color: var(--text-tertiary);
+}
+
+.externalMarkdownBadge {
+	flex: 0 0 auto;
+	padding: 1px 6px;
+	border: 1px solid
+		color-mix(in srgb, var(--status-warning-fg) 28%, transparent);
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--status-warning-fg) 10%, transparent);
+	color: color-mix(in srgb, var(--status-warning-fg) 88%, var(--text-primary));
+	font-size: calc(var(--text-base) * 0.7);
+	font-weight: var(--font-medium);
+	line-height: 1.4;
+	white-space: nowrap;
+	pointer-events: none;
+}
+
+.externalMarkdownHeaderActions {
+	position: relative;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex: 0 0 auto;
+	pointer-events: auto;
+	-webkit-app-region: no-drag;
+}
+
+.externalMarkdownHeaderButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 28px;
+	padding: 0 10px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 62%, transparent);
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--bg-primary) 78%, transparent);
+	color: var(--text-secondary);
+	font-size: calc(var(--text-base) * 0.78);
+	font-weight: var(--font-medium);
+	line-height: 1;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: background var(--transition-fast), color var(--transition-fast),
+		border-color var(--transition-fast);
+}
+
+.externalMarkdownHeaderButton:hover,
+.externalMarkdownHeaderButton:focus-visible {
+	background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+	border-color: color-mix(in srgb, var(--border-default) 88%, transparent);
+	color: var(--text-primary);
+	outline: none;
+}
+
+.externalMarkdownModeSwitch {
+	display: inline-flex;
+	align-items: center;
+	min-height: 28px;
+	padding: 2px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 62%, transparent);
+	border-radius: var(--radius-full);
+	background: color-mix(in srgb, var(--bg-primary) 78%, transparent);
+}
+
+.externalMarkdownModeSwitch .markdownEditorModeSwitch {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 1px;
+}
+
+.externalMarkdownModeSwitch .markdownEditorModeBtn {
+	width: 26px;
+	height: 24px;
+	min-width: 26px;
+	padding: 0;
+	border-radius: var(--radius-full);
+}
+
+.externalMarkdownModeSwitch .markdownEditorModeBtn[data-active="true"] {
+	background: color-mix(in srgb, var(--bg-hover) 88%, transparent);
+	color: var(--text-primary);
+}
+
+.externalMarkdownModeSwitch .markdownEditorModeBtnHint {
+	top: calc(100% + 8px);
 }
 
 .externalMarkdownBody {
@@ -84,44 +220,9 @@
 	background: transparent;
 }
 
-.externalMarkdownEditorPane {
-	position: relative;
-	width: 100%;
-	min-height: 100%;
-}
-
-.externalMarkdownFloatActions {
-	position: sticky;
-	top: calc(var(--external-markdown-chrome-height) - 34px);
-	z-index: 6;
-	display: inline-flex;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 10px;
-	width: min(
-		var(--editor-readable-content-max-width),
-		calc(100% - (2 * var(--editor-readable-content-gutter-compact)))
-	);
-	margin: 0 auto;
-	padding-right: 2px;
-	overflow: visible;
-	pointer-events: none;
-	-webkit-app-region: no-drag;
-}
-
-.externalMarkdownFloatActions > * {
-	pointer-events: auto;
-}
-
-.externalMarkdownFloatActions .markdownEditorToolbar {
-	flex: 0 0 auto;
-}
-
-.externalMarkdownFloatActions .markdownEditorModeSwitch {
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
 .externalMarkdownSaveStatus {
+	min-width: 4.5rem;
+	text-align: right;
 	color: var(--text-tertiary);
 	font-size: calc(var(--text-base) * 0.76);
 	font-weight: var(--font-medium);
@@ -143,23 +244,70 @@
 	color: color-mix(in srgb, var(--status-success-fg) 78%, var(--text-tertiary));
 }
 
-.externalMarkdownError {
-	position: absolute;
-	top: calc(var(--external-markdown-chrome-height) + 8px);
-	left: 50%;
-	z-index: 4;
-	width: min(
-		var(--editor-readable-content-max-width),
-		calc(100vw - (2 * var(--editor-readable-content-gutter-compact)))
+.externalMarkdownStatusBar {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	min-height: var(--external-markdown-status-height);
+	padding: 0 16px;
+	border-top: 1px solid
+		color-mix(in srgb, var(--border-default) 36%, transparent);
+	background: color-mix(
+		in srgb,
+		var(--bg-canvas, var(--bg-primary)) 88%,
+		transparent
 	);
-	padding: 8px 10px;
-	border: 1px solid var(--status-danger-border);
-	border-radius: var(--radius-md);
-	background: var(--status-danger-bg);
+	color: var(--text-tertiary);
+	font-size: calc(var(--text-base) * 0.76);
+	font-variant-numeric: tabular-nums;
+	line-height: 1;
+}
+
+.externalMarkdownStatusBar[data-error="true"] {
+	border-top-color: color-mix(in srgb, var(--status-danger-fg) 32%, transparent);
+	background: color-mix(in srgb, var(--status-danger-bg) 88%, transparent);
 	color: var(--status-danger-fg);
-	font-size: calc(var(--text-base) * 0.9);
-	line-height: 1.4;
-	transform: translateX(-50%);
+}
+
+.externalMarkdownStatusCounts {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.externalMarkdownStatusError {
+	min-width: 0;
+	flex: 1 1 auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-weight: var(--font-medium);
+}
+
+.externalMarkdownStatusDismiss {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: currentcolor;
+	cursor: pointer;
+	opacity: 0.8;
+}
+
+.externalMarkdownStatusDismiss:hover,
+.externalMarkdownStatusDismiss:focus-visible {
+	background: color-mix(in srgb, var(--status-danger-fg) 12%, transparent);
+	opacity: 1;
+	outline: none;
 }
 
 .externalMarkdownEditorShell {
@@ -175,12 +323,13 @@
 	min-height: 100%;
 	margin: 0 auto;
 	padding: calc(var(--external-markdown-chrome-height) + 6px)
-		var(--editor-readable-content-gutter) 50vh;
+		var(--editor-readable-content-gutter)
+		calc(50vh + var(--external-markdown-status-height));
 }
 
 .externalMarkdownEditorShell .rfNodeNoteEditor {
 	width: 100%;
-	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
+	min-height: var(--external-markdown-editor-min-height);
 	margin: 0 auto;
 	border: 0;
 	background: transparent;
@@ -198,7 +347,7 @@
 }
 
 .externalMarkdownEditorShell .rfNodeNoteEditorRaw {
-	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
+	min-height: var(--external-markdown-editor-min-height);
 	padding: 0;
 	border: 0;
 	background: transparent;
@@ -207,7 +356,7 @@
 
 .externalMarkdownEditorShell .tiptapHostInline,
 .externalMarkdownEditorShell .tiptapContentInline {
-	min-height: calc(100vh - var(--external-markdown-chrome-height) - 24px);
+	min-height: var(--external-markdown-editor-min-height);
 }
 
 .externalMarkdownEditorShell .tiptapContentInline {


### PR DESCRIPTION
Closes 

## Description

Improves the Quick Note capture panel and the external markdown window so both feel like proper floating writing surfaces instead of half-finished chrome.

### Summary of changes
- **Quick Note**: clickable destination pill/breadcrumbs, target context summary, destination at top / save at bottom, save-button confirmation morph, remembered position + auto-grow height, word/character counts + empty-state shortcut hint, focus ring, matched vibrancy corner radius
- **External editor**: stronger title hierarchy, interactive folder reveal + outside-space badge + Open in Glyph, mode switch grouped with Open in Glyph, bottom status bar for word count/save/errors (no overlay banner), dim chrome while typing, ⌘F find in minimal chrome, reveal-in-Finder command
- **Shared**: `app:open_note` event for cross-window open; external-markdown windows inherit the main space session so list-collapse load no longer toasts; only real space-relative paths are passed into the editor

### Reasoning
Capture and detached edit windows were hard to discover (destination only via tiny chevrons), cramped (target + save competing for one strip), and noisy (errors over text, list-collapse session errors on open). This pass keeps behavior mostly the same while cleaning layout, feedback, and auxiliary-window space resolution.

### Additional context
- No corresponding GitHub issue was provided for `Closes`.
- Append vs new-note toggle and click-to-rename title were intentionally not included (behavior/infra beyond this UI pass).
- Restart required after pull so Quick Note vibrancy radius and external-markdown space-session fallback take effect on newly created windows.

## Screenshots

Visual changes — please attach screenshots/recordings of:
1. Quick Note with top destination chip, summary, footer save morph, focus ring
2. External editor header with Open in Glyph + raw/rich/preview pills, bottom status strip
3. Dimmed chrome while typing (optional)

## Docs

- Quick Note geometry: `useQuickNoteWindowFrame` (localStorage `glyph.quickNote.frame`) + Rust starts at 680×240, no re-center on show
- Vibrancy radius: `QUICK_NOTE_CORNER_RADIUS = 20` must match CSS `--quick-note-radius: 20px`
- External reveal: `external_markdown_reveal` → `reveal_file_manager_path`
- Space session share: `shares_main_space_session()` includes `external-markdown-*` labels
- List collapse: silently skips when no space session remains

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the Quick Note and external markdown editors so they feel like true floating writing surfaces with clearer destinations, save feedback, and content-sized windows.

- **New Features**
  - Quick Note: clickable destination breadcrumbs with a target summary; save button morphs to confirmation; remembers position and auto-grows height; word/character counts; tighter focus ring and matched vibrancy radius; emits `app:open_note` to the main window on save.
  - External Markdown: header with title, folder reveal via `external_markdown_reveal`, “Open in Glyph” (when inside space); mode switch grouped in header; bottom status bar for word count/save/errors; dim chrome while typing; in-window find (⌘F) in minimal chrome.
  - Shared: cross-window open-note event standardized to `app:open_note`; external-markdown windows inherit the main space session to prevent list-collapse toasts; only real space-relative paths are sent to the editor; improved find centering across different scroll hosts.

- **Migration**
  - Restart the app after pulling so the Quick Note vibrancy radius and external-markdown session sharing apply to new windows.

<sup>Written for commit c730bd674682f98e30abdd5089a414cefff095a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish Quick Note and external markdown floating editor windows
> - Quick Note window gets a redesigned header with destination breadcrumbs and a `QuickNoteTargetSummary` showing word count of the target note, plus a footer with word/character counts and a saved confirmation state.
> - Quick Note remembers its position and auto-resizes to fit content via the new `useQuickNoteWindowFrame` hook; it no longer recenters on open.
> - On macOS, Quick Note uses HUD-style vibrancy with a 20px corner radius via a new `apply_quick_note_vibrancy` function; minimum window size is set to 420×180.
> - External markdown windows gain a structured header (`ExternalMarkdownHeader`) with title, folder reveal, and an 'Open in Glyph' button, plus a footer status bar (`ExternalMarkdownStatusBar`) showing word count and save status. Chrome dims while typing via `useDimChromeWhileTyping`.
> - A new `external_markdown_reveal` Tauri command reveals the file in the OS file manager; the `app:open_note` event replaces `quick-note:open_note` for cross-window note navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c730bd6. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Note now supports word and character counts, save confirmations, target summaries, and persistent window position and sizing.
  * External Markdown windows now show word counts, save status, folder details, and actions to reveal files or open them in Glyph.
  * Added dimmed window controls while typing for a cleaner editing experience.
* **Improvements**
  * Quick Note has a smaller, resizable floating design with improved breadcrumbs, spacing, and macOS vibrancy.
  * Find-in-note behavior now works reliably across editable editor layouts.
  * Improved handling of notes and Markdown files opened outside a space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->