### PR TITLE
Restyle new note button with accent-filled icon (#460) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.12-alpha.6",
+	"version": "0.8.12",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/app/GettingStartedPane.tsx
+++ b/src/components/app/GettingStartedPane.tsx
@@ -6,10 +6,7 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { type ComponentType, useMemo, useState } from "react";
 import { Calendar, Command, X } from "../Icons";
-import {
-	type IconProps,
-	withDefaultIconSize,
-} from "../Icons/NavigationIcons";
+import { type IconProps, withDefaultIconSize } from "../Icons/NavigationIcons";
 import { springPresets } from "../ui/animations";
 import { Button } from "../ui/shadcn/button";
 

--- a/src/components/app/GettingStartedPane.tsx
+++ b/src/components/app/GettingStartedPane.tsx
@@ -1,11 +1,27 @@
-import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import {
+	CheckmarkCircle02Icon,
+	CursorAddSelection02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { type ComponentType, useMemo, useState } from "react";
-import { Calendar, Command, FileText, X } from "../Icons";
-import type { IconProps } from "../Icons/NavigationIcons";
+import { Calendar, Command, X } from "../Icons";
+import {
+	type IconProps,
+	withDefaultIconSize,
+} from "../Icons/NavigationIcons";
 import { springPresets } from "../ui/animations";
 import { Button } from "../ui/shadcn/button";
+
+function CreateNoteIcon(props: IconProps) {
+	return (
+		<HugeiconsIcon
+			icon={CursorAddSelection02Icon}
+			strokeWidth={0.9}
+			{...withDefaultIconSize(props)}
+		/>
+	);
+}
 
 interface GettingStartedPaneProps {
 	commandShortcutParts: string[];
@@ -35,7 +51,7 @@ function buildSteps(showDailyNote: boolean): Step[] {
 			title: "Create your first note",
 			description:
 				"Start writing here, and when you're ready you can also point Glyph at an existing folder of Markdown notes. Your files stay as plain .md in your folder.",
-			icon: FileText,
+			icon: CreateNoteIcon,
 		},
 		{
 			key: "command",

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -1,3 +1,5 @@
+import { CursorAddSelection02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import {
 	Activity,
@@ -45,7 +47,7 @@ import type { FsEntry } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { toast } from "../../lib/toast";
 import { cn } from "../../lib/utils";
-import { Calendar, FileText } from "../Icons";
+import { Calendar } from "../Icons";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
 import type { CreateMarkdownFileOptions } from "../editor/types";
 import { FolioWorkspace } from "../folio/FolioWorkspace";
@@ -104,7 +106,13 @@ function ContextualEmptyState({
 		if (!onboarding.createdFirstNote) {
 			t.push({
 				key: "note",
-				icon: <FileText size="var(--icon-lg)" />,
+				icon: (
+					<HugeiconsIcon
+						icon={CursorAddSelection02Icon}
+						size="var(--icon-lg)"
+						strokeWidth={0.9}
+					/>
+				),
 				text: "Create your first note",
 				action: "New note",
 				onClick: onCreateNote,

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -2,9 +2,9 @@ import {
 	Archive04Icon,
 	ArrowShrinkIcon,
 	ChartRelationshipIcon,
+	CursorAddSelection02Icon,
 	ExpandParagraphIcon,
 	LibraryIcon,
-	NoteIcon,
 	Sorting01Icon,
 	StarIcon,
 } from "@hugeicons/core-free-icons";
@@ -381,8 +381,8 @@ export const SidebarContent = memo(function SidebarContent({
 							}`}
 						>
 							<HugeiconsIcon
-								icon={NoteIcon}
-								size="var(--icon-md)"
+								icon={CursorAddSelection02Icon}
+								size="var(--icon-lg)"
 								strokeWidth={0.9}
 							/>
 							<span className="sidebarQuickActionLabel">

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -7,6 +7,7 @@ import {
 	CalendarAdd01Icon,
 	ChartRelationshipIcon,
 	ColorsIcon,
+	CursorAddSelection02Icon,
 	CursorInWindowIcon,
 	FileImportIcon,
 	Folder01Icon,
@@ -22,7 +23,6 @@ import {
 	Link01Icon,
 	MoveIcon,
 	NoteIcon,
-	PencilEdit02Icon,
 	PinIcon,
 	PinOffIcon,
 	SearchIcon,
@@ -324,7 +324,7 @@ export function useAppCommands({
 				id: "new-note",
 				icon: (
 					<HugeiconsIcon
-						icon={PencilEdit02Icon}
+						icon={CursorAddSelection02Icon}
 						size="var(--icon-lg)"
 						strokeWidth={0.9}
 					/>

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -1,4 +1,8 @@
-import { LibraryIcon, NoteIcon, StarIcon } from "@hugeicons/core-free-icons";
+import {
+	CursorAddSelection02Icon,
+	LibraryIcon,
+	StarIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -181,13 +185,14 @@ export function CollectionTopBar({
 					</Button>
 					<button
 						type="button"
-						className="databaseToolbarChip is-accent"
+						className="databaseToolbarChip"
+						data-kind="new-note"
 						onClick={() => void actions.handleCreateRow()}
 						title="New note"
 					>
 						<HugeiconsIcon
-							icon={NoteIcon}
-							size="var(--icon-md)"
+							icon={CursorAddSelection02Icon}
+							size="var(--icon-lg)"
 							strokeWidth={0.9}
 						/>
 						New Note

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -141,7 +141,7 @@
 }
 
 .sidebarNavBtn[data-kind="new-note"] > svg path {
-	fill: currentColor;
+	fill: currentcolor;
 }
 
 .sidebarNavBtn .sidebarQuickActionLabel {

--- a/src/styles/app/35-sidebar-nav.css
+++ b/src/styles/app/35-sidebar-nav.css
@@ -96,10 +96,6 @@
 	opacity: 1;
 }
 
-.sidebarQuickActionBtn[data-kind="new-note"] .sidebarQuickActionShortcut {
-	color: var(--text-inverse);
-}
-
 .sidebarQuickActionCount {
 	flex: 0 0 auto;
 	margin-left: auto;
@@ -139,6 +135,15 @@
 	fill: currentColor;
 }
 
+/* ── New note: filled accent icon ── */
+.sidebarNavBtn[data-kind="new-note"] > svg {
+	color: var(--interactive-accent);
+}
+
+.sidebarNavBtn[data-kind="new-note"] > svg path {
+	fill: currentColor;
+}
+
 .sidebarNavBtn .sidebarQuickActionLabel {
 	min-width: 0;
 	overflow: hidden;
@@ -146,23 +151,4 @@
 	white-space: nowrap;
 	font-weight: var(--font-normal);
 	line-height: 1;
-}
-
-.sidebarQuickActionBtn[data-kind="new-note"] {
-	background: var(--interactive-accent);
-	color: var(--text-inverse);
-	margin-bottom: 2px;
-}
-
-.sidebarQuickActionBtn[data-kind="new-note"] > svg {
-	color: var(--text-inverse);
-}
-
-.sidebarQuickActionBtn[data-kind="new-note"]:hover {
-	background: var(--interactive-accent-hover);
-	color: var(--text-inverse);
-}
-
-.sidebarQuickActionBtn[data-kind="new-note"]:hover > svg {
-	color: var(--text-inverse);
 }

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -218,7 +218,7 @@
 }
 
 .databaseToolbarChip[data-kind="new-note"] > svg path {
-	fill: currentColor;
+	fill: currentcolor;
 }
 
 .databaseToolbarGroupBy {

--- a/src/styles/app/37-database.css
+++ b/src/styles/app/37-database.css
@@ -212,20 +212,13 @@
 	color: var(--text-primary);
 }
 
-.databaseToolbarChip.is-accent {
-	border-color: color-mix(
-		in srgb,
-		var(--interactive-accent) 72%,
-		var(--border-strong)
-	);
-	background: var(--interactive-accent);
-	color: var(--text-inverse);
-	box-shadow: 0 1px 2px color-mix(in srgb, var(--text-primary) 12%, transparent);
+/* New note: filled accent icon */
+.databaseToolbarChip[data-kind="new-note"] > svg {
+	color: var(--interactive-accent);
 }
 
-.databaseToolbarChip.is-accent:hover {
-	background: var(--interactive-accent-hover);
-	color: var(--text-inverse);
+.databaseToolbarChip[data-kind="new-note"] > svg path {
+	fill: currentColor;
 }
 
 .databaseToolbarGroupBy {


### PR DESCRIPTION
Closes 


## Description

Restyles the New Note affordance so it no longer uses a filled accent button background. The control sits with the rest of the sidebar/database nav rows, and the icon carries the accent instead.

- **Summary of changes**
  - Sidebar New Note: drop accent background; use filled accent `CursorAddSelection02Icon` at `--icon-lg`
  - Databases collection New Note chip: same icon treatment; remove dead `is-accent` chip styles
  - Align New Note icon across command palette, empty-state tip, and Getting Started
  - Remove inverse shortcut/label colors that only existed for the old filled CTA
- **Reasoning**
  - Accent background made New Note dominate the nav; an accent-filled icon keeps it findable without looking like a primary button
  - One icon for every create-note entry point keeps the action recognizable
- **Additional context**
  - `pnpm check` passes (Biome format fix included on this branch)


## Screenshots

Visual change in the sidebar New Note row and databases collection toolbar New Note chip. Please add a light/dark screenshot if useful for review.


## Docs

- Sidebar/databases styles: accent color on the icon via `color: var(--interactive-accent)` and `fill: currentColor` on paths
- Icon: `CursorAddSelection02Icon` from `@hugeicons/core-free-icons`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyled the New Note entry point so the accent lives in a filled icon instead of a filled button, reducing visual weight. The same icon treatment is now used in the sidebar, databases toolbar chip, command palette, empty states, and Getting Started.

- **Refactors**
  - Replaced create‑note icon with `CursorAddSelection02Icon` at `--icon-lg` via `@hugeicons/core-free-icons` and `@hugeicons/react`.
  - Sidebar/databases: removed accent-filled button styles and inverse label/shortcut colors; added icon accent via `color: var(--interactive-accent)` and `fill: currentColor`.
  - Databases toolbar chip: removed dead `is-accent` styles; targeted via `data-kind="new-note"`.
  - Aligned icon usage across command palette, Getting Started, and contextual empty state; cleaned up unused imports.

<sup>Written for commit b219a87fb55b21dfe9a2f9a8f8ee0556bb634664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restyle new note button with an accent-filled icon across sidebar, toolbar, and command palette
> - Replaces the `NoteIcon`/`FileText` icon with `CursorAddSelection02Icon` (from Hugeicons) on the new note button in the sidebar quick actions, collection top bar, command palette, empty state, and onboarding steps.
> - Removes the accent background chip style from the sidebar and database toolbar; instead, only the icon itself is accent-colored and path-filled via CSS on `[data-kind="new-note"]` elements.
> - Behavioral Change: the 'New Note' chip in the collection top bar loses the `is-accent` class and its filled accent background; styling is now driven by the `data-kind` attribute and CSS icon coloring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b219a87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated new-note icons across the app with a consistent cursor-and-selection design.
  * Refined icon sizing and accent colors in the sidebar, empty states, commands, and collection toolbar.
  * Simplified new-note button styling for a cleaner, more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->