### PR TITLE
Add glyph:// deeplink support (#464)[Release]

### DIFF
--- a/docs/architecture/adr/014-deeplink-implementation.md
+++ b/docs/architecture/adr/014-deeplink-implementation.md
@@ -1,0 +1,93 @@
+# ADR 014: Deeplink platform lifecycle and security policy
+
+## Status
+
+Accepted
+
+## Context
+
+ADRs 001–013 lock the product contract for `glyph://` deeplinks. Shipping them requires a single answer for OS delivery, multi-window routing, parser ownership, cold-start queueing, and path/symlink policy so implementation does not invent routes or guess spaces.
+
+## Decision
+
+### Platform delivery
+
+| Platform | Registration | Runtime delivery |
+| --- | --- | --- |
+| macOS | Static scheme via `tauri-plugin-deep-link` (`CFBundleURLTypes`) | Plugin `on_open_url` only. The plugin hooks the same `RunEvent::Opened`, so our own handler stays `file://`-only to avoid dispatching twice |
+| Windows / Linux | Static scheme in plugin config; runtime `register_all` in debug/dev where needed | Plugin `on_open_url`; second-process launches forwarded via `tauri-plugin-single-instance` with `deep-link` feature |
+
+- `file://` / Finder association handling is unchanged (ADR 009).
+- Only the configured scheme `glyph` is accepted. No HTTPS / Universal Links (ADR 011).
+
+### Parser ownership
+
+- **One allowlist parser at the native boundary** (`src-tauri/src/deeplink`).
+- Frontend may build canonical URLs for copy and may call `deeplink_open` for in-note clicks; it does not re-implement route allowlisting.
+- Unknown paths, wrong scheme, missing/extra required params, fragments, non-absolute `space=`, absolute/traversing note `path=` → reject with a visible error (ADR 010).
+
+### Typed action contract
+
+Routes map 1:1 to ADR 013:
+
+| Route | Action |
+| --- | --- |
+| `glyph://open/note?space=&path=` | `OpenNote` |
+| `glyph://open/space?space=` | `OpenSpace` |
+| `glyph://search?space=&q=` | `Search` |
+| `glyph://open/daily-note?space=` | `OpenDailyNote` |
+
+URL shape: path-style with host + path (`glyph://open/note` → host `open`, path `/note`). Query holds parameters. Canonical encoding uses standard percent-encoding so spaces and Unicode round-trip.
+
+### Window routing
+
+Every route targets the main window. Auxiliary windows (quick note, external
+markdown) deliberately inherit the main space session instead of owning one, so
+there is no second window a deeplink could be routed to.
+
+1. Normalize `space=` to an absolute path; canonicalize when the path exists.
+2. Show and focus the main window, then open that space there (reuse `space_open` / the frontend open-space flow).
+3. Emit with `emit_to(MAIN_WINDOW_LABEL, …)`. Plain `emit` is an app-wide broadcast in Tauri v2 regardless of the receiver, so it cannot be used for targeting.
+
+### Native validation
+
+The space directory and, for `open/note`, the resolved note are checked natively
+before anything is dispatched. The shell therefore never re-reads the file to
+test existence, and a stale link fails with one message instead of a
+half-applied space switch.
+
+### Window readiness / queue
+
+- Parsed actions are enqueued in `DeeplinkState` *and* emitted as `deeplink:action`, because the webview is not listening yet on a cold start.
+- Each dispatch carries a process-unique id. The frontend drains `deeplink_take_pending` and discards ids it already handled, so the live emit and its queue mirror cannot run twice and a drain cannot destroy an entry it did not deliver.
+- Rejections are queued and emitted the same way, so a cold-start failure is still reported.
+- The queue is bounded; the oldest entries are dropped first.
+
+### Error wording
+
+Native code emits a coarse machine code (`malformed`, `space_not_found`,
+`note_not_found`, `note_not_markdown`); the frontend owns the wording so
+deeplink failures are translated like every other user-facing string. The
+precise cause stays in the log.
+
+### Symlink and path policy
+
+- **`space=`**: must be absolute. Prefer `canonicalize` so symlinked roots resolve to a real directory. If the path does not exist or is not a directory → error (do not create spaces).
+- **`path=` (notes)**: space-relative only. Validate with `paths::join_under()` (rejects absolute segments and `..`). Lexical containment is the security boundary; the resolved absolute path is not re-canonicalized through user-controlled symlinks for escape (same model as other space FS ops). Missing note for `open/note` → error, no create. Daily note create-if-missing stays on the existing frontend daily-note flow (ADR 012).
+- Do not treat lexical containment alone as full symlink containment for *space roots*; space identity always goes through canonicalize when the root exists.
+
+### Failure UX (ADR 010)
+
+- Parse/route failures emit `deeplink:error` (or an error-shaped action delivery) so the focused/main window shows a toast.
+- Generic messages; avoid dumping raw sensitive path internals beyond what the user already supplied in the URL.
+
+### In-app copy and click (ADR 007)
+
+- File-tree “Copy deeplink” for markdown notes builds `glyph://open/note?space=<abs>&path=<rel>`.
+- In-note `glyph://` activation invokes the same native `deeplink_open` dispatcher as external opens.
+
+## Consequences
+
+- Scheme registration and single-instance are required dependencies for desktop delivery.
+- New routes require a new accepted ADR; the parser stays a closed allowlist.
+- Frontend dispatch reuses existing open-note, open-space, search palette, and daily-note flows; it does not invent parallel navigation.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -524,6 +524,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +686,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -905,6 +931,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1601,10 +1636,12 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
  "time",
@@ -1882,7 +1919,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -2941,6 +2978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,6 +3853,16 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -4717,6 +4774,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "windows-registry 0.5.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4801,6 +4879,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]
@@ -5055,6 +5150,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -5976,6 +6080,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,8 @@ rig-core = { version = "0.24.0", features = ["derive"] }
 schemars = "0.8"
 tauri-plugin-process = "2"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "20"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -33,6 +33,7 @@
 		"opener:default",
 		"process:allow-restart",
 		"store:default",
-		"updater:default"
+		"updater:default",
+		"deep-link:default"
 	]
 }

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -57,7 +57,10 @@ pub struct PendingDeeplinks {
 pub struct DeeplinkState {
     actions: Mutex<VecDeque<DeeplinkEvent>>,
     errors: Mutex<VecDeque<DeeplinkErrorPayload>>,
-    last_os_url: Mutex<Option<(String, Instant)>>,
+    /// Recent OS URLs inside `OS_DEDUPE_WINDOW`. A single "last URL" slot is not
+    /// enough: cold starts can deliver multiple URLs via `get_current`, then
+    /// re-deliver the same set live — each earlier URL would miss a 1-slot check.
+    recent_os_urls: Mutex<VecDeque<(String, Instant)>>,
     next_id: AtomicU64,
 }
 
@@ -91,16 +94,20 @@ impl DeeplinkState {
 
     fn is_repeat_os_url(&self, url: &str) -> bool {
         let mut guard = self
-            .last_os_url
+            .recent_os_urls
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let now = Instant::now();
-        if let Some((previous, at)) = guard.as_ref() {
-            if previous == url && now.duration_since(*at) < OS_DEDUPE_WINDOW {
-                return true;
+        while let Some((_, at)) = guard.front() {
+            if now.duration_since(*at) < OS_DEDUPE_WINDOW {
+                break;
             }
+            guard.pop_front();
         }
-        *guard = Some((url.to_string(), now));
+        if guard.iter().any(|(previous, _)| previous == url) {
+            return true;
+        }
+        guard.push_back((url.to_string(), now));
         false
     }
 }
@@ -293,5 +300,7 @@ mod tests {
         assert!(!state.is_repeat_os_url("glyph://open/space?space=/tmp"));
         assert!(state.is_repeat_os_url("glyph://open/space?space=/tmp"));
         assert!(!state.is_repeat_os_url("glyph://open/space?space=/other"));
+        // Earlier URL is still remembered while a second one is recorded.
+        assert!(state.is_repeat_os_url("glyph://open/space?space=/tmp"));
     }
 }

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -1,0 +1,297 @@
+//! `glyph://` deeplink parse, validation, queue, and dispatch to the app shell.
+
+mod parse;
+
+pub use parse::{parse_deeplink_url, DeeplinkAction, DeeplinkError};
+
+use serde::Serialize;
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tracing::warn;
+
+use crate::window_geometry::MAIN_WINDOW_LABEL;
+
+const DEEPLINK_ACTION_EVENT: &str = "deeplink:action";
+const DEEPLINK_ERROR_EVENT: &str = "deeplink:error";
+/// Guards the documented overlap between `get_current()` at startup and a live
+/// `on_open_url` delivery of the same cold-start URL.
+const OS_DEDUPE_WINDOW: Duration = Duration::from_millis(400);
+const MAX_PENDING: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeeplinkSource {
+    /// Delivered by the OS (`on_open_url`, startup `get_current`).
+    Os,
+    /// Activated from inside the app, e.g. a `glyph://` link in a note.
+    InApp,
+}
+
+/// Dispatched action tagged with a process-unique id. The id lets the frontend
+/// discard the pending-queue mirror of an action it already received live,
+/// without guessing from timing.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeeplinkEvent {
+    pub id: u64,
+    #[serde(flatten)]
+    pub action: DeeplinkAction,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DeeplinkErrorPayload {
+    pub id: u64,
+    pub code: &'static str,
+}
+
+/// Deeplinks that arrived before the app shell was listening.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PendingDeeplinks {
+    pub actions: Vec<DeeplinkEvent>,
+    pub errors: Vec<DeeplinkErrorPayload>,
+}
+
+#[derive(Default)]
+pub struct DeeplinkState {
+    actions: Mutex<VecDeque<DeeplinkEvent>>,
+    errors: Mutex<VecDeque<DeeplinkErrorPayload>>,
+    last_os_url: Mutex<Option<(String, Instant)>>,
+    next_id: AtomicU64,
+}
+
+fn push_bounded<T>(queue: &Mutex<VecDeque<T>>, item: T) {
+    let mut queue = queue.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    queue.push_back(item);
+    while queue.len() > MAX_PENDING {
+        queue.pop_front();
+    }
+}
+
+fn drain<T>(queue: &Mutex<VecDeque<T>>) -> Vec<T> {
+    queue
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .drain(..)
+        .collect()
+}
+
+impl DeeplinkState {
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn take_pending(&self) -> PendingDeeplinks {
+        PendingDeeplinks {
+            actions: drain(&self.actions),
+            errors: drain(&self.errors),
+        }
+    }
+
+    fn is_repeat_os_url(&self, url: &str) -> bool {
+        let mut guard = self
+            .last_os_url
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let now = Instant::now();
+        if let Some((previous, at)) = guard.as_ref() {
+            if previous == url && now.duration_since(*at) < OS_DEDUPE_WINDOW {
+                return true;
+            }
+        }
+        *guard = Some((url.to_string(), now));
+        false
+    }
+}
+
+pub fn handle_url(app: &AppHandle, raw: &str, source: DeeplinkSource) {
+    let Some(state) = app.try_state::<DeeplinkState>() else {
+        warn!("deeplink state unavailable");
+        return;
+    };
+    if source == DeeplinkSource::Os && state.is_repeat_os_url(raw) {
+        return;
+    }
+
+    match parse_deeplink_url(raw).and_then(validate_action) {
+        Ok(action) => dispatch_action(app, &state, action),
+        Err(error) => {
+            warn!("Rejected deeplink {raw}: {error}");
+            dispatch_error(app, &state, &error);
+        }
+    }
+}
+
+/// Resolve the target against the filesystem before the shell is asked to
+/// navigate, so a stale link fails with one clear message instead of a
+/// half-applied space switch.
+fn validate_action(action: DeeplinkAction) -> Result<DeeplinkAction, DeeplinkError> {
+    if !Path::new(action.space_path()).is_dir() {
+        return Err(DeeplinkError::SpaceNotFound);
+    }
+    if let DeeplinkAction::OpenNote { space, path } = &action {
+        let abs = crate::paths::join_under(Path::new(space), Path::new(path))
+            .map_err(|_| DeeplinkError::InvalidNotePath)?;
+        if !crate::utils::is_markdown_path(&abs) {
+            return Err(DeeplinkError::NoteNotMarkdown);
+        }
+        if !abs.is_file() {
+            return Err(DeeplinkError::NoteNotFound);
+        }
+    }
+    Ok(action)
+}
+
+fn dispatch_action(app: &AppHandle, state: &DeeplinkState, action: DeeplinkAction) {
+    let event = DeeplinkEvent {
+        id: state.next_id(),
+        action,
+    };
+    // Queue before emitting: on a cold start the webview is not listening yet.
+    push_bounded(&state.actions, event.clone());
+    show_shell(app);
+    if let Err(error) = app.emit_to(MAIN_WINDOW_LABEL, DEEPLINK_ACTION_EVENT, &event) {
+        warn!("Failed to emit deeplink action: {error}");
+    }
+}
+
+fn dispatch_error(app: &AppHandle, state: &DeeplinkState, error: &DeeplinkError) {
+    let payload = DeeplinkErrorPayload {
+        id: state.next_id(),
+        code: error.code(),
+    };
+    push_bounded(&state.errors, payload.clone());
+    show_shell(app);
+    if let Err(error) = app.emit_to(MAIN_WINDOW_LABEL, DEEPLINK_ERROR_EVENT, &payload) {
+        warn!("Failed to emit deeplink error: {error}");
+    }
+}
+
+/// Every deeplink route needs the main app shell; auxiliary windows (quick
+/// note, external markdown) never own a space session of their own.
+fn show_shell(app: &AppHandle) {
+    if let Err(error) = crate::show_main_window_for_app(app) {
+        warn!("Failed to show main window for deeplink: {error}");
+    }
+}
+
+#[tauri::command]
+pub fn deeplink_take_pending(state: State<'_, DeeplinkState>) -> PendingDeeplinks {
+    state.take_pending()
+}
+
+/// Frontend entry for in-note `glyph://` activation (same path as OS opens).
+/// Async so the filesystem validation never runs on the UI thread.
+#[tauri::command]
+pub async fn deeplink_open(app: AppHandle, url: String) -> Result<(), String> {
+    let trimmed = url.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("empty deeplink".to_string());
+    }
+    handle_url(&app, &trimmed, DeeplinkSource::InApp);
+    Ok(())
+}
+
+/// Consume a cold-start URL the plugin recorded before `on_open_url` was
+/// registered. No-op on macOS, where the run event always arrives after setup.
+pub fn consume_startup_url(app: &AppHandle) {
+    use tauri_plugin_deep_link::DeepLinkExt;
+    let Ok(Some(urls)) = app.deep_link().get_current() else {
+        return;
+    };
+    for url in urls {
+        if url.scheme() == "glyph" {
+            handle_url(app, url.as_str(), DeeplinkSource::Os);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_space() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!("glyph-deeplink-test-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn open_note(space: &Path, path: &str) -> DeeplinkAction {
+        DeeplinkAction::OpenNote {
+            space: space.to_string_lossy().to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    #[test]
+    fn validate_action_checks_space_note_and_extension() {
+        let root = temp_space();
+        fs::write(root.join("a.md"), "hi").unwrap();
+        fs::write(root.join("b.txt"), "x").unwrap();
+
+        assert!(validate_action(open_note(&root, "a.md")).is_ok());
+        assert_eq!(
+            validate_action(open_note(&root, "missing.md")),
+            Err(DeeplinkError::NoteNotFound)
+        );
+        assert_eq!(
+            validate_action(open_note(&root, "b.txt")),
+            Err(DeeplinkError::NoteNotMarkdown)
+        );
+        assert_eq!(
+            validate_action(open_note(&root, "../a.md")),
+            Err(DeeplinkError::InvalidNotePath)
+        );
+        assert_eq!(
+            validate_action(DeeplinkAction::OpenSpace {
+                space: root.join("nope").to_string_lossy().to_string(),
+            }),
+            Err(DeeplinkError::SpaceNotFound)
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn pending_queue_is_bounded_and_drains_once() {
+        let state = DeeplinkState::default();
+        let root = temp_space();
+        for _ in 0..MAX_PENDING + 4 {
+            push_bounded(
+                &state.actions,
+                DeeplinkEvent {
+                    id: state.next_id(),
+                    action: DeeplinkAction::OpenSpace {
+                        space: root.to_string_lossy().to_string(),
+                    },
+                },
+            );
+        }
+        let taken = state.take_pending();
+        assert_eq!(taken.actions.len(), MAX_PENDING);
+        // Ids are monotonic, so the oldest entries were the ones dropped.
+        assert_eq!(taken.actions[0].id, 5);
+
+        let remaining = state.take_pending();
+        assert!(remaining.actions.is_empty());
+        assert!(remaining.errors.is_empty());
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn repeated_os_url_is_suppressed_within_the_window() {
+        let state = DeeplinkState::default();
+        assert!(!state.is_repeat_os_url("glyph://open/space?space=/tmp"));
+        assert!(state.is_repeat_os_url("glyph://open/space?space=/tmp"));
+        assert!(!state.is_repeat_os_url("glyph://open/space?space=/other"));
+    }
+}

--- a/src-tauri/src/deeplink/parse.rs
+++ b/src-tauri/src/deeplink/parse.rs
@@ -1,0 +1,463 @@
+//! Allowlist parser for ADR 013 routes.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Component, Path, PathBuf};
+use url::Url;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DeeplinkAction {
+    OpenNote { space: String, path: String },
+    OpenSpace { space: String },
+    Search { space: String, q: String },
+    OpenDailyNote { space: String },
+}
+
+impl DeeplinkAction {
+    pub fn space_path(&self) -> &str {
+        match self {
+            Self::OpenNote { space, .. }
+            | Self::OpenSpace { space }
+            | Self::Search { space, .. }
+            | Self::OpenDailyNote { space } => space,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeeplinkError {
+    InvalidUrl,
+    WrongScheme,
+    UnknownRoute,
+    MissingParam(&'static str),
+    UnexpectedParam(String),
+    DuplicateParam(String),
+    FragmentNotAllowed,
+    InvalidSpacePath,
+    NotePathAbsolute,
+    NotePathTraversal,
+    InvalidNotePath,
+    EmptyParam(&'static str),
+    SpaceNotFound,
+    NoteNotFound,
+    NoteNotMarkdown,
+}
+
+impl DeeplinkError {
+    /// Coarse machine code for the UI. The frontend owns the wording so that
+    /// deeplink failures are translated like every other user-facing string;
+    /// the precise cause stays in the log via `Display`.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::InvalidUrl
+            | Self::WrongScheme
+            | Self::UnknownRoute
+            | Self::MissingParam(_)
+            | Self::UnexpectedParam(_)
+            | Self::DuplicateParam(_)
+            | Self::FragmentNotAllowed
+            | Self::InvalidSpacePath
+            | Self::NotePathAbsolute
+            | Self::NotePathTraversal
+            | Self::InvalidNotePath
+            | Self::EmptyParam(_) => "malformed",
+            Self::SpaceNotFound => "space_not_found",
+            Self::NoteNotFound => "note_not_found",
+            Self::NoteNotMarkdown => "note_not_markdown",
+        }
+    }
+}
+
+impl std::fmt::Display for DeeplinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidUrl => write!(f, "invalid url"),
+            Self::WrongScheme => write!(f, "unsupported scheme"),
+            Self::UnknownRoute => write!(f, "unknown route"),
+            Self::MissingParam(name) => write!(f, "missing required parameter `{name}`"),
+            Self::UnexpectedParam(name) => write!(f, "unsupported parameter `{name}`"),
+            Self::DuplicateParam(name) => write!(f, "duplicate parameter `{name}`"),
+            Self::FragmentNotAllowed => write!(f, "fragments are not supported"),
+            Self::InvalidSpacePath => write!(f, "space path is invalid"),
+            Self::NotePathAbsolute => write!(f, "note path must be relative"),
+            Self::NotePathTraversal => write!(f, "note path escapes the space"),
+            Self::InvalidNotePath => write!(f, "note path is invalid"),
+            Self::EmptyParam(name) => write!(f, "parameter `{name}` is empty"),
+            Self::SpaceNotFound => write!(f, "space directory not found"),
+            Self::NoteNotFound => write!(f, "note not found"),
+            Self::NoteNotMarkdown => write!(f, "note is not a markdown file"),
+        }
+    }
+}
+
+impl std::error::Error for DeeplinkError {}
+
+/// Parse a raw `glyph://…` URL into a typed action (ADR 013 allowlist only).
+pub fn parse_deeplink_url(raw: &str) -> Result<DeeplinkAction, DeeplinkError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(DeeplinkError::InvalidUrl);
+    }
+
+    let url = Url::parse(trimmed).map_err(|_| DeeplinkError::InvalidUrl)?;
+    if url.scheme() != "glyph" {
+        return Err(DeeplinkError::WrongScheme);
+    }
+    if url.fragment().is_some() {
+        return Err(DeeplinkError::FragmentNotAllowed);
+    }
+
+    let route = route_from_url(&url)?;
+    let params = collect_query_params(&url)?;
+
+    match route.as_str() {
+        "open/note" => {
+            expect_only_keys(&params, &["space", "path"])?;
+            let space = require_space(&params)?;
+            let path = require_note_path(&params)?;
+            Ok(DeeplinkAction::OpenNote { space, path })
+        }
+        "open/space" => {
+            expect_only_keys(&params, &["space"])?;
+            let space = require_space(&params)?;
+            Ok(DeeplinkAction::OpenSpace { space })
+        }
+        "search" => {
+            expect_only_keys(&params, &["space", "q"])?;
+            let space = require_space(&params)?;
+            let q = require_nonempty(&params, "q")?;
+            Ok(DeeplinkAction::Search { space, q })
+        }
+        "open/daily-note" => {
+            expect_only_keys(&params, &["space"])?;
+            let space = require_space(&params)?;
+            Ok(DeeplinkAction::OpenDailyNote { space })
+        }
+        _ => Err(DeeplinkError::UnknownRoute),
+    }
+}
+
+fn route_from_url(url: &Url) -> Result<String, DeeplinkError> {
+    // Canonical shape: glyph://open/note → host "open", path "/note"
+    // Also accept glyph:///open/note (empty host, path "/open/note").
+    let host = url.host_str().unwrap_or("").trim().to_ascii_lowercase();
+    let path = url.path().trim_matches('/');
+    let path_lower = path.to_ascii_lowercase();
+
+    if !host.is_empty() {
+        if path_lower.is_empty() {
+            return Ok(host);
+        }
+        return Ok(format!("{host}/{path_lower}"));
+    }
+
+    if path_lower.is_empty() {
+        return Err(DeeplinkError::UnknownRoute);
+    }
+    Ok(path_lower)
+}
+
+fn collect_query_params(url: &Url) -> Result<BTreeMap<String, String>, DeeplinkError> {
+    let mut map = BTreeMap::new();
+    for (key, value) in url.query_pairs() {
+        let key = key.to_string();
+        if map.contains_key(&key) {
+            return Err(DeeplinkError::DuplicateParam(key));
+        }
+        map.insert(key, value.to_string());
+    }
+    Ok(map)
+}
+
+fn expect_only_keys(
+    params: &BTreeMap<String, String>,
+    allowed: &[&str],
+) -> Result<(), DeeplinkError> {
+    for key in params.keys() {
+        if !allowed.iter().any(|a| a == key) {
+            return Err(DeeplinkError::UnexpectedParam(key.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn require_nonempty(
+    params: &BTreeMap<String, String>,
+    key: &'static str,
+) -> Result<String, DeeplinkError> {
+    let value = params
+        .get(key)
+        .ok_or(DeeplinkError::MissingParam(key))?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(DeeplinkError::EmptyParam(key));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn require_space(params: &BTreeMap<String, String>) -> Result<String, DeeplinkError> {
+    let raw = require_nonempty(params, "space")?;
+    let normalized = normalize_space_path(&raw).map_err(|_| DeeplinkError::InvalidSpacePath)?;
+    Ok(path_to_string(&normalized))
+}
+
+fn require_note_path(params: &BTreeMap<String, String>) -> Result<String, DeeplinkError> {
+    let raw = require_nonempty(params, "path")?;
+    normalize_note_rel_path(&raw)
+}
+
+/// Absolute space path: reject relative; canonicalize when the directory exists.
+pub fn normalize_space_path(raw: &str) -> Result<PathBuf, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("empty space path".to_string());
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err("space path must be absolute".to_string());
+    }
+    // Reject `.` / `..` components in the raw absolute path for stable identity.
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {}
+            Component::CurDir | Component::ParentDir => {
+                return Err("space path must not contain '.' or '..'".to_string());
+            }
+        }
+    }
+    if path.exists() {
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| format!("invalid space path: {e}"))?;
+        if !canonical.is_dir() {
+            return Err("space path is not a directory".to_string());
+        }
+        return Ok(canonical);
+    }
+    // Cold callers may pass a valid absolute path that is not yet readable; still
+    // require absolute form. Existence is re-checked when opening the space.
+    Ok(path)
+}
+
+fn normalize_note_rel_path(raw: &str) -> Result<String, DeeplinkError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(DeeplinkError::EmptyParam("path"));
+    }
+    // Absolute forms are invalid for note path= (ADR 008). Check before any
+    // cosmetic slash stripping so "/etc/passwd" never becomes relative.
+    if trimmed.starts_with('/') || trimmed.starts_with('\\') {
+        return Err(DeeplinkError::NotePathAbsolute);
+    }
+    let path = Path::new(trimmed);
+    if path.is_absolute() {
+        return Err(DeeplinkError::NotePathAbsolute);
+    }
+    let mut parts: Vec<String> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(seg) => {
+                let s = seg.to_string_lossy();
+                if s.is_empty() || s == "." {
+                    continue;
+                }
+                if s == ".." {
+                    return Err(DeeplinkError::NotePathTraversal);
+                }
+                parts.push(s.into_owned());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => return Err(DeeplinkError::NotePathTraversal),
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(DeeplinkError::NotePathAbsolute);
+            }
+        }
+    }
+    if parts.is_empty() {
+        return Err(DeeplinkError::EmptyParam("path"));
+    }
+    Ok(parts.join("/"))
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn abs_space() -> String {
+        if cfg!(windows) {
+            r"C:\vault".to_string()
+        } else {
+            "/Users/me/vault".to_string()
+        }
+    }
+
+    fn encode(s: &str) -> String {
+        urlencoding_lite(s)
+    }
+
+    fn urlencoding_lite(s: &str) -> String {
+        let mut out = String::new();
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                    out.push(b as char);
+                }
+                b'\\' if cfg!(windows) => out.push('\\'),
+                _ => out.push_str(&format!("%{b:02X}")),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn parses_open_note() {
+        let space = abs_space();
+        let raw = format!(
+            "glyph://open/note?space={}&path={}",
+            encode(&space),
+            encode("notes/foo.md")
+        );
+        let action = parse_deeplink_url(&raw).unwrap();
+        assert_eq!(
+            action,
+            DeeplinkAction::OpenNote {
+                space: space.clone(),
+                path: "notes/foo.md".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_open_space_search_daily() {
+        let space = abs_space();
+        assert_eq!(
+            parse_deeplink_url(&format!("glyph://open/space?space={}", encode(&space))).unwrap(),
+            DeeplinkAction::OpenSpace {
+                space: space.clone()
+            }
+        );
+        assert_eq!(
+            parse_deeplink_url(&format!(
+                "glyph://search?space={}&q={}",
+                encode(&space),
+                encode("hello world")
+            ))
+            .unwrap(),
+            DeeplinkAction::Search {
+                space: space.clone(),
+                q: "hello world".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_deeplink_url(&format!(
+                "glyph://open/daily-note?space={}",
+                encode(&space)
+            ))
+            .unwrap(),
+            DeeplinkAction::OpenDailyNote { space }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_route_and_wrong_scheme() {
+        assert_eq!(
+            parse_deeplink_url("glyph://open/calendar?space=/tmp"),
+            Err(DeeplinkError::UnknownRoute)
+        );
+        assert_eq!(
+            parse_deeplink_url("https://example.com/open/note"),
+            Err(DeeplinkError::WrongScheme)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_and_extra_params() {
+        assert!(matches!(
+            parse_deeplink_url("glyph://open/note?path=a.md"),
+            Err(DeeplinkError::MissingParam("space"))
+        ));
+        assert!(matches!(
+            parse_deeplink_url(&format!(
+                "glyph://open/space?space={}&extra=1",
+                encode(&abs_space())
+            )),
+            Err(DeeplinkError::UnexpectedParam(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_relative_space_and_absolute_note_path() {
+        assert!(matches!(
+            parse_deeplink_url("glyph://open/space?space=relative/vault"),
+            Err(DeeplinkError::InvalidSpacePath)
+        ));
+        let space = abs_space();
+        assert!(matches!(
+            parse_deeplink_url(&format!(
+                "glyph://open/note?space={}&path={}",
+                encode(&space),
+                encode("/etc/passwd")
+            )),
+            Err(DeeplinkError::NotePathAbsolute)
+        ));
+        assert!(matches!(
+            parse_deeplink_url(&format!(
+                "glyph://open/note?space={}&path={}",
+                encode(&space),
+                encode("../secret.md")
+            )),
+            Err(DeeplinkError::NotePathTraversal)
+        ));
+    }
+
+    #[test]
+    fn rejects_fragments_and_duplicates() {
+        let space = abs_space();
+        assert_eq!(
+            parse_deeplink_url(&format!(
+                "glyph://open/space?space={}#frag",
+                encode(&space)
+            )),
+            Err(DeeplinkError::FragmentNotAllowed)
+        );
+        assert!(matches!(
+            parse_deeplink_url(&format!(
+                "glyph://open/space?space={}&space={}",
+                encode(&space),
+                encode(&space)
+            )),
+            Err(DeeplinkError::DuplicateParam(_))
+        ));
+    }
+
+    #[test]
+    fn unicode_and_spaces_round_trip_in_query() {
+        let space = abs_space();
+        let note = "notes/こんにちは world.md";
+        let raw = format!(
+            "glyph://open/note?space={}&path={}",
+            encode(&space),
+            encode(note)
+        );
+        let action = parse_deeplink_url(&raw).unwrap();
+        match action {
+            DeeplinkAction::OpenNote { path, .. } => assert_eq!(path, note),
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_host_path_form_accepted() {
+        let space = abs_space();
+        let raw = format!("glyph:///open/space?space={}", encode(&space));
+        assert_eq!(
+            parse_deeplink_url(&raw).unwrap(),
+            DeeplinkAction::OpenSpace { space }
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod app_exit;
 mod custom_theme;
 mod databases;
 mod daily_note_rollover;
+mod deeplink;
 mod external_markdown;
 mod external_link_preview;
 mod file_tree_appearance;
@@ -1011,7 +1012,7 @@ fn main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
     Ok(window)
 }
 
-fn show_main_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
+pub(crate) fn show_main_window_for_app(app: &tauri::AppHandle) -> Result<(), String> {
     let window = main_window(app)?;
     window.show().map_err(|error| error.to_string())?;
     window.unminimize().map_err(|error| error.to_string())?;
@@ -1064,6 +1065,12 @@ fn has_external_markdown_windows(app: &tauri::AppHandle) -> bool {
         .any(|label| external_markdown::is_external_markdown_window(label))
 }
 
+/// Handle OS-opened URLs. Returns true when the open was satisfied by an
+/// external markdown window, so the main window may stay hidden on cold start.
+///
+/// `glyph://` is deliberately not handled here: the deep-link plugin hooks the
+/// same `RunEvent::Opened` and forwards it to `on_open_url`, so branching on it
+/// in both places would dispatch every deeplink twice.
 fn handle_opened_urls(app: &tauri::AppHandle, urls: Vec<url::Url>) -> bool {
     for url in urls {
         if url.scheme() != "file" {
@@ -1417,7 +1424,14 @@ pub fn run() {
     #[cfg(target_os = "macos")]
     macos_webkit_defaults::configure_continuous_spell_checking();
 
+    // Single-instance must be registered first so deep links launched as a
+    // second process are forwarded to the running app (Windows/Linux).
     tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Err(error) = show_main_window_for_app(app) {
+                warn!("Failed to focus main window for second instance: {error}");
+            }
+        }))
         .menu(|app| build_main_menu(app, false, false, &[], &HashMap::new(), &HashMap::new()))
         .on_menu_event(|app, event| match event.id().as_ref() {
             id if id.starts_with("space.recent.") => {
@@ -1492,6 +1506,35 @@ pub fn run() {
             }
             ai_rig::commands::refresh_provider_support_on_startup(app.handle().clone());
 
+            #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                if let Err(error) = app.deep_link().register_all() {
+                    warn!("Failed to register deeplink schemes: {error}");
+                }
+            }
+
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                let handle = app.handle().clone();
+                // The plugin forwards every `RunEvent::Opened` URL on macOS,
+                // including `file://`, so filter by scheme here.
+                app.deep_link().on_open_url(move |event| {
+                    for url in event.urls() {
+                        if url.scheme() == "glyph" {
+                            deeplink::handle_url(
+                                &handle,
+                                url.as_str(),
+                                deeplink::DeeplinkSource::Os,
+                            );
+                        }
+                    }
+                });
+                // On Windows/Linux the plugin emits the cold-start URL during
+                // its own init, before the listener above exists.
+                deeplink::consume_startup_url(app.handle());
+            }
+
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -1544,6 +1587,7 @@ pub fn run() {
         .manage(space::SpaceState::default())
         .manage(app_exit::AppExitState::default())
         .manage(external_markdown::ExternalMarkdownState::default())
+        .manage(deeplink::DeeplinkState::default())
         .manage(MenuState::default())
         .manage(QuickNoteShortcutState::default())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -1552,8 +1596,11 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_deep_link::init())
         .invoke_handler(tauri::generate_handler![
             app_info,
+            deeplink::deeplink_open,
+            deeplink::deeplink_take_pending,
             release_channels::updater_check_release_channel,
             system_fonts_list,
             system_monospace_fonts_list,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.13-alpha.1",
+	"version": "0.8.13-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",
@@ -64,6 +64,11 @@
 			"endpoints": [
 				"https://raw.githubusercontent.com/SidhuK/Glyph/update-manifests/stable/latest.json"
 			]
+		},
+		"deep-link": {
+			"desktop": {
+				"schemes": ["glyph"]
+			}
 		}
 	}
 }

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../contexts";
 import { useCommandShortcuts } from "../../hooks/useCommandShortcuts";
 import { useDailyNote } from "../../hooks/useDailyNote";
+import { useDeeplinkDispatch } from "../../hooks/useDeeplinkDispatch";
 import { useFileImport } from "../../hooks/useFileImport";
 import { useFileTree } from "../../hooks/useFileTree";
 import { useMenuListeners } from "../../hooks/useMenuListeners";
@@ -159,6 +160,7 @@ export function AppShell() {
 		dailyNotesFolder,
 		templateFolder,
 		dailyNoteTemplatePath,
+		settingsSpacePath,
 		sidebarWidth,
 		setSidebarWidth,
 		settingsMode,
@@ -429,9 +431,10 @@ export function AppShell() {
 	}, [createSpace, prepareForSpaceChange, spacePath]);
 
 	const handleSelectSpace = useCallback(
-		async (path: string) => {
-			if (path === spacePath || !(await prepareForSpaceChange())) return;
-			await openSpaceAtPath(path);
+		async (path: string): Promise<boolean> => {
+			if (path === spacePath) return true;
+			if (!(await prepareForSpaceChange())) return false;
+			return await openSpaceAtPath(path);
 		},
 		[openSpaceAtPath, prepareForSpaceChange, spacePath],
 	);
@@ -734,6 +737,17 @@ export function AppShell() {
 		},
 		[setPaletteOpen],
 	);
+
+	useDeeplinkDispatch({
+		spacePath,
+		settingsSpacePath,
+		settingsLoaded,
+		selectSpace: handleSelectSpace,
+		openWorkspaceFile,
+		openPalette,
+		requestOpenDailyNote,
+	});
+
 	const closePalette = useCallback(() => {
 		moveTargetDirsRequestIdRef.current += 1;
 		setPaletteOpen(false);

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1207,7 +1207,9 @@ export function AppShell() {
 		onPrintNote: handlePrintActiveNote,
 		onCloseTab: () => void handleCloseTabOrWindow(),
 		onOpenSpace: handleOpenSpace,
-		onOpenRecentSpaceAtPath: handleSelectSpace,
+		onOpenRecentSpaceAtPath: (path) => {
+			void handleSelectSpace(path);
+		},
 		onCreateSpace: handleCreateSpace,
 		closeSpace: handleCloseSpace,
 		onRevealSpace: handleRevealSpaceFromMenu,

--- a/src/components/app/useTabManager.ts
+++ b/src/components/app/useTabManager.ts
@@ -103,6 +103,9 @@ export function useTabManager(spacePath: string | null) {
 	const [dirtyByPath, setDirtyByPath] = useState<Record<string, boolean>>({});
 	const [historyByTabId, setHistoryByTabId] = useState<TabHistoryById>({});
 	const [tabsRevision, setTabsRevision] = useState(0);
+	// Synchronous twin of tabsRevision so in-flight session restore can see tab
+	// opens that have not re-rendered yet (e.g. cold-start deeplinks).
+	const tabsRevisionRef = useRef(0);
 	const tabIdCounterRef = useRef(0);
 	const tabsRef = useRef<WorkspaceTab[]>([]);
 	const activeTabIdRef = useRef<string | null>(null);
@@ -232,10 +235,11 @@ export function useTabManager(spacePath: string | null) {
 			}
 			nextActiveByPane[nextActivePaneId] = nextActiveTabId;
 			activeTabByPaneRef.current = nextActiveByPane;
+			tabsRevisionRef.current += 1;
 			setTabs(nextTabs);
 			setActiveTabIdState(nextActiveTabId);
 			setActiveTabByPane(nextActiveByPane);
-			setTabsRevision((revision) => revision + 1);
+			setTabsRevision(tabsRevisionRef.current);
 			syncWorkspaceState(nextTabs, nextActiveTabId, previousActiveTarget);
 		},
 		[syncWorkspaceState],
@@ -266,6 +270,7 @@ export function useTabManager(spacePath: string | null) {
 		activeTabIdRef.current = null;
 		historyByTabIdRef.current = {};
 		activeTabByPaneRef.current = { [PRIMARY_EDITOR_PANE_ID]: null };
+		tabsRevisionRef.current = 0;
 		setTabs([]);
 		setActiveTabIdState(null);
 		setSplitLayout(createInitialSplitEditorLayout());
@@ -523,6 +528,11 @@ export function useTabManager(spacePath: string | null) {
 			restoredFocusedPaneId: string | null,
 			activeTabTargetByPane: Record<string, string | null>,
 		) => {
+			// Yield to any tab open that landed while the snapshot was loading
+			// (cold-start deeplink, onboarding note, user click). Check the ref so
+			// this sees commits that have not re-rendered yet.
+			if (tabsRevisionRef.current !== 0) return;
+
 			const nextLayout = restoredLayout ?? createInitialSplitEditorLayout();
 			const layoutPaneIds = new Set(paneIdsInLayout(nextLayout));
 			const fallbackPaneId =

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect } from "react";
 import type { UseFileTreeResult } from "../../hooks/useFileTree";
+import { isGlyphDeeplink } from "../../lib/deeplink";
+import { openDeeplink } from "../../lib/deeplinkOpen";
 import { invoke } from "../../lib/tauri";
 import {
 	isImagePath,
@@ -146,6 +148,10 @@ export function useWorkspaceLinkEvents({
 			if (!detail?.href) return;
 			void (async () => {
 				try {
+					if (isGlyphDeeplink(detail.href)) {
+						await openDeeplink(detail.href);
+						return;
+					}
 					const resolved = await invoke("space_resolve_markdown_link", {
 						href: detail.href,
 						sourcePath: detail.sourcePath,

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -100,6 +100,10 @@ export function useWorkspaceSession({
 }: UseWorkspaceSessionArgs) {
 	const restoredSessionSpaceRef = useRef<string | null>(null);
 	const restoreSessionRequestIdRef = useRef(0);
+	// Live revision so an in-flight restore can yield to a tab change (e.g. a
+	// cold-start deeplink) that committed after the restore effect started.
+	const tabsRevisionRef = useRef(tabsRevision);
+	tabsRevisionRef.current = tabsRevision;
 	const pendingSaveRef = useRef<PendingWorkspaceSessionSave | null>(null);
 	const saveTimerRef = useRef<number | null>(null);
 	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
@@ -173,6 +177,9 @@ export function useWorkspaceSession({
 			const restorableTabs = await validateRestorableSessionTabs(requestedTabs);
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
+				// A deeplink (or any other open) may have bumped revision while we
+				// awaited; do not clobber that navigation with a stale snapshot.
+				tabsRevisionRef.current !== 0 ||
 				(!restorableTabs.length && !(resumeLastSession && snapshot.splitLayout))
 			) {
 				return;

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -1,6 +1,8 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
+import { isGlyphDeeplink } from "../../lib/deeplink";
+import { openDeeplink } from "../../lib/deeplinkOpen";
 import { cssEscape } from "../../utils/dom";
 import {
 	dispatchInternalAnchorClick,
@@ -163,6 +165,10 @@ export function handleEditorClick(
 		return true;
 	}
 	event.preventDefault();
+	if (isGlyphDeeplink(href)) {
+		void openDeeplink(href);
+		return true;
+	}
 	if (
 		editable &&
 		isExpandedMarkdownUrlLink(link) &&

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -1,5 +1,7 @@
 import { EditorView } from "@codemirror/view";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { isGlyphDeeplink } from "../../../lib/deeplink";
+import { openDeeplink } from "../../../lib/deeplinkOpen";
 import {
 	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,
@@ -106,6 +108,10 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 			);
 			const href = markdownLink?.dataset.markdownHref;
 			if (!href) return false;
+			if (isGlyphDeeplink(href)) {
+				void openDeeplink(href);
+				return true;
+			}
 			if (href.startsWith("http://") || href.startsWith("https://")) {
 				void openUrl(href);
 				return true;

--- a/src/components/filetree/FileTreeFileItem.test.tsx
+++ b/src/components/filetree/FileTreeFileItem.test.tsx
@@ -34,6 +34,20 @@ vi.mock("../../lib/nativeContextMenu", () => ({
 	showNativeContextMenu: showNativeContextMenuMock,
 }));
 
+vi.mock("../../lib/pathClipboard", () => ({
+	buildPathCopyMenuItems: (
+		_spacePath: string | null,
+		_relPath: string,
+		options?: { includeDeeplink?: boolean },
+	) => [
+		{ label: "Copy Relative Path", action: () => undefined },
+		{ label: "Copy Absolute Path", action: () => undefined },
+		...(options?.includeDeeplink
+			? [{ label: "Copy Deeplink", action: () => undefined }]
+			: []),
+	],
+}));
+
 const openMarkdownInExternalWindowMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../lib/externalMarkdown", () => ({
@@ -251,6 +265,27 @@ describe("FileTreeFileItem", () => {
 		expect(menuItems?.map((item) => item.label)).not.toContain(
 			"Open in New Window",
 		);
+		expect(menuItems?.map((item) => item.label)).not.toContain("Copy Deeplink");
+	});
+
+	it("shows Copy Deeplink for markdown files", async () => {
+		await renderFileTreeFileItem();
+
+		const button = container.querySelector(
+			".fileTreeRow",
+		) as HTMLButtonElement | null;
+		expect(button).not.toBeNull();
+
+		await act(async () => {
+			button?.dispatchEvent(
+				new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		const menuItems = showNativeContextMenuMock.mock.calls[0]?.[1] as
+			| Array<{ label?: string }>
+			| undefined;
+		expect(menuItems?.map((item) => item.label)).toContain("Copy Deeplink");
 	});
 
 	it("calls arrow navigation when pressing the up or down keys", async () => {

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -258,7 +258,9 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					label: t("fileTree.showInFinder"),
 					action: () => void handleRevealInFinder(),
 				},
-				...buildPathCopyMenuItems(spacePath, entry.rel_path),
+				...buildPathCopyMenuItems(spacePath, entry.rel_path, {
+					includeDeeplink: entry.is_markdown,
+				}),
 				{ type: "separator" },
 				{
 					label: t("fileTree.rename"),

--- a/src/contexts/SpaceContext.tsx
+++ b/src/contexts/SpaceContext.tsx
@@ -31,7 +31,8 @@ interface SpaceContextValue {
 	startIndexRebuild: () => Promise<void>;
 	startIndexSync: () => Promise<void>;
 	onOpenSpace: () => Promise<void>;
-	onOpenSpaceAtPath: (path: string) => Promise<void>;
+	/** Resolves to whether the space is now open. */
+	onOpenSpaceAtPath: (path: string) => Promise<boolean>;
 	onCreateSpace: () => Promise<void>;
 	closeSpace: () => Promise<void>;
 }
@@ -198,11 +199,11 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 	}, []);
 
 	const applySpaceSelection = useCallback(
-		async (path: string, mode: "open" | "create") => {
-			if (isOpeningSpaceRef.current) return;
+		async (path: string, mode: "open" | "create"): Promise<boolean> => {
+			if (isOpeningSpaceRef.current) return false;
 			isOpeningSpaceRef.current = true;
 			try {
-				if (path === currentSpacePathRef.current) return;
+				if (path === currentSpacePathRef.current) return true;
 				const spaceInfo =
 					mode === "create"
 						? await invoke("space_create", { path })
@@ -215,8 +216,10 @@ export function SpaceProvider({ children }: { children: ReactNode }) {
 				setRecentSpaces((prev) => normalizeRecentSpaces(prev, spaceInfo.root));
 				void updateOnboardingSettings({ launcherSeen: true });
 				await setCurrentSpacePath(spaceInfo.root);
+				return true;
 			} catch (err) {
 				setError(extractErrorMessage(err));
+				return false;
 			} finally {
 				isOpeningSpaceRef.current = false;
 			}

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -341,11 +341,14 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		let cancelled = false;
 		const loadAndApplySettings = async () => {
 			try {
-				const s = await loadSettings({ spacePath: spacePathRef.current });
-				if (cancelled) return;
+				const requestedSpacePath = spacePathRef.current;
+				const s = await loadSettings({ spacePath: requestedSpacePath });
+				// Discard if unmounted or the active space changed mid-load so we
+				// never stamp the previous space's folders/template as the new one.
+				if (cancelled || requestedSpacePath !== spacePathRef.current) return;
 				dispatch({
 					type: "hydrateSettings",
-					spacePath: spacePathRef.current,
+					spacePath: requestedSpacePath,
 					aiEnabled: s.ui.aiEnabled,
 					aiAssistantMode: s.ui.aiAssistantMode,
 					dailyNotesFolder: s.dailyNotes?.folder ?? null,

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -46,6 +46,12 @@ interface UILayoutContextValue {
 	dailyNotesFolder: string | null;
 	templateFolder: string | null;
 	dailyNoteTemplatePath: string | null;
+	/**
+	 * The space whose settings `dailyNotesFolder`, `templateFolder` and
+	 * `dailyNoteTemplatePath` currently describe. Hydration is async, so after a
+	 * space switch those three lag until this matches the new space path.
+	 */
+	settingsSpacePath: string | null;
 	showToc: boolean;
 	setShowToc: (show: boolean) => void;
 	folioMode: boolean;
@@ -82,6 +88,7 @@ type UIState = {
 	dailyNotesFolder: string | null;
 	templateFolder: string | null;
 	dailyNoteTemplatePath: string | null;
+	settingsSpacePath: string | null;
 	showToc: boolean;
 	folioMode: boolean;
 	folioScope: FolioScope;
@@ -115,6 +122,7 @@ type UIAction =
 	| { type: "onSpacePathChanged"; hasSpace: boolean }
 	| {
 			type: "hydrateSettings";
+			spacePath: string | null;
 			aiEnabled: boolean;
 			aiAssistantMode: AiAssistantMode;
 			dailyNotesFolder: string | null;
@@ -123,6 +131,13 @@ type UIAction =
 			showToc: boolean;
 			folioMode: boolean;
 			dateDisplayFormat: DateDisplayFormat;
+	  }
+	| {
+			type: "hydrateSpaceSettings";
+			spacePath: string;
+			dailyNotesFolder: string | null;
+			templateFolder: string | null;
+			dailyNoteTemplatePath: string | null;
 	  };
 
 const initialUIState: UIState = {
@@ -134,6 +149,7 @@ const initialUIState: UIState = {
 	dailyNotesFolder: null,
 	templateFolder: null,
 	dailyNoteTemplatePath: null,
+	settingsSpacePath: null,
 	showToc: true,
 	folioMode: false,
 	folioScope: DEFAULT_FOLIO_SCOPE,
@@ -220,9 +236,18 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 						openMarkdownTabs: [],
 						activeMarkdownTabPath: null,
 					};
+		case "hydrateSpaceSettings":
+			return {
+				...state,
+				settingsSpacePath: action.spacePath,
+				dailyNotesFolder: action.dailyNotesFolder,
+				templateFolder: action.templateFolder,
+				dailyNoteTemplatePath: action.dailyNoteTemplatePath,
+			};
 		case "hydrateSettings":
 			return {
 				...state,
+				settingsSpacePath: action.spacePath,
 				aiEnabled: action.aiEnabled,
 				aiPanelOpen: action.aiEnabled ? state.aiPanelOpen : false,
 				aiAssistantMode: action.aiAssistantMode,
@@ -251,6 +276,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		dailyNotesFolder,
 		templateFolder,
 		dailyNoteTemplatePath,
+		settingsSpacePath,
 		showToc,
 		folioMode,
 		folioScope,
@@ -319,6 +345,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 				if (cancelled) return;
 				dispatch({
 					type: "hydrateSettings",
+					spacePath: spacePathRef.current,
 					aiEnabled: s.ui.aiEnabled,
 					aiAssistantMode: s.ui.aiAssistantMode,
 					dailyNotesFolder: s.dailyNotes?.folder ?? null,
@@ -364,16 +391,11 @@ export function UIProvider({ children }: { children: ReactNode }) {
 				const s = await loadSettings({ spacePath });
 				if (cancelled) return;
 				dispatch({
-					type: "setDailyNotesFolder",
-					value: s.dailyNotes?.folder ?? null,
-				});
-				dispatch({
-					type: "setTemplateFolder",
-					value: s.templates?.folder ?? null,
-				});
-				dispatch({
-					type: "setDailyNoteTemplatePath",
-					value: s.templates?.dailyNoteTemplate ?? null,
+					type: "hydrateSpaceSettings",
+					spacePath,
+					dailyNotesFolder: s.dailyNotes?.folder ?? null,
+					templateFolder: s.templates?.folder ?? null,
+					dailyNoteTemplatePath: s.templates?.dailyNoteTemplate ?? null,
 				});
 			} catch {
 				// best-effort settings refresh
@@ -467,6 +489,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			dailyNotesFolder,
 			templateFolder,
 			dailyNoteTemplatePath,
+			settingsSpacePath,
 			showToc,
 			setShowToc,
 			folioMode,
@@ -493,6 +516,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			dailyNotesFolder,
 			templateFolder,
 			dailyNoteTemplatePath,
+			settingsSpacePath,
 			showToc,
 			setShowToc,
 			folioMode,

--- a/src/hooks/useDeeplinkDispatch.ts
+++ b/src/hooks/useDeeplinkDispatch.ts
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import {
+	type DeeplinkErrorPayload,
+	type DeeplinkEvent,
+	isSameSpacePath,
+} from "../lib/deeplink";
+import { invoke } from "../lib/tauri";
+import { useTauriEvent } from "../lib/tauriEvents";
+import { toast } from "../lib/toast";
+
+const DEEPLINK_ERROR_TOAST_ID = "glyph-deeplink-error";
+/**
+ * A deeplink can only act on the new space once React state reflects the
+ * switch. Settings hydration is best-effort and may never land, so the wait is
+ * bounded rather than open-ended.
+ */
+const SPACE_SETTLE_TIMEOUT_MS = 5000;
+/** Ids are only needed long enough to spot a pending-queue replay. */
+const MAX_REMEMBERED_IDS = 256;
+
+type Waiter = { ready: () => boolean; settle: (ready: boolean) => void };
+
+export interface UseDeeplinkDispatchOptions {
+	spacePath: string | null;
+	/** Space whose settings are currently hydrated; see `UIContext`. */
+	settingsSpacePath: string | null;
+	settingsLoaded: boolean;
+	/** Saves the open editors, switches space, and reports whether it worked. */
+	selectSpace: (path: string) => Promise<boolean>;
+	openWorkspaceFile: (path: string) => Promise<void>;
+	openPalette: (mode: "commands" | "search", query?: string) => void;
+	requestOpenDailyNote: () => void;
+}
+
+/**
+ * Routes native `glyph://` deeplinks onto the existing open/search/daily flows.
+ * Native code has already validated the space and note, so failures arrive as
+ * `deeplink:error` codes rather than being re-checked here.
+ */
+export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
+	const { spacePath, settingsSpacePath, settingsLoaded } = options;
+	const { t } = useTranslation("shell");
+
+	const optionsRef = useRef(options);
+	optionsRef.current = options;
+
+	const seenIdsRef = useRef<Set<number>>(new Set());
+	const queueRef = useRef<DeeplinkEvent[]>([]);
+	const runningRef = useRef(false);
+	const waitersRef = useRef<Waiter[]>([]);
+
+	// Resume any action that was waiting on the space (or its settings) to land.
+	// spacePath / settingsSpacePath are read so the effect re-runs when they change;
+	// waiters themselves close over ready() against optionsRef.
+	useEffect(() => {
+		void spacePath;
+		void settingsSpacePath;
+		for (const waiter of [...waitersRef.current]) {
+			if (waiter.ready()) waiter.settle(true);
+		}
+	}, [spacePath, settingsSpacePath]);
+
+	const waitForState = useCallback((ready: () => boolean): Promise<boolean> => {
+		if (ready()) return Promise.resolve(true);
+		return new Promise<boolean>((resolve) => {
+			const waiter: Waiter = {
+				ready,
+				settle: (settled) => {
+					clearTimeout(timer);
+					waitersRef.current = waitersRef.current.filter(
+						(entry) => entry !== waiter,
+					);
+					resolve(settled);
+				},
+			};
+			const timer = setTimeout(
+				() => waiter.settle(false),
+				SPACE_SETTLE_TIMEOUT_MS,
+			);
+			waitersRef.current.push(waiter);
+		});
+	}, []);
+
+	const showError = useCallback(
+		(description?: string) => {
+			toast.error(t("deeplink.openFailed"), {
+				description,
+				id: DEEPLINK_ERROR_TOAST_ID,
+			});
+		},
+		[t],
+	);
+
+	const errorMessage = useCallback(
+		(code: string): string => {
+			switch (code) {
+				case "space_not_found":
+					return t("deeplink.spaceNotFound");
+				case "note_not_found":
+					return t("deeplink.noteNotFound");
+				case "note_not_markdown":
+					return t("deeplink.noteNotMarkdown");
+				default:
+					return t("deeplink.malformed");
+			}
+		},
+		[t],
+	);
+
+	const ensureSpace = useCallback(
+		async (space: string): Promise<boolean> => {
+			if (isSameSpacePath(optionsRef.current.spacePath, space)) return true;
+			// `selectSpace` saves open editors and surfaces its own failures.
+			if (!(await optionsRef.current.selectSpace(space))) return false;
+			return waitForState(() =>
+				isSameSpacePath(optionsRef.current.spacePath, space),
+			);
+		},
+		[waitForState],
+	);
+
+	const runEvent = useCallback(
+		async (event: DeeplinkEvent) => {
+			try {
+				if (!(await ensureSpace(event.space))) {
+					showError();
+					return;
+				}
+				switch (event.kind) {
+					case "open_space":
+						return;
+					case "open_note":
+						await optionsRef.current.openWorkspaceFile(event.path);
+						return;
+					case "search":
+						optionsRef.current.openPalette("search", event.q);
+						return;
+					case "open_daily_note": {
+						// The daily note folder and template are per-space settings, so
+						// acting before they rehydrate would target the previous space.
+						const ready = await waitForState(() =>
+							isSameSpacePath(
+								optionsRef.current.settingsSpacePath,
+								event.space,
+							),
+						);
+						if (!ready) {
+							showError();
+							return;
+						}
+						optionsRef.current.requestOpenDailyNote();
+						return;
+					}
+					default: {
+						const _exhaustive: never = event;
+						return _exhaustive;
+					}
+				}
+			} catch (error) {
+				console.error("Failed to run deeplink", error);
+				showError();
+			}
+		},
+		[ensureSpace, showError, waitForState],
+	);
+
+	const processQueue = useCallback(async () => {
+		if (runningRef.current) return;
+		runningRef.current = true;
+		try {
+			while (queueRef.current.length > 0) {
+				const next = queueRef.current.shift();
+				if (next) await runEvent(next);
+			}
+		} finally {
+			runningRef.current = false;
+		}
+	}, [runEvent]);
+
+	/** Returns false when this id was already handled (live emit vs. queue replay). */
+	const claimId = useCallback((id: number): boolean => {
+		const seen = seenIdsRef.current;
+		if (seen.has(id)) return false;
+		seen.add(id);
+		// Sets iterate in insertion order, so this evicts the oldest ids.
+		while (seen.size > MAX_REMEMBERED_IDS) {
+			const oldest = seen.values().next();
+			if (oldest.done) break;
+			seen.delete(oldest.value);
+		}
+		return true;
+	}, []);
+
+	const enqueue = useCallback(
+		(event: DeeplinkEvent) => {
+			if (!claimId(event.id)) return;
+			queueRef.current.push(event);
+			void processQueue();
+		},
+		[claimId, processQueue],
+	);
+
+	const reportError = useCallback(
+		(payload: DeeplinkErrorPayload) => {
+			if (!claimId(payload.id)) return;
+			showError(errorMessage(payload.code));
+		},
+		[claimId, errorMessage, showError],
+	);
+
+	// Deeplinks are queued natively as well as emitted, because the webview is
+	// not listening yet on a cold start. Draining is idempotent thanks to ids.
+	const drainPending = useCallback(async () => {
+		try {
+			const pending = await invoke("deeplink_take_pending");
+			for (const event of pending.actions) enqueue(event);
+			for (const error of pending.errors) reportError(error);
+		} catch (error) {
+			console.warn("Failed to take pending deeplinks", error);
+		}
+	}, [enqueue, reportError]);
+
+	useTauriEvent("deeplink:action", (payload) => {
+		enqueue(payload);
+		void drainPending();
+	});
+
+	useTauriEvent("deeplink:error", (payload) => {
+		reportError(payload);
+		void drainPending();
+	});
+
+	// Wait for settings so a cold-start deeplink does not race session restore.
+	useEffect(() => {
+		if (!settingsLoaded) return;
+		void drainPending();
+	}, [drainPending, settingsLoaded]);
+}

--- a/src/hooks/useDeeplinkDispatch.ts
+++ b/src/hooks/useDeeplinkDispatch.ts
@@ -196,7 +196,9 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 		(event: DeeplinkEvent) => {
 			if (!claimId(event.id)) return;
 			queueRef.current.push(event);
-			void processQueue();
+			// Hold until bootstrap finishes so live cold-start events cannot race
+			// SpaceContext's session restore `space_open`.
+			if (optionsRef.current.settingsLoaded) void processQueue();
 		},
 		[claimId, processQueue],
 	);
@@ -223,17 +225,19 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 
 	useTauriEvent("deeplink:action", (payload) => {
 		enqueue(payload);
-		void drainPending();
 	});
 
 	useTauriEvent("deeplink:error", (payload) => {
 		reportError(payload);
-		void drainPending();
 	});
 
 	// Wait for settings so a cold-start deeplink does not race session restore.
+	// Drain the native pending queue and process anything already enqueued live.
 	useEffect(() => {
 		if (!settingsLoaded) return;
-		void drainPending();
-	}, [drainPending, settingsLoaded]);
+		void (async () => {
+			await drainPending();
+			void processQueue();
+		})();
+	}, [drainPending, processQueue, settingsLoaded]);
 }

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "Aus Vorlage erstellen",
 		"addFolder": "Ordner hinzufügen",
 		"deleteFile": "Datei löschen",
-		"deleteFolder": "Ordner löschen"
+		"deleteFolder": "Ordner löschen",
+		"copyDeeplink": "Deeplink kopieren",
+		"deeplinkCopied": "Deeplink kopiert.",
+		"deeplinkCopyFailed": "Deeplink konnte nicht kopiert werden"
+	},
+	"deeplink": {
+		"openFailed": "Link konnte nicht geöffnet werden",
+		"malformed": "Dieser Glyph-Link ist ungültig.",
+		"spaceNotFound": "Dieser Space wurde nicht gefunden.",
+		"noteNotFound": "Diese Notiz wurde nicht gefunden.",
+		"noteNotMarkdown": "Dieser Link verweist nicht auf eine Markdown-Notiz."
 	},
 	"commandPalette": {
 		"title": "Befehlspalette",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -75,7 +75,17 @@
 		"importFilesHere": "Import Files Here…",
 		"importFolderHere": "Import Folder Here…",
 		"deleteFile": "Delete file",
-		"deleteFolder": "Delete folder"
+		"deleteFolder": "Delete folder",
+		"copyDeeplink": "Copy Deeplink",
+		"deeplinkCopied": "Copied deeplink.",
+		"deeplinkCopyFailed": "Could not copy deeplink"
+	},
+	"deeplink": {
+		"openFailed": "Could not open link",
+		"malformed": "This Glyph link is not valid.",
+		"spaceNotFound": "That space could not be found.",
+		"noteNotFound": "That note could not be found.",
+		"noteNotMarkdown": "That link does not point to a Markdown note."
 	},
 	"import": {
 		"filesTitle": "Import Files",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "Crear desde plantilla",
 		"addFolder": "Añadir carpeta",
 		"deleteFile": "Eliminar archivo",
-		"deleteFolder": "Eliminar carpeta"
+		"deleteFolder": "Eliminar carpeta",
+		"copyDeeplink": "Copiar enlace profundo",
+		"deeplinkCopied": "Enlace profundo copiado.",
+		"deeplinkCopyFailed": "No se pudo copiar el enlace profundo"
+	},
+	"deeplink": {
+		"openFailed": "No se pudo abrir el enlace",
+		"malformed": "Este enlace de Glyph no es válido.",
+		"spaceNotFound": "No se encontró ese espacio.",
+		"noteNotFound": "No se encontró esa nota.",
+		"noteNotMarkdown": "Ese enlace no apunta a una nota de Markdown."
 	},
 	"commandPalette": {
 		"title": "Paleta de comandos",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "Créer à partir d’un modèle",
 		"addFolder": "Ajouter un dossier",
 		"deleteFile": "Supprimer le fichier",
-		"deleteFolder": "Supprimer le dossier"
+		"deleteFolder": "Supprimer le dossier",
+		"copyDeeplink": "Copier le lien profond",
+		"deeplinkCopied": "Lien profond copié.",
+		"deeplinkCopyFailed": "Impossible de copier le lien profond"
+	},
+	"deeplink": {
+		"openFailed": "Impossible d’ouvrir le lien",
+		"malformed": "Ce lien Glyph n’est pas valide.",
+		"spaceNotFound": "Cet espace est introuvable.",
+		"noteNotFound": "Cette note est introuvable.",
+		"noteNotMarkdown": "Ce lien ne pointe pas vers une note Markdown."
 	},
 	"commandPalette": {
 		"title": "Palette de commandes",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "テンプレートから作成",
 		"addFolder": "フォルダを追加",
 		"deleteFile": "ファイルを削除",
-		"deleteFolder": "フォルダを削除"
+		"deleteFolder": "フォルダを削除",
+		"copyDeeplink": "ディープリンクをコピー",
+		"deeplinkCopied": "ディープリンクをコピーしました。",
+		"deeplinkCopyFailed": "ディープリンクをコピーできませんでした"
+	},
+	"deeplink": {
+		"openFailed": "リンクを開けませんでした",
+		"malformed": "この Glyph リンクは無効です。",
+		"spaceNotFound": "そのスペースが見つかりませんでした。",
+		"noteNotFound": "そのノートが見つかりませんでした。",
+		"noteNotMarkdown": "このリンクは Markdown ノートを指していません。"
 	},
 	"commandPalette": {
 		"title": "コマンドパレット",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "템플릿에서 만들기",
 		"addFolder": "폴더 추가",
 		"deleteFile": "파일 삭제",
-		"deleteFolder": "폴더 삭제"
+		"deleteFolder": "폴더 삭제",
+		"copyDeeplink": "딥링크 복사",
+		"deeplinkCopied": "딥링크를 복사했습니다.",
+		"deeplinkCopyFailed": "딥링크를 복사할 수 없습니다"
+	},
+	"deeplink": {
+		"openFailed": "링크를 열 수 없습니다",
+		"malformed": "유효하지 않은 Glyph 링크입니다.",
+		"spaceNotFound": "해당 스페이스를 찾을 수 없습니다.",
+		"noteNotFound": "해당 노트를 찾을 수 없습니다.",
+		"noteNotMarkdown": "이 링크는 마크다운 노트를 가리키지 않습니다."
 	},
 	"commandPalette": {
 		"title": "명령 팔레트",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -73,7 +73,17 @@
 		"createFromTemplate": "Criar a partir de modelo",
 		"addFolder": "Adicionar pasta",
 		"deleteFile": "Excluir arquivo",
-		"deleteFolder": "Excluir pasta"
+		"deleteFolder": "Excluir pasta",
+		"copyDeeplink": "Copiar deeplink",
+		"deeplinkCopied": "Deeplink copiado.",
+		"deeplinkCopyFailed": "Não foi possível copiar o deeplink"
+	},
+	"deeplink": {
+		"openFailed": "Não foi possível abrir o link",
+		"malformed": "Este link do Glyph não é válido.",
+		"spaceNotFound": "Esse espaço não foi encontrado.",
+		"noteNotFound": "Essa nota não foi encontrada.",
+		"noteNotMarkdown": "Esse link não aponta para uma nota Markdown."
 	},
 	"commandPalette": {
 		"title": "Paleta de comandos",

--- a/src/lib/deeplink.test.ts
+++ b/src/lib/deeplink.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildNoteDeeplink, isGlyphDeeplink } from "./deeplink";
+
+describe("buildNoteDeeplink", () => {
+	it("builds a canonical open/note URL with encoded query values", () => {
+		const url = buildNoteDeeplink("/Users/me/My Vault", "notes/hello world.md");
+		expect(url.startsWith("glyph://open/note?")).toBe(true);
+		expect(url).toContain("space=");
+		expect(url).toContain("path=");
+		expect(url).toContain("hello%20world.md");
+		expect(url).toContain("My%20Vault");
+	});
+
+	it("normalizes leading slashes and backslashes in the note path", () => {
+		const url = buildNoteDeeplink("/space", "\\notes\\a.md");
+		expect(url).toContain("path=notes/a.md");
+	});
+
+	it("rejects empty space or path", () => {
+		expect(() => buildNoteDeeplink("", "a.md")).toThrow(/space/i);
+		expect(() => buildNoteDeeplink("/space", "")).toThrow(/path/i);
+	});
+});
+
+describe("isGlyphDeeplink", () => {
+	it("detects glyph scheme case-insensitively", () => {
+		expect(isGlyphDeeplink("glyph://open/note?space=/x&path=a.md")).toBe(true);
+		expect(isGlyphDeeplink("GLYPH://search?space=/x&q=hi")).toBe(true);
+		expect(isGlyphDeeplink("https://example.com")).toBe(false);
+		expect(isGlyphDeeplink("file:///tmp/a.md")).toBe(false);
+	});
+});

--- a/src/lib/deeplink.ts
+++ b/src/lib/deeplink.ts
@@ -1,0 +1,62 @@
+/** Canonical `glyph://` types and builders. Keep this module dependency-free. */
+
+export type DeeplinkAction =
+	| { kind: "open_note"; space: string; path: string }
+	| { kind: "open_space"; space: string }
+	| { kind: "search"; space: string; q: string }
+	| { kind: "open_daily_note"; space: string };
+
+/**
+ * A dispatched action carries a process-unique id so the frontend can discard
+ * the pending-queue mirror of an action it already handled live.
+ */
+export type DeeplinkEvent = DeeplinkAction & { id: number };
+
+/** Mirrors `DeeplinkError::code()`; unknown values fall back to "malformed". */
+export type DeeplinkErrorPayload = { id: number; code: string };
+
+export type PendingDeeplinks = {
+	actions: DeeplinkEvent[];
+	errors: DeeplinkErrorPayload[];
+};
+
+function encodeQueryValue(value: string): string {
+	return encodeURIComponent(value).replace(/%2F/gi, "/");
+}
+
+function buildQuery(params: Record<string, string>): string {
+	return Object.entries(params)
+		.map(
+			([key, value]) => `${encodeURIComponent(key)}=${encodeQueryValue(value)}`,
+		)
+		.join("&");
+}
+
+/** Build a canonical note deeplink for the file-tree copy action. */
+export function buildNoteDeeplink(spacePath: string, relPath: string): string {
+	const space = spacePath.trim();
+	const path = relPath.trim().replace(/\\/g, "/").replace(/^\/+/, "");
+	if (!space) {
+		throw new Error("No space is open.");
+	}
+	if (!path) {
+		throw new Error("Note path is empty.");
+	}
+	return `glyph://open/note?${buildQuery({ space, path })}`;
+}
+
+export function isGlyphDeeplink(href: string): boolean {
+	return /^glyph:/i.test(href.trim());
+}
+
+/**
+ * Compare space paths the way the filesystem does: separators and a trailing
+ * slash are cosmetic, but case is not. Both sides are canonicalized natively,
+ * so no further normalization is warranted.
+ */
+export function isSameSpacePath(left: string | null, right: string): boolean {
+	if (!left) return false;
+	const normalize = (value: string) =>
+		value.replace(/\\/g, "/").replace(/\/+$/, "");
+	return normalize(left) === normalize(right);
+}

--- a/src/lib/deeplinkOpen.ts
+++ b/src/lib/deeplinkOpen.ts
@@ -1,0 +1,21 @@
+import { i18n } from "../i18n";
+import { isGlyphDeeplink } from "./deeplink";
+import { extractErrorMessage } from "./errorUtils";
+import { invoke } from "./tauri";
+import { toast } from "./toast";
+
+/**
+ * Activate a `glyph://` link from inside the app. Routing lives natively so an
+ * in-note link behaves exactly like the same URL opened from the OS; rejected
+ * links come back asynchronously on the `deeplink:error` event.
+ */
+export async function openDeeplink(href: string): Promise<void> {
+	if (!isGlyphDeeplink(href)) return;
+	try {
+		await invoke("deeplink_open", { url: href.trim() });
+	} catch (error) {
+		toast.error(i18n.t("shell:deeplink.openFailed"), {
+			description: extractErrorMessage(error),
+		});
+	}
+}

--- a/src/lib/pathClipboard.ts
+++ b/src/lib/pathClipboard.ts
@@ -63,18 +63,21 @@ export async function copyNoteDeeplink(
 	spacePath: string | null,
 	relPath: string,
 ): Promise<void> {
+	// Own the clipboard write so failures use the localized deeplink toast
+	// instead of the generic path-copy message from `copyPathToClipboard`.
 	try {
 		if (!spacePath) {
 			throw new Error("No space is open.");
 		}
 		const url = buildNoteDeeplink(spacePath, relPath);
-		await copyPathToClipboard(url, i18n.t("shell:fileTree.deeplinkCopied"));
-	} catch (error) {
-		const message =
-			error instanceof Error ? error.message : "Could not copy deeplink.";
-		toast.error(i18n.t("shell:fileTree.deeplinkCopyFailed"), {
-			description: message,
-		});
+		const clipboard = navigator.clipboard;
+		if (!clipboard?.writeText) {
+			throw new Error("Clipboard is not available.");
+		}
+		await clipboard.writeText(url);
+		toast.success(i18n.t("shell:fileTree.deeplinkCopied"));
+	} catch {
+		toast.error(i18n.t("shell:fileTree.deeplinkCopyFailed"));
 	}
 }
 

--- a/src/lib/pathClipboard.ts
+++ b/src/lib/pathClipboard.ts
@@ -1,5 +1,6 @@
 import { join } from "@tauri-apps/api/path";
 import { i18n } from "../i18n";
+import { buildNoteDeeplink } from "./deeplink";
 import type { NativeContextMenuItem } from "./nativeContextMenu";
 import { toast } from "./toast";
 
@@ -58,11 +59,31 @@ export async function copyAbsolutePath(
 	}
 }
 
+export async function copyNoteDeeplink(
+	spacePath: string | null,
+	relPath: string,
+): Promise<void> {
+	try {
+		if (!spacePath) {
+			throw new Error("No space is open.");
+		}
+		const url = buildNoteDeeplink(spacePath, relPath);
+		await copyPathToClipboard(url, i18n.t("shell:fileTree.deeplinkCopied"));
+	} catch (error) {
+		const message =
+			error instanceof Error ? error.message : "Could not copy deeplink.";
+		toast.error(i18n.t("shell:fileTree.deeplinkCopyFailed"), {
+			description: message,
+		});
+	}
+}
+
 export function buildPathCopyMenuItems(
 	spacePath: string | null,
 	relPath: string,
+	options?: { includeDeeplink?: boolean },
 ): NativeContextMenuItem[] {
-	return [
+	const items: NativeContextMenuItem[] = [
 		{
 			label: i18n.t("shell:fileTree.copyRelativePath"),
 			action: () => void copyRelativePath(relPath),
@@ -72,4 +93,11 @@ export function buildPathCopyMenuItems(
 			action: () => void copyAbsolutePath(spacePath, relPath),
 		},
 	];
+	if (options?.includeDeeplink) {
+		items.push({
+			label: i18n.t("shell:fileTree.copyDeeplink"),
+			action: () => void copyNoteDeeplink(spacePath, relPath),
+		});
+	}
+	return items;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -842,6 +842,11 @@ export interface RolloverMoveResult {
 
 interface TauriCommands {
 	app_info: CommandDef<void, AppInfo>;
+	deeplink_open: CommandDef<{ url: string }, void>;
+	deeplink_take_pending: CommandDef<
+		void,
+		import("./deeplink").PendingDeeplinks
+	>;
 	updater_check_release_channel: CommandDef<
 		{ channel: "stable" | "alpha" },
 		ReleaseChannelUpdate | null

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,6 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
 import type { CustomTheme } from "./customThemes";
+import type { DeeplinkErrorPayload, DeeplinkEvent } from "./deeplink";
 import type { EditorViewMode } from "./editorMode";
 import type { HeadingPaletteId } from "./headingPalettes";
 import type {
@@ -20,6 +21,8 @@ type TauriEventMap = {
 	"menu:app_command": { command_id: string };
 	"menu:open_recent_space": { path: string };
 	"app:open_note": { path: string };
+	"deeplink:action": DeeplinkEvent;
+	"deeplink:error": DeeplinkErrorPayload;
 	"external-markdown:close_requested": undefined;
 	"git_sync:status": import("./tauri").GitSyncStatus;
 	"ai:chunk": { job_id: string; delta: string };


### PR DESCRIPTION
Closes 


## Description

Adds first-class `glyph://` deep linking so Glyph can open spaces, notes, search, and daily notes from the OS, copied links, and in-note clicks.

- **Native allowlist parser** (`src-tauri/src/deeplink`) validates scheme, routes, and params at the boundary; rejects malformed URLs, non-absolute spaces, and absolute/`..` note paths via `paths::join_under()`
- **Routes**: `open/note`, `open/space`, `search`, `open/daily-note` (maps to existing frontend flows)
- **Platform delivery**: `tauri-plugin-deep-link` + `tauri-plugin-single-instance` (deep-link feature); main-window targeting; cold-start pending queue with id-based dedupe
- **In-app**: file-tree “Copy deeplink” for markdown notes; in-note `glyph://` clicks go through the same `deeplink_open` command
- **UX**: coarse error codes from native → translated toasts on the frontend
- **Docs**: ADR 014 covers lifecycle, security, and window routing


## Docs

- ADR: `docs/architecture/adr/014-deeplink-implementation.md`
- Scheme: `glyph://`
- Examples:
  - `glyph://open/note?space=<abs>&path=<rel.md>`
  - `glyph://open/space?space=<abs>`
  - `glyph://search?space=<abs>&q=...`
  - `glyph://open/daily-note?space=<abs>`
- Commands: `deeplink_open`, `deeplink_take_pending`
- Events: `deeplink:action`, `deeplink:error`


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class `glyph://` deep links so users can open spaces, notes, search, and daily notes from the OS and in-app links, with secure native parsing, a startup-safe delivery path, and OS re-delivery suppression.

- **New Features**
  - Native allowlist parser (`src-tauri/src/deeplink`) validates scheme/routes/params and the filesystem: spaces must exist; `open/note` requires an existing Markdown file; rejects absolute or traversing note paths and non-absolute spaces; emits coarse error codes mapped to translated toasts.
  - Routes: `open/note`, `open/space`, `search`, `open/daily-note`; all target the main window with a cold-start queue and id-based dedupe; suppresses OS re-delivery races; drains pending on startup and guards workspace/tab restore so cold-start deeplinks aren’t overwritten; emits `deeplink:action` / `deeplink:error`.
  - In-app support: editor and rendered Markdown clicks on `glyph://` use the native dispatcher; file-tree adds “Copy Deeplink” for Markdown with localized strings; dispatch waits for space switch and settings hydration before acting (e.g., daily notes).
  - Behavioral change: `SpaceContext.applySpaceSelection` and `onOpenSpaceAtPath` now return `Promise<boolean>` to signal success.

- **Dependencies**
  - Added `tauri-plugin-deep-link` and `tauri-plugin-single-instance` (with `deep-link` feature); registered the `glyph` scheme in config and capabilities.

<sup>Written for commit 84179023cbd5983a854b3507fbba952beaf7b955. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `glyph://` deeplink support for opening spaces, notes, search, and daily notes
> - Registers the `glyph` URL scheme on desktop via `tauri-plugin-deep-link` and `tauri-plugin-single-instance`, with a new Rust module ([mod.rs](https://github.com/SidhuK/Glyph/pull/464/files#diff-57330fc548e8e3ec0241776c342c2d6b0c001f1a78b81e9d7434fe96258e8e7d)) handling OS-delivered and in-app URLs, startup queueing, deduplication, and event emission.
> - A strict allowlist parser ([parse.rs](https://github.com/SidhuK/Glyph/pull/464/files#diff-5114f5a1a70ffb25d6f9676921a231b0bad6e430c61e9cd4897d0a294e5183e0)) validates `glyph://` URLs into typed `DeeplinkAction` values or specific error codes, including path canonicalization and query param checks.
> - The frontend hook ([useDeeplinkDispatch.ts](https://github.com/SidhuK/Glyph/pull/464/files#diff-d1b0ff20a4269adeac4fa99fb988b82ae24d25ef23b9b25eb38ea810bae15203)) listens for `deeplink:action`/`deeplink:error` events, sequences actions after settings hydration and space switching, and shows localized error toasts.
> - Clicking `glyph://` links in the rich editor, raw markdown, and rendered markdown now routes through the native dispatcher instead of generic URL handling.
> - File tree context menus for markdown files gain a 'Copy Deeplink' item via [pathClipboard.ts](https://github.com/SidhuK/Glyph/pull/464/files#diff-d0b680f5fa6b4338c78a776d48b555f4de2ee59953da361c61ff3f5dac615560).
> - Session restore in `useTabManager` and `useWorkspaceSession` now skips overwriting tabs that were opened by a cold-start deeplink.
> - Behavioral Change: second-instance launches now focus the running window rather than opening a new one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8417902.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `glyph://` links to open notes, spaces, searches, and daily notes.
  - Added “Copy Deeplink” to Markdown file context menus.
  - Deeplinks now work when clicked in the editor and rendered Markdown content.
  - Links can launch or focus the app and handle startup and queued actions.

- **Bug Fixes**
  - Added validation for malformed, unsafe, missing, or unsupported deeplinks.
  - Added duplicate prevention and clear localized error messages.

- **Documentation**
  - Documented deeplink routes, security rules, supported behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->