### PR TITLE
Fix file-tree external drop targeting

### DIFF
--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -114,6 +114,7 @@ interface FileTreeDirItemProps {
 	appearance?: FileTreeAppearance | null;
 	onOpenAppearancePicker: () => void;
 	fileCount?: number | null;
+	isExternalDropTarget: boolean;
 	onMoveClickSuppressRef: MutableRefObject<boolean>;
 	virtualRowRef?: Ref<HTMLLIElement>;
 	virtualRowStyle?: CSSProperties;
@@ -141,6 +142,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 	appearance,
 	onOpenAppearancePicker,
 	fileCount,
+	isExternalDropTarget,
 	onMoveClickSuppressRef,
 	virtualRowRef,
 	virtualRowStyle,
@@ -275,7 +277,9 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 							title={entry.rel_path || entry.name || "Folder"}
 							data-draggable="true"
 							data-dragging={isDragging ? "true" : undefined}
-							data-drop-target={isRowDropTarget ? "true" : undefined}
+							data-drop-target={
+								isRowDropTarget || isExternalDropTarget ? "true" : undefined
+							}
 							data-has-custom-color={customColor ? "true" : "false"}
 							data-file-tree-kind="dir"
 							data-file-tree-path={entry.rel_path}

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -244,7 +244,12 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 		>
 			<div className="fileTreeRowShell">
 				{isRenaming ? (
-					<div className="fileTreeRow" style={rowStyle}>
+					<div
+						className="fileTreeRow"
+						style={rowStyle}
+						data-file-tree-kind="dir"
+						data-file-tree-path={entry.rel_path}
+					>
 						<DirectoryRenameInput
 							key={`${entry.rel_path}:${entry.name}`}
 							initialName={entry.name.trim() || "New Folder"}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -332,6 +332,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 					<div
 						className="fileTreeRow"
 						style={rowStyle}
+						data-file-tree-kind="file"
 						data-file-tree-path={entry.rel_path}
 					>
 						<span className="fileTreeLeadingSpacer" aria-hidden="true" />

--- a/src/components/filetree/FileTreePane.test.tsx
+++ b/src/components/filetree/FileTreePane.test.tsx
@@ -127,7 +127,6 @@ vi.mock("@tauri-apps/api/window", () => ({
 	getCurrentWindow: () => ({
 		label: "main",
 		onDragDropEvent: vi.fn().mockResolvedValue(vi.fn()),
-		scaleFactor: vi.fn().mockResolvedValue(1),
 	}),
 }));
 

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -126,11 +126,13 @@ function folderBreadcrumbParts(spacePath: string | null, dirPath: string) {
 interface FileTreeRootDropProps {
 	children: ReactNode;
 	targetDirPath?: string;
+	isExternalDropTarget?: boolean;
 }
 
 function FileTreeRootDrop({
 	children,
 	targetDirPath = "",
+	isExternalDropTarget = false,
 }: FileTreeRootDropProps) {
 	const { ref, isDropTarget } = useDroppable({
 		id: targetDirPath ? `file-tree-focused:${targetDirPath}` : "file-tree-root",
@@ -143,7 +145,9 @@ function FileTreeRootDrop({
 		<div
 			ref={ref}
 			className="fileTreeScroll"
-			data-drop-target={isDropTarget ? "true" : undefined}
+			data-drop-target={
+				isDropTarget || isExternalDropTarget ? "true" : undefined
+			}
 		>
 			{children}
 		</div>
@@ -175,9 +179,9 @@ function fileTreeDropTargetAtPoint(
 	const bounds = pane.getBoundingClientRect();
 	if (
 		x < bounds.left ||
-		x > bounds.right ||
+		x >= bounds.right ||
 		y < bounds.top ||
-		y > bounds.bottom
+		y >= bounds.bottom
 	) {
 		return null;
 	}
@@ -642,6 +646,7 @@ export const FileTreePane = memo(function FileTreePane({
 	const [externalDropTargetPath, setExternalDropTargetPath] = useState<
 		string | null
 	>(null);
+	const externalDropEventGenerationRef = useRef(0);
 	const moveClickSuppressRef = useRef(false);
 	const moveClickSuppressResetTimerRef = useRef<ReturnType<
 		typeof window.setTimeout
@@ -1027,6 +1032,7 @@ export const FileTreePane = memo(function FileTreePane({
 		let disposed = false;
 		void currentWindow
 			.onDragDropEvent(async ({ payload }) => {
+				const eventGeneration = ++externalDropEventGenerationRef.current;
 				if (payload.type === "leave") {
 					setExternalDropTargetPath(null);
 					return;
@@ -1042,15 +1048,19 @@ export const FileTreePane = memo(function FileTreePane({
 				const position = navigator.userAgent.includes("Macintosh")
 					? payload.position
 					: payload.position.toLogical(await currentWindow.scaleFactor());
+				if (eventGeneration !== externalDropEventGenerationRef.current) return;
 				const targetDir = fileTreeDropTargetAtPoint(
 					pane,
 					position.x,
 					position.y,
 					focusedDirPathRef.current ?? "",
 				);
-				setExternalDropTargetPath(targetDir);
-				if (payload.type !== "drop" || payload.paths.length === 0) return;
+				if (payload.type !== "drop") {
+					setExternalDropTargetPath(targetDir);
+					return;
+				}
 				setExternalDropTargetPath(null);
+				if (payload.paths.length === 0) return;
 				if (targetDir === null) return;
 				await onImportPathsInDir(payload.paths, targetDir);
 			})
@@ -1104,7 +1114,10 @@ export const FileTreePane = memo(function FileTreePane({
 				}}
 			/>
 			{!hasLoadedFileVisibility ? null : focusedDirPath ? (
-				<FileTreeRootDrop targetDirPath={focusedDirPath}>
+				<FileTreeRootDrop
+					targetDirPath={focusedDirPath}
+					isExternalDropTarget={externalDropTargetPath === focusedDirPath}
+				>
 					<FolderBreadcrumb
 						spacePath={spacePath}
 						dirPath={focusedDirPath}
@@ -1163,7 +1176,7 @@ export const FileTreePane = memo(function FileTreePane({
 					)}
 				</FileTreeRootDrop>
 			) : hasVisibleRootEntries ? (
-				<FileTreeRootDrop>
+				<FileTreeRootDrop isExternalDropTarget={externalDropTargetPath === ""}>
 					<TreeEntries
 						entries={rootEntries}
 						parentDepth={-1}

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -646,7 +646,6 @@ export const FileTreePane = memo(function FileTreePane({
 	const [externalDropTargetPath, setExternalDropTargetPath] = useState<
 		string | null
 	>(null);
-	const externalDropEventGenerationRef = useRef(0);
 	const moveClickSuppressRef = useRef(false);
 	const moveClickSuppressResetTimerRef = useRef<ReturnType<
 		typeof window.setTimeout
@@ -1032,7 +1031,6 @@ export const FileTreePane = memo(function FileTreePane({
 		let disposed = false;
 		void currentWindow
 			.onDragDropEvent(async ({ payload }) => {
-				const eventGeneration = ++externalDropEventGenerationRef.current;
 				if (payload.type === "leave") {
 					setExternalDropTargetPath(null);
 					return;
@@ -1042,17 +1040,10 @@ export const FileTreePane = memo(function FileTreePane({
 					setExternalDropTargetPath(null);
 					return;
 				}
-				// Wry reports macOS file-drop positions in AppKit points even though
-				// Tauri exposes them as physical pixels. Converting again would move a
-				// Retina drop toward the top-left of the tree.
-				const position = navigator.userAgent.includes("Macintosh")
-					? payload.position
-					: payload.position.toLogical(await currentWindow.scaleFactor());
-				if (eventGeneration !== externalDropEventGenerationRef.current) return;
 				const targetDir = fileTreeDropTargetAtPoint(
 					pane,
-					position.x,
-					position.y,
+					payload.position.x,
+					payload.position.y,
 					focusedDirPathRef.current ?? "",
 				);
 				if (payload.type !== "drop") {

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -994,8 +994,12 @@ export const FileTreePane = memo(function FileTreePane({
 				if (payload.type !== "drop" || payload.paths.length === 0) return;
 				const pane = paneRef.current;
 				if (!pane) return;
-				const scaleFactor = await currentWindow.scaleFactor();
-				const position = payload.position.toLogical(scaleFactor);
+				// Wry reports macOS file-drop positions in AppKit points even though
+				// Tauri exposes them as physical pixels. Converting again would move a
+				// Retina drop toward the top-left of the tree.
+				const position = navigator.userAgent.includes("Macintosh")
+					? payload.position
+					: payload.position.toLogical(await currentWindow.scaleFactor());
 				const bounds = pane.getBoundingClientRect();
 				if (
 					position.x < bounds.left ||

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -166,6 +166,36 @@ interface FolderBreadcrumbProps {
 	onExit: () => void;
 }
 
+function fileTreeDropTargetAtPoint(
+	pane: HTMLElement,
+	x: number,
+	y: number,
+	fallbackDirPath: string,
+): string | null {
+	const bounds = pane.getBoundingClientRect();
+	if (
+		x < bounds.left ||
+		x > bounds.right ||
+		y < bounds.top ||
+		y > bounds.bottom
+	) {
+		return null;
+	}
+
+	const hit = document.elementFromPoint(x, y);
+	const row =
+		hit instanceof Element
+			? hit.closest<HTMLElement>("[data-file-tree-path][data-file-tree-kind]")
+			: null;
+	const rowPath =
+		row && pane.contains(row) ? row.dataset.fileTreePath : undefined;
+	return rowPath && row?.dataset.fileTreeKind === "dir"
+		? rowPath
+		: rowPath
+			? parentDir(rowPath)
+			: fallbackDirPath;
+}
+
 function FolderBreadcrumb({
 	spacePath,
 	dirPath,
@@ -256,6 +286,7 @@ interface TreeEntriesProps {
 	folderFileCounts: Record<string, number>;
 	showFolderFileCounts: boolean;
 	showNonMarkdownFiles: boolean;
+	externalDropTargetPath: string | null;
 	onOpenAppearancePicker: (entry: FsEntry) => void;
 	pinnedFiles: string[];
 	onTogglePinnedFile: (path: string) => Promise<void>;
@@ -342,6 +373,7 @@ function TreeEntries({
 	folderFileCounts,
 	showFolderFileCounts,
 	showNonMarkdownFiles,
+	externalDropTargetPath,
 	onOpenAppearancePicker,
 	pinnedFiles,
 	onTogglePinnedFile,
@@ -504,6 +536,7 @@ function TreeEntries({
 									? (folderFileCounts[entry.rel_path] ?? null)
 									: null
 							}
+							isExternalDropTarget={externalDropTargetPath === entry.rel_path}
 							onOpenAppearancePicker={() => onOpenAppearancePicker(entry)}
 							onStartRename={() => onStartRename(entry.rel_path)}
 							onCommitRename={onCommitDirRename}
@@ -606,6 +639,9 @@ export const FileTreePane = memo(function FileTreePane({
 	} = useVisibleFilePreviews(spacePath, focusedDirPath);
 	const [appearancePickerTarget, setAppearancePickerTarget] =
 		useState<AppearancePickerTarget | null>(null);
+	const [externalDropTargetPath, setExternalDropTargetPath] = useState<
+		string | null
+	>(null);
 	const moveClickSuppressRef = useRef(false);
 	const moveClickSuppressResetTimerRef = useRef<ReturnType<
 		typeof window.setTimeout
@@ -991,40 +1027,31 @@ export const FileTreePane = memo(function FileTreePane({
 		let disposed = false;
 		void currentWindow
 			.onDragDropEvent(async ({ payload }) => {
-				if (payload.type !== "drop" || payload.paths.length === 0) return;
+				if (payload.type === "leave") {
+					setExternalDropTargetPath(null);
+					return;
+				}
 				const pane = paneRef.current;
-				if (!pane) return;
+				if (!pane) {
+					setExternalDropTargetPath(null);
+					return;
+				}
 				// Wry reports macOS file-drop positions in AppKit points even though
 				// Tauri exposes them as physical pixels. Converting again would move a
 				// Retina drop toward the top-left of the tree.
 				const position = navigator.userAgent.includes("Macintosh")
 					? payload.position
 					: payload.position.toLogical(await currentWindow.scaleFactor());
-				const bounds = pane.getBoundingClientRect();
-				if (
-					position.x < bounds.left ||
-					position.x > bounds.right ||
-					position.y < bounds.top ||
-					position.y > bounds.bottom
-				) {
-					return;
-				}
-
-				const hit = document.elementFromPoint(position.x, position.y);
-				const row =
-					hit instanceof Element
-						? hit.closest<HTMLElement>(
-								"[data-file-tree-path][data-file-tree-kind]",
-							)
-						: null;
-				const rowPath =
-					row && pane.contains(row) ? row.dataset.fileTreePath : undefined;
-				const targetDir =
-					rowPath && row?.dataset.fileTreeKind === "dir"
-						? rowPath
-						: rowPath
-							? parentDir(rowPath)
-							: (focusedDirPathRef.current ?? "");
+				const targetDir = fileTreeDropTargetAtPoint(
+					pane,
+					position.x,
+					position.y,
+					focusedDirPathRef.current ?? "",
+				);
+				setExternalDropTargetPath(targetDir);
+				if (payload.type !== "drop" || payload.paths.length === 0) return;
+				setExternalDropTargetPath(null);
+				if (targetDir === null) return;
 				await onImportPathsInDir(payload.paths, targetDir);
 			})
 			.then((stopListening) => {
@@ -1114,6 +1141,7 @@ export const FileTreePane = memo(function FileTreePane({
 							folderFileCounts={folderFileCounts}
 							showFolderFileCounts={showFolderFileCounts}
 							showNonMarkdownFiles={showNonMarkdownFilesSetting}
+							externalDropTargetPath={externalDropTargetPath}
 							onOpenAppearancePicker={handleOpenAppearancePicker}
 							pinnedFiles={pinnedFiles}
 							onTogglePinnedFile={onTogglePinnedFile}
@@ -1164,6 +1192,7 @@ export const FileTreePane = memo(function FileTreePane({
 						folderFileCounts={folderFileCounts}
 						showFolderFileCounts={showFolderFileCounts}
 						showNonMarkdownFiles={showNonMarkdownFilesSetting}
+						externalDropTargetPath={externalDropTargetPath}
 						onOpenAppearancePicker={handleOpenAppearancePicker}
 						pinnedFiles={pinnedFiles}
 						onTogglePinnedFile={onTogglePinnedFile}


### PR DESCRIPTION
Closes 


## Description

Fixes external file imports dropped into the file tree, particularly on macOS Retina displays where coordinates were being converted twice.

- Use the correct coordinate space for macOS drag/drop events
- Resolve the directory under the pointer for folder and file rows
- Highlight the folder that will receive an external drop


## Screenshots

No screenshots included; this is drag-and-drop interaction behavior.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external file drops in the file tree so imports land in the correct folder with accurate drag-over highlighting. Simplifies macOS drag/drop coordinate handling and unifies hit-testing across rows and the root pane.

- Bug Fixes
  - Use OS-provided drag/drop coordinates without extra scaling to avoid Retina mis-scaling.
  - Add `fileTreeDropTargetAtPoint` and track `externalDropTargetPath` to resolve the target dir from the cursor, set `data-drop-target` on the hovered folder or root/focused container, and clear on leave/drop; ignore events outside the pane.
  - Ensure rename-mode rows for both files and folders include `data-file-tree-kind`/`data-file-tree-path` for reliable hit-testing.
  - Remove stale `scaleFactor` test mock.

<sup>Written for commit 37e0cd7d6aca8bcdb16350c03cec06c2a8510dbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file-tree external drop targeting to highlight and use the directory under the cursor
> - Introduces `fileTreeDropTargetAtPoint` in [FileTreePane.tsx](https://github.com/SidhuK/Glyph/pull/466/files#diff-131490b72392f147fa6a9bc361ada159c4605876713d86d25e4cc50665c868e2) to compute the drop target directory from pointer coordinates by walking the DOM for `data-file-tree-kind`/`data-file-tree-path` attributes.
> - Adds `data-file-tree-kind` and `data-file-tree-path` attributes to dir and file rows (including rename rows) in [FileTreeDirItem.tsx](https://github.com/SidhuK/Glyph/pull/466/files#diff-f1399e164824dab69cfd8062254cafe1688cf8d2db48bc081b248f92257d1ef1) and [FileTreeFileItem.tsx](https://github.com/SidhuK/Glyph/pull/466/files#diff-72af9dd5db7795be1a3f98ed8162fd4222c9bebb029d198a4098e67f0279bd13) to support hit testing.
> - Tracks `externalDropTargetPath` state in `FileTreePane` and propagates it down to `FileTreeRootDrop` and `FileTreeDirItem` so the hovered directory is visually highlighted during an external drag.
> - On drop, the resolved target directory is passed to `onImportPathsInDir` instead of always importing to a fixed location.
> - Behavioral Change: scale factor conversion (`scaleFactor`/`toLogical`) is removed; raw `payload.position.x/y` coordinates are now used directly for hit testing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37e0cd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dragging files from outside the app into the file tree.
  * The directory under the pointer is highlighted as the active drop target.
  * Drop targeting works across focused and root directory views, including platform-specific pointer behavior.
  * The highlight clears automatically after a drop or when the pointer leaves the file tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->