### PR TITLE
Fix deep-link cold-start initialization (#468) [Release]

### DIFF
--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -7,7 +7,7 @@ pub use parse::{parse_deeplink_url, DeeplinkAction, DeeplinkError};
 use serde::Serialize;
 use std::collections::VecDeque;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -61,6 +61,7 @@ pub struct DeeplinkState {
     /// enough: cold starts can deliver multiple URLs via `get_current`, then
     /// re-deliver the same set live — each earlier URL would miss a 1-slot check.
     recent_os_urls: Mutex<VecDeque<(String, Instant)>>,
+    startup_complete: AtomicBool,
     next_id: AtomicU64,
 }
 
@@ -81,6 +82,14 @@ fn drain<T>(queue: &Mutex<VecDeque<T>>) -> Vec<T> {
 }
 
 impl DeeplinkState {
+    pub(crate) fn mark_startup_complete(&self) {
+        self.startup_complete.store(true, Ordering::Release);
+    }
+
+    fn startup_complete(&self) -> bool {
+        self.startup_complete.load(Ordering::Acquire)
+    }
+
     fn next_id(&self) -> u64 {
         self.next_id.fetch_add(1, Ordering::Relaxed) + 1
     }
@@ -157,7 +166,7 @@ fn dispatch_action(app: &AppHandle, state: &DeeplinkState, action: DeeplinkActio
     };
     // Queue before emitting: on a cold start the webview is not listening yet.
     push_bounded(&state.actions, event.clone());
-    show_shell(app);
+    show_shell(app, state);
     if let Err(error) = app.emit_to(MAIN_WINDOW_LABEL, DEEPLINK_ACTION_EVENT, &event) {
         warn!("Failed to emit deeplink action: {error}");
     }
@@ -169,7 +178,7 @@ fn dispatch_error(app: &AppHandle, state: &DeeplinkState, error: &DeeplinkError)
         code: error.code(),
     };
     push_bounded(&state.errors, payload.clone());
-    show_shell(app);
+    show_shell(app, state);
     if let Err(error) = app.emit_to(MAIN_WINDOW_LABEL, DEEPLINK_ERROR_EVENT, &payload) {
         warn!("Failed to emit deeplink error: {error}");
     }
@@ -177,7 +186,13 @@ fn dispatch_error(app: &AppHandle, state: &DeeplinkState, error: &DeeplinkError)
 
 /// Every deeplink route needs the main app shell; auxiliary windows (quick
 /// note, external markdown) never own a space session of their own.
-fn show_shell(app: &AppHandle) {
+fn show_shell(app: &AppHandle, state: &DeeplinkState) {
+    // The first macOS `Opened` event can arrive before the app's initial
+    // `MainEventsCleared` pass. Let that normal startup pass create the lazy
+    // main window instead of creating it from inside the URL callback.
+    if !state.startup_complete() && app.get_webview_window(MAIN_WINDOW_LABEL).is_none() {
+        return;
+    }
     if let Err(error) = crate::show_main_window_for_app(app) {
         warn!("Failed to show main window for deeplink: {error}");
     }

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -82,6 +82,22 @@ fn drain<T>(queue: &Mutex<VecDeque<T>>) -> Vec<T> {
 }
 
 impl DeeplinkState {
+    pub(crate) fn has_pending(&self) -> bool {
+        if !self
+            .actions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty()
+        {
+            return true;
+        }
+        !self
+            .errors
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_empty()
+    }
+
     pub(crate) fn mark_startup_complete(&self) {
         self.startup_complete.store(true, Ordering::Release);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1762,7 +1762,10 @@ pub fn run() {
                 }
                 RunEvent::MainEventsCleared if initial_launch_pending => {
                     initial_launch_pending = false;
-                    if !initial_launch_received_file_open {
+                    let has_pending_deeplink = app_handle
+                        .try_state::<deeplink::DeeplinkState>()
+                        .is_some_and(|state| state.has_pending());
+                    if !initial_launch_received_file_open || has_pending_deeplink {
                         if let Err(error) = show_main_window_for_app(app_handle) {
                             warn!("Failed to show main window: {error}");
                         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1767,6 +1767,9 @@ pub fn run() {
                             warn!("Failed to show main window: {error}");
                         }
                     }
+                    if let Some(state) = app_handle.try_state::<deeplink::DeeplinkState>() {
+                        state.mark_startup_complete();
+                    }
                 }
                 #[cfg(target_os = "macos")]
                 RunEvent::Reopen { .. } if !initial_launch_pending => {


### PR DESCRIPTION
Closes


## Description

Fixes the macOS cold-start deep-link race that could leave Glyph unresponsive when launched from a `glyph://` link.

- Keeps cold-start deep-link actions queued until the initial app window startup pass completes.
- Preserves immediate window showing/focusing for links opened while Glyph is already running.
- Prevents duplicate main-window initialization during startup.

## Docs

No documentation changes are needed.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a macOS cold-start deep-link race that could leave Glyph unresponsive when opened via `glyph://`. Deep links now wait for the first startup pass, and the main window is created then if any are pending.

- **Bug Fixes**
  - Add `startup_complete` on `DeeplinkState`; queue actions/errors until set after the first `MainEventsCleared`.
  - On startup, create the main window when pending deep links exist (even without a file-open event) so queued events deliver.
  - Update `show_shell` to no-op during cold start if the main window doesn’t exist yet; keep immediate show/focus when already running.

<sup>Written for commit f049ca991a3ed222ea5269e72d090dfa3bc993e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deep-link cold-start initialization to defer window creation until startup completes
> - Adds a `startup_complete` flag to `DeeplinkState` with `has_pending()`, `mark_startup_complete()`, and `startup_complete()` methods in [mod.rs](https://github.com/SidhuK/Glyph/pull/468/files#diff-57330fc548e8e3ec0241776c342c2d6b0c001f1a78b81e9d7434fe96258e8e7d)
> - `show_shell` now returns early if startup is not complete and no main window exists, preventing premature window creation during cold-start deep-links
> - In [lib.rs](https://github.com/SidhuK/Glyph/pull/468/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c), the `MainEventsCleared` handler shows the main window when there are pending deep-links even if a file-open event was received, then calls `mark_startup_complete()` so subsequent deep-link callbacks can show the window
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f049ca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-link handling during application startup.
  * Deep links are now deferred until the main application window is ready, preventing missed actions or errors during launch.
  * Existing window display and event behavior remains unchanged after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->