### PR TITLE
Fix sidebar expansion initialization

### DIFF
--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -634,7 +634,9 @@ export const FileTreePane = memo(function FileTreePane({
 		Record<string, number>
 	>({});
 	const [taskSummaryRefreshKey, setTaskSummaryRefreshKey] = useState(0);
-	const [focusedDirPath, setFocusedDirPath] = useState<string | null>(null);
+	const [focusedDirPath, setFocusedDirPath] = useState<string | null>(
+		activeDirPath,
+	);
 	const {
 		filePreviewsByPath,
 		clearVisiblePreviewPaths,


### PR DESCRIPTION
Closes


## Description

Initialize the file-tree focused directory from the active directory path so the sidebar opens with the correct directory expanded/focused.

- Summary: preserve the active directory as the initial focused directory.
- Reasoning: prevents the sidebar expansion state from starting empty when an active directory is already available.


## Docs

No documentation changes are needed for this internal bugfix.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize the file tree’s focus from the active directory so the sidebar opens with the correct folder expanded on load.

- **Bug Fixes**
  - Set `focusedDirPath` initial state to `activeDirPath` in `FileTreePane` to prevent an empty expansion state when an active directory exists.

<sup>Written for commit 5f946254879447db1659e67d344a2d957d23c6ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar expansion initialization in `FileTreePane` to use active directory
> Initializes `focusedDirPath` state with `activeDirPath` instead of `null`, so `useVisibleFilePreviews` receives the correct active directory on first render rather than a null value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f94625.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The file tree now initially focuses on the currently active directory, providing a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->