### PR TITLE
fix: make menu commands work when a file is opened from Finder

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,15 +134,21 @@ struct AppCommandPayload {
 }
 
 #[derive(Default)]
+struct PendingMenuCommands {
+    commands: Vec<AppCommandPayload>,
+    shell_ready: bool,
+}
+
+#[derive(Default)]
 struct MenuState {
     recent_spaces: Mutex<Vec<String>>,
     show_markdown_menu: Mutex<bool>,
     menu_shortcuts: Mutex<HashMap<String, Option<String>>>,
     menu_labels: Mutex<HashMap<String, String>>,
-    /// Commands that arrived while the main window did not exist (e.g. the app
-    /// was cold-started into an external markdown window via Finder). The shell
-    /// drains them on mount; see `menu_take_pending_commands`.
-    pending_commands: Mutex<Vec<AppCommandPayload>>,
+    /// Commands that arrive before the shell event listener is ready. The shell
+    /// drains them once that listener has registered; see
+    /// `menu_take_pending_commands`.
+    pending_commands: Mutex<PendingMenuCommands>,
 }
 
 #[derive(Default)]
@@ -994,6 +1000,12 @@ fn main_window(app: &tauri::AppHandle) -> Result<tauri::WebviewWindow, String> {
         return Ok(window);
     }
 
+    if let Some(state) = app.try_state::<MenuState>() {
+        if let Ok(mut pending) = state.pending_commands.lock() {
+            pending.shell_ready = false;
+        }
+    }
+
     let config = app
         .config()
         .app
@@ -1104,6 +1116,38 @@ fn emit_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
     );
 }
 
+fn dispatch_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
+    let should_queue = app
+        .try_state::<MenuState>()
+        .is_some_and(|state| match state.pending_commands.lock() {
+            Ok(mut pending) if !pending.shell_ready => {
+                pending.commands.push(AppCommandPayload {
+                    command_id: command_id.to_string(),
+                });
+                true
+            }
+            Ok(_) => false,
+            Err(_) => {
+                warn!("Failed to lock pending menu commands");
+                false
+            }
+        });
+
+    if should_queue {
+        if app
+            .get_webview_window(window_geometry::MAIN_WINDOW_LABEL)
+            .is_none()
+        {
+            if let Err(error) = show_main_window_for_app(app) {
+                warn!("Failed to show main window for menu command {command_id}: {error}");
+            }
+        }
+        return;
+    }
+
+    emit_menu_command_to_main(app, command_id);
+}
+
 #[tauri::command(rename_all = "snake_case")]
 fn set_quick_note_global_shortcut(
     app: tauri::AppHandle,
@@ -1192,15 +1236,17 @@ fn set_markdown_menu_visible(app: tauri::AppHandle, visible: bool) -> Result<(),
     Ok(())
 }
 
-/// Drain menu commands that were queued while the main window did not exist
-/// (e.g. the app was cold-started into an external markdown window). The main
-/// shell replays them once its webview is listening.
+/// Drain menu commands queued before the main shell registered its listener,
+/// then allow future commands to be emitted directly.
 #[tauri::command]
 fn menu_take_pending_commands(state: State<'_, MenuState>) -> Vec<AppCommandPayload> {
     state
         .pending_commands
         .lock()
-        .map(|mut pending| std::mem::take(&mut *pending))
+        .map(|mut pending| {
+            pending.shell_ready = true;
+            std::mem::take(&mut pending.commands)
+        })
         .unwrap_or_default()
 }
 
@@ -1490,7 +1536,7 @@ pub fn run() {
                 );
             }
             "file.print_note" => {
-                emit_menu_command_to_main(app, "print-note");
+                dispatch_menu_command_to_main(app, "print-note");
             }
             "file.close_tab" => {
                 // External markdown windows close themselves via Close Tab;
@@ -1507,7 +1553,7 @@ pub fn run() {
                         return;
                     }
                 }
-                emit_menu_command_to_main(app, "close-active-tab");
+                dispatch_menu_command_to_main(app, "close-active-tab");
             }
             #[cfg(target_os = "macos")]
             "edit.paste_without_formatting" => {
@@ -1527,27 +1573,7 @@ pub fn run() {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                if app
-                    .get_webview_window(window_geometry::MAIN_WINDOW_LABEL)
-                    .is_none()
-                {
-                    // The app may be running with only an external markdown window
-                    // (a file opened from Finder), so the main window does not
-                    // exist. Queue the command for the shell to replay on mount,
-                    // then reveal the main window.
-                    if let Some(state) = app.try_state::<MenuState>() {
-                        let _ = state.pending_commands.lock().map(|mut pending| {
-                            pending.push(AppCommandPayload {
-                                command_id: command.id,
-                            });
-                        });
-                    }
-                    if let Err(error) = show_main_window_for_app(app) {
-                        warn!("Failed to show main window for menu command {id}: {error}");
-                    }
-                } else {
-                    emit_menu_command_to_main(app, &command.id);
-                }
+                dispatch_menu_command_to_main(app, &command.id);
             }
         })
         .setup(|app| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1117,10 +1117,13 @@ fn emit_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
 }
 
 fn dispatch_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
+    let main_window_missing = app
+        .get_webview_window(window_geometry::MAIN_WINDOW_LABEL)
+        .is_none();
     let should_queue = app
         .try_state::<MenuState>()
         .is_some_and(|state| match state.pending_commands.lock() {
-            Ok(mut pending) if !pending.shell_ready => {
+            Ok(mut pending) if main_window_missing || !pending.shell_ready => {
                 pending.commands.push(AppCommandPayload {
                     command_id: command_id.to_string(),
                 });
@@ -1134,10 +1137,7 @@ fn dispatch_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
         });
 
     if should_queue {
-        if app
-            .get_webview_window(window_geometry::MAIN_WINDOW_LABEL)
-            .is_none()
-        {
+        if main_window_missing {
             if let Err(error) = show_main_window_for_app(app) {
                 warn!("Failed to show main window for menu command {command_id}: {error}");
             }
@@ -1653,8 +1653,18 @@ pub fn run() {
             }
 
             if is_main_window_label(window.label()) {
-                if let WindowEvent::CloseRequested { .. } = event {
-                    destroy_auxiliary_persisted_windows(window.app_handle());
+                match event {
+                    WindowEvent::CloseRequested { .. } => {
+                        destroy_auxiliary_persisted_windows(window.app_handle());
+                    }
+                    WindowEvent::Destroyed => {
+                        if let Some(state) = window.app_handle().try_state::<MenuState>() {
+                            if let Ok(mut pending) = state.pending_commands.lock() {
+                                pending.shell_ready = false;
+                            }
+                        }
+                    }
+                    _ => {}
                 }
             }
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -139,6 +139,10 @@ struct MenuState {
     show_markdown_menu: Mutex<bool>,
     menu_shortcuts: Mutex<HashMap<String, Option<String>>>,
     menu_labels: Mutex<HashMap<String, String>>,
+    /// Commands that arrived while the main window did not exist (e.g. the app
+    /// was cold-started into an external markdown window via Finder). The shell
+    /// drains them on mount; see `menu_take_pending_commands`.
+    pending_commands: Mutex<Vec<AppCommandPayload>>,
 }
 
 #[derive(Default)]
@@ -1090,6 +1094,16 @@ fn should_exit_after_external_markdown_close(app: &tauri::AppHandle) -> bool {
     })
 }
 
+fn emit_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {
+    let _ = app.emit_to(
+        window_geometry::MAIN_WINDOW_LABEL,
+        "menu:app_command",
+        AppCommandPayload {
+            command_id: command_id.to_string(),
+        },
+    );
+}
+
 #[tauri::command(rename_all = "snake_case")]
 fn set_quick_note_global_shortcut(
     app: tauri::AppHandle,
@@ -1176,6 +1190,18 @@ fn set_markdown_menu_visible(app: tauri::AppHandle, visible: bool) -> Result<(),
     .map_err(|error| error.to_string())?;
     app.set_menu(menu).map_err(|error| error.to_string())?;
     Ok(())
+}
+
+/// Drain menu commands that were queued while the main window did not exist
+/// (e.g. the app was cold-started into an external markdown window). The main
+/// shell replays them once its webview is listening.
+#[tauri::command]
+fn menu_take_pending_commands(state: State<'_, MenuState>) -> Vec<AppCommandPayload> {
+    state
+        .pending_commands
+        .lock()
+        .map(|mut pending| std::mem::take(&mut *pending))
+        .unwrap_or_default()
 }
 
 #[tauri::command(rename_all = "snake_case")]
@@ -1464,13 +1490,24 @@ pub fn run() {
                 );
             }
             "file.print_note" => {
-                let _ = app.emit_to(
-                    window_geometry::MAIN_WINDOW_LABEL,
-                    "menu:app_command",
-                    AppCommandPayload {
-                        command_id: "print-note".to_string(),
-                    },
-                );
+                emit_menu_command_to_main(app, "print-note");
+            }
+            "file.close_tab" => {
+                // External markdown windows close themselves via Close Tab;
+                // the main window owns tab management everywhere else.
+                if let Some((label, _window)) = focused_editor_window(app) {
+                    if external_markdown::is_external_markdown_window(&label) {
+                        let _ = app.emit_to(
+                            label,
+                            "menu:app_command",
+                            AppCommandPayload {
+                                command_id: "close-active-tab".to_string(),
+                            },
+                        );
+                        return;
+                    }
+                }
+                emit_menu_command_to_main(app, "close-active-tab");
             }
             #[cfg(target_os = "macos")]
             "edit.paste_without_formatting" => {
@@ -1490,13 +1527,27 @@ pub fn run() {
                 let Some(command) = menu_manifest::command_for_menu_id(id) else {
                     return;
                 };
-                let _ = app.emit_to(
-                    window_geometry::MAIN_WINDOW_LABEL,
-                    "menu:app_command",
-                    AppCommandPayload {
-                        command_id: command.id,
-                    },
-                );
+                if app
+                    .get_webview_window(window_geometry::MAIN_WINDOW_LABEL)
+                    .is_none()
+                {
+                    // The app may be running with only an external markdown window
+                    // (a file opened from Finder), so the main window does not
+                    // exist. Queue the command for the shell to replay on mount,
+                    // then reveal the main window.
+                    if let Some(state) = app.try_state::<MenuState>() {
+                        let _ = state.pending_commands.lock().map(|mut pending| {
+                            pending.push(AppCommandPayload {
+                                command_id: command.id,
+                            });
+                        });
+                    }
+                    if let Err(error) = show_main_window_for_app(app) {
+                        warn!("Failed to show main window for menu command {id}: {error}");
+                    }
+                } else {
+                    emit_menu_command_to_main(app, &command.id);
+                }
             }
         })
         .setup(|app| {
@@ -1613,6 +1664,7 @@ pub fn run() {
             set_recent_spaces_menu,
             set_menu_shortcuts,
             set_menu_labels,
+            menu_take_pending_commands,
             set_window_vibrancy_theme,
             external_markdown::open_external_markdown_path,
             external_markdown::external_markdown_window_path,

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,7 +1,8 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
 import { buildHelpMenuCommandHandlers } from "../lib/helpMenu";
+import { invoke } from "../lib/tauri";
 import { useTauriEvent } from "../lib/tauriEvents";
 
 interface UseMenuListenersProps {
@@ -180,4 +181,19 @@ export function useMenuListeners({
 
 	useTauriEvent("menu:app_command", handleAppCommand);
 	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);
+
+	useEffect(() => {
+		// Commands clicked while the main window did not exist yet (e.g. the
+		// app was cold-started into an external markdown window) are queued on
+		// the Rust side and replayed here once the shell is listening.
+		void invoke("menu_take_pending_commands")
+			.then((commands) => {
+				for (const command of commands) {
+					handleAppCommand(command);
+				}
+			})
+			.catch(() => {
+				// Nothing pending or IPC unavailable; the live listener covers it.
+			});
+	}, [handleAppCommand]);
 }

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { toast } from "sonner";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { buildHelpMenuCommandHandlers } from "../lib/helpMenu";
 import { invoke } from "../lib/tauri";
 import { listenTauriEvent, useTauriEvent } from "../lib/tauriEvents";
+import { toast } from "../lib/toast";
 
 interface UseMenuListenersProps {
 	onNewNote: () => void;

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo } from "react";
+import { toast } from "sonner";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
+import { extractErrorMessage } from "../lib/errorUtils";
 import { buildHelpMenuCommandHandlers } from "../lib/helpMenu";
 import { invoke } from "../lib/tauri";
-import { useTauriEvent } from "../lib/tauriEvents";
+import { listenTauriEvent, useTauriEvent } from "../lib/tauriEvents";
 
 interface UseMenuListenersProps {
 	onNewNote: () => void;
@@ -179,21 +181,35 @@ export function useMenuListeners({
 		],
 	);
 
-	useTauriEvent("menu:app_command", handleAppCommand);
 	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);
 
 	useEffect(() => {
-		// Commands clicked while the main window did not exist yet (e.g. the
-		// app was cold-started into an external markdown window) are queued on
-		// the Rust side and replayed here once the shell is listening.
-		void invoke("menu_take_pending_commands")
-			.then((commands) => {
+		let cancelled = false;
+		let unlisten: (() => void) | null = null;
+
+		void listenTauriEvent("menu:app_command", handleAppCommand)
+			.then(async (stop) => {
+				unlisten = stop;
+				if (cancelled) {
+					stop();
+					return;
+				}
+
+				const commands = await invoke("menu_take_pending_commands");
+				if (cancelled) return;
 				for (const command of commands) {
 					handleAppCommand(command);
 				}
 			})
-			.catch(() => {
-				// Nothing pending or IPC unavailable; the live listener covers it.
+			.catch((error: unknown) => {
+				if (cancelled) return;
+				console.error("Failed to replay pending menu commands", error);
+				toast.error(extractErrorMessage(error));
 			});
+
+		return () => {
+			cancelled = true;
+			unlisten?.();
+		};
 	}, [handleAppCommand]);
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -910,6 +910,7 @@ interface TauriCommands {
 		void
 	>;
 	set_menu_labels: CommandDef<{ labels: Record<string, string> }, void>;
+	menu_take_pending_commands: CommandDef<void, { command_id: string }[]>;
 	set_window_vibrancy_theme: CommandDef<{ theme: string }, void>;
 	external_link_preview: CommandDef<{ url: string }, ExternalLinkPreview>;
 	open_external_markdown_path: CommandDef<{ path: string }, void>;


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/462

## Description

Opening a `.md` file directly from Finder cold-starts Glyph into an external markdown window only — the main window is never created (`"create": false` in `tauri.conf.json`), so every menu command routed to `MAIN_WINDOW_LABEL` was dropped. File > About, File > Settings, and File > New Note were "dead."

- **Queue + reveal:** when a menu command fires and the main window does not exist, queue it on the Rust side and reveal the main window via `show_main_window_for_app`. The main shell replays queued commands on mount through `menu_take_pending_commands`, mirroring the existing `deeplink_take_pending` cold-start pattern. Exactly-once: we only queue when the window is missing, so there is no double-execution with live emits.
- **Close Tab routing:** `file.close_tab` now routes to a focused external-markdown window (it already implements `close-active-tab`), matching the `paste_without_formatting` focused-window pattern. This also prevents Cmd+W in a Finder-opened file from popping up the main window.
- Extracted `emit_menu_command_to_main` helper, reused by `file.print_note`.

Behavior: About/Settings reveal the main window and open the settings/about view; space-scoped commands (New Note) reveal the main window and no-op until a space is opened, matching the "point Glyph at a folder" flow.

## Screenshots

N/A — non-visual fix.

## Docs

No documentation changes needed.

## Ready?

- [x] Documented what's new
- [x] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dead menu commands when opening a .md from Finder by queueing them until the main window exists or the menu listener is ready, then replaying. About/Settings/New Note work again, and Cmd+W closes the Finder-opened window.

- **Bug Fixes**
  - Queue and replay menu commands when the main window is missing or the shell listener isn’t ready; reveal the main window via `show_main_window_for_app`. Register the listener first, then drain via `menu_take_pending_commands`.
  - Route `file.close_tab` to the focused external markdown window; otherwise send `close-active-tab` to the main window.
  - Consolidate menu dispatch in `dispatch_menu_command_to_main` (uses `emit_menu_command_to_main`) and reuse it for `file.print_note` and generic menu routing.

<sup>Written for commit d3dd9090d29f128c4c56954705835aba9df763e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix menu commands to queue and replay when a file is opened from Finder
> - Adds a `PendingMenuCommands` queue in `MenuState` ([lib.rs](https://github.com/SidhuK/Glyph/pull/471/files#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7c)) that buffers menu commands arriving before the shell-side listener has registered.
> - New `dispatch_menu_command_to_main` function checks shell readiness before emitting; if not ready or the main window is missing, it enqueues the command and attempts to show the window.
> - New Tauri command `menu_take_pending_commands` lets the shell signal readiness and drain any buffered commands in one call.
> - `useMenuListeners` ([useMenuListeners.ts](https://github.com/SidhuK/Glyph/pull/471/files#diff-458445d9950c3ba8eb6debbcc27c624314204f9e6c30945143dbb8df960c27f1)) now calls `menu_take_pending_commands` after registering its listener and replays each queued command via `handleAppCommand`.
> - Behavioral Change: menu commands are no longer emitted immediately on `on_menu_event`; they go through queuing semantics, and destroying the main window resets shell readiness so subsequent commands re-queue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3dd909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu actions selected before the main window loads are now queued and processed automatically once the app is ready.
  * Print and standard menu commands now reach the correct window.
  * Close-tab actions are routed to the focused Markdown window.
  * The main window is revealed when required to handle a menu action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->