### PR TITLE
ci: split frontend and Rust PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           filters: |
             frontend:
+              - '.github/workflows/pr-checks.yml'
               - 'src/**'
               - 'public/**'
               - 'index.html'
@@ -45,13 +46,24 @@ jobs:
               - 'tsconfig.node.json'
               - 'vite.config.ts'
             rust:
+              - '.github/workflows/pr-checks.yml'
               - 'src-tauri/**'
 
   frontend:
-    name: Frontend
+    name: Frontend / ${{ matrix.name }}
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Check
+            command: pnpm check
+          - name: Test
+            command: pnpm test
+          - name: Build
+            command: pnpm build
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -83,20 +95,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check formatting and lint
-        run: pnpm check
-
-      - name: Test
-        run: pnpm test
-
-      - name: Build
-        run: pnpm build
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
 
   rust:
-    name: Rust
+    name: Rust / ${{ matrix.name }}
     needs: changes
     if: needs.changes.outputs.rust == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Check
+            command: cargo check
+          - name: Test
+            command: cargo test
+          - name: Clippy
+            command: cargo clippy -- -D warnings
+          - name: Format
+            command: cargo fmt --check
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -107,16 +125,13 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
+          components: clippy, rustfmt
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           workspaces: src-tauri -> target
 
-      - name: Check
+      - name: ${{ matrix.name }}
         working-directory: src-tauri
-        run: cargo check
-
-      - name: Test
-        working-directory: src-tauri
-        run: cargo test
+        run: ${{ matrix.command }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -111,10 +111,6 @@ jobs:
             command: cargo check
           - name: Test
             command: cargo test
-          - name: Clippy
-            command: cargo clippy -- -D warnings
-          - name: Format
-            command: cargo fmt --check
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -125,7 +121,6 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
-          components: clippy, rustfmt
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2


### PR DESCRIPTION
Closes

## Description

Split the aggregate PR validation jobs into independently reported frontend and Rust checks.

- Adds frontend Check, Test, and Build statuses
- Adds Rust Check, Test, Clippy, and Format statuses
- Ensures workflow changes trigger both validation matrices

## Docs

No documentation changes are needed.

## Ready?

- [ ] Documented what is new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split CI into separate frontend and Rust PR checks so each status reports independently. This makes failures clearer and only runs what changed.

- **Refactors**
  - Frontend matrix: `pnpm check`, `pnpm test`, `pnpm build` (named "Frontend / <step>").
  - Rust matrix: `cargo check`, `cargo test` (named "Rust / <step>"); removed Clippy and Format gates.
  - Added path filters so edits to `.github/workflows/pr-checks.yml` trigger both matrices.
  - Matrices use fail-fast: false.

<sup>Written for commit d62f269245994428432f43ac9d22c42c20f5b689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split frontend and Rust PR checks into parallel matrix jobs
> - Frontend checks (Check, Test, Build) and Rust checks (Check, Test) now run as separate matrix job variants, potentially in parallel, rather than as sequential steps within a single job.
> - Changes to [pr-checks.yml](.github/workflows/pr-checks.yml) now trigger both frontend and Rust jobs via the paths-filter step.
> - `fail-fast` is disabled so a failure in one variant does not cancel the others.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d62f269.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->