### PR TITLE
Icons: 1.5 stroke width, DEV badge, separate dev build config (#479) [Release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"lint": "biome lint .",
 		"check": "biome check .",
 		"preview": "vite preview",
-		"tauri": "tauri"
+		"tauri": "node scripts/tauri.mjs"
 	},
 	"dependencies": {
 		"@codemirror/autocomplete": "^6.20.3",

--- a/scripts/tauri.mjs
+++ b/scripts/tauri.mjs
@@ -1,0 +1,14 @@
+import { spawnSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+
+if (args[0] === "dev") {
+	args.splice(1, 0, "--config", "src-tauri/tauri.dev.conf.json");
+}
+
+const result = spawnSync("tauri", args, {
+	stdio: "inherit",
+});
+
+if (result.error) throw result.error;
+process.exitCode = result.status ?? 1;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.14-alpha.2",
+	"version": "0.8.14-alpha.3",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,4 @@
+{
+	"productName": "Glyph Dev",
+	"identifier": "com.karatsidhu.glyph.dev"
+}

--- a/src/components/HugeiconsIcon.tsx
+++ b/src/components/HugeiconsIcon.tsx
@@ -1,0 +1,11 @@
+import { HugeiconsIcon as BaseHugeiconsIcon } from "@hugeicons/react";
+import type { ComponentProps } from "react";
+
+type HugeiconsIconProps = ComponentProps<typeof BaseHugeiconsIcon>;
+
+export function HugeiconsIcon({
+	strokeWidth = 1.5,
+	...props
+}: HugeiconsIconProps) {
+	return <BaseHugeiconsIcon strokeWidth={strokeWidth} {...props} />;
+}

--- a/src/components/Icons/ActionIcons.tsx
+++ b/src/components/Icons/ActionIcons.tsx
@@ -12,54 +12,54 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 
 export const Plus = (props: IconProps) => (
-	<HugeiconsIcon icon={Add} strokeWidth={0.9} {...withDefaultIconSize(props)} />
+	<HugeiconsIcon icon={Add} strokeWidth={1.5} {...withDefaultIconSize(props)} />
 );
 export const Trash2 = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Delete}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const RefreshCw = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArrowReloadHorizontalIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Save = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={SaveIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Copy = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Copy01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Download = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Download04Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Upload = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Upload04Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const X = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Close}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );

--- a/src/components/Icons/ActionIcons.tsx
+++ b/src/components/Icons/ActionIcons.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Add,
 	ArrowReloadHorizontalIcon,
@@ -8,58 +9,32 @@ import {
 	Save as SaveIcon,
 	Upload04Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 
 export const Plus = (props: IconProps) => (
-	<HugeiconsIcon icon={Add} strokeWidth={1.5} {...withDefaultIconSize(props)} />
+	<HugeiconsIcon icon={Add} {...withDefaultIconSize(props)} />
 );
 export const Trash2 = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Delete}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Delete} {...withDefaultIconSize(props)} />
 );
 export const RefreshCw = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArrowReloadHorizontalIcon}
-		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Save = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={SaveIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={SaveIcon} {...withDefaultIconSize(props)} />
 );
 export const Copy = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Copy01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Copy01Icon} {...withDefaultIconSize(props)} />
 );
 export const Download = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Download04Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Download04Icon} {...withDefaultIconSize(props)} />
 );
 export const Upload = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Upload04Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Upload04Icon} {...withDefaultIconSize(props)} />
 );
 export const X = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Close}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Close} {...withDefaultIconSize(props)} />
 );

--- a/src/components/Icons/EditorIcons.tsx
+++ b/src/components/Icons/EditorIcons.tsx
@@ -20,98 +20,98 @@ import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 export const Bold = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={BoldIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Italic = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ItalicIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Underline = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={TextUnderlineIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Strikethrough = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={StrikethroughIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Code = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={SourceCodeIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Quote = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={QuoteIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const List = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={LeftToRightListBulletIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ListOrdered = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ListOrderedIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ListChecks = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ListChecksIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Heading1 = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Heading1Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Heading2 = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Heading2Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Heading3 = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Heading3Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Link2 = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Link2Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Edit = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={EditIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );

--- a/src/components/Icons/EditorIcons.tsx
+++ b/src/components/Icons/EditorIcons.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Bold as BoldIcon,
 	Edit as EditIcon,
@@ -14,104 +15,50 @@ import {
 	Strikethrough as StrikethroughIcon,
 	TextUnderlineIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 
 export const Bold = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={BoldIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={BoldIcon} {...withDefaultIconSize(props)} />
 );
 export const Italic = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ItalicIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ItalicIcon} {...withDefaultIconSize(props)} />
 );
 export const Underline = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={TextUnderlineIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={TextUnderlineIcon} {...withDefaultIconSize(props)} />
 );
 export const Strikethrough = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={StrikethroughIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={StrikethroughIcon} {...withDefaultIconSize(props)} />
 );
 export const Code = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={SourceCodeIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={SourceCodeIcon} {...withDefaultIconSize(props)} />
 );
 export const Quote = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={QuoteIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={QuoteIcon} {...withDefaultIconSize(props)} />
 );
 export const List = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={LeftToRightListBulletIcon}
-		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ListOrdered = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ListOrderedIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ListOrderedIcon} {...withDefaultIconSize(props)} />
 );
 export const ListChecks = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ListChecksIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ListChecksIcon} {...withDefaultIconSize(props)} />
 );
 export const Heading1 = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Heading1Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Heading1Icon} {...withDefaultIconSize(props)} />
 );
 export const Heading2 = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Heading2Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Heading2Icon} {...withDefaultIconSize(props)} />
 );
 export const Heading3 = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Heading3Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Heading3Icon} {...withDefaultIconSize(props)} />
 );
 export const Link2 = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Link2Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Link2Icon} {...withDefaultIconSize(props)} />
 );
 export const Edit = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={EditIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={EditIcon} {...withDefaultIconSize(props)} />
 );

--- a/src/components/Icons/FileIcons.tsx
+++ b/src/components/Icons/FileIcons.tsx
@@ -30,175 +30,175 @@ import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 export const FileText = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={NoteIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const File = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={FileIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileCode = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={FileCodeIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileImage = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={FileImageIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileJson = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={DocumentCodeIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileSpreadsheet = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Xls01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileCsv = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Csv01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FilePdf = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Pdf01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileDoc = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Doc01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileTxt = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Txt01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileHtml = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={HtmlFile01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileCss = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={CssFile01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FileXml = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Xml01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FilePpt = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Ppt01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Film = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={FilmIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Music = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={MusicIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Archive = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArchiveIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Database = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={DatabaseIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Table = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={TableIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Kanban = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={KanbanIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Cpu = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={CpuIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Palette = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={PaletteIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Hash = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={HashIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Files = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Document}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Tags = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={HashIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );

--- a/src/components/Icons/FileIcons.tsx
+++ b/src/components/Icons/FileIcons.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Archive as ArchiveIcon,
 	Cpu as CpuIcon,
@@ -24,181 +25,80 @@ import {
 	Xls01Icon,
 	Xml01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type IconProps, withDefaultIconSize } from "./NavigationIcons";
 
 export const FileText = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={NoteIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={NoteIcon} {...withDefaultIconSize(props)} />
 );
 export const File = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={FileIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={FileIcon} {...withDefaultIconSize(props)} />
 );
 export const FileCode = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={FileCodeIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={FileCodeIcon} {...withDefaultIconSize(props)} />
 );
 export const FileImage = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={FileImageIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={FileImageIcon} {...withDefaultIconSize(props)} />
 );
 export const FileJson = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={DocumentCodeIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={DocumentCodeIcon} {...withDefaultIconSize(props)} />
 );
 export const FileSpreadsheet = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Xls01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Xls01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileCsv = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Csv01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Csv01Icon} {...withDefaultIconSize(props)} />
 );
 export const FilePdf = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Pdf01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Pdf01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileDoc = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Doc01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Doc01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileTxt = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Txt01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Txt01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileHtml = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={HtmlFile01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={HtmlFile01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileCss = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={CssFile01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={CssFile01Icon} {...withDefaultIconSize(props)} />
 );
 export const FileXml = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Xml01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Xml01Icon} {...withDefaultIconSize(props)} />
 );
 export const FilePpt = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Ppt01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Ppt01Icon} {...withDefaultIconSize(props)} />
 );
 export const Film = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={FilmIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={FilmIcon} {...withDefaultIconSize(props)} />
 );
 export const Music = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={MusicIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={MusicIcon} {...withDefaultIconSize(props)} />
 );
 export const Archive = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ArchiveIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ArchiveIcon} {...withDefaultIconSize(props)} />
 );
 export const Database = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={DatabaseIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={DatabaseIcon} {...withDefaultIconSize(props)} />
 );
 export const Table = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={TableIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={TableIcon} {...withDefaultIconSize(props)} />
 );
 export const Kanban = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={KanbanIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={KanbanIcon} {...withDefaultIconSize(props)} />
 );
 export const Cpu = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={CpuIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={CpuIcon} {...withDefaultIconSize(props)} />
 );
 export const Palette = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={PaletteIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={PaletteIcon} {...withDefaultIconSize(props)} />
 );
 export const Hash = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={HashIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={HashIcon} {...withDefaultIconSize(props)} />
 );
 export const Files = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Document}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Document} {...withDefaultIconSize(props)} />
 );
 export const Tags = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={HashIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={HashIcon} {...withDefaultIconSize(props)} />
 );

--- a/src/components/Icons/NavigationIcons.tsx
+++ b/src/components/Icons/NavigationIcons.tsx
@@ -24,63 +24,63 @@ export function withDefaultIconSize({
 export const Search = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={SearchIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Command = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={CommandIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ChevronRight = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArrowRight}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ChevronUp = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArrowUp}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const ChevronDown = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={ArrowDown}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const FolderOpen = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Archive04Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const LayoutAlignLeft = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={LayoutAlignLeftIcon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Settings = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Settings01Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );
 export const Calendar = (props: IconProps) => (
 	<HugeiconsIcon
 		icon={Calendar03Icon}
-		strokeWidth={0.9}
+		strokeWidth={1.5}
 		{...withDefaultIconSize(props)}
 	/>
 );

--- a/src/components/Icons/NavigationIcons.tsx
+++ b/src/components/Icons/NavigationIcons.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Archive04Icon,
 	ArrowDown,
@@ -9,7 +10,6 @@ import {
 	Search as SearchIcon,
 	Settings01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 
 export type IconProps = Omit<ComponentProps<typeof HugeiconsIcon>, "icon">;
@@ -22,65 +22,29 @@ export function withDefaultIconSize({
 }
 
 export const Search = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={SearchIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={SearchIcon} {...withDefaultIconSize(props)} />
 );
 export const Command = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={CommandIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={CommandIcon} {...withDefaultIconSize(props)} />
 );
 export const ChevronRight = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ArrowRight}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ArrowRight} {...withDefaultIconSize(props)} />
 );
 export const ChevronUp = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ArrowUp}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ArrowUp} {...withDefaultIconSize(props)} />
 );
 export const ChevronDown = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={ArrowDown}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={ArrowDown} {...withDefaultIconSize(props)} />
 );
 export const FolderOpen = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Archive04Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Archive04Icon} {...withDefaultIconSize(props)} />
 );
 export const LayoutAlignLeft = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={LayoutAlignLeftIcon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={LayoutAlignLeftIcon} {...withDefaultIconSize(props)} />
 );
 export const Settings = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Settings01Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Settings01Icon} {...withDefaultIconSize(props)} />
 );
 export const Calendar = (props: IconProps) => (
-	<HugeiconsIcon
-		icon={Calendar03Icon}
-		strokeWidth={1.5}
-		{...withDefaultIconSize(props)}
-	/>
+	<HugeiconsIcon icon={Calendar03Icon} {...withDefaultIconSize(props)} />
 );

--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -291,7 +291,7 @@ function TagRowIcon({
 			icon={Tag01Icon}
 			className="tagsIcon"
 			size="var(--icon-sm)"
-			strokeWidth={0.9}
+			strokeWidth={1.5}
 		/>
 	);
 }

--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Tag01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import {
 	type CSSProperties,
@@ -291,7 +291,6 @@ function TagRowIcon({
 			icon={Tag01Icon}
 			className="tagsIcon"
 			size="var(--icon-sm)"
-			strokeWidth={1.5}
 		/>
 	);
 }

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { ArrowUp02Icon, AtIcon, StopIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { BorderBeam } from "border-beam";
 import {
 	type Dispatch,
@@ -539,11 +539,7 @@ export function AIComposer({
 										onClick={handleInsertMentionTrigger}
 										disabled={isAwaitingResponse}
 									>
-										<HugeiconsIcon
-											icon={AtIcon}
-											size="var(--icon-sm)"
-											strokeWidth={1.5}
-										/>
+										<HugeiconsIcon icon={AtIcon} size="var(--icon-sm)" />
 									</Button>
 								</div>
 								<div className="aiComposerRight">
@@ -564,11 +560,7 @@ export function AIComposer({
 									aria-label="Stop"
 									title="Stop"
 								>
-									<HugeiconsIcon
-										icon={StopIcon}
-										size="var(--icon-md)"
-										strokeWidth={1.5}
-									/>
+									<HugeiconsIcon icon={StopIcon} size="var(--icon-md)" />
 								</button>
 							) : (
 								<Button

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -542,7 +542,7 @@ export function AIComposer({
 										<HugeiconsIcon
 											icon={AtIcon}
 											size="var(--icon-sm)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 										/>
 									</Button>
 								</div>
@@ -567,7 +567,7 @@ export function AIComposer({
 									<HugeiconsIcon
 										icon={StopIcon}
 										size="var(--icon-md)"
-										strokeWidth={0.9}
+										strokeWidth={1.5}
 									/>
 								</button>
 							) : (

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -408,7 +408,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 						<HugeiconsIcon
 							icon={ChatAdd01Icon}
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</Button>
 					<Button
@@ -436,7 +436,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 						<HugeiconsIcon
 							icon={Logout05Icon}
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</Button>
 				</div>

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -1,6 +1,6 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { cn } from "@/lib/utils";
 import { ChatAdd01Icon, Logout05Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAISidebarContext, useUILayoutContext } from "../../contexts";
@@ -405,11 +405,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 						disabled={chat.status === "streaming"}
 						onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
 					>
-						<HugeiconsIcon
-							icon={ChatAdd01Icon}
-							size="var(--icon-sm)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={ChatAdd01Icon} size="var(--icon-sm)" />
 					</Button>
 					<Button
 						type="button"
@@ -433,11 +429,7 @@ export function AIPanel({ onClose }: AIPanelProps) {
 						title="Minimize"
 						onPointerDown={(e: React.PointerEvent) => e.stopPropagation()}
 					>
-						<HugeiconsIcon
-							icon={Logout05Icon}
-							size="var(--icon-sm)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={Logout05Icon} size="var(--icon-sm)" />
 					</Button>
 				</div>
 			</div>

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import {
 	type MouseEvent as ReactMouseEvent,
@@ -288,7 +288,6 @@ export function ModelSelector({
 														<HugeiconsIcon
 															icon={InformationCircleIcon}
 															size="var(--icon-md)"
-															strokeWidth={1.5}
 														/>
 													</button>
 												)}

--- a/src/components/ai/ModelSelector.tsx
+++ b/src/components/ai/ModelSelector.tsx
@@ -288,7 +288,7 @@ export function ModelSelector({
 														<HugeiconsIcon
 															icon={InformationCircleIcon}
 															size="var(--icon-md)"
-															strokeWidth={0.9}
+															strokeWidth={1.5}
 														/>
 													</button>
 												)}

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Archive04Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	useInfiniteQuery,
 	useQuery,
@@ -648,11 +648,7 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 			<header className="activityTimelineHeader">
 				<div>
 					<h1 className="activityTimelineTitle">
-						<HugeiconsIcon
-							icon={Archive04Icon}
-							size="var(--icon-2xl)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={Archive04Icon} size="var(--icon-2xl)" />
 						<span>All Notes</span>
 					</h1>
 					<p

--- a/src/components/app/ActivityTimelinePane.tsx
+++ b/src/components/app/ActivityTimelinePane.tsx
@@ -651,7 +651,7 @@ export const ActivityTimelinePane = memo(function ActivityTimelinePane({
 						<HugeiconsIcon
 							icon={Archive04Icon}
 							size="var(--icon-2xl)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						<span>All Notes</span>
 					</h1>

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { TimelineEventIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
@@ -250,11 +250,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 					title={t("allNotes.showActivity")}
 					aria-label={t("allNotes.showActivity")}
 				>
-					<HugeiconsIcon
-						icon={TimelineEventIcon}
-						strokeWidth={1.5}
-						data-icon="inline-start"
-					/>
+					<HugeiconsIcon icon={TimelineEventIcon} data-icon="inline-start" />
 					<span>{t("allNotes.showActivity")}</span>
 				</Button>
 			</header>

--- a/src/components/app/AllDocsPane.tsx
+++ b/src/components/app/AllDocsPane.tsx
@@ -252,7 +252,7 @@ export const AllDocsPane = memo(function AllDocsPane({
 				>
 					<HugeiconsIcon
 						icon={TimelineEventIcon}
-						strokeWidth={1}
+						strokeWidth={1.5}
 						data-icon="inline-start"
 					/>
 					<span>{t("allNotes.showActivity")}</span>

--- a/src/components/app/CommandList.tsx
+++ b/src/components/app/CommandList.tsx
@@ -74,7 +74,7 @@ function ResultIcon({ result }: { result: PaletteResult }) {
 							? TableIcon
 							: null;
 	return icon ? (
-		<HugeiconsIcon icon={icon} size="var(--icon-md)" strokeWidth={0.9} />
+		<HugeiconsIcon icon={icon} size="var(--icon-md)" strokeWidth={1.5} />
 	) : (
 		<FileText size="var(--icon-md)" />
 	);

--- a/src/components/app/CommandList.tsx
+++ b/src/components/app/CommandList.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Folder01Icon,
 	TableIcon,
 	Tag01Icon,
 	UserIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { Fragment, type ReactNode, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -74,7 +74,7 @@ function ResultIcon({ result }: { result: PaletteResult }) {
 							? TableIcon
 							: null;
 	return icon ? (
-		<HugeiconsIcon icon={icon} size="var(--icon-md)" strokeWidth={1.5} />
+		<HugeiconsIcon icon={icon} size="var(--icon-md)" />
 	) : (
 		<FileText size="var(--icon-md)" />
 	);

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -1,6 +1,6 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { cn } from "@/lib/utils";
 import { StarIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -549,11 +549,7 @@ export function CommandPalette({
 												: "commandPalette.saveSearch",
 										)}
 									>
-										<HugeiconsIcon
-											icon={StarIcon}
-											size="var(--icon-md)"
-											strokeWidth={1.5}
-										/>
+										<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
 									</button>
 								</div>
 							) : null}

--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -552,7 +552,7 @@ export function CommandPalette({
 										<HugeiconsIcon
 											icon={StarIcon}
 											size="var(--icon-md)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 										/>
 									</button>
 								</div>

--- a/src/components/app/PinnedCollectionCard.tsx
+++ b/src/components/app/PinnedCollectionCard.tsx
@@ -46,7 +46,7 @@ export function PinnedCollectionCard({
 						<HugeiconsIcon
 							icon={LibraryIcon}
 							size="var(--icon-md)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						<strong>{collection.name}</strong>
 					</span>
@@ -63,7 +63,7 @@ export function PinnedCollectionCard({
 				<HugeiconsIcon
 					icon={StarIcon}
 					size="var(--icon-md)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			</button>
 		</article>

--- a/src/components/app/PinnedCollectionCard.tsx
+++ b/src/components/app/PinnedCollectionCard.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LibraryIcon, StarIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import type { WorkspaceDatabaseSummary } from "../../lib/tauri";
@@ -43,11 +43,7 @@ export function PinnedCollectionCard({
 			>
 				<span className="pinnedCollectionCardCopy">
 					<span className="pinnedCollectionCardTitle">
-						<HugeiconsIcon
-							icon={LibraryIcon}
-							size="var(--icon-md)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={LibraryIcon} size="var(--icon-md)" />
 						<strong>{collection.name}</strong>
 					</span>
 					<span>{collectionDescription(collection, t)}</span>
@@ -60,11 +56,7 @@ export function PinnedCollectionCard({
 				title={t("collections.unpin")}
 				aria-label={t("collections.unpinNamed", { name: collection.name })}
 			>
-				<HugeiconsIcon
-					icon={StarIcon}
-					size="var(--icon-md)"
-					strokeWidth={1.5}
-				/>
+				<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
 			</button>
 		</article>
 	);

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -383,7 +383,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={CursorAddSelection02Icon}
 								size="var(--icon-lg)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.newNote")}
@@ -412,7 +412,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={StarIcon}
 								size="var(--icon-md)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.pinned")}
@@ -440,7 +440,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={Archive04Icon}
 								size="var(--icon-md)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.allNotes")}
@@ -468,7 +468,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={LibraryIcon}
 								size="var(--icon-md)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.collections")}
@@ -492,7 +492,7 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={ChartRelationshipIcon}
 								size="var(--icon-md)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.connections")}
@@ -524,7 +524,7 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={Sorting01Icon}
 											size="var(--icon-sm)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 											className="sidebarStackHeaderSortIcon"
 											aria-hidden="true"
 										/>
@@ -558,7 +558,7 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={ExpandParagraphIcon}
 											size="var(--icon-sm)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 										/>
 									</button>
 									<button
@@ -571,7 +571,7 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={ArrowShrinkIcon}
 											size="var(--icon-sm)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 										/>
 									</button>
 								</div>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Archive04Icon,
 	ArrowShrinkIcon,
@@ -8,7 +9,6 @@ import {
 	Sorting01Icon,
 	StarIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQuery } from "@tanstack/react-query";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -383,7 +383,6 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={CursorAddSelection02Icon}
 								size="var(--icon-lg)"
-								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.newNote")}
@@ -409,11 +408,7 @@ export const SidebarContent = memo(function SidebarContent({
 							onClick={onOpenPinnedDocs}
 							title={t("sidebar.pinned")}
 						>
-							<HugeiconsIcon
-								icon={StarIcon}
-								size="var(--icon-md)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.pinned")}
 							</span>
@@ -437,11 +432,7 @@ export const SidebarContent = memo(function SidebarContent({
 							onFocus={onPrefetchAllDocs}
 							title={t("sidebar.allNotes")}
 						>
-							<HugeiconsIcon
-								icon={Archive04Icon}
-								size="var(--icon-md)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={Archive04Icon} size="var(--icon-md)" />
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.allNotes")}
 							</span>
@@ -465,11 +456,7 @@ export const SidebarContent = memo(function SidebarContent({
 							onFocus={() => onPrefetchDatabases()}
 							title={t("sidebar.collections")}
 						>
-							<HugeiconsIcon
-								icon={LibraryIcon}
-								size="var(--icon-md)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={LibraryIcon} size="var(--icon-md)" />
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.collections")}
 							</span>
@@ -492,7 +479,6 @@ export const SidebarContent = memo(function SidebarContent({
 							<HugeiconsIcon
 								icon={ChartRelationshipIcon}
 								size="var(--icon-md)"
-								strokeWidth={1.5}
 							/>
 							<span className="sidebarQuickActionLabel">
 								{t("sidebar.connections")}
@@ -524,7 +510,6 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={Sorting01Icon}
 											size="var(--icon-sm)"
-											strokeWidth={1.5}
 											className="sidebarStackHeaderSortIcon"
 											aria-hidden="true"
 										/>
@@ -558,7 +543,6 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={ExpandParagraphIcon}
 											size="var(--icon-sm)"
-											strokeWidth={1.5}
 										/>
 									</button>
 									<button
@@ -571,7 +555,6 @@ export const SidebarContent = memo(function SidebarContent({
 										<HugeiconsIcon
 											icon={ArrowShrinkIcon}
 											size="var(--icon-sm)"
-											strokeWidth={1.5}
 										/>
 									</button>
 								</div>

--- a/src/components/app/SidebarHeader.tsx
+++ b/src/components/app/SidebarHeader.tsx
@@ -45,9 +45,6 @@ export function SidebarHeader({
 						}`}
 					>
 						<LayoutAlignLeft size="var(--icon-md)" />
-						{import.meta.env.DEV && (
-							<span className="sidebarDevBadge">{t("sidebar.devBadge")}</span>
-						)}
 					</WindowChromeIconButton>
 					<WindowChromeUpdateButton
 						updateReady={autoUpdater.updateReady}

--- a/src/components/app/SidebarHeader.tsx
+++ b/src/components/app/SidebarHeader.tsx
@@ -45,6 +45,9 @@ export function SidebarHeader({
 						}`}
 					>
 						<LayoutAlignLeft size="var(--icon-md)" />
+						{import.meta.env.DEV && (
+							<span className="sidebarDevBadge">{t("sidebar.devBadge")}</span>
+						)}
 					</WindowChromeIconButton>
 					<WindowChromeUpdateButton
 						updateReady={autoUpdater.updateReady}

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -1,8 +1,8 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	ArrowLeft02Icon,
 	ArrowUpRight01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { memo, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -55,11 +55,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 						className="sidebarQuickActionBtn settingsBackButton"
 						onClick={closeSettings}
 					>
-						<HugeiconsIcon
-							icon={ArrowLeft02Icon}
-							size="var(--icon-md)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={ArrowLeft02Icon} size="var(--icon-md)" />
 						<span className="sidebarQuickActionLabel">Back</span>
 					</button>
 				</div>
@@ -195,11 +191,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							onClick={() => void openUrl(licenseStatus.purchase_url)}
 						>
 							Buy official license
-							<HugeiconsIcon
-								icon={ArrowUpRight01Icon}
-								size="var(--icon-sm)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={ArrowUpRight01Icon} size="var(--icon-sm)" />
 						</Button>
 					</div>
 				) : (
@@ -218,11 +210,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 							onClick={() => void openUrl(GLYPH_LINKS.discord)}
 						>
 							Send feedback
-							<HugeiconsIcon
-								icon={ArrowUpRight01Icon}
-								size="var(--icon-sm)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={ArrowUpRight01Icon} size="var(--icon-sm)" />
 						</Button>
 					</div>
 				)}

--- a/src/components/app/SidebarSettingsContent.tsx
+++ b/src/components/app/SidebarSettingsContent.tsx
@@ -58,7 +58,7 @@ export const SidebarSettingsContent = memo(function SidebarSettingsContent() {
 						<HugeiconsIcon
 							icon={ArrowLeft02Icon}
 							size="var(--icon-md)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						<span className="sidebarQuickActionLabel">Back</span>
 					</button>

--- a/src/components/app/TabBar.tsx
+++ b/src/components/app/TabBar.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import {
 	type DragEndEvent,
@@ -6,7 +7,6 @@ import {
 } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { Cancel01Icon, PinIcon, PinOffIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import type { MouseEvent, MutableRefObject } from "react";
 import { useTranslation } from "react-i18next";
@@ -364,13 +364,11 @@ const TabItem = memo(function TabItem({
 					<HugeiconsIcon
 						icon={PinIcon}
 						size={13}
-						strokeWidth={1.5}
 						className="mainTabPinIcon mainTabPinIconPinned"
 					/>
 					<HugeiconsIcon
 						icon={PinOffIcon}
 						size={13}
-						strokeWidth={1.5}
 						className="mainTabPinIcon mainTabPinIconUnpin"
 					/>
 				</button>
@@ -381,12 +379,7 @@ const TabItem = memo(function TabItem({
 					onClick={handleClose}
 					aria-label={`Close ${label}`}
 				>
-					<HugeiconsIcon
-						icon={Cancel01Icon}
-						size={13}
-						strokeWidth={1.5}
-						aria-hidden="true"
-					/>
+					<HugeiconsIcon icon={Cancel01Icon} size={13} aria-hidden="true" />
 				</button>
 			)}
 			<button

--- a/src/components/app/WindowChromeIconButton.tsx
+++ b/src/components/app/WindowChromeIconButton.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 interface WindowChromeIconButtonProps {
 	ariaLabel: string;
@@ -17,6 +18,8 @@ export function WindowChromeIconButton({
 	title,
 	children,
 }: WindowChromeIconButtonProps) {
+	const { t } = useTranslation("shell");
+
 	return (
 		<button
 			data-sidebar="trigger"
@@ -30,6 +33,9 @@ export function WindowChromeIconButton({
 			title={title}
 		>
 			{children}
+			{import.meta.env.DEV && (
+				<span className="sidebarDevBadge">{t("sidebar.devBadge")}</span>
+			)}
 		</button>
 	);
 }

--- a/src/components/app/WindowChromeUpdateButton.tsx
+++ b/src/components/app/WindowChromeUpdateButton.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Download04Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { AnimatePresence, m } from "motion/react";
 
 interface WindowChromeUpdateButtonProps {

--- a/src/components/app/calendar/CalendarMonth.tsx
+++ b/src/components/app/calendar/CalendarMonth.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { ArrowLeft01Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	type Day,
 	addMonths,
@@ -129,11 +129,7 @@ export function CalendarMonth({
 						aria-label={t("calendar.previousMonth")}
 						onClick={() => goToMonth(-1)}
 					>
-						<HugeiconsIcon
-							icon={ArrowLeft01Icon}
-							size="var(--icon-lg)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={ArrowLeft01Icon} size="var(--icon-lg)" />
 					</button>
 					<button
 						type="button"
@@ -141,11 +137,7 @@ export function CalendarMonth({
 						aria-label={t("calendar.nextMonth")}
 						onClick={() => goToMonth(1)}
 					>
-						<HugeiconsIcon
-							icon={ArrowRight01Icon}
-							size="var(--icon-lg)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={ArrowRight01Icon} size="var(--icon-lg)" />
 					</button>
 				</div>
 			</header>

--- a/src/components/app/calendar/DayNotesPanel.tsx
+++ b/src/components/app/calendar/DayNotesPanel.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Calendar03Icon, NoteIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { CalendarDateNote } from "../../../lib/tauri";
@@ -41,7 +41,6 @@ function NoteRow({
 					<HugeiconsIcon
 						icon={isDaily ? Calendar03Icon : NoteIcon}
 						size="var(--icon-md)"
-						strokeWidth={1.5}
 					/>
 				</span>
 				<span className="calendarNoteText">

--- a/src/components/app/calendar/DayNotesPanel.tsx
+++ b/src/components/app/calendar/DayNotesPanel.tsx
@@ -41,7 +41,7 @@ function NoteRow({
 					<HugeiconsIcon
 						icon={isDaily ? Calendar03Icon : NoteIcon}
 						size="var(--icon-md)"
-						strokeWidth={1.4}
+						strokeWidth={1.5}
 					/>
 				</span>
 				<span className="calendarNoteText">

--- a/src/components/app/editorCommands.tsx
+++ b/src/components/app/editorCommands.tsx
@@ -78,7 +78,7 @@ export function buildEditorCommands({
 			<HugeiconsIcon
 				icon={command.icon}
 				size="var(--icon-lg)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 		enabled,

--- a/src/components/app/editorCommands.tsx
+++ b/src/components/app/editorCommands.tsx
@@ -1,9 +1,9 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	CodeIcon,
 	EyeIcon,
 	PencilEdit02Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { dispatchEditorMenuAction } from "../../lib/appEvents";
 import type { EditorViewMode } from "../../lib/editorMode";
 import { ChevronDown, ChevronUp } from "../Icons";
@@ -74,13 +74,7 @@ export function buildEditorCommands({
 
 	const viewModeCommands: Command[] = VIEW_MODE_COMMANDS.map((command) => ({
 		id: command.id,
-		icon: (
-			<HugeiconsIcon
-				icon={command.icon}
-				size="var(--icon-lg)"
-				strokeWidth={1.5}
-			/>
-		),
+		icon: <HugeiconsIcon icon={command.icon} size="var(--icon-lg)" />,
 		enabled,
 		allowInEditable: true,
 		action: () => {

--- a/src/components/app/movePickerCommands.tsx
+++ b/src/components/app/movePickerCommands.tsx
@@ -29,7 +29,7 @@ export function buildMovePickerCommands({
 				<HugeiconsIcon
 					icon={Folder01Icon}
 					size="var(--icon-lg)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			),
 			category: "Move Destination",
@@ -42,7 +42,7 @@ export function buildMovePickerCommands({
 				<HugeiconsIcon
 					icon={Folder01Icon}
 					size="var(--icon-lg)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			),
 			category: "Move Destination",

--- a/src/components/app/movePickerCommands.tsx
+++ b/src/components/app/movePickerCommands.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Folder01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { UseFileTreeResult } from "../../hooks/useFileTree";
 import type { Command } from "./commandPaletteHelpers";
 
@@ -25,26 +25,14 @@ export function buildMovePickerCommands({
 		{
 			id: "move-picker-root",
 			label: "/",
-			icon: (
-				<HugeiconsIcon
-					icon={Folder01Icon}
-					size="var(--icon-lg)"
-					strokeWidth={1.5}
-				/>
-			),
+			icon: <HugeiconsIcon icon={Folder01Icon} size="var(--icon-lg)" />,
 			category: "Move Destination",
 			action: () => moveTo(""),
 		},
 		...moveTargetDirs.map((directory) => ({
 			id: `move-picker:${directory}`,
 			label: `/${directory}`,
-			icon: (
-				<HugeiconsIcon
-					icon={Folder01Icon}
-					size="var(--icon-lg)"
-					strokeWidth={1.5}
-				/>
-			),
+			icon: <HugeiconsIcon icon={Folder01Icon} size="var(--icon-lg)" />,
 			category: "Move Destination",
 			action: () => moveTo(directory),
 		})),

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -154,7 +154,7 @@ function buildAiCommands({
 				<HugeiconsIcon
 					icon={AiBrain04Icon}
 					size="var(--icon-lg)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			),
 			shortcut: { meta: true, shift: true, key: "a" },
@@ -167,7 +167,7 @@ function buildAiCommands({
 				<HugeiconsIcon
 					icon={Link01Icon}
 					size="var(--icon-lg)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			),
 			shortcut: { meta: true, alt: true, key: "a" },
@@ -180,7 +180,7 @@ function buildAiCommands({
 				<HugeiconsIcon
 					icon={Link01Icon}
 					size="var(--icon-lg)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			),
 			shortcut: { meta: true, alt: true, shift: true, key: "a" },
@@ -322,7 +322,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={CursorAddSelection02Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "n" },
@@ -335,7 +335,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={NoteIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: true,
@@ -348,7 +348,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={ColorsIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "m" },
@@ -361,7 +361,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={FileImportIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -373,7 +373,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={FolderImportIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -385,7 +385,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={CursorInWindowIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "t" },
@@ -403,7 +403,7 @@ export function useAppCommands({
 			).map(([id, icon, edge]) => ({
 				id,
 				icon: (
-					<HugeiconsIcon icon={icon} size="var(--icon-lg)" strokeWidth={0.9} />
+					<HugeiconsIcon icon={icon} size="var(--icon-lg)" strokeWidth={1.5} />
 				),
 				enabled: Boolean(spacePath),
 				action: () => splitPaneWithBlank(edge),
@@ -427,7 +427,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={activeTabIsPinned ? PinOffIcon : PinIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: activeTabCanPin,
@@ -449,7 +449,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={TableIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -461,7 +461,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Folder01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -477,7 +477,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={NoteIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled:
@@ -491,7 +491,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={CalendarAdd01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "d" },
@@ -512,7 +512,7 @@ export function useAppCommands({
 								: PinIcon
 						}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
@@ -528,7 +528,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={NoteIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "s" },
@@ -542,7 +542,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={ChartRelationshipIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "g" },
@@ -559,7 +559,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "i" },
@@ -576,7 +576,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={NoteIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "c" },
@@ -591,7 +591,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Link01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(activeFilePath),
@@ -609,7 +609,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Link01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
@@ -626,7 +626,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={MoveIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
@@ -643,7 +643,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={ArrowLeft}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "[" },
@@ -657,7 +657,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={ArrowRight}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "]" },
@@ -671,7 +671,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={SearchIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "p" },
@@ -685,7 +685,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Archive04Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -698,7 +698,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={ChartRelationshipIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -710,7 +710,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={LibraryIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -723,7 +723,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Calendar03Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -735,7 +735,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Folder01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "n" },
@@ -750,7 +750,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={FolderOpenIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "o" },
@@ -762,7 +762,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={FolderOpenIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -774,7 +774,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={FolderRemoveIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -786,7 +786,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Link01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -804,7 +804,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={SidebarLeftIcon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, shift: true, key: "b" },
@@ -816,7 +816,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={SquareLock02Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				action: async () => {
@@ -840,7 +840,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Settings01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "," },
@@ -852,7 +852,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Settings01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -864,7 +864,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={SquareLock02Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				action: () => openSettings("general"),
@@ -875,7 +875,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Settings01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath),
@@ -887,7 +887,7 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={Settings01Icon}
 						size="var(--icon-lg)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				),
 				action: handleOpenAiSettings,

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	AiBrain04Icon,
 	Archive04Icon,
@@ -31,7 +32,6 @@ import {
 	SquareLock02Icon,
 	TableIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { type Dispatch, type SetStateAction, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -150,39 +150,21 @@ function buildAiCommands({
 	return [
 		{
 			id: "toggle-ai",
-			icon: (
-				<HugeiconsIcon
-					icon={AiBrain04Icon}
-					size="var(--icon-lg)"
-					strokeWidth={1.5}
-				/>
-			),
+			icon: <HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-lg)" />,
 			shortcut: { meta: true, shift: true, key: "a" },
 			enabled: Boolean(spacePath),
 			action: () => setAiPanelOpen((v) => !v),
 		},
 		{
 			id: "ai-attach-current-note",
-			icon: (
-				<HugeiconsIcon
-					icon={Link01Icon}
-					size="var(--icon-lg)"
-					strokeWidth={1.5}
-				/>
-			),
+			icon: <HugeiconsIcon icon={Link01Icon} size="var(--icon-lg)" />,
 			shortcut: { meta: true, alt: true, key: "a" },
 			enabled: Boolean(activeMarkdownTabPath),
 			action: () => void attachCurrentNoteToAi(),
 		},
 		{
 			id: "ai-attach-all-open-notes",
-			icon: (
-				<HugeiconsIcon
-					icon={Link01Icon}
-					size="var(--icon-lg)"
-					strokeWidth={1.5}
-				/>
-			),
+			icon: <HugeiconsIcon icon={Link01Icon} size="var(--icon-lg)" />,
 			shortcut: { meta: true, alt: true, shift: true, key: "a" },
 			enabled: openMarkdownTabsLength > 0,
 			action: () => void attachAllOpenNotesToAi(),
@@ -322,7 +304,6 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={CursorAddSelection02Icon}
 						size="var(--icon-lg)"
-						strokeWidth={1.5}
 					/>
 				),
 				shortcut: { meta: true, key: "n" },
@@ -331,63 +312,33 @@ export function useAppCommands({
 			},
 			{
 				id: "open-quick-note",
-				icon: (
-					<HugeiconsIcon
-						icon={NoteIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={NoteIcon} size="var(--icon-lg)" />,
 				enabled: true,
 				allowInEditable: true,
 				action: openQuickNoteWindow,
 			},
 			{
 				id: "create-from-template",
-				icon: (
-					<HugeiconsIcon
-						icon={ColorsIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={ColorsIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, shift: true, key: "m" },
 				enabled: Boolean(spacePath),
 				action: handleCreateFromTemplateFromMenu,
 			},
 			{
 				id: "import-files",
-				icon: (
-					<HugeiconsIcon
-						icon={FileImportIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={FileImportIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: handleImportFilesFromMenu,
 			},
 			{
 				id: "import-folder",
-				icon: (
-					<HugeiconsIcon
-						icon={FolderImportIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={FolderImportIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: handleImportFolderFromMenu,
 			},
 			{
 				id: "new-tab",
-				icon: (
-					<HugeiconsIcon
-						icon={CursorInWindowIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={CursorInWindowIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "t" },
 				enabled: Boolean(spacePath),
 				allowInEditable: true,
@@ -402,9 +353,7 @@ export function useAppCommands({
 				] as const
 			).map(([id, icon, edge]) => ({
 				id,
-				icon: (
-					<HugeiconsIcon icon={icon} size="var(--icon-lg)" strokeWidth={1.5} />
-				),
+				icon: <HugeiconsIcon icon={icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: () => splitPaneWithBlank(edge),
 			})),
@@ -427,7 +376,6 @@ export function useAppCommands({
 					<HugeiconsIcon
 						icon={activeTabIsPinned ? PinOffIcon : PinIcon}
 						size="var(--icon-lg)"
-						strokeWidth={1.5}
 					/>
 				),
 				enabled: activeTabCanPin,
@@ -445,25 +393,13 @@ export function useAppCommands({
 			},
 			{
 				id: "new-database",
-				icon: (
-					<HugeiconsIcon
-						icon={TableIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={TableIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: createDatabaseAndOpen,
 			},
 			{
 				id: "new-folder",
-				icon: (
-					<HugeiconsIcon
-						icon={Folder01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Folder01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: () => {
 					const dir =
@@ -473,13 +409,7 @@ export function useAppCommands({
 			},
 			{
 				id: "duplicate-current-note",
-				icon: (
-					<HugeiconsIcon
-						icon={NoteIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={NoteIcon} size="var(--icon-lg)" />,
 				enabled:
 					activeMarkdownTabPath !== null &&
 					isMarkdownPath(activeMarkdownTabPath),
@@ -487,13 +417,7 @@ export function useAppCommands({
 			},
 			{
 				id: "open-daily-note",
-				icon: (
-					<HugeiconsIcon
-						icon={CalendarAdd01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={CalendarAdd01Icon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, shift: true, key: "d" },
 				enabled: Boolean(spacePath),
 				action: requestOpenDailyNote,
@@ -512,7 +436,6 @@ export function useAppCommands({
 								: PinIcon
 						}
 						size="var(--icon-lg)"
-						strokeWidth={1.5}
 					/>
 				),
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
@@ -524,13 +447,7 @@ export function useAppCommands({
 			},
 			{
 				id: "save-note",
-				icon: (
-					<HugeiconsIcon
-						icon={NoteIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={NoteIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "s" },
 				enabled: Boolean(spacePath),
 				allowInEditable: true,
@@ -539,11 +456,7 @@ export function useAppCommands({
 			{
 				id: "open-local-connections",
 				icon: (
-					<HugeiconsIcon
-						icon={ChartRelationshipIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={ChartRelationshipIcon} size="var(--icon-lg)" />
 				),
 				shortcut: { meta: true, shift: true, key: "g" },
 				enabled: Boolean(activeMarkdownTabPath),
@@ -556,11 +469,7 @@ export function useAppCommands({
 			{
 				id: "toggle-note-info-sidebar",
 				icon: (
-					<HugeiconsIcon
-						icon={InformationCircleIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={InformationCircleIcon} size="var(--icon-lg)" />
 				),
 				shortcut: { meta: true, shift: true, key: "i" },
 				enabled: Boolean(activeMarkdownTabPath),
@@ -572,13 +481,7 @@ export function useAppCommands({
 			},
 			{
 				id: "copy-note-markdown",
-				icon: (
-					<HugeiconsIcon
-						icon={NoteIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={NoteIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, shift: true, key: "c" },
 				enabled: Boolean(activeMarkdownTabPath),
 				allowInEditable: true,
@@ -587,13 +490,7 @@ export function useAppCommands({
 			{
 				id: "copy-active-file-relative-path",
 				label: "Copy current file relative path",
-				icon: (
-					<HugeiconsIcon
-						icon={Link01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Link01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(activeFilePath),
 				allowInEditable: true,
 				searchTerms: ["copy file path", "relative path"],
@@ -605,13 +502,7 @@ export function useAppCommands({
 			{
 				id: "copy-active-file-absolute-path",
 				label: "Copy current file absolute path",
-				icon: (
-					<HugeiconsIcon
-						icon={Link01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Link01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
 				allowInEditable: true,
 				searchTerms: ["copy file path", "absolute path", "full path"],
@@ -622,13 +513,7 @@ export function useAppCommands({
 			},
 			{
 				id: "move-active-file",
-				icon: (
-					<HugeiconsIcon
-						icon={MoveIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={MoveIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath) && Boolean(activeFilePath),
 				action: () => {
 					if (!activeFilePath) return;
@@ -639,13 +524,7 @@ export function useAppCommands({
 			},
 			{
 				id: "go-back-note",
-				icon: (
-					<HugeiconsIcon
-						icon={ArrowLeft}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={ArrowLeft} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "[" },
 				enabled: canGoBack,
 				allowInEditable: true,
@@ -653,13 +532,7 @@ export function useAppCommands({
 			},
 			{
 				id: "go-forward-note",
-				icon: (
-					<HugeiconsIcon
-						icon={ArrowRight}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={ArrowRight} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "]" },
 				enabled: canGoForward,
 				allowInEditable: true,
@@ -667,13 +540,7 @@ export function useAppCommands({
 			},
 			{
 				id: "quick-open",
-				icon: (
-					<HugeiconsIcon
-						icon={SearchIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={SearchIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "p" },
 				enabled: Boolean(spacePath),
 				allowInEditable: true,
@@ -681,13 +548,7 @@ export function useAppCommands({
 			},
 			{
 				id: "open-all-docs",
-				icon: (
-					<HugeiconsIcon
-						icon={Archive04Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Archive04Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: openAllDocsTab,
 			},
@@ -695,49 +556,27 @@ export function useAppCommands({
 				id: "open-connections",
 				label: "Open Connections",
 				icon: (
-					<HugeiconsIcon
-						icon={ChartRelationshipIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={ChartRelationshipIcon} size="var(--icon-lg)" />
 				),
 				enabled: Boolean(spacePath),
 				action: openConnectionsView,
 			},
 			{
 				id: "open-databases",
-				icon: (
-					<HugeiconsIcon
-						icon={LibraryIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={LibraryIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: () => openDatabasesTab(),
 			},
 			{
 				id: "open-calendar",
 				label: "Open calendar",
-				icon: (
-					<HugeiconsIcon
-						icon={Calendar03Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Calendar03Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: openCalendar,
 			},
 			{
 				id: "create-space",
-				icon: (
-					<HugeiconsIcon
-						icon={Folder01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Folder01Icon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, shift: true, key: "n" },
 				action: onCreateSpace,
 			},
@@ -746,49 +585,25 @@ export function useAppCommands({
 				labelKey: spacePath
 					? "shell:workspace.openAnotherSpace"
 					: "shell:workspace.openSpace",
-				icon: (
-					<HugeiconsIcon
-						icon={FolderOpenIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={FolderOpenIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "o" },
 				action: onOpenSpace,
 			},
 			{
 				id: "reveal-space",
-				icon: (
-					<HugeiconsIcon
-						icon={FolderOpenIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={FolderOpenIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: handleRevealSpaceFromMenu,
 			},
 			{
 				id: "close-space",
-				icon: (
-					<HugeiconsIcon
-						icon={FolderRemoveIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={FolderRemoveIcon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: closeSpace,
 			},
 			{
 				id: "git-sync-now",
-				icon: (
-					<HugeiconsIcon
-						icon={Link01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Link01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: async () => {
 					try {
@@ -800,25 +615,13 @@ export function useAppCommands({
 			},
 			{
 				id: "toggle-sidebar",
-				icon: (
-					<HugeiconsIcon
-						icon={SidebarLeftIcon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={SidebarLeftIcon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, shift: true, key: "b" },
 				action: () => setSidebarCollapsed(!sidebarCollapsed),
 			},
 			{
 				id: "buy-glyph-license",
-				icon: (
-					<HugeiconsIcon
-						icon={SquareLock02Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={SquareLock02Icon} size="var(--icon-lg)" />,
 				action: async () => {
 					try {
 						const status = await getLicenseStatus();
@@ -836,60 +639,30 @@ export function useAppCommands({
 			},
 			{
 				id: "open-settings",
-				icon: (
-					<HugeiconsIcon
-						icon={Settings01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Settings01Icon} size="var(--icon-lg)" />,
 				shortcut: { meta: true, key: "," },
 				action: () => openSettings(),
 			},
 			{
 				id: "open-space-settings",
-				icon: (
-					<HugeiconsIcon
-						icon={Settings01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Settings01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: handleOpenSpaceSettings,
 			},
 			{
 				id: "open-license-settings",
-				icon: (
-					<HugeiconsIcon
-						icon={SquareLock02Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={SquareLock02Icon} size="var(--icon-lg)" />,
 				action: () => openSettings("general"),
 			},
 			{
 				id: "open-git-sync-settings",
-				icon: (
-					<HugeiconsIcon
-						icon={Settings01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Settings01Icon} size="var(--icon-lg)" />,
 				enabled: Boolean(spacePath),
 				action: gitSync.openGitSettings,
 			},
 			{
 				id: "open-ai-settings",
-				icon: (
-					<HugeiconsIcon
-						icon={Settings01Icon}
-						size="var(--icon-lg)"
-						strokeWidth={1.5}
-					/>
-				),
+				icon: <HugeiconsIcon icon={Settings01Icon} size="var(--icon-lg)" />,
 				action: handleOpenAiSettings,
 			},
 		];

--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -169,7 +169,7 @@ export function SpaceConnectionsView() {
 							icon={LoaderCircle}
 							className="animate-spin"
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						Loading notes and links…
 					</div>
@@ -195,7 +195,7 @@ export function SpaceConnectionsView() {
 							icon={LoaderCircle}
 							className="animate-spin"
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						Arranging connections…
 					</div>
@@ -216,7 +216,7 @@ export function SpaceConnectionsView() {
 							icon={Refresh01Icon}
 							data-icon="inline-start"
 							size="var(--icon-md)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						Retry
 					</Button>

--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LoaderCircle, Refresh01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSpace } from "../../contexts";
 import type { SpaceConnections } from "../../lib/tauri";
@@ -169,7 +169,6 @@ export function SpaceConnectionsView() {
 							icon={LoaderCircle}
 							className="animate-spin"
 							size="var(--icon-sm)"
-							strokeWidth={1.5}
 						/>
 						Loading notes and links…
 					</div>
@@ -195,7 +194,6 @@ export function SpaceConnectionsView() {
 							icon={LoaderCircle}
 							className="animate-spin"
 							size="var(--icon-sm)"
-							strokeWidth={1.5}
 						/>
 						Arranging connections…
 					</div>
@@ -216,7 +214,6 @@ export function SpaceConnectionsView() {
 							icon={Refresh01Icon}
 							data-icon="inline-start"
 							size="var(--icon-md)"
-							strokeWidth={1.5}
 						/>
 						Retry
 					</Button>

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -668,7 +668,7 @@ export function DatabaseBoard({
 																		<HugeiconsIcon
 																			icon={Calendar03Icon}
 																			size="var(--icon-xs)"
-																			strokeWidth={1}
+																			strokeWidth={1.5}
 																			aria-hidden="true"
 																		/>
 																		{compactUpdatedLabel}
@@ -742,7 +742,7 @@ export function DatabaseBoard({
 																		iconName={iconNameForTag(tag)}
 																		className="databaseTagPillIcon"
 																		size="var(--icon-xs)"
-																		strokeWidth={1.2}
+																		strokeWidth={1.5}
 																	/>
 																	{formatDatabaseTagLabel(tag)}
 																</span>
@@ -780,7 +780,7 @@ export function DatabaseBoard({
 												className="databaseBoardAddCardIcon"
 												aria-hidden="true"
 											>
-												<Plus size="var(--icon-sm)" strokeWidth={1.8} />
+												<Plus size="var(--icon-sm)" strokeWidth={1.5} />
 											</span>
 											<span className="databaseBoardAddCardLabel">New</span>
 										</button>

--- a/src/components/database/DatabaseBoard.tsx
+++ b/src/components/database/DatabaseBoard.tsx
@@ -1,6 +1,6 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { DragDropProvider, type DragEndEvent } from "@dnd-kit/react";
 import { Calendar03Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m, useReducedMotion } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useDateDisplayFormat, useFileTreeContext } from "../../contexts";
@@ -668,7 +668,6 @@ export function DatabaseBoard({
 																		<HugeiconsIcon
 																			icon={Calendar03Icon}
 																			size="var(--icon-xs)"
-																			strokeWidth={1.5}
 																			aria-hidden="true"
 																		/>
 																		{compactUpdatedLabel}
@@ -742,7 +741,6 @@ export function DatabaseBoard({
 																		iconName={iconNameForTag(tag)}
 																		className="databaseTagPillIcon"
 																		size="var(--icon-xs)"
-																		strokeWidth={1.5}
 																	/>
 																	{formatDatabaseTagLabel(tag)}
 																</span>
@@ -780,7 +778,7 @@ export function DatabaseBoard({
 												className="databaseBoardAddCardIcon"
 												aria-hidden="true"
 											>
-												<Plus size="var(--icon-sm)" strokeWidth={1.5} />
+												<Plus size="var(--icon-sm)" />
 											</span>
 											<span className="databaseBoardAddCardLabel">New</span>
 										</button>

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -167,7 +167,7 @@ export function DatabaseBoardLaneView({
 					}
 					className="databaseBoardLaneTitleIcon"
 					size="var(--icon-sm)"
-					strokeWidth={1.2}
+					strokeWidth={1.5}
 					aria-hidden="true"
 				/>
 			) : (

--- a/src/components/database/DatabaseBoardViews.tsx
+++ b/src/components/database/DatabaseBoardViews.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import {
 	KeyboardSensor,
@@ -6,7 +7,6 @@ import {
 	useDroppable,
 } from "@dnd-kit/react";
 import { Tag01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import {
 	type MouseEvent,
@@ -167,7 +167,6 @@ export function DatabaseBoardLaneView({
 					}
 					className="databaseBoardLaneTitleIcon"
 					size="var(--icon-sm)"
-					strokeWidth={1.5}
 					aria-hidden="true"
 				/>
 			) : (

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -91,7 +91,6 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 					iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 					className="databaseTagPillIcon"
 					size="var(--icon-xs)"
-					strokeWidth={1.5}
 				/>
 			) : null}
 			{item.label}
@@ -199,7 +198,6 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 								iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 								className="databaseTagPillIcon"
 								size="var(--icon-xs)"
-								strokeWidth={1.5}
 							/>
 						) : null}
 						{item.label}
@@ -585,7 +583,6 @@ function DatabaseCellEditor({
 								iconName={iconNameForTag(value)}
 								className="databaseTagPillIcon"
 								size="var(--icon-xs)"
-								strokeWidth={1.5}
 							/>
 							<span>{formatDatabaseTagLabel(value)}</span>
 							<X size="var(--icon-xs)" />

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -91,7 +91,7 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 					iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 					className="databaseTagPillIcon"
 					size="var(--icon-xs)"
-					strokeWidth={1.2}
+					strokeWidth={1.5}
 				/>
 			) : null}
 			{item.label}
@@ -199,7 +199,7 @@ function ResponsivePillList({ items }: { items: DatabaseDisplayPill[] }) {
 								iconName={item.iconName ?? DEFAULT_TAG_ICON_NAME}
 								className="databaseTagPillIcon"
 								size="var(--icon-xs)"
-								strokeWidth={1.2}
+								strokeWidth={1.5}
 							/>
 						) : null}
 						{item.label}
@@ -585,7 +585,7 @@ function DatabaseCellEditor({
 								iconName={iconNameForTag(value)}
 								className="databaseTagPillIcon"
 								size="var(--icon-xs)"
-								strokeWidth={1.2}
+								strokeWidth={1.5}
 							/>
 							<span>{formatDatabaseTagLabel(value)}</span>
 							<X size="var(--icon-xs)" />

--- a/src/components/database/DatabaseColumnIcon.tsx
+++ b/src/components/database/DatabaseColumnIcon.tsx
@@ -322,7 +322,7 @@ export function DatabaseColumnIcon({
 		<HugeiconsIcon
 			icon={iconDefinition(resolvedIconName)}
 			size={size}
-			strokeWidth={strokeWidth ?? 0.9}
+			strokeWidth={strokeWidth ?? 1.5}
 			className={className}
 		/>
 	);

--- a/src/components/database/DatabaseColumnIcon.tsx
+++ b/src/components/database/DatabaseColumnIcon.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	Activity01Icon,
 	AiIdeaIcon,
@@ -140,7 +141,6 @@ import {
 	WorkflowCircle01Icon,
 	ZapIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 import {
 	getDatabaseColumnIconOption,
@@ -322,7 +322,7 @@ export function DatabaseColumnIcon({
 		<HugeiconsIcon
 			icon={iconDefinition(resolvedIconName)}
 			size={size}
-			strokeWidth={strokeWidth ?? 1.5}
+			strokeWidth={strokeWidth}
 			className={className}
 		/>
 	);

--- a/src/components/database/DatabaseFolderPicker.tsx
+++ b/src/components/database/DatabaseFolderPicker.tsx
@@ -97,7 +97,7 @@ export function DatabaseFolderPicker({
 				<HugeiconsIcon
 					icon={Folder03Icon}
 					size="var(--icon-md)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			</span>
 			<span className="databasePickerTriggerText">

--- a/src/components/database/DatabaseFolderPicker.tsx
+++ b/src/components/database/DatabaseFolderPicker.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Folder03Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { join } from "@tauri-apps/api/path";
 import { useState } from "react";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -94,11 +94,7 @@ export function DatabaseFolderPicker({
 			}}
 		>
 			<span className="databasePickerTriggerIcon">
-				<HugeiconsIcon
-					icon={Folder03Icon}
-					size="var(--icon-md)"
-					strokeWidth={1.5}
-				/>
+				<HugeiconsIcon icon={Folder03Icon} size="var(--icon-md)" />
 			</span>
 			<span className="databasePickerTriggerText">
 				<span className="databasePickerTriggerLabel">{selectedLabel}</span>

--- a/src/components/database/DatabaseTableViews.tsx
+++ b/src/components/database/DatabaseTableViews.tsx
@@ -79,7 +79,7 @@ export function DatabaseTableGroupHeader({
 						title={`Add note to ${label}`}
 						aria-label={`Add note to ${label}`}
 					>
-						<Plus size="var(--icon-sm)" strokeWidth={1.5} aria-hidden="true" />
+						<Plus size="var(--icon-sm)" aria-hidden="true" />
 					</button>
 				) : null}
 			</td>

--- a/src/components/database/DatabaseTableViews.tsx
+++ b/src/components/database/DatabaseTableViews.tsx
@@ -79,7 +79,7 @@ export function DatabaseTableGroupHeader({
 						title={`Add note to ${label}`}
 						aria-label={`Add note to ${label}`}
 					>
-						<Plus size="var(--icon-sm)" strokeWidth={1.6} aria-hidden="true" />
+						<Plus size="var(--icon-sm)" strokeWidth={1.5} aria-hidden="true" />
 					</button>
 				) : null}
 			</td>

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -502,7 +502,7 @@ export function DatabaseViewOptionsPopover({
 					<HugeiconsIcon
 						icon={SlidersVerticalIcon}
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				</Button>
 			</PopoverTrigger>
@@ -587,7 +587,7 @@ export function DatabaseViewOptionsPopover({
 								<HugeiconsIcon
 									icon={GridViewIcon}
 									size="var(--icon-lg)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 								/>
 							}
 							label="Columns"
@@ -601,7 +601,7 @@ export function DatabaseViewOptionsPopover({
 							<HugeiconsIcon
 								icon={FilterMailIcon}
 								size="var(--icon-lg)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 						}
 						label="Filter by"
@@ -618,7 +618,7 @@ export function DatabaseViewOptionsPopover({
 							<HugeiconsIcon
 								icon={TextFontIcon}
 								size="var(--icon-lg)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 						}
 						label="Sort by"
@@ -632,7 +632,7 @@ export function DatabaseViewOptionsPopover({
 								<HugeiconsIcon
 									icon={Cards01Icon}
 									size="var(--icon-lg)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 								/>
 							}
 							label="Card fields"

--- a/src/components/database/DatabaseViewOptionsPopover.tsx
+++ b/src/components/database/DatabaseViewOptionsPopover.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { cn } from "@/lib/utils";
 import {
 	Cards01Icon,
@@ -6,7 +7,6 @@ import {
 	SlidersVerticalIcon,
 	TextFontIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import {
 	type ReactNode,
 	useCallback,
@@ -499,11 +499,7 @@ export function DatabaseViewOptionsPopover({
 					title="View settings"
 					aria-label="View settings"
 				>
-					<HugeiconsIcon
-						icon={SlidersVerticalIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={SlidersVerticalIcon} size="var(--icon-md)" />
 				</Button>
 			</PopoverTrigger>
 			<PopoverContent
@@ -583,13 +579,7 @@ export function DatabaseViewOptionsPopover({
 					/>
 					{isTableView ? (
 						<OptionMenuRow
-							icon={
-								<HugeiconsIcon
-									icon={GridViewIcon}
-									size="var(--icon-lg)"
-									strokeWidth={1.5}
-								/>
-							}
+							icon={<HugeiconsIcon icon={GridViewIcon} size="var(--icon-lg)" />}
 							label="Columns"
 							value={`${visibleCount} selected`}
 							active={activePanel === "columns"}
@@ -597,13 +587,7 @@ export function DatabaseViewOptionsPopover({
 						/>
 					) : null}
 					<OptionMenuRow
-						icon={
-							<HugeiconsIcon
-								icon={FilterMailIcon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
-						}
+						icon={<HugeiconsIcon icon={FilterMailIcon} size="var(--icon-lg)" />}
 						label="Filter by"
 						value={
 							config.filters.length > 0
@@ -614,13 +598,7 @@ export function DatabaseViewOptionsPopover({
 						onClick={() => togglePanel("filters")}
 					/>
 					<OptionMenuRow
-						icon={
-							<HugeiconsIcon
-								icon={TextFontIcon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
-						}
+						icon={<HugeiconsIcon icon={TextFontIcon} size="var(--icon-lg)" />}
 						label="Sort by"
 						value={sortLabel(activeSort ?? undefined, resolvedColumns)}
 						active={activePanel === "sort"}
@@ -628,13 +606,7 @@ export function DatabaseViewOptionsPopover({
 					/>
 					{config.view.layout === "board" ? (
 						<OptionMenuRow
-							icon={
-								<HugeiconsIcon
-									icon={Cards01Icon}
-									size="var(--icon-lg)"
-									strokeWidth={1.5}
-								/>
-							}
+							icon={<HugeiconsIcon icon={Cards01Icon} size="var(--icon-lg)" />}
 							label="Card fields"
 							value={cardFieldsLabel(config.view.board_card_fields)}
 							active={activePanel === "card_fields"}

--- a/src/components/databases/ActionMenuTrigger.tsx
+++ b/src/components/databases/ActionMenuTrigger.tsx
@@ -34,7 +34,7 @@ function renderMenuIcon(iconKey: ActionMenuIconKey): ReactNode {
 				<HugeiconsIcon
 					icon={LibraryIcon}
 					size="var(--icon-sm)"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 				/>
 			);
 	}

--- a/src/components/databases/ActionMenuTrigger.tsx
+++ b/src/components/databases/ActionMenuTrigger.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LibraryIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type MouseEvent, type ReactNode, useCallback } from "react";
 import {
 	type ActionMenuIconKey,
@@ -30,13 +30,7 @@ function renderMenuIcon(iconKey: ActionMenuIconKey): ReactNode {
 		case "plus":
 			return <Plus size="var(--icon-sm)" />;
 		case "library":
-			return (
-				<HugeiconsIcon
-					icon={LibraryIcon}
-					size="var(--icon-sm)"
-					strokeWidth={1.5}
-				/>
-			);
+			return <HugeiconsIcon icon={LibraryIcon} size="var(--icon-sm)" />;
 	}
 }
 

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -144,7 +144,7 @@ export function CollectionTopBar({
 					<HugeiconsIcon
 						icon={LibraryIcon}
 						size="var(--icon-sm)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 					<span className="databasesCollectionSwitcherLabel">
 						{collectionMenuLabel}
@@ -169,7 +169,7 @@ export function CollectionTopBar({
 						<HugeiconsIcon
 							icon={StarIcon}
 							size="var(--icon-md)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</Button>
 					<Button
@@ -193,7 +193,7 @@ export function CollectionTopBar({
 						<HugeiconsIcon
 							icon={CursorAddSelection02Icon}
 							size="var(--icon-lg)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						New Note
 					</button>

--- a/src/components/databases/CollectionTopBar.tsx
+++ b/src/components/databases/CollectionTopBar.tsx
@@ -1,9 +1,9 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	CursorAddSelection02Icon,
 	LibraryIcon,
 	StarIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { UseDatabasesPaneReturn } from "../../hooks/database/useDatabasesPane";
@@ -141,11 +141,7 @@ export function CollectionTopBar({
 					contentClassName="databasesDropdownContent databasesCollectionMenu"
 					itemClassName="databasesDropdownItem databasesCollectionMenuItem"
 				>
-					<HugeiconsIcon
-						icon={LibraryIcon}
-						size="var(--icon-sm)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={LibraryIcon} size="var(--icon-sm)" />
 					<span className="databasesCollectionSwitcherLabel">
 						{collectionMenuLabel}
 					</span>
@@ -166,11 +162,7 @@ export function CollectionTopBar({
 						aria-label={t(isPinned ? "collections.unpin" : "collections.pin")}
 						aria-pressed={isPinned}
 					>
-						<HugeiconsIcon
-							icon={StarIcon}
-							size="var(--icon-md)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
 					</Button>
 					<Button
 						type="button"
@@ -193,7 +185,6 @@ export function CollectionTopBar({
 						<HugeiconsIcon
 							icon={CursorAddSelection02Icon}
 							size="var(--icon-lg)"
-							strokeWidth={1.5}
 						/>
 						New Note
 					</button>

--- a/src/components/databases/CreateCollectionDialog.tsx
+++ b/src/components/databases/CreateCollectionDialog.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LibraryIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useState } from "react";
 import {
 	folderNameFromPath,
@@ -125,11 +125,7 @@ export function CreateCollectionDialog({
 			>
 				<div className="createCollectionHero">
 					<div className="createCollectionIcon" aria-hidden="true">
-						<HugeiconsIcon
-							icon={LibraryIcon}
-							size="var(--icon-xl)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={LibraryIcon} size="var(--icon-xl)" />
 					</div>
 					<DialogHeader className="createCollectionHeader text-center sm:text-center items-center">
 						<p className="createCollectionEyebrow">Collections</p>

--- a/src/components/databases/CreateCollectionDialog.tsx
+++ b/src/components/databases/CreateCollectionDialog.tsx
@@ -128,7 +128,7 @@ export function CreateCollectionDialog({
 						<HugeiconsIcon
 							icon={LibraryIcon}
 							size="var(--icon-xl)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</div>
 					<DialogHeader className="createCollectionHeader text-center sm:text-center items-center">

--- a/src/components/databases/DatabaseViewTabs.tsx
+++ b/src/components/databases/DatabaseViewTabs.tsx
@@ -178,7 +178,7 @@ export function DatabaseViewTabs({
 						icon={MoreVerticalIcon}
 						className="databasesViewTabMenuIcon"
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 						color="currentColor"
 						aria-hidden
 					/>

--- a/src/components/databases/DatabaseViewTabs.tsx
+++ b/src/components/databases/DatabaseViewTabs.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { MoreVerticalIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import { useCallback, useRef } from "react";
 import type { DatabaseView, SaveDatabase } from "../../hooks/database/types";
@@ -178,7 +178,6 @@ export function DatabaseViewTabs({
 						icon={MoreVerticalIcon}
 						className="databasesViewTabMenuIcon"
 						size="var(--icon-md)"
-						strokeWidth={1.5}
 						color="currentColor"
 						aria-hidden
 					/>

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LibraryIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useReducedMotion } from "motion/react";
 import { useDatabasesPane } from "../../hooks/database/useDatabasesPane";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
@@ -179,11 +179,7 @@ function DatabasesPaneContent({
 					{ui.error ? (
 						<div className="databaseNotice databaseNoticeError">{ui.error}</div>
 					) : null}
-					<HugeiconsIcon
-						icon={LibraryIcon}
-						size="var(--icon-3xl)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={LibraryIcon} size="var(--icon-3xl)" />
 					<div className="databasesEmptyTitle">
 						{selection.summaries.length === 0
 							? "Create your first collection"

--- a/src/components/databases/DatabasesPane.tsx
+++ b/src/components/databases/DatabasesPane.tsx
@@ -182,7 +182,7 @@ function DatabasesPaneContent({
 					<HugeiconsIcon
 						icon={LibraryIcon}
 						size="var(--icon-3xl)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 					<div className="databasesEmptyTitle">
 						{selection.summaries.length === 0

--- a/src/components/editor/EditorRibbon.tsx
+++ b/src/components/editor/EditorRibbon.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { NoteAddIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { m } from "motion/react";
 import { memo } from "react";
@@ -128,11 +128,7 @@ export const EditorRibbon = memo(function EditorRibbon({
 							whileTap={canEdit ? { scale: 0.97 } : undefined}
 							transition={springPresets.snappy}
 						>
-							<HugeiconsIcon
-								icon={NoteAddIcon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={NoteAddIcon} size="var(--icon-lg)" />
 						</m.button>
 					) : null}
 					<span className="ribbonDivider" />

--- a/src/components/editor/EditorRibbon.tsx
+++ b/src/components/editor/EditorRibbon.tsx
@@ -131,7 +131,7 @@ export const EditorRibbon = memo(function EditorRibbon({
 							<HugeiconsIcon
 								icon={NoteAddIcon}
 								size="var(--icon-lg)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 						</m.button>
 					) : null}

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -62,7 +62,7 @@ export function EditorViewModeSwitch({
 							<HugeiconsIcon
 								icon={item.icon}
 								size="var(--icon-md)"
-								strokeWidth={isActive ? 1.5 : 1}
+								strokeWidth={1.5}
 							/>
 						</button>
 						<span

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -1,9 +1,9 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	CodeIcon,
 	EyeIcon,
 	PencilEdit02Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useTranslation } from "react-i18next";
 import type { EditorViewMode } from "../../lib/editorMode";
 
@@ -59,11 +59,7 @@ export function EditorViewModeSwitch({
 							data-active={isActive || undefined}
 							onClick={() => onModeChange(item.id)}
 						>
-							<HugeiconsIcon
-								icon={item.icon}
-								size="var(--icon-md)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={item.icon} size="var(--icon-md)" />
 						</button>
 						<span
 							className="markdownEditorModeBtnHint"

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -133,7 +133,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 							<HugeiconsIcon
 								icon={PlayIcon}
 								size="var(--icon-sm)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 							/>
 						</button>
 					) : null}
@@ -153,7 +153,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						<HugeiconsIcon
 							icon={codeBlock.copied ? Tick02Icon : Copy01Icon}
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</button>
 				</div>

--- a/src/components/editor/NoteEditorSurface.tsx
+++ b/src/components/editor/NoteEditorSurface.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Copy01Icon, PlayIcon, Tick02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { EditorContent } from "@tiptap/react";
 import { memo } from "react";
@@ -130,11 +130,7 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 							title={t("codeBlock.runPreview")}
 							aria-label={t("codeBlock.runPreview")}
 						>
-							<HugeiconsIcon
-								icon={PlayIcon}
-								size="var(--icon-sm)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={PlayIcon} size="var(--icon-sm)" />
 						</button>
 					) : null}
 					<button
@@ -153,7 +149,6 @@ export const NoteEditorSurface = memo(function NoteEditorSurface({
 						<HugeiconsIcon
 							icon={codeBlock.copied ? Tick02Icon : Copy01Icon}
 							size="var(--icon-sm)"
-							strokeWidth={1.5}
 						/>
 					</button>
 				</div>

--- a/src/components/editor/RibbonColorPopover.tsx
+++ b/src/components/editor/RibbonColorPopover.tsx
@@ -46,7 +46,7 @@ export function RibbonColorPopover({
 					<HugeiconsIcon
 						icon={PaintBucketIcon}
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				</m.button>
 			</DropdownMenuTrigger>

--- a/src/components/editor/RibbonColorPopover.tsx
+++ b/src/components/editor/RibbonColorPopover.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { PaintBucketIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { m } from "motion/react";
 import { useTranslation } from "react-i18next";
@@ -43,11 +43,7 @@ export function RibbonColorPopover({
 					whileTap={canEdit ? { scale: 0.97 } : undefined}
 					transition={springPresets.snappy}
 				>
-					<HugeiconsIcon
-						icon={PaintBucketIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={PaintBucketIcon} size="var(--icon-md)" />
 				</m.button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent

--- a/src/components/editor/RibbonHighlightPopover.tsx
+++ b/src/components/editor/RibbonHighlightPopover.tsx
@@ -46,7 +46,7 @@ export function RibbonHighlightPopover({
 					<HugeiconsIcon
 						icon={HighlighterIcon}
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				</m.button>
 			</DropdownMenuTrigger>

--- a/src/components/editor/RibbonHighlightPopover.tsx
+++ b/src/components/editor/RibbonHighlightPopover.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { HighlighterIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import { m } from "motion/react";
 import { useTranslation } from "react-i18next";
@@ -43,11 +43,7 @@ export function RibbonHighlightPopover({
 					whileTap={canEdit ? { scale: 0.97 } : undefined}
 					transition={springPresets.snappy}
 				>
-					<HugeiconsIcon
-						icon={HighlighterIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={HighlighterIcon} size="var(--icon-md)" />
 				</m.button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LocationAdd01Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { type MouseEvent, memo, useCallback, useMemo } from "react";
 import {
 	type NativeContextMenuItem,
@@ -117,11 +117,7 @@ const TableAxisControl = memo(function TableAxisControl({
 			onMouseDown={onControlMouseDown}
 			onClick={nativeMenusEnabled ? handleNativeMenuClick : undefined}
 		>
-			<HugeiconsIcon
-				icon={LocationAdd01Icon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={LocationAdd01Icon} size="var(--icon-md)" />
 		</button>
 	);
 

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -120,7 +120,7 @@ const TableAxisControl = memo(function TableAxisControl({
 			<HugeiconsIcon
 				icon={LocationAdd01Icon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		</button>
 	);

--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { Extension } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
@@ -24,7 +24,6 @@ function iconMarkup(copied: boolean): string {
 		createElement(HugeiconsIcon, {
 			icon: copied ? Tick02Icon : Copy01Icon,
 			size: "var(--icon-sm)",
-			strokeWidth: 1.5,
 		}),
 	);
 }

--- a/src/components/editor/extensions/codeBlockCopyControls.ts
+++ b/src/components/editor/extensions/codeBlockCopyControls.ts
@@ -24,7 +24,7 @@ function iconMarkup(copied: boolean): string {
 		createElement(HugeiconsIcon, {
 			icon: copied ? Tick02Icon : Copy01Icon,
 			size: "var(--icon-sm)",
-			strokeWidth: 0.9,
+			strokeWidth: 1.5,
 		}),
 	);
 }

--- a/src/components/editor/noteProperties/PropertyKindBadge.tsx
+++ b/src/components/editor/noteProperties/PropertyKindBadge.tsx
@@ -44,7 +44,7 @@ export function PropertyKindBadge({
 						<HugeiconsIcon
 							icon={icon}
 							size="var(--icon-sm)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 					</Button>
 				</DropdownMenuTrigger>
@@ -67,7 +67,7 @@ export function PropertyKindBadge({
 									<HugeiconsIcon
 										icon={PROPERTY_KIND_ICONS[menuKind]}
 										size="var(--icon-sm)"
-										strokeWidth={0.9}
+										strokeWidth={1.5}
 									/>
 								</span>
 								<span className="notePropertyKindOptionLabel">
@@ -83,7 +83,7 @@ export function PropertyKindBadge({
 
 	return (
 		<div className="notePropertyKindBadge">
-			<HugeiconsIcon icon={icon} size="var(--icon-sm)" strokeWidth={0.9} />
+			<HugeiconsIcon icon={icon} size="var(--icon-sm)" strokeWidth={1.5} />
 		</div>
 	);
 }

--- a/src/components/editor/noteProperties/PropertyKindBadge.tsx
+++ b/src/components/editor/noteProperties/PropertyKindBadge.tsx
@@ -1,4 +1,4 @@
-import { HugeiconsIcon } from "@hugeicons/react";
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Button } from "../../ui/shadcn/button";
 import {
 	DropdownMenu,
@@ -41,11 +41,7 @@ export function PropertyKindBadge({
 						className="notePropertyKindBadge notePropertyKindTrigger"
 						title={`Property type: ${label}`}
 					>
-						<HugeiconsIcon
-							icon={icon}
-							size="var(--icon-sm)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={icon} size="var(--icon-sm)" />
 					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
@@ -67,7 +63,6 @@ export function PropertyKindBadge({
 									<HugeiconsIcon
 										icon={PROPERTY_KIND_ICONS[menuKind]}
 										size="var(--icon-sm)"
-										strokeWidth={1.5}
 									/>
 								</span>
 								<span className="notePropertyKindOptionLabel">
@@ -83,7 +78,7 @@ export function PropertyKindBadge({
 
 	return (
 		<div className="notePropertyKindBadge">
-			<HugeiconsIcon icon={icon} size="var(--icon-sm)" strokeWidth={1.5} />
+			<HugeiconsIcon icon={icon} size="var(--icon-sm)" />
 		</div>
 	);
 }

--- a/src/components/editor/rollover/DailyNoteRollover.tsx
+++ b/src/components/editor/rollover/DailyNoteRollover.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Audit02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/src/components/editor/rollover/RolloverTaskActions.tsx
+++ b/src/components/editor/rollover/RolloverTaskActions.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { NextWeekIcon, Sun02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { useEffect, useState } from "react";

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { useDraggable } from "@dnd-kit/react";
 import {
 	ArrowRight02Icon,
 	Folder01Icon,
 	Folder03Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import type {
 	CSSProperties,
@@ -299,7 +299,6 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 								<HugeiconsIcon
 									icon={isExpanded ? Folder03Icon : Folder01Icon}
 									size="var(--icon-sm)"
-									strokeWidth={1.5}
 									className="fileTreeChevron fileTreeFolderIcon"
 								/>
 							)}
@@ -351,7 +350,6 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 										<HugeiconsIcon
 											icon={ArrowRight02Icon}
 											size="var(--icon-sm)"
-											strokeWidth={1.5}
 										/>
 									</span>
 								</div>

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -299,7 +299,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 								<HugeiconsIcon
 									icon={isExpanded ? Folder03Icon : Folder01Icon}
 									size="var(--icon-sm)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 									className="fileTreeChevron fileTreeFolderIcon"
 								/>
 							)}
@@ -351,7 +351,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 										<HugeiconsIcon
 											icon={ArrowRight02Icon}
 											size="var(--icon-sm)"
-											strokeWidth={0.9}
+											strokeWidth={1.5}
 										/>
 									</span>
 								</div>

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -403,7 +403,7 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 							<HugeiconsIcon
 								icon={StarIcon}
 								size="var(--icon-sm)"
-								strokeWidth={0.9}
+								strokeWidth={1.5}
 								className="fileTreePinIcon"
 							/>
 						) : null}

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -1,6 +1,6 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { useDraggable } from "@dnd-kit/react";
 import { StarIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { m } from "motion/react";
 import type {
 	CSSProperties,
@@ -403,7 +403,6 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 							<HugeiconsIcon
 								icon={StarIcon}
 								size="var(--icon-sm)"
-								strokeWidth={1.5}
 								className="fileTreePinIcon"
 							/>
 						) : null}

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -556,7 +556,7 @@ export const FolioNoteListItem = memo(
 									iconName="link"
 									className="folioNoteUrlIcon"
 									size="var(--icon-xs)"
-									strokeWidth={1.2}
+									strokeWidth={1.5}
 								/>
 								{firstUrlLabel}
 							</a>
@@ -572,7 +572,7 @@ export const FolioNoteListItem = memo(
 										iconName={iconNameForTag(tag)}
 										className="folioNoteTagIcon"
 										size="var(--icon-xs)"
-										strokeWidth={1.2}
+										strokeWidth={1.5}
 									/>
 									{formatDatabaseTagLabel(tag)}
 								</span>

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -556,7 +556,6 @@ export const FolioNoteListItem = memo(
 									iconName="link"
 									className="folioNoteUrlIcon"
 									size="var(--icon-xs)"
-									strokeWidth={1.5}
 								/>
 								{firstUrlLabel}
 							</a>
@@ -572,7 +571,6 @@ export const FolioNoteListItem = memo(
 										iconName={iconNameForTag(tag)}
 										className="folioNoteTagIcon"
 										size="var(--icon-xs)"
-										strokeWidth={1.5}
 									/>
 									{formatDatabaseTagLabel(tag)}
 								</span>

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	ArrangeByLettersAZIcon,
 	Calendar03Icon,
 	Clock01Icon,
 	SearchIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { memo } from "react";
 import type { FolioNotesSortMode } from "./folioScopes";
 
@@ -32,11 +32,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 		<header className="folioNotesHeader">
 			<div className="folioNotesControls">
 				<label className="folioNotesSearch">
-					<HugeiconsIcon
-						icon={SearchIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={SearchIcon} size="var(--icon-md)" />
 					<input
 						type="text"
 						inputMode="search"
@@ -47,11 +43,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 					/>
 				</label>
 				<label className="folioNotesSort">
-					<HugeiconsIcon
-						icon={sortIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={sortIcon} size="var(--icon-md)" />
 					<select
 						className="folioNotesSortSelect"
 						value={sortMode}

--- a/src/components/folio/FolioScopeHeader.tsx
+++ b/src/components/folio/FolioScopeHeader.tsx
@@ -35,7 +35,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 					<HugeiconsIcon
 						icon={SearchIcon}
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 					<input
 						type="text"
@@ -50,7 +50,7 @@ export const FolioScopeHeader = memo(function FolioScopeHeader({
 					<HugeiconsIcon
 						icon={sortIcon}
 						size="var(--icon-md)"
-						strokeWidth={1}
+						strokeWidth={1.5}
 					/>
 					<select
 						className="folioNotesSortSelect"

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -1,8 +1,8 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	AiBrain04Icon,
 	LayoutAlignRightIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	useAISidebarContext,
@@ -568,11 +568,7 @@ export function MarkdownEditorPane({
 							}
 							aria-pressed={aiEnabled ? aiPanelOpen : undefined}
 						>
-							<HugeiconsIcon
-								icon={AiBrain04Icon}
-								size="var(--icon-md)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
 						</button>
 						<button
 							type="button"
@@ -586,7 +582,6 @@ export function MarkdownEditorPane({
 							<HugeiconsIcon
 								icon={LayoutAlignRightIcon}
 								size="var(--icon-md)"
-								strokeWidth={1.5}
 							/>
 						</button>
 					</div>

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -571,7 +571,7 @@ export function MarkdownEditorPane({
 							<HugeiconsIcon
 								icon={AiBrain04Icon}
 								size="var(--icon-md)"
-								strokeWidth={isAiPanelActive ? 1.5 : 1}
+								strokeWidth={1.5}
 							/>
 						</button>
 						<button
@@ -586,7 +586,7 @@ export function MarkdownEditorPane({
 							<HugeiconsIcon
 								icon={LayoutAlignRightIcon}
 								size="var(--icon-md)"
-								strokeWidth={infoPanelOpen ? 1.5 : 1}
+								strokeWidth={1.5}
 							/>
 						</button>
 					</div>

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -321,7 +321,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 						<HugeiconsIcon
 							icon={BadgeInfoIcon}
 							size="var(--icon-sm)"
-							strokeWidth={1}
+							strokeWidth={1.5}
 						/>
 						Info
 					</button>
@@ -337,7 +337,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 							<HugeiconsIcon
 								icon={GitBranchIcon}
 								size="var(--icon-sm)"
-								strokeWidth={1}
+								strokeWidth={1.5}
 							/>
 							Version history
 						</button>
@@ -546,7 +546,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
 									size="var(--icon-sm)"
-									strokeWidth={1}
+									strokeWidth={1.5}
 								/>
 								Info
 							</h3>

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	BadgeInfoIcon,
 	GitBranchIcon,
 	InformationCircleIcon,
 	Link04Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { memo, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
@@ -318,11 +318,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 						data-active={activeTab === "info" ? "true" : undefined}
 						onClick={() => setActiveTab("info")}
 					>
-						<HugeiconsIcon
-							icon={BadgeInfoIcon}
-							size="var(--icon-sm)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={BadgeInfoIcon} size="var(--icon-sm)" />
 						Info
 					</button>
 					{hasGitHistoryTab ? (
@@ -334,11 +330,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 							data-active={activeTab === "history" ? "true" : undefined}
 							onClick={() => setActiveTab("history")}
 						>
-							<HugeiconsIcon
-								icon={GitBranchIcon}
-								size="var(--icon-sm)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={GitBranchIcon} size="var(--icon-sm)" />
 							Version history
 						</button>
 					) : null}
@@ -546,7 +538,6 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
 									size="var(--icon-sm)"
-									strokeWidth={1.5}
 								/>
 								Info
 							</h3>

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -373,7 +373,7 @@ export function QuickNoteWindow() {
 							<HugeiconsIcon
 								icon={CheckmarkCircle02Icon}
 								size="var(--icon-lg)"
-								strokeWidth={1.6}
+								strokeWidth={1.5}
 								aria-hidden="true"
 							/>
 							<span className="quickNoteSaveLabel">

--- a/src/components/quick-note/QuickNoteWindow.tsx
+++ b/src/components/quick-note/QuickNoteWindow.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { emitTo } from "@tauri-apps/api/event";
 import type { Editor } from "@tiptap/core";
@@ -373,7 +373,6 @@ export function QuickNoteWindow() {
 							<HugeiconsIcon
 								icon={CheckmarkCircle02Icon}
 								size="var(--icon-lg)"
-								strokeWidth={1.5}
 								aria-hidden="true"
 							/>
 							<span className="quickNoteSaveLabel">

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -136,7 +136,7 @@ export function AboutSettingsPane() {
 							<HugeiconsIcon
 								icon={GlobeIcon}
 								size="var(--icon-lg)"
-								strokeWidth={1.6}
+								strokeWidth={1.5}
 							/>
 							Website
 						</Button>
@@ -150,7 +150,7 @@ export function AboutSettingsPane() {
 							<HugeiconsIcon
 								icon={DiscordIcon}
 								size="var(--icon-lg)"
-								strokeWidth={1.6}
+								strokeWidth={1.5}
 							/>
 							Discord
 						</Button>
@@ -164,7 +164,7 @@ export function AboutSettingsPane() {
 							<HugeiconsIcon
 								icon={File01Icon}
 								size="var(--icon-lg)"
-								strokeWidth={1.6}
+								strokeWidth={1.5}
 							/>
 							Terms
 						</Button>
@@ -178,7 +178,7 @@ export function AboutSettingsPane() {
 							<HugeiconsIcon
 								icon={Shield01Icon}
 								size="var(--icon-lg)"
-								strokeWidth={1.6}
+								strokeWidth={1.5}
 							/>
 							Privacy
 						</Button>
@@ -311,7 +311,7 @@ export function AboutSettingsPane() {
 								<HugeiconsIcon
 									icon={ListViewIcon}
 									size="var(--icon-md)"
-									strokeWidth={1.6}
+									strokeWidth={1.5}
 								/>
 								View Changelog
 							</Button>

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	DiscordIcon,
 	File01Icon,
@@ -5,7 +6,6 @@ import {
 	ListViewIcon,
 	Shield01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
@@ -133,11 +133,7 @@ export function AboutSettingsPane() {
 							className="aboutLinkButton"
 							onClick={() => void openUrl(GLYPH_LINKS.website)}
 						>
-							<HugeiconsIcon
-								icon={GlobeIcon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={GlobeIcon} size="var(--icon-lg)" />
 							Website
 						</Button>
 						<Button
@@ -147,11 +143,7 @@ export function AboutSettingsPane() {
 							className="aboutLinkButton"
 							onClick={() => void openUrl(GLYPH_LINKS.discord)}
 						>
-							<HugeiconsIcon
-								icon={DiscordIcon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={DiscordIcon} size="var(--icon-lg)" />
 							Discord
 						</Button>
 						<Button
@@ -161,11 +153,7 @@ export function AboutSettingsPane() {
 							className="aboutLinkButton"
 							onClick={() => void openUrl(GLYPH_LINKS.terms)}
 						>
-							<HugeiconsIcon
-								icon={File01Icon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={File01Icon} size="var(--icon-lg)" />
 							Terms
 						</Button>
 						<Button
@@ -175,11 +163,7 @@ export function AboutSettingsPane() {
 							className="aboutLinkButton"
 							onClick={() => void openUrl(GLYPH_LINKS.privacy)}
 						>
-							<HugeiconsIcon
-								icon={Shield01Icon}
-								size="var(--icon-lg)"
-								strokeWidth={1.5}
-							/>
+							<HugeiconsIcon icon={Shield01Icon} size="var(--icon-lg)" />
 							Privacy
 						</Button>
 					</div>
@@ -308,11 +292,7 @@ export function AboutSettingsPane() {
 								variant="outline"
 								onClick={() => void openUrl(GLYPH_LINKS.changelog)}
 							>
-								<HugeiconsIcon
-									icon={ListViewIcon}
-									size="var(--icon-md)"
-									strokeWidth={1.5}
-								/>
+								<HugeiconsIcon icon={ListViewIcon} size="var(--icon-md)" />
 								View Changelog
 							</Button>
 						</div>

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -181,7 +181,7 @@ export function GitSettingsPane() {
 								<HugeiconsIcon
 									icon={CheckmarkCircle02Icon}
 									size="var(--icon-md)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 								/>
 							}
 							value={status?.git_installed ? "Installed" : "Missing"}
@@ -198,7 +198,7 @@ export function GitSettingsPane() {
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
 									size="var(--icon-md)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 								/>
 							}
 							value={repoStateLabel}
@@ -215,7 +215,7 @@ export function GitSettingsPane() {
 								<HugeiconsIcon
 									icon={Link01Icon}
 									size="var(--icon-md)"
-									strokeWidth={0.9}
+									strokeWidth={1.5}
 								/>
 							}
 							value={
@@ -237,7 +237,7 @@ export function GitSettingsPane() {
 									<HugeiconsIcon
 										icon={GitBranchIcon}
 										size="var(--icon-md)"
-										strokeWidth={0.9}
+										strokeWidth={1.5}
 									/>
 								}
 								value={config.branch}

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	CheckmarkCircle02Icon,
 	GitBranchIcon,
 	InformationCircleIcon,
 	Link01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ATTACHMENT_LOCATION_OPTIONS } from "../../lib/attachmentStorage";
 import { extractErrorMessage } from "../../lib/errorUtils";
@@ -181,7 +181,6 @@ export function GitSettingsPane() {
 								<HugeiconsIcon
 									icon={CheckmarkCircle02Icon}
 									size="var(--icon-md)"
-									strokeWidth={1.5}
 								/>
 							}
 							value={status?.git_installed ? "Installed" : "Missing"}
@@ -198,7 +197,6 @@ export function GitSettingsPane() {
 								<HugeiconsIcon
 									icon={InformationCircleIcon}
 									size="var(--icon-md)"
-									strokeWidth={1.5}
 								/>
 							}
 							value={repoStateLabel}
@@ -211,13 +209,7 @@ export function GitSettingsPane() {
 						interactive={false}
 					>
 						<SettingsValueCard
-							icon={
-								<HugeiconsIcon
-									icon={Link01Icon}
-									size="var(--icon-md)"
-									strokeWidth={1.5}
-								/>
-							}
+							icon={<HugeiconsIcon icon={Link01Icon} size="var(--icon-md)" />}
 							value={
 								config?.remote_url ??
 								"Open a folder that already has Git initialized."
@@ -234,11 +226,7 @@ export function GitSettingsPane() {
 						>
 							<SettingsValueCard
 								icon={
-									<HugeiconsIcon
-										icon={GitBranchIcon}
-										size="var(--icon-md)"
-										strokeWidth={1.5}
-									/>
+									<HugeiconsIcon icon={GitBranchIcon} size="var(--icon-md)" />
 								}
 								value={config.branch}
 								mono

--- a/src/components/settings/SettingsScaffold.tsx
+++ b/src/components/settings/SettingsScaffold.tsx
@@ -159,7 +159,7 @@ export function SettingsInfoHint({
 					<HugeiconsIcon
 						icon={InformationCircleIcon}
 						size="var(--icon-md)"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				</button>
 			</PopoverTrigger>

--- a/src/components/settings/SettingsScaffold.tsx
+++ b/src/components/settings/SettingsScaffold.tsx
@@ -1,6 +1,6 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { cn } from "@/lib/utils";
 import { InformationCircleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { KeyboardEvent, MouseEvent, ReactNode } from "react";
 import { Toggle } from "../base/toggle/toggle";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
@@ -156,11 +156,7 @@ export function SettingsInfoHint({
 					className="settingsInfoButton"
 					aria-label={ariaLabel}
 				>
-					<HugeiconsIcon
-						icon={InformationCircleIcon}
-						size="var(--icon-md)"
-						strokeWidth={1.5}
-					/>
+					<HugeiconsIcon icon={InformationCircleIcon} size="var(--icon-md)" />
 				</button>
 			</PopoverTrigger>
 			<PopoverContent

--- a/src/components/settings/ShortcutsSettingsPane.tsx
+++ b/src/components/settings/ShortcutsSettingsPane.tsx
@@ -290,7 +290,7 @@ export function ShortcutsSettingsPane() {
 												<HugeiconsIcon
 													icon={ReloadIcon}
 													size="var(--icon-md)"
-													strokeWidth={0.9}
+													strokeWidth={1.5}
 												/>
 											</Button>
 										</div>

--- a/src/components/settings/ShortcutsSettingsPane.tsx
+++ b/src/components/settings/ShortcutsSettingsPane.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { ReloadIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useShortcutBindings } from "../../hooks/useShortcutBindings";
@@ -290,7 +290,6 @@ export function ShortcutsSettingsPane() {
 												<HugeiconsIcon
 													icon={ReloadIcon}
 													size="var(--icon-md)"
-													strokeWidth={1.5}
 												/>
 											</Button>
 										</div>

--- a/src/components/settings/ai/AiCodexAccountSection.tsx
+++ b/src/components/settings/ai/AiCodexAccountSection.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Calendar03Icon, Time04Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "../../ui/shadcn/button";
 import { SettingsRow, SettingsSection } from "../SettingsScaffold";
 import {
@@ -156,7 +156,6 @@ export function AiCodexAccountSection({
 													<HugeiconsIcon
 														icon={WindowIcon}
 														size="var(--icon-lg)"
-														strokeWidth={1.5}
 														aria-hidden="true"
 													/>
 													<span>{shortLabel}</span>

--- a/src/components/settings/ai/AiCodexAccountSection.tsx
+++ b/src/components/settings/ai/AiCodexAccountSection.tsx
@@ -156,7 +156,7 @@ export function AiCodexAccountSection({
 													<HugeiconsIcon
 														icon={WindowIcon}
 														size="var(--icon-lg)"
-														strokeWidth={1.6}
+														strokeWidth={1.5}
 														aria-hidden="true"
 													/>
 													<span>{shortLabel}</span>

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -39,14 +39,14 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 			<HugeiconsIcon
 				icon={Settings01Icon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 	},
 	{
 		id: "appearance",
 		renderIcon: () => (
-			<HugeiconsIcon icon={Sun03Icon} size="var(--icon-md)" strokeWidth={0.9} />
+			<HugeiconsIcon icon={Sun03Icon} size="var(--icon-md)" strokeWidth={1.5} />
 		),
 	},
 	{
@@ -55,7 +55,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 			<HugeiconsIcon
 				icon={CommandIcon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 	},
@@ -65,7 +65,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 			<HugeiconsIcon
 				icon={AiBrain04Icon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 	},
@@ -79,7 +79,7 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 			<HugeiconsIcon
 				icon={GitBranchIcon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 	},
@@ -89,14 +89,14 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 			<HugeiconsIcon
 				icon={Archive02Icon}
 				size="var(--icon-md)"
-				strokeWidth={0.9}
+				strokeWidth={1.5}
 			/>
 		),
 	},
 	{
 		id: "usage",
 		renderIcon: () => (
-			<HugeiconsIcon icon={ChartIcon} size="var(--icon-md)" strokeWidth={0.9} />
+			<HugeiconsIcon icon={ChartIcon} size="var(--icon-md)" strokeWidth={1.5} />
 		),
 	},
 ];

--- a/src/components/settings/settingsConfig.tsx
+++ b/src/components/settings/settingsConfig.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	AiBrain04Icon,
 	Archive02Icon,
@@ -7,7 +8,6 @@ import {
 	Settings01Icon,
 	Sun03Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ReactElement } from "react";
 import { FolderOpen } from "../Icons/NavigationIcons";
 
@@ -36,37 +36,23 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 	{
 		id: "general",
 		renderIcon: () => (
-			<HugeiconsIcon
-				icon={Settings01Icon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={Settings01Icon} size="var(--icon-md)" />
 		),
 	},
 	{
 		id: "appearance",
-		renderIcon: () => (
-			<HugeiconsIcon icon={Sun03Icon} size="var(--icon-md)" strokeWidth={1.5} />
-		),
+		renderIcon: () => <HugeiconsIcon icon={Sun03Icon} size="var(--icon-md)" />,
 	},
 	{
 		id: "shortcuts",
 		renderIcon: () => (
-			<HugeiconsIcon
-				icon={CommandIcon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={CommandIcon} size="var(--icon-md)" />
 		),
 	},
 	{
 		id: "ai",
 		renderIcon: () => (
-			<HugeiconsIcon
-				icon={AiBrain04Icon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
 		),
 	},
 	{
@@ -76,28 +62,18 @@ export const SETTINGS_TABS: SettingsTabMeta[] = [
 	{
 		id: "git",
 		renderIcon: () => (
-			<HugeiconsIcon
-				icon={GitBranchIcon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={GitBranchIcon} size="var(--icon-md)" />
 		),
 	},
 	{
 		id: "about",
 		renderIcon: () => (
-			<HugeiconsIcon
-				icon={Archive02Icon}
-				size="var(--icon-md)"
-				strokeWidth={1.5}
-			/>
+			<HugeiconsIcon icon={Archive02Icon} size="var(--icon-md)" />
 		),
 	},
 	{
 		id: "usage",
-		renderIcon: () => (
-			<HugeiconsIcon icon={ChartIcon} size="var(--icon-md)" strokeWidth={1.5} />
-		),
+		renderIcon: () => <HugeiconsIcon icon={ChartIcon} size="var(--icon-md)" />,
 	},
 ];
 

--- a/src/components/status/PriorityPropertyPill.tsx
+++ b/src/components/status/PriorityPropertyPill.tsx
@@ -50,7 +50,7 @@ export function PriorityPropertyPill({
 				icon={priorityPropertyIconForValue(value)}
 				className="propertyValueTextIcon"
 				size="var(--icon-sm)"
-				strokeWidth={1.3}
+				strokeWidth={1.5}
 			/>
 			<span>{label}</span>
 		</span>

--- a/src/components/status/PriorityPropertyPill.tsx
+++ b/src/components/status/PriorityPropertyPill.tsx
@@ -1,10 +1,10 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	FullSignalIcon,
 	LowSignalIcon,
 	MediumSignalIcon,
 	NoSignalIcon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 import {
 	priorityLabel,
@@ -50,7 +50,6 @@ export function PriorityPropertyPill({
 				icon={priorityPropertyIconForValue(value)}
 				className="propertyValueTextIcon"
 				size="var(--icon-sm)"
-				strokeWidth={1.5}
 			/>
 			<span>{label}</span>
 		</span>

--- a/src/components/status/StatusPropertyPill.tsx
+++ b/src/components/status/StatusPropertyPill.tsx
@@ -66,7 +66,7 @@ export function StatusPropertyPill({
 				icon={statusPropertyIconForValue(value)}
 				className="propertyValueTextIcon"
 				size="var(--icon-sm)"
-				strokeWidth={1.3}
+				strokeWidth={1.5}
 			/>
 			<span>{label}</span>
 		</span>

--- a/src/components/status/StatusPropertyPill.tsx
+++ b/src/components/status/StatusPropertyPill.tsx
@@ -1,3 +1,4 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import {
 	ActivityCircleIcon,
 	Archive02Icon,
@@ -10,7 +11,6 @@ import {
 	Queue02Icon,
 	Task01Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import type { ComponentProps } from "react";
 import {
 	statusLabel,
@@ -66,7 +66,6 @@ export function StatusPropertyPill({
 				icon={statusPropertyIconForValue(value)}
 				className="propertyValueTextIcon"
 				size="var(--icon-sm)"
-				strokeWidth={1.5}
 			/>
 			<span>{label}</span>
 		</span>

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -68,7 +68,7 @@ function DialogContent({
 						<HugeiconsIcon
 							icon={Close}
 							size="var(--icon-lg)"
-							strokeWidth={0.9}
+							strokeWidth={1.5}
 						/>
 						<span className="sr-only">Close</span>
 					</DialogPrimitive.Close>

--- a/src/components/ui/shadcn/dialog.tsx
+++ b/src/components/ui/shadcn/dialog.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Close } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import type * as React from "react";
 
@@ -65,11 +65,7 @@ function DialogContent({
 						data-slot="dialog-close"
 						className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-[var(--icon-lg)]"
 					>
-						<HugeiconsIcon
-							icon={Close}
-							size="var(--icon-lg)"
-							strokeWidth={1.5}
-						/>
+						<HugeiconsIcon icon={Close} size="var(--icon-lg)" />
 						<span className="sr-only">Close</span>
 					</DialogPrimitive.Close>
 				)}

--- a/src/components/ui/shadcn/dropdown-menu.tsx
+++ b/src/components/ui/shadcn/dropdown-menu.tsx
@@ -1,5 +1,5 @@
+import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { ArrowRight01Icon, Circle } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import type * as React from "react";
 
@@ -96,7 +96,6 @@ function DropdownMenuRadioItem({
 						icon={Circle}
 						size="var(--icon-xs)"
 						className="fill-current"
-						strokeWidth={1.5}
 					/>
 				</DropdownMenuPrimitive.ItemIndicator>
 			</span>
@@ -168,7 +167,6 @@ function DropdownMenuSubTrigger({
 					icon={ArrowRight01Icon}
 					size="var(--icon-xs)"
 					className="text-muted-foreground"
-					strokeWidth={1.5}
 					aria-hidden="true"
 				/>
 			</span>

--- a/src/components/ui/shadcn/dropdown-menu.tsx
+++ b/src/components/ui/shadcn/dropdown-menu.tsx
@@ -96,7 +96,7 @@ function DropdownMenuRadioItem({
 						icon={Circle}
 						size="var(--icon-xs)"
 						className="fill-current"
-						strokeWidth={0.9}
+						strokeWidth={1.5}
 					/>
 				</DropdownMenuPrimitive.ItemIndicator>
 			</span>
@@ -168,7 +168,7 @@ function DropdownMenuSubTrigger({
 					icon={ArrowRight01Icon}
 					size="var(--icon-xs)"
 					className="text-muted-foreground"
-					strokeWidth={0.9}
+					strokeWidth={1.5}
 					aria-hidden="true"
 				/>
 			</span>

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Seitenleiste einklappen",
 		"expand": "Seitenleiste ausklappen",
+		"devBadge": "DEV",
 		"newNote": "Neue Notiz",
 		"pinned": "Angeheftet",
 		"allNotes": "Alle Notizen",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Collapse sidebar",
 		"expand": "Expand sidebar",
+		"devBadge": "DEV",
 		"newNote": "New Note",
 		"pinned": "Pinned",
 		"allNotes": "All Notes",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Contraer barra lateral",
 		"expand": "Expandir barra lateral",
+		"devBadge": "DEV",
 		"newNote": "Nueva nota",
 		"pinned": "Fijadas",
 		"allNotes": "Todas las notas",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Réduire la barre latérale",
 		"expand": "Développer la barre latérale",
+		"devBadge": "DEV",
 		"newNote": "Nouvelle note",
 		"pinned": "Épinglées",
 		"allNotes": "Toutes les notes",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "サイドバーを折りたたむ",
 		"expand": "サイドバーを展開",
+		"devBadge": "DEV",
 		"newNote": "新規ノート",
 		"pinned": "ピン留め",
 		"allNotes": "すべてのノート",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "사이드바 접기",
 		"expand": "사이드바 펼치기",
+		"devBadge": "DEV",
 		"newNote": "새 노트",
 		"pinned": "고정됨",
 		"allNotes": "모든 노트",

--- a/src/i18n/locales/pl/shell.json
+++ b/src/i18n/locales/pl/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Zwiń pasek boczny",
 		"expand": "Rozwiń pasek boczny",
+		"devBadge": "DEV",
 		"newNote": "Nowa notatka",
 		"pinned": "Przypięte",
 		"allNotes": "Wszystkie",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -2,6 +2,7 @@
 	"sidebar": {
 		"collapse": "Recolher barra lateral",
 		"expand": "Expandir barra lateral",
+		"devBadge": "DEV",
 		"newNote": "Nova nota",
 		"pinned": "Fixadas",
 		"allNotes": "Todas as notas",

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -81,6 +81,7 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	position: relative;
 	width: 26px;
 	height: 26px;
 	padding: 0;
@@ -94,6 +95,27 @@
 	cursor: pointer;
 	-webkit-app-region: no-drag;
 	transition: background-color 120ms ease, color 120ms ease;
+}
+
+.sidebarDevBadge {
+	position: absolute;
+	right: -4px;
+	bottom: -4px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 22px;
+	height: 13px;
+	padding: 0 3px;
+	border: 2px solid var(--bg-sidebar);
+	border-radius: 999px;
+	background: var(--interactive-accent);
+	color: var(--text-inverse);
+	font-size: 7px;
+	font-weight: var(--font-bold);
+	line-height: 1;
+	letter-spacing: 0.08em;
+	pointer-events: none;
 }
 
 .windowChromeSidebarToggle:hover,

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -156,7 +156,7 @@ button.tagsIconPicker {
 	box-shadow: none;
 }
 
-.appearancePickerDialog {
+.commandPalette.appearancePickerDialog {
 	width: min(420px, calc(100vw - 48px));
 	height: min(75vh, 600px);
 	display: flex;
@@ -165,8 +165,25 @@ button.tagsIconPicker {
 	border-radius: var(--radius-2xl);
 }
 
+.appearancePickerDialog .commandPaletteHeader {
+	min-height: 0;
+	align-items: stretch;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px 10px;
+}
+
+.appearancePickerDialog .commandPaletteInputWrapper {
+	width: 100%;
+	flex: 0 0 42px;
+}
+
+.appearancePickerDialog .commandPaletteBody {
+	flex: 1 1 0;
+}
+
 .appearancePickerScroll {
-	flex: 1;
+	flex: 1 1 0;
 	min-height: 0;
 	padding: 8px 10px 10px;
 }

--- a/src/styles/app/37-database-pickers.css
+++ b/src/styles/app/37-database-pickers.css
@@ -360,7 +360,7 @@
 	[data-slot="dropdown-menu-label"]
 	svg {
 	opacity: 0.45;
-	stroke-width: 0.9;
+	stroke-width: 1.5;
 }
 
 [data-slot="dropdown-menu-content"].databasePickerMenu

--- a/src/styles/app/37-database-pickers.css
+++ b/src/styles/app/37-database-pickers.css
@@ -360,7 +360,6 @@
 	[data-slot="dropdown-menu-label"]
 	svg {
 	opacity: 0.45;
-	stroke-width: 1.5;
 }
 
 [data-slot="dropdown-menu-content"].databasePickerMenu


### PR DESCRIPTION
Closes


## Description

Bumps the stroke width of all Hugeicons-based icons from 0.9 to 1.5 for crisper, more legible rendering at small sizes, and separates dev builds from release builds.

- **Icon stroke width 1.5**: updated every icon component (`ActionIcons`, `EditorIcons`, `FileIcons`, `NavigationIcons`) plus all inline `HugeiconsIcon` usages (command palette, AI panel, editor ribbon, database views, settings, etc.) from `strokeWidth={0.9}` to `strokeWidth={1.5}`.
- **Dev build config**: `pnpm tauri` now routes through `scripts/tauri.mjs`, which injects `--config src-tauri/tauri.dev.conf.json` for `tauri dev`. Dev builds get their own product name ("Glyph Dev") and bundle identifier (`com.karatsidhu.glyph.dev`) so they no longer clash with the installed release app.
- **DEV badge**: in dev builds, a small "DEV" badge appears on the sidebar toggle so it's obvious which build is running (i18n string added across all locales).
- **Version bump** to `0.8.14-alpha.3`.
- **CSS polish**: scoped the appearance-picker dialog styles under `.commandPalette` (was leaking as a bare `.appearancePickerDialog`) and added styles for the dev badge.

### Notes for reviewers

- `pnpm check` (Biome) passes.
- `pnpm build` fails with pre-existing TypeScript errors that also exist on `main` (untouched files: `src/main.tsx` ThemeProvider `children` prop, `src/components/database/DatabaseTable.tsx:684`, `src/components/databases/DatabaseViewTabs.tsx:125`). Not introduced by this branch.

## Screenshots

Visual change: icons now render with 1.5 stroke width; dev builds show a DEV badge on the sidebar toggle. (No screenshots attached.)

## Docs

- `pnpm tauri dev` now uses `src-tauri/tauri.dev.conf.json` — dev builds are named "Glyph Dev" with identifier `com.karatsidhu.glyph.dev` and won't overwrite the release install. Builds (`pnpm tauri build`, etc.) are unaffected.
- New i18n key: `sidebar.devBadge`.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Increase Hugeicons-based icon stroke width across the app and introduce clearer dev build separation with visual DEV labeling.

New Features:
- Display a DEV badge on the sidebar toggle when running development builds to distinguish them from release builds.

Enhancements:
- Standardize Hugeicons icon stroke width to 1.5 across navigation, editor, file, database, command palette, and other UI surfaces for improved legibility.
- Refine appearance picker dialog styling to be scoped to the command palette and adjust layout of its header, input, and body.
- Add styling for the DEV badge in the sidebar toggle.

Build:
- Route `pnpm tauri` through a Node wrapper script that injects a dedicated dev Tauri config, giving dev builds separate product metadata and bundle identifiers.

Documentation:
- Add a new `sidebar.devBadge` i18n string across supported locales to label the DEV badge.

Chores:
- Add a dedicated `src-tauri/tauri.dev.conf.json` configuration file for Tauri development builds.
- Bump the app version to 0.8.14-alpha.3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Hugeicons icons to a 1.5 stroke width via a shared `HugeiconsIcon` wrapper, and added a separate dev build with a clear DEV badge so it won’t be confused with the release app.

- **New Features**
  - Icons: introduced `src/components/HugeiconsIcon.tsx` with default `strokeWidth=1.5` and replaced inline usages app-wide (navigation, editor, databases, command palette, dialogs).
  - Dev build config: `pnpm tauri` now runs through `scripts/tauri.mjs` to inject `src-tauri/tauri.dev.conf.json` for `tauri dev`, naming the app “Glyph Dev” with identifier `com.karatsidhu.glyph.dev`.
  - DEV badge: shows on the sidebar toggle in dev builds (i18n key `sidebar.devBadge`), with new `.sidebarDevBadge` styling.

- **Migration**
  - Use `pnpm tauri dev` to launch the separate dev app; release builds remain unchanged.
  - If you maintain custom locales, add `sidebar.devBadge`.

<sup>Written for commit c298edee5a1e7c1b220f78fdbcf2fbfa47d6ff5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set default icon stroke width to 1.5 and add DEV badge for development builds
> - Introduces a local [`HugeiconsIcon` wrapper](https://github.com/SidhuK/Glyph/pull/479/files#diff-bd5341382a111487dc1f0ba7023852165b2e8b631471c9242a7f20bd1b5759d0) that defaults `strokeWidth` to 1.5, replacing direct `@hugeicons/react` imports across the entire codebase and removing all explicit `strokeWidth={0.9}` overrides.
> - Adds a DEV badge to the window chrome sidebar toggle in development builds via `WindowChromeIconButton`, styled with [04-sidebar.css](https://github.com/SidhuK/Glyph/pull/479/files#diff-7923cc47a03739cffc91cfaa16dde80a6c8aff6d7e542cb7a643580fa73e20bf) and localized in all supported languages.
> - Adds [tauri.dev.conf.json](https://github.com/SidhuK/Glyph/pull/479/files#diff-9ad9fc795f2207ff54357aaeed1d01a880371ec4f564d44dd9fdffe3dc094b85) with a distinct product name (`Glyph Dev`) and bundle identifier, and a [tauri.mjs](https://github.com/SidhuK/Glyph/pull/479/files#diff-505675f228197b3e4056542225c2eaa0d5673c59ad479fc2f3e8cef417167fcf) script that injects this config automatically when running `npm run tauri dev`.
> - Behavioral Change: all icons previously rendered at stroke width 0.9 now render at 1.5 by default; only icons with an explicit `strokeWidth` prop will differ from this new default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c298ede.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Visual Improvements**
  - Standardized icon styling across navigation, editor, database, settings, and other interface areas for a clearer, more consistent appearance.
  - Improved the appearance picker dialog layout and spacing.
  - Refined database picker icon presentation.

- **Development**
  - Development builds now display a localized “DEV” badge in the sidebar.
  - Updated the application version for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->