### PR TITLE
Deepen shared modules: theme previews, settings persistence, suggestions, inline rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Run the narrowest permitted verification during development and the full permitt
 
 **Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: Markdown and space metadata in `.glyph/`; derived SQLite index in app support.
 
-Repo extras: internal product and engineering docs live in `docs/`. The docs folder is for human user only. It is not the source of truth. If you are an AI agent, do not use docs/ folder to understand or work with the code. 
+Repo extras: agents may read `docs/agents/` and `docs/adr/`. All other content under `docs/` is human-only and must not be used to understand or work with the code.
 
 ## Frontend Overview (`src/`)
 
@@ -93,7 +93,8 @@ Agents and reviewers should flag these patterns unless the change includes a cle
 
 ## Version Control
 
-- Always use native `gh` CLI. If GitHub CLI is not available, use git commands (push, pull, fetch, commit, squash, rebase, etc.)
+- Use `git` for repository operations, including push, pull, fetch, commit, squash, and rebase.
+- Use the native `gh` CLI for GitHub issues, pull requests, reviews, and other GitHub-hosted operations.
 
 ## Tool Restrictions
 
@@ -101,7 +102,7 @@ Agents and reviewers should flag these patterns unless the change includes a cle
 
 ## Development Platform
 
-- Glyph is a MacOS ONLY app. It is not being developed for Linux and Windows. Any code, suggestions or comments regarding Windows or Linux should be skipped, while solely focussing on MacOS developement.
+- Glyph is a macOS-only app. It is not being developed for Linux or Windows. Focus code, suggestions, and comments solely on macOS development.
 
 ## Agent skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Run the narrowest permitted verification during development and the full permitt
 
 **Glyph** — offline-first desktop note-taking app. Frontend: React 19 + TypeScript + Vite + Tailwind 4 (`src/`). Backend: Tauri 2 + Rust (`src-tauri/`). Editor: TipTap + Markdown. AI: Rig-backed multi-provider chat plus Codex/ChatGPT account integration. UI: shadcn/ui + Radix + Motion. Storage: Markdown and space metadata in `.glyph/`; derived SQLite index in app support.
 
-Repo extras: agents may read `docs/agents/` and `docs/adr/`. All other content under `docs/` is human-only and must not be used to understand or work with the code.
+Repo extras: agents may read `docs/agents/` and `docs/architecture/adr/`. All other content under `docs/` is human-only and must not be used to understand or work with the code.
 
 ## Frontend Overview (`src/`)
 
@@ -116,4 +116,4 @@ Five canonical labels, each named after its role: `needs-triage`, `needs-info`, 
 
 ### Domain docs
 
-Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+Read relevant decisions in `docs/architecture/adr/`. See `docs/agents/domain.md` for the domain-doc workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,26 @@ Agents and reviewers should flag these patterns unless the change includes a cle
 
 ## Version Control
 
-- Always use native `git` commands (push, pull, fetch, commit, squash, rebase, etc.) and never use the `gh` CLI for these operations.
+- Always use native `gh` CLI. If Github CLI is not available, use git commands (push, pull, fetch, commit, squash, rebase, etc.)
 
 ## Tool Restrictions
 
 - Browser and computer-use tools are completely forbidden. Do not use them under any circumstances.
+
+## Development Platform
+
+- Glyph is a MacOS ONLY app. It is not being developed for Linux and Windows. Any code, suggestions or comments regarding Windows or Linux should be skipped, while solely focussing on MacOS developement.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues on this repo, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical labels, each named after its role: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Agents and reviewers should flag these patterns unless the change includes a cle
 
 ## Version Control
 
-- Always use native `gh` CLI. If Github CLI is not available, use git commands (push, pull, fetch, commit, squash, rebase, etc.)
+- Always use native `gh` CLI. If GitHub CLI is not available, use git commands (push, pull, fetch, commit, squash, rebase, etc.)
 
 ## Tool Restrictions
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -6,7 +6,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 - **`CONTEXT.md`** at the repo root, or
 - **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+- **`docs/architecture/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
 
@@ -17,7 +17,7 @@ Single-context repo (most repos):
 ```
 /
 ├── CONTEXT.md
-├── docs/adr/
+├── docs/architecture/adr/
 │   ├── 0001-event-sourced-orders.md
 │   └── 0002-postgres-for-write-model.md
 └── src/
@@ -28,7 +28,7 @@ Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 ```
 /
 ├── CONTEXT-MAP.md
-├── docs/adr/                          ← system-wide decisions
+├── docs/architecture/adr/             ← system-wide decisions
 └── src/
     ├── ordering/
     │   ├── CONTEXT.md

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-enableGlobalVirtualStore: true
-
 allowBuilds:
   '@biomejs/biome': true
   esbuild: true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.14-alpha.3",
+	"version": "0.8.14-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/InlineRenameInput.tsx
+++ b/src/components/InlineRenameInput.tsx
@@ -27,8 +27,13 @@ export function InlineRenameInput({
 	const commit = async () => {
 		if (submittedRef.current) return;
 		submittedRef.current = true;
-		const committed = await onCommit(value);
-		if (!committed) submittedRef.current = false;
+		try {
+			const committed = await onCommit(value);
+			if (!committed) submittedRef.current = false;
+		} catch (error) {
+			submittedRef.current = false;
+			console.error("Failed to commit inline rename", error);
+		}
 	};
 
 	return (
@@ -42,6 +47,7 @@ export function InlineRenameInput({
 			onMouseDown={
 				containPointerEvents
 					? (event) => {
+							event.preventDefault();
 							event.stopPropagation();
 						}
 					: undefined

--- a/src/components/InlineRenameInput.tsx
+++ b/src/components/InlineRenameInput.tsx
@@ -5,7 +5,7 @@ interface InlineRenameInputProps {
 	className: string;
 	placeholder: string;
 	containPointerEvents?: boolean;
-	onCommit: (value: string) => unknown;
+	onCommit: (value: string) => boolean | Promise<boolean>;
 	onCancel: () => void;
 }
 
@@ -28,7 +28,7 @@ export function InlineRenameInput({
 		if (submittedRef.current) return;
 		submittedRef.current = true;
 		const committed = await onCommit(value);
-		if (committed === false) submittedRef.current = false;
+		if (!committed) submittedRef.current = false;
 	};
 
 	return (
@@ -42,7 +42,6 @@ export function InlineRenameInput({
 			onMouseDown={
 				containPointerEvents
 					? (event) => {
-							event.preventDefault();
 							event.stopPropagation();
 						}
 					: undefined
@@ -58,6 +57,7 @@ export function InlineRenameInput({
 			onBlur={() => void commit()}
 			onKeyDown={(event) => {
 				if (event.key === "Enter") {
+					if (event.nativeEvent.isComposing) return;
 					event.preventDefault();
 					void commit();
 					return;

--- a/src/components/InlineRenameInput.tsx
+++ b/src/components/InlineRenameInput.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from "react";
+
+interface InlineRenameInputProps {
+	initialValue: string;
+	className: string;
+	placeholder: string;
+	containPointerEvents?: boolean;
+	onCommit: (value: string) => unknown;
+	onCancel: () => void;
+}
+
+export function InlineRenameInput({
+	initialValue,
+	className,
+	placeholder,
+	containPointerEvents = false,
+	onCommit,
+	onCancel,
+}: InlineRenameInputProps) {
+	const [value, setValue] = useState(initialValue);
+	const submittedRef = useRef(false);
+	const focusInput = useCallback((input: HTMLInputElement | null) => {
+		input?.focus();
+		input?.select();
+	}, []);
+
+	const commit = async () => {
+		if (submittedRef.current) return;
+		submittedRef.current = true;
+		const committed = await onCommit(value);
+		if (committed === false) submittedRef.current = false;
+	};
+
+	return (
+		<input
+			ref={focusInput}
+			className={className}
+			value={value}
+			placeholder={placeholder}
+			onFocus={(event) => event.currentTarget.select()}
+			onChange={(event) => setValue(event.target.value)}
+			onMouseDown={
+				containPointerEvents
+					? (event) => {
+							event.preventDefault();
+							event.stopPropagation();
+						}
+					: undefined
+			}
+			onClick={
+				containPointerEvents
+					? (event) => {
+							event.preventDefault();
+							event.stopPropagation();
+						}
+					: undefined
+			}
+			onBlur={() => void commit()}
+			onKeyDown={(event) => {
+				if (event.key === "Enter") {
+					event.preventDefault();
+					void commit();
+					return;
+				}
+				if (event.key === "Escape") {
+					event.preventDefault();
+					submittedRef.current = true;
+					onCancel();
+				}
+			}}
+		/>
+	);
+}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -289,6 +289,7 @@ export const SidebarContent = memo(function SidebarContent({
 			if (renamed) {
 				setRenamingPath(null);
 			}
+			return renamed !== null;
 		},
 		[onRenameDir],
 	);
@@ -296,12 +297,13 @@ export const SidebarContent = memo(function SidebarContent({
 	const handleCommitFileRename = useCallback(
 		async (path: string, nextName: string) => {
 			const renamed = await onRenameDir(path, nextName, "file");
-			if (!renamed) return;
+			if (!renamed) return false;
 			setRenamingPath(null);
 			if (pendingNewNotePath === path) {
 				onOpenFile(renamed);
 				setPendingNewNotePath(null);
 			}
+			return true;
 		},
 		[onOpenFile, onRenameDir, pendingNewNotePath],
 	);

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -690,6 +690,9 @@ function DatabaseCellEditor({
 					onError={(error) => setSaveError(extractErrorMessage(error))}
 					onColorChange={onStatusColorChange}
 				/>
+				{saveError ? (
+					<div className="databaseCellError">{saveError}</div>
+				) : null}
 			</div>
 		);
 	}
@@ -717,6 +720,9 @@ function DatabaseCellEditor({
 					}}
 					onError={(error) => setSaveError(extractErrorMessage(error))}
 				/>
+				{saveError ? (
+					<div className="databaseCellError">{saveError}</div>
+				) : null}
 			</div>
 		);
 	}
@@ -1111,7 +1117,7 @@ export function DatabaseCell({
 			const currentValue = cellValue.value_text ?? "";
 			if (editable) {
 				return (
-					<>
+					<div className="databaseTagEditor">
 						<PropertyOptionPicker
 							kind="status"
 							value={currentValue}
@@ -1120,7 +1126,6 @@ export function DatabaseCell({
 							triggerClassName="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
 							triggerTitle={displayText || "Change status"}
 							stopTriggerClickPropagation
-							onTriggerFocus={handleSelectRow}
 							onTriggerClick={handleSelectRow}
 							onChange={(value) => {
 								setSaveError("");
@@ -1137,7 +1142,7 @@ export function DatabaseCell({
 						{saveError ? (
 							<div className="databaseCellError">{saveError}</div>
 						) : null}
-					</>
+					</div>
 				);
 			}
 			return (
@@ -1161,7 +1166,7 @@ export function DatabaseCell({
 			const currentValue = cellValue.value_text ?? "";
 			if (editable) {
 				return (
-					<>
+					<div className="databaseTagEditor">
 						<PropertyOptionPicker
 							kind="priority"
 							value={currentValue}
@@ -1169,7 +1174,6 @@ export function DatabaseCell({
 							triggerClassName="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
 							triggerTitle={displayText || "Change priority"}
 							stopTriggerClickPropagation
-							onTriggerFocus={handleSelectRow}
 							onTriggerClick={handleSelectRow}
 							onChange={(value) => {
 								setSaveError("");
@@ -1185,7 +1189,7 @@ export function DatabaseCell({
 						{saveError ? (
 							<div className="databaseCellError">{saveError}</div>
 						) : null}
-					</>
+					</div>
 				);
 			}
 			return (

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useDateDisplayFormat, useFileTreeContext } from "../../contexts";
 import {
@@ -11,14 +10,6 @@ import type { DatabaseColumn, DatabaseRow } from "../../lib/database/types";
 import { formatDisplayDate } from "../../lib/dateDisplayFormat";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
-	priorityColorKey,
-	priorityOptionsWithCustomValues,
-} from "../../lib/priorityProperties";
-import {
-	statusColorKey,
-	statusOptionsWithCustomValues,
-} from "../../lib/statusProperties";
-import {
 	DEFAULT_TAG_ICON_NAME,
 	resolveTagIconName,
 	tagIconOverridesFromAppearance,
@@ -30,16 +21,10 @@ import {
 	normalizeTagDraftPrefix,
 	normalizeTagToken,
 } from "../editor/noteProperties/utils";
-import { EDITOR_TEXT_COLORS, type EditorTextColor } from "../editor/textColors";
+import type { EditorTextColor } from "../editor/textColors";
 import { PriorityPropertyPill } from "../status/PriorityPropertyPill";
+import { PropertyOptionPicker } from "../status/PropertyOptionPicker";
 import { StatusPropertyPill } from "../status/StatusPropertyPill";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "../ui/shadcn/dropdown-menu";
 import { Input } from "../ui/shadcn/input";
 import { DatabaseColumnIcon } from "./DatabaseColumnIcon";
 import {
@@ -682,165 +667,56 @@ function DatabaseCellEditor({
 
 	if (isStatusColumn) {
 		const currentValue = cellValue.value_text ?? "";
-		const currentStatusId = statusColorKey(currentValue);
-		const statusOptions = statusOptionsWithCustomValues([
-			currentValue,
-			...valueOptions,
-		]);
 		return (
 			<div className="databaseTagEditor">
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<button
-							type="button"
-							className="notePropertyStatusTrigger databaseStatusTrigger"
-							onFocus={handleSelectRow}
-							onClick={(event) => {
-								handleSelectRow();
-								event.stopPropagation();
-							}}
-						>
-							<StatusPropertyPill
-								value={currentValue || "not_started"}
-								colors={statusColors}
-							/>
-						</button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent
-						align="start"
-						sideOffset={6}
-						className="databasePickerMenu notePropertyStatusMenu"
-					>
-						<div className="notePropertyStatusOptions">
-							{statusOptions.map((option) => (
-								<DropdownMenuItem
-									key={option.id}
-									className="notePropertyStatusOption"
-									data-selected={
-										statusColorKey(option.label) === currentStatusId
-											? "true"
-											: "false"
-									}
-									onClick={async () => {
-										try {
-											await onSave(row.note_path, column, {
-												kind: "status",
-												value_text: option.label,
-												value_bool: null,
-												value_list: [],
-											});
-										} catch (error) {
-											setSaveError(extractErrorMessage(error));
-											return;
-										}
-										onClose();
-									}}
-								>
-									<StatusPropertyPill
-										value={option.label}
-										colors={statusColors}
-									/>
-								</DropdownMenuItem>
-							))}
-						</div>
-						{currentStatusId && onStatusColorChange ? (
-							<>
-								<DropdownMenuSeparator className="databaseBoardContextMenuSeparator" />
-								<div className="notePropertyStatusColorRibbon">
-									{EDITOR_TEXT_COLORS.map((color) => (
-										<button
-											key={color.id}
-											type="button"
-											className="databaseBoardColorRibbonSwatch"
-											style={
-												{
-													"--database-tone": `var(${color.cssVar})`,
-												} as CSSProperties
-											}
-											onClick={() =>
-												onStatusColorChange(currentValue, color.id)
-											}
-											title={color.label}
-											aria-label={`Set ${currentValue} color to ${color.label}`}
-										/>
-									))}
-									<button
-										type="button"
-										className="databaseBoardColorRibbonClear"
-										onClick={() => onStatusColorChange(currentValue, null)}
-										title="Clear color"
-										aria-label={`Clear color for ${currentValue}`}
-									>
-										<span />
-									</button>
-								</div>
-							</>
-						) : null}
-					</DropdownMenuContent>
-				</DropdownMenu>
+				<PropertyOptionPicker
+					kind="status"
+					value={currentValue}
+					valueOptions={valueOptions}
+					colors={statusColors}
+					triggerClassName="notePropertyStatusTrigger databaseStatusTrigger"
+					onTriggerFocus={handleSelectRow}
+					onTriggerClick={handleSelectRow}
+					stopTriggerClickPropagation
+					onChange={async (value) => {
+						await onSave(row.note_path, column, {
+							kind: "status",
+							value_text: value,
+							value_bool: null,
+							value_list: [],
+						});
+						onClose();
+					}}
+					onError={(error) => setSaveError(extractErrorMessage(error))}
+					onColorChange={onStatusColorChange}
+				/>
 			</div>
 		);
 	}
 
 	if (isPriorityColumn) {
 		const currentValue = cellValue.value_text ?? "";
-		const currentPriorityId = priorityColorKey(currentValue);
-		const priorityOptions = priorityOptionsWithCustomValues([
-			currentValue,
-			...valueOptions,
-		]);
 		return (
 			<div className="databaseTagEditor">
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<button
-							type="button"
-							className="notePropertyStatusTrigger databaseStatusTrigger"
-							onFocus={handleSelectRow}
-							onClick={(event) => {
-								handleSelectRow();
-								event.stopPropagation();
-							}}
-						>
-							<PriorityPropertyPill value={currentValue || "no"} />
-						</button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent
-						align="start"
-						sideOffset={6}
-						className="databasePickerMenu notePropertyStatusMenu"
-					>
-						<div className="notePropertyStatusOptions">
-							{priorityOptions.map((option) => (
-								<DropdownMenuItem
-									key={option.id}
-									className="notePropertyStatusOption"
-									data-selected={
-										priorityColorKey(option.label) === currentPriorityId
-											? "true"
-											: "false"
-									}
-									onClick={async () => {
-										try {
-											await onSave(row.note_path, column, {
-												kind: "priority",
-												value_text: option.label,
-												value_bool: null,
-												value_list: [],
-											});
-										} catch (error) {
-											setSaveError(extractErrorMessage(error));
-											return;
-										}
-										onClose();
-									}}
-								>
-									<PriorityPropertyPill value={option.label} />
-								</DropdownMenuItem>
-							))}
-						</div>
-					</DropdownMenuContent>
-				</DropdownMenu>
+				<PropertyOptionPicker
+					kind="priority"
+					value={currentValue}
+					valueOptions={valueOptions}
+					triggerClassName="notePropertyStatusTrigger databaseStatusTrigger"
+					onTriggerFocus={handleSelectRow}
+					onTriggerClick={handleSelectRow}
+					stopTriggerClickPropagation
+					onChange={async (value) => {
+						await onSave(row.note_path, column, {
+							kind: "priority",
+							value_text: value,
+							value_bool: null,
+							value_list: [],
+						});
+						onClose();
+					}}
+					onError={(error) => setSaveError(extractErrorMessage(error))}
+				/>
 			</div>
 		);
 	}
@@ -1119,6 +995,7 @@ export function DatabaseCell({
 		noteAppearance,
 	);
 	const [editing, setEditing] = useState(false);
+	const [saveError, setSaveError] = useState("");
 	const displayText =
 		cellValue.kind === "datetime"
 			? formatDatabaseDateTime(cellValue.value_text, dateDisplayFormat)
@@ -1232,100 +1109,35 @@ export function DatabaseCell({
 		}
 		if (cellValue.kind === "status") {
 			const currentValue = cellValue.value_text ?? "";
-			const currentStatusId = statusColorKey(currentValue);
-			const statusOptions = statusOptionsWithCustomValues([
-				currentValue,
-				...valueOptions,
-			]);
 			if (editable) {
 				return (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								className="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
-								onClick={(event) => {
-									handleSelectRow();
-									event.stopPropagation();
-								}}
-								title={displayText || "Change status"}
-							>
-								<StatusPropertyPill
-									value={currentValue || "not_started"}
-									colors={statusColors}
-								/>
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="start"
-							sideOffset={6}
-							className="databasePickerMenu notePropertyStatusMenu"
-						>
-							<div className="notePropertyStatusOptions">
-								{statusOptions.map((option) => (
-									<DropdownMenuItem
-										key={option.id}
-										className="notePropertyStatusOption"
-										data-selected={
-											statusColorKey(option.label) === currentStatusId
-												? "true"
-												: "false"
-										}
-										onClick={async () => {
-											try {
-												await onSave(row.note_path, column, {
-													kind: "status",
-													value_text: option.label,
-													value_bool: null,
-													value_list: [],
-												});
-											} catch (error) {
-												console.error("Failed to save database status", error);
-											}
-										}}
-									>
-										<StatusPropertyPill
-											value={option.label}
-											colors={statusColors}
-										/>
-									</DropdownMenuItem>
-								))}
-							</div>
-							{currentStatusId && onStatusColorChange ? (
-								<>
-									<DropdownMenuSeparator className="databaseBoardContextMenuSeparator" />
-									<div className="notePropertyStatusColorRibbon">
-										{EDITOR_TEXT_COLORS.map((color) => (
-											<button
-												key={color.id}
-												type="button"
-												className="databaseBoardColorRibbonSwatch"
-												style={
-													{
-														"--database-tone": `var(${color.cssVar})`,
-													} as CSSProperties
-												}
-												onClick={() =>
-													onStatusColorChange(currentValue, color.id)
-												}
-												title={color.label}
-												aria-label={`Set ${currentValue} color to ${color.label}`}
-											/>
-										))}
-										<button
-											type="button"
-											className="databaseBoardColorRibbonClear"
-											onClick={() => onStatusColorChange(currentValue, null)}
-											title="Clear color"
-											aria-label={`Clear color for ${currentValue}`}
-										>
-											<span />
-										</button>
-									</div>
-								</>
-							) : null}
-						</DropdownMenuContent>
-					</DropdownMenu>
+					<>
+						<PropertyOptionPicker
+							kind="status"
+							value={currentValue}
+							valueOptions={valueOptions}
+							colors={statusColors}
+							triggerClassName="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
+							triggerTitle={displayText || "Change status"}
+							stopTriggerClickPropagation
+							onTriggerFocus={handleSelectRow}
+							onTriggerClick={handleSelectRow}
+							onChange={(value) => {
+								setSaveError("");
+								return onSave(row.note_path, column, {
+									kind: "status",
+									value_text: value,
+									value_bool: null,
+									value_list: [],
+								});
+							}}
+							onError={(error) => setSaveError(extractErrorMessage(error))}
+							onColorChange={onStatusColorChange}
+						/>
+						{saveError ? (
+							<div className="databaseCellError">{saveError}</div>
+						) : null}
+					</>
 				);
 			}
 			return (
@@ -1347,64 +1159,33 @@ export function DatabaseCell({
 		}
 		if (cellValue.kind === "priority") {
 			const currentValue = cellValue.value_text ?? "";
-			const currentPriorityId = priorityColorKey(currentValue);
-			const priorityOptions = priorityOptionsWithCustomValues([
-				currentValue,
-				...valueOptions,
-			]);
 			if (editable) {
 				return (
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<button
-								type="button"
-								className="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
-								onClick={(event) => {
-									handleSelectRow();
-									event.stopPropagation();
-								}}
-								title={displayText || "Change priority"}
-							>
-								<PriorityPropertyPill value={currentValue || "no"} />
-							</button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="start"
-							sideOffset={6}
-							className="databasePickerMenu notePropertyStatusMenu"
-						>
-							<div className="notePropertyStatusOptions">
-								{priorityOptions.map((option) => (
-									<DropdownMenuItem
-										key={option.id}
-										className="notePropertyStatusOption"
-										data-selected={
-											priorityColorKey(option.label) === currentPriorityId
-												? "true"
-												: "false"
-										}
-										onClick={async () => {
-											try {
-												await onSave(row.note_path, column, {
-													kind: "priority",
-													value_text: option.label,
-													value_bool: null,
-													value_list: [],
-												});
-											} catch (error) {
-												console.error(
-													"Failed to save database priority",
-													error,
-												);
-											}
-										}}
-									>
-										<PriorityPropertyPill value={option.label} />
-									</DropdownMenuItem>
-								))}
-							</div>
-						</DropdownMenuContent>
-					</DropdownMenu>
+					<>
+						<PropertyOptionPicker
+							kind="priority"
+							value={currentValue}
+							valueOptions={valueOptions}
+							triggerClassName="databaseCellButton is-pill-list notePropertyStatusTrigger databaseStatusTrigger"
+							triggerTitle={displayText || "Change priority"}
+							stopTriggerClickPropagation
+							onTriggerFocus={handleSelectRow}
+							onTriggerClick={handleSelectRow}
+							onChange={(value) => {
+								setSaveError("");
+								return onSave(row.note_path, column, {
+									kind: "priority",
+									value_text: value,
+									value_bool: null,
+									value_list: [],
+								});
+							}}
+							onError={(error) => setSaveError(extractErrorMessage(error))}
+						/>
+						{saveError ? (
+							<div className="databaseCellError">{saveError}</div>
+						) : null}
+					</>
 				);
 			}
 			return (

--- a/src/components/database/DatabaseTable.tsx
+++ b/src/components/database/DatabaseTable.tsx
@@ -331,6 +331,7 @@ export function DatabaseTable({
 	const table = useReactTable({
 		data: rows,
 		columns: tableColumns,
+		getRowId: (row) => row.note_path,
 		getCoreRowModel: getCoreRowModel(),
 		enableColumnResizing: true,
 		columnResizeMode: "onChange",

--- a/src/components/editor/extensions/markdownLinkAutocomplete.ts
+++ b/src/components/editor/extensions/markdownLinkAutocomplete.ts
@@ -5,7 +5,7 @@ import {
 	type EditorLinkSuggestion,
 	suggestMarkdownLinks,
 } from "../../../lib/linkSuggestions";
-import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const MD_LINK_SUGGESTION_KEY = new PluginKey("markdown-link-suggestion");
 
@@ -72,30 +72,13 @@ export const MarkdownLinkAutocomplete = Extension.create({
 						.run();
 				},
 				render: () =>
-					createTipTapSuggestionMenu<EditorLinkSuggestion>({
+					createTipTapTextSuggestionMenu<EditorLinkSuggestion>({
 						menuClassName: "wikiLinkSuggestionMenu",
 						lockEditorScroll: false,
-						renderItem: ({ item, isActive, select }) => {
-							const button = document.createElement("button");
-							button.type = "button";
-							button.className = "wikiLinkSuggestionItem";
-							button.classList.toggle("active", isActive);
-
-							const title = document.createElement("span");
-							title.className = "wikiLinkSuggestionTitle";
-							title.textContent = item.title;
-
-							const path = document.createElement("span");
-							path.className = "wikiLinkSuggestionPath";
-							path.textContent = item.insertText;
-
-							button.append(title, path);
-							button.addEventListener("mousedown", (event) => {
-								event.preventDefault();
-								select(item);
-							});
-							return button;
-						},
+						itemContent: (item) => ({
+							title: item.title,
+							description: item.insertText,
+						}),
 					}),
 			}),
 		];

--- a/src/components/editor/extensions/personAutocomplete.ts
+++ b/src/components/editor/extensions/personAutocomplete.ts
@@ -2,7 +2,7 @@ import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import Suggestion from "@tiptap/suggestion";
 import { type PersonCount, invoke } from "../../../lib/tauri";
-import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const PERSON_SUGGESTION_KEY = new PluginKey("person-suggestion");
 
@@ -103,31 +103,16 @@ export const PersonAutocomplete = Extension.create({
 						.run();
 				},
 				render: () =>
-					createTipTapSuggestionMenu<PersonSuggestionItem>({
+					createTipTapTextSuggestionMenu<PersonSuggestionItem>({
 						menuClassName: "wikiLinkSuggestionMenu",
 						lockEditorScroll: false,
 						resetSelectionOnUpdate: true,
-						renderItem: ({ item, isActive, select }) => {
-							const button = document.createElement("button");
-							button.type = "button";
-							button.className = "wikiLinkSuggestionItem";
-							button.classList.toggle("active", isActive);
-							const meta = item.isNew
+						itemContent: (item) => ({
+							title: `@${item.handle}`,
+							description: item.isNew
 								? "Create mention"
-								: `${item.count ?? 0} note${item.count === 1 ? "" : "s"}`;
-							const title = document.createElement("span");
-							title.className = "wikiLinkSuggestionTitle";
-							title.textContent = `@${item.handle}`;
-							const path = document.createElement("span");
-							path.className = "wikiLinkSuggestionPath";
-							path.textContent = String(meta);
-							button.append(title, path);
-							button.addEventListener("mousedown", (event) => {
-								event.preventDefault();
-								select(item);
-							});
-							return button;
-						},
+								: `${item.count ?? 0} note${item.count === 1 ? "" : "s"}`,
+						}),
 					}),
 			}),
 		];

--- a/src/components/editor/extensions/tagAutocomplete.ts
+++ b/src/components/editor/extensions/tagAutocomplete.ts
@@ -7,7 +7,7 @@ import {
 	normalizeTagDraftPrefix,
 	normalizeTagToken,
 } from "../noteProperties/utils";
-import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const TAG_SUGGESTION_KEY = new PluginKey("tag-suggestion");
 
@@ -122,31 +122,14 @@ export const TagAutocomplete = Extension.create({
 						.run();
 				},
 				render: () =>
-					createTipTapSuggestionMenu<TagSuggestionItem>({
+					createTipTapTextSuggestionMenu<TagSuggestionItem>({
 						menuClassName: "wikiLinkSuggestionMenu",
-						renderItem: ({ item, isActive, select }) => {
-							const button = document.createElement("button");
-							button.type = "button";
-							button.className = "wikiLinkSuggestionItem";
-							button.classList.toggle("active", isActive);
-
-							const title = document.createElement("span");
-							title.className = "wikiLinkSuggestionTitle";
-							title.textContent = `#${item.tag}`;
-
-							const path = document.createElement("span");
-							path.className = "wikiLinkSuggestionPath";
-							path.textContent = item.isNew
+						itemContent: (item) => ({
+							title: `#${item.tag}`,
+							description: item.isNew
 								? "Create tag"
-								: `${item.count} note${item.count === 1 ? "" : "s"}`;
-
-							button.append(title, path);
-							button.addEventListener("mousedown", (event) => {
-								event.preventDefault();
-								select(item);
-							});
-							return button;
-						},
+								: `${item.count} note${item.count === 1 ? "" : "s"}`,
+						}),
 					}),
 			}),
 		];

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -17,7 +17,7 @@ import {
 	wikiLinkAttrsToMarkdown,
 } from "../markdown/wikiLinkCodec";
 import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
-import { createTipTapSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
 const WIKI_LINK_INPUT_REGEX = /(!?\[\[[^\]\n]+\]\])$/;
 const WIKI_LINK_PASTE_REGEX = /(!?\[\[[^\]\n]+\]\])/g;
@@ -310,29 +310,12 @@ export const WikiLink = Node.create({
 						.run();
 				},
 				render: () =>
-					createTipTapSuggestionMenu<EditorLinkSuggestion>({
+					createTipTapTextSuggestionMenu<EditorLinkSuggestion>({
 						menuClassName: "wikiLinkSuggestionMenu",
-						renderItem: ({ item, isActive, select }) => {
-							const button = document.createElement("button");
-							button.type = "button";
-							button.className = "wikiLinkSuggestionItem";
-							button.classList.toggle("active", isActive);
-
-							const title = document.createElement("span");
-							title.className = "wikiLinkSuggestionTitle";
-							title.textContent = item.title;
-
-							const path = document.createElement("span");
-							path.className = "wikiLinkSuggestionPath";
-							path.textContent = item.path;
-
-							button.append(title, path);
-							button.addEventListener("mousedown", (event) => {
-								event.preventDefault();
-								select(item);
-							});
-							return button;
-						},
+						itemContent: (item) => ({
+							title: item.title,
+							description: item.path,
+						}),
 					}),
 			}),
 		];

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,29 +1,15 @@
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useDateDisplayFormat } from "../../../contexts";
-import {
-	priorityColorKey,
-	priorityOptionsWithCustomValues,
-} from "../../../lib/priorityProperties";
-import {
-	statusColorKey,
-	statusOptionsWithCustomValues,
-} from "../../../lib/statusProperties";
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 import { X } from "../../Icons";
 import { Toggle } from "../../base/toggle/toggle";
 import { PriorityPropertyPill } from "../../status/PriorityPropertyPill";
+import { PropertyOptionPicker } from "../../status/PropertyOptionPicker";
 import { StatusPropertyPill } from "../../status/StatusPropertyPill";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "../../ui/shadcn/dropdown-menu";
 import { Input } from "../../ui/shadcn/input";
 import { useWikiLinkAutocomplete } from "../hooks/useWikiLinkAutocomplete";
-import { EDITOR_TEXT_COLORS, type EditorTextColor } from "../textColors";
+import type { EditorTextColor } from "../textColors";
 import { WikiLinkedText } from "./WikiLinkedText";
 import {
 	buildTagSuggestions,
@@ -175,120 +161,29 @@ export function NotePropertyValueField({
 
 	if (property.kind === "status") {
 		const currentValue = property.value_text ?? "";
-		const currentStatusId = statusColorKey(currentValue);
-		const statusOptions = statusOptionsWithCustomValues([currentValue]);
 		return (
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<button
-						type="button"
-						className="notePropertyStatusTrigger"
-						aria-label={property.key || "Status property"}
-					>
-						<StatusPropertyPill
-							value={currentValue || "not_started"}
-							colors={statusColors}
-						/>
-					</button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent
-					align="start"
-					sideOffset={6}
-					className="databasePickerMenu notePropertyStatusMenu"
-				>
-					<div className="notePropertyStatusOptions">
-						{statusOptions.map((option) => (
-							<DropdownMenuItem
-								key={option.id}
-								className="notePropertyStatusOption"
-								data-selected={
-									statusColorKey(option.label) === currentStatusId
-										? "true"
-										: "false"
-								}
-								onClick={() => onUpdate(index, { value_text: option.label })}
-							>
-								<StatusPropertyPill
-									value={option.label}
-									colors={statusColors}
-								/>
-							</DropdownMenuItem>
-						))}
-					</div>
-					{currentStatusId ? (
-						<>
-							<DropdownMenuSeparator className="databaseBoardContextMenuSeparator" />
-							<div className="notePropertyStatusColorRibbon">
-								{EDITOR_TEXT_COLORS.map((color) => (
-									<button
-										key={color.id}
-										type="button"
-										className="databaseBoardColorRibbonSwatch"
-										style={
-											{
-												"--database-tone": `var(${color.cssVar})`,
-											} as CSSProperties
-										}
-										onClick={() => onStatusColorChange(currentValue, color.id)}
-										title={color.label}
-										aria-label={`Set ${currentValue} color to ${color.label}`}
-									/>
-								))}
-								<button
-									type="button"
-									className="databaseBoardColorRibbonClear"
-									onClick={() => onStatusColorChange(currentValue, null)}
-									title="Clear color"
-									aria-label={`Clear color for ${currentValue}`}
-								>
-									<span />
-								</button>
-							</div>
-						</>
-					) : null}
-				</DropdownMenuContent>
-			</DropdownMenu>
+			<PropertyOptionPicker
+				kind="status"
+				value={currentValue}
+				colors={statusColors}
+				triggerClassName="notePropertyStatusTrigger"
+				triggerAriaLabel={property.key || "Status property"}
+				onChange={(value) => onUpdate(index, { value_text: value })}
+				onColorChange={onStatusColorChange}
+			/>
 		);
 	}
 
 	if (property.kind === "priority") {
 		const currentValue = property.value_text ?? "";
-		const currentPriorityId = priorityColorKey(currentValue);
-		const priorityOptions = priorityOptionsWithCustomValues([currentValue]);
 		return (
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<button
-						type="button"
-						className="notePropertyStatusTrigger"
-						aria-label={property.key || "Priority property"}
-					>
-						<PriorityPropertyPill value={currentValue || "no"} />
-					</button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent
-					align="start"
-					sideOffset={6}
-					className="databasePickerMenu notePropertyStatusMenu"
-				>
-					<div className="notePropertyStatusOptions">
-						{priorityOptions.map((option) => (
-							<DropdownMenuItem
-								key={option.id}
-								className="notePropertyStatusOption"
-								data-selected={
-									priorityColorKey(option.label) === currentPriorityId
-										? "true"
-										: "false"
-								}
-								onClick={() => onUpdate(index, { value_text: option.label })}
-							>
-								<PriorityPropertyPill value={option.label} />
-							</DropdownMenuItem>
-						))}
-					</div>
-				</DropdownMenuContent>
-			</DropdownMenu>
+			<PropertyOptionPicker
+				kind="priority"
+				value={currentValue}
+				triggerClassName="notePropertyStatusTrigger"
+				triggerAriaLabel={property.key || "Priority property"}
+				onChange={(value) => onUpdate(index, { value_text: value })}
+			/>
 		);
 	}
 

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -37,14 +37,16 @@ function renderTextSuggestionItem<T>({
 	isActive,
 	select,
 	itemContent,
+	itemActiveClassName,
 }: RenderTipTapSuggestionItemOptions<T> & {
 	itemContent: TipTapTextSuggestionMenuOptions<T>["itemContent"];
+	itemActiveClassName: string;
 }): HTMLElement {
 	const content = itemContent(item);
 	const button = document.createElement("button");
 	button.type = "button";
 	button.className = "wikiLinkSuggestionItem";
-	button.classList.toggle("active", isActive);
+	button.classList.toggle(itemActiveClassName, isActive);
 
 	const title = document.createElement("span");
 	title.className = "wikiLinkSuggestionTitle";
@@ -202,12 +204,18 @@ export function createTipTapSuggestionMenu<T>({
 
 export function createTipTapTextSuggestionMenu<T>({
 	itemContent,
+	itemActiveClassName = "active",
 	...options
 }: TipTapTextSuggestionMenuOptions<T>) {
 	return createTipTapSuggestionMenu<T>({
 		...options,
+		itemActiveClassName,
 		renderItem: (renderOptions) =>
-			renderTextSuggestionItem({ ...renderOptions, itemContent }),
+			renderTextSuggestionItem({
+				...renderOptions,
+				itemContent,
+				itemActiveClassName,
+			}),
 	});
 }
 

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -24,6 +24,44 @@ interface TipTapSuggestionMenuOptions<T> {
 	onEscape?: (view: EditorView) => void;
 }
 
+interface TipTapTextSuggestionMenuOptions<T>
+	extends Omit<TipTapSuggestionMenuOptions<T>, "renderItem"> {
+	itemContent: (item: T) => {
+		title: string;
+		description: string;
+	};
+}
+
+function renderTextSuggestionItem<T>({
+	item,
+	isActive,
+	select,
+	itemContent,
+}: RenderTipTapSuggestionItemOptions<T> & {
+	itemContent: TipTapTextSuggestionMenuOptions<T>["itemContent"];
+}): HTMLElement {
+	const content = itemContent(item);
+	const button = document.createElement("button");
+	button.type = "button";
+	button.className = "wikiLinkSuggestionItem";
+	button.classList.toggle("active", isActive);
+
+	const title = document.createElement("span");
+	title.className = "wikiLinkSuggestionTitle";
+	title.textContent = content.title;
+
+	const description = document.createElement("span");
+	description.className = "wikiLinkSuggestionPath";
+	description.textContent = content.description;
+
+	button.append(title, description);
+	button.addEventListener("mousedown", (event) => {
+		event.preventDefault();
+		select(item);
+	});
+	return button;
+}
+
 function placeMenu(menu: HTMLElement, rect: DOMRect): void {
 	const pad = 8;
 	const gap = 6;
@@ -160,6 +198,17 @@ export function createTipTapSuggestionMenu<T>({
 			activeProps = null;
 		},
 	};
+}
+
+export function createTipTapTextSuggestionMenu<T>({
+	itemContent,
+	...options
+}: TipTapTextSuggestionMenuOptions<T>) {
+	return createTipTapSuggestionMenu<T>({
+		...options,
+		renderItem: (renderOptions) =>
+			renderTextSuggestionItem({ ...renderOptions, itemContent }),
+	});
 }
 
 export function exitTipTapSuggestion(view: EditorView): void {

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -13,13 +13,14 @@ import type {
 	MutableRefObject,
 	Ref,
 } from "react";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useSpace } from "../../contexts";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import type { FileTreeAppearance, FsEntry } from "../../lib/tauri";
 import { Plus } from "../Icons";
+import { InlineRenameInput } from "../InlineRenameInput";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { isEditorTextColor } from "../editor/textColors";
 import {
@@ -34,64 +35,6 @@ import {
 	springTransition,
 } from "./fileTreeItemHelpers";
 import { fileTreeAppearanceNativeMenu } from "./fileTreeNativeContextMenu";
-
-function DirectoryRenameInput({
-	initialName,
-	relPath,
-	onCommitRename,
-	onCancelRename,
-}: {
-	initialName: string;
-	relPath: string;
-	onCommitRename: (dirPath: string, nextName: string) => Promise<void> | void;
-	onCancelRename: () => void;
-}) {
-	const [draftName, setDraftName] = useState(initialName);
-	const renameSubmittedRef = useRef(false);
-	const inputRef = useRef<HTMLInputElement | null>(null);
-
-	useEffect(() => {
-		inputRef.current?.focus();
-		inputRef.current?.select();
-	}, []);
-
-	const commitRename = async () => {
-		if (renameSubmittedRef.current) return;
-		renameSubmittedRef.current = true;
-		await onCommitRename(relPath, draftName);
-	};
-
-	return (
-		<input
-			ref={inputRef}
-			className="plainTextInput fileTreeRenameInput"
-			value={draftName}
-			placeholder="New Folder"
-			onChange={(event) => setDraftName(event.target.value)}
-			onMouseDown={(event) => {
-				event.preventDefault();
-				event.stopPropagation();
-			}}
-			onClick={(event) => {
-				event.preventDefault();
-				event.stopPropagation();
-			}}
-			onBlur={() => void commitRename()}
-			onKeyDown={(event) => {
-				if (event.key === "Enter") {
-					event.preventDefault();
-					void commitRename();
-					return;
-				}
-				if (event.key === "Escape") {
-					event.preventDefault();
-					renameSubmittedRef.current = true;
-					onCancelRename();
-				}
-			}}
-		/>
-	);
-}
 
 interface FileTreeDirItemProps {
 	entry: FsEntry;
@@ -250,12 +193,14 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 						data-file-tree-kind="dir"
 						data-file-tree-path={entry.rel_path}
 					>
-						<DirectoryRenameInput
+						<InlineRenameInput
 							key={`${entry.rel_path}:${entry.name}`}
-							initialName={entry.name.trim() || "New Folder"}
-							relPath={entry.rel_path}
-							onCommitRename={onCommitRename}
-							onCancelRename={onCancelRename}
+							initialValue={entry.name.trim() || "New Folder"}
+							className="plainTextInput fileTreeRenameInput"
+							placeholder="New Folder"
+							containPointerEvents
+							onCommit={(nextName) => onCommitRename(entry.rel_path, nextName)}
+							onCancel={onCancelRename}
 						/>
 					</div>
 				) : (

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -45,7 +45,7 @@ interface FileTreeDirItemProps {
 	onToggleDir: (dirPath: string) => void;
 	onSelectDir: (dirPath: string) => void;
 	onStartRename: () => void;
-	onCommitRename: (dirPath: string, nextName: string) => Promise<void> | void;
+	onCommitRename: (dirPath: string, nextName: string) => Promise<boolean>;
 	onCancelRename: () => void;
 	onNewFileInDir: (dirPath: string) => unknown;
 	onCreateFromTemplateInDir: (dirPath: string) => unknown;

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -56,7 +56,7 @@ interface FileTreeFileItemProps {
 	onRequestCreateFolder: (dirPath: string) => unknown;
 	onDuplicateFile: (path: string) => unknown;
 	onStartRename: () => void;
-	onCommitRename: (path: string, nextName: string) => Promise<void> | void;
+	onCommitRename: (path: string, nextName: string) => Promise<boolean>;
 	onCancelRename: () => void;
 	parentDirPath: string;
 	onDeletePath: (path: string, kind: "dir" | "file") => void;

--- a/src/components/filetree/FileTreeFileItem.tsx
+++ b/src/components/filetree/FileTreeFileItem.tsx
@@ -9,7 +9,7 @@ import type {
 	MutableRefObject,
 	Ref,
 } from "react";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useEditorContext, useSpace } from "../../contexts";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
@@ -23,6 +23,7 @@ import type {
 	NoteTaskSummary,
 } from "../../lib/tauri";
 import { basename, splitEditableFileName } from "../../utils/path";
+import { InlineRenameInput } from "../InlineRenameInput";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { isEditorTextColor } from "../editor/textColors";
@@ -42,70 +43,6 @@ import { getFileTypeInfo } from "./fileTypeUtils";
 const DEFAULT_MOVE_CLICK_SUPPRESS_REF: MutableRefObject<boolean> = {
 	current: false,
 };
-
-function FileRenameInput({
-	initialName,
-	relPath,
-	fileStem,
-	fileExt,
-	onCommitRename,
-	onCancelRename,
-}: {
-	initialName: string;
-	relPath: string;
-	fileStem: string;
-	fileExt: string;
-	onCommitRename: (path: string, nextName: string) => Promise<void> | void;
-	onCancelRename: () => void;
-}) {
-	const [draftName, setDraftName] = useState(initialName);
-	const renameSubmittedRef = useRef(false);
-	const inputRef = useRef<HTMLInputElement | null>(null);
-
-	useEffect(() => {
-		inputRef.current?.focus();
-		inputRef.current?.select();
-	}, []);
-
-	const commitRename = async () => {
-		if (renameSubmittedRef.current) return;
-		renameSubmittedRef.current = true;
-		const nextStem = draftName.trim() || fileStem || initialName.trim();
-		const nextName = `${nextStem}${fileExt}`;
-		await onCommitRename(relPath, nextName);
-	};
-
-	return (
-		<input
-			ref={inputRef}
-			className="plainTextInput fileTreeRenameInput"
-			value={draftName}
-			placeholder="Untitled"
-			onChange={(event) => setDraftName(event.target.value)}
-			onMouseDown={(event) => {
-				event.preventDefault();
-				event.stopPropagation();
-			}}
-			onClick={(event) => {
-				event.preventDefault();
-				event.stopPropagation();
-			}}
-			onBlur={() => void commitRename()}
-			onKeyDown={(event) => {
-				if (event.key === "Enter") {
-					event.preventDefault();
-					void commitRename();
-					return;
-				}
-				if (event.key === "Escape") {
-					event.preventDefault();
-					renameSubmittedRef.current = true;
-					onCancelRename();
-				}
-			}}
-		/>
-	);
-}
 
 interface FileTreeFileItemProps {
 	entry: FsEntry;
@@ -336,14 +273,18 @@ export const FileTreeFileItem = memo(function FileTreeFileItem({
 						data-file-tree-path={entry.rel_path}
 					>
 						<span className="fileTreeLeadingSpacer" aria-hidden="true" />
-						<FileRenameInput
+						<InlineRenameInput
 							key={`${entry.rel_path}:${entry.name}`}
-							initialName={fileStem || entry.name.trim() || "Untitled"}
-							relPath={entry.rel_path}
-							fileStem={fileStem}
-							fileExt={fileExt}
-							onCommitRename={onCommitRename}
-							onCancelRename={onCancelRename}
+							initialValue={fileStem || entry.name.trim() || "Untitled"}
+							className="plainTextInput fileTreeRenameInput"
+							placeholder="Untitled"
+							containPointerEvents
+							onCommit={(draftName) => {
+								const nextStem =
+									draftName.trim() || fileStem || entry.name.trim();
+								return onCommitRename(entry.rel_path, `${nextStem}${fileExt}`);
+							}}
+							onCancel={onCancelRename}
 						/>
 					</div>
 				) : (

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -78,8 +78,8 @@ interface FileTreePaneProps {
 	renamingPath: string | null;
 	onStartRename: (path: string) => void;
 	onCancelRename: () => void;
-	onCommitFileRename: (path: string, nextName: string) => Promise<void>;
-	onCommitDirRename: (dirPath: string, nextName: string) => Promise<void>;
+	onCommitFileRename: (path: string, nextName: string) => Promise<boolean>;
+	onCommitDirRename: (dirPath: string, nextName: string) => Promise<boolean>;
 	onMovePath: (
 		fromPath: string,
 		toDirPath: string,
@@ -283,8 +283,8 @@ interface TreeEntriesProps {
 	onDuplicateFile: (path: string) => Promise<string | null>;
 	onDeletePath: (path: string, kind: "dir" | "file") => Promise<void>;
 	onStartRename: (path: string) => void;
-	onCommitDirRename: (dirPath: string, nextName: string) => Promise<void>;
-	onCommitFileRename: (path: string, nextName: string) => Promise<void>;
+	onCommitDirRename: (dirPath: string, nextName: string) => Promise<boolean>;
+	onCommitFileRename: (path: string, nextName: string) => Promise<boolean>;
 	onCancelRename: () => void;
 	itemAppearance: Record<string, FileTreeAppearance>;
 	folderFileCounts: Record<string, number>;

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -7,7 +7,6 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
-	useRef,
 	useState,
 } from "react";
 import { useSpace } from "../../contexts";
@@ -18,6 +17,7 @@ import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
 import type { FileTreeAppearance, NoteTaskSummary } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { basename, parentDir, splitEditableFileName } from "../../utils/path";
+import { InlineRenameInput } from "../InlineRenameInput";
 import { TaskProgressIndicator } from "../checklists/TaskProgressIndicator";
 import { DatabaseColumnIcon } from "../database/DatabaseColumnIcon";
 import { formatDatabaseTagLabel } from "../database/databaseTagLabel";
@@ -332,67 +332,6 @@ function useFolioFirstUrl(note: FolioItem): string {
 	return url;
 }
 
-function FolioRenameInput({
-	initialName,
-	relPath,
-	fileStem,
-	fileExt,
-	onCommitRename,
-	onCancelRename,
-}: {
-	initialName: string;
-	relPath: string;
-	fileStem: string;
-	fileExt: string;
-	onCommitRename: (
-		path: string,
-		nextName: string,
-	) => Promise<boolean> | boolean;
-	onCancelRename: () => void;
-}) {
-	const [draftName, setDraftName] = useState(initialName);
-	const submittedRef = useRef(false);
-	const inputRef = useRef<HTMLInputElement | null>(null);
-
-	useEffect(() => {
-		inputRef.current?.focus();
-		inputRef.current?.select();
-	}, []);
-
-	const commitRename = async () => {
-		if (submittedRef.current) return;
-		submittedRef.current = true;
-		const nextStem = draftName.trim() || fileStem || initialName.trim();
-		const renamed = await onCommitRename(relPath, `${nextStem}${fileExt}`);
-		if (!renamed) {
-			submittedRef.current = false;
-		}
-	};
-
-	return (
-		<input
-			ref={inputRef}
-			className="plainTextInput folioNoteRenameInput"
-			value={draftName}
-			placeholder="Untitled"
-			onChange={(event) => setDraftName(event.target.value)}
-			onBlur={() => void commitRename()}
-			onKeyDown={(event) => {
-				if (event.key === "Enter") {
-					event.preventDefault();
-					void commitRename();
-					return;
-				}
-				if (event.key === "Escape") {
-					event.preventDefault();
-					submittedRef.current = true;
-					onCancelRename();
-				}
-			}}
-		/>
-	);
-}
-
 export const FolioNoteListItem = memo(
 	forwardRef<HTMLLIElement, FolioNoteListItemProps>(function FolioNoteListItem(
 		{
@@ -613,14 +552,21 @@ export const FolioNoteListItem = memo(
 						style={rowStyle}
 					>
 						<span className="folioNoteRowTop">
-							<FolioRenameInput
+							<InlineRenameInput
 								key={`${note.note_path}:${fileStem}`}
-								initialName={fileStem || titleFromPath(note.note_path)}
-								relPath={note.note_path}
-								fileStem={fileStem}
-								fileExt={fileExt}
-								onCommitRename={onCommitRename}
-								onCancelRename={onCancelRename}
+								initialValue={fileStem || titleFromPath(note.note_path)}
+								className="plainTextInput folioNoteRenameInput"
+								placeholder="Untitled"
+								onCommit={(draftName) => {
+									const initialName = fileStem || titleFromPath(note.note_path);
+									const nextStem =
+										draftName.trim() || fileStem || initialName.trim();
+									return onCommitRename(
+										note.note_path,
+										`${nextStem}${fileExt}`,
+									);
+								}}
+								onCancel={onCancelRename}
 							/>
 							{taskProgress}
 						</span>

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -334,11 +334,11 @@ export function AppearanceSettingsPane() {
 
 	const lightOptions: readonly UiThemeOption<UiLightThemeId>[] = [
 		...LIGHT_THEME_OPTIONS,
-		...customThemeOptions(customThemes, "light"),
+		...customThemeOptions(customThemes),
 	];
 	const darkOptions: readonly UiThemeOption<UiDarkThemeId>[] = [
 		...DARK_THEME_OPTIONS,
-		...customThemeOptions(customThemes, "dark"),
+		...customThemeOptions(customThemes),
 	];
 	const lightTheme =
 		lightOptions.find((option) => option.id === lightThemeId.value) ??

--- a/src/components/settings/AppearanceThemeCard.tsx
+++ b/src/components/settings/AppearanceThemeCard.tsx
@@ -1,5 +1,4 @@
 import { cn } from "@/lib/utils";
-import type { CSSProperties } from "react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type {
@@ -7,11 +6,7 @@ import type {
 	UiDarkThemeId,
 	UiLightThemeId,
 } from "../../lib/settings";
-import {
-	type UiThemeOption,
-	type UiThemePreview,
-	sortUiThemeOptions,
-} from "../../lib/uiThemes";
+import { type UiThemeOption, sortUiThemeOptions } from "../../lib/uiThemes";
 import { ChevronDown } from "../Icons";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/shadcn/popover";
 import { AppearanceThemeModePicker } from "./AppearanceThemeModePicker";
@@ -34,12 +29,19 @@ interface AppearanceThemeCardProps {
 	onTranslucentAppChange: (enabled: boolean) => Promise<void>;
 }
 
-function getBadgeStyle(preview: UiThemePreview): CSSProperties {
-	return {
-		"--theme-preview-badge-bg": preview.badgeBackground,
-		"--theme-preview-badge-border": preview.badgeBorder,
-		"--theme-preview-badge-text": preview.badgeText,
-	} as CSSProperties;
+function ThemeBadge({
+	mode,
+	themeId,
+}: { mode: "light" | "dark"; themeId: string }) {
+	return (
+		<span
+			className={cn("appearanceThemeBadge appearanceThemePreview", mode)}
+			data-light-theme={mode === "light" ? themeId : undefined}
+			data-dark-theme={mode === "dark" ? themeId : undefined}
+		>
+			Aa
+		</span>
+	);
 }
 
 function ThemeSelector<T extends string>({
@@ -70,11 +72,10 @@ function ThemeSelector<T extends string>({
 					<button
 						type="button"
 						className={cn("appearanceThemeDropdownTrigger", open && "is-open")}
-						style={getBadgeStyle(selected.preview)}
 						aria-expanded={open}
 					>
 						<span className="appearanceThemeDropdownLeading">
-							<span className="appearanceThemeBadge">Aa</span>
+							<ThemeBadge mode={mode} themeId={selected.id} />
 							<span className="appearanceThemeDropdownTitle">
 								{selected.label}
 							</span>
@@ -112,7 +113,6 @@ function ThemeSelector<T extends string>({
 										"appearanceThemeDropdownOption",
 										selectedOption && "is-selected",
 									)}
-									style={getBadgeStyle(option.preview)}
 									onClick={() => {
 										void onSelect(option.id);
 										setOpen(false);
@@ -120,7 +120,7 @@ function ThemeSelector<T extends string>({
 									aria-pressed={selectedOption}
 								>
 									<span className="appearanceThemeDropdownOptionLead">
-										<span className="appearanceThemeBadge">Aa</span>
+										<ThemeBadge mode={mode} themeId={option.id} />
 										<span className="appearanceThemeDropdownOptionTitle">
 											{option.label}
 										</span>

--- a/src/components/status/PropertyOptionPicker.tsx
+++ b/src/components/status/PropertyOptionPicker.tsx
@@ -1,0 +1,162 @@
+import type { MouseEvent } from "react";
+import {
+	priorityColorKey,
+	priorityOptionsWithCustomValues,
+} from "../../lib/priorityProperties";
+import {
+	statusColorKey,
+	statusOptionsWithCustomValues,
+} from "../../lib/statusProperties";
+import { EDITOR_TEXT_COLORS, type EditorTextColor } from "../editor/textColors";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "../ui/shadcn/dropdown-menu";
+import { PriorityPropertyPill } from "./PriorityPropertyPill";
+import { StatusPropertyPill } from "./StatusPropertyPill";
+
+interface PropertyPickerBaseProps {
+	value: string;
+	valueOptions?: readonly string[];
+	triggerClassName: string;
+	triggerTitle?: string;
+	triggerAriaLabel?: string;
+	onTriggerFocus?: () => void;
+	onTriggerClick?: () => void;
+	stopTriggerClickPropagation?: boolean;
+	onChange: (value: string) => void | Promise<void>;
+	onError?: (error: unknown) => void;
+}
+
+interface StatusPropertyPickerProps extends PropertyPickerBaseProps {
+	kind: "status";
+	colors?: Record<string, EditorTextColor>;
+	onColorChange?: (value: string, color: EditorTextColor | null) => void;
+}
+
+interface PriorityPropertyPickerProps extends PropertyPickerBaseProps {
+	kind: "priority";
+}
+
+export type PropertyOptionPickerProps =
+	| StatusPropertyPickerProps
+	| PriorityPropertyPickerProps;
+
+function handleTriggerClick(
+	event: MouseEvent<HTMLButtonElement>,
+	onClick: (() => void) | undefined,
+	stopPropagation: boolean | undefined,
+): void {
+	onClick?.();
+	if (stopPropagation) event.stopPropagation();
+}
+
+export function PropertyOptionPicker(props: PropertyOptionPickerProps) {
+	const values = [props.value, ...(props.valueOptions ?? [])];
+	const isStatus = props.kind === "status";
+	const selectedId = isStatus
+		? statusColorKey(props.value)
+		: priorityColorKey(props.value);
+	const options = isStatus
+		? statusOptionsWithCustomValues(values)
+		: priorityOptionsWithCustomValues(values);
+
+	const selectValue = async (value: string) => {
+		try {
+			await props.onChange(value);
+		} catch (error) {
+			props.onError?.(error);
+		}
+	};
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					className={props.triggerClassName}
+					title={props.triggerTitle}
+					aria-label={props.triggerAriaLabel}
+					onFocus={props.onTriggerFocus}
+					onClick={(event) =>
+						handleTriggerClick(
+							event,
+							props.onTriggerClick,
+							props.stopTriggerClickPropagation,
+						)
+					}
+				>
+					{isStatus ? (
+						<StatusPropertyPill
+							value={props.value || "not_started"}
+							colors={props.colors}
+						/>
+					) : (
+						<PriorityPropertyPill value={props.value || "no"} />
+					)}
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent
+				align="start"
+				sideOffset={6}
+				className="databasePickerMenu notePropertyStatusMenu"
+			>
+				<div className="notePropertyStatusOptions">
+					{options.map((option) => (
+						<DropdownMenuItem
+							key={option.id}
+							className="notePropertyStatusOption"
+							data-selected={
+								(isStatus
+									? statusColorKey(option.label)
+									: priorityColorKey(option.label)) === selectedId
+									? "true"
+									: "false"
+							}
+							onClick={() => void selectValue(option.label)}
+						>
+							{isStatus ? (
+								<StatusPropertyPill
+									value={option.label}
+									colors={props.colors}
+								/>
+							) : (
+								<PriorityPropertyPill value={option.label} />
+							)}
+						</DropdownMenuItem>
+					))}
+				</div>
+				{isStatus && selectedId && props.onColorChange ? (
+					<>
+						<DropdownMenuSeparator className="databaseBoardContextMenuSeparator" />
+						<div className="notePropertyStatusColorRibbon">
+							{EDITOR_TEXT_COLORS.map((color) => (
+								<button
+									key={color.id}
+									type="button"
+									className="databaseBoardColorRibbonSwatch"
+									style={{ background: `var(${color.cssVar})` }}
+									onClick={() => props.onColorChange?.(props.value, color.id)}
+									title={color.label}
+									aria-label={`Set ${props.value} color to ${color.label}`}
+								/>
+							))}
+							<button
+								type="button"
+								className="databaseBoardColorRibbonClear"
+								onClick={() => props.onColorChange?.(props.value, null)}
+								title="Clear color"
+								aria-label={`Clear color for ${props.value}`}
+							>
+								<span />
+							</button>
+						</div>
+					</>
+				) : null}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/src/lib/customThemes.ts
+++ b/src/lib/customThemes.ts
@@ -201,7 +201,7 @@ function themeRule(theme: CustomTheme, mode: "light" | "dark"): string {
 	const declarations = paletteVariables(theme[mode])
 		.map(([property, value]) => `\t${property}: ${value};`)
 		.join("\n");
-	return `:root.${mode}[data-${mode}-theme="${id}"] {\n${declarations}\n}`;
+	return `:where(:root, .appearanceThemePreview).${mode}[data-${mode}-theme="${id}"] {\n${declarations}\n}`;
 }
 
 export function buildCustomThemeCss(themes: readonly CustomTheme[]): string {
@@ -223,25 +223,15 @@ export function applyCustomThemes(themes: readonly CustomTheme[]): void {
 
 export function customThemeOption(
 	theme: CustomTheme,
-	mode: "light" | "dark",
 ): UiThemeOption<CustomUiThemeId> {
-	const palette = theme[mode];
 	return {
 		id: customThemeId(theme.name),
 		label: theme.name,
-		preview: {
-			badgeBackground: palette.surface,
-			badgeBorder: palette.border,
-			badgeText: palette.accent,
-			surface: palette.background,
-			text: palette.foreground,
-		},
 	};
 }
 
 export function customThemeOptions(
 	themes: readonly CustomTheme[],
-	mode: "light" | "dark",
 ): UiThemeOption<CustomUiThemeId>[] {
-	return themes.map((theme) => customThemeOption(theme, mode));
+	return themes.map(customThemeOption);
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -360,7 +360,7 @@ function asReleaseChannel(value: unknown): ReleaseChannel {
 	return value === "alpha" ? "alpha" : "stable";
 }
 
-async function emitSettingsUpdated(payload: {
+interface SettingsUpdatedPayload {
 	spacePath?: string;
 	ui?: {
 		theme?: ThemeMode;
@@ -423,7 +423,11 @@ async function emitSettingsUpdated(payload: {
 	shortcuts?: {
 		bindings?: ShortcutBindings;
 	};
-}): Promise<void> {
+}
+
+async function emitSettingsUpdated(
+	payload: SettingsUpdatedPayload,
+): Promise<void> {
 	try {
 		if (payload.spacePath) {
 			await emitTo(getCurrentWindow().label, "settings:updated", payload);
@@ -572,6 +576,21 @@ const KEYS = {
 	databaseShowColumnColor: "database.showColumnColor",
 	spaceScopedSettings: "space.scopedSettings",
 } as const;
+
+type SettingsKey = (typeof KEYS)[keyof typeof KEYS];
+
+async function persistSetting<Value>(
+	key: SettingsKey,
+	value: Value,
+	payload: SettingsUpdatedPayload,
+	afterSave?: (value: Value) => void,
+): Promise<void> {
+	const store = await getSettingsStore();
+	await store.set(key, value);
+	await saveSettingsStore(store);
+	afterSave?.(value);
+	void emitSettingsUpdated(payload);
+}
 
 function isShortcutBindingRecord(
 	value: unknown,
@@ -1257,206 +1276,162 @@ export async function resetAllShortcutBindings(): Promise<void> {
 }
 
 export async function setAiAssistantMode(mode: AiAssistantMode): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.aiAssistantMode, mode);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { aiAssistantMode: mode } });
+	await persistSetting(KEYS.aiAssistantMode, mode, {
+		ui: { aiAssistantMode: mode },
+	});
 }
 
 export async function setAiEnabled(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.aiEnabled, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { aiEnabled: enabled } });
+	await persistSetting(KEYS.aiEnabled, enabled, { ui: { aiEnabled: enabled } });
 }
 
 export async function setLanguage(language: AppLanguage): Promise<void> {
-	const store = await getSettingsStore();
 	const normalized = normalizeAppLanguage(language);
-	await store.set(KEYS.language, normalized);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { language: normalized } });
+	await persistSetting(KEYS.language, normalized, {
+		ui: { language: normalized },
+	});
 }
 
 export async function setDateDisplayFormat(
 	format: DateDisplayFormat,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = normalizeDateDisplayFormat(format);
-	await store.set(KEYS.dateDisplayFormat, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { dateDisplayFormat: next } });
+	await persistSetting(KEYS.dateDisplayFormat, next, {
+		ui: { dateDisplayFormat: next },
+	});
 }
 
 export async function setThemeMode(theme: ThemeMode): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.theme, theme);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { theme } });
+	await persistSetting(KEYS.theme, theme, { ui: { theme } });
 }
 
 export async function setUiLightThemeId(
 	lightThemeId: UiLightThemeId,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiLightThemeId(lightThemeId);
-	await store.set(KEYS.lightThemeId, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { lightThemeId: next } });
+	await persistSetting(KEYS.lightThemeId, next, { ui: { lightThemeId: next } });
 }
 
 export async function setUiDarkThemeId(
 	darkThemeId: UiDarkThemeId,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiDarkThemeId(darkThemeId);
-	await store.set(KEYS.darkThemeId, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { darkThemeId: next } });
+	await persistSetting(KEYS.darkThemeId, next, { ui: { darkThemeId: next } });
 }
 
 export async function setUiCustomThemes(
 	customThemes: readonly CustomTheme[],
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = normalizeCustomThemes(customThemes);
-	await store.set(KEYS.customThemes, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { customThemes: next } });
+	await persistSetting(KEYS.customThemes, next, { ui: { customThemes: next } });
 }
 
 export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiFontFamily(fontFamily);
-	await store.set(KEYS.fontFamily, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { fontFamily: next } });
+	await persistSetting(KEYS.fontFamily, next, { ui: { fontFamily: next } });
 }
 
 export async function setUiEditorFontFamily(
 	fontFamily: UiFontFamily,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiEditorFontFamily(fontFamily);
-	await store.set(KEYS.editorFontFamily, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { editorFontFamily: next } });
+	await persistSetting(KEYS.editorFontFamily, next, {
+		ui: { editorFontFamily: next },
+	});
 }
 
 export async function setUiMonoFontFamily(
 	fontFamily: UiFontFamily,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiMonoFontFamily(fontFamily);
-	await store.set(KEYS.monoFontFamily, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { monoFontFamily: next } });
+	await persistSetting(KEYS.monoFontFamily, next, {
+		ui: { monoFontFamily: next },
+	});
 }
 
 export async function setUiFontSize(fontSize: UiFontSize): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiFontSize(fontSize);
-	await store.set(KEYS.fontSize, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { fontSize: next } });
+	await persistSetting(KEYS.fontSize, next, { ui: { fontSize: next } });
 }
 
 export async function setUiEditorFontSize(fontSize: UiFontSize): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiEditorFontSize(fontSize);
-	await store.set(KEYS.editorFontSize, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { editorFontSize: next } });
+	await persistSetting(KEYS.editorFontSize, next, {
+		ui: { editorFontSize: next },
+	});
 }
 
 export async function setUiTranslucentApp(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.translucentApp, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { translucentApp: enabled } });
+	await persistSetting(KEYS.translucentApp, enabled, {
+		ui: { translucentApp: enabled },
+	});
 }
 
 export async function setUiCornerRadiusStyle(
 	style: UiCornerRadiusStyle,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asUiCornerRadiusStyle(style);
-	await store.set(KEYS.cornerRadiusStyle, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { cornerRadiusStyle: next } });
+	await persistSetting(KEYS.cornerRadiusStyle, next, {
+		ui: { cornerRadiusStyle: next },
+	});
 }
 
 export async function setShowToc(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.showToc, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { showToc: enabled } });
+	await persistSetting(KEYS.showToc, enabled, { ui: { showToc: enabled } });
 }
 
 export async function setShowFileTreeFolderCounts(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.showFileTreeFolderCounts, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { showFileTreeFolderCounts: enabled } });
+	await persistSetting(KEYS.showFileTreeFolderCounts, enabled, {
+		ui: { showFileTreeFolderCounts: enabled },
+	});
 }
 
 export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.showNonMarkdownFiles, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { showNonMarkdownFiles: enabled } });
+	await persistSetting(KEYS.showNonMarkdownFiles, enabled, {
+		ui: { showNonMarkdownFiles: enabled },
+	});
 }
 
 export async function setFileTreeSortMode(
 	sortMode: FileTreeSortMode,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.fileTreeSortMode, sortMode);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { fileTreeSortMode: sortMode } });
+	await persistSetting(KEYS.fileTreeSortMode, sortMode, {
+		ui: { fileTreeSortMode: sortMode },
+	});
 }
 
 export async function setFolioMode(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.folioMode, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { folioMode: enabled } });
+	await persistSetting(KEYS.folioMode, enabled, { ui: { folioMode: enabled } });
 }
 
 export async function setClassicAllNotesByDefault(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.classicAllNotesByDefault, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { classicAllNotesByDefault: enabled } });
+	await persistSetting(KEYS.classicAllNotesByDefault, enabled, {
+		ui: { classicAllNotesByDefault: enabled },
+	});
 }
 
 export async function setResumeLastSession(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.resumeLastSession, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { resumeLastSession: enabled } });
+	await persistSetting(KEYS.resumeLastSession, enabled, {
+		ui: { resumeLastSession: enabled },
+	});
 }
 
 export async function setKeepRunningOnLastWindowClose(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.keepRunningOnLastWindowClose, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { keepRunningOnLastWindowClose: enabled } });
+	await persistSetting(KEYS.keepRunningOnLastWindowClose, enabled, {
+		ui: { keepRunningOnLastWindowClose: enabled },
+	});
 }
 
 export async function setEditorShowCollapsibleHeadings(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorShowCollapsibleHeadings, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorShowCollapsibleHeadings, enabled, {
 		editor: { showCollapsibleHeadings: enabled },
 	});
 }
@@ -1464,10 +1439,7 @@ export async function setEditorShowCollapsibleHeadings(
 export async function setEditorShowCollapsibleLists(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorShowCollapsibleLists, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorShowCollapsibleLists, enabled, {
 		editor: { showCollapsibleLists: enabled },
 	});
 }
@@ -1475,10 +1447,7 @@ export async function setEditorShowCollapsibleLists(
 export async function setEditorColorfulHeadings(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorColorfulHeadings, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorColorfulHeadings, enabled, {
 		editor: { colorfulHeadings: enabled },
 	});
 }
@@ -1486,10 +1455,7 @@ export async function setEditorColorfulHeadings(
 export async function setEditorShowHeadingPrefixes(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorShowHeadingPrefixes, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorShowHeadingPrefixes, enabled, {
 		editor: { showHeadingPrefixes: enabled },
 	});
 }
@@ -1497,20 +1463,14 @@ export async function setEditorShowHeadingPrefixes(
 export async function setEditorHeadingPaletteId(
 	headingPaletteId: HeadingPaletteId,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asHeadingPaletteId(headingPaletteId);
-	await store.set(KEYS.editorHeadingPaletteId, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorHeadingPaletteId, next, {
 		editor: { headingPaletteId: next },
 	});
 }
 
 export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorBeautifulTags, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorBeautifulTags, enabled, {
 		editor: { beautifulTags: enabled },
 	});
 }
@@ -1518,10 +1478,7 @@ export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
 export async function setEditorShowFrontmatterInEditor(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorShowFrontmatterInEditor, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorShowFrontmatterInEditor, enabled, {
 		editor: { showFrontmatterInEditor: enabled },
 	});
 }
@@ -1529,22 +1486,18 @@ export async function setEditorShowFrontmatterInEditor(
 export async function setEditorDefaultEditorMode(
 	mode: EditorViewMode,
 ): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asDefaultEditorMode(mode);
-	await store.set(KEYS.editorDefaultEditorMode, next);
-	await saveSettingsStore(store);
-	setCachedDefaultEditorViewMode(next);
-	void emitSettingsUpdated({
-		editor: { defaultEditorMode: next },
-	});
+	await persistSetting(
+		KEYS.editorDefaultEditorMode,
+		next,
+		{ editor: { defaultEditorMode: next } },
+		setCachedDefaultEditorViewMode,
+	);
 }
 
 export async function setEditorWidthMode(mode: EditorWidthMode): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asEditorWidthMode(mode);
-	await store.set(KEYS.editorEditorWidthMode, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorEditorWidthMode, next, {
 		editor: { editorWidthMode: next },
 	});
 }
@@ -1567,10 +1520,7 @@ export async function setEditorAttachmentStorageMode(
 		});
 		return;
 	}
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorAttachmentStorageMode, nextMode);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorAttachmentStorageMode, nextMode, {
 		editor: { attachmentStorageMode: nextMode },
 	});
 }
@@ -1600,10 +1550,7 @@ export async function setEditorAttachmentFolder(
 		});
 		return;
 	}
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorAttachmentFolder, nextFolder);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorAttachmentFolder, nextFolder, {
 		editor: { attachmentFolder: nextFolder },
 	});
 }
@@ -1611,10 +1558,7 @@ export async function setEditorAttachmentFolder(
 export async function setEditorEnablePeopleMentionsAsTags(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorEnablePeopleMentionsAsTags, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorEnablePeopleMentionsAsTags, enabled, {
 		editor: { enablePeopleMentionsAsTags: enabled },
 	});
 }
@@ -1622,19 +1566,13 @@ export async function setEditorEnablePeopleMentionsAsTags(
 export async function setEditorRawMarkdownVimMode(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorRawMarkdownVimMode, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorRawMarkdownVimMode, enabled, {
 		editor: { rawMarkdownVimMode: enabled },
 	});
 }
 
 export async function setEditorSpellCheck(enabled: boolean): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorSpellCheck, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorSpellCheck, enabled, {
 		editor: { spellCheck: enabled },
 	});
 }
@@ -1642,20 +1580,14 @@ export async function setEditorSpellCheck(enabled: boolean): Promise<void> {
 export async function setEditorShowExternalLinkPreviews(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.editorShowExternalLinkPreviews, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorShowExternalLinkPreviews, enabled, {
 		editor: { showExternalLinkPreviews: enabled },
 	});
 }
 
 export async function setEditorFocusMode(mode: FocusMode): Promise<void> {
-	const store = await getSettingsStore();
 	const next = asFocusMode(mode);
-	await store.set(KEYS.editorFocusMode, next);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
+	await persistSetting(KEYS.editorFocusMode, next, {
 		editor: { focusMode: next },
 	});
 }
@@ -1707,10 +1639,9 @@ export async function setQuickNotesFolder(
 		void emitSettingsUpdated({ spacePath, quickNotes: { folder: nextFolder } });
 		return;
 	}
-	const store = await getSettingsStore();
-	await store.set(KEYS.quickNotesFolder, nextFolder);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ quickNotes: { folder: nextFolder } });
+	await persistSetting(KEYS.quickNotesFolder, nextFolder, {
+		quickNotes: { folder: nextFolder },
+	});
 }
 
 export async function getTemplatesFolder(
@@ -1798,10 +1729,9 @@ export async function setDailyNoteTemplate(
 export async function setDatabaseShowColumnColor(
 	enabled: boolean,
 ): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(KEYS.databaseShowColumnColor, enabled);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ database: { showColumnColor: enabled } });
+	await persistSetting(KEYS.databaseShowColumnColor, enabled, {
+		database: { showColumnColor: enabled },
+	});
 }
 
 export async function setAutoUpdateLastCheckedAt(
@@ -1824,10 +1754,9 @@ export async function setReleaseChannel(
 	channel: ReleaseChannel,
 ): Promise<void> {
 	const nextChannel = asReleaseChannel(channel);
-	const store = await getSettingsStore();
-	await store.set(KEYS.releaseChannel, nextChannel);
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ ui: { releaseChannel: nextChannel } });
+	await persistSetting(KEYS.releaseChannel, nextChannel, {
+		ui: { releaseChannel: nextChannel },
+	});
 }
 
 export async function getRecentFiles(): Promise<RecentFile[]> {

--- a/src/lib/uiThemes.ts
+++ b/src/lib/uiThemes.ts
@@ -4,229 +4,87 @@ import {
 	isCustomThemeId,
 } from "./customThemes";
 
-export interface UiThemePreview {
-	badgeBackground: string;
-	badgeBorder: string;
-	badgeText: string;
-	surface: string;
-	text: string;
-}
-
 export interface UiThemeOption<T extends string> {
 	id: T;
 	label: string;
-	preview: UiThemePreview;
 }
 
 export const LIGHT_THEME_OPTIONS = [
 	{
 		id: "glyph-default",
 		label: "Glyph",
-		preview: {
-			badgeBackground: "#f7f6f3",
-			badgeBorder: "#e3e2de",
-			badgeText: "#37352f",
-			surface: "#ffffff",
-			text: "#37352f",
-		},
 	},
 	{
 		id: "ayu-light",
 		label: "Ayu",
-		preview: {
-			badgeBackground: "#fcfcfc",
-			badgeBorder: "#d9d8d7",
-			badgeText: "#ff9940",
-			surface: "#fcfcfc",
-			text: "#5c6773",
-		},
 	},
 	{
 		id: "catppuccin-latte",
 		label: "Catppuccin Latte",
-		preview: {
-			badgeBackground: "#eff1f5",
-			badgeBorder: "#ccd0da",
-			badgeText: "#8839ef",
-			surface: "#eff1f5",
-			text: "#4c4f69",
-		},
 	},
 	{
 		id: "claude-light",
 		label: "Claude",
-		preview: {
-			badgeBackground: "#faf3ef",
-			badgeBorder: "#e8d5cc",
-			badgeText: "#c96442",
-			surface: "#faf9f5",
-			text: "#141413",
-		},
 	},
 	{
 		id: "codex-light",
 		label: "Codex",
-		preview: {
-			badgeBackground: "#e8f2fc",
-			badgeBorder: "#b3d4f0",
-			badgeText: "#0169cc",
-			surface: "#ffffff",
-			text: "#0d0d0d",
-		},
 	},
 	{
 		id: "everforest-light",
 		label: "Everforest",
-		preview: {
-			badgeBackground: "#f1efe6",
-			badgeBorder: "#d2cab7",
-			badgeText: "#7f9b4e",
-			surface: "#f6f2e8",
-			text: "#475258",
-		},
 	},
 	{
 		id: "flexoki-light",
 		label: "Flexoki Light",
-		preview: {
-			badgeBackground: "#F2F0E5",
-			badgeBorder: "#CECDC3",
-			badgeText: "#205EA6",
-			surface: "#FFFCF0",
-			text: "#100F0F",
-		},
 	},
 	{
 		id: "github-light",
 		label: "GitHub",
-		preview: {
-			badgeBackground: "#ffffff",
-			badgeBorder: "#d0d7de",
-			badgeText: "#0969da",
-			surface: "#ffffff",
-			text: "#1f2328",
-		},
 	},
 	{
 		id: "gruvbox-light",
 		label: "Gruvbox",
-		preview: {
-			badgeBackground: "#fbf1c7",
-			badgeBorder: "#d5c4a1",
-			badgeText: "#af3a03",
-			surface: "#fbf1c7",
-			text: "#3c3836",
-		},
 	},
 	{
 		id: "horizon-light",
 		label: "Horizon Light",
-		preview: {
-			badgeBackground: "#fdf0ed",
-			badgeBorder: "#f9cec3",
-			badgeText: "#1d8991",
-			surface: "#fdf0ed",
-			text: "#403c3d",
-		},
 	},
 	{
 		id: "linear-light",
 		label: "Linear",
-		preview: {
-			badgeBackground: "#f4f5fb",
-			badgeBorder: "#d9dced",
-			badgeText: "#5e6ad2",
-			surface: "#f7f7f8",
-			text: "#222530",
-		},
 	},
 	{
 		id: "nord-light",
 		label: "Nord Light",
-		preview: {
-			badgeBackground: "#eceff4",
-			badgeBorder: "#c4cad4",
-			badgeText: "#5e81ac",
-			surface: "#eceff4",
-			text: "#2e3440",
-		},
 	},
 	{
 		id: "notion",
 		label: "Notion",
-		preview: {
-			badgeBackground: "#f7f3ee",
-			badgeBorder: "#ddd4c9",
-			badgeText: "#2383c6",
-			surface: "#ffffff",
-			text: "#37352f",
-		},
 	},
 	{
 		id: "one-light",
 		label: "One Light",
-		preview: {
-			badgeBackground: "#f6f7fb",
-			badgeBorder: "#d8dde7",
-			badgeText: "#4078f2",
-			surface: "#fafafa",
-			text: "#383a42",
-		},
 	},
 	{
 		id: "raycast-light",
 		label: "Raycast",
-		preview: {
-			badgeBackground: "#fff1f1",
-			badgeBorder: "#ffd4d4",
-			badgeText: "#ff6363",
-			surface: "#ffffff",
-			text: "#030303",
-		},
 	},
 	{
 		id: "rose-pine-dawn",
 		label: "Rose Pine Dawn",
-		preview: {
-			badgeBackground: "#faf4ed",
-			badgeBorder: "#e1d0c8",
-			badgeText: "#b4637a",
-			surface: "#faf4ed",
-			text: "#575279",
-		},
 	},
 	{
 		id: "solarized-light",
 		label: "Solarized Light",
-		preview: {
-			badgeBackground: "#fdf6e3",
-			badgeBorder: "#d9cda8",
-			badgeText: "#b58900",
-			surface: "#fdf6e3",
-			text: "#586e75",
-		},
 	},
 	{
 		id: "tokyo-night-day",
 		label: "Tokyo Night Day",
-		preview: {
-			badgeBackground: "#e9e9ed",
-			badgeBorder: "#c7cbe0",
-			badgeText: "#3760bf",
-			surface: "#e1e2e7",
-			text: "#3760bf",
-		},
 	},
 	{
 		id: "xcode-light",
 		label: "Xcode",
-		preview: {
-			badgeBackground: "#f6f6f6",
-			badgeBorder: "#d6d6d6",
-			badgeText: "#0066cc",
-			surface: "#ffffff",
-			text: "#3d3d3d",
-		},
 	},
 ] as const satisfies readonly UiThemeOption<string>[];
 
@@ -234,222 +92,82 @@ export const DARK_THEME_OPTIONS = [
 	{
 		id: "glyph-default-dark",
 		label: "Glyph",
-		preview: {
-			badgeBackground: "#252525",
-			badgeBorder: "#3a3a3a",
-			badgeText: "#e8e8e8",
-			surface: "#191919",
-			text: "#e8e8e8",
-		},
 	},
 	{
 		id: "ayu-dark",
 		label: "Ayu Dark",
-		preview: {
-			badgeBackground: "#141821",
-			badgeBorder: "#1b1f29",
-			badgeText: "#e6b450",
-			surface: "#10141c",
-			text: "#bfbdb6",
-		},
 	},
 	{
 		id: "catppuccin-mocha",
 		label: "Catppuccin Mocha",
-		preview: {
-			badgeBackground: "#181825",
-			badgeBorder: "#313244",
-			badgeText: "#cba6f7",
-			surface: "#1e1e2e",
-			text: "#cdd6f4",
-		},
 	},
 	{
 		id: "claude-dark",
 		label: "Claude",
-		preview: {
-			badgeBackground: "#2a2420",
-			badgeBorder: "#4a3830",
-			badgeText: "#d97757",
-			surface: "#141413",
-			text: "#e8e6dc",
-		},
 	},
 	{
 		id: "codex-dark",
 		label: "Codex",
-		preview: {
-			badgeBackground: "#1a2636",
-			badgeBorder: "#2a3f5c",
-			badgeText: "#4da3ff",
-			surface: "#181818",
-			text: "#ffffff",
-		},
 	},
 	{
 		id: "dracula",
 		label: "Dracula",
-		preview: {
-			badgeBackground: "#181a24",
-			badgeBorder: "#3a3752",
-			badgeText: "#bd93f9",
-			surface: "#282a36",
-			text: "#f8f8f2",
-		},
 	},
 	{
 		id: "everforest-dark",
 		label: "Everforest Dark",
-		preview: {
-			badgeBackground: "#2d353b",
-			badgeBorder: "#475258",
-			badgeText: "#a7c080",
-			surface: "#2d353b",
-			text: "#d3c6aa",
-		},
 	},
 	{
 		id: "flexoki-dark",
 		label: "Flexoki Dark",
-		preview: {
-			badgeBackground: "#282726",
-			badgeBorder: "#403E3C",
-			badgeText: "#4385BE",
-			surface: "#1C1B1A",
-			text: "#CECDC3",
-		},
 	},
 	{
 		id: "github-dark",
 		label: "GitHub Dark",
-		preview: {
-			badgeBackground: "#0d1117",
-			badgeBorder: "#30363d",
-			badgeText: "#58a6ff",
-			surface: "#0d1117",
-			text: "#e6edf3",
-		},
 	},
 	{
 		id: "gruvbox-dark",
 		label: "Gruvbox Dark",
-		preview: {
-			badgeBackground: "#1d2021",
-			badgeBorder: "#3c3836",
-			badgeText: "#fe8019",
-			surface: "#282828",
-			text: "#ebdbb2",
-		},
 	},
 	{
 		id: "monokai",
 		label: "Monokai",
-		preview: {
-			badgeBackground: "#1e1f1c",
-			badgeBorder: "#414339",
-			badgeText: "#f8f8f2",
-			surface: "#272822",
-			text: "#f8f8f2",
-		},
 	},
 	{
 		id: "night-owl",
 		label: "Night Owl",
-		preview: {
-			badgeBackground: "#07111d",
-			badgeBorder: "#16314c",
-			badgeText: "#82aaff",
-			surface: "#011627",
-			text: "#d6deeb",
-		},
 	},
 	{
 		id: "nord-dark",
 		label: "Nord Dark",
-		preview: {
-			badgeBackground: "#232833",
-			badgeBorder: "#3f4858",
-			badgeText: "#88c0d0",
-			surface: "#2e3440",
-			text: "#eceff4",
-		},
 	},
 	{
 		id: "one-dark",
 		label: "One Dark",
-		preview: {
-			badgeBackground: "#151922",
-			badgeBorder: "#2d3443",
-			badgeText: "#61afef",
-			surface: "#282c34",
-			text: "#abb2bf",
-		},
 	},
 	{
 		id: "raycast-dark",
 		label: "Raycast",
-		preview: {
-			badgeBackground: "#1f1010",
-			badgeBorder: "#4a2828",
-			badgeText: "#ff6363",
-			surface: "#101010",
-			text: "#fefefe",
-		},
 	},
 	{
 		id: "rose-pine-moon",
 		label: "Rose Pine",
-		preview: {
-			badgeBackground: "#171521",
-			badgeBorder: "#383154",
-			badgeText: "#eb9cb4",
-			surface: "#232136",
-			text: "#e0def4",
-		},
 	},
 	{
 		id: "solarized-dark",
 		label: "Solarized Dark",
-		preview: {
-			badgeBackground: "#001f27",
-			badgeBorder: "#0b3b47",
-			badgeText: "#ff4d4d",
-			surface: "#002b36",
-			text: "#93a1a1",
-		},
 	},
 	{
 		id: "tokyo-night",
 		label: "Tokyo Night",
-		preview: {
-			badgeBackground: "#13141d",
-			badgeBorder: "#28304a",
-			badgeText: "#7dcfff",
-			surface: "#1a1b26",
-			text: "#c0caf5",
-		},
 	},
 	{
 		id: "xcode-dark",
 		label: "Xcode",
-		preview: {
-			badgeBackground: "#34353b",
-			badgeBorder: "#4a4b52",
-			badgeText: "#6bdfff",
-			surface: "#292a30",
-			text: "#cecfd0",
-		},
 	},
 	{
 		id: "vesper",
 		label: "Vesper",
-		preview: {
-			badgeBackground: "#101010",
-			badgeBorder: "#505050",
-			badgeText: "#FFC799",
-			surface: "#101010",
-			text: "#FFFFFF",
-		},
 	},
 ] as const satisfies readonly UiThemeOption<string>[];
 

--- a/src/styles/app/27-settings-appearance.css
+++ b/src/styles/app/27-settings-appearance.css
@@ -129,9 +129,9 @@
 	min-width: 24px;
 	padding: 0;
 	border-radius: 6px;
-	border: 1px solid var(--theme-preview-badge-border);
-	background: var(--theme-preview-badge-bg);
-	color: var(--theme-preview-badge-text);
+	border: 1px solid var(--border-default);
+	background: var(--bg-secondary);
+	color: var(--interactive-accent);
 	font-size: calc(var(--text-base) * 0.68);
 	font-weight: var(--font-semibold);
 	letter-spacing: -0.04em;

--- a/src/styles/themes/dark-themes.css
+++ b/src/styles/themes/dark-themes.css
@@ -1,4 +1,4 @@
-:root.dark {
+:where(:root, .appearanceThemePreview).dark {
 	--glyph-inline-color-gray: #b6c2cf;
 	--glyph-inline-color-brown: #d4a574;
 	--glyph-inline-color-orange: #fba034;
@@ -24,8 +24,11 @@
 		rgba(0, 0, 0, 0.25);
 }
 
-:root.dark:not([data-dark-theme]),
-:root.dark[data-dark-theme="glyph-default-dark"] {
+:where(:root, .appearanceThemePreview).dark:not([data-dark-theme]),
+:where(
+		:root,
+		.appearanceThemePreview
+	).dark[data-dark-theme="glyph-default-dark"] {
 	/* Clean neutral default — warm charcoal surfaces with soft off-white text. */
 	--bg-primary: #191919;
 	--bg-secondary: #252525;
@@ -83,7 +86,7 @@
 	--glass-bg: rgba(25, 25, 25, 0.72);
 }
 
-:root.dark[data-dark-theme="solarized-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="solarized-dark"] {
 	--bg-primary: #002b36;
 	--bg-secondary: #073642;
 	--bg-tertiary: #0a4250;
@@ -128,7 +131,7 @@
 	--glass-bg: rgba(0, 43, 54, 0.66);
 }
 
-:root.dark[data-dark-theme="github-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="github-dark"] {
 	--bg-primary: #0d1117;
 	--bg-secondary: #161b22;
 	--bg-tertiary: #1f2630;
@@ -173,7 +176,7 @@
 	--glass-bg: rgba(13, 17, 23, 0.68);
 }
 
-:root.dark[data-dark-theme="nord-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="nord-dark"] {
 	--bg-primary: #2e3440;
 	--bg-secondary: #343c4a;
 	--bg-tertiary: #3b4252;
@@ -218,7 +221,7 @@
 	--glass-bg: rgba(46, 52, 64, 0.64);
 }
 
-:root.dark[data-dark-theme="tokyo-night"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="tokyo-night"] {
 	--bg-primary: #1a1b26;
 	--bg-secondary: #1f2335;
 	--bg-tertiary: #24283b;
@@ -263,7 +266,7 @@
 	--glass-bg: rgba(26, 27, 38, 0.66);
 }
 
-:root.dark[data-dark-theme="dracula"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="dracula"] {
 	--bg-primary: #282a36;
 	--bg-secondary: #303341;
 	--bg-tertiary: #383c4d;
@@ -308,7 +311,7 @@
 	--glass-bg: rgba(40, 42, 54, 0.68);
 }
 
-:root.dark[data-dark-theme="night-owl"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="night-owl"] {
 	--bg-primary: #011627;
 	--bg-secondary: #0b1d32;
 	--bg-tertiary: #10243c;
@@ -342,7 +345,7 @@
 	--glass-bg: rgba(1, 22, 39, 0.68);
 }
 
-:root.dark[data-dark-theme="one-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="one-dark"] {
 	--bg-primary: #282c34;
 	--bg-secondary: #21252b;
 	--bg-tertiary: #2f343d;
@@ -376,7 +379,7 @@
 	--glass-bg: rgba(40, 44, 52, 0.68);
 }
 
-:root.dark[data-dark-theme="rose-pine-moon"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="rose-pine-moon"] {
 	--bg-primary: #232136;
 	--bg-secondary: #2a273f;
 	--bg-tertiary: #312c4f;
@@ -410,7 +413,10 @@
 	--glass-bg: rgba(35, 33, 54, 0.7);
 }
 
-:root.dark[data-dark-theme="catppuccin-mocha"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).dark[data-dark-theme="catppuccin-mocha"] {
 	--bg-primary: #1e1e2e;
 	--bg-secondary: #181825;
 	--bg-tertiary: #11111b;
@@ -455,9 +461,9 @@
 	--glass-bg: rgba(30, 30, 46, 0.72);
 }
 
-:root.dark[data-dark-theme="night-owl"],
-:root.dark[data-dark-theme="one-dark"],
-:root.dark[data-dark-theme="rose-pine-moon"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="night-owl"],
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="one-dark"],
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="rose-pine-moon"] {
 	--text-error: var(--status-danger-fg);
 	--feedback-error-bg: color-mix(
 		in srgb,
@@ -487,7 +493,7 @@
 	--callout-error: var(--status-danger-fg);
 }
 
-:root.dark[data-dark-theme="gruvbox-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="gruvbox-dark"] {
 	--bg-primary: #282828;
 	--bg-secondary: #1d2021;
 	--bg-tertiary: #3c3836;
@@ -532,7 +538,7 @@
 	--glass-bg: rgba(40, 40, 40, 0.72);
 }
 
-:root.dark[data-dark-theme="monokai"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="monokai"] {
 	--bg-primary: #272822;
 	--bg-secondary: #1e1f1c;
 	--bg-tertiary: #414339;
@@ -577,7 +583,7 @@
 	--glass-bg: rgba(39, 40, 34, 0.72);
 }
 
-:root.dark[data-dark-theme="ayu-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="ayu-dark"] {
 	--bg-primary: #10141c;
 	--bg-secondary: #141821;
 	--bg-tertiary: #0d1017;
@@ -622,7 +628,7 @@
 	--glass-bg: rgba(16, 20, 28, 0.74);
 }
 
-:root.dark[data-dark-theme="vesper"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="vesper"] {
 	--bg-primary: #101010;
 	--bg-secondary: #161616;
 	--bg-tertiary: #1c1c1c;
@@ -667,7 +673,7 @@
 	--glass-bg: rgba(16, 16, 16, 0.74);
 }
 
-:root.dark[data-dark-theme="flexoki-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="flexoki-dark"] {
 	--bg-primary: #1c1b1a;
 	--bg-secondary: #282726;
 	--bg-tertiary: #343331;
@@ -712,7 +718,7 @@
 	--glass-bg: rgba(28, 27, 26, 0.74);
 }
 
-:root.dark[data-dark-theme="everforest-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="everforest-dark"] {
 	--bg-primary: #2d353b;
 	--bg-secondary: #343f44;
 	--bg-tertiary: #3d484d;
@@ -757,7 +763,7 @@
 	--glass-bg: rgba(45, 53, 59, 0.72);
 }
 
-:root.dark[data-dark-theme="claude-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="claude-dark"] {
 	--bg-primary: #141413;
 	--bg-secondary: #1f1e1c;
 	--bg-tertiary: #2a2926;
@@ -802,7 +808,7 @@
 	--glass-bg: rgba(20, 20, 19, 0.74);
 }
 
-:root.dark[data-dark-theme="codex-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="codex-dark"] {
 	--bg-primary: #181818;
 	--bg-secondary: #222222;
 	--bg-tertiary: #2a2a2a;
@@ -847,7 +853,7 @@
 	--glass-bg: rgba(24, 24, 24, 0.74);
 }
 
-:root.dark[data-dark-theme="raycast-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="raycast-dark"] {
 	--bg-primary: #101010;
 	--bg-secondary: #181818;
 	--bg-tertiary: #222222;
@@ -892,7 +898,7 @@
 	--glass-bg: rgba(16, 16, 16, 0.74);
 }
 
-:root.dark[data-dark-theme="xcode-dark"] {
+:where(:root, .appearanceThemePreview).dark[data-dark-theme="xcode-dark"] {
 	--bg-primary: #292a30;
 	--bg-secondary: #32333a;
 	--bg-tertiary: #3a3b42;

--- a/src/styles/themes/light-themes.css
+++ b/src/styles/themes/light-themes.css
@@ -1,5 +1,5 @@
-:root.light:not([data-light-theme]),
-:root.light[data-light-theme="glyph-default"] {
+:where(:root, .appearanceThemePreview).light:not([data-light-theme]),
+:where(:root, .appearanceThemePreview).light[data-light-theme="glyph-default"] {
 	/* Clean neutral default — white surfaces, soft gray chrome, Notion-style ink. */
 	--bg-primary: #ffffff;
 	--bg-secondary: #f7f6f3;
@@ -40,7 +40,7 @@
 	--shadow-float: none;
 }
 
-:root.light[data-light-theme="notion"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="notion"] {
 	--bg-primary: #ffffff;
 	--bg-secondary: #f8f7f4;
 	--bg-tertiary: #f2f1ed;
@@ -85,7 +85,10 @@
 	--glass-bg: rgba(255, 255, 255, 0.82);
 }
 
-:root.light[data-light-theme="solarized-light"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="solarized-light"] {
 	--bg-primary: #fdf6e3;
 	--bg-secondary: #f5efdc;
 	--bg-tertiary: #eee8d5;
@@ -130,7 +133,7 @@
 	--glass-bg: rgba(253, 246, 227, 0.84);
 }
 
-:root.light[data-light-theme="github-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="github-light"] {
 	--bg-primary: #ffffff;
 	--bg-secondary: #f6f8fa;
 	--bg-tertiary: #eff2f5;
@@ -175,7 +178,7 @@
 	--glass-bg: rgba(255, 255, 255, 0.86);
 }
 
-:root.light[data-light-theme="nord-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="nord-light"] {
 	--bg-primary: #eceff4;
 	--bg-secondary: #e5e9f0;
 	--bg-tertiary: #d8dee9;
@@ -220,7 +223,10 @@
 	--glass-bg: rgba(236, 239, 244, 0.82);
 }
 
-:root.light[data-light-theme="everforest-light"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="everforest-light"] {
 	--bg-primary: #f6f2e8;
 	--bg-secondary: #f1ede1;
 	--bg-tertiary: #e6dfcf;
@@ -251,7 +257,7 @@
 	--glass-bg: rgba(246, 242, 232, 0.84);
 }
 
-:root.light[data-light-theme="linear-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="linear-light"] {
 	--bg-primary: #f7f7f8;
 	--bg-secondary: #f2f3f7;
 	--bg-tertiary: #e8ebf2;
@@ -282,7 +288,7 @@
 	--glass-bg: rgba(247, 247, 248, 0.84);
 }
 
-:root.light[data-light-theme="one-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="one-light"] {
 	--bg-primary: #fafafa;
 	--bg-secondary: #f5f6f9;
 	--bg-tertiary: #eceff5;
@@ -313,7 +319,10 @@
 	--glass-bg: rgba(250, 250, 250, 0.86);
 }
 
-:root.light[data-light-theme="rose-pine-dawn"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="rose-pine-dawn"] {
 	--bg-primary: #faf4ed;
 	--bg-secondary: #f7efe5;
 	--bg-tertiary: #f0e4d7;
@@ -344,7 +353,10 @@
 	--glass-bg: rgba(250, 244, 237, 0.86);
 }
 
-:root.light[data-light-theme="catppuccin-latte"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="catppuccin-latte"] {
 	--bg-primary: #eff1f5;
 	--bg-secondary: #e6e9ef;
 	--bg-tertiary: #dce0e8;
@@ -389,10 +401,16 @@
 	--glass-bg: rgba(239, 241, 245, 0.84);
 }
 
-:root.light[data-light-theme="everforest-light"],
-:root.light[data-light-theme="linear-light"],
-:root.light[data-light-theme="one-light"],
-:root.light[data-light-theme="rose-pine-dawn"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="everforest-light"],
+:where(:root, .appearanceThemePreview).light[data-light-theme="linear-light"],
+:where(:root, .appearanceThemePreview).light[data-light-theme="one-light"],
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="rose-pine-dawn"] {
 	--text-placeholder: color-mix(in srgb, var(--text-primary) 40%, transparent);
 	--text-inverse: var(--bg-primary);
 	--text-accent: var(--text-primary);
@@ -425,7 +443,7 @@
 	--callout-error: var(--status-danger-fg);
 }
 
-:root.light[data-light-theme="gruvbox-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="gruvbox-light"] {
 	--bg-primary: #fbf1c7;
 	--bg-secondary: #f2e5bc;
 	--bg-tertiary: #ebdbb2;
@@ -470,7 +488,7 @@
 	--glass-bg: rgba(251, 241, 199, 0.84);
 }
 
-:root.light[data-light-theme="ayu-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="ayu-light"] {
 	--bg-primary: #fcfcfc;
 	--bg-secondary: #f8f9fa;
 	--bg-tertiary: #f0eee4;
@@ -515,7 +533,10 @@
 	--glass-bg: rgba(252, 252, 252, 0.86);
 }
 
-:root.light[data-light-theme="tokyo-night-day"] {
+:where(
+		:root,
+		.appearanceThemePreview
+	).light[data-light-theme="tokyo-night-day"] {
 	--bg-primary: #e1e2e7;
 	--bg-secondary: #d8dbe4;
 	--bg-tertiary: #cfd5e3;
@@ -560,7 +581,7 @@
 	--glass-bg: rgba(225, 226, 231, 0.84);
 }
 
-:root.light[data-light-theme="horizon-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="horizon-light"] {
 	--bg-primary: #fdf0ed;
 	--bg-secondary: #fbe4df;
 	--bg-tertiary: #fadad1;
@@ -605,7 +626,7 @@
 	--glass-bg: rgba(253, 240, 237, 0.84);
 }
 
-:root.light[data-light-theme="flexoki-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="flexoki-light"] {
 	--bg-primary: #fffcf0;
 	--bg-secondary: #f2f0e5;
 	--bg-tertiary: #e6e4d9;
@@ -650,7 +671,7 @@
 	--glass-bg: rgba(255, 252, 240, 0.86);
 }
 
-:root.light[data-light-theme="claude-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="claude-light"] {
 	--bg-primary: #faf9f5;
 	--bg-secondary: #f5f4ed;
 	--bg-tertiary: #ecebe4;
@@ -695,7 +716,7 @@
 	--glass-bg: rgba(250, 249, 245, 0.86);
 }
 
-:root.light[data-light-theme="codex-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="codex-light"] {
 	--bg-primary: #ffffff;
 	--bg-secondary: #f7f8fa;
 	--bg-tertiary: #eef1f5;
@@ -740,7 +761,7 @@
 	--glass-bg: rgba(255, 255, 255, 0.86);
 }
 
-:root.light[data-light-theme="xcode-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="xcode-light"] {
 	--bg-primary: #ffffff;
 	--bg-secondary: #f6f6f6;
 	--bg-tertiary: #f0f0f0;
@@ -785,7 +806,7 @@
 	--glass-bg: rgba(255, 255, 255, 0.86);
 }
 
-:root.light[data-light-theme="raycast-light"] {
+:where(:root, .appearanceThemePreview).light[data-light-theme="raycast-light"] {
 	--bg-primary: #ffffff;
 	--bg-secondary: #f7f7f7;
 	--bg-tertiary: #eeeeee;


### PR DESCRIPTION
Closes


## Description

Refactor that deepens several shared modules and removes duplication, centered on settings and theme previews.

- **Theme previews use real theme CSS.** Theme selectors in `dark-themes.css` / `light-themes.css` (and custom theme CSS in `customThemes.ts`) now match `:where(:root, .appearanceThemePreview)`, so the theme-picker badge renders the actual theme colors instead of JS-computed inline styles. `UiThemePreview` and `uiThemes.ts` are removed; `customThemeOption`/`customThemeOptions` no longer take a mode.
- **Settings persistence deduped.** `settings.ts` gains a `persistSetting` helper and an extracted `SettingsUpdatedPayload` type, collapsing the repeated get-store → set → save → emit pattern across all setters.
- **Shared suggestion menu.** `tiptapSuggestionMenu.ts` adds `createTipTapTextSuggestionMenu`, replacing duplicated item rendering in the markdown-link, person, tag, and wiki-link autocompletes.
- **Shared inline rename.** New `InlineRenameInput` component, used by `FileTreeDirItem`, `FileTreeFileItem`, and `FolioNoteListItem`.
- **Shared status/priority picker.** New `PropertyOptionPicker` unifies the status and priority dropdown logic in `DatabaseCell` and `NotePropertyValueField`.

Net: ~480 lines removed.

Also bundles some agent-workflow housekeeping (`AGENTS.md` `gh` CLI guidance, `docs/agents/*`) and a `pnpm-workspace.yaml` cleanup.


## Screenshots

The appearance theme-picker badge now previews themes with their actual colors — worth a quick visual check.


## Docs

No documentation changes needed. The theme-preview approach is self-documenting via the `:where(:root, .appearanceThemePreview)` selector.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Unify UI theming, settings persistence, suggestion menus, and inline rename behavior while reducing duplication across shared modules.

New Features:
- Add a shared PropertyOptionPicker for status and priority properties used in databases and note properties.
- Introduce a reusable InlineRenameInput component for inline file and folder renaming in the file tree and folio views.
- Provide a generic createTipTapTextSuggestionMenu helper for text-based autocomplete menus in the editor.

Enhancements:
- Make appearance theme previews render using real theme CSS by aligning theme selectors and preview badges with light/dark theme variables and custom themes.
- Deduplicate settings persistence logic via a common persistSetting helper and shared SettingsUpdatedPayload type.
- Surface database status/priority save errors inline in DatabaseCell to improve feedback.
- Simplify UI theme option definitions by removing per-theme preview color data and relying on CSS-driven previews.
- Update AGENTS guidance to standardize on GitHub CLI usage, Mac-only platform focus, and add domain/issue-tracker/triage-labels docs.
- Tidy pnpm workspace configuration by removing the global virtual store setting.

Documentation:
- Add agent-facing documentation for domain modeling, GitHub-based issue tracking, and triage labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deepens shared modules to remove UI duplication and standardize behavior across themes, settings, suggestions, and inline rename. Theme badges now render using real theme CSS instead of inline JS; settings setters persist via one helper; editor autocompletes share a text suggestion menu; inline rename is unified across file tree and folio.

- Theme previews: broaden selectors to :where(:root, .appearanceThemePreview) for light/dark and custom themes; preview badges now use theme tokens (border/background/accent). UiThemeOption no longer has preview. Custom themes: call customThemeOptions(customThemes) only.
- Suggestions: replace createTipTapSuggestionMenu with createTipTapTextSuggestionMenu in markdown link, wiki link, person, and tag extensions.
- Inline rename: new InlineRenameInput used in file tree and folio. Rename commit handlers now return Promise<boolean>; update FileTreePane/SidebarContent props. Enter commits, Escape cancels.
- Status/priority picker: new PropertyOptionPicker replaces bespoke menus in DatabaseCell and NotePropertyValueField; DatabaseCell surfaces inline save errors.
- Tables: DatabaseTable sets a stable getRowId using note_path.
- Settings: add persistSetting and typed SettingsUpdatedPayload; existing settings:updated events remain.
- Housekeeping: add docs under docs/agents/, clean up pnpm-workspace.yaml, bump Tauri to 0.8.14-alpha.4.

<sup>Written for commit dd2c1f75863df08af8611a8bae1f8009cf3f38d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate theme previews, settings persistence, suggestions, and inline rename into shared components
> - Theme CSS selectors in [dark-themes.css](https://github.com/SidhuK/Glyph/pull/487/files#diff-ba77a405961f839593d45ad3acf90ca1c14b867c4cb3b6516986fcfbc7ede96a) and [light-themes.css](https://github.com/SidhuK/Glyph/pull/487/files#diff-42525ac11f2e621c6aca4513c44dcae0fb6198baeced688bb50d75d19d576b8f) now match `.appearanceThemePreview` elements in addition to `:root`, enabling in-place theme preview badges rendered by [AppearanceThemeCard.tsx](https://github.com/SidhuK/Glyph/pull/487/files#diff-046c021d3a2eba1f670314618484e4a152db7eb70eeb5f62a44609935c963920) without inline CSS variables.
> - Adds `persistSetting` helper in [settings.ts](https://github.com/SidhuK/Glyph/pull/487/files#diff-b5f5521c9795e314efdf6293ad3afda789a1402bbf5e2a304e20efa8134d2a15) that centralises store get/set/save, optional callback, and `settings:updated` emit; all ~40 setter functions are refactored to use it.
> - Adds shared [InlineRenameInput.tsx](https://github.com/SidhuK/Glyph/pull/487/files#diff-66860826e34297adc54091c2bc2ef212dd392d3940f157c8c57d984ab9ab2b5e) component (focus-select, IME-safe Enter, Escape-to-cancel, optional pointer-event containment) and replaces inline rename inputs in the file tree and folio list.
> - Adds `createTipTapTextSuggestionMenu` in [tiptapSuggestionMenu.ts](https://github.com/SidhuK/Glyph/pull/487/files#diff-9d92279b466b86ca5124a3840186d9480c007271f11aa98730062ebd66fbd692) with a `title`/`description` item API; switches wiki link, tag, person, and markdown link autocomplete extensions to use it.
> - Adds shared `PropertyOptionPicker` in [PropertyOptionPicker.tsx](https://github.com/SidhuK/Glyph/pull/487/files#diff-aaf1d349b3adf53e5bc0c5fb18cdd1bddc15ceacc1f88f4250ba757cbf31230f) for status/priority selection with inline color ribbon; replaces duplicate dropdown implementations in `DatabaseCell`, `DatabaseCellEditor`, and `NotePropertyValueField`.
> - `UiThemeOption` and `customThemeOption` no longer carry a `preview` color object; callers that previously read preview palette values will now receive only `id` and `label`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd2c1f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline rename support for files, folders, and notes, including commit, cancel, and retry behavior.
  * Added reusable status and priority pickers with save-error handling.
  * Improved editor suggestion menus with consistent titles, descriptions, and selection behavior.
  * Enhanced custom theme previews across light and dark themes.

* **Bug Fixes**
  * Custom themes now display correctly in both theme modes and preview containers.
  * Improved persistence and update handling for settings changes.

* **Documentation**
  * Expanded guidance for repository context, issue tracking, triage labels, and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->