### PR TITLE
Consolidate settings definitions (#485)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1109,10 +1109,13 @@ fn should_exit_after_external_markdown_close(app: &tauri::AppHandle) -> bool {
 }
 
 #[cfg(target_os = "macos")]
+const KEEP_RUNNING_ON_LAST_WINDOW_CLOSE_SETTING_KEY: &str = "ui.keepRunningOnLastWindowClose";
+
+#[cfg(target_os = "macos")]
 fn keep_running_on_last_window_close(app: &tauri::AppHandle) -> bool {
     app.store("settings.json")
         .ok()
-        .and_then(|store| store.get("ui.keepRunningOnLastWindowClose"))
+        .and_then(|store| store.get(KEEP_RUNNING_ON_LAST_WINDOW_CLOSE_SETTING_KEY))
         .and_then(|value| value.as_bool())
         .unwrap_or(false)
 }

--- a/src/components/app/settingsPaletteRegistry.ts
+++ b/src/components/app/settingsPaletteRegistry.ts
@@ -3,52 +3,25 @@ import { LANGUAGE_OPTIONS } from "../../i18n/locales";
 import {
 	type AppSettings,
 	DATE_DISPLAY_FORMAT_OPTIONS,
-	DEFAULT_QUICK_NOTES_FOLDER,
+	DURABLE_SETTINGS,
 	MAX_EDITOR_FONT_SIZE,
 	MAX_UI_FONT_SIZE,
 	MIN_EDITOR_FONT_SIZE,
 	MIN_UI_FONT_SIZE,
-	setAiAssistantMode,
-	setAiEnabled,
-	setClassicAllNotesByDefault,
-	setDailyNotesFolder,
-	setDatabaseShowColumnColor,
-	setDateDisplayFormat,
-	setEditorAttachmentStorageMode,
-	setEditorBeautifulTags,
-	setEditorColorfulHeadings,
-	setEditorRawMarkdownVimMode,
-	setEditorShowCollapsibleHeadings,
-	setEditorShowCollapsibleLists,
-	setEditorShowExternalLinkPreviews,
-	setEditorShowFrontmatterInEditor,
-	setEditorSpellCheck,
-	setEditorWidthMode,
-	setFileTreeSortMode,
-	setFolioMode,
-	setKeepRunningOnLastWindowClose,
-	setLanguage,
-	setQuickNotesFolder,
-	setReleaseChannel,
-	setResumeLastSession,
-	setShowFileTreeFolderCounts,
-	setShowNonMarkdownFiles,
-	setShowToc,
+	SPACE_SETTINGS,
 	setTemplatesFolder,
-	setThemeMode,
-	setUiDarkThemeId,
-	setUiEditorFontFamily,
-	setUiEditorFontSize,
-	setUiFontFamily,
-	setUiFontSize,
-	setUiLightThemeId,
-	setUiMonoFontFamily,
-	setUiTranslucentApp,
+	writeSpaceSetting,
 } from "../../lib/settings";
+import type {
+	ApplicationSettingDefinition,
+	SpaceSettingDefinition,
+} from "../../lib/settings/definitions";
 import { invoke } from "../../lib/tauri";
 import { DARK_THEME_OPTIONS, LIGHT_THEME_OPTIONS } from "../../lib/uiThemes";
 import type { SettingsTab } from "../settings/settingsConfig";
 import { SETTINGS_SEARCH_ENTRIES } from "../settings/settingsSearch";
+
+type PaletteSettingValue = string | number | boolean | null;
 
 export type PaletteSettingControl =
 	| "toggle"
@@ -72,86 +45,86 @@ export interface PaletteSettingDefinition {
 	min?: number;
 	max?: number;
 	options?: readonly PaletteSettingOption[];
-	read: (settings: AppSettings) => string | number | boolean | null;
+	read: (settings: AppSettings) => PaletteSettingValue;
 	write: (
-		value: string | number | boolean | null,
+		value: PaletteSettingValue,
 		spacePath: string | null,
 	) => Promise<void>;
 }
 
 type EditablePaletteSettingDefinition = Omit<PaletteSettingDefinition, "tab">;
+type SettingBinding = Pick<
+	EditablePaletteSettingDefinition,
+	"id" | "scope" | "read" | "write"
+>;
 
 function invalidValue(): never {
 	throw new Error(i18n.t("shell:commandPalette.invalidSettingValue"));
 }
 
-function requireString(value: string | number | boolean | null): string {
-	return typeof value === "string" ? value : invalidValue();
+function searchableId<Value>(
+	definition:
+		| ApplicationSettingDefinition<Value>
+		| SpaceSettingDefinition<Value>,
+): string {
+	if (definition.discovery.kind === "search") return definition.discovery.id;
+	throw new Error(`Palette setting is hidden: ${definition.discovery.reason}`);
 }
 
-function requireBoolean(value: string | number | boolean | null): boolean {
-	return typeof value === "boolean" ? value : invalidValue();
+function bindApplicationSetting<Value extends PaletteSettingValue>(
+	definition: ApplicationSettingDefinition<Value>,
+): SettingBinding {
+	return {
+		id: searchableId(definition),
+		scope: "application",
+		read: definition.read,
+		write: async (value) => {
+			const result = definition.parse(value);
+			if (!result.ok) invalidValue();
+			await definition.write(result.value);
+		},
+	};
 }
 
-function requireNumber(value: string | number | boolean | null): number {
-	return typeof value === "number" && Number.isFinite(value)
-		? value
-		: invalidValue();
-}
-
-function scope(spacePath: string | null) {
-	return { spacePath };
+function bindSpaceSetting<Value extends PaletteSettingValue>(
+	definition: SpaceSettingDefinition<Value>,
+): SettingBinding {
+	return {
+		id: searchableId(definition),
+		scope: "space",
+		read: definition.read,
+		write: async (value, spacePath) => {
+			const result = definition.parse(value);
+			if (!result.ok) invalidValue();
+			await writeSpaceSetting(definition, result.value, { spacePath });
+		},
+	};
 }
 
 const editableDefinitions: readonly EditablePaletteSettingDefinition[] = [
 	{
-		id: "general-language",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.language),
 		control: "choice",
 		options: LANGUAGE_OPTIONS.map(({ id, nativeLabel }) => ({
 			value: id,
 			label: nativeLabel,
 		})),
-		read: (settings) => settings.ui.language,
-		write: async (value) => {
-			const language = requireString(value);
-			const option = LANGUAGE_OPTIONS.find(({ id }) => id === language);
-			if (!option) invalidValue();
-			await setLanguage(option.id);
-		},
 	},
 	{
-		id: "general-date-format",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.dateDisplayFormat),
 		control: "choice",
 		options: DATE_DISPLAY_FORMAT_OPTIONS,
-		read: (settings) => settings.ui.dateDisplayFormat,
-		write: async (value) => {
-			const format = requireString(value);
-			const option = DATE_DISPLAY_FORMAT_OPTIONS.find(
-				(candidate) => candidate.value === format,
-			);
-			if (!option) invalidValue();
-			await setDateDisplayFormat(option.value);
-		},
 	},
 	{
-		id: "general-resume-last-session",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.resumeLastSession),
 		control: "toggle",
-		read: (settings) => settings.ui.resumeLastSession,
-		write: (value) => setResumeLastSession(requireBoolean(value)),
 	},
 	{
-		id: "general-keep-running-on-close",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.keepRunningOnLastWindowClose),
 		control: "toggle",
-		read: (settings) => settings.ui.keepRunningOnLastWindowClose,
-		write: (value) => setKeepRunningOnLastWindowClose(requireBoolean(value)),
 	},
 	{
-		id: "appearance-theme-mode",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.theme),
 		control: "choice",
 		defaultVisible: true,
 		options: [
@@ -159,138 +132,68 @@ const editableDefinitions: readonly EditablePaletteSettingDefinition[] = [
 			{ value: "light", label: "Light" },
 			{ value: "dark", label: "Dark" },
 		],
-		read: (settings) => settings.ui.theme,
-		write: async (value) => {
-			const mode = requireString(value);
-			if (mode !== "system" && mode !== "light" && mode !== "dark")
-				invalidValue();
-			await setThemeMode(mode);
-		},
 	},
 	{
-		id: "appearance-light-theme",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.lightThemeId),
 		control: "choice",
 		options: LIGHT_THEME_OPTIONS.map(({ id, label }) => ({ value: id, label })),
-		read: (settings) => settings.ui.lightThemeId,
-		write: async (value) => {
-			const id = requireString(value);
-			const option = LIGHT_THEME_OPTIONS.find(
-				(candidate) => candidate.id === id,
-			);
-			if (!option) invalidValue();
-			await setUiLightThemeId(option.id);
-		},
 	},
 	{
-		id: "appearance-dark-theme",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.darkThemeId),
 		control: "choice",
 		options: DARK_THEME_OPTIONS.map(({ id, label }) => ({ value: id, label })),
-		read: (settings) => settings.ui.darkThemeId,
-		write: async (value) => {
-			const id = requireString(value);
-			const option = DARK_THEME_OPTIONS.find(
-				(candidate) => candidate.id === id,
-			);
-			if (!option) invalidValue();
-			await setUiDarkThemeId(option.id);
-		},
 	},
 	{
-		id: "appearance-translucent-app",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.translucentApp),
 		control: "toggle",
-		read: (settings) => settings.ui.translucentApp,
-		write: (value) => setUiTranslucentApp(requireBoolean(value)),
 	},
 	{
-		id: "appearance-interface-font",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.fontFamily),
 		control: "text",
-		read: (settings) => settings.ui.fontFamily,
-		write: (value) => setUiFontFamily(requireString(value)),
 	},
 	{
-		id: "appearance-editor-font",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorFontFamily),
 		control: "text",
-		read: (settings) => settings.ui.editorFontFamily,
-		write: (value) => setUiEditorFontFamily(requireString(value)),
 	},
 	{
-		id: "appearance-monospace-font",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.monoFontFamily),
 		control: "text",
-		read: (settings) => settings.ui.monoFontFamily,
-		write: (value) => setUiMonoFontFamily(requireString(value)),
 	},
 	{
-		id: "appearance-ui-font-size",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.fontSize),
 		control: "number",
 		min: MIN_UI_FONT_SIZE,
 		max: MAX_UI_FONT_SIZE,
-		read: (settings) => settings.ui.fontSize,
-		write: (value) => setUiFontSize(requireNumber(value)),
 	},
 	{
-		id: "appearance-editor-font-size",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorFontSize),
 		control: "number",
 		min: MIN_EDITOR_FONT_SIZE,
 		max: MAX_EDITOR_FONT_SIZE,
-		read: (settings) => settings.ui.editorFontSize,
-		write: (value) => setUiEditorFontSize(requireNumber(value)),
 	},
 	{
-		id: "ai-features",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.aiEnabled),
 		control: "toggle",
 		defaultVisible: true,
-		read: (settings) => settings.ui.aiEnabled,
-		write: (value) => setAiEnabled(requireBoolean(value)),
 	},
 	{
-		id: "ai-assistant-behavior-tools",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.aiAssistantMode),
 		control: "choice",
 		options: [
 			{ value: "chat", label: "Chat" },
 			{ value: "create", label: "Create" },
 		],
-		read: (settings) => settings.ui.aiAssistantMode,
-		write: async (value) => {
-			const mode = requireString(value);
-			if (mode !== "chat" && mode !== "create") invalidValue();
-			await setAiAssistantMode(mode);
-		},
 	},
 	{
-		id: "space-daily-notes-folder",
-		scope: "space",
+		...bindSpaceSetting(SPACE_SETTINGS.dailyNotesFolder),
 		control: "path",
-		read: (settings) => settings.dailyNotes.folder,
-		write: (value, spacePath) =>
-			setDailyNotesFolder(
-				value === null ? null : requireString(value),
-				scope(spacePath),
-			),
 	},
 	{
-		id: "space-quick-notes-folder",
-		scope: "space",
+		...bindSpaceSetting(SPACE_SETTINGS.quickNotesFolder),
 		control: "path",
-		read: (settings) => settings.quickNotes.folder,
-		write: (value, spacePath) =>
-			setQuickNotesFolder(
-				value === null ? DEFAULT_QUICK_NOTES_FOLDER : requireString(value),
-				scope(spacePath),
-			),
 	},
 	{
-		id: "space-attachments-location",
-		scope: "space",
+		...bindSpaceSetting(SPACE_SETTINGS.attachmentStorageMode),
 		control: "choice",
 		options: [
 			{ value: "space-root", label: "Space root" },
@@ -298,29 +201,16 @@ const editableDefinitions: readonly EditablePaletteSettingDefinition[] = [
 			{ value: "note-folder", label: "Note folder" },
 			{ value: "note-subfolder", label: "Note subfolder" },
 		],
-		read: (settings) => settings.editor.attachmentStorageMode,
-		write: async (value, spacePath) => {
-			const mode = requireString(value);
-			if (
-				mode !== "space-root" &&
-				mode !== "specific-folder" &&
-				mode !== "note-folder" &&
-				mode !== "note-subfolder"
-			)
-				invalidValue();
-			await setEditorAttachmentStorageMode(mode, scope(spacePath));
-		},
 	},
 	{
 		id: "space-template-folder",
 		scope: "space",
 		control: "path",
 		read: (settings) => settings.templates.folder,
-		write: (value, spacePath) =>
-			setTemplatesFolder(
-				value === null ? null : requireString(value),
-				scope(spacePath),
-			),
+		write: (value, spacePath) => {
+			if (typeof value !== "string" && value !== null) invalidValue();
+			return setTemplatesFolder(value, { spacePath });
+		},
 	},
 	{
 		id: "space-search-index-status",
@@ -332,119 +222,71 @@ const editableDefinitions: readonly EditablePaletteSettingDefinition[] = [
 		},
 	},
 	{
-		id: "general-editor-table-of-contents",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.showToc),
 		control: "toggle",
 		defaultVisible: true,
-		read: (settings) => settings.ui.showToc,
-		write: (value) => setShowToc(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-frontmatter",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorShowFrontmatterInEditor),
 		control: "toggle",
-		read: (settings) => settings.editor.showFrontmatterInEditor,
-		write: (value) => setEditorShowFrontmatterInEditor(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-colorful-headings",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorColorfulHeadings),
 		control: "toggle",
-		read: (settings) => settings.editor.colorfulHeadings,
-		write: (value) => setEditorColorfulHeadings(requireBoolean(value)),
 	},
 	{
-		id: "appearance-editor-presentation-beautiful-tags",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorBeautifulTags),
 		control: "toggle",
-		read: (settings) => settings.editor.beautifulTags,
-		write: (value) => setEditorBeautifulTags(requireBoolean(value)),
 	},
 	{
-		id: "appearance-editor-presentation-width",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorWidthMode),
 		control: "choice",
 		options: [
 			{ value: "compact", label: "Compact" },
 			{ value: "comfortable", label: "Comfortable" },
 			{ value: "wide", label: "Wide" },
 		],
-		read: (settings) => settings.editor.editorWidthMode,
-		write: async (value) => {
-			const width = requireString(value);
-			if (width !== "compact" && width !== "comfortable" && width !== "wide")
-				invalidValue();
-			await setEditorWidthMode(width);
-		},
 	},
 	{
-		id: "general-editor-collapsible-headings",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorShowCollapsibleHeadings),
 		control: "toggle",
-		read: (settings) => settings.editor.showCollapsibleHeadings,
-		write: (value) => setEditorShowCollapsibleHeadings(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-collapsible-lists",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorShowCollapsibleLists),
 		control: "toggle",
-		read: (settings) => settings.editor.showCollapsibleLists,
-		write: (value) => setEditorShowCollapsibleLists(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-spell-check",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorSpellCheck),
 		control: "toggle",
 		defaultVisible: true,
-		read: (settings) => settings.editor.spellCheck,
-		write: (value) => setEditorSpellCheck(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-external-link-previews",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorShowExternalLinkPreviews),
 		control: "toggle",
-		read: (settings) => settings.editor.showExternalLinkPreviews,
-		write: (value) => setEditorShowExternalLinkPreviews(requireBoolean(value)),
 	},
 	{
-		id: "general-editor-vim-mode",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.editorRawMarkdownVimMode),
 		control: "toggle",
-		read: (settings) => settings.editor.rawMarkdownVimMode,
-		write: (value) => setEditorRawMarkdownVimMode(requireBoolean(value)),
 	},
 	{
-		id: "appearance-layout-folio-mode",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.folioMode),
 		control: "toggle",
 		defaultVisible: true,
-		read: (settings) => settings.ui.folioMode,
-		write: (value) => setFolioMode(requireBoolean(value)),
 	},
 	{
-		id: "appearance-layout-classic-all-notes",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.classicAllNotesByDefault),
 		control: "toggle",
-		read: (settings) => settings.ui.classicAllNotesByDefault,
-		write: (value) => setClassicAllNotesByDefault(requireBoolean(value)),
 	},
 	{
-		id: "general-file-tree-folder-counts",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.showFileTreeFolderCounts),
 		control: "toggle",
-		read: (settings) => settings.ui.showFileTreeFolderCounts,
-		write: (value) => setShowFileTreeFolderCounts(requireBoolean(value)),
 	},
 	{
-		id: "general-file-tree-non-markdown-files",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.showNonMarkdownFiles),
 		control: "toggle",
-		read: (settings) => settings.ui.showNonMarkdownFiles,
-		write: (value) => setShowNonMarkdownFiles(requireBoolean(value)),
 	},
 	{
-		id: "general-file-tree-sort",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.fileTreeSortMode),
 		control: "choice",
 		defaultVisible: true,
 		options: [
@@ -455,35 +297,20 @@ const editableDefinitions: readonly EditablePaletteSettingDefinition[] = [
 			{ value: "created-desc", label: "Created newest" },
 			{ value: "created-asc", label: "Created oldest" },
 		],
-		read: (settings) => settings.ui.fileTreeSortMode,
-		write: async (value) => {
-			const mode = requireString(value);
-			if (
-				mode !== "name-asc" &&
-				mode !== "name-desc" &&
-				mode !== "modified-desc" &&
-				mode !== "modified-asc" &&
-				mode !== "created-desc" &&
-				mode !== "created-asc"
-			)
-				invalidValue();
-			await setFileTreeSortMode(mode);
-		},
 	},
 	{
-		id: "appearance-database-column-color",
-		scope: "application",
+		...bindApplicationSetting(DURABLE_SETTINGS.databaseShowColumnColor),
 		control: "toggle",
-		read: (settings) => settings.database.showColumnColor,
-		write: (value) => setDatabaseShowColumnColor(requireBoolean(value)),
 	},
 	{
 		id: "about-alpha-releases",
 		scope: "application",
 		control: "toggle",
 		read: (settings) => settings.ui.releaseChannel === "alpha",
-		write: (value) =>
-			setReleaseChannel(requireBoolean(value) ? "alpha" : "stable"),
+		write: async (value) => {
+			if (typeof value !== "boolean") invalidValue();
+			await DURABLE_SETTINGS.releaseChannel.write(value ? "alpha" : "stable");
+		},
 	},
 ];
 
@@ -494,9 +321,8 @@ const settingsTabById = new Map(
 export const PALETTE_SETTINGS_REGISTRY: readonly PaletteSettingDefinition[] =
 	editableDefinitions.map((definition) => {
 		const tab = settingsTabById.get(definition.id);
-		if (!tab) {
+		if (!tab)
 			throw new Error(`Missing settings search entry: ${definition.id}`);
-		}
 		return { ...definition, tab };
 	});
 

--- a/src/components/settings/AboutSettingsPane.tsx
+++ b/src/components/settings/AboutSettingsPane.tsx
@@ -11,11 +11,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useUpdaterContext } from "../../contexts";
 import { GLYPH_LINKS } from "../../lib/helpMenu";
 import { useLicenseStatus } from "../../lib/license";
-import {
-	type ReleaseChannel,
-	loadSettings,
-	setReleaseChannel,
-} from "../../lib/settings";
+import { type ReleaseChannel, loadSettings } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import type { AppInfo } from "../../lib/tauri";
 import { invoke } from "../../lib/tauri";
 import { Button } from "../ui/shadcn/button";
@@ -237,7 +234,8 @@ export function AboutSettingsPane() {
 										setUpdateStatus("");
 										setReleaseChannelState(nextChannel);
 										setIsSavingReleaseChannel(true);
-										void setReleaseChannel(nextChannel)
+										void DURABLE_SETTINGS.releaseChannel
+											.write(nextChannel)
 											.catch((cause) => {
 												setReleaseChannelState(previous);
 												setError(

--- a/src/components/settings/AiSettingsPane.tsx
+++ b/src/components/settings/AiSettingsPane.tsx
@@ -3,11 +3,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { resolveActiveProfileId } from "../../lib/aiProfiles";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { isMissingFileError } from "../../lib/fsErrors";
-import {
-	loadSettings,
-	setAiAssistantMode,
-	setAiEnabled,
-} from "../../lib/settings";
+import { loadSettings } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import { type AiProfile, invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import {
@@ -56,7 +53,7 @@ export function AiSettingsPane() {
 	const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
 	const [error, setError] = useState("");
 	const setAiToolsEnabled = useCallback(async (checked: boolean) => {
-		await setAiAssistantMode(checked ? "create" : "chat");
+		await DURABLE_SETTINGS.aiAssistantMode.write(checked ? "create" : "chat");
 	}, []);
 	const aiToolsEnabled = useSettingsBoolean(true, setAiToolsEnabled, setError);
 	const setAiToolsEnabledChecked = aiToolsEnabled.setChecked;
@@ -136,7 +133,7 @@ export function AiSettingsPane() {
 		setError("");
 		setAiEnabledState(enabled);
 		try {
-			await setAiEnabled(enabled);
+			await DURABLE_SETTINGS.aiEnabled.write(enabled);
 		} catch (e) {
 			setError(extractErrorMessage(e));
 		}

--- a/src/components/settings/AppearanceSettingsPane.tsx
+++ b/src/components/settings/AppearanceSettingsPane.tsx
@@ -18,17 +18,8 @@ import {
 	type UiDarkThemeId,
 	type UiLightThemeId,
 	loadSettings,
-	setClassicAllNotesByDefault,
-	setDatabaseShowColumnColor,
-	setEditorBeautifulTags,
-	setEditorWidthMode,
-	setFolioMode,
-	setThemeMode,
-	setUiCustomThemes,
-	setUiDarkThemeId,
-	setUiLightThemeId,
-	setUiTranslucentApp,
 } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import {
 	DARK_THEME_OPTIONS,
@@ -70,43 +61,47 @@ export function AppearanceSettingsPane() {
 	const [isHydrated, setIsHydrated] = useState(false);
 	const themeMode = useSettingsValue<ThemeMode>(
 		"system",
-		setThemeMode,
+		DURABLE_SETTINGS.theme.write,
 		setError,
 	);
 	const lightThemeId = useSettingsValue<UiLightThemeId>(
 		GLYPH_DEFAULT_LIGHT_THEME_ID,
-		setUiLightThemeId,
+		DURABLE_SETTINGS.lightThemeId.write,
 		setError,
 	);
 	const darkThemeId = useSettingsValue<UiDarkThemeId>(
 		GLYPH_DEFAULT_DARK_THEME_ID,
-		setUiDarkThemeId,
+		DURABLE_SETTINGS.darkThemeId.write,
 		setError,
 	);
 	const translucentApp = useSettingsValue<boolean>(
 		DEFAULT_UI_TRANSLUCENT_APP,
-		setUiTranslucentApp,
+		DURABLE_SETTINGS.translucentApp.write,
 		setError,
 	);
 	const editorWidthMode = useSettingsValue<EditorWidthMode>(
 		"compact",
-		setEditorWidthMode,
+		DURABLE_SETTINGS.editorWidthMode.write,
 		setError,
 	);
 	const beautifulTags = useSettingsBoolean(
 		false,
-		setEditorBeautifulTags,
+		DURABLE_SETTINGS.editorBeautifulTags.write,
 		setError,
 	);
-	const folioMode = useSettingsBoolean(false, setFolioMode, setError);
+	const folioMode = useSettingsBoolean(
+		false,
+		DURABLE_SETTINGS.folioMode.write,
+		setError,
+	);
 	const classicAllNotes = useSettingsBoolean(
 		false,
-		setClassicAllNotesByDefault,
+		DURABLE_SETTINGS.classicAllNotesByDefault.write,
 		setError,
 	);
 	const showColumnColor = useSettingsBoolean(
 		true,
-		setDatabaseShowColumnColor,
+		DURABLE_SETTINGS.databaseShowColumnColor.write,
 		setError,
 	);
 	const {
@@ -284,7 +279,7 @@ export function AppearanceSettingsPane() {
 	);
 
 	const persistCustomThemes = useCallback(async (next: CustomTheme[]) => {
-		await setUiCustomThemes(next);
+		await DURABLE_SETTINGS.customThemes.write(next);
 		setCustomThemesState(next);
 	}, []);
 
@@ -309,11 +304,11 @@ export function AppearanceSettingsPane() {
 					? GLYPH_DEFAULT_DARK_THEME_ID
 					: darkThemeId.value;
 			if (nextLight !== lightThemeId.value) {
-				await setUiLightThemeId(nextLight);
+				await DURABLE_SETTINGS.lightThemeId.write(nextLight);
 				lightThemeId.setValue(nextLight);
 			}
 			if (nextDark !== darkThemeId.value) {
-				await setUiDarkThemeId(nextDark);
+				await DURABLE_SETTINGS.darkThemeId.write(nextDark);
 				darkThemeId.setValue(nextDark);
 			}
 			await persistCustomThemes(

--- a/src/components/settings/GeneralSettingsPane.test.tsx
+++ b/src/components/settings/GeneralSettingsPane.test.tsx
@@ -6,10 +6,13 @@ import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GeneralSettingsPane } from "./GeneralSettingsPane";
 
-const { useLicenseStatusMock, useTauriEventMock } = vi.hoisted(() => ({
-	useLicenseStatusMock: vi.fn(),
-	useTauriEventMock: vi.fn(),
-}));
+const { settingWriter, useLicenseStatusMock, useTauriEventMock } = vi.hoisted(
+	() => ({
+		settingWriter: () => ({ write: vi.fn(() => Promise.resolve()) }),
+		useLicenseStatusMock: vi.fn(),
+		useTauriEventMock: vi.fn(),
+	}),
+);
 
 vi.mock("../../lib/settings", () => ({
 	isFocusMode: (value: unknown) =>
@@ -51,24 +54,29 @@ vi.mock("../../lib/settings", () => ({
 			},
 		}),
 	),
-	setLanguage: vi.fn(() => Promise.resolve()),
-	setDateDisplayFormat: vi.fn(() => Promise.resolve()),
-	setResumeLastSession: vi.fn(() => Promise.resolve()),
-	setKeepRunningOnLastWindowClose: vi.fn(() => Promise.resolve()),
-	setShowToc: vi.fn(() => Promise.resolve()),
-	setEditorShowFrontmatterInEditor: vi.fn(() => Promise.resolve()),
-	setEditorShowHeadingPrefixes: vi.fn(() => Promise.resolve()),
-	setEditorColorfulHeadings: vi.fn(() => Promise.resolve()),
-	setEditorHeadingPaletteId: vi.fn(() => Promise.resolve()),
-	setEditorShowCollapsibleHeadings: vi.fn(() => Promise.resolve()),
-	setEditorShowCollapsibleLists: vi.fn(() => Promise.resolve()),
-	setEditorSpellCheck: vi.fn(() => Promise.resolve()),
-	setEditorShowExternalLinkPreviews: vi.fn(() => Promise.resolve()),
-	setEditorRawMarkdownVimMode: vi.fn(() => Promise.resolve()),
-	setEditorDefaultEditorMode: vi.fn(() => Promise.resolve()),
-	setEditorFocusMode: vi.fn(() => Promise.resolve()),
-	setShowFileTreeFolderCounts: vi.fn(() => Promise.resolve()),
-	setShowNonMarkdownFiles: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../lib/settings/definitions", () => ({
+	DURABLE_SETTINGS: {
+		language: settingWriter(),
+		dateDisplayFormat: settingWriter(),
+		resumeLastSession: settingWriter(),
+		keepRunningOnLastWindowClose: settingWriter(),
+		showToc: settingWriter(),
+		editorShowFrontmatterInEditor: settingWriter(),
+		editorShowHeadingPrefixes: settingWriter(),
+		editorColorfulHeadings: settingWriter(),
+		editorHeadingPaletteId: settingWriter(),
+		editorShowCollapsibleHeadings: settingWriter(),
+		editorShowCollapsibleLists: settingWriter(),
+		editorSpellCheck: settingWriter(),
+		editorShowExternalLinkPreviews: settingWriter(),
+		editorRawMarkdownVimMode: settingWriter(),
+		editorDefaultEditorMode: settingWriter(),
+		editorFocusMode: settingWriter(),
+		showFileTreeFolderCounts: settingWriter(),
+		showNonMarkdownFiles: settingWriter(),
+	},
 }));
 
 vi.mock("react-i18next", () => ({

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -21,25 +21,8 @@ import {
 	isDateDisplayFormat,
 	isFocusMode,
 	loadSettings,
-	setDateDisplayFormat,
-	setEditorColorfulHeadings,
-	setEditorDefaultEditorMode,
-	setEditorFocusMode,
-	setEditorHeadingPaletteId,
-	setEditorRawMarkdownVimMode,
-	setEditorShowCollapsibleHeadings,
-	setEditorShowCollapsibleLists,
-	setEditorShowExternalLinkPreviews,
-	setEditorShowFrontmatterInEditor,
-	setEditorShowHeadingPrefixes,
-	setEditorSpellCheck,
-	setKeepRunningOnLastWindowClose,
-	setLanguage,
-	setResumeLastSession,
-	setShowFileTreeFolderCounts,
-	setShowNonMarkdownFiles,
-	setShowToc,
 } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { LicenseSettingsCard } from "../licensing/LicenseSettingsCard";
 import { FileTreeSettingsSection } from "./FileTreeSettingsSection";
@@ -81,79 +64,87 @@ export function GeneralSettingsPane() {
 	const [language, setLanguageState] = useState<AppLanguage>("en");
 	const dateFormat = useSettingsValue<DateDisplayFormat>(
 		DEFAULT_DATE_DISPLAY_FORMAT,
-		setDateDisplayFormat,
+		DURABLE_SETTINGS.dateDisplayFormat.write,
 		setError,
 	);
 	const defaultEditorMode = useSettingsValue<EditorViewMode>(
 		getDefaultEditorViewMode,
-		setEditorDefaultEditorMode,
+		DURABLE_SETTINGS.editorDefaultEditorMode.write,
 		setError,
 	);
 	const focusMode = useSettingsValue<FocusMode>(
 		"off",
-		setEditorFocusMode,
+		DURABLE_SETTINGS.editorFocusMode.write,
 		setError,
 	);
 	const resumeLastSession = useSettingsBoolean(
 		false,
-		setResumeLastSession,
+		DURABLE_SETTINGS.resumeLastSession.write,
 		setError,
 	);
 	const keepRunningOnLastWindowClose = useSettingsBoolean(
 		false,
-		setKeepRunningOnLastWindowClose,
+		DURABLE_SETTINGS.keepRunningOnLastWindowClose.write,
 		setError,
 	);
-	const showToc = useSettingsBoolean(true, setShowToc, setError);
+	const showToc = useSettingsBoolean(
+		true,
+		DURABLE_SETTINGS.showToc.write,
+		setError,
+	);
 	const showFrontmatter = useSettingsBoolean(
 		false,
-		setEditorShowFrontmatterInEditor,
+		DURABLE_SETTINGS.editorShowFrontmatterInEditor.write,
 		setError,
 	);
 	const colorfulHeadings = useSettingsBoolean(
 		false,
-		setEditorColorfulHeadings,
+		DURABLE_SETTINGS.editorColorfulHeadings.write,
 		setError,
 	);
 	const headingPrefixes = useSettingsBoolean(
 		true,
-		setEditorShowHeadingPrefixes,
+		DURABLE_SETTINGS.editorShowHeadingPrefixes.write,
 		setError,
 	);
 	const headingPalette = useSettingsValue<HeadingPaletteId>(
 		DEFAULT_HEADING_PALETTE_ID,
-		setEditorHeadingPaletteId,
+		DURABLE_SETTINGS.editorHeadingPaletteId.write,
 		setError,
 	);
 	const collapsibleHeadings = useSettingsBoolean(
 		false,
-		setEditorShowCollapsibleHeadings,
+		DURABLE_SETTINGS.editorShowCollapsibleHeadings.write,
 		setError,
 	);
 	const collapsibleLists = useSettingsBoolean(
 		false,
-		setEditorShowCollapsibleLists,
+		DURABLE_SETTINGS.editorShowCollapsibleLists.write,
 		setError,
 	);
-	const spellCheck = useSettingsBoolean(true, setEditorSpellCheck, setError);
+	const spellCheck = useSettingsBoolean(
+		true,
+		DURABLE_SETTINGS.editorSpellCheck.write,
+		setError,
+	);
 	const externalLinkPreviews = useSettingsBoolean(
 		false,
-		setEditorShowExternalLinkPreviews,
+		DURABLE_SETTINGS.editorShowExternalLinkPreviews.write,
 		setError,
 	);
 	const rawMarkdownVimMode = useSettingsBoolean(
 		false,
-		setEditorRawMarkdownVimMode,
+		DURABLE_SETTINGS.editorRawMarkdownVimMode.write,
 		setError,
 	);
 	const folderCounts = useSettingsBoolean(
 		false,
-		setShowFileTreeFolderCounts,
+		DURABLE_SETTINGS.showFileTreeFolderCounts.write,
 		setError,
 	);
 	const nonMarkdownFiles = useSettingsBoolean(
 		true,
-		setShowNonMarkdownFiles,
+		DURABLE_SETTINGS.showNonMarkdownFiles.write,
 		setError,
 	);
 
@@ -329,7 +320,7 @@ export function GeneralSettingsPane() {
 		const previous = language;
 		setLanguageState(nextLanguage);
 		try {
-			await setLanguage(nextLanguage);
+			await DURABLE_SETTINGS.language.write(nextLanguage);
 		} catch (cause) {
 			setLanguageState(previous);
 			setError(cause instanceof Error ? cause.message : String(cause));

--- a/src/components/settings/SpaceSettingsPane.test.tsx
+++ b/src/components/settings/SpaceSettingsPane.test.tsx
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SpaceSettingsPane } from "./SpaceSettingsPane";
 
 const {
-	getDailyNotesFolderMock,
 	invokeMock,
 	loadSettingsMock,
 	setDailyNotesFolderMock,
@@ -15,8 +14,8 @@ const {
 	setEditorAttachmentStorageModeMock,
 	setEditorEnablePeopleMentionsAsTagsMock,
 	setQuickNotesFolderMock,
+	writeSpaceSettingMock,
 } = vi.hoisted(() => ({
-	getDailyNotesFolderMock: vi.fn(() => Promise.resolve(null)),
 	invokeMock: vi.fn(),
 	loadSettingsMock: vi.fn(() =>
 		Promise.resolve({
@@ -34,11 +33,30 @@ const {
 			},
 		}),
 	),
-	setDailyNotesFolderMock: vi.fn(() => Promise.resolve()),
-	setEditorAttachmentFolderMock: vi.fn(() => Promise.resolve()),
-	setEditorAttachmentStorageModeMock: vi.fn(() => Promise.resolve()),
+	setDailyNotesFolderMock: vi.fn(
+		(_value: unknown, _scope: { spacePath?: string | null }) =>
+			Promise.resolve(),
+	),
+	setEditorAttachmentFolderMock: vi.fn(
+		(_value: unknown, _scope: { spacePath?: string | null }) =>
+			Promise.resolve(),
+	),
+	setEditorAttachmentStorageModeMock: vi.fn(
+		(_value: unknown, _scope: { spacePath?: string | null }) =>
+			Promise.resolve(),
+	),
 	setEditorEnablePeopleMentionsAsTagsMock: vi.fn(() => Promise.resolve()),
-	setQuickNotesFolderMock: vi.fn(() => Promise.resolve()),
+	setQuickNotesFolderMock: vi.fn(
+		(_value: unknown, _scope: { spacePath?: string | null }) =>
+			Promise.resolve(),
+	),
+	writeSpaceSettingMock: vi.fn(
+		(
+			_definition: { field: string },
+			_value: unknown,
+			_scope: { spacePath?: string | null },
+		) => Promise.resolve(),
+	),
 }));
 
 (
@@ -57,16 +75,29 @@ vi.mock("../../lib/settings", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../lib/settings")>();
 	return {
 		...actual,
-		getDailyNotesFolder: getDailyNotesFolderMock,
 		loadSettings: loadSettingsMock,
-		setDailyNotesFolder: setDailyNotesFolderMock,
-		setEditorAttachmentFolder: setEditorAttachmentFolderMock,
-		setEditorAttachmentStorageMode: setEditorAttachmentStorageModeMock,
-		setEditorEnablePeopleMentionsAsTags:
-			setEditorEnablePeopleMentionsAsTagsMock,
-		setQuickNotesFolder: setQuickNotesFolderMock,
+		writeSpaceSetting: writeSpaceSettingMock,
 	};
 });
+
+vi.mock("../../lib/settings/definitions", () => ({
+	DURABLE_SETTINGS: {
+		editorEnablePeopleMentionsAsTags: {
+			write: setEditorEnablePeopleMentionsAsTagsMock,
+		},
+	},
+	SPACE_SETTINGS: {
+		dailyNotesFolder: { field: "dailyNotesFolder" },
+		quickNotesFolder: { field: "quickNotesFolder" },
+		attachmentStorageMode: { field: "attachmentStorageMode" },
+		attachmentFolder: { field: "attachmentFolder" },
+	},
+	isAttachmentStorageMode: (value: unknown) =>
+		value === "space-root" ||
+		value === "specific-folder" ||
+		value === "note-folder" ||
+		value === "note-subfolder",
+}));
 
 vi.mock("../../lib/tauri", () => ({
 	invoke: invokeMock,
@@ -173,6 +204,24 @@ describe("SpaceSettingsPane", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		invokeMock.mockResolvedValue("/spaces/test");
+		writeSpaceSettingMock.mockImplementation(
+			(
+				definition: { field: string },
+				value: unknown,
+				scope: { spacePath?: string | null },
+			) => {
+				if (definition.field === "attachmentStorageMode") {
+					return setEditorAttachmentStorageModeMock(value, scope);
+				}
+				if (definition.field === "attachmentFolder") {
+					return setEditorAttachmentFolderMock(value, scope);
+				}
+				if (definition.field === "dailyNotesFolder") {
+					return setDailyNotesFolderMock(value, scope);
+				}
+				return setQuickNotesFolderMock(value, scope);
+			},
+		);
 
 		container = document.createElement("div");
 		document.body.appendChild(container);

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -14,12 +14,12 @@ import {
 	DEFAULT_QUICK_NOTES_FOLDER,
 	isAttachmentStorageMode,
 	loadSettings,
-	setDailyNotesFolder,
-	setEditorAttachmentFolder,
-	setEditorAttachmentStorageMode,
-	setEditorEnablePeopleMentionsAsTags,
-	setQuickNotesFolder,
+	writeSpaceSetting,
 } from "../../lib/settings";
+import {
+	DURABLE_SETTINGS,
+	SPACE_SETTINGS,
+} from "../../lib/settings/definitions";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { normalizeRelPath, validateRelFolderPath } from "../../utils/path";
@@ -122,7 +122,7 @@ export function SpaceSettingsPane() {
 					enabled: checked,
 				});
 				if (currentSpacePath) await startIndexRebuild();
-				await setEditorEnablePeopleMentionsAsTags(checked);
+				await DURABLE_SETTINGS.editorEnablePeopleMentionsAsTags.write(checked);
 				setEnablePeopleMentionsAsTags(checked);
 			})()
 				.catch((cause) => {
@@ -142,9 +142,13 @@ export function SpaceSettingsPane() {
 		try {
 			const selection = await selectFolderRelativeToSpace();
 			if (selection === null) return;
-			await setDailyNotesFolder(selection.relativePath || null, {
-				spacePath: selection.spacePath,
-			});
+			await writeSpaceSetting(
+				SPACE_SETTINGS.dailyNotesFolder,
+				selection.relativePath || null,
+				{
+					spacePath: selection.spacePath,
+				},
+			);
 			setCurrentSpacePath(selection.spacePath);
 			setDailyNotesFolderState(selection.relativePath || null);
 		} catch (cause) {
@@ -158,7 +162,9 @@ export function SpaceSettingsPane() {
 		setDailyNotesError(null);
 		try {
 			const spacePath = requireSpacePath(currentSpacePath);
-			await setDailyNotesFolder(null, { spacePath });
+			await writeSpaceSetting(SPACE_SETTINGS.dailyNotesFolder, null, {
+				spacePath,
+			});
 			setDailyNotesFolderState(null);
 		} catch (cause) {
 			setDailyNotesError(
@@ -172,16 +178,24 @@ export function SpaceSettingsPane() {
 			setAttachmentError(null);
 			try {
 				const spacePath = requireSpacePath(currentSpacePath);
-				await setEditorAttachmentStorageMode(nextMode, { spacePath });
+				await writeSpaceSetting(
+					SPACE_SETTINGS.attachmentStorageMode,
+					nextMode,
+					{ spacePath },
+				);
 				setAttachmentStorageModeState(nextMode);
 
 				const shouldResetFolder =
 					modesUseDifferentFolderSemantics(attachmentStorageMode, nextMode) ||
 					(modeRequiresAttachmentFolder(nextMode) && !attachmentFolder);
 				if (shouldResetFolder) {
-					await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, {
-						spacePath,
-					});
+					await writeSpaceSetting(
+						SPACE_SETTINGS.attachmentFolder,
+						DEFAULT_ATTACHMENT_FOLDER,
+						{
+							spacePath,
+						},
+					);
 					setAttachmentFolderState(DEFAULT_ATTACHMENT_FOLDER);
 				}
 			} catch (cause) {
@@ -203,7 +217,9 @@ export function SpaceSettingsPane() {
 		const normalized = normalizeRelPath(attachmentFolder);
 		try {
 			const spacePath = requireSpacePath(currentSpacePath);
-			await setEditorAttachmentFolder(normalized, { spacePath });
+			await writeSpaceSetting(SPACE_SETTINGS.attachmentFolder, normalized, {
+				spacePath,
+			});
 			setAttachmentFolderState(normalized);
 		} catch (cause) {
 			setAttachmentError(
@@ -217,9 +233,13 @@ export function SpaceSettingsPane() {
 		try {
 			const selection = await selectFolderRelativeToSpace();
 			if (selection === null) return;
-			await setEditorAttachmentFolder(selection.relativePath, {
-				spacePath: selection.spacePath,
-			});
+			await writeSpaceSetting(
+				SPACE_SETTINGS.attachmentFolder,
+				selection.relativePath,
+				{
+					spacePath: selection.spacePath,
+				},
+			);
 			setCurrentSpacePath(selection.spacePath);
 			setAttachmentFolderState(
 				selection.relativePath || DEFAULT_ATTACHMENT_FOLDER,
@@ -235,7 +255,11 @@ export function SpaceSettingsPane() {
 		setAttachmentError(null);
 		try {
 			const spacePath = requireSpacePath(currentSpacePath);
-			await setEditorAttachmentFolder(DEFAULT_ATTACHMENT_FOLDER, { spacePath });
+			await writeSpaceSetting(
+				SPACE_SETTINGS.attachmentFolder,
+				DEFAULT_ATTACHMENT_FOLDER,
+				{ spacePath },
+			);
 			setAttachmentFolderState(DEFAULT_ATTACHMENT_FOLDER);
 		} catch (cause) {
 			setAttachmentError(
@@ -249,7 +273,8 @@ export function SpaceSettingsPane() {
 		try {
 			const selection = await selectFolderRelativeToSpace();
 			if (selection === null) return;
-			await setQuickNotesFolder(
+			await writeSpaceSetting(
+				SPACE_SETTINGS.quickNotesFolder,
 				selection.relativePath || DEFAULT_QUICK_NOTES_FOLDER,
 				{ spacePath: selection.spacePath },
 			);
@@ -270,7 +295,11 @@ export function SpaceSettingsPane() {
 		setQuickNotesError(null);
 		try {
 			const spacePath = requireSpacePath(currentSpacePath);
-			await setQuickNotesFolder(DEFAULT_QUICK_NOTES_FOLDER, { spacePath });
+			await writeSpaceSetting(
+				SPACE_SETTINGS.quickNotesFolder,
+				DEFAULT_QUICK_NOTES_FOLDER,
+				{ spacePath },
+			);
 			setQuickNotesFolderState(DEFAULT_QUICK_NOTES_FOLDER);
 		} catch (cause) {
 			setQuickNotesError(

--- a/src/components/settings/TemplatesSettingsPane.tsx
+++ b/src/components/settings/TemplatesSettingsPane.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-	getDailyNoteTemplate,
-	getTemplatesFolder,
-	setDailyNoteTemplate,
+	loadSettings,
 	setTemplatesFolder,
+	writeSpaceSetting,
 } from "../../lib/settings";
+import { SPACE_SETTINGS } from "../../lib/settings/definitions";
 import { invoke } from "../../lib/tauri";
 import { listTemplates } from "../../lib/templates";
 import { SettingsFolderPicker } from "./SettingsFolderPicker";
@@ -78,16 +78,12 @@ export function TemplateSettingsSections() {
 		void (async () => {
 			try {
 				const currentSpace = await ensureCurrentSpaceOpen();
-				const settingsScope = { spacePath: currentSpace };
-				const [folder, dailyTemplate] = await Promise.all([
-					getTemplatesFolder(settingsScope),
-					getDailyNoteTemplate(settingsScope),
-				]);
+				const settings = await loadSettings({ spacePath: currentSpace });
 				if (cancelled) return;
 				setSettingsState({
 					currentSpacePath: currentSpace,
-					templatesFolder: folder,
-					dailyNoteTemplatePath: dailyTemplate,
+					templatesFolder: settings.templates.folder,
+					dailyNoteTemplatePath: settings.templates.dailyNoteTemplate,
 					error: null,
 				});
 			} catch (cause) {
@@ -115,9 +111,13 @@ export function TemplateSettingsSections() {
 					...current,
 					dailyNoteTemplatePath: null,
 				}));
-				void setDailyNoteTemplate(null, {
-					spacePath: currentSpacePath,
-				}).catch((cause) => {
+				void writeSpaceSetting(
+					SPACE_SETTINGS.templatesDailyNoteTemplate,
+					null,
+					{
+						spacePath: currentSpacePath,
+					},
+				).catch((cause) => {
 					if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 					setSettingsState((current) => ({
 						...current,
@@ -159,9 +159,13 @@ export function TemplateSettingsSections() {
 					)
 				) {
 					const writeId = beginDailyTemplateWrite();
-					void setDailyNoteTemplate(null, {
-						spacePath: currentSpacePath,
-					})
+					void writeSpaceSetting(
+						SPACE_SETTINGS.templatesDailyNoteTemplate,
+						null,
+						{
+							spacePath: currentSpacePath,
+						},
+					)
 						.then(() => {
 							if (
 								cancelled ||
@@ -219,7 +223,9 @@ export function TemplateSettingsSections() {
 				spacePath: selection.spacePath,
 			});
 			writeId = beginDailyTemplateWrite();
-			await setDailyNoteTemplate(null, { spacePath: selection.spacePath });
+			await writeSpaceSetting(SPACE_SETTINGS.templatesDailyNoteTemplate, null, {
+				spacePath: selection.spacePath,
+			});
 			if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 			setSettingsState((current) => ({
 				...current,
@@ -272,7 +278,11 @@ export function TemplateSettingsSections() {
 			setSettingsState((current) => ({ ...current, error: null }));
 			try {
 				const spacePath = requireSpacePath(currentSpacePath);
-				await setDailyNoteTemplate(next, { spacePath });
+				await writeSpaceSetting(
+					SPACE_SETTINGS.templatesDailyNoteTemplate,
+					next,
+					{ spacePath },
+				);
 				if (writeId !== latestDailyTemplateWriteIdRef.current) return;
 				setSettingsState((current) => ({
 					...current,

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -1,4 +1,5 @@
 import { i18n } from "../../i18n";
+import { SEARCHABLE_SETTING_IDS } from "../../lib/settings/definitions";
 import { SETTINGS_TABS, type SettingsTab } from "./settingsConfig";
 
 export interface SettingsSearchEntry {
@@ -129,6 +130,15 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchDef[] = [
 	...SETTINGS_TAB_DEFS,
 	...SETTINGS_SEARCH_DEFS,
 ];
+
+const settingsSearchIds = new Set(
+	SETTINGS_SEARCH_ENTRIES.map((definition) => definition.id),
+);
+for (const id of SEARCHABLE_SETTING_IDS) {
+	if (!settingsSearchIds.has(id)) {
+		throw new Error(`Missing settings search entry: ${id}`);
+	}
+}
 
 function readKeywords(
 	nsKey: string,

--- a/src/components/settings/useAppearanceCornerRadius.ts
+++ b/src/components/settings/useAppearanceCornerRadius.ts
@@ -3,8 +3,8 @@ import { applyUiCornerRadius } from "../../lib/appearance";
 import {
 	DEFAULT_UI_CORNER_RADIUS_STYLE,
 	type UiCornerRadiusStyle,
-	setUiCornerRadiusStyle,
 } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import { useSettingsValue } from "./useSettingsValue";
 
 interface UseAppearanceCornerRadiusOptions {
@@ -18,7 +18,7 @@ export function useAppearanceCornerRadius({
 }: UseAppearanceCornerRadiusOptions) {
 	const setting = useSettingsValue(
 		DEFAULT_UI_CORNER_RADIUS_STYLE,
-		setUiCornerRadiusStyle,
+		DURABLE_SETTINGS.cornerRadiusStyle.write,
 		setError,
 	);
 

--- a/src/components/settings/useAppearanceTypography.ts
+++ b/src/components/settings/useAppearanceTypography.ts
@@ -1,15 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { applyUiTypography } from "../../lib/appearance";
-import {
-	type AppSettings,
-	type UiFontFamily,
-	type UiFontSize,
-	setUiEditorFontFamily,
-	setUiEditorFontSize,
-	setUiFontFamily,
-	setUiFontSize,
-	setUiMonoFontFamily,
-} from "../../lib/settings";
+import type { AppSettings, UiFontFamily, UiFontSize } from "../../lib/settings";
+import { DURABLE_SETTINGS } from "../../lib/settings/definitions";
 import {
 	DEFAULT_FONT_FAMILY,
 	loadAvailableFonts,
@@ -38,23 +30,27 @@ export function useAppearanceTypography({
 }: UseAppearanceTypographyOptions) {
 	const fontFamily = useSettingsValue<UiFontFamily>(
 		DEFAULT_FONT_FAMILY,
-		setUiFontFamily,
+		DURABLE_SETTINGS.fontFamily.write,
 		setError,
 	);
 	const editorFontFamily = useSettingsValue<UiFontFamily>(
 		DEFAULT_FONT_FAMILY,
-		setUiEditorFontFamily,
+		DURABLE_SETTINGS.editorFontFamily.write,
 		setError,
 	);
 	const monoFontFamily = useSettingsValue<UiFontFamily>(
 		"JetBrains Mono",
-		setUiMonoFontFamily,
+		DURABLE_SETTINGS.monoFontFamily.write,
 		setError,
 	);
-	const uiFontSize = useSettingsValue<UiFontSize>(14, setUiFontSize, setError);
+	const uiFontSize = useSettingsValue<UiFontSize>(
+		14,
+		DURABLE_SETTINGS.fontSize.write,
+		setError,
+	);
 	const editorFontSize = useSettingsValue<UiFontSize>(
 		16,
-		setUiEditorFontSize,
+		DURABLE_SETTINGS.editorFontSize.write,
 		setError,
 	);
 	const [availableFonts, setAvailableFonts] = useState<string[]>([

--- a/src/contexts/FileTreeContext.tsx
+++ b/src/contexts/FileTreeContext.tsx
@@ -14,8 +14,8 @@ import {
 	type FileTreeSortMode,
 	isFileTreeSortMode,
 	loadSettings,
-	setFileTreeSortMode as persistFileTreeSortMode,
 } from "../lib/settings";
+import { DURABLE_SETTINGS } from "../lib/settings/definitions";
 import { normalizeTagIconKey } from "../lib/tagIcons";
 import type {
 	FileTreeAppearance,
@@ -616,7 +616,8 @@ export function FileTreeProvider({ children }: { children: ReactNode }) {
 			fileTreeSortModeRequestVersionRef.current = requestVersion;
 			setFileTreeSortModeState(nextSortMode);
 			setIsSavingFileTreeSortMode(true);
-			return persistFileTreeSortMode(nextSortMode)
+			return DURABLE_SETTINGS.fileTreeSortMode
+				.write(nextSortMode)
 				.catch((error) => {
 					if (requestVersion === fileTreeSortModeRequestVersionRef.current) {
 						setFileTreeSortModeState(previous);

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -25,10 +25,8 @@ import {
 	type AiAssistantMode,
 	loadSettings,
 	reloadFromDisk,
-	setAiAssistantMode as saveAiAssistantMode,
-	setFolioMode as saveFolioMode,
-	setShowToc as saveShowToc,
 } from "../lib/settings";
+import { DURABLE_SETTINGS } from "../lib/settings/definitions";
 import { useTauriEvent } from "../lib/tauriEvents";
 import { useSpace } from "./SpaceContext";
 
@@ -411,17 +409,17 @@ export function UIProvider({ children }: { children: ReactNode }) {
 
 	const setAiAssistantMode = useCallback((mode: AiAssistantMode) => {
 		dispatch({ type: "setAiAssistantMode", value: mode });
-		void saveAiAssistantMode(mode);
+		void DURABLE_SETTINGS.aiAssistantMode.write(mode);
 	}, []);
 
 	const setShowToc = useCallback((show: boolean) => {
 		dispatch({ type: "setShowToc", value: show });
-		void saveShowToc(show);
+		void DURABLE_SETTINGS.showToc.write(show);
 	}, []);
 
 	const setFolioMode = useCallback((enabled: boolean) => {
 		dispatch({ type: "setFolioMode", value: enabled });
-		void saveFolioMode(enabled);
+		void DURABLE_SETTINGS.folioMode.write(enabled);
 	}, []);
 
 	const setFolioScope = useCallback(

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -75,9 +75,9 @@ describe("settings colorful headings", () => {
 	});
 
 	it("persists and emits colorful headings changes", async () => {
-		const { setEditorColorfulHeadings } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setEditorColorfulHeadings(true);
+		await DURABLE_SETTINGS.editorColorfulHeadings.write(true);
 
 		expect(storeState.get("editor.colorfulHeadings")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -111,9 +111,9 @@ describe("settings spell check", () => {
 	});
 
 	it("persists and emits spell check changes", async () => {
-		const { setEditorSpellCheck } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setEditorSpellCheck(false);
+		await DURABLE_SETTINGS.editorSpellCheck.write(false);
 
 		expect(storeState.get("editor.spellCheck")).toBe(false);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -147,9 +147,9 @@ describe("settings Raw Markdown Vim Mode", () => {
 	});
 
 	it("persists and emits Raw Markdown Vim Mode changes", async () => {
-		const { setEditorRawMarkdownVimMode } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setEditorRawMarkdownVimMode(true);
+		await DURABLE_SETTINGS.editorRawMarkdownVimMode.write(true);
 
 		expect(storeState.get("editor.rawMarkdownVimMode")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -179,8 +179,8 @@ describe("settings Folio Mode", () => {
 	});
 
 	it("persists and emits Folio Mode changes", async () => {
-		const { setFolioMode } = await import("./settings");
-		await setFolioMode(true);
+		const { DURABLE_SETTINGS } = await import("./settings");
+		await DURABLE_SETTINGS.folioMode.write(true);
 		expect(storeState.get("ui.folioMode")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			ui: { folioMode: true },
@@ -202,8 +202,8 @@ describe("settings workspace session restore", () => {
 	});
 
 	it("persists and emits resume last session changes", async () => {
-		const { setResumeLastSession } = await import("./settings");
-		await setResumeLastSession(true);
+		const { DURABLE_SETTINGS } = await import("./settings");
+		await DURABLE_SETTINGS.resumeLastSession.write(true);
 		expect(storeState.get("ui.resumeLastSession")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			ui: { resumeLastSession: true },
@@ -359,16 +359,16 @@ describe("settings corner radius style", () => {
 	});
 
 	it("persists and emits corner radius style changes", async () => {
-		const { setUiCornerRadiusStyle } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setUiCornerRadiusStyle("sharp");
+		await DURABLE_SETTINGS.cornerRadiusStyle.write("sharp");
 
 		expect(storeState.get("ui.cornerRadiusStyle")).toBe("sharp");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			ui: { cornerRadiusStyle: "sharp" },
 		});
 
-		await setUiCornerRadiusStyle("round");
+		await DURABLE_SETTINGS.cornerRadiusStyle.write("round");
 
 		expect(storeState.get("ui.cornerRadiusStyle")).toBe("round");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -402,16 +402,16 @@ describe("settings app translucency", () => {
 	});
 
 	it("persists and emits app translucency changes", async () => {
-		const { setUiTranslucentApp } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setUiTranslucentApp(true);
+		await DURABLE_SETTINGS.translucentApp.write(true);
 
 		expect(storeState.get("ui.translucentApp")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
 			ui: { translucentApp: true },
 		});
 
-		await setUiTranslucentApp(false);
+		await DURABLE_SETTINGS.translucentApp.write(false);
 
 		expect(storeState.get("ui.translucentApp")).toBe(false);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -450,9 +450,9 @@ describe("settings editor font family", () => {
 	});
 
 	it("persists and emits editor font changes", async () => {
-		const { setUiEditorFontFamily } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setUiEditorFontFamily("Literata");
+		await DURABLE_SETTINGS.editorFontFamily.write("Literata");
 
 		expect(storeState.get("ui.editorFontFamily")).toBe("Literata");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -486,9 +486,9 @@ describe("settings editor width mode", () => {
 	});
 
 	it("persists and emits editor width mode changes", async () => {
-		const { setEditorWidthMode } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setEditorWidthMode("comfortable");
+		await DURABLE_SETTINGS.editorWidthMode.write("comfortable");
 
 		expect(storeState.get("editor.editorWidthMode")).toBe("comfortable");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -522,9 +522,9 @@ describe("settings show frontmatter in editor", () => {
 	});
 
 	it("persists and emits frontmatter visibility changes", async () => {
-		const { setEditorShowFrontmatterInEditor } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setEditorShowFrontmatterInEditor(true);
+		await DURABLE_SETTINGS.editorShowFrontmatterInEditor.write(true);
 
 		expect(storeState.get("editor.showFrontmatterInEditor")).toBe(true);
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -550,10 +550,13 @@ describe("attachment storage settings", () => {
 	});
 
 	it("persists and emits attachment mode changes", async () => {
-		const { setEditorAttachmentStorageMode } = await import("./settings");
+		const { SPACE_SETTINGS, writeSpaceSetting } = await import("./settings");
 
-		await setEditorAttachmentStorageMode("space-root");
-		await setEditorAttachmentStorageMode("note-subfolder");
+		await writeSpaceSetting(SPACE_SETTINGS.attachmentStorageMode, "space-root");
+		await writeSpaceSetting(
+			SPACE_SETTINGS.attachmentStorageMode,
+			"note-subfolder",
+		);
 
 		expect(storeState.get("editor.attachmentStorageMode")).toBe(
 			"note-subfolder",
@@ -564,9 +567,9 @@ describe("attachment storage settings", () => {
 	});
 
 	it("persists and emits attachment folder changes", async () => {
-		const { setEditorAttachmentFolder } = await import("./settings");
+		const { SPACE_SETTINGS, writeSpaceSetting } = await import("./settings");
 
-		await setEditorAttachmentFolder("assets/uploads");
+		await writeSpaceSetting(SPACE_SETTINGS.attachmentFolder, "assets/uploads");
 
 		expect(storeState.get("editor.attachmentFolder")).toBe("assets/uploads");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {
@@ -582,12 +585,14 @@ describe("attachment storage settings", () => {
 	});
 
 	it("rejects invalid attachment folder paths", async () => {
-		const { setEditorAttachmentFolder } = await import("./settings");
+		const { SPACE_SETTINGS, writeSpaceSetting } = await import("./settings");
 
-		await expect(setEditorAttachmentFolder("../secret")).rejects.toThrow("..");
-		await expect(setEditorAttachmentFolder(".hidden")).rejects.toThrow(
-			"hidden",
-		);
+		await expect(
+			writeSpaceSetting(SPACE_SETTINGS.attachmentFolder, "../secret"),
+		).rejects.toThrow("..");
+		await expect(
+			writeSpaceSetting(SPACE_SETTINGS.attachmentFolder, ".hidden"),
+		).rejects.toThrow("hidden");
 	});
 });
 
@@ -618,19 +623,23 @@ describe("space-scoped settings", () => {
 	});
 
 	it("persists folder settings under the explicit space path", async () => {
-		const {
-			setDailyNotesFolder,
-			setEditorAttachmentStorageMode,
-			setQuickNotesFolder,
-			setTemplatesFolder,
-		} = await import("./settings");
+		const { SPACE_SETTINGS, setTemplatesFolder, writeSpaceSetting } =
+			await import("./settings");
 
-		await setDailyNotesFolder("Daily", { spacePath: "/spaces/work" });
-		await setQuickNotesFolder("Inbox", { spacePath: "/spaces/work" });
-		await setTemplatesFolder("Templates", { spacePath: "/spaces/work" });
-		await setEditorAttachmentStorageMode("specific-folder", {
+		await writeSpaceSetting(SPACE_SETTINGS.dailyNotesFolder, "Daily", {
 			spacePath: "/spaces/work",
 		});
+		await writeSpaceSetting(SPACE_SETTINGS.quickNotesFolder, "Inbox", {
+			spacePath: "/spaces/work",
+		});
+		await setTemplatesFolder("Templates", { spacePath: "/spaces/work" });
+		await writeSpaceSetting(
+			SPACE_SETTINGS.attachmentStorageMode,
+			"specific-folder",
+			{
+				spacePath: "/spaces/work",
+			},
+		);
 
 		expect(storeState.get("space.scopedSettings")).toEqual({
 			"/spaces/work": {
@@ -808,9 +817,9 @@ describe("settings language", () => {
 	});
 
 	it("persists and emits language changes", async () => {
-		const { setLanguage } = await import("./settings");
+		const { DURABLE_SETTINGS } = await import("./settings");
 
-		await setLanguage("es");
+		await DURABLE_SETTINGS.language.write("es");
 
 		expect(storeState.get("ui.language")).toBe("es");
 		expect(emitMock).toHaveBeenCalledWith("settings:updated", {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,33 +1,27 @@
-import { emit, emitTo } from "@tauri-apps/api/event";
-import { getCurrentWindow } from "@tauri-apps/api/window";
-import { normalizeRelPath, validateRelFolderPath } from "../utils/path";
-import {
-	ATTACHMENT_MODE_UI,
-	DEFAULT_ATTACHMENT_FOLDER,
-} from "./attachmentStorage";
-import {
-	DEFAULT_EDITOR_VIEW_MODE,
-	type EditorViewMode,
-	isEditorViewMode,
-	setCachedDefaultEditorViewMode,
-} from "./editorMode";
-import {
-	DEFAULT_HEADING_PALETTE_ID,
-	type HeadingPaletteId,
-	asHeadingPaletteId,
-} from "./headingPalettes";
+import { normalizeRelPath } from "../utils/path";
+import { setCachedDefaultEditorViewMode } from "./editorMode";
 export { DEFAULT_ATTACHMENT_FOLDER } from "./attachmentStorage";
-import { type AppLanguage, normalizeAppLanguage } from "../i18n/locales";
 import {
 	type CustomTheme,
 	customThemeId,
 	isCustomThemeId,
-	normalizeCustomThemes,
 } from "./customThemes";
 import {
-	type DateDisplayFormat,
-	normalizeDateDisplayFormat,
-} from "./dateDisplayFormat";
+	DURABLE_SETTINGS,
+	INTERNAL_SETTING_KEYS,
+	SPACE_SETTINGS,
+	type SpaceSettingDefinition,
+	emitSettingsUpdated,
+} from "./settings/definitions";
+import type {
+	AppSettings,
+	EffectiveShortcutBindings,
+	RecentFile,
+	ShortcutBindings,
+	ShortcutSettings,
+	SpaceScopedSettings,
+	SpaceScopedSettingsMap,
+} from "./settings/model";
 import {
 	getSettingsStore,
 	invalidateSettingsCache,
@@ -47,16 +41,44 @@ import {
 	isShortcutActionId,
 } from "./shortcuts/registry";
 import { invoke } from "./tauri";
-import type { AiAssistantMode } from "./tauri";
 import {
 	GLYPH_DEFAULT_DARK_THEME_ID,
 	GLYPH_DEFAULT_LIGHT_THEME_ID,
-	type UiDarkThemeId,
-	type UiLightThemeId,
-	asUiDarkThemeId,
-	asUiLightThemeId,
 } from "./uiThemes";
 
+export {
+	DEFAULT_QUICK_NOTES_FOLDER,
+	DEFAULT_UI_CORNER_RADIUS_STYLE,
+	DEFAULT_UI_TRANSLUCENT_APP,
+	DURABLE_SETTINGS,
+	MAX_EDITOR_FONT_SIZE,
+	MAX_UI_FONT_SIZE,
+	MIN_EDITOR_FONT_SIZE,
+	MIN_UI_FONT_SIZE,
+	SPACE_SETTINGS,
+	isAttachmentStorageMode,
+	isFileTreeSortMode,
+	isFocusMode,
+	isUiCornerRadiusStyle,
+} from "./settings/definitions";
+export type {
+	AppSettings,
+	AttachmentStorageMode,
+	AutoUpdateCheckInterval,
+	EditorWidthMode,
+	EffectiveShortcutBindings,
+	FileTreeSortMode,
+	FocusMode,
+	RecentFile,
+	ReleaseChannel,
+	SettingsUpdatedPayload,
+	ShortcutBindings,
+	ShortcutSettings,
+	ThemeMode,
+	UiCornerRadiusStyle,
+	UiFontFamily,
+	UiFontSize,
+} from "./settings/model";
 export type { AiAssistantMode } from "./tauri";
 export type { DateDisplayFormat } from "./dateDisplayFormat";
 export {
@@ -68,237 +90,10 @@ export {
 export type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
 export type { AppLanguage } from "../i18n/locales";
 
-export type ReleaseChannel = "stable" | "alpha";
-export type FileTreeSortMode =
-	| "name-asc"
-	| "name-desc"
-	| "modified-desc"
-	| "modified-asc"
-	| "created-desc"
-	| "created-asc";
-const FILE_TREE_SORT_MODES = new Set<FileTreeSortMode>([
-	"name-asc",
-	"name-desc",
-	"modified-desc",
-	"modified-asc",
-	"created-desc",
-	"created-asc",
-]);
-
-function getSettingValue<T>(
-	entries: Map<string, unknown>,
-	key: string,
-): T | undefined {
-	return entries.get(key) as T | undefined;
-}
-
-export type ThemeMode = "system" | "light" | "dark";
-const THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
-export type AutoUpdateCheckInterval = "3h";
-const AUTO_UPDATE_CHECK_INTERVALS = new Set<AutoUpdateCheckInterval>(["3h"]);
-export type AttachmentStorageMode =
-	| "space-root"
-	| "specific-folder"
-	| "note-folder"
-	| "note-subfolder";
-const ATTACHMENT_STORAGE_MODES = new Set<AttachmentStorageMode>(
-	Object.keys(ATTACHMENT_MODE_UI) as AttachmentStorageMode[],
-);
-export type UiCornerRadiusStyle = "default" | "sharp" | "round";
-const UI_CORNER_RADIUS_STYLES = new Set<UiCornerRadiusStyle>([
-	"default",
-	"sharp",
-	"round",
-]);
-
-export function isUiCornerRadiusStyle(
-	value: unknown,
-): value is UiCornerRadiusStyle {
-	return (
-		typeof value === "string" &&
-		UI_CORNER_RADIUS_STYLES.has(value as UiCornerRadiusStyle)
-	);
-}
-
-export const DEFAULT_UI_CORNER_RADIUS_STYLE: UiCornerRadiusStyle = "default";
-
-function asUiCornerRadiusStyle(value: unknown): UiCornerRadiusStyle {
-	return isUiCornerRadiusStyle(value) ? value : DEFAULT_UI_CORNER_RADIUS_STYLE;
-}
-
-const DEFAULT_UI_FONT_FAMILY = "Geist";
-const DEFAULT_UI_EDITOR_FONT_FAMILY = DEFAULT_UI_FONT_FAMILY;
-const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
-const DEFAULT_AUTO_UPDATE_CHECK_INTERVAL: AutoUpdateCheckInterval = "3h";
-export const MIN_UI_FONT_SIZE = 7;
-export const MAX_UI_FONT_SIZE = 40;
-const DEFAULT_UI_FONT_SIZE = 14;
-export const MIN_EDITOR_FONT_SIZE = 10;
-export const MAX_EDITOR_FONT_SIZE = 40;
-const DEFAULT_EDITOR_FONT_SIZE = 16;
-export const DEFAULT_UI_TRANSLUCENT_APP = false;
-const DEFAULT_AI_ENABLED = true;
-export const DEFAULT_QUICK_NOTES_FOLDER = "Quick Notes";
-export type UiFontFamily = string;
-export type UiFontSize = number;
-const AI_ASSISTANT_MODES = new Set<AiAssistantMode>(["chat", "create"]);
-export type EditorWidthMode = "compact" | "comfortable" | "wide";
-const EDITOR_WIDTH_MODES = new Set<EditorWidthMode>([
-	"compact",
-	"comfortable",
-	"wide",
-]);
-export type FocusMode = "off" | "paragraph" | "sentence";
-const FOCUS_MODES = new Set<FocusMode>(["off", "paragraph", "sentence"]);
-interface DatabaseSettings {
-	showColumnColor: boolean;
-}
-
-interface QuickNotesSettings {
-	folder: string;
-}
-
-interface EditorSettings {
-	showCollapsibleHeadings: boolean;
-	showCollapsibleLists: boolean;
-	showFrontmatterInEditor: boolean;
-	showHeadingPrefixes: boolean;
-	colorfulHeadings: boolean;
-	headingPaletteId: HeadingPaletteId;
-	beautifulTags: boolean;
-	editorWidthMode: EditorWidthMode;
-	defaultEditorMode: EditorViewMode;
-	attachmentStorageMode: AttachmentStorageMode;
-	attachmentFolder: string | null;
-	enablePeopleMentionsAsTags: boolean;
-	rawMarkdownVimMode: boolean;
-	spellCheck: boolean;
-	showExternalLinkPreviews: boolean;
-	focusMode: FocusMode;
-}
-
-interface FileTreeSettings {
-	showFolderFileCounts: boolean;
-	showNonMarkdownFiles: boolean;
-	sortMode: FileTreeSortMode;
-}
-
-export interface ShortcutSettings {
-	version: 1;
-	bindings: Partial<Record<ShortcutActionId, Shortcut | null>>;
-}
-
-export type ShortcutBindings = ShortcutSettings["bindings"];
-export type EffectiveShortcutBindings = Record<
-	ShortcutActionId,
-	Shortcut | null
->;
-
 const DEFAULT_SHORTCUT_SETTINGS: ShortcutSettings = {
 	version: 1,
 	bindings: {},
 };
-
-const DEFAULT_DATABASE_SETTINGS: DatabaseSettings = {
-	showColumnColor: true,
-};
-
-const DEFAULT_EDITOR_SETTINGS: EditorSettings = {
-	showCollapsibleHeadings: false,
-	showCollapsibleLists: false,
-	showFrontmatterInEditor: false,
-	showHeadingPrefixes: true,
-	colorfulHeadings: false,
-	headingPaletteId: DEFAULT_HEADING_PALETTE_ID,
-	beautifulTags: false,
-	editorWidthMode: "compact",
-	defaultEditorMode: DEFAULT_EDITOR_VIEW_MODE,
-	attachmentStorageMode: "note-folder",
-	attachmentFolder: DEFAULT_ATTACHMENT_FOLDER,
-	enablePeopleMentionsAsTags: false,
-	rawMarkdownVimMode: false,
-	spellCheck: true,
-	showExternalLinkPreviews: false,
-	focusMode: "off",
-};
-
-const DEFAULT_FILE_TREE_SETTINGS: FileTreeSettings = {
-	showFolderFileCounts: false,
-	showNonMarkdownFiles: true,
-	sortMode: "name-asc",
-};
-
-export function isFileTreeSortMode(value: unknown): value is FileTreeSortMode {
-	return (
-		typeof value === "string" &&
-		FILE_TREE_SORT_MODES.has(value as FileTreeSortMode)
-	);
-}
-
-function asThemeMode(value: unknown): ThemeMode {
-	return typeof value === "string" && THEME_MODES.has(value as ThemeMode)
-		? (value as ThemeMode)
-		: "system";
-}
-
-function asFileTreeSortMode(value: unknown): FileTreeSortMode {
-	return isFileTreeSortMode(value)
-		? value
-		: DEFAULT_FILE_TREE_SETTINGS.sortMode;
-}
-
-function asAutoUpdateCheckInterval(value: unknown): AutoUpdateCheckInterval {
-	if (value === "launch" || value === "12h") {
-		return "3h";
-	}
-	return typeof value === "string" &&
-		AUTO_UPDATE_CHECK_INTERVALS.has(value as AutoUpdateCheckInterval)
-		? (value as AutoUpdateCheckInterval)
-		: DEFAULT_AUTO_UPDATE_CHECK_INTERVAL;
-}
-
-function asAiAssistantMode(value: unknown): AiAssistantMode {
-	return typeof value === "string" &&
-		AI_ASSISTANT_MODES.has(value as AiAssistantMode)
-		? (value as AiAssistantMode)
-		: "create";
-}
-
-function asAttachmentStorageMode(value: unknown): AttachmentStorageMode {
-	return isAttachmentStorageMode(value)
-		? value
-		: DEFAULT_EDITOR_SETTINGS.attachmentStorageMode;
-}
-
-export function isAttachmentStorageMode(
-	value: unknown,
-): value is AttachmentStorageMode {
-	return (
-		typeof value === "string" &&
-		ATTACHMENT_STORAGE_MODES.has(value as AttachmentStorageMode)
-	);
-}
-
-function asEditorWidthMode(value: unknown): EditorWidthMode {
-	return typeof value === "string" &&
-		EDITOR_WIDTH_MODES.has(value as EditorWidthMode)
-		? (value as EditorWidthMode)
-		: DEFAULT_EDITOR_SETTINGS.editorWidthMode;
-}
-
-function asDefaultEditorMode(value: unknown): EditorViewMode {
-	return isEditorViewMode(value)
-		? value
-		: DEFAULT_EDITOR_SETTINGS.defaultEditorMode;
-}
-
-export function isFocusMode(value: unknown): value is FocusMode {
-	return typeof value === "string" && FOCUS_MODES.has(value as FocusMode);
-}
-
-function asFocusMode(value: unknown): FocusMode {
-	return isFocusMode(value) ? value : DEFAULT_EDITOR_SETTINGS.focusMode;
-}
 
 /** Falls back to the Glyph preset when a selected custom theme no longer exists. */
 function resolveSelectedThemeId<T extends string>(
@@ -311,194 +106,6 @@ function resolveSelectedThemeId<T extends string>(
 		? themeId
 		: fallback;
 }
-
-function asUiFontFamily(
-	value: unknown,
-	fallback: UiFontFamily = DEFAULT_UI_FONT_FAMILY,
-): UiFontFamily {
-	if (typeof value !== "string") return fallback;
-	const trimmed = value.trim();
-	if (!trimmed) return fallback;
-	return trimmed.slice(0, 80);
-}
-
-function asUiEditorFontFamily(value: unknown): UiFontFamily {
-	return asUiFontFamily(value, DEFAULT_UI_EDITOR_FONT_FAMILY);
-}
-
-function asUiMonoFontFamily(value: unknown): UiFontFamily {
-	if (typeof value !== "string") return DEFAULT_UI_MONO_FONT_FAMILY;
-	const trimmed = value.trim();
-	if (!trimmed) return DEFAULT_UI_MONO_FONT_FAMILY;
-	return trimmed.slice(0, 80);
-}
-
-function asUiFontSize(value: unknown): UiFontSize {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return Math.max(
-			MIN_UI_FONT_SIZE,
-			Math.min(MAX_UI_FONT_SIZE, Math.round(value)),
-		);
-	}
-	if (value === "small") return 12;
-	if (value === "medium") return DEFAULT_UI_FONT_SIZE;
-	if (value === "large") return 16;
-	return DEFAULT_UI_FONT_SIZE;
-}
-
-function asUiEditorFontSize(value: unknown): UiFontSize {
-	if (typeof value === "number" && Number.isFinite(value)) {
-		return Math.max(
-			MIN_EDITOR_FONT_SIZE,
-			Math.min(MAX_EDITOR_FONT_SIZE, Math.round(value)),
-		);
-	}
-	return DEFAULT_EDITOR_FONT_SIZE;
-}
-
-function asReleaseChannel(value: unknown): ReleaseChannel {
-	return value === "alpha" ? "alpha" : "stable";
-}
-
-interface SettingsUpdatedPayload {
-	spacePath?: string;
-	ui?: {
-		theme?: ThemeMode;
-		autoUpdateCheckInterval?: AutoUpdateCheckInterval;
-		releaseChannel?: ReleaseChannel;
-		lightThemeId?: UiLightThemeId;
-		darkThemeId?: UiDarkThemeId;
-		customThemes?: CustomTheme[];
-		fontFamily?: UiFontFamily;
-		editorFontFamily?: UiFontFamily;
-		monoFontFamily?: UiFontFamily;
-		fontSize?: UiFontSize;
-		editorFontSize?: UiFontSize;
-		translucentApp?: boolean;
-		cornerRadiusStyle?: UiCornerRadiusStyle;
-		showToc?: boolean;
-		showFileTreeFolderCounts?: boolean;
-		showNonMarkdownFiles?: boolean;
-		fileTreeSortMode?: FileTreeSortMode;
-		folioMode?: boolean;
-		classicAllNotesByDefault?: boolean;
-		resumeLastSession?: boolean;
-		keepRunningOnLastWindowClose?: boolean;
-		aiAssistantMode?: AiAssistantMode;
-		aiEnabled?: boolean;
-		language?: AppLanguage;
-		dateDisplayFormat?: DateDisplayFormat;
-	};
-	dailyNotes?: {
-		folder?: string | null;
-	};
-	quickNotes?: {
-		folder?: string;
-	};
-	templates?: {
-		folder?: string | null;
-		dailyNoteTemplate?: string | null;
-	};
-	database?: {
-		showColumnColor?: boolean;
-	};
-	editor?: {
-		showCollapsibleHeadings?: boolean;
-		showCollapsibleLists?: boolean;
-		showFrontmatterInEditor?: boolean;
-		showHeadingPrefixes?: boolean;
-		colorfulHeadings?: boolean;
-		headingPaletteId?: HeadingPaletteId;
-		beautifulTags?: boolean;
-		editorWidthMode?: EditorWidthMode;
-		defaultEditorMode?: EditorViewMode;
-		attachmentStorageMode?: AttachmentStorageMode;
-		attachmentFolder?: string | null;
-		enablePeopleMentionsAsTags?: boolean;
-		rawMarkdownVimMode?: boolean;
-		spellCheck?: boolean;
-		showExternalLinkPreviews?: boolean;
-		focusMode?: FocusMode;
-	};
-	shortcuts?: {
-		bindings?: ShortcutBindings;
-	};
-}
-
-async function emitSettingsUpdated(
-	payload: SettingsUpdatedPayload,
-): Promise<void> {
-	try {
-		if (payload.spacePath) {
-			await emitTo(getCurrentWindow().label, "settings:updated", payload);
-			return;
-		}
-		await emit("settings:updated", payload);
-	} catch {
-		// best-effort cross-window sync
-	}
-}
-
-export interface RecentFile {
-	path: string;
-	spacePath: string;
-	openedAt: number;
-}
-
-export interface AppSettings {
-	currentSpacePath: string | null;
-	recentSpaces: string[];
-	recentFiles: RecentFile[];
-	ui: {
-		aiEnabled: boolean;
-		language: AppLanguage;
-		theme: ThemeMode;
-		autoUpdateCheckInterval: AutoUpdateCheckInterval;
-		releaseChannel: ReleaseChannel;
-		lightThemeId: UiLightThemeId;
-		darkThemeId: UiDarkThemeId;
-		customThemes: CustomTheme[];
-		fontFamily: UiFontFamily;
-		editorFontFamily: UiFontFamily;
-		monoFontFamily: UiFontFamily;
-		fontSize: UiFontSize;
-		editorFontSize: UiFontSize;
-		translucentApp: boolean;
-		cornerRadiusStyle: UiCornerRadiusStyle;
-		showToc: boolean;
-		showFileTreeFolderCounts: boolean;
-		showNonMarkdownFiles: boolean;
-		fileTreeSortMode: FileTreeSortMode;
-		folioMode: boolean;
-		classicAllNotesByDefault: boolean;
-		resumeLastSession: boolean;
-		keepRunningOnLastWindowClose: boolean;
-		aiAssistantMode: AiAssistantMode;
-		dateDisplayFormat: DateDisplayFormat;
-	};
-	dailyNotes: {
-		folder: string | null;
-	};
-	quickNotes: QuickNotesSettings;
-	templates: {
-		folder: string | null;
-		dailyNoteTemplate: string | null;
-	};
-	shortcuts: ShortcutSettings;
-	editor: EditorSettings;
-	database: DatabaseSettings;
-}
-
-interface SpaceScopedSettings {
-	dailyNotesFolder?: string | null;
-	quickNotesFolder?: string;
-	templatesFolder?: string | null;
-	templatesDailyNoteTemplate?: string | null;
-	attachmentStorageMode?: AttachmentStorageMode;
-	attachmentFolder?: string | null;
-}
-
-type SpaceScopedSettingsMap = Record<string, SpaceScopedSettings>;
 
 export interface SettingsScope {
 	spacePath?: string | null;
@@ -519,77 +126,6 @@ async function withSpaceScopedSettingsWriteLock<T>(
 	const run = spaceScopedSettingsWriteQueue.then(operation, operation);
 	spaceScopedSettingsWriteQueue = run.catch(() => {});
 	return run;
-}
-
-const KEYS = {
-	currentSpacePath: "space.currentPath",
-	recentSpaces: "space.recent",
-	recentFiles: "files.recent",
-	aiEnabled: "ui.aiEnabled",
-	language: "ui.language",
-	dateDisplayFormat: "ui.dateDisplayFormat",
-	aiAssistantMode: "ui.aiAssistantMode",
-	theme: "ui.theme",
-	autoUpdateCheckInterval: "ui.autoUpdateCheckInterval",
-	releaseChannel: "updates.releaseChannel",
-	lightThemeId: "ui.lightThemeId",
-	darkThemeId: "ui.darkThemeId",
-	customThemes: "ui.customThemes",
-	fontFamily: "ui.fontFamily",
-	editorFontFamily: "ui.editorFontFamily",
-	monoFontFamily: "ui.monoFontFamily",
-	fontSize: "ui.fontSize",
-	editorFontSize: "ui.editorFontSize",
-	translucentApp: "ui.translucentApp",
-	cornerRadiusStyle: "ui.cornerRadiusStyle",
-	showToc: "ui.showToc",
-	showFileTreeFolderCounts: "ui.fileTree.showFolderFileCounts",
-	showNonMarkdownFiles: "ui.fileTree.showNonMarkdownFiles",
-	fileTreeSortMode: "ui.fileTree.sortMode",
-	folioMode: "ui.folioMode",
-	classicAllNotesByDefault: "ui.classicAllNotesByDefault",
-	resumeLastSession: "ui.resumeLastSession",
-	keepRunningOnLastWindowClose: "ui.keepRunningOnLastWindowClose",
-	editorShowCollapsibleHeadings: "editor.showCollapsibleHeadings",
-	editorShowCollapsibleLists: "editor.showCollapsibleLists",
-	editorShowFrontmatterInEditor: "editor.showFrontmatterInEditor",
-	editorShowHeadingPrefixes: "editor.showHeadingPrefixes",
-	editorColorfulHeadings: "editor.colorfulHeadings",
-	editorHeadingPaletteId: "editor.headingPaletteId",
-	editorBeautifulTags: "editor.beautifulTags",
-	editorEditorWidthMode: "editor.editorWidthMode",
-	editorDefaultEditorMode: "editor.defaultEditorMode",
-	editorAttachmentStorageMode: "editor.attachmentStorageMode",
-	editorAttachmentFolder: "editor.attachmentFolder",
-	editorEnablePeopleMentionsAsTags: "editor.enablePeopleMentionsAsTags",
-	editorRawMarkdownVimMode: "editor.rawMarkdownVimMode",
-	editorSpellCheck: "editor.spellCheck",
-	editorShowExternalLinkPreviews: "editor.showExternalLinkPreviews",
-	editorFocusMode: "editor.focusMode",
-	autoUpdateLastCheckedAt: "updates.lastCheckedAt",
-	dailyNotesFolder: "dailyNotes.folder",
-	quickNotesFolder: "quickNotes.folder",
-	templatesFolder: "templates.folder",
-	templatesDailyNoteTemplate: "templates.dailyNoteTemplate",
-	shortcutsVersion: "shortcuts.version",
-	shortcutsBindings: "shortcuts.bindings",
-	databaseShowColumnColor: "database.showColumnColor",
-	spaceScopedSettings: "space.scopedSettings",
-} as const;
-
-type SettingsKey = (typeof KEYS)[keyof typeof KEYS];
-
-async function persistSetting<Value>(
-	key: SettingsKey,
-	value: Value,
-	payload: SettingsUpdatedPayload,
-	afterSave?: (value: Value) => void,
-): Promise<void> {
-	const store = await getSettingsStore();
-	await store.set(key, value);
-	await saveSettingsStore(store);
-	afterSave?.(value);
-	void emitSettingsUpdated(payload);
 }
 
 function isShortcutBindingRecord(
@@ -698,13 +234,14 @@ function normalizeSpaceScopedSettings(value: unknown): SpaceScopedSettings {
 	if (!isRecord(value)) return {};
 	const out: SpaceScopedSettings = {};
 	if ("dailyNotesFolder" in value) {
-		out.dailyNotesFolder =
-			typeof value.dailyNotesFolder === "string"
-				? normalizeRelPath(value.dailyNotesFolder) || null
-				: null;
+		out.dailyNotesFolder = SPACE_SETTINGS.dailyNotesFolder.normalize(
+			value.dailyNotesFolder,
+		);
 	}
-	if (typeof value.quickNotesFolder === "string") {
-		out.quickNotesFolder = normalizeQuickNotesFolder(value.quickNotesFolder);
+	if ("quickNotesFolder" in value) {
+		out.quickNotesFolder = SPACE_SETTINGS.quickNotesFolder.normalize(
+			value.quickNotesFolder,
+		);
 	}
 	if ("templatesFolder" in value) {
 		out.templatesFolder =
@@ -714,20 +251,19 @@ function normalizeSpaceScopedSettings(value: unknown): SpaceScopedSettings {
 	}
 	if ("templatesDailyNoteTemplate" in value) {
 		out.templatesDailyNoteTemplate =
-			typeof value.templatesDailyNoteTemplate === "string"
-				? normalizeRelPath(value.templatesDailyNoteTemplate) || null
-				: null;
+			SPACE_SETTINGS.templatesDailyNoteTemplate.normalize(
+				value.templatesDailyNoteTemplate,
+			);
 	}
 	if ("attachmentStorageMode" in value) {
-		out.attachmentStorageMode = asAttachmentStorageMode(
+		out.attachmentStorageMode = SPACE_SETTINGS.attachmentStorageMode.normalize(
 			value.attachmentStorageMode,
 		);
 	}
 	if ("attachmentFolder" in value) {
-		out.attachmentFolder =
-			typeof value.attachmentFolder === "string"
-				? normalizeRelPath(value.attachmentFolder) || DEFAULT_ATTACHMENT_FOLDER
-				: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
+		out.attachmentFolder = SPACE_SETTINGS.attachmentFolder.normalize(
+			value.attachmentFolder,
+		);
 	}
 	return out;
 }
@@ -766,13 +302,44 @@ async function updateActiveSpaceSettings(
 	await withSpaceScopedSettingsWriteLock(async () => {
 		const store = await getSettingsStore();
 		const map = normalizeSpaceScopedSettingsMap(
-			await store.get<unknown>(KEYS.spaceScopedSettings),
+			await store.get<unknown>(INTERNAL_SETTING_KEYS.spaceScopedSettings),
 		);
 		map[spacePath] = { ...map[spacePath], ...patch };
-		await store.set(KEYS.spaceScopedSettings, map);
+		await store.set(INTERNAL_SETTING_KEYS.spaceScopedSettings, map);
 		await saveSettingsStore(store);
 	});
 	return spacePath;
+}
+
+export async function writeSpaceSetting<Value>(
+	definition: SpaceSettingDefinition<Value>,
+	value: Value,
+	scope?: SettingsScope,
+): Promise<void> {
+	const normalized = definition.normalize(value);
+	const validationError = definition.validate?.(normalized);
+	if (validationError) throw new Error(validationError);
+
+	const spacePath = await updateActiveSpaceSettings(
+		definition.patch(normalized),
+		scope,
+	);
+	if (spacePath) {
+		void emitSettingsUpdated({
+			...definition.change(normalized),
+			spacePath,
+		});
+		return;
+	}
+
+	const store = await getSettingsStore();
+	if (normalized === null) {
+		await store.delete(definition.legacyKey);
+	} else {
+		await store.set(definition.legacyKey, normalized);
+	}
+	await saveSettingsStore(store);
+	void emitSettingsUpdated(definition.change(normalized));
 }
 
 export function findShortcutConflict(
@@ -792,12 +359,6 @@ export function findShortcutConflict(
 	return null;
 }
 
-function normalizeQuickNotesFolder(value: unknown): string {
-	if (typeof value !== "string") return DEFAULT_QUICK_NOTES_FOLDER;
-	const normalized = normalizeRelPath(value);
-	return normalized || DEFAULT_QUICK_NOTES_FOLDER;
-}
-
 export async function reloadFromDisk(): Promise<void> {
 	const store = await getSettingsStore();
 	await store.reload();
@@ -814,322 +375,173 @@ function isRecentFileArray(value: unknown): value is RecentFile[] {
 				"path" in item &&
 				"spacePath" in item &&
 				"openedAt" in item &&
-				typeof (item as RecentFile).path === "string" &&
-				typeof (item as RecentFile).spacePath === "string" &&
-				typeof (item as RecentFile).openedAt === "number",
+				typeof item.path === "string" &&
+				typeof item.spacePath === "string" &&
+				typeof item.openedAt === "number",
 		)
 	);
+}
+
+function loadSpaceSettingValue<Value>(
+	definition: SpaceSettingDefinition<Value>,
+	entries: ReadonlyMap<string, unknown>,
+	activeSettings: SpaceScopedSettings | undefined,
+	hasActiveSpace: boolean,
+): Value {
+	const storedValue = hasActiveSpace
+		? activeSettings?.[definition.field]
+		: entries.get(definition.legacyKey);
+	return definition.normalize(storedValue);
 }
 
 export async function loadSettings(
 	scope?: SettingsScope,
 ): Promise<AppSettings> {
 	const entries = await loadSettingsEntries();
-	const currentSpacePathRaw = getSettingValue<string | null>(
-		entries,
-		KEYS.currentSpacePath,
+	const currentSpacePathRaw = entries.get(
+		INTERNAL_SETTING_KEYS.currentSpacePath,
 	);
-	const recentSpacesRaw = getSettingValue<string[] | null>(
-		entries,
-		KEYS.recentSpaces,
+	const recentSpacesRaw = entries.get(INTERNAL_SETTING_KEYS.recentSpaces);
+	const rawRecentFiles = entries.get(INTERNAL_SETTING_KEYS.recentFiles);
+	const rawShortcutSettingsVersion = entries.get(
+		INTERNAL_SETTING_KEYS.shortcutsVersion,
 	);
-	const rawRecentFiles = getSettingValue(entries, KEYS.recentFiles);
-	const rawAiEnabled = getSettingValue<boolean | null>(entries, KEYS.aiEnabled);
-	const rawLanguage = getSettingValue(entries, KEYS.language);
-	const rawDateDisplayFormat = getSettingValue(entries, KEYS.dateDisplayFormat);
-	const rawAiAssistantMode = getSettingValue(entries, KEYS.aiAssistantMode);
-	const rawTheme = getSettingValue(entries, KEYS.theme);
-	const rawAutoUpdateCheckInterval = getSettingValue(
-		entries,
-		KEYS.autoUpdateCheckInterval,
+	const rawShortcutBindings = entries.get(
+		INTERNAL_SETTING_KEYS.shortcutsBindings,
 	);
-	const rawReleaseChannel = getSettingValue(entries, KEYS.releaseChannel);
-	const rawLightThemeId = getSettingValue(entries, KEYS.lightThemeId);
-	const rawDarkThemeId = getSettingValue(entries, KEYS.darkThemeId);
-	const rawFontFamily = getSettingValue(entries, KEYS.fontFamily);
-	const rawEditorFontFamily = getSettingValue(entries, KEYS.editorFontFamily);
-	const rawMonoFontFamily = getSettingValue(entries, KEYS.monoFontFamily);
-	const rawFontSize = getSettingValue(entries, KEYS.fontSize);
-	const rawEditorFontSize = getSettingValue(entries, KEYS.editorFontSize);
-	const rawTranslucentApp = getSettingValue<boolean | null>(
-		entries,
-		KEYS.translucentApp,
-	);
-	const rawCornerRadiusStyle = getSettingValue(entries, KEYS.cornerRadiusStyle);
-	const rawShowToc = getSettingValue<boolean | null>(entries, KEYS.showToc);
-	const rawShowFileTreeFolderCounts = getSettingValue<boolean | null>(
-		entries,
-		KEYS.showFileTreeFolderCounts,
-	);
-	const rawShowNonMarkdownFiles = getSettingValue<boolean | null>(
-		entries,
-		KEYS.showNonMarkdownFiles,
-	);
-	const rawFileTreeSortMode = getSettingValue(entries, KEYS.fileTreeSortMode);
-	const rawFolioMode = getSettingValue<boolean | null>(entries, KEYS.folioMode);
-	const rawClassicAllNotesByDefault = getSettingValue<boolean | null>(
-		entries,
-		KEYS.classicAllNotesByDefault,
-	);
-	const rawResumeLastSession = getSettingValue<boolean | null>(
-		entries,
-		KEYS.resumeLastSession,
-	);
-	const rawKeepRunningOnLastWindowClose = getSettingValue<boolean | null>(
-		entries,
-		KEYS.keepRunningOnLastWindowClose,
-	);
-	const dailyNotesFolderRaw = getSettingValue<string | null>(
-		entries,
-		KEYS.dailyNotesFolder,
-	);
-	const rawQuickNotesFolder = getSettingValue(entries, KEYS.quickNotesFolder);
-	const templatesFolderRaw = getSettingValue<string | null>(
-		entries,
-		KEYS.templatesFolder,
-	);
-	const templatesDailyNoteTemplateRaw = getSettingValue<string | null>(
-		entries,
-		KEYS.templatesDailyNoteTemplate,
-	);
-	const rawEditorShowCollapsibleHeadings = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorShowCollapsibleHeadings,
-	);
-	const rawEditorShowCollapsibleLists = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorShowCollapsibleLists,
-	);
-	const rawEditorShowFrontmatterInEditor = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorShowFrontmatterInEditor,
-	);
-	const rawEditorShowHeadingPrefixes = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorShowHeadingPrefixes,
-	);
-	const rawEditorColorfulHeadings = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorColorfulHeadings,
-	);
-	const rawEditorHeadingPaletteId = getSettingValue(
-		entries,
-		KEYS.editorHeadingPaletteId,
-	);
-	const rawEditorBeautifulTags = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorBeautifulTags,
-	);
-	const rawEditorWidthMode = getSettingValue(
-		entries,
-		KEYS.editorEditorWidthMode,
-	);
-	const rawEditorDefaultEditorMode = getSettingValue(
-		entries,
-		KEYS.editorDefaultEditorMode,
-	);
-	const rawEditorAttachmentStorageMode = getSettingValue(
-		entries,
-		KEYS.editorAttachmentStorageMode,
-	);
-	const rawEditorAttachmentFolder = getSettingValue<string | null>(
-		entries,
-		KEYS.editorAttachmentFolder,
-	);
-	const rawEditorEnablePeopleMentionsAsTags = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorEnablePeopleMentionsAsTags,
-	);
-	const rawEditorRawMarkdownVimMode = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorRawMarkdownVimMode,
-	);
-	const rawEditorSpellCheck = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorSpellCheck,
-	);
-	const rawEditorShowExternalLinkPreviews = getSettingValue<boolean | null>(
-		entries,
-		KEYS.editorShowExternalLinkPreviews,
-	);
-	const rawEditorFocusMode = getSettingValue(entries, KEYS.editorFocusMode);
-	const rawDatabaseShowColumnColor = getSettingValue<boolean | null>(
-		entries,
-		KEYS.databaseShowColumnColor,
-	);
-	const rawShortcutSettingsVersion = getSettingValue<number | null>(
-		entries,
-		KEYS.shortcutsVersion,
-	);
-	const rawShortcutBindings = getSettingValue(entries, KEYS.shortcutsBindings);
-	const rawSpaceScopedSettings = getSettingValue(
-		entries,
-		KEYS.spaceScopedSettings,
+	const rawSpaceScopedSettings = entries.get(
+		INTERNAL_SETTING_KEYS.spaceScopedSettings,
 	);
 	const scopedSettings = normalizeSpaceScopedSettingsMap(
 		rawSpaceScopedSettings,
 	);
 	const activeSettingsSpacePath = await activeSpacePath(scope);
 	const currentSpacePath =
-		activeSettingsSpacePath ?? currentSpacePathRaw ?? null;
+		activeSettingsSpacePath ??
+		(typeof currentSpacePathRaw === "string" ? currentSpacePathRaw : null);
 	const activeScopedSettings = activeSettingsSpacePath
 		? scopedSettings[activeSettingsSpacePath]
 		: undefined;
 	const hasActiveSpace = Boolean(activeSettingsSpacePath);
-	const recentSpaces = recentSpacesRaw ?? [];
+	const recentSpaces = Array.isArray(recentSpacesRaw)
+		? recentSpacesRaw.filter((path): path is string => typeof path === "string")
+		: [];
 	const recentFiles = isRecentFileArray(rawRecentFiles) ? rawRecentFiles : [];
-	const aiEnabled =
-		typeof rawAiEnabled === "boolean" ? rawAiEnabled : DEFAULT_AI_ENABLED;
-	const language = normalizeAppLanguage(rawLanguage);
-	const dateDisplayFormat = normalizeDateDisplayFormat(rawDateDisplayFormat);
-	const aiAssistantMode = asAiAssistantMode(rawAiAssistantMode);
-	const theme = asThemeMode(rawTheme);
-	const autoUpdateCheckInterval = asAutoUpdateCheckInterval(
-		rawAutoUpdateCheckInterval,
-	);
-	const releaseChannel = asReleaseChannel(rawReleaseChannel);
-	const customThemes = normalizeCustomThemes(
-		getSettingValue(entries, KEYS.customThemes),
-	);
+	const aiEnabled = DURABLE_SETTINGS.aiEnabled.load(entries);
+	const language = DURABLE_SETTINGS.language.load(entries);
+	const dateDisplayFormat = DURABLE_SETTINGS.dateDisplayFormat.load(entries);
+	const aiAssistantMode = DURABLE_SETTINGS.aiAssistantMode.load(entries);
+	const theme = DURABLE_SETTINGS.theme.load(entries);
+	const autoUpdateCheckInterval =
+		DURABLE_SETTINGS.autoUpdateCheckInterval.load(entries);
+	const releaseChannel = DURABLE_SETTINGS.releaseChannel.load(entries);
+	const customThemes = DURABLE_SETTINGS.customThemes.load(entries);
 	const lightThemeId = resolveSelectedThemeId(
-		asUiLightThemeId(rawLightThemeId),
+		DURABLE_SETTINGS.lightThemeId.load(entries),
 		customThemes,
 		GLYPH_DEFAULT_LIGHT_THEME_ID,
 	);
 	const darkThemeId = resolveSelectedThemeId(
-		asUiDarkThemeId(rawDarkThemeId),
+		DURABLE_SETTINGS.darkThemeId.load(entries),
 		customThemes,
 		GLYPH_DEFAULT_DARK_THEME_ID,
 	);
-	const fontFamily = asUiFontFamily(rawFontFamily);
-	const monoFontFamily = asUiMonoFontFamily(rawMonoFontFamily);
-	const editorFontFamily =
-		rawEditorFontFamily === undefined || rawEditorFontFamily === null
-			? fontFamily
-			: asUiEditorFontFamily(rawEditorFontFamily);
-	const fontSize = asUiFontSize(rawFontSize);
-	const editorFontSize =
-		rawEditorFontSize === undefined || rawEditorFontSize === null
-			? DEFAULT_EDITOR_FONT_SIZE
-			: asUiEditorFontSize(rawEditorFontSize);
-	const translucentApp =
-		typeof rawTranslucentApp === "boolean"
-			? rawTranslucentApp
-			: DEFAULT_UI_TRANSLUCENT_APP;
-	const cornerRadiusStyle = asUiCornerRadiusStyle(rawCornerRadiusStyle);
-	const showToc = typeof rawShowToc === "boolean" ? rawShowToc : true;
+	const fontFamily = DURABLE_SETTINGS.fontFamily.load(entries);
+	const editorFontFamily = entries.has(DURABLE_SETTINGS.editorFontFamily.key)
+		? DURABLE_SETTINGS.editorFontFamily.load(entries)
+		: fontFamily;
+	const monoFontFamily = DURABLE_SETTINGS.monoFontFamily.load(entries);
+	const fontSize = DURABLE_SETTINGS.fontSize.load(entries);
+	const editorFontSize = DURABLE_SETTINGS.editorFontSize.load(entries);
+	const translucentApp = DURABLE_SETTINGS.translucentApp.load(entries);
+	const cornerRadiusStyle = DURABLE_SETTINGS.cornerRadiusStyle.load(entries);
+	const showToc = DURABLE_SETTINGS.showToc.load(entries);
 	const showFileTreeFolderCounts =
-		typeof rawShowFileTreeFolderCounts === "boolean"
-			? rawShowFileTreeFolderCounts
-			: DEFAULT_FILE_TREE_SETTINGS.showFolderFileCounts;
+		DURABLE_SETTINGS.showFileTreeFolderCounts.load(entries);
 	const showNonMarkdownFiles =
-		typeof rawShowNonMarkdownFiles === "boolean"
-			? rawShowNonMarkdownFiles
-			: DEFAULT_FILE_TREE_SETTINGS.showNonMarkdownFiles;
-	const fileTreeSortMode = asFileTreeSortMode(rawFileTreeSortMode);
-	const folioMode = typeof rawFolioMode === "boolean" ? rawFolioMode : false;
+		DURABLE_SETTINGS.showNonMarkdownFiles.load(entries);
+	const fileTreeSortMode = DURABLE_SETTINGS.fileTreeSortMode.load(entries);
+	const folioMode = DURABLE_SETTINGS.folioMode.load(entries);
 	const classicAllNotesByDefault =
-		typeof rawClassicAllNotesByDefault === "boolean"
-			? rawClassicAllNotesByDefault
-			: false;
-	const resumeLastSession =
-		typeof rawResumeLastSession === "boolean" ? rawResumeLastSession : false;
+		DURABLE_SETTINGS.classicAllNotesByDefault.load(entries);
+	const resumeLastSession = DURABLE_SETTINGS.resumeLastSession.load(entries);
 	const keepRunningOnLastWindowClose =
-		typeof rawKeepRunningOnLastWindowClose === "boolean"
-			? rawKeepRunningOnLastWindowClose
-			: false;
-	const dailyNotesFolder = hasActiveSpace
-		? (activeScopedSettings?.dailyNotesFolder ?? null)
-		: typeof dailyNotesFolderRaw === "string"
-			? normalizeRelPath(dailyNotesFolderRaw) || null
-			: null;
-	const quickNotesFolder = hasActiveSpace
-		? (activeScopedSettings?.quickNotesFolder ?? DEFAULT_QUICK_NOTES_FOLDER)
-		: normalizeQuickNotesFolder(rawQuickNotesFolder);
+		DURABLE_SETTINGS.keepRunningOnLastWindowClose.load(entries);
+	const dailyNotesFolder = loadSpaceSettingValue(
+		SPACE_SETTINGS.dailyNotesFolder,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
+	const quickNotesFolder = loadSpaceSettingValue(
+		SPACE_SETTINGS.quickNotesFolder,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
+	const legacyTemplatesFolder = entries.get(
+		INTERNAL_SETTING_KEYS.templatesFolder,
+	);
 	const templatesFolder = hasActiveSpace
 		? (activeScopedSettings?.templatesFolder ?? null)
-		: typeof templatesFolderRaw === "string"
-			? normalizeRelPath(templatesFolderRaw)
+		: typeof legacyTemplatesFolder === "string"
+			? normalizeRelPath(legacyTemplatesFolder)
 			: null;
-	const templatesDailyNoteTemplate = hasActiveSpace
-		? (activeScopedSettings?.templatesDailyNoteTemplate ?? null)
-		: typeof templatesDailyNoteTemplateRaw === "string"
-			? normalizeRelPath(templatesDailyNoteTemplateRaw) || null
-			: null;
+	const templatesDailyNoteTemplate = loadSpaceSettingValue(
+		SPACE_SETTINGS.templatesDailyNoteTemplate,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
 	const shortcutBindings = sanitizeShortcutBindings(rawShortcutBindings);
 	const shortcuts: ShortcutSettings = {
 		version:
 			rawShortcutSettingsVersion === 1 ? 1 : DEFAULT_SHORTCUT_SETTINGS.version,
 		bindings: shortcutBindings,
 	};
-	const attachmentStorageMode = hasActiveSpace
-		? (activeScopedSettings?.attachmentStorageMode ??
-			DEFAULT_EDITOR_SETTINGS.attachmentStorageMode)
-		: asAttachmentStorageMode(rawEditorAttachmentStorageMode);
-	const attachmentFolder = hasActiveSpace
-		? (activeScopedSettings?.attachmentFolder ??
-			DEFAULT_EDITOR_SETTINGS.attachmentFolder)
-		: typeof rawEditorAttachmentFolder === "string"
-			? normalizeRelPath(rawEditorAttachmentFolder) || DEFAULT_ATTACHMENT_FOLDER
-			: DEFAULT_EDITOR_SETTINGS.attachmentFolder;
-	const editor: EditorSettings = {
+	const attachmentStorageMode = loadSpaceSettingValue(
+		SPACE_SETTINGS.attachmentStorageMode,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
+	const attachmentFolder = loadSpaceSettingValue(
+		SPACE_SETTINGS.attachmentFolder,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
+	const editor: AppSettings["editor"] = {
 		showCollapsibleHeadings:
-			typeof rawEditorShowCollapsibleHeadings === "boolean"
-				? rawEditorShowCollapsibleHeadings
-				: DEFAULT_EDITOR_SETTINGS.showCollapsibleHeadings,
+			DURABLE_SETTINGS.editorShowCollapsibleHeadings.load(entries),
 		showCollapsibleLists:
-			typeof rawEditorShowCollapsibleLists === "boolean"
-				? rawEditorShowCollapsibleLists
-				: DEFAULT_EDITOR_SETTINGS.showCollapsibleLists,
+			DURABLE_SETTINGS.editorShowCollapsibleLists.load(entries),
 		showFrontmatterInEditor:
-			typeof rawEditorShowFrontmatterInEditor === "boolean"
-				? rawEditorShowFrontmatterInEditor
-				: DEFAULT_EDITOR_SETTINGS.showFrontmatterInEditor,
+			DURABLE_SETTINGS.editorShowFrontmatterInEditor.load(entries),
 		showHeadingPrefixes:
-			typeof rawEditorShowHeadingPrefixes === "boolean"
-				? rawEditorShowHeadingPrefixes
-				: DEFAULT_EDITOR_SETTINGS.showHeadingPrefixes,
-		colorfulHeadings:
-			typeof rawEditorColorfulHeadings === "boolean"
-				? rawEditorColorfulHeadings
-				: DEFAULT_EDITOR_SETTINGS.colorfulHeadings,
-		headingPaletteId: asHeadingPaletteId(rawEditorHeadingPaletteId),
-		beautifulTags:
-			typeof rawEditorBeautifulTags === "boolean"
-				? rawEditorBeautifulTags
-				: DEFAULT_EDITOR_SETTINGS.beautifulTags,
-		editorWidthMode: asEditorWidthMode(rawEditorWidthMode),
-		defaultEditorMode: asDefaultEditorMode(rawEditorDefaultEditorMode),
+			DURABLE_SETTINGS.editorShowHeadingPrefixes.load(entries),
+		colorfulHeadings: DURABLE_SETTINGS.editorColorfulHeadings.load(entries),
+		headingPaletteId: DURABLE_SETTINGS.editorHeadingPaletteId.load(entries),
+		beautifulTags: DURABLE_SETTINGS.editorBeautifulTags.load(entries),
+		editorWidthMode: DURABLE_SETTINGS.editorWidthMode.load(entries),
+		defaultEditorMode: DURABLE_SETTINGS.editorDefaultEditorMode.load(entries),
 		attachmentStorageMode,
 		attachmentFolder,
 		enablePeopleMentionsAsTags:
-			typeof rawEditorEnablePeopleMentionsAsTags === "boolean"
-				? rawEditorEnablePeopleMentionsAsTags
-				: DEFAULT_EDITOR_SETTINGS.enablePeopleMentionsAsTags,
-		rawMarkdownVimMode:
-			typeof rawEditorRawMarkdownVimMode === "boolean"
-				? rawEditorRawMarkdownVimMode
-				: DEFAULT_EDITOR_SETTINGS.rawMarkdownVimMode,
-		spellCheck:
-			typeof rawEditorSpellCheck === "boolean"
-				? rawEditorSpellCheck
-				: DEFAULT_EDITOR_SETTINGS.spellCheck,
+			DURABLE_SETTINGS.editorEnablePeopleMentionsAsTags.load(entries),
+		rawMarkdownVimMode: DURABLE_SETTINGS.editorRawMarkdownVimMode.load(entries),
+		spellCheck: DURABLE_SETTINGS.editorSpellCheck.load(entries),
 		showExternalLinkPreviews:
-			typeof rawEditorShowExternalLinkPreviews === "boolean"
-				? rawEditorShowExternalLinkPreviews
-				: DEFAULT_EDITOR_SETTINGS.showExternalLinkPreviews,
-		focusMode: asFocusMode(rawEditorFocusMode),
+			DURABLE_SETTINGS.editorShowExternalLinkPreviews.load(entries),
+		focusMode: DURABLE_SETTINGS.editorFocusMode.load(entries),
 	};
-	const database: DatabaseSettings = {
-		showColumnColor:
-			typeof rawDatabaseShowColumnColor === "boolean"
-				? rawDatabaseShowColumnColor
-				: DEFAULT_DATABASE_SETTINGS.showColumnColor,
+	const database: AppSettings["database"] = {
+		showColumnColor: DURABLE_SETTINGS.databaseShowColumnColor.load(entries),
 	};
 	setCachedDefaultEditorViewMode(editor.defaultEditorMode);
 	return {
 		currentSpacePath,
-		recentSpaces: Array.isArray(recentSpaces) ? recentSpaces : [],
+		recentSpaces,
 		recentFiles,
 		ui: {
 			aiEnabled,
@@ -1176,24 +588,29 @@ export async function loadSettings(
 
 export async function setCurrentSpacePath(path: string): Promise<void> {
 	const store = await getSettingsStore();
-	await store.set(KEYS.currentSpacePath, path);
-	const prev = (await store.get<string[] | null>(KEYS.recentSpaces)) ?? [];
+	await store.set(INTERNAL_SETTING_KEYS.currentSpacePath, path);
+	const prev =
+		(await store.get<string[] | null>(INTERNAL_SETTING_KEYS.recentSpaces)) ??
+		[];
 	const next = [path, ...prev.filter((p) => p !== path)].slice(0, 20);
-	await store.set(KEYS.recentSpaces, next);
+	await store.set(INTERNAL_SETTING_KEYS.recentSpaces, next);
 	await saveSettingsStore(store);
 }
 
 export async function clearCurrentSpacePath(): Promise<void> {
 	const store = await getSettingsStore();
-	await store.set(KEYS.currentSpacePath, null);
+	await store.set(INTERNAL_SETTING_KEYS.currentSpacePath, null);
 	await saveSettingsStore(store);
 }
 
 async function saveShortcutBindingsToStore(bindings: ShortcutBindings) {
 	const store = await getSettingsStore();
 	const sanitized = sanitizeShortcutBindings(bindings);
-	await store.set(KEYS.shortcutsVersion, DEFAULT_SHORTCUT_SETTINGS.version);
-	await store.set(KEYS.shortcutsBindings, sanitized);
+	await store.set(
+		INTERNAL_SETTING_KEYS.shortcutsVersion,
+		DEFAULT_SHORTCUT_SETTINGS.version,
+	);
+	await store.set(INTERNAL_SETTING_KEYS.shortcutsBindings, sanitized);
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({ shortcuts: { bindings: sanitized } });
 	return sanitized;
@@ -1268,386 +685,11 @@ export async function resetShortcutBinding(
 export async function resetAllShortcutBindings(): Promise<void> {
 	return withShortcutBindingsWriteLock(async () => {
 		const store = await getSettingsStore();
-		await store.delete(KEYS.shortcutsVersion);
-		await store.delete(KEYS.shortcutsBindings);
+		await store.delete(INTERNAL_SETTING_KEYS.shortcutsVersion);
+		await store.delete(INTERNAL_SETTING_KEYS.shortcutsBindings);
 		await saveSettingsStore(store);
 		void emitSettingsUpdated({ shortcuts: { bindings: {} } });
 	});
-}
-
-export async function setAiAssistantMode(mode: AiAssistantMode): Promise<void> {
-	await persistSetting(KEYS.aiAssistantMode, mode, {
-		ui: { aiAssistantMode: mode },
-	});
-}
-
-export async function setAiEnabled(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.aiEnabled, enabled, { ui: { aiEnabled: enabled } });
-}
-
-export async function setLanguage(language: AppLanguage): Promise<void> {
-	const normalized = normalizeAppLanguage(language);
-	await persistSetting(KEYS.language, normalized, {
-		ui: { language: normalized },
-	});
-}
-
-export async function setDateDisplayFormat(
-	format: DateDisplayFormat,
-): Promise<void> {
-	const next = normalizeDateDisplayFormat(format);
-	await persistSetting(KEYS.dateDisplayFormat, next, {
-		ui: { dateDisplayFormat: next },
-	});
-}
-
-export async function setThemeMode(theme: ThemeMode): Promise<void> {
-	await persistSetting(KEYS.theme, theme, { ui: { theme } });
-}
-
-export async function setUiLightThemeId(
-	lightThemeId: UiLightThemeId,
-): Promise<void> {
-	const next = asUiLightThemeId(lightThemeId);
-	await persistSetting(KEYS.lightThemeId, next, { ui: { lightThemeId: next } });
-}
-
-export async function setUiDarkThemeId(
-	darkThemeId: UiDarkThemeId,
-): Promise<void> {
-	const next = asUiDarkThemeId(darkThemeId);
-	await persistSetting(KEYS.darkThemeId, next, { ui: { darkThemeId: next } });
-}
-
-export async function setUiCustomThemes(
-	customThemes: readonly CustomTheme[],
-): Promise<void> {
-	const next = normalizeCustomThemes(customThemes);
-	await persistSetting(KEYS.customThemes, next, { ui: { customThemes: next } });
-}
-
-export async function setUiFontFamily(fontFamily: UiFontFamily): Promise<void> {
-	const next = asUiFontFamily(fontFamily);
-	await persistSetting(KEYS.fontFamily, next, { ui: { fontFamily: next } });
-}
-
-export async function setUiEditorFontFamily(
-	fontFamily: UiFontFamily,
-): Promise<void> {
-	const next = asUiEditorFontFamily(fontFamily);
-	await persistSetting(KEYS.editorFontFamily, next, {
-		ui: { editorFontFamily: next },
-	});
-}
-
-export async function setUiMonoFontFamily(
-	fontFamily: UiFontFamily,
-): Promise<void> {
-	const next = asUiMonoFontFamily(fontFamily);
-	await persistSetting(KEYS.monoFontFamily, next, {
-		ui: { monoFontFamily: next },
-	});
-}
-
-export async function setUiFontSize(fontSize: UiFontSize): Promise<void> {
-	const next = asUiFontSize(fontSize);
-	await persistSetting(KEYS.fontSize, next, { ui: { fontSize: next } });
-}
-
-export async function setUiEditorFontSize(fontSize: UiFontSize): Promise<void> {
-	const next = asUiEditorFontSize(fontSize);
-	await persistSetting(KEYS.editorFontSize, next, {
-		ui: { editorFontSize: next },
-	});
-}
-
-export async function setUiTranslucentApp(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.translucentApp, enabled, {
-		ui: { translucentApp: enabled },
-	});
-}
-
-export async function setUiCornerRadiusStyle(
-	style: UiCornerRadiusStyle,
-): Promise<void> {
-	const next = asUiCornerRadiusStyle(style);
-	await persistSetting(KEYS.cornerRadiusStyle, next, {
-		ui: { cornerRadiusStyle: next },
-	});
-}
-
-export async function setShowToc(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.showToc, enabled, { ui: { showToc: enabled } });
-}
-
-export async function setShowFileTreeFolderCounts(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.showFileTreeFolderCounts, enabled, {
-		ui: { showFileTreeFolderCounts: enabled },
-	});
-}
-
-export async function setShowNonMarkdownFiles(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.showNonMarkdownFiles, enabled, {
-		ui: { showNonMarkdownFiles: enabled },
-	});
-}
-
-export async function setFileTreeSortMode(
-	sortMode: FileTreeSortMode,
-): Promise<void> {
-	await persistSetting(KEYS.fileTreeSortMode, sortMode, {
-		ui: { fileTreeSortMode: sortMode },
-	});
-}
-
-export async function setFolioMode(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.folioMode, enabled, { ui: { folioMode: enabled } });
-}
-
-export async function setClassicAllNotesByDefault(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.classicAllNotesByDefault, enabled, {
-		ui: { classicAllNotesByDefault: enabled },
-	});
-}
-
-export async function setResumeLastSession(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.resumeLastSession, enabled, {
-		ui: { resumeLastSession: enabled },
-	});
-}
-
-export async function setKeepRunningOnLastWindowClose(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.keepRunningOnLastWindowClose, enabled, {
-		ui: { keepRunningOnLastWindowClose: enabled },
-	});
-}
-
-export async function setEditorShowCollapsibleHeadings(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorShowCollapsibleHeadings, enabled, {
-		editor: { showCollapsibleHeadings: enabled },
-	});
-}
-
-export async function setEditorShowCollapsibleLists(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorShowCollapsibleLists, enabled, {
-		editor: { showCollapsibleLists: enabled },
-	});
-}
-
-export async function setEditorColorfulHeadings(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorColorfulHeadings, enabled, {
-		editor: { colorfulHeadings: enabled },
-	});
-}
-
-export async function setEditorShowHeadingPrefixes(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorShowHeadingPrefixes, enabled, {
-		editor: { showHeadingPrefixes: enabled },
-	});
-}
-
-export async function setEditorHeadingPaletteId(
-	headingPaletteId: HeadingPaletteId,
-): Promise<void> {
-	const next = asHeadingPaletteId(headingPaletteId);
-	await persistSetting(KEYS.editorHeadingPaletteId, next, {
-		editor: { headingPaletteId: next },
-	});
-}
-
-export async function setEditorBeautifulTags(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.editorBeautifulTags, enabled, {
-		editor: { beautifulTags: enabled },
-	});
-}
-
-export async function setEditorShowFrontmatterInEditor(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorShowFrontmatterInEditor, enabled, {
-		editor: { showFrontmatterInEditor: enabled },
-	});
-}
-
-export async function setEditorDefaultEditorMode(
-	mode: EditorViewMode,
-): Promise<void> {
-	const next = asDefaultEditorMode(mode);
-	await persistSetting(
-		KEYS.editorDefaultEditorMode,
-		next,
-		{ editor: { defaultEditorMode: next } },
-		setCachedDefaultEditorViewMode,
-	);
-}
-
-export async function setEditorWidthMode(mode: EditorWidthMode): Promise<void> {
-	const next = asEditorWidthMode(mode);
-	await persistSetting(KEYS.editorEditorWidthMode, next, {
-		editor: { editorWidthMode: next },
-	});
-}
-
-export async function setEditorAttachmentStorageMode(
-	mode: AttachmentStorageMode,
-	scope?: SettingsScope,
-): Promise<void> {
-	const nextMode = asAttachmentStorageMode(mode);
-	const spacePath = await updateActiveSpaceSettings(
-		{
-			attachmentStorageMode: nextMode,
-		},
-		scope,
-	);
-	if (spacePath) {
-		void emitSettingsUpdated({
-			spacePath,
-			editor: { attachmentStorageMode: nextMode },
-		});
-		return;
-	}
-	await persistSetting(KEYS.editorAttachmentStorageMode, nextMode, {
-		editor: { attachmentStorageMode: nextMode },
-	});
-}
-
-export async function setEditorAttachmentFolder(
-	folder: string | null,
-	scope?: SettingsScope,
-): Promise<void> {
-	const nextFolder =
-		typeof folder === "string"
-			? normalizeRelPath(folder) || DEFAULT_ATTACHMENT_FOLDER
-			: DEFAULT_ATTACHMENT_FOLDER;
-	const validationError = validateRelFolderPath(nextFolder);
-	if (validationError) {
-		throw new Error(validationError);
-	}
-	const spacePath = await updateActiveSpaceSettings(
-		{
-			attachmentFolder: nextFolder,
-		},
-		scope,
-	);
-	if (spacePath) {
-		void emitSettingsUpdated({
-			spacePath,
-			editor: { attachmentFolder: nextFolder },
-		});
-		return;
-	}
-	await persistSetting(KEYS.editorAttachmentFolder, nextFolder, {
-		editor: { attachmentFolder: nextFolder },
-	});
-}
-
-export async function setEditorEnablePeopleMentionsAsTags(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorEnablePeopleMentionsAsTags, enabled, {
-		editor: { enablePeopleMentionsAsTags: enabled },
-	});
-}
-
-export async function setEditorRawMarkdownVimMode(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorRawMarkdownVimMode, enabled, {
-		editor: { rawMarkdownVimMode: enabled },
-	});
-}
-
-export async function setEditorSpellCheck(enabled: boolean): Promise<void> {
-	await persistSetting(KEYS.editorSpellCheck, enabled, {
-		editor: { spellCheck: enabled },
-	});
-}
-
-export async function setEditorShowExternalLinkPreviews(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.editorShowExternalLinkPreviews, enabled, {
-		editor: { showExternalLinkPreviews: enabled },
-	});
-}
-
-export async function setEditorFocusMode(mode: FocusMode): Promise<void> {
-	const next = asFocusMode(mode);
-	await persistSetting(KEYS.editorFocusMode, next, {
-		editor: { focusMode: next },
-	});
-}
-
-export async function getDailyNotesFolder(
-	scope?: SettingsScope,
-): Promise<string | null> {
-	return (await loadSettings(scope)).dailyNotes.folder;
-}
-
-export async function setDailyNotesFolder(
-	folder: string | null,
-	scope?: SettingsScope,
-): Promise<void> {
-	const nextFolder =
-		typeof folder === "string" ? normalizeRelPath(folder) || null : null;
-	const spacePath = await updateActiveSpaceSettings(
-		{
-			dailyNotesFolder: nextFolder,
-		},
-		scope,
-	);
-	if (spacePath) {
-		void emitSettingsUpdated({ spacePath, dailyNotes: { folder: nextFolder } });
-		return;
-	}
-	const store = await getSettingsStore();
-	if (nextFolder === null) {
-		await store.delete(KEYS.dailyNotesFolder);
-	} else {
-		await store.set(KEYS.dailyNotesFolder, nextFolder);
-	}
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({ dailyNotes: { folder: nextFolder } });
-}
-
-export async function setQuickNotesFolder(
-	folder: string,
-	scope?: SettingsScope,
-): Promise<void> {
-	const nextFolder = normalizeQuickNotesFolder(folder);
-	const spacePath = await updateActiveSpaceSettings(
-		{
-			quickNotesFolder: nextFolder,
-		},
-		scope,
-	);
-	if (spacePath) {
-		void emitSettingsUpdated({ spacePath, quickNotes: { folder: nextFolder } });
-		return;
-	}
-	await persistSetting(KEYS.quickNotesFolder, nextFolder, {
-		quickNotes: { folder: nextFolder },
-	});
-}
-
-export async function getTemplatesFolder(
-	scope?: SettingsScope,
-): Promise<string | null> {
-	return (await loadSettings(scope)).templates.folder;
 }
 
 export async function setTemplatesFolder(
@@ -1673,10 +715,10 @@ export async function setTemplatesFolder(
 	}
 	const store = await getSettingsStore();
 	if (nextFolder === null) {
-		await store.delete(KEYS.templatesFolder);
-		await store.delete(KEYS.templatesDailyNoteTemplate);
+		await store.delete(INTERNAL_SETTING_KEYS.templatesFolder);
+		await store.delete(SPACE_SETTINGS.templatesDailyNoteTemplate.legacyKey);
 	} else {
-		await store.set(KEYS.templatesFolder, nextFolder);
+		await store.set(INTERNAL_SETTING_KEYS.templatesFolder, nextFolder);
 	}
 	await saveSettingsStore(store);
 	void emitSettingsUpdated({
@@ -1684,53 +726,6 @@ export async function setTemplatesFolder(
 			folder: nextFolder,
 			dailyNoteTemplate: nextFolder === null ? null : undefined,
 		},
-	});
-}
-
-export async function getDailyNoteTemplate(
-	scope?: SettingsScope,
-): Promise<string | null> {
-	return (await loadSettings(scope)).templates.dailyNoteTemplate;
-}
-
-export async function setDailyNoteTemplate(
-	templatePath: string | null,
-	scope?: SettingsScope,
-): Promise<void> {
-	const nextPath =
-		typeof templatePath === "string"
-			? normalizeRelPath(templatePath) || null
-			: null;
-	const spacePath = await updateActiveSpaceSettings(
-		{
-			templatesDailyNoteTemplate: nextPath,
-		},
-		scope,
-	);
-	if (spacePath) {
-		void emitSettingsUpdated({
-			spacePath,
-			templates: { dailyNoteTemplate: nextPath },
-		});
-		return;
-	}
-	const store = await getSettingsStore();
-	if (nextPath === null) {
-		await store.delete(KEYS.templatesDailyNoteTemplate);
-	} else {
-		await store.set(KEYS.templatesDailyNoteTemplate, nextPath);
-	}
-	await saveSettingsStore(store);
-	void emitSettingsUpdated({
-		templates: { dailyNoteTemplate: nextPath },
-	});
-}
-
-export async function setDatabaseShowColumnColor(
-	enabled: boolean,
-): Promise<void> {
-	await persistSetting(KEYS.databaseShowColumnColor, enabled, {
-		database: { showColumnColor: enabled },
 	});
 }
 
@@ -1743,25 +738,19 @@ export async function setAutoUpdateLastCheckedAt(
 		!Number.isFinite(timestamp) ||
 		timestamp <= 0
 	) {
-		await store.delete(KEYS.autoUpdateLastCheckedAt);
+		await store.delete(INTERNAL_SETTING_KEYS.autoUpdateLastCheckedAt);
 	} else {
-		await store.set(KEYS.autoUpdateLastCheckedAt, Math.floor(timestamp));
+		await store.set(
+			INTERNAL_SETTING_KEYS.autoUpdateLastCheckedAt,
+			Math.floor(timestamp),
+		);
 	}
 	await saveSettingsStore(store);
 }
 
-export async function setReleaseChannel(
-	channel: ReleaseChannel,
-): Promise<void> {
-	const nextChannel = asReleaseChannel(channel);
-	await persistSetting(KEYS.releaseChannel, nextChannel, {
-		ui: { releaseChannel: nextChannel },
-	});
-}
-
 export async function getRecentFiles(): Promise<RecentFile[]> {
 	const store = await getSettingsStore();
-	const raw = await store.get<unknown>(KEYS.recentFiles);
+	const raw = await store.get<unknown>(INTERNAL_SETTING_KEYS.recentFiles);
 	return isRecentFileArray(raw) ? raw : [];
 }
 
@@ -1770,7 +759,7 @@ export async function addRecentFile(
 	spacePath: string,
 ): Promise<void> {
 	const store = await getSettingsStore();
-	const raw = await store.get<unknown>(KEYS.recentFiles);
+	const raw = await store.get<unknown>(INTERNAL_SETTING_KEYS.recentFiles);
 	const recent = isRecentFileArray(raw) ? raw : [];
 	const filtered = recent.filter(
 		(r) => r.path !== path || r.spacePath !== spacePath,
@@ -1779,6 +768,6 @@ export async function addRecentFile(
 		{ path, spacePath, openedAt: Date.now() },
 		...filtered,
 	].slice(0, 20);
-	await store.set(KEYS.recentFiles, next);
+	await store.set(INTERNAL_SETTING_KEYS.recentFiles, next);
 	await saveSettingsStore(store);
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -447,9 +447,10 @@ export async function loadSettings(
 		GLYPH_DEFAULT_DARK_THEME_ID,
 	);
 	const fontFamily = DURABLE_SETTINGS.fontFamily.load(entries);
-	const editorFontFamily = entries.has(DURABLE_SETTINGS.editorFontFamily.key)
-		? DURABLE_SETTINGS.editorFontFamily.load(entries)
-		: fontFamily;
+	const editorFontFamily =
+		entries.get(DURABLE_SETTINGS.editorFontFamily.key) == null
+			? fontFamily
+			: DURABLE_SETTINGS.editorFontFamily.load(entries);
 	const monoFontFamily = DURABLE_SETTINGS.monoFontFamily.load(entries);
 	const fontSize = DURABLE_SETTINGS.fontSize.load(entries);
 	const editorFontSize = DURABLE_SETTINGS.editorFontSize.load(entries);

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -683,7 +683,8 @@ export const SPACE_SETTINGS = {
 			typeof value === "string"
 				? normalizeRelPath(value) || DEFAULT_QUICK_NOTES_FOLDER
 				: DEFAULT_QUICK_NOTES_FOLDER,
-		parse: parseString,
+		parse: (value) =>
+			value === null ? parsed(DEFAULT_QUICK_NOTES_FOLDER) : parseString(value),
 		read: (settings) => settings.quickNotes.folder,
 		patch: (value) => ({ quickNotesFolder: value }),
 		change: (value) => ({ quickNotes: { folder: value } }),

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -1,0 +1,740 @@
+import { emit, emitTo } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { isAppLanguage, normalizeAppLanguage } from "../../i18n/locales";
+import { normalizeRelPath, validateRelFolderPath } from "../../utils/path";
+import { DEFAULT_ATTACHMENT_FOLDER } from "../attachmentStorage";
+import { type CustomTheme, normalizeCustomThemes } from "../customThemes";
+import {
+	DEFAULT_DATE_DISPLAY_FORMAT,
+	isDateDisplayFormat,
+	normalizeDateDisplayFormat,
+} from "../dateDisplayFormat";
+import {
+	DEFAULT_EDITOR_VIEW_MODE,
+	isEditorViewMode,
+	setCachedDefaultEditorViewMode,
+} from "../editorMode";
+import {
+	DEFAULT_HEADING_PALETTE_ID,
+	asHeadingPaletteId,
+	isHeadingPaletteId,
+} from "../headingPalettes";
+import { getSettingsStore, saveSettingsStore } from "../settingsStore";
+import {
+	GLYPH_DEFAULT_DARK_THEME_ID,
+	GLYPH_DEFAULT_LIGHT_THEME_ID,
+	asUiDarkThemeId,
+	asUiLightThemeId,
+	isUiDarkThemeId,
+	isUiLightThemeId,
+} from "../uiThemes";
+import type {
+	AppSettings,
+	AttachmentStorageMode,
+	AutoUpdateCheckInterval,
+	EditorWidthMode,
+	FileTreeSortMode,
+	FocusMode,
+	ReleaseChannel,
+	SettingsUpdatedPayload,
+	SpaceScopedSettings,
+	ThemeMode,
+	UiCornerRadiusStyle,
+	UiFontFamily,
+	UiFontSize,
+} from "./model";
+
+export const MIN_UI_FONT_SIZE = 7;
+export const MAX_UI_FONT_SIZE = 40;
+export const MIN_EDITOR_FONT_SIZE = 10;
+export const MAX_EDITOR_FONT_SIZE = 40;
+export const DEFAULT_UI_TRANSLUCENT_APP = false;
+export const DEFAULT_QUICK_NOTES_FOLDER = "Quick Notes";
+
+const DEFAULT_UI_FONT_FAMILY = "Geist";
+const DEFAULT_UI_MONO_FONT_FAMILY = "JetBrains Mono";
+const DEFAULT_AUTO_UPDATE_CHECK_INTERVAL: AutoUpdateCheckInterval = "3h";
+const DEFAULT_UI_FONT_SIZE = 14;
+const DEFAULT_EDITOR_FONT_SIZE = 16;
+const DEFAULT_FILE_TREE_SORT_MODE: FileTreeSortMode = "name-asc";
+const DEFAULT_EDITOR_WIDTH_MODE: EditorWidthMode = "compact";
+const DEFAULT_FOCUS_MODE: FocusMode = "off";
+const DEFAULT_ATTACHMENT_STORAGE_MODE: AttachmentStorageMode = "note-folder";
+
+export const DEFAULT_UI_CORNER_RADIUS_STYLE: UiCornerRadiusStyle = "default";
+
+type SettingDiscovery =
+	| { readonly kind: "search"; readonly id: string }
+	| { readonly kind: "hidden"; readonly reason: string };
+
+interface NativeConsumption {
+	readonly kind: "settings-store";
+	readonly consumer: "last-window-close-policy";
+}
+
+export type SettingParseResult<Value> =
+	| { readonly ok: true; readonly value: Value }
+	| { readonly ok: false };
+
+export interface ApplicationSettingDefinition<Value> {
+	readonly key: string;
+	readonly defaultValue: Value;
+	readonly discovery: SettingDiscovery;
+	readonly nativeConsumption?: NativeConsumption;
+	readonly normalize: (value: unknown) => Value;
+	readonly parse: (value: unknown) => SettingParseResult<Value>;
+	readonly load: (entries: ReadonlyMap<string, unknown>) => Value;
+	readonly read: (settings: AppSettings) => Value;
+	readonly write: (value: Value) => Promise<void>;
+}
+
+interface ApplicationSettingConfig<Value> {
+	readonly key: string;
+	readonly defaultValue: Value;
+	readonly discovery: SettingDiscovery;
+	readonly nativeConsumption?: NativeConsumption;
+	readonly normalize: (value: unknown) => Value;
+	readonly parse: (value: unknown) => SettingParseResult<Value>;
+	readonly read: (settings: AppSettings) => Value;
+	readonly change: (value: Value) => SettingsUpdatedPayload;
+	readonly afterSave?: (value: Value) => void;
+}
+
+export interface SpaceSettingDefinition<Value> {
+	readonly legacyKey: string;
+	readonly field: keyof SpaceScopedSettings;
+	readonly defaultValue: Value;
+	readonly discovery: SettingDiscovery;
+	readonly normalize: (value: unknown) => Value;
+	readonly parse: (value: unknown) => SettingParseResult<Value>;
+	readonly read: (settings: AppSettings) => Value;
+	readonly patch: (value: Value) => SpaceScopedSettings;
+	readonly change: (value: Value) => SettingsUpdatedPayload;
+	readonly validate?: (value: Value) => string | null;
+}
+
+const INVALID_PARSE_RESULT: SettingParseResult<never> = { ok: false };
+
+function searchable(id: string): SettingDiscovery {
+	return { kind: "search", id };
+}
+
+function hidden(reason: string): SettingDiscovery {
+	return { kind: "hidden", reason };
+}
+
+function parsed<Value>(value: Value): SettingParseResult<Value> {
+	return { ok: true, value };
+}
+
+export async function emitSettingsUpdated(
+	payload: SettingsUpdatedPayload,
+): Promise<void> {
+	try {
+		if (payload.spacePath) {
+			await emitTo(getCurrentWindow().label, "settings:updated", payload);
+			return;
+		}
+		await emit("settings:updated", payload);
+	} catch {
+		// Cross-window synchronization is best effort during window teardown.
+	}
+}
+
+function defineApplicationSetting<Value>(
+	config: ApplicationSettingConfig<Value>,
+): ApplicationSettingDefinition<Value> {
+	const write = async (value: Value): Promise<void> => {
+		const normalized = config.normalize(value);
+		const store = await getSettingsStore();
+		await store.set(config.key, normalized);
+		await saveSettingsStore(store);
+		config.afterSave?.(normalized);
+		void emitSettingsUpdated(config.change(normalized));
+	};
+
+	return {
+		key: config.key,
+		defaultValue: config.defaultValue,
+		discovery: config.discovery,
+		nativeConsumption: config.nativeConsumption,
+		normalize: config.normalize,
+		parse: config.parse,
+		load: (entries) => config.normalize(entries.get(config.key)),
+		read: config.read,
+		write,
+	};
+}
+
+function defineSpaceSetting<Value>(
+	config: SpaceSettingDefinition<Value>,
+): SpaceSettingDefinition<Value> {
+	return config;
+}
+
+function booleanSetting(
+	config: Omit<ApplicationSettingConfig<boolean>, "normalize" | "parse">,
+): ApplicationSettingDefinition<boolean> {
+	return defineApplicationSetting({
+		...config,
+		normalize: (value) =>
+			typeof value === "boolean" ? value : config.defaultValue,
+		parse: (value) =>
+			typeof value === "boolean" ? parsed(value) : INVALID_PARSE_RESULT,
+	});
+}
+
+function nullablePath(value: unknown): string | null {
+	return typeof value === "string" ? normalizeRelPath(value) || null : null;
+}
+
+function isThemeMode(value: unknown): value is ThemeMode {
+	return value === "system" || value === "light" || value === "dark";
+}
+
+export function isFileTreeSortMode(value: unknown): value is FileTreeSortMode {
+	return (
+		value === "name-asc" ||
+		value === "name-desc" ||
+		value === "modified-desc" ||
+		value === "modified-asc" ||
+		value === "created-desc" ||
+		value === "created-asc"
+	);
+}
+
+function isAiAssistantMode(value: unknown): value is "chat" | "create" {
+	return value === "chat" || value === "create";
+}
+
+export function isAttachmentStorageMode(
+	value: unknown,
+): value is AttachmentStorageMode {
+	return (
+		value === "space-root" ||
+		value === "specific-folder" ||
+		value === "note-folder" ||
+		value === "note-subfolder"
+	);
+}
+
+function isEditorWidthMode(value: unknown): value is EditorWidthMode {
+	return value === "compact" || value === "comfortable" || value === "wide";
+}
+
+export function isFocusMode(value: unknown): value is FocusMode {
+	return value === "off" || value === "paragraph" || value === "sentence";
+}
+
+export function isUiCornerRadiusStyle(
+	value: unknown,
+): value is UiCornerRadiusStyle {
+	return value === "default" || value === "sharp" || value === "round";
+}
+
+function normalizeUiFontFamily(
+	value: unknown,
+	fallback: UiFontFamily = DEFAULT_UI_FONT_FAMILY,
+): UiFontFamily {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	return trimmed ? trimmed.slice(0, 80) : fallback;
+}
+
+function normalizeUiMonoFontFamily(value: unknown): UiFontFamily {
+	return normalizeUiFontFamily(value, DEFAULT_UI_MONO_FONT_FAMILY);
+}
+
+function normalizeUiFontSize(value: unknown): UiFontSize {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return Math.max(
+			MIN_UI_FONT_SIZE,
+			Math.min(MAX_UI_FONT_SIZE, Math.round(value)),
+		);
+	}
+	if (value === "small") return 12;
+	if (value === "large") return 16;
+	return DEFAULT_UI_FONT_SIZE;
+}
+
+function normalizeEditorFontSize(value: unknown): UiFontSize {
+	if (typeof value === "number" && Number.isFinite(value)) {
+		return Math.max(
+			MIN_EDITOR_FONT_SIZE,
+			Math.min(MAX_EDITOR_FONT_SIZE, Math.round(value)),
+		);
+	}
+	return DEFAULT_EDITOR_FONT_SIZE;
+}
+
+function parseFiniteNumber(value: unknown): SettingParseResult<number> {
+	return typeof value === "number" && Number.isFinite(value)
+		? parsed(value)
+		: INVALID_PARSE_RESULT;
+}
+
+function parseString(value: unknown): SettingParseResult<string> {
+	return typeof value === "string" ? parsed(value) : INVALID_PARSE_RESULT;
+}
+
+function normalizeAutoUpdateCheckInterval(
+	value: unknown,
+): AutoUpdateCheckInterval {
+	return value === "3h" || value === "launch" || value === "12h"
+		? "3h"
+		: DEFAULT_AUTO_UPDATE_CHECK_INTERVAL;
+}
+
+function normalizeAttachmentFolder(value: unknown): string | null {
+	return typeof value === "string"
+		? normalizeRelPath(value) || DEFAULT_ATTACHMENT_FOLDER
+		: DEFAULT_ATTACHMENT_FOLDER;
+}
+
+/**
+ * Coordinated settings intentionally outside the one-value definition path.
+ * They require write locks, ordered collections, timestamps, or multi-field
+ * updates rather than an independent load/write lifecycle.
+ */
+export const INTERNAL_SETTING_KEYS = {
+	currentSpacePath: "space.currentPath",
+	recentSpaces: "space.recent",
+	recentFiles: "files.recent",
+	autoUpdateLastCheckedAt: "updates.lastCheckedAt",
+	shortcutsVersion: "shortcuts.version",
+	shortcutsBindings: "shortcuts.bindings",
+	spaceScopedSettings: "space.scopedSettings",
+	templatesFolder: "templates.folder",
+} as const;
+
+export const DURABLE_SETTINGS = {
+	aiEnabled: booleanSetting({
+		key: "ui.aiEnabled",
+		defaultValue: true,
+		discovery: searchable("ai-features"),
+		read: (settings) => settings.ui.aiEnabled,
+		change: (value) => ({ ui: { aiEnabled: value } }),
+	}),
+	language: defineApplicationSetting({
+		key: "ui.language",
+		defaultValue: normalizeAppLanguage(undefined),
+		discovery: searchable("general-language"),
+		normalize: normalizeAppLanguage,
+		parse: (value) =>
+			isAppLanguage(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.language,
+		change: (value) => ({ ui: { language: value } }),
+	}),
+	dateDisplayFormat: defineApplicationSetting({
+		key: "ui.dateDisplayFormat",
+		defaultValue: DEFAULT_DATE_DISPLAY_FORMAT,
+		discovery: searchable("general-date-format"),
+		normalize: normalizeDateDisplayFormat,
+		parse: (value) =>
+			isDateDisplayFormat(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.dateDisplayFormat,
+		change: (value) => ({ ui: { dateDisplayFormat: value } }),
+	}),
+	aiAssistantMode: defineApplicationSetting<
+		AppSettings["ui"]["aiAssistantMode"]
+	>({
+		key: "ui.aiAssistantMode",
+		defaultValue: "create",
+		discovery: searchable("ai-assistant-behavior-tools"),
+		normalize: (value) => (isAiAssistantMode(value) ? value : "create"),
+		parse: (value) =>
+			isAiAssistantMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.aiAssistantMode,
+		change: (value) => ({ ui: { aiAssistantMode: value } }),
+	}),
+	theme: defineApplicationSetting<ThemeMode>({
+		key: "ui.theme",
+		defaultValue: "system",
+		discovery: searchable("appearance-theme-mode"),
+		normalize: (value) => (isThemeMode(value) ? value : "system"),
+		parse: (value) =>
+			isThemeMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.theme,
+		change: (value) => ({ ui: { theme: value } }),
+	}),
+	autoUpdateCheckInterval: defineApplicationSetting({
+		key: "ui.autoUpdateCheckInterval",
+		defaultValue: DEFAULT_AUTO_UPDATE_CHECK_INTERVAL,
+		discovery: hidden("The interval is fixed and has no editable control."),
+		normalize: normalizeAutoUpdateCheckInterval,
+		parse: (value) => (value === "3h" ? parsed(value) : INVALID_PARSE_RESULT),
+		read: (settings) => settings.ui.autoUpdateCheckInterval,
+		change: (value) => ({ ui: { autoUpdateCheckInterval: value } }),
+	}),
+	releaseChannel: defineApplicationSetting<ReleaseChannel>({
+		key: "updates.releaseChannel",
+		defaultValue: "stable",
+		discovery: searchable("about-alpha-releases"),
+		normalize: (value) => (value === "alpha" ? "alpha" : "stable"),
+		parse: (value) =>
+			value === "alpha" || value === "stable"
+				? parsed(value)
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.releaseChannel,
+		change: (value) => ({ ui: { releaseChannel: value } }),
+	}),
+	customThemes: defineApplicationSetting<CustomTheme[]>({
+		key: "ui.customThemes",
+		defaultValue: [],
+		discovery: searchable("appearance-custom-themes"),
+		normalize: normalizeCustomThemes,
+		parse: (value) =>
+			Array.isArray(value)
+				? parsed(normalizeCustomThemes(value))
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.customThemes,
+		change: (value) => ({ ui: { customThemes: value } }),
+	}),
+	lightThemeId: defineApplicationSetting({
+		key: "ui.lightThemeId",
+		defaultValue: GLYPH_DEFAULT_LIGHT_THEME_ID,
+		discovery: searchable("appearance-light-theme"),
+		normalize: asUiLightThemeId,
+		parse: (value) =>
+			isUiLightThemeId(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.lightThemeId,
+		change: (value) => ({ ui: { lightThemeId: value } }),
+	}),
+	darkThemeId: defineApplicationSetting({
+		key: "ui.darkThemeId",
+		defaultValue: GLYPH_DEFAULT_DARK_THEME_ID,
+		discovery: searchable("appearance-dark-theme"),
+		normalize: asUiDarkThemeId,
+		parse: (value) =>
+			isUiDarkThemeId(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.darkThemeId,
+		change: (value) => ({ ui: { darkThemeId: value } }),
+	}),
+	fontFamily: defineApplicationSetting({
+		key: "ui.fontFamily",
+		defaultValue: DEFAULT_UI_FONT_FAMILY,
+		discovery: searchable("appearance-interface-font"),
+		normalize: normalizeUiFontFamily,
+		parse: parseString,
+		read: (settings) => settings.ui.fontFamily,
+		change: (value) => ({ ui: { fontFamily: value } }),
+	}),
+	editorFontFamily: defineApplicationSetting({
+		key: "ui.editorFontFamily",
+		defaultValue: DEFAULT_UI_FONT_FAMILY,
+		discovery: searchable("appearance-editor-font"),
+		normalize: (value) => normalizeUiFontFamily(value, DEFAULT_UI_FONT_FAMILY),
+		parse: parseString,
+		read: (settings) => settings.ui.editorFontFamily,
+		change: (value) => ({ ui: { editorFontFamily: value } }),
+	}),
+	monoFontFamily: defineApplicationSetting({
+		key: "ui.monoFontFamily",
+		defaultValue: DEFAULT_UI_MONO_FONT_FAMILY,
+		discovery: searchable("appearance-monospace-font"),
+		normalize: normalizeUiMonoFontFamily,
+		parse: parseString,
+		read: (settings) => settings.ui.monoFontFamily,
+		change: (value) => ({ ui: { monoFontFamily: value } }),
+	}),
+	fontSize: defineApplicationSetting({
+		key: "ui.fontSize",
+		defaultValue: DEFAULT_UI_FONT_SIZE,
+		discovery: searchable("appearance-ui-font-size"),
+		normalize: normalizeUiFontSize,
+		parse: parseFiniteNumber,
+		read: (settings) => settings.ui.fontSize,
+		change: (value) => ({ ui: { fontSize: value } }),
+	}),
+	editorFontSize: defineApplicationSetting({
+		key: "ui.editorFontSize",
+		defaultValue: DEFAULT_EDITOR_FONT_SIZE,
+		discovery: searchable("appearance-editor-font-size"),
+		normalize: normalizeEditorFontSize,
+		parse: parseFiniteNumber,
+		read: (settings) => settings.ui.editorFontSize,
+		change: (value) => ({ ui: { editorFontSize: value } }),
+	}),
+	translucentApp: booleanSetting({
+		key: "ui.translucentApp",
+		defaultValue: DEFAULT_UI_TRANSLUCENT_APP,
+		discovery: searchable("appearance-translucent-app"),
+		read: (settings) => settings.ui.translucentApp,
+		change: (value) => ({ ui: { translucentApp: value } }),
+	}),
+	cornerRadiusStyle: defineApplicationSetting({
+		key: "ui.cornerRadiusStyle",
+		defaultValue: DEFAULT_UI_CORNER_RADIUS_STYLE,
+		discovery: hidden("The current search catalog has no corner-radius row."),
+		normalize: (value) =>
+			isUiCornerRadiusStyle(value) ? value : DEFAULT_UI_CORNER_RADIUS_STYLE,
+		parse: (value) =>
+			isUiCornerRadiusStyle(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.cornerRadiusStyle,
+		change: (value) => ({ ui: { cornerRadiusStyle: value } }),
+	}),
+	showToc: booleanSetting({
+		key: "ui.showToc",
+		defaultValue: true,
+		discovery: searchable("general-editor-table-of-contents"),
+		read: (settings) => settings.ui.showToc,
+		change: (value) => ({ ui: { showToc: value } }),
+	}),
+	showFileTreeFolderCounts: booleanSetting({
+		key: "ui.fileTree.showFolderFileCounts",
+		defaultValue: false,
+		discovery: searchable("general-file-tree-folder-counts"),
+		read: (settings) => settings.ui.showFileTreeFolderCounts,
+		change: (value) => ({ ui: { showFileTreeFolderCounts: value } }),
+	}),
+	showNonMarkdownFiles: booleanSetting({
+		key: "ui.fileTree.showNonMarkdownFiles",
+		defaultValue: true,
+		discovery: searchable("general-file-tree-non-markdown-files"),
+		read: (settings) => settings.ui.showNonMarkdownFiles,
+		change: (value) => ({ ui: { showNonMarkdownFiles: value } }),
+	}),
+	fileTreeSortMode: defineApplicationSetting({
+		key: "ui.fileTree.sortMode",
+		defaultValue: DEFAULT_FILE_TREE_SORT_MODE,
+		discovery: searchable("general-file-tree-sort"),
+		normalize: (value) =>
+			isFileTreeSortMode(value) ? value : DEFAULT_FILE_TREE_SORT_MODE,
+		parse: (value) =>
+			isFileTreeSortMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.ui.fileTreeSortMode,
+		change: (value) => ({ ui: { fileTreeSortMode: value } }),
+	}),
+	folioMode: booleanSetting({
+		key: "ui.folioMode",
+		defaultValue: false,
+		discovery: searchable("appearance-layout-folio-mode"),
+		read: (settings) => settings.ui.folioMode,
+		change: (value) => ({ ui: { folioMode: value } }),
+	}),
+	classicAllNotesByDefault: booleanSetting({
+		key: "ui.classicAllNotesByDefault",
+		defaultValue: false,
+		discovery: searchable("appearance-layout-classic-all-notes"),
+		read: (settings) => settings.ui.classicAllNotesByDefault,
+		change: (value) => ({ ui: { classicAllNotesByDefault: value } }),
+	}),
+	resumeLastSession: booleanSetting({
+		key: "ui.resumeLastSession",
+		defaultValue: false,
+		discovery: searchable("general-resume-last-session"),
+		read: (settings) => settings.ui.resumeLastSession,
+		change: (value) => ({ ui: { resumeLastSession: value } }),
+	}),
+	keepRunningOnLastWindowClose: booleanSetting({
+		key: "ui.keepRunningOnLastWindowClose",
+		defaultValue: false,
+		discovery: searchable("general-keep-running-on-close"),
+		nativeConsumption: {
+			kind: "settings-store",
+			consumer: "last-window-close-policy",
+		},
+		read: (settings) => settings.ui.keepRunningOnLastWindowClose,
+		change: (value) => ({ ui: { keepRunningOnLastWindowClose: value } }),
+	}),
+	editorShowCollapsibleHeadings: booleanSetting({
+		key: "editor.showCollapsibleHeadings",
+		defaultValue: false,
+		discovery: searchable("general-editor-collapsible-headings"),
+		read: (settings) => settings.editor.showCollapsibleHeadings,
+		change: (value) => ({ editor: { showCollapsibleHeadings: value } }),
+	}),
+	editorShowCollapsibleLists: booleanSetting({
+		key: "editor.showCollapsibleLists",
+		defaultValue: false,
+		discovery: searchable("general-editor-collapsible-lists"),
+		read: (settings) => settings.editor.showCollapsibleLists,
+		change: (value) => ({ editor: { showCollapsibleLists: value } }),
+	}),
+	editorShowFrontmatterInEditor: booleanSetting({
+		key: "editor.showFrontmatterInEditor",
+		defaultValue: false,
+		discovery: searchable("general-editor-frontmatter"),
+		read: (settings) => settings.editor.showFrontmatterInEditor,
+		change: (value) => ({ editor: { showFrontmatterInEditor: value } }),
+	}),
+	editorShowHeadingPrefixes: booleanSetting({
+		key: "editor.showHeadingPrefixes",
+		defaultValue: true,
+		discovery: searchable("general-editor-heading-prefixes"),
+		read: (settings) => settings.editor.showHeadingPrefixes,
+		change: (value) => ({ editor: { showHeadingPrefixes: value } }),
+	}),
+	editorColorfulHeadings: booleanSetting({
+		key: "editor.colorfulHeadings",
+		defaultValue: false,
+		discovery: searchable("general-editor-colorful-headings"),
+		read: (settings) => settings.editor.colorfulHeadings,
+		change: (value) => ({ editor: { colorfulHeadings: value } }),
+	}),
+	editorHeadingPaletteId: defineApplicationSetting({
+		key: "editor.headingPaletteId",
+		defaultValue: DEFAULT_HEADING_PALETTE_ID,
+		discovery: hidden("The heading palette is grouped with colorful headings."),
+		normalize: asHeadingPaletteId,
+		parse: (value) =>
+			isHeadingPaletteId(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.headingPaletteId,
+		change: (value) => ({ editor: { headingPaletteId: value } }),
+	}),
+	editorBeautifulTags: booleanSetting({
+		key: "editor.beautifulTags",
+		defaultValue: false,
+		discovery: searchable("appearance-editor-presentation-beautiful-tags"),
+		read: (settings) => settings.editor.beautifulTags,
+		change: (value) => ({ editor: { beautifulTags: value } }),
+	}),
+	editorWidthMode: defineApplicationSetting({
+		key: "editor.editorWidthMode",
+		defaultValue: DEFAULT_EDITOR_WIDTH_MODE,
+		discovery: searchable("appearance-editor-presentation-width"),
+		normalize: (value) =>
+			isEditorWidthMode(value) ? value : DEFAULT_EDITOR_WIDTH_MODE,
+		parse: (value) =>
+			isEditorWidthMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.editorWidthMode,
+		change: (value) => ({ editor: { editorWidthMode: value } }),
+	}),
+	editorDefaultEditorMode: defineApplicationSetting({
+		key: "editor.defaultEditorMode",
+		defaultValue: DEFAULT_EDITOR_VIEW_MODE,
+		discovery: hidden("The default editor mode is not exposed in search."),
+		normalize: (value) =>
+			isEditorViewMode(value) ? value : DEFAULT_EDITOR_VIEW_MODE,
+		parse: (value) =>
+			isEditorViewMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.defaultEditorMode,
+		change: (value) => ({ editor: { defaultEditorMode: value } }),
+		afterSave: setCachedDefaultEditorViewMode,
+	}),
+	editorEnablePeopleMentionsAsTags: booleanSetting({
+		key: "editor.enablePeopleMentionsAsTags",
+		defaultValue: false,
+		discovery: searchable("space-search-index-people-tags"),
+		read: (settings) => settings.editor.enablePeopleMentionsAsTags,
+		change: (value) => ({ editor: { enablePeopleMentionsAsTags: value } }),
+	}),
+	editorRawMarkdownVimMode: booleanSetting({
+		key: "editor.rawMarkdownVimMode",
+		defaultValue: false,
+		discovery: searchable("general-editor-vim-mode"),
+		read: (settings) => settings.editor.rawMarkdownVimMode,
+		change: (value) => ({ editor: { rawMarkdownVimMode: value } }),
+	}),
+	editorSpellCheck: booleanSetting({
+		key: "editor.spellCheck",
+		defaultValue: true,
+		discovery: searchable("general-editor-spell-check"),
+		read: (settings) => settings.editor.spellCheck,
+		change: (value) => ({ editor: { spellCheck: value } }),
+	}),
+	editorShowExternalLinkPreviews: booleanSetting({
+		key: "editor.showExternalLinkPreviews",
+		defaultValue: false,
+		discovery: searchable("general-editor-external-link-previews"),
+		read: (settings) => settings.editor.showExternalLinkPreviews,
+		change: (value) => ({ editor: { showExternalLinkPreviews: value } }),
+	}),
+	editorFocusMode: defineApplicationSetting({
+		key: "editor.focusMode",
+		defaultValue: DEFAULT_FOCUS_MODE,
+		discovery: hidden("Focus mode is controlled from the editor."),
+		normalize: (value) => (isFocusMode(value) ? value : DEFAULT_FOCUS_MODE),
+		parse: (value) =>
+			isFocusMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.focusMode,
+		change: (value) => ({ editor: { focusMode: value } }),
+	}),
+	databaseShowColumnColor: booleanSetting({
+		key: "database.showColumnColor",
+		defaultValue: true,
+		discovery: searchable("appearance-database-column-color"),
+		read: (settings) => settings.database.showColumnColor,
+		change: (value) => ({ database: { showColumnColor: value } }),
+	}),
+} as const;
+
+export const SPACE_SETTINGS = {
+	dailyNotesFolder: defineSpaceSetting({
+		legacyKey: "dailyNotes.folder",
+		field: "dailyNotesFolder",
+		defaultValue: null,
+		discovery: searchable("space-daily-notes-folder"),
+		normalize: nullablePath,
+		parse: (value) =>
+			typeof value === "string" || value === null
+				? parsed(value)
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.dailyNotes.folder,
+		patch: (value) => ({ dailyNotesFolder: value }),
+		change: (value) => ({ dailyNotes: { folder: value } }),
+	}),
+	quickNotesFolder: defineSpaceSetting({
+		legacyKey: "quickNotes.folder",
+		field: "quickNotesFolder",
+		defaultValue: DEFAULT_QUICK_NOTES_FOLDER,
+		discovery: searchable("space-quick-notes-folder"),
+		normalize: (value) =>
+			typeof value === "string"
+				? normalizeRelPath(value) || DEFAULT_QUICK_NOTES_FOLDER
+				: DEFAULT_QUICK_NOTES_FOLDER,
+		parse: parseString,
+		read: (settings) => settings.quickNotes.folder,
+		patch: (value) => ({ quickNotesFolder: value }),
+		change: (value) => ({ quickNotes: { folder: value } }),
+	}),
+	templatesDailyNoteTemplate: defineSpaceSetting({
+		legacyKey: "templates.dailyNoteTemplate",
+		field: "templatesDailyNoteTemplate",
+		defaultValue: null,
+		discovery: searchable("space-default-daily-template"),
+		normalize: nullablePath,
+		parse: (value) =>
+			typeof value === "string" || value === null
+				? parsed(value)
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.templates.dailyNoteTemplate,
+		patch: (value) => ({ templatesDailyNoteTemplate: value }),
+		change: (value) => ({ templates: { dailyNoteTemplate: value } }),
+	}),
+	attachmentStorageMode: defineSpaceSetting({
+		legacyKey: "editor.attachmentStorageMode",
+		field: "attachmentStorageMode",
+		defaultValue: DEFAULT_ATTACHMENT_STORAGE_MODE,
+		discovery: searchable("space-attachments-location"),
+		normalize: (value) =>
+			isAttachmentStorageMode(value) ? value : DEFAULT_ATTACHMENT_STORAGE_MODE,
+		parse: (value) =>
+			isAttachmentStorageMode(value) ? parsed(value) : INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.attachmentStorageMode,
+		patch: (value) => ({ attachmentStorageMode: value }),
+		change: (value) => ({ editor: { attachmentStorageMode: value } }),
+	}),
+	attachmentFolder: defineSpaceSetting({
+		legacyKey: "editor.attachmentFolder",
+		field: "attachmentFolder",
+		defaultValue: DEFAULT_ATTACHMENT_FOLDER,
+		discovery: hidden("The folder is part of the attachment location control."),
+		normalize: normalizeAttachmentFolder,
+		parse: (value) =>
+			typeof value === "string" || value === null
+				? parsed(value)
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.editor.attachmentFolder,
+		patch: (value) => ({ attachmentFolder: value }),
+		change: (value) => ({ editor: { attachmentFolder: value } }),
+		validate: (value) => validateRelFolderPath(value ?? ""),
+	}),
+} as const;
+
+export const SEARCHABLE_SETTING_IDS = [
+	...Object.values(DURABLE_SETTINGS),
+	...Object.values(SPACE_SETTINGS),
+].flatMap((definition) =>
+	definition.discovery.kind === "search" ? [definition.discovery.id] : [],
+);

--- a/src/lib/settings/model.ts
+++ b/src/lib/settings/model.ts
@@ -1,0 +1,155 @@
+import type { AppLanguage } from "../../i18n/locales";
+import type { CustomTheme } from "../customThemes";
+import type { DateDisplayFormat } from "../dateDisplayFormat";
+import type { EditorViewMode } from "../editorMode";
+import type { HeadingPaletteId } from "../headingPalettes";
+import type { Shortcut } from "../shortcuts";
+import type { ShortcutActionId } from "../shortcuts/registry";
+import type { AiAssistantMode } from "../tauri";
+import type { UiDarkThemeId, UiLightThemeId } from "../uiThemes";
+
+export type ReleaseChannel = "stable" | "alpha";
+export type FileTreeSortMode =
+	| "name-asc"
+	| "name-desc"
+	| "modified-desc"
+	| "modified-asc"
+	| "created-desc"
+	| "created-asc";
+export type ThemeMode = "system" | "light" | "dark";
+export type AutoUpdateCheckInterval = "3h";
+export type AttachmentStorageMode =
+	| "space-root"
+	| "specific-folder"
+	| "note-folder"
+	| "note-subfolder";
+export type UiCornerRadiusStyle = "default" | "sharp" | "round";
+export type UiFontFamily = string;
+export type UiFontSize = number;
+export type EditorWidthMode = "compact" | "comfortable" | "wide";
+export type FocusMode = "off" | "paragraph" | "sentence";
+
+export interface DatabaseSettings {
+	showColumnColor: boolean;
+}
+
+export interface QuickNotesSettings {
+	folder: string;
+}
+
+export interface EditorSettings {
+	showCollapsibleHeadings: boolean;
+	showCollapsibleLists: boolean;
+	showFrontmatterInEditor: boolean;
+	showHeadingPrefixes: boolean;
+	colorfulHeadings: boolean;
+	headingPaletteId: HeadingPaletteId;
+	beautifulTags: boolean;
+	editorWidthMode: EditorWidthMode;
+	defaultEditorMode: EditorViewMode;
+	attachmentStorageMode: AttachmentStorageMode;
+	attachmentFolder: string | null;
+	enablePeopleMentionsAsTags: boolean;
+	rawMarkdownVimMode: boolean;
+	spellCheck: boolean;
+	showExternalLinkPreviews: boolean;
+	focusMode: FocusMode;
+}
+
+export interface FileTreeSettings {
+	showFolderFileCounts: boolean;
+	showNonMarkdownFiles: boolean;
+	sortMode: FileTreeSortMode;
+}
+
+export interface ShortcutSettings {
+	version: 1;
+	bindings: Partial<Record<ShortcutActionId, Shortcut | null>>;
+}
+
+export type ShortcutBindings = ShortcutSettings["bindings"];
+export type EffectiveShortcutBindings = Record<
+	ShortcutActionId,
+	Shortcut | null
+>;
+
+export interface RecentFile {
+	path: string;
+	spacePath: string;
+	openedAt: number;
+}
+
+export interface AppSettings {
+	currentSpacePath: string | null;
+	recentSpaces: string[];
+	recentFiles: RecentFile[];
+	ui: {
+		aiEnabled: boolean;
+		language: AppLanguage;
+		theme: ThemeMode;
+		autoUpdateCheckInterval: AutoUpdateCheckInterval;
+		releaseChannel: ReleaseChannel;
+		lightThemeId: UiLightThemeId;
+		darkThemeId: UiDarkThemeId;
+		customThemes: CustomTheme[];
+		fontFamily: UiFontFamily;
+		editorFontFamily: UiFontFamily;
+		monoFontFamily: UiFontFamily;
+		fontSize: UiFontSize;
+		editorFontSize: UiFontSize;
+		translucentApp: boolean;
+		cornerRadiusStyle: UiCornerRadiusStyle;
+		showToc: boolean;
+		showFileTreeFolderCounts: boolean;
+		showNonMarkdownFiles: boolean;
+		fileTreeSortMode: FileTreeSortMode;
+		folioMode: boolean;
+		classicAllNotesByDefault: boolean;
+		resumeLastSession: boolean;
+		keepRunningOnLastWindowClose: boolean;
+		aiAssistantMode: AiAssistantMode;
+		dateDisplayFormat: DateDisplayFormat;
+	};
+	dailyNotes: {
+		folder: string | null;
+	};
+	quickNotes: QuickNotesSettings;
+	templates: {
+		folder: string | null;
+		dailyNoteTemplate: string | null;
+	};
+	shortcuts: ShortcutSettings;
+	editor: EditorSettings;
+	database: DatabaseSettings;
+}
+
+export interface SpaceScopedSettings {
+	dailyNotesFolder?: string | null;
+	quickNotesFolder?: string;
+	templatesFolder?: string | null;
+	templatesDailyNoteTemplate?: string | null;
+	attachmentStorageMode?: AttachmentStorageMode;
+	attachmentFolder?: string | null;
+}
+
+export type SpaceScopedSettingsMap = Record<string, SpaceScopedSettings>;
+
+interface SettingsChangeSections {
+	ui: AppSettings["ui"];
+	dailyNotes: AppSettings["dailyNotes"];
+	quickNotes: AppSettings["quickNotes"];
+	templates: AppSettings["templates"];
+	database: AppSettings["database"];
+	editor: AppSettings["editor"];
+	shortcuts: Pick<ShortcutSettings, "bindings">;
+}
+
+type SettingsChanges = {
+	[Section in keyof SettingsChangeSections]?: Partial<
+		SettingsChangeSections[Section]
+	>;
+};
+
+export type SettingsUpdatedPayload = SettingsChanges & {
+	spacePath?: string;
+};

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,21 +1,7 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
-import type { CustomTheme } from "./customThemes";
 import type { DeeplinkErrorPayload, DeeplinkEvent } from "./deeplink";
-import type { EditorViewMode } from "./editorMode";
-import type { HeadingPaletteId } from "./headingPalettes";
-import type {
-	AppLanguage,
-	AttachmentStorageMode,
-	AutoUpdateCheckInterval,
-	DateDisplayFormat,
-	EditorWidthMode,
-	FileTreeSortMode,
-	FocusMode,
-	ReleaseChannel,
-	UiCornerRadiusStyle,
-} from "./settings";
-import type { UiDarkThemeId, UiLightThemeId } from "./uiThemes";
+import type { SettingsUpdatedPayload } from "./settings/model";
 
 type TauriEventMap = {
 	"menu:app_command": { command_id: string };
@@ -63,81 +49,7 @@ type TauriEventMap = {
 		removed: boolean;
 	};
 	"index:progress": import("./tauri").IndexProgress;
-	"settings:updated": {
-		spacePath?: string;
-		ui?: {
-			theme?: string;
-			autoUpdateCheckInterval?: AutoUpdateCheckInterval;
-			releaseChannel?: ReleaseChannel;
-			lightThemeId?: UiLightThemeId;
-			darkThemeId?: UiDarkThemeId;
-			customThemes?: CustomTheme[];
-			fontFamily?: string;
-			editorFontFamily?: string;
-			monoFontFamily?: string;
-			fontSize?: number;
-			editorFontSize?: number;
-			translucentApp?: boolean;
-			cornerRadiusStyle?: UiCornerRadiusStyle;
-			showToc?: boolean;
-			showFileTreeFolderCounts?: boolean;
-			showNonMarkdownFiles?: boolean;
-			fileTreeSortMode?: FileTreeSortMode;
-			folioMode?: boolean;
-			classicAllNotesByDefault?: boolean;
-			resumeLastSession?: boolean;
-			keepRunningOnLastWindowClose?: boolean;
-			aiEnabled?: boolean;
-			aiAssistantMode?: "chat" | "create";
-			language?: AppLanguage;
-			dateDisplayFormat?: DateDisplayFormat;
-		};
-		dailyNotes?: {
-			folder?: string | null;
-		};
-		quickNotes?: {
-			folder?: string;
-		};
-		templates?: {
-			folder?: string | null;
-			dailyNoteTemplate?: string | null;
-		};
-		database?: {
-			showColumnColor?: boolean;
-		};
-		editor?: {
-			showCollapsibleHeadings?: boolean;
-			showCollapsibleLists?: boolean;
-			showFrontmatterInEditor?: boolean;
-			showHeadingPrefixes?: boolean;
-			colorfulHeadings?: boolean;
-			headingPaletteId?: HeadingPaletteId;
-			beautifulTags?: boolean;
-			editorWidthMode?: EditorWidthMode;
-			defaultEditorMode?: EditorViewMode;
-			attachmentStorageMode?: AttachmentStorageMode;
-			attachmentFolder?: string | null;
-			enablePeopleMentionsAsTags?: boolean;
-			rawMarkdownVimMode?: boolean;
-			spellCheck?: boolean;
-			showExternalLinkPreviews?: boolean;
-			focusMode?: FocusMode;
-		};
-		shortcuts?: {
-			bindings?: Partial<
-				Record<
-					string,
-					{
-						key: string;
-						meta?: boolean;
-						ctrl?: boolean;
-						alt?: boolean;
-						shift?: boolean;
-					} | null
-				>
-			>;
-		};
-	};
+	"settings:updated": SettingsUpdatedPayload;
 };
 
 type TauriEventHandler<K extends keyof TauriEventMap> =


### PR DESCRIPTION
Closes https://github.com/SidhuK/Glyph/issues/485

## Description

Gives each regular durable setting a single owner for its storage key, scope, default, normalization, and `settings:updated` change mapping. Follows the `persistSetting` subtraction from #487 without rebuilding it.

- New `src/lib/settings/definitions.ts` declares `DURABLE_SETTINGS` (application-scoped) and `SPACE_SETTINGS` (space-scoped) plus a typed `write`/`writeSpaceSetting` interface.
- New `src/lib/settings/model.ts` holds the typed `AppSettings`, `SettingsUpdatedPayload`, and related types.
- `loadSettings` consumes the definitions, so loading and writing share one normalization rule.
- Deletes ~40 one-off `set*` wrappers and the duplicate `KEYS` map; all callers (panes, contexts, hooks) now write through the definitions.
- Command palette definitions bind their `read`/`write`/validation to the same definitions instead of importing one setter each.
- `tauriEvents.ts` reuses the single `SettingsUpdatedPayload` type instead of a second hand-written payload shape.
- Complex multi-value operations (shortcuts, templates folder, recent files, current space) stay explicit under `INTERNAL_SETTING_KEYS`.
- `settingsSearch.ts` now asserts every searchable durable setting has a registered search entry.
- Rust keeps reading the same settings-store key via a named constant (`ui.keepRunningOnLastWindowClose`).

Net: `src/lib/settings.ts` drops from ~1,784 lines to ~773, with the durable facts relocated into the definitions module rather than duplicated.

## Docs

No user-facing documentation changes. This is an internal refactor with the same storage format, event names, and cross-window behavior.

## Ready?

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Consolidate durable application and space settings into shared typed definitions and models, updating consumers to read/write through these central APIs while preserving behavior and storage formats.

Enhancements:
- Introduce centralized settings definition and model modules for durable UI, editor, and space-scoped settings, including normalization, validation, and change payload typing.
- Refactor settings loading and writing logic to consume the shared definitions, replacing ad-hoc setters, key maps, and duplicated normalization code across the app and command palette.
- Unify settings-related typing for Tauri events and Rust usage by reusing a single SettingsUpdatedPayload type and a shared constant for the keep-running-on-close key.
- Add assertions that all searchable durable settings have corresponding search entries to keep palette and search definitions in sync.

Tests:
- Update and extend settings-related tests to cover the new definition-based write paths and space-scoped setting behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates all durable settings into central typed definitions to own keys, scope, defaults, normalization, and `settings:updated` payloads. Old behavior: many one-off `set*` wrappers and a duplicate key map. New behavior: `DURABLE_SETTINGS` and `SPACE_SETTINGS` with typed `write`/`writeSpaceSetting`; storage format and events unchanged.

- Adds `src/lib/settings/definitions.ts` (`DURABLE_SETTINGS`, `SPACE_SETTINGS`) and `src/lib/settings/model.ts` (`AppSettings`, `SettingsUpdatedPayload`).
- `loadSettings` now uses the definitions for defaults/normalization; removes ~40 `set*` wrappers and the duplicate keys map.
- Updates callers (settings panes, contexts, palette registry, hooks) to write via the definitions; `tauriEvents` now imports the shared `SettingsUpdatedPayload` type.
- `settingsSearch` verifies all durable searchable settings are covered and throws on startup when missing.
- macOS: Rust reads `ui.keepRunningOnLastWindowClose` via a named constant; no behavior change.
- Tests updated for definition-based write paths and space-scoped behavior.

**Migration for contributors**
- Replace `setX` calls with `DURABLE_SETTINGS.<id>.write(value)` for app-scoped settings or `writeSpaceSetting(SPACE_SETTINGS.<id>, value, { spacePath })` for space-scoped settings.
- Register new durable settings in `definitions.ts` (normalization and change mapping) and add a search entry if it should be discoverable.

<sup>Written for commit 5c8fd4513552ce42945217d059e8767b807f9b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate settings definitions into centralized `DURABLE_SETTINGS` and `SPACE_SETTINGS` registries
> - Introduces [src/lib/settings/definitions.ts](https://github.com/SidhuK/Glyph/pull/488/files#diff-33ee2f92b01ba3a81468305eddcc6a7149f5ede4771c7fcd3111f058178f7491) and [src/lib/settings/model.ts](https://github.com/SidhuK/Glyph/pull/488/files#diff-393d306426dad77d80b096a07965c97a38d9554b8af3bcf9023d5720a27767d1) as canonical sources for all settings types, defaults, normalization, parsing, and Tauri event emission.
> - Replaces dozens of per-setting setter functions (e.g. `setEditorSpellCheck`, `setFolioMode`) across settings panes, contexts, and the palette registry with `DURABLE_SETTINGS.<key>.write()` and `writeSpaceSetting(SPACE_SETTINGS.<key>, ...)`.
> - Adds `writeSpaceSetting` to handle normalization, validation, space-scoped vs. legacy durable storage selection, and event emission in one place.
> - Settings search now validates at module init that every `SEARCHABLE_SETTING_IDS` entry has a corresponding search entry, throwing on mismatch.
> - Risk: The public API of [src/lib/settings.ts](https://github.com/SidhuK/Glyph/pull/488/files#diff-b5f5521c9795e314efdf6293ad3afda789a1402bbf5e2a304e20efa8134d2a15) changes substantially — many previously exported setter functions are removed, and normalization/validation outcomes may differ where DURABLE_SETTINGS/SPACE_SETTINGS definitions diverge from the old bespoke logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c8fd45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Settings across appearance, editor, AI, templates, file tree, and workspace preferences now use consistent persistence and validation.
  - Settings updates provide more reliable normalization, error handling, rollback behavior, and cross-window synchronization.
  - Workspace-specific settings, including daily notes, attachments, quick notes, and templates, now save more consistently.
  - Settings search is more robust and detects incomplete searchable-setting coverage.
- **Bug Fixes**
  - Improved macOS behavior for keeping the app running after the final window closes.
- **Tests**
  - Expanded coverage for application and workspace setting persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->