### PR TITLE
Own Space lifecycle in one submit queue

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -43,6 +43,7 @@ import {
 	nextDatabasesOpenRequest,
 } from "../../lib/database/openDatabasesRequest";
 import { DATABASES_TAB_ID } from "../../lib/databases";
+import { type DeeplinkAction, isSameSpacePath } from "../../lib/deeplink";
 import {
 	ACTIVITY_DOCS_PAGE_SIZE,
 	invalidateAllDocsPrefetch,
@@ -59,6 +60,12 @@ import { requestSearchJump } from "../../lib/searchJump";
 import { loadSettings } from "../../lib/settings";
 import { getShortcutTooltip, toTauriAccelerator } from "../../lib/shortcuts";
 import { SPACE_CONNECTIONS_TAB_ID } from "../../lib/spaceConnections";
+import {
+	SPACE_SETTINGS_WAIT_MS,
+	type SpaceLifecycle,
+	createSpaceLifecycle,
+	waitUntil,
+} from "../../lib/spaceLifecycle";
 import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { listTemplates, renderTemplate } from "../../lib/templates";
@@ -392,7 +399,47 @@ export function AppShell() {
 		tabsRevision,
 	} = useTabManager(spacePath);
 	const { getBinding, actionsWithBindings } = useShortcutBindings();
-	const flushWorkspaceSession = useWorkspaceSession({
+
+	const spacePathRef = useRef(spacePath);
+	spacePathRef.current = spacePath;
+	const settingsSpacePathRef = useRef(settingsSpacePath);
+	settingsSpacePathRef.current = settingsSpacePath;
+	const saveAllEditorsRef = useRef(saveAllEditors);
+	saveAllEditorsRef.current = saveAllEditors;
+	const openSpaceAtPathRef = useRef(openSpaceAtPath);
+	openSpaceAtPathRef.current = openSpaceAtPath;
+	const closeSpaceRef = useRef(closeSpace);
+	closeSpaceRef.current = closeSpace;
+	const flushSessionRef = useRef<() => Promise<void>>(async () => {});
+	const restoreSessionRef = useRef<
+		(path: string, generation: number) => Promise<void>
+	>(async () => {});
+	const applyNavigationRef = useRef<(action: DeeplinkAction) => Promise<void>>(
+		async () => {},
+	);
+	const lifecycleRef = useRef<SpaceLifecycle | null>(null);
+	if (!lifecycleRef.current) {
+		lifecycleRef.current = createSpaceLifecycle({
+			currentSpacePath: () => spacePathRef.current,
+			saveEditors: async () => {
+				await saveAllEditorsRef.current();
+			},
+			flushSession: () => flushSessionRef.current(),
+			activateSpace: (path) => openSpaceAtPathRef.current(path),
+			closeSpace: () => closeSpaceRef.current(),
+			hydrateSettings: (path) =>
+				waitUntil(
+					() => isSameSpacePath(settingsSpacePathRef.current, path),
+					SPACE_SETTINGS_WAIT_MS,
+				),
+			restoreSession: (path, generation) =>
+				restoreSessionRef.current(path, generation),
+			applyNavigation: (action) => applyNavigationRef.current(action),
+		});
+	}
+	const spaceLifecycle = lifecycleRef.current;
+
+	const { flushPendingSave, restoreWorkspaceSession } = useWorkspaceSession({
 		spacePath,
 		settingsLoaded,
 		resumeLastSession,
@@ -403,44 +450,60 @@ export function AppShell() {
 		focusedPaneId,
 		activeTabPath,
 		tabsRevision,
+		enqueueSessionFlush: async () => {
+			const result = await spaceLifecycle.submit({ kind: "flushSession" });
+			return result.kind === "ok";
+		},
 		restoreWorkspaceTabs,
 	});
+	flushSessionRef.current = flushPendingSave;
+	restoreSessionRef.current = restoreWorkspaceSession;
 
-	const prepareForSpaceChange = useCallback(async (): Promise<boolean> => {
-		try {
-			await saveAllEditors();
-			await flushWorkspaceSession();
-			return true;
-		} catch (cause) {
-			console.error("Failed to save the current space before switching", cause);
+	const reportSaveFailure = useCallback(
+		(failed: boolean) => {
+			if (!failed) return false;
 			setError(t("workspace.switchSaveFailed"));
-			return false;
-		}
-	}, [flushWorkspaceSession, saveAllEditors, setError, t]);
+			return true;
+		},
+		[setError, t],
+	);
 
 	const handleOpenSpace = useCallback(async () => {
-		if (spacePath && !(await prepareForSpaceChange())) return;
+		if (spacePath) {
+			const result = await spaceLifecycle.submit({ kind: "checkpoint" });
+			if (reportSaveFailure(result.kind === "failed")) return;
+		}
 		await openSpace();
-	}, [openSpace, prepareForSpaceChange, spacePath]);
+	}, [openSpace, reportSaveFailure, spaceLifecycle, spacePath]);
 
 	const handleCreateSpace = useCallback(async () => {
-		if (spacePath && !(await prepareForSpaceChange())) return;
+		if (spacePath) {
+			const result = await spaceLifecycle.submit({ kind: "checkpoint" });
+			if (reportSaveFailure(result.kind === "failed")) return;
+		}
 		await createSpace();
-	}, [createSpace, prepareForSpaceChange, spacePath]);
+	}, [createSpace, reportSaveFailure, spaceLifecycle, spacePath]);
 
 	const handleSelectSpace = useCallback(
 		async (path: string): Promise<boolean> => {
-			if (path === spacePath) return true;
-			if (!(await prepareForSpaceChange())) return false;
-			return await openSpaceAtPath(path);
+			const result = await spaceLifecycle.submit({
+				kind: "activate",
+				path,
+				mode: "open",
+			});
+			if (result.kind === "failed") {
+				if (result.error === "save_failed") reportSaveFailure(true);
+				return false;
+			}
+			return true;
 		},
-		[openSpaceAtPath, prepareForSpaceChange, spacePath],
+		[reportSaveFailure, spaceLifecycle],
 	);
 
 	const handleCloseSpace = useCallback(async () => {
-		if (!(await prepareForSpaceChange())) return;
-		await closeSpace();
-	}, [closeSpace, prepareForSpaceChange]);
+		const result = await spaceLifecycle.submit({ kind: "close" });
+		if (result.kind === "failed") reportSaveFailure(true);
+	}, [reportSaveFailure, spaceLifecycle]);
 
 	useEffect(() => {
 		const visible =
@@ -725,14 +788,35 @@ export function AppShell() {
 		[setPaletteOpen],
 	);
 
+	applyNavigationRef.current = async (action: DeeplinkAction) => {
+		switch (action.kind) {
+			case "open_space":
+				return;
+			case "open_note":
+				await openWorkspaceFile(action.path);
+				return;
+			case "search":
+				openPalette("search", action.q);
+				return;
+			case "open_daily_note":
+				requestOpenDailyNote();
+				return;
+			default: {
+				const _exhaustive: never = action;
+				return _exhaustive;
+			}
+		}
+	};
+
+	useEffect(() => {
+		if (!spacePath || !settingsLoaded || resumeLastSession === null) return;
+		void spaceLifecycle.submit({ kind: "restore" });
+	}, [resumeLastSession, settingsLoaded, spaceLifecycle, spacePath]);
+
 	useDeeplinkDispatch({
-		spacePath,
-		settingsSpacePath,
 		settingsLoaded,
-		selectSpace: handleSelectSpace,
-		openWorkspaceFile,
-		openPalette,
-		requestOpenDailyNote,
+		submitNavigate: (event) =>
+			spaceLifecycle.submit({ kind: "navigate", action: event }),
 	});
 
 	const closePalette = useCallback(() => {

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -72,6 +72,7 @@ interface UseWorkspaceSessionArgs {
 	focusedPaneId: string;
 	activeTabPath: string | null;
 	tabsRevision: number;
+	enqueueSessionFlush: () => Promise<boolean>;
 	restoreWorkspaceTabs: (
 		tabSnapshots: WorkspaceSessionTabSnapshot[],
 		activeTabTarget: string | null,
@@ -97,12 +98,13 @@ export function useWorkspaceSession({
 	focusedPaneId,
 	activeTabPath,
 	tabsRevision,
+	enqueueSessionFlush,
 	restoreWorkspaceTabs,
 }: UseWorkspaceSessionArgs) {
 	const restoredSessionSpaceRef = useRef<string | null>(null);
 	const restoreSessionRequestIdRef = useRef(0);
-	// Live revision so an in-flight restore can yield to a tab change (e.g. a
-	// cold-start deeplink) that committed after the restore effect started.
+	// Live revision so an in-flight restore can yield to a tab change that
+	// committed after restore started.
 	const tabsRevisionRef = useRef(tabsRevision);
 	tabsRevisionRef.current = tabsRevision;
 	const pendingSaveRef = useRef<PendingWorkspaceSessionSave | null>(null);
@@ -143,24 +145,20 @@ export function useWorkspaceSession({
 		}
 	}, [clearSaveTimer]);
 
-	useEffect(() => {
-		if (restoredSessionSpaceRef.current !== spacePath) {
-			restoredSessionSpaceRef.current = null;
-			restoreSessionRequestIdRef.current += 1;
-		}
-		if (
-			!spacePath ||
-			!settingsLoaded ||
-			resumeLastSession === null ||
-			tabsRevision !== 0 ||
-			restoredSessionSpaceRef.current === spacePath
-		) {
-			return;
-		}
-		if (welcomeNotePath) return;
+	const restoreWorkspaceSession = useCallback(
+		async (_spacePath: string, _generation: number): Promise<void> => {
+			if (
+				!spacePath ||
+				!settingsLoaded ||
+				resumeLastSession === null ||
+				tabsRevisionRef.current !== 0 ||
+				restoredSessionSpaceRef.current === spacePath
+			) {
+				return;
+			}
+			if (welcomeNotePath) return;
 
-		const requestId = ++restoreSessionRequestIdRef.current;
-		void (async () => {
+			const requestId = ++restoreSessionRequestIdRef.current;
 			const snapshot = await loadWorkspaceSessionSnapshot(spacePath);
 			if (requestId !== restoreSessionRequestIdRef.current || !snapshot) {
 				return;
@@ -178,8 +176,6 @@ export function useWorkspaceSession({
 			const restorableTabs = await validateRestorableSessionTabs(requestedTabs);
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
-				// A deeplink (or any other open) may have bumped revision while we
-				// awaited; do not clobber that navigation with a stale snapshot.
 				tabsRevisionRef.current !== 0 ||
 				(!restorableTabs.length && !(resumeLastSession && snapshot.splitLayout))
 			) {
@@ -199,20 +195,22 @@ export function useWorkspaceSession({
 				resumeLastSession ? snapshot.activeTabTargetByPane : {},
 			);
 			restoredSessionSpaceRef.current = spacePath;
-		})().catch((cause) => {
-			console.error("Failed to restore workspace session", cause);
-		});
-		return () => {
+		},
+		[
+			restoreWorkspaceTabs,
+			resumeLastSession,
+			welcomeNotePath,
+			settingsLoaded,
+			spacePath,
+		],
+	);
+
+	useEffect(() => {
+		if (restoredSessionSpaceRef.current !== spacePath) {
+			restoredSessionSpaceRef.current = null;
 			restoreSessionRequestIdRef.current += 1;
-		};
-	}, [
-		restoreWorkspaceTabs,
-		resumeLastSession,
-		welcomeNotePath,
-		settingsLoaded,
-		spacePath,
-		tabsRevision,
-	]);
+		}
+	}, [spacePath]);
 
 	useEffect(() => {
 		if (saveSpaceRef.current !== spacePath) {
@@ -269,7 +267,8 @@ export function useWorkspaceSession({
 			.onCloseRequested(async (event) => {
 				event.preventDefault();
 				try {
-					await flushPendingSave();
+					const flushed = await enqueueSessionFlush();
+					if (!flushed) throw new Error("session flush failed");
 				} catch (cause) {
 					console.error(
 						"Failed to save workspace session before closing",
@@ -316,14 +315,17 @@ export function useWorkspaceSession({
 			disposed = true;
 			unlisten?.();
 		};
-	}, [flushPendingSave]);
+	}, [enqueueSessionFlush]);
 
 	useEffect(() => {
 		let disposed = false;
 		let unlisten: (() => void) | null = null;
 		void listen("app:exit_requested", () => {
-			void flushPendingSave()
-				.then(() => invoke("app_confirm_exit"))
+			void enqueueSessionFlush()
+				.then((flushed) => {
+					if (!flushed) throw new Error("session flush failed");
+					return invoke("app_confirm_exit");
+				})
 				.catch((cause) => {
 					console.error(
 						"Failed to save workspace session before quitting",
@@ -359,7 +361,7 @@ export function useWorkspaceSession({
 			disposed = true;
 			unlisten?.();
 		};
-	}, [flushPendingSave]);
+	}, [enqueueSessionFlush]);
 
-	return flushPendingSave;
+	return { flushPendingSave, restoreWorkspaceSession };
 }

--- a/src/components/app/useWorkspaceSession.ts
+++ b/src/components/app/useWorkspaceSession.ts
@@ -103,8 +103,6 @@ export function useWorkspaceSession({
 }: UseWorkspaceSessionArgs) {
 	const restoredSessionSpaceRef = useRef<string | null>(null);
 	const restoreSessionRequestIdRef = useRef(0);
-	// Live revision so an in-flight restore can yield to a tab change that
-	// committed after restore started.
 	const tabsRevisionRef = useRef(tabsRevision);
 	tabsRevisionRef.current = tabsRevision;
 	const pendingSaveRef = useRef<PendingWorkspaceSessionSave | null>(null);
@@ -147,11 +145,12 @@ export function useWorkspaceSession({
 
 	const restoreWorkspaceSession = useCallback(
 		async (_spacePath: string, _generation: number): Promise<void> => {
+			const revisionAtStart = tabsRevisionRef.current;
 			if (
 				!spacePath ||
 				!settingsLoaded ||
 				resumeLastSession === null ||
-				tabsRevisionRef.current !== 0 ||
+				revisionAtStart !== 0 ||
 				restoredSessionSpaceRef.current === spacePath
 			) {
 				return;
@@ -176,7 +175,7 @@ export function useWorkspaceSession({
 			const restorableTabs = await validateRestorableSessionTabs(requestedTabs);
 			if (
 				requestId !== restoreSessionRequestIdRef.current ||
-				tabsRevisionRef.current !== 0 ||
+				tabsRevisionRef.current !== revisionAtStart ||
 				(!restorableTabs.length && !(resumeLastSession && snapshot.splitLayout))
 			) {
 				return;

--- a/src/hooks/useDeeplinkDispatch.ts
+++ b/src/hooks/useDeeplinkDispatch.ts
@@ -1,86 +1,26 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import {
-	type DeeplinkErrorPayload,
-	type DeeplinkEvent,
-	isSameSpacePath,
-} from "../lib/deeplink";
+import type { DeeplinkErrorPayload, DeeplinkEvent } from "../lib/deeplink";
+import type { SpaceLifecycleResult } from "../lib/spaceLifecycle";
 import { invoke } from "../lib/tauri";
 import { useTauriEvent } from "../lib/tauriEvents";
 import { toast } from "../lib/toast";
 
 const DEEPLINK_ERROR_TOAST_ID = "glyph-deeplink-error";
-/**
- * A deeplink can only act on the new space once React state reflects the
- * switch. Settings hydration is best-effort and may never land, so the wait is
- * bounded rather than open-ended.
- */
-const SPACE_SETTLE_TIMEOUT_MS = 5000;
-/** Ids are only needed long enough to spot a pending-queue replay. */
 const MAX_REMEMBERED_IDS = 256;
 
-type Waiter = { ready: () => boolean; settle: (ready: boolean) => void };
-
 export interface UseDeeplinkDispatchOptions {
-	spacePath: string | null;
-	/** Space whose settings are currently hydrated; see `UIContext`. */
-	settingsSpacePath: string | null;
 	settingsLoaded: boolean;
-	/** Saves the open editors, switches space, and reports whether it worked. */
-	selectSpace: (path: string) => Promise<boolean>;
-	openWorkspaceFile: (path: string) => Promise<void>;
-	openPalette: (mode: "commands" | "search", query?: string) => void;
-	requestOpenDailyNote: () => void;
+	submitNavigate: (event: DeeplinkEvent) => Promise<SpaceLifecycleResult>;
 }
 
-/**
- * Routes native `glyph://` deeplinks onto the existing open/search/daily flows.
- * Native code has already validated the space and note, so failures arrive as
- * `deeplink:error` codes rather than being re-checked here.
- */
 export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
-	const { spacePath, settingsSpacePath, settingsLoaded } = options;
+	const { settingsLoaded } = options;
 	const { t } = useTranslation("shell");
-
 	const optionsRef = useRef(options);
 	optionsRef.current = options;
-
 	const seenIdsRef = useRef<Set<number>>(new Set());
-	const queueRef = useRef<DeeplinkEvent[]>([]);
-	const runningRef = useRef(false);
-	const waitersRef = useRef<Waiter[]>([]);
-
-	// Resume any action that was waiting on the space (or its settings) to land.
-	// spacePath / settingsSpacePath are read so the effect re-runs when they change;
-	// waiters themselves close over ready() against optionsRef.
-	useEffect(() => {
-		void spacePath;
-		void settingsSpacePath;
-		for (const waiter of [...waitersRef.current]) {
-			if (waiter.ready()) waiter.settle(true);
-		}
-	}, [spacePath, settingsSpacePath]);
-
-	const waitForState = useCallback((ready: () => boolean): Promise<boolean> => {
-		if (ready()) return Promise.resolve(true);
-		return new Promise<boolean>((resolve) => {
-			const waiter: Waiter = {
-				ready,
-				settle: (settled) => {
-					clearTimeout(timer);
-					waitersRef.current = waitersRef.current.filter(
-						(entry) => entry !== waiter,
-					);
-					resolve(settled);
-				},
-			};
-			const timer = setTimeout(
-				() => waiter.settle(false),
-				SPACE_SETTLE_TIMEOUT_MS,
-			);
-			waitersRef.current.push(waiter);
-		});
-	}, []);
+	const heldRef = useRef<DeeplinkEvent[]>([]);
 
 	const showError = useCallback(
 		(description?: string) => {
@@ -108,82 +48,10 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 		[t],
 	);
 
-	const ensureSpace = useCallback(
-		async (space: string): Promise<boolean> => {
-			if (isSameSpacePath(optionsRef.current.spacePath, space)) return true;
-			// `selectSpace` saves open editors and surfaces its own failures.
-			if (!(await optionsRef.current.selectSpace(space))) return false;
-			return waitForState(() =>
-				isSameSpacePath(optionsRef.current.spacePath, space),
-			);
-		},
-		[waitForState],
-	);
-
-	const runEvent = useCallback(
-		async (event: DeeplinkEvent) => {
-			try {
-				if (!(await ensureSpace(event.space))) {
-					showError();
-					return;
-				}
-				switch (event.kind) {
-					case "open_space":
-						return;
-					case "open_note":
-						await optionsRef.current.openWorkspaceFile(event.path);
-						return;
-					case "search":
-						optionsRef.current.openPalette("search", event.q);
-						return;
-					case "open_daily_note": {
-						// The daily note folder and template are per-space settings, so
-						// acting before they rehydrate would target the previous space.
-						const ready = await waitForState(() =>
-							isSameSpacePath(
-								optionsRef.current.settingsSpacePath,
-								event.space,
-							),
-						);
-						if (!ready) {
-							showError();
-							return;
-						}
-						optionsRef.current.requestOpenDailyNote();
-						return;
-					}
-					default: {
-						const _exhaustive: never = event;
-						return _exhaustive;
-					}
-				}
-			} catch (error) {
-				console.error("Failed to run deeplink", error);
-				showError();
-			}
-		},
-		[ensureSpace, showError, waitForState],
-	);
-
-	const processQueue = useCallback(async () => {
-		if (runningRef.current) return;
-		runningRef.current = true;
-		try {
-			while (queueRef.current.length > 0) {
-				const next = queueRef.current.shift();
-				if (next) await runEvent(next);
-			}
-		} finally {
-			runningRef.current = false;
-		}
-	}, [runEvent]);
-
-	/** Returns false when this id was already handled (live emit vs. queue replay). */
 	const claimId = useCallback((id: number): boolean => {
 		const seen = seenIdsRef.current;
 		if (seen.has(id)) return false;
 		seen.add(id);
-		// Sets iterate in insertion order, so this evicts the oldest ids.
 		while (seen.size > MAX_REMEMBERED_IDS) {
 			const oldest = seen.values().next();
 			if (oldest.done) break;
@@ -192,15 +60,23 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 		return true;
 	}, []);
 
+	const pump = useCallback(() => {
+		if (!optionsRef.current.settingsLoaded) return;
+		const held = heldRef.current.splice(0);
+		for (const event of held) {
+			void optionsRef.current.submitNavigate(event).then((result) => {
+				if (result.kind === "failed") showError();
+			});
+		}
+	}, [showError]);
+
 	const enqueue = useCallback(
 		(event: DeeplinkEvent) => {
 			if (!claimId(event.id)) return;
-			queueRef.current.push(event);
-			// Hold until bootstrap finishes so live cold-start events cannot race
-			// SpaceContext's session restore `space_open`.
-			if (optionsRef.current.settingsLoaded) void processQueue();
+			heldRef.current.push(event);
+			pump();
 		},
-		[claimId, processQueue],
+		[claimId, pump],
 	);
 
 	const reportError = useCallback(
@@ -211,8 +87,6 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 		[claimId, errorMessage, showError],
 	);
 
-	// Deeplinks are queued natively as well as emitted, because the webview is
-	// not listening yet on a cold start. Draining is idempotent thanks to ids.
 	const drainPending = useCallback(async () => {
 		try {
 			const pending = await invoke("deeplink_take_pending");
@@ -231,13 +105,8 @@ export function useDeeplinkDispatch(options: UseDeeplinkDispatchOptions): void {
 		reportError(payload);
 	});
 
-	// Wait for settings so a cold-start deeplink does not race session restore.
-	// Drain the native pending queue and process anything already enqueued live.
 	useEffect(() => {
 		if (!settingsLoaded) return;
-		void (async () => {
-			await drainPending();
-			void processQueue();
-		})();
-	}, [drainPending, processQueue, settingsLoaded]);
+		void drainPending().then(pump);
+	}, [drainPending, pump, settingsLoaded]);
 }

--- a/src/lib/spaceLifecycle.test.ts
+++ b/src/lib/spaceLifecycle.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import type { DeeplinkAction } from "./deeplink";
+import {
+	type SpaceLifecycleAdapters,
+	createSpaceLifecycle,
+} from "./spaceLifecycle";
+
+function createHarness(initialPath: string | null = null) {
+	let spacePath = initialPath;
+	const calls: string[] = [];
+	let hydrateOk = true;
+	let activateOk = true;
+	let saveShouldThrow = false;
+	let flushShouldThrow = false;
+	let pendingFlush: Promise<void> | null = null;
+	const navigations: DeeplinkAction[] = [];
+
+	const adapters: SpaceLifecycleAdapters = {
+		currentSpacePath: () => spacePath,
+		saveEditors: async () => {
+			calls.push("save");
+			if (saveShouldThrow) throw new Error("save failed");
+		},
+		flushSession: async () => {
+			calls.push("flush");
+			if (flushShouldThrow) throw new Error("flush failed");
+			if (pendingFlush) await pendingFlush;
+		},
+		activateSpace: async (path, mode) => {
+			calls.push(`activate:${mode}:${path}`);
+			if (!activateOk) return false;
+			spacePath = path;
+			return true;
+		},
+		closeSpace: async () => {
+			calls.push("close");
+			spacePath = null;
+		},
+		hydrateSettings: async (path) => {
+			calls.push(`hydrate:${path}`);
+			return hydrateOk;
+		},
+		restoreSession: async (path, generation) => {
+			calls.push(`restore:${path}:${generation}`);
+		},
+		applyNavigation: async (action) => {
+			calls.push(`navigate:${action.kind}`);
+			navigations.push(action);
+		},
+	};
+
+	return {
+		lifecycle: createSpaceLifecycle(adapters),
+		calls,
+		navigations,
+		get spacePath() {
+			return spacePath;
+		},
+		setHydrateOk(value: boolean) {
+			hydrateOk = value;
+		},
+		setActivateOk(value: boolean) {
+			activateOk = value;
+		},
+		setSaveShouldThrow(value: boolean) {
+			saveShouldThrow = value;
+		},
+		setFlushShouldThrow(value: boolean) {
+			flushShouldThrow = value;
+		},
+		setPendingFlush(promise: Promise<void>) {
+			pendingFlush = promise;
+		},
+	};
+}
+
+describe("createSpaceLifecycle", () => {
+	it("opens, restores after hydrate, and treats the current space as success", async () => {
+		const h = createHarness();
+		const opened = await h.lifecycle.submit({
+			kind: "activate",
+			path: "/vault",
+			mode: "open",
+		});
+		expect(opened).toEqual({ kind: "ok", spacePath: "/vault" });
+		expect(h.calls).toEqual(["activate:open:/vault"]);
+
+		const restored = await h.lifecycle.submit({ kind: "restore" });
+		expect(restored.kind).toBe("ok");
+		expect(h.calls).toEqual([
+			"activate:open:/vault",
+			"hydrate:/vault",
+			"restore:/vault:0",
+		]);
+
+		const again = await h.lifecycle.submit({
+			kind: "activate",
+			path: "/vault",
+			mode: "open",
+		});
+		expect(again).toEqual({ kind: "ok", spacePath: "/vault" });
+		expect(h.calls[h.calls.length - 1]).toBe("restore:/vault:0");
+	});
+
+	it("creates through the same activate path", async () => {
+		const h = createHarness();
+		const created = await h.lifecycle.submit({
+			kind: "activate",
+			path: "/new",
+			mode: "create",
+		});
+		expect(created).toEqual({ kind: "ok", spacePath: "/new" });
+		expect(h.calls).toEqual(["activate:create:/new"]);
+	});
+
+	it("saves before switching and stops when save fails", async () => {
+		const h = createHarness("/current");
+		h.setSaveShouldThrow(true);
+		const result = await h.lifecycle.submit({
+			kind: "activate",
+			path: "/next",
+			mode: "open",
+		});
+		expect(result).toEqual({
+			kind: "failed",
+			spacePath: "/current",
+			error: "save_failed",
+		});
+		expect(h.spacePath).toBe("/current");
+		expect(h.calls).toEqual(["save"]);
+	});
+
+	it("keeps the previous space when activation fails", async () => {
+		const h = createHarness("/current");
+		h.setActivateOk(false);
+		const result = await h.lifecycle.submit({
+			kind: "activate",
+			path: "/next",
+			mode: "open",
+		});
+		expect(result).toEqual({
+			kind: "failed",
+			spacePath: "/current",
+			error: "activate_failed",
+		});
+		expect(h.spacePath).toBe("/current");
+		expect(h.calls).toEqual(["save", "flush", "activate:open:/next"]);
+	});
+
+	it("skips restore when a live navigation bumped generation", async () => {
+		const h = createHarness("/vault");
+		const restore = h.lifecycle.submit({ kind: "restore" });
+		const nav = h.lifecycle.submit({
+			kind: "navigate",
+			action: { kind: "open_note", space: "/vault", path: "a.md" },
+		});
+		await Promise.all([restore, nav]);
+		expect(h.calls.filter((call) => call.startsWith("restore:"))).toEqual([]);
+		expect(h.navigations).toEqual([
+			{ kind: "open_note", space: "/vault", path: "a.md" },
+		]);
+	});
+
+	it("runs pending navigations in order", async () => {
+		const h = createHarness("/vault");
+		const first = h.lifecycle.submit({
+			kind: "navigate",
+			action: { kind: "open_note", space: "/vault", path: "one.md" },
+		});
+		const second = h.lifecycle.submit({
+			kind: "navigate",
+			action: { kind: "open_note", space: "/vault", path: "two.md" },
+		});
+		await Promise.all([first, second]);
+		expect(
+			h.navigations.map((action) =>
+				action.kind === "open_note" ? action.path : "",
+			),
+		).toEqual(["one.md", "two.md"]);
+	});
+
+	it("hydrates before opening a daily note", async () => {
+		const h = createHarness("/vault");
+		await h.lifecycle.submit({
+			kind: "navigate",
+			action: { kind: "open_daily_note", space: "/vault" },
+		});
+		expect(h.calls).toEqual(["hydrate:/vault", "navigate:open_daily_note"]);
+	});
+
+	it("waits for a queued session flush before close", async () => {
+		const h = createHarness("/vault");
+		let release = () => {};
+		h.setPendingFlush(
+			new Promise<void>((resolve) => {
+				release = resolve;
+			}),
+		);
+		const flush = h.lifecycle.submit({ kind: "flushSession" });
+		const close = h.lifecycle.submit({ kind: "close" });
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(h.calls).toEqual(["flush"]);
+		expect(h.spacePath).toBe("/vault");
+		release();
+		await Promise.all([flush, close]);
+		expect(h.calls).toEqual(["flush", "save", "flush", "close"]);
+		expect(h.spacePath).toBeNull();
+	});
+
+	it("surfaces a session save failure without closing", async () => {
+		const h = createHarness("/vault");
+		h.setFlushShouldThrow(true);
+		const result = await h.lifecycle.submit({ kind: "flushSession" });
+		expect(result).toEqual({
+			kind: "failed",
+			spacePath: "/vault",
+			error: "session_save_failed",
+		});
+		expect(h.spacePath).toBe("/vault");
+	});
+});

--- a/src/lib/spaceLifecycle.ts
+++ b/src/lib/spaceLifecycle.ts
@@ -1,0 +1,234 @@
+import { type DeeplinkAction, isSameSpacePath } from "./deeplink";
+
+export const SPACE_SETTINGS_WAIT_MS = 5000;
+
+export type SpaceLifecycleIntent =
+	| { kind: "activate"; path: string; mode: "open" | "create" }
+	| { kind: "checkpoint" }
+	| { kind: "close" }
+	| { kind: "restore" }
+	| { kind: "flushSession" }
+	| { kind: "navigate"; action: DeeplinkAction };
+
+export type SpaceLifecycleError =
+	| "save_failed"
+	| "activate_failed"
+	| "session_save_failed";
+
+export type SpaceLifecycleResult =
+	| { kind: "ok"; spacePath: string | null }
+	| { kind: "failed"; spacePath: string | null; error: SpaceLifecycleError };
+
+export type SpaceLifecycleAdapters = {
+	currentSpacePath: () => string | null;
+	saveEditors: () => Promise<void>;
+	flushSession: () => Promise<void>;
+	activateSpace: (path: string, mode: "open" | "create") => Promise<boolean>;
+	closeSpace: () => Promise<void>;
+	hydrateSettings: (spacePath: string) => Promise<boolean>;
+	restoreSession: (spacePath: string, generation: number) => Promise<void>;
+	applyNavigation: (action: DeeplinkAction) => Promise<void>;
+};
+
+export type SpaceLifecycle = {
+	submit: (intent: SpaceLifecycleIntent) => Promise<SpaceLifecycleResult>;
+};
+
+export function waitUntil(
+	ready: () => boolean,
+	timeoutMs: number,
+): Promise<boolean> {
+	if (ready()) return Promise.resolve(true);
+	return new Promise((resolve) => {
+		const startedAt = Date.now();
+		const id = setInterval(() => {
+			if (ready()) {
+				clearInterval(id);
+				resolve(true);
+				return;
+			}
+			if (Date.now() - startedAt >= timeoutMs) {
+				clearInterval(id);
+				resolve(false);
+			}
+		}, 16);
+	});
+}
+
+export function createSpaceLifecycle(
+	adapters: SpaceLifecycleAdapters,
+): SpaceLifecycle {
+	let generation = 0;
+	let skipRestore = false;
+	let queue: Promise<void> = Promise.resolve();
+
+	const snapshotPath = () => adapters.currentSpacePath();
+
+	const submit = (
+		intent: SpaceLifecycleIntent,
+	): Promise<SpaceLifecycleResult> => {
+		if (intent.kind === "navigate") {
+			generation += 1;
+			skipRestore = true;
+		}
+		const run = queue.then(
+			() => perform(intent),
+			() => perform(intent),
+		);
+		queue = run.then(
+			() => undefined,
+			() => undefined,
+		);
+		return run;
+	};
+
+	const perform = async (
+		intent: SpaceLifecycleIntent,
+	): Promise<SpaceLifecycleResult> => {
+		switch (intent.kind) {
+			case "activate":
+				return activate(intent.path, intent.mode, false);
+			case "checkpoint":
+				return checkpoint();
+			case "close":
+				return closeSpace();
+			case "restore":
+				return restore();
+			case "flushSession":
+				return flushSession();
+			case "navigate":
+				return navigate(intent.action);
+			default: {
+				const _exhaustive: never = intent;
+				return _exhaustive;
+			}
+		}
+	};
+
+	const activate = async (
+		path: string,
+		mode: "open" | "create",
+		fromNavigate: boolean,
+	): Promise<SpaceLifecycleResult> => {
+		if (isSameSpacePath(snapshotPath(), path)) {
+			return { kind: "ok", spacePath: snapshotPath() };
+		}
+		const saved = await saveCurrent();
+		if (!saved) {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "save_failed",
+			};
+		}
+		try {
+			const opened = await adapters.activateSpace(path, mode);
+			if (!opened) {
+				return {
+					kind: "failed",
+					spacePath: snapshotPath(),
+					error: "activate_failed",
+				};
+			}
+			if (!fromNavigate) skipRestore = false;
+			return { kind: "ok", spacePath: snapshotPath() };
+		} catch {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "activate_failed",
+			};
+		}
+	};
+
+	const closeSpace = async (): Promise<SpaceLifecycleResult> => {
+		const saved = await saveCurrent();
+		if (!saved) {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "save_failed",
+			};
+		}
+		try {
+			await adapters.closeSpace();
+			return { kind: "ok", spacePath: snapshotPath() };
+		} catch {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "activate_failed",
+			};
+		}
+	};
+
+	const restore = async (): Promise<SpaceLifecycleResult> => {
+		const spacePath = snapshotPath();
+		if (!spacePath || skipRestore) return { kind: "ok", spacePath };
+		const started = generation;
+		await adapters.hydrateSettings(spacePath);
+		if (skipRestore) {
+			return { kind: "ok", spacePath };
+		}
+		await adapters.restoreSession(spacePath, started);
+		return { kind: "ok", spacePath };
+	};
+
+	const flushSession = async (): Promise<SpaceLifecycleResult> => {
+		try {
+			await adapters.flushSession();
+			return { kind: "ok", spacePath: snapshotPath() };
+		} catch {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "session_save_failed",
+			};
+		}
+	};
+
+	const navigate = async (
+		action: DeeplinkAction,
+	): Promise<SpaceLifecycleResult> => {
+		const switched = await activate(action.space, "open", true);
+		if (switched.kind === "failed") return switched;
+		if (action.kind === "open_daily_note") {
+			const ready = await adapters.hydrateSettings(action.space);
+			if (!ready) {
+				return {
+					kind: "failed",
+					spacePath: snapshotPath(),
+					error: "activate_failed",
+				};
+			}
+		}
+		await adapters.applyNavigation(action);
+		return { kind: "ok", spacePath: snapshotPath() };
+	};
+
+	const saveCurrent = async (): Promise<boolean> => {
+		if (!snapshotPath()) return true;
+		try {
+			await adapters.saveEditors();
+			await adapters.flushSession();
+			return true;
+		} catch {
+			return false;
+		}
+	};
+
+	const checkpoint = async (): Promise<SpaceLifecycleResult> => {
+		if (!(await saveCurrent())) {
+			return {
+				kind: "failed",
+				spacePath: snapshotPath(),
+				error: "save_failed",
+			};
+		}
+		return { kind: "ok", spacePath: snapshotPath() };
+	};
+
+	return {
+		submit,
+	};
+}


### PR DESCRIPTION
Fixes https://github.com/SidhuK/Glyph/issues/481

Glyph users keep the Space they asked for. A failed switch no longer looks like it succeeded, and a cold-start deeplink is not overwritten by leftover tabs.

Maintainers get one `submit(intent)` entry point. Save, activate, hydrate, restore, navigate, close, and quit share a queue instead of waiting on `settingsLoaded`, `tabsRevision`, and deeplink waiter lists in separate hooks.

Startup, picker, recent Space, menu, and deeplink now call that queue. Native `space_open` and the deeplink parser stay adapters. Session snapshot format is unchanged.

Verified with `pnpm check`, `pnpm test`, and `pnpm build`.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Unify space lifecycle operations into a single queued submit flow so navigation, startup, and session management share consistent saving, activation, restore, and deeplink handling.

New Features:
- Introduce a SpaceLifecycle abstraction that sequences space activation, closing, session restore, flushing, and deeplink navigation through a single intent queue.

Bug Fixes:
- Ensure failed space switches and navigation keep the previous space active and report errors instead of appearing to succeed.
- Prevent cold-start deeplink navigation from overwriting or racing with restored tabs and sessions.

Enhancements:
- Refactor deeplink handling to delegate navigation through the SpaceLifecycle, simplifying state waiting and error reporting.
- Integrate workspace session restore and flush with the SpaceLifecycle so exit and close requests wait on a shared, ordered save pipeline.

Tests:
- Add unit tests for SpaceLifecycle to verify sequencing, error propagation, restore skipping on live navigation, and interaction with queued session flushes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Owns Space open/close/restore/deeplink through a single lifecycle queue to remove startup/deeplink races and keep the correct Space active. Previously, separate waiters could make a failed switch look successful and let cold-start deeplinks be overwritten; now save→flush→activate/close→hydrate→restore→navigate run in order, live navigation cancels stale restores, and in‑flight restores abort if tabs change.

- Add `src/lib/spaceLifecycle.ts` with `submit(intent)` (`activate`, `checkpoint`, `close`, `restore`, `flushSession`, `navigate`), `SPACE_SETTINGS_WAIT_MS`, and `waitUntil`; hydrate before daily-note navigation.
- Wire `AppShell` to the lifecycle via adapters for saving editors, session flush, activate/close, settings hydration, session restore, and navigation application.
- Refactor `useWorkspaceSession` to return `{ flushPendingSave, restoreWorkspaceSession }`, accept `enqueueSessionFlush`, and abort a restore when `tabsRevision` changes; window close/quit now await the queued flush path.
- Simplify `useDeeplinkDispatch` to accept `settingsLoaded` and `submitNavigate`; it de-duplicates ids, defers all work to the lifecycle, and only shows error toasts.
- Keep session snapshot format and native `space_open`/deeplink parser unchanged; add `src/lib/spaceLifecycle.test.ts` covering sequencing, save/activate failures, pending-flush-before-close, hydration for daily notes, navigation ordering, and restore skipping on generation bump.

<sup>Written for commit 1eef90e6359c4dec5ea4764112e274db992cfed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sequence space lifecycle operations through a single submit queue
> - Introduces `createSpaceLifecycle` in [spaceLifecycle.ts](https://github.com/SidhuK/Glyph/pull/489/files#diff-7224a654c6d1426497099a039d395e0e4408fe7462d664e45a211e4a2bc51b15), a serialized queue that orders space activation/creation/closure, session save/restore, and deeplink navigation through a shared promise chain.
> - [AppShell](https://github.com/SidhuK/Glyph/pull/489/files#diff-477852990e593378558fb04daea6895ce1e01057aa65bc0cb05795f64e3c10ed) now submits lifecycle intents (`checkpoint`, `activate`, `close`, `restore`, `navigate`) instead of running the previous ad-hoc `prepareForSpaceChange` flow; failures surface via `setError`.
> - [useWorkspaceSession](https://github.com/SidhuK/Glyph/pull/489/files#diff-1ed7c6845003bbcabe8b18b4d8fe2d284776d56a8c8abe970c63e5a631a80b3c) no longer auto-restores on mount; it exposes `restoreWorkspaceSession` for the lifecycle to call at the right time, and blocks app close/exit if session flush fails.
> - [useDeeplinkDispatch](https://github.com/SidhuK/Glyph/pull/489/files#diff-d1b0ff20a4269adeac4fa99fb988b82ae24d25ef23b9b25eb38ea810bae15203) removes its own space/settings synchronization and instead buffers deeplink actions until settings are loaded, then forwards them to the lifecycle.
> - Behavioral Change: space changes, session saves, and deeplink navigation are now strictly ordered — a pending save failure will block the subsequent space action rather than proceeding silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e6e298c. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->