### PR TITLE
Treat version suffixes as note names, not file extensions

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -58,8 +58,11 @@ pub fn path_extension_lower(path: &str) -> Option<String> {
 }
 
 pub fn has_explicit_file_extension(path: &str) -> bool {
-    path_extension_lower(path)
-        .is_some_and(|ext| !ext.is_empty() && !ext.chars().any(char::is_whitespace))
+    path_extension_lower(path).is_some_and(|ext| {
+        !ext.is_empty()
+            && !ext.chars().any(char::is_whitespace)
+            && ext.chars().any(|c| c.is_ascii_alphabetic())
+    })
 }
 
 pub fn is_markdown_extension(ext: &str) -> bool {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -50,7 +50,7 @@ export function fileExtension(path: string): string {
 
 export function hasExplicitFileExtension(path: string): boolean {
 	const ext = fileExtension(path);
-	return ext.length > 0 && !/\s/.test(ext);
+	return ext.length > 0 && !/\s/.test(ext) && /[a-z]/i.test(ext);
 }
 
 export function isImagePath(path: string): boolean {


### PR DESCRIPTION
Closes


## Description

Wiki links whose last dotted token is numeric (`Glyph 0.2.14`, `0.8.2`) were rejected as unsupported non-markdown targets. The click handler and Rust resolver treated that token as a file extension, so they never looked up or created `….md`.

- Require at least one letter in `hasExplicitFileExtension` / `has_explicit_file_extension`.
- `.md`, `.pdf`, `.zip`, `.csv` still count as extensions. Version suffixes do not.
- Same predicate on TS and Rust so resolve, create, and indexing stay aligned.

No issue linked.


## Docs

No documentation changes. The check is the existing explicit-extension helper used by wiki-link click, resolve, and outgoing-link indexing.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Treat numeric dotted suffixes as version-like names instead of file extensions so wiki-link resolution stays consistent between Rust and TypeScript.

Bug Fixes:
- Fix rejection of wiki links whose final dotted segment is purely numeric by ensuring they are no longer treated as file extensions.

Enhancements:
- Align explicit file-extension detection logic between Rust and TypeScript by requiring at least one alphabetic character in the extension.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat version suffixes as note names by requiring alphabetic characters in file extensions
> Updates `has_explicit_file_extension` (Rust, [utils.rs](https://github.com/SidhuK/Glyph/pull/493/files#diff-4f274dd1ca75182d02776a1d87a862ed1ec42410077ba81ee4bae33f0949bfae)) and `hasExplicitFileExtension` (TypeScript, [path.ts](https://github.com/SidhuK/Glyph/pull/493/files#diff-6400e8d998102dfecfa0a7ea230b282e6078f9da18c7f14fc59af91703f4b912)) to require at least one ASCII alphabetic character in the extension. This prevents version suffixes like `.1`, `.2`, or purely numeric/punctuation segments from being treated as file extensions, so filenames such as `note-v1.2` are interpreted as note names rather than files with extensions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfb86a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats numeric dotted suffixes in wiki links as part of the note name, so links like "Glyph 0.2.14" now resolve/create "Glyph 0.2.14.md". Previously, the last numeric token was treated as a file extension and the link was rejected.

**Review notes**
- Tightens `hasExplicitFileExtension`/`has_explicit_file_extension` in TS and Rust to require at least one alphabetic character in the extension; ".md", ".pdf", ".zip", and ".csv" still match, while purely numeric suffixes do not.
- Aligns link click handling, path resolution, and outgoing-link indexing across runtimes; no migration or config changes needed.

<sup>Written for commit dfb86a8912712aa648dd4f363cd0fe86470ddeeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file extension detection to reject extensions that contain only numbers or symbols.
  * Extensions must now include at least one alphabetic character and contain no whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->