### PR TITLE
Honor heading/block wikilinks and live note/search embeds

### DIFF
--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -20,7 +20,12 @@ import {
 	type TagClickDetail,
 	WIKI_LINK_CLICK_EVENT,
 	type WikiLinkClickDetail,
+	queueWikiAnchorNavigation,
 } from "../editor/markdown/editorEvents";
+import {
+	isSearchQueryWikiTarget,
+	searchQueryFromWikiTarget,
+} from "../editor/markdown/wikiLinkCodec";
 
 interface UseWorkspaceLinkEventsArgs {
 	activeMarkdownTabPath: string | null;
@@ -38,16 +43,30 @@ export function useWorkspaceLinkEvents({
 	setError,
 }: UseWorkspaceLinkEventsArgs) {
 	const openOrCreateWikiLinkTarget = useCallback(
-		async (rawTarget: string) => {
+		async (rawTarget: string, anchor?: WikiLinkClickDetail) => {
 			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 			if (!normalizedTarget) return;
+			const openResolved = async (path: string) => {
+				if (
+					anchor &&
+					(anchor.anchorKind === "heading" || anchor.anchorKind === "block") &&
+					anchor.anchor
+				) {
+					queueWikiAnchorNavigation({
+						path: normalizeRelPath(path),
+						anchorKind: anchor.anchorKind,
+						anchor: anchor.anchor,
+					});
+				}
+				await openWorkspaceFile(path);
+			};
 			if (isPdfPath(normalizedTarget)) {
 				const resolved = await invoke("space_resolve_wikilink", {
 					target: normalizedTarget,
 				});
 				if (resolved) {
-					await openWorkspaceFile(resolved);
+					await openResolved(resolved);
 					return;
 				}
 				setError(`Could not resolve PDF wikilink: ${rawTarget}`);
@@ -62,7 +81,7 @@ export function useWorkspaceLinkEvents({
 				target: normalizedTarget,
 			});
 			if (resolved) {
-				await openWorkspaceFile(resolved);
+				await openResolved(resolved);
 				return;
 			}
 
@@ -83,7 +102,7 @@ export function useWorkspaceLinkEvents({
 				openParentDir: parentDir(nextRelPath),
 			});
 			if (createdPath) {
-				await openWorkspaceFile(createdPath);
+				await openResolved(createdPath);
 				return;
 			}
 
@@ -92,7 +111,7 @@ export function useWorkspaceLinkEvents({
 				target: normalizedTarget,
 			});
 			if (fallbackResolved) {
-				await openWorkspaceFile(fallbackResolved);
+				await openResolved(fallbackResolved);
 				return;
 			}
 
@@ -107,12 +126,17 @@ export function useWorkspaceLinkEvents({
 			if (!detail?.target) return;
 			void (async () => {
 				try {
+					if (isSearchQueryWikiTarget(detail.target)) {
+						openPalette("search", searchQueryFromWikiTarget(detail.target));
+						return;
+					}
+
 					const targetWithoutAnchor =
 						detail.target.split("#", 1)[0] ?? detail.target;
 					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 					if (!normalizedTarget) return;
 
-					if (detail.embed || isImagePath(normalizedTarget)) {
+					if (isImagePath(normalizedTarget)) {
 						const resolvedImage = await invoke("space_resolve_image_wikilink", {
 							target: normalizedTarget,
 						});
@@ -125,7 +149,7 @@ export function useWorkspaceLinkEvents({
 					}
 
 					if (isPdfPath(normalizedTarget)) {
-						await openOrCreateWikiLinkTarget(detail.target);
+						await openOrCreateWikiLinkTarget(detail.target, detail);
 						return;
 					}
 
@@ -135,7 +159,7 @@ export function useWorkspaceLinkEvents({
 						);
 						return;
 					}
-					await openOrCreateWikiLinkTarget(detail.target);
+					await openOrCreateWikiLinkTarget(detail.target, detail);
 				} catch (e) {
 					setError(
 						`Failed to open wikilink: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/components/editor/FloatingTOC.tsx
+++ b/src/components/editor/FloatingTOC.tsx
@@ -1,5 +1,11 @@
 import { memo, useId, useState } from "react";
+import { i18n } from "../../i18n";
+import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import type { TOCHeading } from "./hooks/useTableOfContents";
+import {
+	copyWikiLinkMarkdown,
+	wikiLinkMarkdownForNote,
+} from "./markdown/wikiLinkClipboard";
 
 const MIN_HEADINGS = 2;
 
@@ -32,6 +38,7 @@ interface FloatingTOCProps {
 	getHeadingPreview: (heading: TOCHeading) => string | null;
 	headings: TOCHeading[];
 	onSelectHeading: (heading: TOCHeading) => void;
+	relPath?: string;
 }
 
 export const FloatingTOC = memo(function FloatingTOC({
@@ -39,6 +46,7 @@ export const FloatingTOC = memo(function FloatingTOC({
 	getHeadingPreview,
 	headings,
 	onSelectHeading,
+	relPath,
 }: FloatingTOCProps) {
 	const [previewHeadingId, setPreviewHeadingId] = useState<string | null>(null);
 	const [outlineOpen, setOutlineOpen] = useState(false);
@@ -49,6 +57,16 @@ export const FloatingTOC = memo(function FloatingTOC({
 		(heading) => heading.id === previewHeadingId,
 	);
 	const previewText = previewHeading ? getHeadingPreview(previewHeading) : null;
+	const copyHeadingLink = (heading: TOCHeading) => {
+		if (!relPath) return;
+		void copyWikiLinkMarkdown(
+			wikiLinkMarkdownForNote({
+				relPath,
+				anchorKind: "heading",
+				anchor: heading.text,
+			}),
+		);
+	};
 
 	if (headings.length < MIN_HEADINGS) return null;
 
@@ -126,6 +144,15 @@ export const FloatingTOC = memo(function FloatingTOC({
 								onSelectHeading(heading);
 								setOutlineOpen(false);
 							}}
+							onContextMenu={(event) => {
+								if (!relPath) return;
+								void showNativeContextMenu(event, [
+									{
+										label: i18n.t("editor:wikiLink.copyHeadingLink"),
+										action: () => copyHeadingLink(heading),
+									},
+								]);
+							}}
 							title={heading.text}
 						>
 							<span className="floatingTocOutlineText">{heading.text}</span>
@@ -142,6 +169,15 @@ export const FloatingTOC = memo(function FloatingTOC({
 					id={panelId}
 					onMouseEnter={() => setPreviewHeadingId(previewHeading.id)}
 					onClick={() => onSelectHeading(previewHeading)}
+					onContextMenu={(event) => {
+						if (!relPath) return;
+						void showNativeContextMenu(event, [
+							{
+								label: i18n.t("editor:wikiLink.copyHeadingLink"),
+								action: () => copyHeadingLink(previewHeading),
+							},
+						]);
+					}}
 					onKeyDown={(event) => {
 						if (event.key === "Escape") {
 							event.preventDefault();

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -288,6 +288,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		enableFocusMode,
 		enableHydrateInlineImages: !deferHeavyFeatures,
 		enableMarkdownLinkAutocomplete: !deferHeavyFeatures,
+		enableWikiLiveEmbeds: !deferHeavyFeatures,
 		pasteMarkdownBehavior,
 		placeholder,
 		onChange,

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -19,7 +19,7 @@ import {
 } from "./markdown/wikiLinkClipboard";
 import {
 	collectBlockIdsFromDoc,
-	ensureTrailingBlockId,
+	generateBlockId,
 	parseTrailingBlockId,
 } from "./markdown/wikiLinkSlices";
 import type { WikiLinkAnchorKind } from "./markdown/wikiLinkTypes";
@@ -255,18 +255,19 @@ export function handleEditorContextMenu(
 					return;
 				}
 				if (!editable || !heading) return;
-				const existing = collectBlockIdsFromDoc(view.state.doc);
-				const ensured = ensureTrailingBlockId(blockText, existing);
-				const from = $pos.before($pos.depth) + 1;
-				const to = from + block.content.size;
+				const id = generateBlockId(collectBlockIdsFromDoc(view.state.doc));
+				const insertAt = $pos.before($pos.depth) + 1 + block.content.size;
+				const prefix = blockText.trimEnd().length > 0 ? " " : "";
 				view.dispatch(
-					view.state.tr.insertText(ensured.line, from, to).scrollIntoView(),
+					view.state.tr
+						.insertText(`${prefix}^${id}`, insertAt)
+						.scrollIntoView(),
 				);
 				void copyWikiLinkMarkdown(
 					wikiLinkMarkdownForNote({
 						relPath,
 						anchorKind: "block",
-						anchor: ensured.id,
+						anchor: id,
 					}),
 				);
 			},

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -1,8 +1,10 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
+import { i18n } from "../../i18n";
 import { isGlyphDeeplink } from "../../lib/deeplink";
 import { openDeeplink } from "../../lib/deeplinkOpen";
+import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { cssEscape } from "../../utils/dom";
 import {
 	dispatchInternalAnchorClick,
@@ -11,6 +13,16 @@ import {
 	dispatchTagClick,
 	dispatchWikiLinkClick,
 } from "./markdown/editorEvents";
+import {
+	copyWikiLinkMarkdown,
+	wikiLinkMarkdownForNote,
+} from "./markdown/wikiLinkClipboard";
+import {
+	collectBlockIdsFromDoc,
+	ensureTrailingBlockId,
+	parseTrailingBlockId,
+} from "./markdown/wikiLinkSlices";
+import type { WikiLinkAnchorKind } from "./markdown/wikiLinkTypes";
 
 function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
 	const href = link.getAttribute("href")?.trim() ?? "";
@@ -126,11 +138,9 @@ export function handleEditorClick(
 			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
 			target: wikiLink.getAttribute("data-target") ?? "",
 			alias: wikiLink.getAttribute("data-alias") || null,
-			anchorKind:
-				(wikiLink.getAttribute("data-anchor-kind") as
-					| "none"
-					| "heading"
-					| "block") ?? "none",
+			anchorKind: wikiAnchorKindFromDom(
+				wikiLink.getAttribute("data-anchor-kind"),
+			),
 			anchor: wikiLink.getAttribute("data-anchor") || null,
 			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
 			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
@@ -188,5 +198,78 @@ export function handleEditorClick(
 		href,
 		sourcePath: relPath,
 	});
+	return true;
+}
+
+function wikiAnchorKindFromDom(value: string | null): WikiLinkAnchorKind {
+	if (value === "heading" || value === "block") return value;
+	return "none";
+}
+
+export function handleEditorContextMenu(
+	event: MouseEvent,
+	view: EditorView,
+	relPath: string,
+	editable: boolean,
+): boolean {
+	if (!relPath) return false;
+	const heading = (() => {
+		const target = event.target instanceof Element ? event.target : null;
+		const headingEl = target?.closest("h1, h2, h3, h4, h5, h6");
+		return headingEl?.textContent?.trim() || null;
+	})();
+	const $pos = view.state.doc.resolve(view.state.selection.from);
+	const block = $pos.parent;
+	const blockText = block.isTextblock ? block.textContent : "";
+	void showNativeContextMenu(event, [
+		...(heading
+			? [
+					{
+						label: i18n.t("editor:wikiLink.copyHeadingLink"),
+						action: () => {
+							void copyWikiLinkMarkdown(
+								wikiLinkMarkdownForNote({
+									relPath,
+									anchorKind: "heading",
+									anchor: heading,
+								}),
+							);
+						},
+					},
+				]
+			: []),
+		{
+			label: i18n.t("editor:wikiLink.copyBlockLink"),
+			action: () => {
+				if (!block.isTextblock) return;
+				const currentId = parseTrailingBlockId(blockText);
+				if (currentId) {
+					void copyWikiLinkMarkdown(
+						wikiLinkMarkdownForNote({
+							relPath,
+							anchorKind: "block",
+							anchor: currentId,
+						}),
+					);
+					return;
+				}
+				if (!editable) return;
+				const existing = collectBlockIdsFromDoc(view.state.doc);
+				const ensured = ensureTrailingBlockId(blockText, existing);
+				const from = $pos.before($pos.depth) + 1;
+				const to = from + block.content.size;
+				view.dispatch(
+					view.state.tr.insertText(ensured.line, from, to).scrollIntoView(),
+				);
+				void copyWikiLinkMarkdown(
+					wikiLinkMarkdownForNote({
+						relPath,
+						anchorKind: "block",
+						anchor: ensured.id,
+					}),
+				);
+			},
+		},
+	]);
 	return true;
 }

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -213,14 +213,16 @@ export function handleEditorContextMenu(
 	editable: boolean,
 ): boolean {
 	if (!relPath) return false;
-	const heading = (() => {
-		const target = event.target instanceof Element ? event.target : null;
-		const headingEl = target?.closest("h1, h2, h3, h4, h5, h6");
-		return headingEl?.textContent?.trim() || null;
-	})();
-	const $pos = view.state.doc.resolve(view.state.selection.from);
+	const target = event.target instanceof Element ? event.target : null;
+	const heading =
+		target?.closest("h1, h2, h3, h4, h5, h6")?.textContent?.trim() || null;
+	const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+	if (!coords) return false;
+	const $pos = view.state.doc.resolve(coords.pos);
 	const block = $pos.parent;
 	const blockText = block.isTextblock ? block.textContent : "";
+	const blockId = parseTrailingBlockId(blockText);
+	if (!heading && !blockId) return false;
 	void showNativeContextMenu(event, [
 		...(heading
 			? [
@@ -242,18 +244,17 @@ export function handleEditorContextMenu(
 			label: i18n.t("editor:wikiLink.copyBlockLink"),
 			action: () => {
 				if (!block.isTextblock) return;
-				const currentId = parseTrailingBlockId(blockText);
-				if (currentId) {
+				if (blockId) {
 					void copyWikiLinkMarkdown(
 						wikiLinkMarkdownForNote({
 							relPath,
 							anchorKind: "block",
-							anchor: currentId,
+							anchor: blockId,
 						}),
 					);
 					return;
 				}
-				if (!editable) return;
+				if (!editable || !heading) return;
 				const existing = collectBlockIdsFromDoc(view.state.doc);
 				const ensured = ensureTrailingBlockId(blockText, existing);
 				const from = $pos.before($pos.depth) + 1;

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -616,6 +616,7 @@ interface CreateEditorExtensionsOptions {
 	enablePeopleMentions?: boolean;
 	enableFocusMode?: boolean;
 	enableExternalLinkPreviews?: boolean;
+	enableWikiLiveEmbeds?: boolean;
 	currentPath?: string;
 	currentPathResolver?: (() => string) | null;
 	placeholder?: string | null;
@@ -635,6 +636,7 @@ export function createEditorExtensions(
 		enablePeopleMentions = false,
 		enableFocusMode = false,
 		enableExternalLinkPreviews = false,
+		enableWikiLiveEmbeds = true,
 		currentPath = "",
 		currentPathResolver = null,
 		placeholder = null,
@@ -700,7 +702,9 @@ export function createEditorExtensions(
 					}),
 				]
 			: []),
-		...(enableWikiLinks ? [WikiLink] : []),
+		...(enableWikiLinks
+			? [WikiLink.configure({ liveEmbeds: enableWikiLiveEmbeds })]
+			: []),
 		...(enableEditingExtensions && enableMarkdownLinkAutocomplete
 			? [
 					MarkdownLinkAutocomplete.configure({

--- a/src/components/editor/extensions/wikiLink.integration.test.ts
+++ b/src/components/editor/extensions/wikiLink.integration.test.ts
@@ -52,4 +52,14 @@ describe("WikiLink markdown manager integration", () => {
 		const out = manager.serialize(json);
 		expect(out).toContain("![[assets/cover.png]]");
 	});
+
+	it("round-trips note and search embeds", () => {
+		const manager = new MarkdownManager({
+			extensions: [StarterKit, WikiLink],
+		});
+		const json = manager.parse("See ![[Note#Heading]] and ![[query: inbox]]");
+		const out = manager.serialize(json);
+		expect(out).toContain("![[Note#Heading]]");
+		expect(out).toContain("![[query: inbox]]");
+	});
 });

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -15,9 +15,16 @@ import {
 import {
 	parseWikiLink,
 	wikiLinkAttrsToMarkdown,
+	wikiLinkChipLabel,
 } from "../markdown/wikiLinkCodec";
 import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
 import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
+import {
+	createWikiLinkChipNodeView,
+	createWikiLinkEmbedNodeView,
+	createWikiLinkImageNodeView,
+	isLiveWikiEmbed,
+} from "./wikiLinkEmbedView";
 
 const WIKI_LINK_INPUT_REGEX = /(!?\[\[[^\]\n]+\]\])$/;
 const WIKI_LINK_PASTE_REGEX = /(!?\[\[[^\]\n]+\]\])/g;
@@ -88,6 +95,7 @@ export const WikiLink = Node.create({
 	addOptions() {
 		return {
 			suggestionLimit: 8,
+			liveEmbeds: true,
 		};
 	},
 	inline: true,
@@ -154,18 +162,28 @@ export const WikiLink = Node.create({
 			];
 		}
 
-		const targetName = target.split("/").pop()?.replace(/\.md$/i, "") || target;
-		const displayName = alias || targetName;
+		const targetName = wikiLinkChipLabel({
+			alias: alias || null,
+			anchor: typeof node.attrs.anchor === "string" ? node.attrs.anchor : null,
+			anchorKind:
+				node.attrs.anchorKind === "heading" || node.attrs.anchorKind === "block"
+					? node.attrs.anchorKind
+					: "none",
+			target,
+		});
+		const displayName = targetName;
 		return [
 			"span",
 			mergeAttributes(HTMLAttributes, {
 				"data-wikilink": "true",
+				"data-wikilink-embed": node.attrs.embed ? "true" : "false",
 				"data-target": node.attrs.target,
 				"data-anchor-kind": node.attrs.anchorKind,
 				"data-anchor": node.attrs.anchor ?? "",
 				"data-alias": node.attrs.alias ?? "",
+				"data-raw": node.attrs.raw ?? wikiLinkAttrsToMarkdown(node.attrs),
 				"data-unresolved": String(Boolean(node.attrs.unresolved)),
-				class: "wikiLink",
+				class: node.attrs.embed ? "wikiLink wikiLinkEmbedChip" : "wikiLink",
 			}),
 			WIKI_LINK_FILE_ICON,
 			["span", { class: "wikiLinkLabel" }, displayName],
@@ -202,6 +220,28 @@ export const WikiLink = Node.create({
 				attributes: parsed,
 			};
 		},
+	},
+	addNodeView() {
+		return ({ node }) => {
+			const target =
+				typeof node.attrs.target === "string" ? node.attrs.target.trim() : "";
+			if (node.attrs.embed && target && isImageTarget(target)) {
+				return createWikiLinkImageNodeView(node);
+			}
+			if (
+				isLiveWikiEmbed(
+					{
+						embed: Boolean(node.attrs.embed),
+						target:
+							typeof node.attrs.target === "string" ? node.attrs.target : "",
+					},
+					this.options.liveEmbeds,
+				)
+			) {
+				return createWikiLinkEmbedNodeView(node);
+			}
+			return createWikiLinkChipNodeView(node);
+		};
 	},
 	addCommands() {
 		return {

--- a/src/components/editor/extensions/wikiLinkEmbed.tsx
+++ b/src/components/editor/extensions/wikiLinkEmbed.tsx
@@ -1,0 +1,203 @@
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
+import type { Root } from "react-dom/client";
+import { I18nextProvider, useTranslation } from "react-i18next";
+import { i18n } from "../../../i18n";
+import { queryClient } from "../../../lib/queryClient";
+import { type SearchResult, invoke } from "../../../lib/tauri";
+import { isMarkdownPath, normalizeRelPath } from "../../../utils/path";
+import { NotePreviewContent } from "../../preview/NotePreviewContent";
+import { dispatchWikiLinkClick } from "../markdown/editorEvents";
+import {
+	isSearchQueryWikiTarget,
+	searchQueryFromWikiTarget,
+	wikiLinkAttrsToMarkdown,
+	wikiLinkChipLabel,
+} from "../markdown/wikiLinkCodec";
+import {
+	extractBlockSlice,
+	extractHeadingSlice,
+	extractNoteBodySlice,
+} from "../markdown/wikiLinkSlices";
+import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
+
+const SEARCH_EMBED_LIMIT = 20;
+
+function wikiEmbedQueryKey(attrs: WikiLinkAttrs): unknown[] {
+	if (isSearchQueryWikiTarget(attrs.target)) {
+		return ["wiki-search-embed", searchQueryFromWikiTarget(attrs.target)];
+	}
+	return ["wiki-embed", attrs.target, attrs.anchorKind, attrs.anchor];
+}
+
+export function WikiLinkEmbedCard({ attrs }: { attrs: WikiLinkAttrs }) {
+	const { t } = useTranslation("editor");
+	const title = wikiLinkChipLabel(attrs);
+
+	const query = useQuery({
+		queryKey: wikiEmbedQueryKey(attrs),
+		queryFn: () => loadWikiEmbed(attrs),
+	});
+
+	if (query.isPending) {
+		return (
+			<div className="wikiLinkEmbedCard">
+				<div className="wikiLinkEmbedHeader">
+					<span className="wikiLinkEmbedTitle">{title}</span>
+				</div>
+				<div className="wikiLinkEmbedBody wikiLinkEmbedStatus">
+					{t("wikiLink.embedLoading")}
+				</div>
+			</div>
+		);
+	}
+
+	if (query.isError || !query.data) {
+		return (
+			<div className="wikiLinkEmbedCard">
+				<div className="wikiLinkEmbedHeader">
+					<span className="wikiLinkEmbedTitle">{title}</span>
+				</div>
+				<div className="wikiLinkEmbedBody wikiLinkEmbedStatus">
+					{t("wikiLink.embedMissing")}
+				</div>
+			</div>
+		);
+	}
+
+	if (query.data.kind === "search") {
+		return (
+			<div className="wikiLinkEmbedCard">
+				<div className="wikiLinkEmbedHeader">
+					<span className="wikiLinkEmbedTitle">
+						{attrs.alias?.trim() || t("wikiLink.searchTitle")}
+					</span>
+					<span className="wikiLinkEmbedMeta">{query.data.query}</span>
+				</div>
+				{query.data.results.length === 0 ? (
+					<div className="wikiLinkEmbedBody wikiLinkEmbedStatus">
+						{t("wikiLink.searchNoResults")}
+					</div>
+				) : (
+					<ul className="wikiLinkEmbedHits">
+						{query.data.results.map((result) => (
+							<li
+								key={`${result.id}:${result.line ?? ""}:${result.match_index ?? ""}`}
+							>
+								<button
+									type="button"
+									className="wikiLinkEmbedHit"
+									onClick={(event) => {
+										event.preventDefault();
+										event.stopPropagation();
+										dispatchWikiLinkClick({
+											raw: `[[${result.id}]]`,
+											target: result.id,
+											alias: result.title || null,
+											anchorKind: "none",
+											anchor: null,
+											unresolved: false,
+										});
+									}}
+								>
+									<span className="wikiLinkEmbedHitTitle">
+										{result.title || result.id}
+									</span>
+									{result.snippet ? (
+										<span className="wikiLinkEmbedHitSnippet">
+											{result.snippet}
+										</span>
+									) : null}
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="wikiLinkEmbedCard">
+			<div className="wikiLinkEmbedHeader">
+				<span className="wikiLinkEmbedTitle">{title}</span>
+				<span className="wikiLinkEmbedMeta">{query.data.relPath}</span>
+			</div>
+			<div className="wikiLinkEmbedBody">
+				{query.data.content.trim() ? (
+					<NotePreviewContent
+						status="ok"
+						relPath={query.data.relPath}
+						content={query.data.content}
+						interactive
+					/>
+				) : (
+					<div className="wikiLinkEmbedStatus">{t("wikiLink.embedEmpty")}</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+type WikiEmbedData =
+	| { kind: "note"; relPath: string; content: string }
+	| { kind: "search"; query: string; results: SearchResult[] };
+
+async function loadWikiEmbed(attrs: WikiLinkAttrs): Promise<WikiEmbedData> {
+	if (isSearchQueryWikiTarget(attrs.target)) {
+		const query = searchQueryFromWikiTarget(attrs.target);
+		const results = await invoke("search_parse_and_run", {
+			raw_query: query,
+			limit: SEARCH_EMBED_LIMIT,
+		});
+		return { kind: "search", query, results };
+	}
+
+	const resolved = await invoke("space_resolve_wikilink", {
+		target: attrs.target,
+	});
+	if (!resolved || !isMarkdownPath(resolved)) {
+		throw new Error("Note not found");
+	}
+	const relPath = normalizeRelPath(resolved);
+	const doc = await invoke("space_read_text", { path: relPath });
+	const content = sliceEmbeddedMarkdown(doc.text, attrs);
+	if (!content.trim()) {
+		return { kind: "note", relPath, content: "" };
+	}
+	return { kind: "note", relPath, content };
+}
+
+function sliceEmbeddedMarkdown(markdown: string, attrs: WikiLinkAttrs): string {
+	if (attrs.anchorKind === "heading" && attrs.anchor) {
+		return extractHeadingSlice(markdown, attrs.anchor) ?? "";
+	}
+	if (attrs.anchorKind === "block" && attrs.anchor) {
+		return extractBlockSlice(markdown, attrs.anchor) ?? "";
+	}
+	return extractNoteBodySlice(markdown);
+}
+
+export function wikiEmbedDomAttributes(
+	attrs: WikiLinkAttrs,
+): Record<string, string> {
+	return {
+		"data-wikilink": "true",
+		"data-wikilink-embed": "true",
+		"data-target": attrs.target,
+		"data-anchor-kind": attrs.anchorKind,
+		"data-anchor": attrs.anchor ?? "",
+		"data-alias": attrs.alias ?? "",
+		"data-raw": attrs.raw || wikiLinkAttrsToMarkdown(attrs),
+		"data-unresolved": String(Boolean(attrs.unresolved)),
+	};
+}
+
+export function renderWikiLinkEmbed(root: Root, attrs: WikiLinkAttrs): void {
+	root.render(
+		<I18nextProvider i18n={i18n}>
+			<QueryClientProvider client={queryClient}>
+				<WikiLinkEmbedCard attrs={attrs} />
+			</QueryClientProvider>
+		</I18nextProvider>,
+	);
+}

--- a/src/components/editor/extensions/wikiLinkEmbed.tsx
+++ b/src/components/editor/extensions/wikiLinkEmbed.tsx
@@ -129,6 +129,7 @@ export function WikiLinkEmbedCard({ attrs }: { attrs: WikiLinkAttrs }) {
 						relPath={query.data.relPath}
 						content={query.data.content}
 						interactive
+						chrome="minimal"
 					/>
 				) : (
 					<div className="wikiLinkEmbedStatus">{t("wikiLink.embedEmpty")}</div>

--- a/src/components/editor/extensions/wikiLinkEmbedView.ts
+++ b/src/components/editor/extensions/wikiLinkEmbedView.ts
@@ -1,0 +1,147 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { NodeView } from "@tiptap/pm/view";
+import { type Root, createRoot } from "react-dom/client";
+import { isImageTarget } from "../../../lib/linkSuggestions";
+import { wikiLinkChipLabel } from "../markdown/wikiLinkCodec";
+import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
+import { renderWikiLinkEmbed, wikiEmbedDomAttributes } from "./wikiLinkEmbed";
+
+export function isLiveWikiEmbed(
+	attrs: Pick<WikiLinkAttrs, "embed" | "target">,
+	liveEmbeds: boolean,
+): boolean {
+	if (!liveEmbeds || !attrs.embed) return false;
+	const target = typeof attrs.target === "string" ? attrs.target.trim() : "";
+	if (!target) return false;
+	return !isImageTarget(target);
+}
+
+function attrsFromNode(node: ProseMirrorNode): WikiLinkAttrs {
+	return {
+		raw: typeof node.attrs.raw === "string" ? node.attrs.raw : "",
+		target: typeof node.attrs.target === "string" ? node.attrs.target : "",
+		alias: typeof node.attrs.alias === "string" ? node.attrs.alias : null,
+		embed: Boolean(node.attrs.embed),
+		anchorKind:
+			node.attrs.anchorKind === "heading" || node.attrs.anchorKind === "block"
+				? node.attrs.anchorKind
+				: "none",
+		anchor: typeof node.attrs.anchor === "string" ? node.attrs.anchor : null,
+		unresolved: Boolean(node.attrs.unresolved),
+	};
+}
+
+export function createWikiLinkImageNodeView(node: ProseMirrorNode): NodeView {
+	const attrs = attrsFromNode(node);
+	const dom = document.createElement("img");
+	const render = (next: WikiLinkAttrs) => {
+		const fallbackName = next.target.split("/").pop() ?? next.target;
+		dom.src = next.target;
+		dom.alt = next.alias?.trim() || fallbackName;
+		dom.className = "markdownImage wikiLinkEmbedImage";
+		dom.setAttribute("data-wikilink", "true");
+		dom.setAttribute("data-wikilink-embed", "true");
+		dom.setAttribute("data-target", next.target);
+		dom.setAttribute("data-alias", next.alias ?? "");
+		dom.setAttribute("data-raw", next.raw);
+	};
+	render(attrs);
+	return {
+		dom,
+		update(updatedNode) {
+			if (updatedNode.type.name !== "wikiLink") return false;
+			const next = attrsFromNode(updatedNode);
+			if (!next.embed || !isImageTarget(next.target)) return false;
+			render(next);
+			return true;
+		},
+		ignoreMutation: () => true,
+	};
+}
+
+export function createWikiLinkChipNodeView(node: ProseMirrorNode): NodeView {
+	const attrs = attrsFromNode(node);
+	const dom = document.createElement("span");
+	const render = (next: WikiLinkAttrs) => {
+		dom.className = next.embed ? "wikiLink wikiLinkEmbedChip" : "wikiLink";
+		dom.setAttribute("data-wikilink", "true");
+		dom.setAttribute("data-wikilink-embed", next.embed ? "true" : "false");
+		dom.setAttribute("data-target", next.target);
+		dom.setAttribute("data-anchor-kind", next.anchorKind);
+		dom.setAttribute("data-anchor", next.anchor ?? "");
+		dom.setAttribute("data-alias", next.alias ?? "");
+		dom.setAttribute("data-raw", next.raw);
+		dom.setAttribute("data-unresolved", String(Boolean(next.unresolved)));
+		dom.replaceChildren();
+		const icon = document.createElement("span");
+		icon.className = "wikiLinkIcon";
+		icon.setAttribute("aria-hidden", "true");
+		const label = document.createElement("span");
+		label.className = "wikiLinkLabel";
+		label.textContent = wikiLinkChipLabel(next);
+		dom.append(icon, label);
+	};
+	render(attrs);
+	return {
+		dom,
+		update(updatedNode) {
+			if (updatedNode.type.name !== "wikiLink") return false;
+			const next = attrsFromNode(updatedNode);
+			if (isLiveWikiEmbed(next, true)) return false;
+			render(next);
+			return true;
+		},
+		ignoreMutation: () => true,
+	};
+}
+
+export function createWikiLinkEmbedNodeView(node: ProseMirrorNode): NodeView {
+	const dom = document.createElement("div");
+	dom.className = "wikiLinkEmbed";
+	const applyDomAttrs = (attrs: WikiLinkAttrs) => {
+		const next = wikiEmbedDomAttributes(attrs);
+		for (const [key, value] of Object.entries(next)) {
+			dom.setAttribute(key, value);
+		}
+	};
+
+	let root: Root | null = createRoot(dom);
+	const render = (attrs: WikiLinkAttrs) => {
+		if (!root) return;
+		applyDomAttrs(attrs);
+		renderWikiLinkEmbed(root, attrs);
+	};
+
+	render(attrsFromNode(node));
+
+	return {
+		dom,
+		update(updatedNode) {
+			if (updatedNode.type.name !== "wikiLink") return false;
+			const attrs = attrsFromNode(updatedNode);
+			if (!isLiveWikiEmbed(attrs, true)) return false;
+			render(attrs);
+			return true;
+		},
+		selectNode() {
+			dom.classList.add("is-selected");
+		},
+		deselectNode() {
+			dom.classList.remove("is-selected");
+		},
+		destroy() {
+			queueMicrotask(() => {
+				root?.unmount();
+				root = null;
+			});
+		},
+		ignoreMutation: () => true,
+		stopEvent: (event) => {
+			const target = event.target;
+			return (
+				target instanceof Element &&
+				Boolean(target.closest(".wikiLinkEmbedHit"))
+			);
+		},
+	};
+}

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -16,7 +16,10 @@ import {
 } from "../../../lib/notePreview";
 import { invoke } from "../../../lib/tauri";
 import { toast } from "../../../lib/toast";
-import { handleEditorClick } from "../editorClickHandlers";
+import {
+	handleEditorClick,
+	handleEditorContextMenu,
+} from "../editorClickHandlers";
 import { createEditorExtensions } from "../extensions";
 import type { MathEditRequest } from "../extensions/math/mathOptions";
 import { handleTagDecorationMouseDown } from "../extensions/tagDecorations";
@@ -235,6 +238,7 @@ interface UseNoteEditorOptions {
 	enableFocusMode?: boolean;
 	enableHydrateInlineImages?: boolean;
 	enableMarkdownLinkAutocomplete?: boolean;
+	enableWikiLiveEmbeds?: boolean;
 	pasteMarkdownBehavior?: PasteMarkdownBehavior;
 	placeholder?: string;
 	onChange: (nextMarkdown: string) => void;
@@ -313,6 +317,7 @@ export function useNoteEditor({
 	enableFocusMode = false,
 	enableHydrateInlineImages = true,
 	enableMarkdownLinkAutocomplete = true,
+	enableWikiLiveEmbeds = true,
 	pasteMarkdownBehavior = "plain-text",
 	placeholder = "Start writing or press / for commands",
 	onChange,
@@ -388,6 +393,7 @@ export function useNoteEditor({
 				currentPath: "",
 				currentPathResolver: () => relPathRef.current,
 				enableMarkdownLinkAutocomplete,
+				enableWikiLiveEmbeds,
 				enablePeopleMentions: peopleMentionsEnabled,
 				enableFocusMode,
 				enableExternalLinkPreviews: externalLinkPreviewsEnabled,
@@ -398,6 +404,7 @@ export function useNoteEditor({
 		[
 			additionalExtensions,
 			enableMarkdownLinkAutocomplete,
+			enableWikiLiveEmbeds,
 			enableFocusMode,
 			externalLinkPreviewsEnabled,
 			handleListCollapseChange,
@@ -545,6 +552,15 @@ export function useNoteEditor({
 							relPathRef.current,
 							interactiveRef.current,
 							modeRef.current === "rich",
+						);
+					},
+					contextmenu: (view, event): boolean => {
+						if (!(event instanceof MouseEvent)) return false;
+						return handleEditorContextMenu(
+							event,
+							view,
+							relPathRef.current,
+							modeRef.current === "rich" && interactiveRef.current,
 						);
 					},
 					paste: (_view, event) => {

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -500,6 +500,7 @@ export function useNoteEditor({
 		void additionalExtensions;
 		void peopleMentionsEnabled;
 		void enableMarkdownLinkAutocomplete;
+		void enableWikiLiveEmbeds;
 		void enableFocusMode;
 		void showExternalLinkPreviews;
 		void mode;
@@ -518,6 +519,7 @@ export function useNoteEditor({
 		additionalExtensions,
 		peopleMentionsEnabled,
 		enableMarkdownLinkAutocomplete,
+		enableWikiLiveEmbeds,
 		enableFocusMode,
 		showExternalLinkPreviews,
 		mode,
@@ -724,6 +726,7 @@ export function useNoteEditor({
 			additionalExtensions,
 			peopleMentionsEnabled,
 			enableMarkdownLinkAutocomplete,
+			enableWikiLiveEmbeds,
 			enableFocusMode,
 			showExternalLinkPreviews,
 			mode,

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -70,3 +70,40 @@ export function dispatchInternalAnchorClick(
 		}),
 	);
 }
+
+export const WIKI_ANCHOR_NAVIGATE_EVENT = "glyph:wiki-anchor-navigate";
+
+export interface WikiAnchorNavigateDetail {
+	path: string;
+	anchorKind: "heading" | "block";
+	anchor: string;
+}
+
+let pendingWikiAnchor: WikiAnchorNavigateDetail | null = null;
+
+export function queueWikiAnchorNavigation(
+	detail: WikiAnchorNavigateDetail,
+): void {
+	pendingWikiAnchor = detail;
+	window.dispatchEvent(
+		new CustomEvent<WikiAnchorNavigateDetail>(WIKI_ANCHOR_NAVIGATE_EVENT, {
+			detail,
+		}),
+	);
+}
+
+export function peekWikiAnchorNavigation(
+	path: string,
+): WikiAnchorNavigateDetail | null {
+	if (!pendingWikiAnchor || pendingWikiAnchor.path !== path) return null;
+	return pendingWikiAnchor;
+}
+
+export function takeWikiAnchorNavigation(
+	path: string,
+): WikiAnchorNavigateDetail | null {
+	const detail = peekWikiAnchorNavigation(path);
+	if (!detail) return null;
+	pendingWikiAnchor = null;
+	return detail;
+}

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -79,12 +79,12 @@ export interface WikiAnchorNavigateDetail {
 	anchor: string;
 }
 
-let pendingWikiAnchor: WikiAnchorNavigateDetail | null = null;
+const pendingWikiAnchors = new Map<string, WikiAnchorNavigateDetail>();
 
 export function queueWikiAnchorNavigation(
 	detail: WikiAnchorNavigateDetail,
 ): void {
-	pendingWikiAnchor = detail;
+	pendingWikiAnchors.set(detail.path, detail);
 	window.dispatchEvent(
 		new CustomEvent<WikiAnchorNavigateDetail>(WIKI_ANCHOR_NAVIGATE_EVENT, {
 			detail,
@@ -95,15 +95,14 @@ export function queueWikiAnchorNavigation(
 export function peekWikiAnchorNavigation(
 	path: string,
 ): WikiAnchorNavigateDetail | null {
-	if (!pendingWikiAnchor || pendingWikiAnchor.path !== path) return null;
-	return pendingWikiAnchor;
+	return pendingWikiAnchors.get(path) ?? null;
 }
 
 export function takeWikiAnchorNavigation(
 	path: string,
 ): WikiAnchorNavigateDetail | null {
-	const detail = peekWikiAnchorNavigation(path);
+	const detail = pendingWikiAnchors.get(path) ?? null;
 	if (!detail) return null;
-	pendingWikiAnchor = null;
+	pendingWikiAnchors.delete(path);
 	return detail;
 }

--- a/src/components/editor/markdown/wikiLinkClipboard.ts
+++ b/src/components/editor/markdown/wikiLinkClipboard.ts
@@ -1,0 +1,37 @@
+import { i18n } from "../../../i18n";
+import { toast } from "../../../lib/toast";
+import {
+	wikiLinkAttrsToMarkdown,
+	wikiTargetFromRelPath,
+} from "./wikiLinkCodec";
+import type { WikiLinkAnchorKind } from "./wikiLinkTypes";
+
+export async function copyWikiLinkMarkdown(markdown: string): Promise<boolean> {
+	try {
+		const clipboard = navigator.clipboard;
+		if (!clipboard?.writeText) {
+			throw new Error("Clipboard is not available.");
+		}
+		await clipboard.writeText(markdown);
+		toast.success(i18n.t("editor:wikiLink.copiedLink"));
+		return true;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		toast.error(i18n.t("editor:wikiLink.copyFailed"), { description: message });
+		return false;
+	}
+}
+
+export function wikiLinkMarkdownForNote(options: {
+	anchor?: string | null;
+	anchorKind?: WikiLinkAnchorKind;
+	relPath: string;
+}): string {
+	return wikiLinkAttrsToMarkdown({
+		target: wikiTargetFromRelPath(options.relPath),
+		alias: null,
+		embed: false,
+		anchorKind: options.anchorKind ?? "none",
+		anchor: options.anchor ?? null,
+	});
+}

--- a/src/components/editor/markdown/wikiLinkCodec.test.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.test.ts
@@ -24,6 +24,20 @@ describe("wikiLinkCodec", () => {
 		});
 	});
 
+	it("parses search query embeds without treating hashes as headings", () => {
+		expect(parseWikiLink("![[query: #inbox tag:work]]")).toMatchObject({
+			target: "query: #inbox tag:work",
+			embed: true,
+			anchorKind: "none",
+			anchor: null,
+		});
+		expect(parseWikiLink("[[search: foo|Saved]]")).toMatchObject({
+			target: "search: foo",
+			alias: "Saved",
+			embed: false,
+		});
+	});
+
 	it("parses heading and block anchors", () => {
 		expect(parseWikiLink("[[Note#Section]]")).toMatchObject({
 			target: "Note",
@@ -44,6 +58,14 @@ describe("wikiLinkCodec", () => {
 	});
 
 	it("serializes attrs back to wikilink markdown", () => {
+		expect(
+			wikiLinkAttrsToMarkdown({
+				target: "query: #inbox",
+				embed: true,
+				anchorKind: "none",
+				anchor: null,
+			}),
+		).toBe("![[query: #inbox]]");
 		expect(
 			wikiLinkAttrsToMarkdown({
 				target: "Note",

--- a/src/components/editor/markdown/wikiLinkCodec.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.ts
@@ -1,7 +1,7 @@
 import { basename } from "../../../utils/path";
-import type { WikiLinkAttrs } from "./wikiLinkTypes";
+import type { WikiLinkAnchorKind, WikiLinkAttrs } from "./wikiLinkTypes";
 
-type WikiLinkAnchorKind = "none" | "heading" | "block";
+const SEARCH_QUERY_TARGET_PATTERN = /^(?:query|search)\s*:/i;
 
 function findUnescapedIndex(text: string, needle: string): number {
 	for (let i = 0; i < text.length; i += 1) {
@@ -27,6 +27,18 @@ export function parseWikiLink(raw: string): WikiLinkAttrs | null {
 	const left = aliasIdx >= 0 ? inner.slice(0, aliasIdx).trim() : inner;
 	const alias = aliasIdx >= 0 ? inner.slice(aliasIdx + 1).trim() : "";
 	if (!left) return null;
+
+	if (isSearchQueryWikiTarget(left)) {
+		return {
+			raw,
+			target: left,
+			alias: alias || null,
+			embed,
+			anchorKind: "none",
+			anchor: null,
+			unresolved: false,
+		};
+	}
 
 	const hashIdx = findUnescapedIndex(left, "#");
 	const target = (hashIdx >= 0 ? left.slice(0, hashIdx) : left).trim();
@@ -121,4 +133,35 @@ export function wikiLinksToStandardMarkdown(markdown: string): string {
 		cursor = span.end;
 	}
 	return out + markdown.slice(cursor);
+}
+
+export function isSearchQueryWikiTarget(target: string): boolean {
+	return SEARCH_QUERY_TARGET_PATTERN.test(target.trim());
+}
+
+export function searchQueryFromWikiTarget(target: string): string {
+	return target.trim().replace(SEARCH_QUERY_TARGET_PATTERN, "").trim();
+}
+
+export function wikiTargetFromRelPath(relPath: string): string {
+	return basename(relPath).replace(/\.(md|markdown)$/i, "") || relPath;
+}
+
+export function wikiLinkChipLabel(
+	attrs: Pick<WikiLinkAttrs, "alias" | "anchor" | "anchorKind" | "target">,
+): string {
+	const alias = attrs.alias?.trim() ?? "";
+	if (alias) return alias;
+	if (isSearchQueryWikiTarget(attrs.target)) {
+		return searchQueryFromWikiTarget(attrs.target) || attrs.target;
+	}
+	const targetName =
+		basename(attrs.target).replace(/\.(md|markdown)$/i, "") || attrs.target;
+	if (attrs.anchorKind === "heading" && attrs.anchor) {
+		return `${targetName} › ${attrs.anchor}`;
+	}
+	if (attrs.anchorKind === "block" && attrs.anchor) {
+		return `${targetName} › ^${attrs.anchor}`;
+	}
+	return targetName;
 }

--- a/src/components/editor/markdown/wikiLinkSlices.ts
+++ b/src/components/editor/markdown/wikiLinkSlices.ts
@@ -1,0 +1,172 @@
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { splitYamlFrontmatter } from "../../../lib/notePreview";
+import { resolveAnchorHeading } from "./headingAnchor";
+
+/** Trailing block pin, e.g. `Paragraph text ^abc12`. */
+export const BLOCK_ID_PATTERN = /(?:^|\s)(\^[A-Za-z0-9-]+)(?=\s*$)/;
+
+const BLOCK_ID_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+const BLOCK_ID_LENGTH = 6;
+const HEADING_LINE_PATTERN = /^(#{1,6})[\t ]+(.+?)[\t ]*#*[\t ]*$/;
+const FENCE_PATTERN = /^\s*(`{3,}|~{3,})/;
+
+export function parseTrailingBlockId(line: string): string | null {
+	const match = line.match(BLOCK_ID_PATTERN);
+	const token = match?.[1];
+	if (!token || token.length < 2) return null;
+	return token.slice(1);
+}
+
+function eachMarkdownLine(
+	markdown: string,
+	visit: (line: string, lineStart: number) => boolean | undefined,
+): void {
+	let lineStart = 0;
+	while (lineStart <= markdown.length) {
+		const lineEnd = markdown.indexOf("\n", lineStart);
+		const end = lineEnd === -1 ? markdown.length : lineEnd;
+		const line = markdown.slice(lineStart, end).replace(/\r$/, "");
+		if (visit(line, lineStart) === false) return;
+		if (lineEnd === -1) break;
+		lineStart = lineEnd + 1;
+	}
+}
+
+export function findBlockIdOffset(
+	markdown: string,
+	blockId: string,
+): number | null {
+	const needle = blockId.trim();
+	if (!needle) return null;
+	let found: number | null = null;
+	eachMarkdownLine(markdown, (line, lineStart) => {
+		if (parseTrailingBlockId(line) !== needle) return;
+		found = lineStart;
+		return false;
+	});
+	return found;
+}
+
+export function collectBlockIdsFromDoc(doc: ProseMirrorNode): Set<string> {
+	const ids = new Set<string>();
+	doc.descendants((node) => {
+		if (!node.isTextblock) return;
+		const id = parseTrailingBlockId(node.textContent ?? "");
+		if (id) ids.add(id);
+	});
+	return ids;
+}
+
+export function collectBlockIds(markdown: string): Set<string> {
+	const ids = new Set<string>();
+	eachMarkdownLine(markdown, (line) => {
+		const id = parseTrailingBlockId(line);
+		if (id) ids.add(id);
+	});
+	return ids;
+}
+
+export function generateBlockId(existing: ReadonlySet<string>): string {
+	for (let attempt = 0; attempt < 32; attempt += 1) {
+		let id = "";
+		const bytes = crypto.getRandomValues(new Uint8Array(BLOCK_ID_LENGTH));
+		for (const byte of bytes) {
+			id += BLOCK_ID_ALPHABET[byte % BLOCK_ID_ALPHABET.length];
+		}
+		if (!existing.has(id)) return id;
+	}
+	return Date.now().toString(36);
+}
+
+export function ensureTrailingBlockId(
+	line: string,
+	existing: ReadonlySet<string>,
+): { id: string; line: string } {
+	const current = parseTrailingBlockId(line);
+	if (current) return { id: current, line };
+	const id = generateBlockId(existing);
+	const trimmed = line.replace(/\s+$/, "");
+	const next = trimmed.length > 0 ? `${trimmed} ^${id}` : `^${id}`;
+	return { id, line: next };
+}
+
+function headingsInMarkdown(markdown: string) {
+	const headings: Array<{
+		id: string;
+		level: number;
+		text: string;
+		pos: number;
+	}> = [];
+	let fenceMarker: string | null = null;
+	eachMarkdownLine(markdown, (line, lineStart) => {
+		const fenceMatch = line.match(FENCE_PATTERN);
+		if (fenceMatch?.[1]) {
+			const marker = fenceMatch[1];
+			if (!fenceMarker) {
+				fenceMarker = marker;
+			} else if (
+				marker[0] === fenceMarker[0] &&
+				marker.length >= fenceMarker.length &&
+				line.slice(fenceMatch[0].length).trim().length === 0
+			) {
+				fenceMarker = null;
+			}
+			return;
+		}
+		if (fenceMarker) return;
+		const headingMatch = line.match(HEADING_LINE_PATTERN);
+		const headingText = headingMatch?.[2]?.trim();
+		if (!headingMatch?.[1] || !headingText) return;
+		headings.push({
+			id: `slice-${lineStart}`,
+			level: headingMatch[1].length,
+			text: headingText,
+			pos: lineStart,
+		});
+	});
+	return headings;
+}
+
+export function extractHeadingSlice(
+	markdown: string,
+	anchor: string,
+): string | null {
+	const headings = headingsInMarkdown(markdown);
+	const heading = resolveAnchorHeading(headings, anchor);
+	if (!heading) return null;
+
+	const start = heading.pos;
+	let end = markdown.length;
+	for (const candidate of headings) {
+		if (candidate.pos <= start) continue;
+		if (candidate.level <= heading.level) {
+			end = candidate.pos;
+			break;
+		}
+	}
+	const slice = markdown.slice(start, end).trim();
+	return slice || null;
+}
+
+export function extractBlockSlice(
+	markdown: string,
+	blockId: string,
+): string | null {
+	const offset = findBlockIdOffset(markdown, blockId);
+	if (offset === null) return null;
+	const lineEnd = markdown.indexOf("\n", offset);
+	const end = lineEnd === -1 ? markdown.length : lineEnd;
+	const line = markdown.slice(offset, end).replace(/\r$/, "");
+	const withoutId = line.replace(BLOCK_ID_PATTERN, "").trimEnd();
+	return withoutId || line;
+}
+
+export function extractNoteBodySlice(markdown: string): string {
+	return splitYamlFrontmatter(markdown).body.trim();
+}
+
+export function headingTextFromLine(line: string): string | null {
+	const match = line.match(HEADING_LINE_PATTERN);
+	const text = match?.[2]?.trim();
+	return text || null;
+}

--- a/src/components/editor/markdown/wikiLinkTypes.ts
+++ b/src/components/editor/markdown/wikiLinkTypes.ts
@@ -1,4 +1,4 @@
-type WikiLinkAnchorKind = "none" | "heading" | "block";
+export type WikiLinkAnchorKind = "none" | "heading" | "block";
 
 export interface WikiLinkAttrs {
 	raw: string;

--- a/src/components/editor/raw/contentDecorations.ts
+++ b/src/components/editor/raw/contentDecorations.ts
@@ -3,12 +3,12 @@ import type { Range, Text } from "@codemirror/state";
 import { Decoration, type EditorView } from "@codemirror/view";
 import { FOOTNOTE_PATTERN, footnoteKindAt } from "../markdown/footnote";
 import { parseWikiLink } from "../markdown/wikiLinkCodec";
+import { BLOCK_ID_PATTERN } from "../markdown/wikiLinkSlices";
 import { INLINE_TAG_PATTERN } from "../noteProperties/utils";
 
 const WIKI_LINK_PATTERN = /!?\[\[[^\]\n]+\]\]/g;
 const HIGHLIGHT_PATTERN = /==([^=\n]+)==/g;
 const COMMENT_PATTERN = /%%(?:[^%]|%(?!%))*%%/g;
-const BLOCK_ID_PATTERN = /(?:^|\s)(\^[A-Za-z0-9-]+)(?=\s*$)/;
 const FRONTMATTER_SCAN_LIMIT = 500;
 
 function isCodePosition(view: EditorView, position: number): boolean {

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -1,7 +1,9 @@
 import { EditorView } from "@codemirror/view";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { i18n } from "../../../i18n";
 import { isGlyphDeeplink } from "../../../lib/deeplink";
 import { openDeeplink } from "../../../lib/deeplinkOpen";
+import { showNativeContextMenu } from "../../../lib/nativeContextMenu";
 import {
 	dispatchInternalAnchorClick,
 	dispatchMarkdownLinkClick,
@@ -12,7 +14,17 @@ import {
 	type FootnoteKind,
 	findFootnoteCounterpartOffset,
 } from "../markdown/footnote";
+import {
+	copyWikiLinkMarkdown,
+	wikiLinkMarkdownForNote,
+} from "../markdown/wikiLinkClipboard";
 import { parseWikiLink } from "../markdown/wikiLinkCodec";
+import {
+	collectBlockIds,
+	ensureTrailingBlockId,
+	headingTextFromLine,
+	parseTrailingBlockId,
+} from "../markdown/wikiLinkSlices";
 
 function toggleTask(view: EditorView, target: HTMLElement): boolean {
 	const markerPosition = Number(target.dataset.taskMarkerPosition);
@@ -124,6 +136,65 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 				return true;
 			}
 			dispatchMarkdownLinkClick({ href, sourcePath: getRelPath() });
+			return true;
+		},
+		contextmenu: (event: MouseEvent, view: EditorView) => {
+			const relPath = getRelPath();
+			if (!relPath) return false;
+			const offset = view.posAtCoords({ x: event.clientX, y: event.clientY });
+			if (offset === null) return false;
+			const line = view.state.doc.lineAt(offset);
+			const heading = headingTextFromLine(line.text);
+			const existingIds = collectBlockIds(view.state.doc.toString());
+			void showNativeContextMenu(event, [
+				...(heading
+					? [
+							{
+								label: i18n.t("editor:wikiLink.copyHeadingLink"),
+								action: () => {
+									void copyWikiLinkMarkdown(
+										wikiLinkMarkdownForNote({
+											relPath,
+											anchorKind: "heading",
+											anchor: heading,
+										}),
+									);
+								},
+							},
+						]
+					: []),
+				{
+					label: i18n.t("editor:wikiLink.copyBlockLink"),
+					action: () => {
+						const currentId = parseTrailingBlockId(line.text);
+						if (currentId) {
+							void copyWikiLinkMarkdown(
+								wikiLinkMarkdownForNote({
+									relPath,
+									anchorKind: "block",
+									anchor: currentId,
+								}),
+							);
+							return;
+						}
+						const ensured = ensureTrailingBlockId(line.text, existingIds);
+						view.dispatch({
+							changes: {
+								from: line.from,
+								to: line.to,
+								insert: ensured.line,
+							},
+						});
+						void copyWikiLinkMarkdown(
+							wikiLinkMarkdownForNote({
+								relPath,
+								anchorKind: "block",
+								anchor: ensured.id,
+							}),
+						);
+					},
+				},
+			]);
 			return true;
 		},
 	};

--- a/src/components/editor/raw/interactions.ts
+++ b/src/components/editor/raw/interactions.ts
@@ -145,6 +145,8 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 			if (offset === null) return false;
 			const line = view.state.doc.lineAt(offset);
 			const heading = headingTextFromLine(line.text);
+			const blockId = parseTrailingBlockId(line.text);
+			if (!heading && !blockId) return false;
 			const existingIds = collectBlockIds(view.state.doc.toString());
 			void showNativeContextMenu(event, [
 				...(heading
@@ -166,13 +168,12 @@ export function createRawMarkdownEventHandlers(getRelPath: () => string) {
 				{
 					label: i18n.t("editor:wikiLink.copyBlockLink"),
 					action: () => {
-						const currentId = parseTrailingBlockId(line.text);
-						if (currentId) {
+						if (blockId) {
 							void copyWikiLinkMarkdown(
 								wikiLinkMarkdownForNote({
 									relPath,
 									anchorKind: "block",
-									anchor: currentId,
+									anchor: blockId,
 								}),
 							);
 							return;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -36,7 +36,10 @@ import { LocalNoteConnectionsDialog } from "../connections/LocalNoteConnectionsD
 import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
-import { parseWikiLink } from "../editor/markdown/wikiLinkCodec";
+import {
+	isSearchQueryWikiTarget,
+	parseWikiLink,
+} from "../editor/markdown/wikiLinkCodec";
 import { DailyNoteRollover } from "../editor/rollover/DailyNoteRollover";
 import type {
 	ExtractToNoteActions,
@@ -102,6 +105,7 @@ function extractLinkedNotes(markdown: string): LinkedNoteItem[] {
 		const raw = match[0];
 		const parsed = parseWikiLink(raw);
 		if (!parsed?.target) continue;
+		if (isSearchQueryWikiTarget(parsed.target)) continue;
 		const target = parsed.target.trim();
 		if (!target) continue;
 		const existing = out.get(target);
@@ -366,11 +370,13 @@ export function MarkdownEditorPane({
 
 	const getPlainText = useCallback(() => textRef.current, [textRef]);
 	useInternalAnchorNavigation({
-		relPath,
-		mode,
+		editor: tocSource?.editor ?? null,
 		getPlainText,
-		tocHeadings,
+		mode,
+		rawEditorRef,
+		relPath,
 		selectVisibleHeading,
+		tocHeadings,
 	});
 
 	useEffect(() => {
@@ -640,6 +646,7 @@ export function MarkdownEditorPane({
 				activeId={tocActiveId}
 				getHeadingPreview={getPreviewForHeading}
 				onSelectHeading={scrollToHeading}
+				relPath={relPath}
 				visible={
 					showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain"
 				}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -37,9 +37,15 @@ import { EditorViewModeSwitch } from "../editor/EditorViewModeSwitch";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import { useTableOfContents } from "../editor/hooks/useTableOfContents";
 import {
+	WIKI_ANCHOR_NAVIGATE_EVENT,
+	type WikiAnchorNavigateDetail,
+	peekWikiAnchorNavigation,
+} from "../editor/markdown/editorEvents";
+import {
 	isSearchQueryWikiTarget,
 	parseWikiLink,
 } from "../editor/markdown/wikiLinkCodec";
+import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import { DailyNoteRollover } from "../editor/rollover/DailyNoteRollover";
 import type {
 	ExtractToNoteActions,
@@ -222,6 +228,20 @@ export function MarkdownEditorPane({
 		setEditorMode: setMode,
 		spacePath,
 	});
+	const handleRawEditorReadyAndNavigate = useCallback(
+		(editor: RawMarkdownEditorHandle | null) => {
+			handleRawEditorReady(editor);
+			if (!editor) return;
+			const pending = peekWikiAnchorNavigation(normalizeRelPath(relPath));
+			if (!pending) return;
+			window.dispatchEvent(
+				new CustomEvent<WikiAnchorNavigateDetail>(WIKI_ANCHOR_NAVIGATE_EVENT, {
+					detail: pending,
+				}),
+			);
+		},
+		[handleRawEditorReady, relPath],
+	);
 	const requestEditorMode = useCallback(
 		async (nextMode: NoteInlineEditorMode) => {
 			flushPendingEdits();
@@ -630,7 +650,7 @@ export function MarkdownEditorPane({
 										}}
 										onFrontmatterCommit={runAutosave}
 										onEditorReady={handleEditorReady}
-										onRawEditorReady={handleRawEditorReady}
+										onRawEditorReady={handleRawEditorReadyAndNavigate}
 										onFlushPendingEditsReady={handleRichEditorFlushReady}
 										extractToNoteActions={extractToNoteActions}
 										rolloverTaskActions={rolloverTaskActions}

--- a/src/components/preview/MarkdownFloatingToc.tsx
+++ b/src/components/preview/MarkdownFloatingToc.tsx
@@ -6,6 +6,7 @@ interface MarkdownFloatingTocProps {
 	getHeadingPreview: (heading: TOCHeading) => string | null;
 	headings: TOCHeading[];
 	onSelectHeading: (heading: TOCHeading) => void;
+	relPath: string;
 	visible: boolean;
 }
 
@@ -14,6 +15,7 @@ export function MarkdownFloatingToc({
 	getHeadingPreview,
 	headings,
 	onSelectHeading,
+	relPath,
 	visible,
 }: MarkdownFloatingTocProps) {
 	if (!visible) return null;
@@ -23,6 +25,7 @@ export function MarkdownFloatingToc({
 			activeId={activeId}
 			getHeadingPreview={getHeadingPreview}
 			onSelectHeading={onSelectHeading}
+			relPath={relPath}
 		/>
 	);
 }

--- a/src/components/preview/NotePreviewContent.tsx
+++ b/src/components/preview/NotePreviewContent.tsx
@@ -1,7 +1,9 @@
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import type { NotePreviewData } from "./notePreviewShared";
 
-export function NotePreviewContent(data: NotePreviewData) {
+export function NotePreviewContent(
+	data: NotePreviewData & { interactive?: boolean },
+) {
 	if (data.status === "error") {
 		return <div className="markdownEditorInfoEmpty">{data.message}</div>;
 	}
@@ -17,9 +19,10 @@ export function NotePreviewContent(data: NotePreviewData) {
 				relPath={data.relPath}
 				mode="preview"
 				onChange={() => {}}
-				interactive={false}
+				interactive={data.interactive ?? false}
 				acceptSearchJumps={false}
 				deferHeavyFeatures
+				chrome="minimal"
 			/>
 		</div>
 	);

--- a/src/components/preview/NotePreviewContent.tsx
+++ b/src/components/preview/NotePreviewContent.tsx
@@ -2,7 +2,10 @@ import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import type { NotePreviewData } from "./notePreviewShared";
 
 export function NotePreviewContent(
-	data: NotePreviewData & { interactive?: boolean },
+	data: NotePreviewData & {
+		chrome?: "full" | "minimal";
+		interactive?: boolean;
+	},
 ) {
 	if (data.status === "error") {
 		return <div className="markdownEditorInfoEmpty">{data.message}</div>;
@@ -22,7 +25,7 @@ export function NotePreviewContent(
 				interactive={data.interactive ?? false}
 				acceptSearchJumps={false}
 				deferHeavyFeatures
-				chrome="minimal"
+				chrome={data.chrome}
 			/>
 		</div>
 	);

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -83,7 +83,8 @@ function navigateWikiAnchor(options: {
 	if (options.mode === "plain") {
 		const offset = findBlockIdOffset(markdown, options.anchor);
 		if (offset === null) return false;
-		options.rawEditor?.selectRange(offset, offset);
+		if (!options.rawEditor) return false;
+		options.rawEditor.selectRange(offset, offset);
 		return true;
 	}
 

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -1,50 +1,181 @@
-import { useEffect, useRef } from "react";
+import type { Editor } from "@tiptap/react";
+import { type RefObject, useEffect } from "react";
 import type { EditorViewMode } from "../../lib/editorMode";
+import { normalizeRelPath } from "../../utils/path";
 import type { TOCHeading } from "../editor/hooks/useTableOfContents";
+import {
+	findScrollParent,
+	getHeadingElement,
+} from "../editor/hooks/useTableOfContents";
 import {
 	INTERNAL_ANCHOR_CLICK_EVENT,
 	type InternalAnchorClickDetail,
+	WIKI_ANCHOR_NAVIGATE_EVENT,
+	type WikiAnchorNavigateDetail,
+	peekWikiAnchorNavigation,
+	takeWikiAnchorNavigation,
 } from "../editor/markdown/editorEvents";
 import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
+import { findBlockIdOffset } from "../editor/markdown/wikiLinkSlices";
+import type { RawMarkdownEditorHandle } from "../editor/raw/types";
 import { analyzeNoteInfo } from "./noteInfoAnalysis";
 
 interface UseInternalAnchorNavigationArgs {
-	relPath: string;
-	mode: EditorViewMode;
+	editor: Editor | null;
 	getPlainText: () => string;
-	tocHeadings: readonly TOCHeading[];
+	mode: EditorViewMode;
+	rawEditorRef: RefObject<RawMarkdownEditorHandle | null>;
+	relPath: string;
 	selectVisibleHeading: (heading: TOCHeading) => void;
+	tocHeadings: readonly TOCHeading[];
+}
+
+function scrollElementIntoView(el: HTMLElement): void {
+	const scrollContainer = findScrollParent(el);
+	if (scrollContainer) {
+		const containerRect = scrollContainer.getBoundingClientRect();
+		const elRect = el.getBoundingClientRect();
+		const offset =
+			elRect.top - containerRect.top + scrollContainer.scrollTop - 20;
+		scrollContainer.scrollTo({ top: offset, behavior: "smooth" });
+		return;
+	}
+	el.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+function findBlockPosInEditor(editor: Editor, blockId: string): number | null {
+	const needle = `^${blockId}`;
+	let found: number | null = null;
+	editor.state.doc.descendants((node, pos) => {
+		if (found !== null || !node.isTextblock) return;
+		const text = node.textContent ?? "";
+		const match = text.match(/(?:^|\s)(\^[A-Za-z0-9-]+)(?=\s*$)/);
+		if (match?.[1] === needle) {
+			found = pos;
+			return false;
+		}
+	});
+	return found;
+}
+
+function navigateWikiAnchor(options: {
+	anchor: string;
+	anchorKind: "heading" | "block";
+	editor: Editor | null;
+	getPlainText: () => string;
+	mode: EditorViewMode;
+	rawEditor: RawMarkdownEditorHandle | null;
+	selectVisibleHeading: (heading: TOCHeading) => void;
+	tocHeadings: readonly TOCHeading[];
+}): boolean {
+	const markdown = options.getPlainText();
+	if (options.anchorKind === "heading") {
+		const headings =
+			options.mode === "plain"
+				? analyzeNoteInfo(markdown, markdown, true).headings
+				: options.tocHeadings;
+		const heading = resolveAnchorHeading(headings, options.anchor);
+		if (!heading) return false;
+		options.selectVisibleHeading(heading);
+		return true;
+	}
+
+	if (options.mode === "plain") {
+		const offset = findBlockIdOffset(markdown, options.anchor);
+		if (offset === null) return false;
+		options.rawEditor?.selectRange(offset, offset);
+		return true;
+	}
+
+	if (!options.editor) return false;
+	const pos = findBlockPosInEditor(options.editor, options.anchor);
+	if (pos === null) return false;
+	try {
+		const headingLike: TOCHeading = {
+			id: `block-${options.anchor}`,
+			level: 1,
+			text: options.anchor,
+			pos,
+		};
+		const el = getHeadingElement(options.editor, headingLike);
+		if (el) scrollElementIntoView(el);
+		options.editor.commands.setTextSelection(pos + 1);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 export function useInternalAnchorNavigation({
-	relPath,
-	mode,
+	editor,
 	getPlainText,
-	tocHeadings,
+	mode,
+	rawEditorRef,
+	relPath,
 	selectVisibleHeading,
+	tocHeadings,
 }: UseInternalAnchorNavigationArgs) {
-	const tocHeadingsRef = useRef(tocHeadings);
-	tocHeadingsRef.current = tocHeadings;
-
 	useEffect(() => {
+		const rawEditor = rawEditorRef.current;
+		const apply = (anchorKind: "heading" | "block", anchor: string) =>
+			navigateWikiAnchor({
+				anchor,
+				anchorKind,
+				editor,
+				getPlainText,
+				mode,
+				rawEditor,
+				selectVisibleHeading,
+				tocHeadings,
+			});
+
+		const tryPending = () => {
+			const pending = peekWikiAnchorNavigation(normalizeRelPath(relPath));
+			if (!pending) return;
+			if (apply(pending.anchorKind, pending.anchor)) {
+				takeWikiAnchorNavigation(normalizeRelPath(relPath));
+			}
+		};
+
 		const onInternalAnchorClick = (event: Event) => {
 			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
 			if (!detail || detail.sourcePath !== relPath) return;
+			apply("heading", detail.anchor);
+		};
 
-			const headings =
-				mode === "plain"
-					? analyzeNoteInfo(getPlainText(), getPlainText(), true).headings
-					: tocHeadingsRef.current;
-			const heading = resolveAnchorHeading(headings, detail.anchor);
-			if (heading) selectVisibleHeading(heading);
+		const onWikiAnchorNavigate = (event: Event) => {
+			const detail = (event as CustomEvent<WikiAnchorNavigateDetail>).detail;
+			if (
+				!detail ||
+				normalizeRelPath(detail.path) !== normalizeRelPath(relPath)
+			) {
+				return;
+			}
+			if (apply(detail.anchorKind, detail.anchor)) {
+				takeWikiAnchorNavigation(normalizeRelPath(relPath));
+			}
 		};
 
 		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
+		window.addEventListener(WIKI_ANCHOR_NAVIGATE_EVENT, onWikiAnchorNavigate);
+		tryPending();
 		return () => {
 			window.removeEventListener(
 				INTERNAL_ANCHOR_CLICK_EVENT,
 				onInternalAnchorClick,
 			);
+			window.removeEventListener(
+				WIKI_ANCHOR_NAVIGATE_EVENT,
+				onWikiAnchorNavigate,
+			);
 		};
-	}, [getPlainText, mode, relPath, selectVisibleHeading]);
+	}, [
+		editor,
+		getPlainText,
+		mode,
+		rawEditorRef,
+		relPath,
+		selectVisibleHeading,
+		tocHeadings,
+	]);
 }

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -116,7 +116,6 @@ export function useInternalAnchorNavigation({
 	tocHeadings,
 }: UseInternalAnchorNavigationArgs) {
 	useEffect(() => {
-		const rawEditor = rawEditorRef.current;
 		const apply = (anchorKind: "heading" | "block", anchor: string) =>
 			navigateWikiAnchor({
 				anchor,
@@ -124,7 +123,7 @@ export function useInternalAnchorNavigation({
 				editor,
 				getPlainText,
 				mode,
-				rawEditor,
+				rawEditor: rawEditorRef.current,
 				selectVisibleHeading,
 				tocHeadings,
 			});

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -268,5 +268,16 @@
 			"title": "Highlight: Clear",
 			"description": "Remove text highlight"
 		}
+	},
+	"wikiLink": {
+		"copyHeadingLink": "Copy heading link",
+		"copyBlockLink": "Copy block link",
+		"copiedLink": "Copied wikilink.",
+		"copyFailed": "Could not copy wikilink",
+		"embedLoading": "Loading embed…",
+		"embedMissing": "Note not found",
+		"embedEmpty": "Nothing to embed",
+		"searchTitle": "Search",
+		"searchNoResults": "No matching notes"
 	}
 }

--- a/src/lib/linkSuggestions.ts
+++ b/src/lib/linkSuggestions.ts
@@ -1,4 +1,4 @@
-import { isImagePath, isPdfPath } from "../utils/path";
+import { isImagePath, isMarkdownPath, isPdfPath } from "../utils/path";
 import { invoke } from "./tauri";
 
 export interface EditorLinkSuggestion {
@@ -51,20 +51,22 @@ export async function suggestWikiLinks({
 	limit,
 	query,
 }: SuggestWikiLinksOptions): Promise<EditorLinkSuggestion[]> {
-	const requestLimit = embedOnly ? Math.min(limit * 4, 200) : limit;
 	const results = await invoke("space_suggest_links", {
 		request: {
 			query,
 			markdown_only: true,
 			include_pdf: !embedOnly && includeAttachments,
 			include_images: embedOnly || includeAttachments,
-			strip_markdown_ext: !embedOnly,
+			strip_markdown_ext: true,
 			relative_to_source: false,
-			limit: requestLimit,
+			limit,
 		},
 	});
 	return results
-		.filter((item) => !embedOnly || isImageTarget(item.path))
+		.filter((item) => {
+			if (!embedOnly) return true;
+			return isImageTarget(item.path) || isMarkdownPath(item.path);
+		})
 		.slice(0, limit)
 		.map(toEditorSuggestion);
 }

--- a/src/lib/spaceChange.ts
+++ b/src/lib/spaceChange.ts
@@ -131,6 +131,8 @@ export function applySpaceChange(change: SpaceChange): void {
 	invalidateDerived(path, false);
 	if (change.kind === "content") {
 		for (const fn of openNoteListeners) fn(path);
+		void queryClient.invalidateQueries({ queryKey: ["wiki-embed"] });
+		void queryClient.invalidateQueries({ queryKey: ["wiki-search-embed"] });
 	}
 }
 

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -217,7 +217,8 @@
 }
 
 .wikiLinkEmbed.is-selected .wikiLinkEmbedCard {
-	outline: 2px solid color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+	outline: 2px solid
+		color-mix(in srgb, var(--interactive-accent) 55%, transparent);
 	outline-offset: 1px;
 }
 
@@ -233,7 +234,8 @@
 	align-items: baseline;
 	gap: var(--space-2);
 	padding: var(--space-2) var(--space-3);
-	border-bottom: 1px solid color-mix(in srgb, var(--border-light) 80%, transparent);
+	border-bottom: 1px solid
+		color-mix(in srgb, var(--border-light) 80%, transparent);
 }
 
 .wikiLinkEmbedTitle {

--- a/src/styles/app/25-node-note-content.css
+++ b/src/styles/app/25-node-note-content.css
@@ -209,6 +209,109 @@
 	);
 }
 
+.wikiLinkEmbed {
+	display: block;
+	width: 100%;
+	margin: var(--space-3) 0;
+	white-space: normal;
+}
+
+.wikiLinkEmbed.is-selected .wikiLinkEmbedCard {
+	outline: 2px solid color-mix(in srgb, var(--interactive-accent) 55%, transparent);
+	outline-offset: 1px;
+}
+
+.wikiLinkEmbedCard {
+	border: 1px solid color-mix(in srgb, var(--border-default) 78%, transparent);
+	border-radius: var(--radius-md);
+	background: color-mix(in srgb, var(--bg-secondary) 58%, var(--bg-primary));
+	overflow: hidden;
+}
+
+.wikiLinkEmbedHeader {
+	display: flex;
+	align-items: baseline;
+	gap: var(--space-2);
+	padding: var(--space-2) var(--space-3);
+	border-bottom: 1px solid color-mix(in srgb, var(--border-light) 80%, transparent);
+}
+
+.wikiLinkEmbedTitle {
+	color: var(--text-primary);
+	font-weight: var(--font-semibold);
+	font-size: calc(var(--editor-font-size) * 0.92);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wikiLinkEmbedMeta {
+	color: var(--text-tertiary);
+	font-size: calc(var(--editor-font-size) * 0.78);
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wikiLinkEmbedBody {
+	padding: var(--space-3);
+	max-height: 28rem;
+	overflow: auto;
+}
+
+.wikiLinkEmbedStatus {
+	color: var(--text-tertiary);
+	font-size: calc(var(--editor-font-size) * 0.9);
+}
+
+.wikiLinkEmbedHits {
+	list-style: none;
+	margin: 0;
+	padding: var(--space-2);
+	display: grid;
+	gap: 2px;
+}
+
+.wikiLinkEmbedHit {
+	appearance: none;
+	display: grid;
+	gap: 2px;
+	width: 100%;
+	padding: var(--space-2) var(--space-3);
+	border: 0;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.wikiLinkEmbedHit:hover,
+.wikiLinkEmbedHit:focus-visible {
+	background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
+	outline: none;
+}
+
+.wikiLinkEmbedHitTitle {
+	color: var(--text-primary);
+	font-weight: var(--font-medium);
+}
+
+.wikiLinkEmbedHitSnippet {
+	color: var(--text-tertiary);
+	font-size: calc(var(--editor-font-size) * 0.85);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wikiLinkEmbed .linkedNotePreviewText {
+	min-height: 0;
+}
+
 .tiptapContentInline .tagToken {
 	display: inline-block;
 	color: color-mix(in srgb, var(--interactive-accent) 70%, var(--text-primary));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #495

Wikilinks already parsed `[[Note#Heading]]`, `[[Note#^id]]`, aliases, and `![[...]]`, but clicks stripped the anchor and embeds only inlined images.

This wires the stored attrs through to navigation and rendering:

- **Heading and block links.** Opening `[[Note#Heading]]` or `[[Note#^id]]` opens the note and scrolls to that heading or trailing `^id` pin (rich, preview, and raw). Same-note jumps reuse the existing in-note scroll path.
- **Block pins.** Trailing `^id` tokens stay stable. Copy block link from the editor or raw context menu; if the line has no pin, one is created first. Copy heading link from the outline, heading context menu, and raw headings.
- **Aliases.** Unchanged: `[[Recipes|Bake book]]` still displays Bake book and points at Recipes.
- **Live embeds.** `![[Note]]`, `![[Note#Heading]]`, and `![[Note#^id]]` render a live slice of the source. Clicks still open the source (including nested wikilinks). Nested embeds collapse to chips so they cannot recurse.
- **Search embeds.** `![[query: ...]]` / `![[search: ...]]` render a live hit list from `search_parse_and_run`. Hashes in the query are not treated as heading anchors. Clicking a hit opens that note. Clicking the embed itself opens search.

Image embeds are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a3e0fa5-065a-46c7-adb4-8a943de8ff90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a3e0fa5-065a-46c7-adb4-8a943de8ff90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Support anchored wikilinks and live embeds for notes and search results across rich, preview, and raw editors.

New Features:
- Enable live note embeds for wikilinks with optional heading or block anchors to render slices of the source note.
- Add live search embeds for query/search wikilinks that display dynamic hit lists powered by the search engine.
- Provide heading and block link copy actions from the outline, rich editor, and raw editor to generate stable anchored wikilinks.

Enhancements:
- Preserve and honor heading and block anchors when opening wikilinks, including cross-note navigation and in-note scrolling.
- Improve wiki link rendering with chip labels that reflect aliases, headings, blocks, and search queries, plus dedicated embed card styling.
- Extend internal anchor navigation to handle block pins and queued wiki-anchor navigation events when notes open.
- Make inline and preview editors aware of wiki live embeds through configurable editor extensions and interactive note previews.

Tests:
- Expand wiki link codec and integration tests to cover search query embeds and round-tripping of note and search embeds.

Chores:
- Invalidate wiki embed-related queries when note content changes to keep embedded views up to date.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors heading and block anchors in wikilinks and renders live note and search embeds. Previously clicks dropped anchors and embeds showed images only; now `[[Note#Heading]]`/`[[Note#^id]]` scroll to the anchor across views, and `![[Note]]`/`![[query: …]]` show live content.

- Navigation: Anchored wikilinks open and scroll in rich, preview, and raw. Anchors queue per-path via `queueWikiAnchorNavigation`, and raw-mode block/heading jumps retry after the editor mounts so they don’t get lost. `[[query: …]]` opens the search palette instead of resolving a file.
- Context menus: Right‑click a heading or a pinned block to “Copy heading link”/“Copy block link” in rich, raw, and the TOC; if a block has no pin we append a `^id` without stripping inline marks. Native menus remain elsewhere.
- Embeds: `wikiLink` node view renders chips, images, or live cards. `![[Note]]`, `![[Note#Heading]]`, `![[Note#^id]]`, and `![[query: …]]` render live content when `enableWikiLiveEmbeds` is on (deferred features off by default; enabling later reinitializes the editor). `#` in search queries is treated as text; clicking a result opens the note, clicking the card opens search. Embed cards use minimal chrome; previews keep full chrome so math renders.
- Caching: Note edits invalidate `["wiki-embed"]` and `["wiki-search-embed"]`. PDFs and non-embed images are unchanged.

<sup>Written for commit bcd817a04a46aa735c53aaa1329d2252bffe321b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add heading/block wikilink navigation and live note/search embed rendering
> - Clicking a wikilink with a heading or block anchor queues in-note navigation so the editor scrolls to the target once the note opens; clicking search-query wikilinks (`[[query: ...]]`) opens the search palette.
> - WikiLink nodes now render as live embed cards when `embed=true`: note embeds show a preview of the note body (sliced to the target heading/block); search embeds show a live result list with clickable hits.
> - Right-clicking in the rich or raw editor shows a context menu to copy a heading or block wikilink; if a block has no ID, one is generated and inserted before copying.
> - Right-clicking a TOC item copies a wikilink to that heading.
> - Wiki embed suggestions now include note targets in addition to images.
> - Live embed cards refresh when the underlying note content changes.
> - Behavioral Change: `enableWikiLiveEmbeds` defaults to `true` in `createEditorExtensions`, so embed wikilinks render as live cards unless heavy features are deferred.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcd817a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki-links now support live note previews, image embeds, and search-result embeds.
  * Navigate directly to headings and block references from wiki-links.
  * Copy heading and block wiki-links from editor and table-of-contents context menus.
  * Search-query wiki-links open the search palette or display matching results.
  * Added loading, empty, error, and result states for embedded content.
* **Bug Fixes**
  * Improved wiki-link suggestions and refresh behavior after note edits.
  * Preserved wiki-link syntax when editing embedded notes and searches.
* **Style**
  * Added polished layouts and interaction states for wiki-link embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->