### PR TITLE
Fix tab close button positioning

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.14-alpha.7",
+	"version": "0.8.14-alpha.8",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -581,7 +581,6 @@
 	color: var(--text-primary);
 	opacity: 1;
 	box-shadow: none;
-	transform: translateY(-50%);
 }
 
 .mainTabClose:active {
@@ -631,7 +630,6 @@
 @media (prefers-reduced-motion: reduce) {
 	.mainTab,
 	.mainTab::before,
-	.mainTabClose,
 	.mainTabPin,
 	.mainTabAdd,
 	.mainTabActiveTitle,
@@ -645,10 +643,6 @@
 	.mainTab,
 	.mainTab::before {
 		animation: none;
-	}
-
-	.mainTabClose:hover {
-		transform: translateY(-50%);
 	}
 
 	.mainTabPin:hover {


### PR DESCRIPTION
Closes


## Description

Fixes the tab close button jumping vertically on hover by removing the conflicting transform and its reduced-motion hover override. Bumps the app version to `0.8.14-alpha.8`.

- Removes the close-button transform that caused the jump
- Keeps the pin-button hover transform intact
- Updates the Tauri app version


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

Not provided.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Fix tab close button hover behavior and bump the desktop app version.

Bug Fixes:
- Prevent the tab close button from jumping vertically on hover by removing the conflicting transform and reduced-motion override.

Build:
- Update the Tauri app version to 0.8.14-alpha.8.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the tab close button from jumping vertically on hover by removing its `translateY(-50%)` transform and reduced-motion hover override. The close button now stays stationary on hover; pin button hover behavior is unchanged. Also bumps the Tauri app version to 0.8.14-alpha.8.

**Changes**
- Removes `transform: translateY(-50%)` from `.mainTabClose` and its reduced-motion hover rule.
- Keeps `.mainTabPin` hover transform intact.
- Updates Tauri app version to `0.8.14-alpha.8`.

<sup>Written for commit e665e2fffd7880bef682d586691bb1a2cfd28e6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tab close button vertical shift on hover
> Removes `transform: translateY(-50%)` from the `.mainTabClose:hover` rule in [17-main-tabs.css](https://github.com/SidhuK/Glyph/pull/501/files#diff-5a8854af0ae24051bf6370e54a98038a64f792cc2d76b424d7e993ac7a881843), which was causing the close button to shift vertically when hovered. Also cleans up now-unnecessary reduced-motion overrides for the same transform.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e665e2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved tab close-button hover behavior by removing redundant motion effects.
  - Simplified reduced-motion behavior for tab controls.

- **Chores**
  - Updated the application version to `0.8.14-alpha.8`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->