### PR TITLE
Fix pending app menu commands

### DIFF
--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
 import { extractErrorMessage } from "../lib/errorUtils";
@@ -30,6 +30,10 @@ interface UseMenuListenersProps {
 	onAttachAllOpenNotesToAi: () => void;
 	onOpenAiSettings: () => void;
 	onEditorAction: (action: string) => void;
+}
+
+interface AppMenuCommand {
+	command_id: string;
 }
 
 export function useMenuListeners({
@@ -67,7 +71,7 @@ export function useMenuListeners({
 		[onOpenRecentSpaceAtPath],
 	);
 	const handleAppCommand = useCallback(
-		(payload: { command_id: string }) => {
+		(payload: AppMenuCommand) => {
 			void dispatchAppCommand(payload.command_id, {
 				"new-note": onNewNote,
 				"create-from-template": onCreateFromTemplate,
@@ -175,21 +179,45 @@ export function useMenuListeners({
 			openSettings,
 		],
 	);
+	const replayingPendingCommandsRef = useRef(true);
+	const bufferedLiveCommandsRef = useRef<AppMenuCommand[]>([]);
+	const handleMenuCommand = useCallback(
+		(command: AppMenuCommand) => {
+			if (replayingPendingCommandsRef.current) {
+				bufferedLiveCommandsRef.current.push(command);
+				return;
+			}
+			handleAppCommand(command);
+		},
+		[handleAppCommand],
+	);
 
 	const replayPendingMenuCommands = useCallback(() => {
+		let cancelled = false;
 		void invoke("menu_take_pending_commands")
 			.then((commands) => {
+				if (cancelled) return;
 				for (const command of commands) handleAppCommand(command);
+				for (const command of bufferedLiveCommandsRef.current) {
+					handleAppCommand(command);
+				}
+				bufferedLiveCommandsRef.current = [];
+				replayingPendingCommandsRef.current = false;
 			})
 			.catch((error: unknown) => {
+				if (cancelled) return;
+				replayingPendingCommandsRef.current = false;
 				console.error("Failed to replay pending menu commands", error);
 				toast.error(extractErrorMessage(error));
 			});
+		return () => {
+			cancelled = true;
+		};
 	}, [handleAppCommand]);
 
 	useTauriEvent(
 		"menu:app_command",
-		handleAppCommand,
+		handleMenuCommand,
 		replayPendingMenuCommands,
 	);
 	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);

--- a/src/hooks/useMenuListeners.ts
+++ b/src/hooks/useMenuListeners.ts
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useUILayoutContext } from "../contexts";
 import { dispatchAppCommand } from "../lib/commands/commandDispatcher";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { buildHelpMenuCommandHandlers } from "../lib/helpMenu";
 import type { PeriodKind } from "../lib/periodNotes";
 import { invoke } from "../lib/tauri";
-import { listenTauriEvent, useTauriEvent } from "../lib/tauriEvents";
+import { useTauriEvent } from "../lib/tauriEvents";
 import { toast } from "../lib/toast";
 
 interface UseMenuListenersProps {
@@ -176,35 +176,21 @@ export function useMenuListeners({
 		],
 	);
 
-	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);
-
-	useEffect(() => {
-		let cancelled = false;
-		let unlisten: (() => void) | null = null;
-
-		void listenTauriEvent("menu:app_command", handleAppCommand)
-			.then(async (stop) => {
-				unlisten = stop;
-				if (cancelled) {
-					stop();
-					return;
-				}
-
-				const commands = await invoke("menu_take_pending_commands");
-				if (cancelled) return;
-				for (const command of commands) {
-					handleAppCommand(command);
-				}
+	const replayPendingMenuCommands = useCallback(() => {
+		void invoke("menu_take_pending_commands")
+			.then((commands) => {
+				for (const command of commands) handleAppCommand(command);
 			})
 			.catch((error: unknown) => {
-				if (cancelled) return;
 				console.error("Failed to replay pending menu commands", error);
 				toast.error(extractErrorMessage(error));
 			});
-
-		return () => {
-			cancelled = true;
-			unlisten?.();
-		};
 	}, [handleAppCommand]);
+
+	useTauriEvent(
+		"menu:app_command",
+		handleAppCommand,
+		replayPendingMenuCommands,
+	);
+	useTauriEvent("menu:open_recent_space", handleOpenRecentSpace);
 }

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -1,5 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { DeeplinkErrorPayload, DeeplinkEvent } from "./deeplink";
 import type { SettingsUpdatedPayload } from "./settings/model";
 
@@ -78,21 +78,27 @@ function runUnlisten(unlisten: (() => void) | null): void {
 export function useTauriEvent<K extends keyof TauriEventMap>(
 	event: K,
 	handler: TauriEventHandler<K>,
-	onListening?: () => void,
+	onListening?: () => (() => void) | undefined,
 ): void {
 	const handlerRef = useRef(handler);
-	handlerRef.current = handler;
 	const onListeningRef = useRef(onListening);
-	onListeningRef.current = onListening;
+
+	useLayoutEffect(() => {
+		handlerRef.current = handler;
+		onListeningRef.current = onListening;
+	}, [handler, onListening]);
 
 	useEffect(() => {
 		let cancelled = false;
 		let unlisten: (() => void) | null = null;
+		let onListeningCleanup: (() => void) | null = null;
 		let didUnlisten = false;
 		let pendingTeardown = false;
 
 		const cleanup = () => {
 			if (didUnlisten) return;
+			runUnlisten(onListeningCleanup);
+			onListeningCleanup = null;
 			if (unlisten) {
 				runUnlisten(unlisten);
 				unlisten = null;
@@ -118,7 +124,7 @@ export function useTauriEvent<K extends keyof TauriEventMap>(
 				return;
 			}
 			unlisten = stop;
-			onListeningRef.current?.();
+			onListeningCleanup = onListeningRef.current?.() ?? null;
 			if (pendingTeardown && !didUnlisten) {
 				runUnlisten(unlisten);
 				unlisten = null;

--- a/src/lib/tauriEvents.ts
+++ b/src/lib/tauriEvents.ts
@@ -78,9 +78,12 @@ function runUnlisten(unlisten: (() => void) | null): void {
 export function useTauriEvent<K extends keyof TauriEventMap>(
 	event: K,
 	handler: TauriEventHandler<K>,
+	onListening?: () => void,
 ): void {
 	const handlerRef = useRef(handler);
 	handlerRef.current = handler;
+	const onListeningRef = useRef(onListening);
+	onListeningRef.current = onListening;
 
 	useEffect(() => {
 		let cancelled = false;
@@ -115,6 +118,7 @@ export function useTauriEvent<K extends keyof TauriEventMap>(
 				return;
 			}
 			unlisten = stop;
+			onListeningRef.current?.();
 			if (pendingTeardown && !didUnlisten) {
 				runUnlisten(unlisten);
 				unlisten = null;


### PR DESCRIPTION
Closes


## Description

Replays pending app-menu commands after the shared Tauri event listener has attached.

- Moves app-command subscription to `useTauriEvent`
- Replays queued commands through the listener readiness callback
- Removes the separate subscription and its cleanup path


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Ensure app menu commands are correctly replayed once the shared Tauri event listener is attached.

Bug Fixes:
- Fix lost or delayed pending app menu commands by replaying them when the Tauri listener becomes ready.

Enhancements:
- Extend the shared useTauriEvent hook to support an on-listening callback for post-subscription logic.
- Simplify menu listener setup by removing a separate app-command subscription and manual cleanup logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees app-menu commands queued before the Tauri listener mounts are delivered in order. Previously, `menu:app_command` events emitted before subscription could be dropped or interleaved; now we replay pending commands first and buffer live commands until replay completes.

- Subscribes to `menu:app_command` via `useTauriEvent` and uses the new `onListening` callback to call `invoke("menu_take_pending_commands")`, then flushes any buffered live commands.
- Buffers live app-menu commands while pending commands are replayed to preserve ordering; shows a toast on replay failure and continues with live events.
- Extends `useTauriEvent(event, handler, onListening?)` to support an optional `onListening` that can return a cleanup; updates refs with `useLayoutEffect` and tears down the callback with the listener.
- Removes the manual `listenTauriEvent` subscription and cleanup path in `useMenuListeners`.
- Keeps `menu:open_recent_space` on `useTauriEvent`; live handling is otherwise unchanged.

<sup>Written for commit a0f3d84da35d20da15dfc242c5d971946697c498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pending app menu commands by buffering live events during replay
> - Adds an `onListening` callback to `useTauriEvent` in [tauriEvents.ts](https://github.com/SidhuK/Glyph/pull/503/files#diff-5d43da17fb4bd27694b86661be7cea96095a9214688c979893df0fb0909e1c4f), invoked once the Tauri listener is registered, with cleanup support on teardown.
> - Updates [useMenuListeners.ts](https://github.com/SidhuK/Glyph/pull/503/files#diff-458445d9950c3ba8eb6debbcc27c624314204f9e6c30945143dbb8df960c27f1) to buffer incoming `menu:app_command` events while replaying pending commands fetched via `invoke("menu_take_pending_commands")`.
> - Once the listener is ready, pending commands are dispatched first, then any buffered live commands are flushed in order.
> - Errors during replay are caught, logged, and shown as a toast notification.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a0f3d84. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pending menu commands when the application reconnects to menu events.
  * Failures during command replay are now logged and surfaced through a toast notification.
* **Reliability**
  * Event listeners now confirm successful registration before pending commands are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->