### PR TITLE
Refine editor mode switch and toolbar labels

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.14-alpha.8",
+	"version": "0.8.14-alpha.9",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -35,12 +35,32 @@ export function EditorViewModeSwitch({
 }: EditorViewModeSwitchProps) {
 	const { t } = useTranslation("editor");
 	const [isPinnedOpen, setIsPinnedOpen] = useState(false);
+	const [largeNoteDismissal, setLargeNoteDismissal] = useState({
+		largeNote,
+		mode,
+		dismissed: false,
+	});
+	if (
+		largeNoteDismissal.largeNote !== largeNote ||
+		largeNoteDismissal.mode !== mode
+	) {
+		setLargeNoteDismissal({ largeNote, mode, dismissed: false });
+	}
 	const activeMode = VIEW_MODES.find((item) => item.id === mode);
 
 	if (!activeMode) return null;
 
 	const activeLabel = t(activeMode.labelKey);
-	const shouldShowBubble = isPinnedOpen || (largeNote && mode !== "plain");
+	const shouldOpenForLargeNote = largeNote && mode !== "plain";
+	const shouldShowBubble =
+		isPinnedOpen || (shouldOpenForLargeNote && !largeNoteDismissal.dismissed);
+	const closeBubble = () => {
+		setIsPinnedOpen(false);
+		if (shouldOpenForLargeNote) {
+			setLargeNoteDismissal((current) => ({ ...current, dismissed: true }));
+		}
+	};
+
 	return (
 		<div
 			className="markdownEditorModeSwitch"
@@ -55,16 +75,17 @@ export function EditorViewModeSwitch({
 				) {
 					return;
 				}
-				setIsPinnedOpen(false);
+				closeBubble();
 			}}
-			onMouseLeave={() => setIsPinnedOpen(false)}
+			onFocus={() => setIsPinnedOpen(true)}
+			onMouseLeave={closeBubble}
 		>
 			<button
 				type="button"
 				className="markdownEditorModeBtn markdownEditorModeCurrentBtn"
 				aria-label={activeLabel}
 				aria-expanded={shouldShowBubble}
-				onClick={() => setIsPinnedOpen((open) => !open)}
+				onClick={() => setIsPinnedOpen(true)}
 			>
 				<HugeiconsIcon icon={activeMode.icon} size="var(--icon-md)" />
 			</button>

--- a/src/components/editor/EditorViewModeSwitch.tsx
+++ b/src/components/editor/EditorViewModeSwitch.tsx
@@ -4,6 +4,7 @@ import {
 	EyeIcon,
 	PencilEdit02Icon,
 } from "@hugeicons/core-free-icons";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { EditorViewMode } from "../../lib/editorMode";
 
@@ -33,25 +34,48 @@ export function EditorViewModeSwitch({
 	largeNote = false,
 }: EditorViewModeSwitchProps) {
 	const { t } = useTranslation("editor");
+	const [isPinnedOpen, setIsPinnedOpen] = useState(false);
+	const activeMode = VIEW_MODES.find((item) => item.id === mode);
+
+	if (!activeMode) return null;
+
+	const activeLabel = t(activeMode.labelKey);
+	const shouldShowBubble = isPinnedOpen || (largeNote && mode !== "plain");
 	return (
 		<div
 			className="markdownEditorModeSwitch"
 			role="toolbar"
 			aria-label={t("mode.label")}
+			data-open={shouldShowBubble || undefined}
+			onBlur={(event) => {
+				const nextFocus = event.relatedTarget;
+				if (
+					nextFocus instanceof Node &&
+					event.currentTarget.contains(nextFocus)
+				) {
+					return;
+				}
+				setIsPinnedOpen(false);
+			}}
+			onMouseLeave={() => setIsPinnedOpen(false)}
 		>
-			{VIEW_MODES.map((item) => {
-				const label = t(item.labelKey);
-				const isActive = mode === item.id;
-				const showLargeNoteHint = largeNote && item.id !== "plain";
-				const hint = showLargeNoteHint ? t("mode.largeNoteHint") : label;
+			<button
+				type="button"
+				className="markdownEditorModeBtn markdownEditorModeCurrentBtn"
+				aria-label={activeLabel}
+				aria-expanded={shouldShowBubble}
+				onClick={() => setIsPinnedOpen((open) => !open)}
+			>
+				<HugeiconsIcon icon={activeMode.icon} size="var(--icon-md)" />
+			</button>
+			<div className="markdownEditorModeBubble">
+				{VIEW_MODES.map((item) => {
+					const label = t(item.labelKey);
+					const isActive = mode === item.id;
 
-				return (
-					<span
-						key={item.id}
-						className="markdownEditorModeBtnWrap"
-						data-caution={showLargeNoteHint || undefined}
-					>
+					return (
 						<button
+							key={item.id}
 							type="button"
 							className="markdownEditorModeBtn"
 							aria-pressed={isActive}
@@ -61,16 +85,9 @@ export function EditorViewModeSwitch({
 						>
 							<HugeiconsIcon icon={item.icon} size="var(--icon-md)" />
 						</button>
-						<span
-							className="markdownEditorModeBtnHint"
-							data-warning={showLargeNoteHint || undefined}
-							role="tooltip"
-						>
-							{hint}
-						</span>
-					</span>
-				);
-			})}
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/src/components/preview/MarkdownEditorPane.test.tsx
+++ b/src/components/preview/MarkdownEditorPane.test.tsx
@@ -27,6 +27,7 @@ vi.mock("react-i18next", () => ({
 				"mode.raw": "Raw",
 				"mode.rich": "Rich",
 				"mode.preview": "Preview",
+				"toolbar.info": "Info",
 			};
 			return labels[key] ?? options?.defaultValue ?? key;
 		},
@@ -407,7 +408,7 @@ describe("MarkdownEditorPane", () => {
 		});
 
 		const infoButton = Array.from(container.querySelectorAll("button")).find(
-			(button) => button.getAttribute("aria-label") === "Open info",
+			(button) => button.getAttribute("aria-label") === "Info",
 		);
 		expect(infoButton).not.toBeNull();
 		await act(async () => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -4,6 +4,7 @@ import {
 	LayoutAlignRightIcon,
 } from "@hugeicons/core-free-icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
 	useAISidebarContext,
 	useEditorRegistration,
@@ -162,6 +163,7 @@ export function MarkdownEditorPane({
 	extractToNoteActions,
 	active = true,
 }: MarkdownEditorPaneProps) {
+	const { t } = useTranslation("editor");
 	const [infoPanelText, setInfoPanelText] = useState("");
 	const preferredEditorModeRef = useRef<NoteInlineEditorMode | null>(null);
 	const initialText = initialDoc?.text ?? peekCachedMarkdownDoc(relPath) ?? "";
@@ -552,20 +554,8 @@ export function MarkdownEditorPane({
 								setInfoPanelOpen(() => false);
 								setAiPanelOpen((open) => !open);
 							}}
-							aria-label={
-								aiEnabled
-									? aiPanelOpen
-										? "Close AI panel"
-										: "Open AI panel"
-									: "Open AI settings"
-							}
-							title={
-								aiEnabled
-									? aiPanelOpen
-										? "Close AI panel"
-										: "Open AI panel"
-									: "Open AI settings"
-							}
+							aria-label={t("toolbar.aiPanel")}
+							title={t("toolbar.aiPanel")}
 							aria-pressed={aiEnabled ? aiPanelOpen : undefined}
 						>
 							<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
@@ -575,8 +565,8 @@ export function MarkdownEditorPane({
 							className="markdownEditorToolbarBtn"
 							data-active={infoPanelOpen || undefined}
 							onClick={toggleInfoPanel}
-							aria-label={infoPanelOpen ? "Close info" : "Open info"}
-							title={infoPanelOpen ? "Close info" : "Open info"}
+							aria-label={t("toolbar.info")}
+							title={t("toolbar.info")}
 							aria-pressed={infoPanelOpen}
 						>
 							<HugeiconsIcon

--- a/src/i18n/locales/de/editor.json
+++ b/src/i18n/locales/de/editor.json
@@ -5,6 +5,10 @@
 		"rich": "Rich",
 		"preview": "Vorschau"
 	},
+	"toolbar": {
+		"aiPanel": "KI-Bereich",
+		"info": "Info"
+	},
 	"ribbon": {
 		"bold": "Fett",
 		"italic": "Kursiv",

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -3,8 +3,11 @@
 		"label": "Editor mode",
 		"raw": "Raw",
 		"rich": "Rich",
-		"preview": "Preview",
-		"largeNoteHint": "May be slow on large notes"
+		"preview": "Preview"
+	},
+	"toolbar": {
+		"aiPanel": "AI panel",
+		"info": "Info"
 	},
 	"rollover": {
 		"bannerLabel": "Daily note rollover",

--- a/src/i18n/locales/es/editor.json
+++ b/src/i18n/locales/es/editor.json
@@ -5,6 +5,10 @@
 		"rich": "Enriquecido",
 		"preview": "Vista previa"
 	},
+	"toolbar": {
+		"aiPanel": "Panel de IA",
+		"info": "Información"
+	},
 	"ribbon": {
 		"bold": "Negrita",
 		"italic": "Cursiva",

--- a/src/i18n/locales/fr/editor.json
+++ b/src/i18n/locales/fr/editor.json
@@ -5,6 +5,10 @@
 		"rich": "Enrichi",
 		"preview": "Aperçu"
 	},
+	"toolbar": {
+		"aiPanel": "Panneau IA",
+		"info": "Infos"
+	},
 	"ribbon": {
 		"bold": "Gras",
 		"italic": "Italique",

--- a/src/i18n/locales/ja/editor.json
+++ b/src/i18n/locales/ja/editor.json
@@ -5,6 +5,10 @@
 		"rich": "リッチ",
 		"preview": "プレビュー"
 	},
+	"toolbar": {
+		"aiPanel": "AIパネル",
+		"info": "情報"
+	},
 	"ribbon": {
 		"bold": "太字",
 		"italic": "斜体",

--- a/src/i18n/locales/ko/editor.json
+++ b/src/i18n/locales/ko/editor.json
@@ -5,6 +5,10 @@
 		"rich": "리치",
 		"preview": "미리보기"
 	},
+	"toolbar": {
+		"aiPanel": "AI 패널",
+		"info": "정보"
+	},
 	"ribbon": {
 		"bold": "굵게",
 		"italic": "기울임꼴",

--- a/src/i18n/locales/pl/editor.json
+++ b/src/i18n/locales/pl/editor.json
@@ -3,8 +3,11 @@
 		"label": "Tryb edytora",
 		"raw": "Źródłowy",
 		"rich": "WYSIWYG",
-		"preview": "Podgląd",
-		"largeNoteHint": "Może działać wolno przy dużych notatkach"
+		"preview": "Podgląd"
+	},
+	"toolbar": {
+		"aiPanel": "Panel AI",
+		"info": "Informacje"
 	},
 	"rollover": {
 		"bannerLabel": "Przenoszenie zaległych notatek dziennych",

--- a/src/i18n/locales/pt-BR/editor.json
+++ b/src/i18n/locales/pt-BR/editor.json
@@ -5,6 +5,10 @@
 		"rich": "Rico",
 		"preview": "Pré-visualização"
 	},
+	"toolbar": {
+		"aiPanel": "Painel de IA",
+		"info": "Informações"
+	},
 	"ribbon": {
 		"bold": "Negrito",
 		"italic": "Itálico",

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -95,38 +95,37 @@
 }
 
 .markdownEditorModeSwitch {
-	display: inline-grid;
-	grid-template-columns: repeat(3, minmax(0, auto));
-	align-items: center;
-	gap: 2px;
-	overflow: visible;
-}
-
-.markdownEditorModeBtnWrap {
+	--markdown-editor-mode-bubble-offset: 6px;
 	position: relative;
 	display: inline-flex;
+	align-items: center;
 }
 
-.markdownEditorModeBtnWrap .markdownEditorModeBtn:disabled {
-	pointer-events: none;
+.markdownEditorModeSwitch::after {
+	position: absolute;
+	top: 100%;
+	left: -36px;
+	width: calc(100% + 72px);
+	height: var(--markdown-editor-mode-bubble-offset);
+	content: "";
 }
 
-.markdownEditorModeBtnHint {
+.markdownEditorModeCurrentBtn {
+	color: var(--text-primary);
+}
+
+.markdownEditorModeBubble {
 	position: absolute;
 	z-index: 30;
-	top: calc(100% + 6px);
+	top: calc(100% + var(--markdown-editor-mode-bubble-offset));
 	left: 50%;
-	width: max-content;
-	max-width: 168px;
-	padding: 4px 8px;
+	display: inline-flex;
+	gap: 2px;
+	padding: 3px;
+	border: 1px solid color-mix(in srgb, var(--border-default) 72%, transparent);
 	border-radius: var(--radius-md);
-	background: var(--bg-tertiary);
-	color: var(--text-secondary);
-	font-size: calc(var(--text-base) * 0.66);
-	font-weight: var(--font-medium);
-	line-height: 1.25;
-	text-align: center;
-	text-wrap: balance;
+	background: var(--bg-primary);
+	box-shadow: var(--shadow-float);
 	opacity: 0;
 	visibility: hidden;
 	pointer-events: none;
@@ -134,24 +133,13 @@
 	transition: opacity 140ms ease, visibility 140ms ease, transform 140ms ease;
 }
 
-.markdownEditorModeBtnHint[data-warning="true"] {
-	background: color-mix(in srgb, var(--callout-warning) 14%, var(--bg-primary));
-	color: var(--status-warning-fg);
-}
-
-.markdownEditorModeBtnWrap:hover .markdownEditorModeBtnHint,
-.markdownEditorModeBtnWrap:focus-within .markdownEditorModeBtnHint {
+.markdownEditorModeSwitch:hover .markdownEditorModeBubble,
+.markdownEditorModeSwitch:focus-within .markdownEditorModeBubble,
+.markdownEditorModeSwitch[data-open="true"] .markdownEditorModeBubble {
 	opacity: 1;
 	visibility: visible;
+	pointer-events: auto;
 	transform: translateX(-50%) translateY(0);
-}
-
-.markdownEditorModeBtnWrap[data-caution="true"] .markdownEditorModeBtn {
-	color: color-mix(in srgb, var(--status-warning-fg) 72%, var(--text-tertiary));
-}
-
-.markdownEditorModeBtnWrap[data-caution="true"] .markdownEditorModeBtn:hover {
-	color: var(--status-warning-fg);
 }
 
 .markdownEditorTaskProgress {

--- a/src/styles/app/30-markdown-editor-pane.css
+++ b/src/styles/app/30-markdown-editor-pane.css
@@ -134,7 +134,6 @@
 }
 
 .markdownEditorModeSwitch:hover .markdownEditorModeBubble,
-.markdownEditorModeSwitch:focus-within .markdownEditorModeBubble,
 .markdownEditorModeSwitch[data-open="true"] .markdownEditorModeBubble {
 	opacity: 1;
 	visibility: visible;

--- a/src/styles/app/47-external-markdown.css
+++ b/src/styles/app/47-external-markdown.css
@@ -186,6 +186,21 @@
 	border-radius: var(--radius-full);
 }
 
+.externalMarkdownModeSwitch .markdownEditorModeBubble {
+	left: auto;
+	right: 0;
+	transform: translateY(-2px);
+}
+
+.externalMarkdownModeSwitch
+	.markdownEditorModeSwitch:hover
+	.markdownEditorModeBubble,
+.externalMarkdownModeSwitch
+	.markdownEditorModeSwitch[data-open="true"]
+	.markdownEditorModeBubble {
+	transform: translateY(0);
+}
+
 .externalMarkdownModeSwitch
 	.markdownEditorModeBubble
 	.markdownEditorModeBtn[data-active="true"] {

--- a/src/styles/app/47-external-markdown.css
+++ b/src/styles/app/47-external-markdown.css
@@ -193,10 +193,6 @@
 	color: var(--text-primary);
 }
 
-.externalMarkdownModeSwitch .markdownEditorModeBubble {
-	top: calc(100% + var(--markdown-editor-mode-bubble-offset));
-}
-
 .externalMarkdownBody {
 	flex: 1;
 	min-height: 0;

--- a/src/styles/app/47-external-markdown.css
+++ b/src/styles/app/47-external-markdown.css
@@ -175,8 +175,7 @@
 }
 
 .externalMarkdownModeSwitch .markdownEditorModeSwitch {
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 1px;
+	--markdown-editor-mode-bubble-offset: 8px;
 }
 
 .externalMarkdownModeSwitch .markdownEditorModeBtn {
@@ -187,13 +186,15 @@
 	border-radius: var(--radius-full);
 }
 
-.externalMarkdownModeSwitch .markdownEditorModeBtn[data-active="true"] {
+.externalMarkdownModeSwitch
+	.markdownEditorModeBubble
+	.markdownEditorModeBtn[data-active="true"] {
 	background: color-mix(in srgb, var(--bg-hover) 88%, transparent);
 	color: var(--text-primary);
 }
 
-.externalMarkdownModeSwitch .markdownEditorModeBtnHint {
-	top: calc(100% + 8px);
+.externalMarkdownModeSwitch .markdownEditorModeBubble {
+	top: calc(100% + var(--markdown-editor-mode-bubble-offset));
 }
 
 .externalMarkdownBody {


### PR DESCRIPTION
Closes


## Description

Refines the markdown editor mode switch and toolbar labels.

- Replaces the always-visible mode buttons with an expandable mode bubble around the current mode.
- Adds localized labels for the AI panel and info toolbar buttons in all supported locales.
- Updates the existing info-button test and related editor styles.

## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

No screenshots included.

## Docs

No documentation changes are needed for this UI cleanup.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Refine the markdown editor mode switch UI and localize toolbar controls for the editor.

Enhancements:
- Replace the always-visible editor mode buttons with an expandable mode bubble around the current mode, including updated styling for inline and external markdown editors.
- Localize the AI panel and info toolbar button labels in the markdown editor across all supported locales.

Tests:
- Adjust the markdown editor pane test expectations to match the updated, localized info button label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlines the editor mode switch and localizes toolbar labels. Previously all modes were inline with per-button tooltips; now a single current‑mode button opens a mode bubble on hover/focus/click, it auto‑opens for large notes in non‑plain mode until dismissed, and the large‑note tooltip is removed. Also fixes bubble positioning and clipping in the external markdown editor.

- Opens on hover, focus, and click; closes on blur or mouse leave; click pins it open. Auto‑open resets when mode or note size changes. The current‑mode button reflects state via aria-expanded.
- Selecting a mode from the bubble switches modes in both inline and external editors; in the external editor the bubble aligns to the right and remains visible (no clipping).
- Info and AI toolbar buttons now use localized labels and still toggle their panels.

- Required actions
  - Update tests to open the bubble before selecting a mode and assert the current‑mode button’s aria-expanded. Adjust info-button label assertions to “Info”.
  - Replace hardcoded labels with i18n keys `editor.toolbar.info` and `editor.toolbar.aiPanel`.
  - Remove any reliance on `mode.largeNoteHint`.

<sup>Written for commit e719fc4131679515a12ce8a64972486cf9dddd01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace editor mode switch per-button tooltips with a popover bubble UI
> - Reworks [EditorViewModeSwitch.tsx](https://github.com/SidhuK/Glyph/pull/504/files#diff-43f4cf4c930cf4473fc70fb2eba96c419f19cce5446983391e0fa7ddd8dbf634) from three individually-wrapped buttons with per-button tooltips into a single current-mode button that reveals a floating bubble containing all mode buttons on hover, focus, or click.
> - For large notes, the bubble auto-opens once per (largeNote, mode) tuple instead of showing a per-button warning hint; the `largeNoteHint` i18n key is removed.
> - Toolbar buttons for AI panel and Info in [MarkdownEditorPane.tsx](https://github.com/SidhuK/Glyph/pull/504/files#diff-db5b61c6611a5998ee760a3301783d01d7e787fa0d3232c9f01dca73ba7b615d) now use localized `aria-label` and `title` text instead of English-only "Open/Close" toggle strings, with new `toolbar.aiPanel` and `toolbar.info` keys added across all locale files.
> - Behavioral Change: the per-button caution/warning styling for large notes is removed; the bubble replaces it as the sole affordance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e719fc4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an improved editor mode switcher with a pinned-open option, active-mode indicator, and selectable mode bubble.
  - Mode controls now respond more naturally to hover, focus, and pointer movement.
- **Accessibility**
  - Added translated labels and titles for AI panel and information controls.
  - Improved expanded-state communication for the active mode control.
- **Localization**
  - Added editor toolbar translations across supported languages.
- **Style**
  - Updated mode-switcher presentation and positioning for a cleaner interface.
- **Bug Fixes**
  - Removed outdated per-mode hints and obsolete warning states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->