### PR TITLE
Add Show in Finder to file tree folders

### DIFF
--- a/src-tauri/src/space_fs/read_write/paths.rs
+++ b/src-tauri/src/space_fs/read_write/paths.rs
@@ -265,9 +265,6 @@ pub async fn space_reveal_path(
         if !abs.exists() {
             return Err("path does not exist".to_string());
         }
-        if !abs.is_file() {
-            return Err("path is not a file".to_string());
-        }
         reveal_file_manager_path(&abs)
     })
     .await

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.14",
+	"version": "0.8.15-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/filetree/FileTreeDirItem.tsx
+++ b/src/components/filetree/FileTreeDirItem.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { useSpace } from "../../contexts";
 import { showNativeContextMenu } from "../../lib/nativeContextMenu";
 import { buildPathCopyMenuItems } from "../../lib/pathClipboard";
+import { invoke } from "../../lib/tauri";
 import type { FileTreeAppearance, FsEntry } from "../../lib/tauri";
 import { Plus } from "../Icons";
 import { InlineRenameInput } from "../InlineRenameInput";
@@ -123,6 +124,13 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 		},
 		[draggableRef, handleRef, rowDroppableRef],
 	);
+	const handleRevealInFinder = useCallback(async () => {
+		try {
+			await invoke("space_reveal_path", { path: entry.rel_path });
+		} catch (error) {
+			console.error("Failed to show folder in Finder", error);
+		}
+	}, [entry.rel_path]);
 	const handleContextMenu = useCallback(
 		(event: MouseEvent) => {
 			void showNativeContextMenu(event, [
@@ -147,6 +155,10 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 					action: () => void onImportFolderInDir(entry.rel_path),
 				},
 				{ type: "separator" },
+				{
+					label: t("fileTree.showInFinder"),
+					action: () => void handleRevealInFinder(),
+				},
 				...buildPathCopyMenuItems(spacePath, entry.rel_path),
 				{ type: "separator" },
 				{
@@ -165,6 +177,7 @@ export const FileTreeDirItem = memo(function FileTreeDirItem({
 		},
 		[
 			entry.rel_path,
+			handleRevealInFinder,
 			onOpenAppearancePicker,
 			onCreateFromTemplateInDir,
 			onDeletePath,


### PR DESCRIPTION
Closes 


## Description

Right-clicking a folder in the file tree now has Show in Finder, matching notes.

The folder menu calls the existing `space_reveal_path` command. That command no longer rejects directories, so Finder can select a folder the same way it selects a file. Paths still have to exist under the space root.

This branch also includes a `tauri.conf.json` version bump to `0.8.15-alpha.1` that landed before the Finder change.

- Summary of changes: folder context menu item; `space_reveal_path` accepts directories
- Reasoning: users had to reveal a file in the folder, then navigate in Finder
- Additional context: Discord request. Breadcrumb folder menus still omit Show in Finder.


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.

(Feel free to delete this section for non-visual changes.)


## Docs

No docs change. Reuses `fileTree.showInFinder`. `space_reveal_path` now means any existing space path, not files only.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Add support for revealing folders in the file tree via the existing space_reveal_path command and update the desktop app configuration version.

New Features:
- Add a Show in Finder option to folder items in the file tree context menu so users can reveal folders directly in the file manager.

Enhancements:
- Allow the space_reveal_path backend command to work with directory paths in addition to files.

Build:
- Bump the Tauri configuration version to 0.8.15-alpha.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Show in Finder” to folder items in the file tree and updates `space_reveal_path` to reveal directories as well as files. Previously folders could not be revealed; now any existing path under the space root is supported, reducing extra navigation.

- Confirm the folder context menu shows `fileTree.showInFinder` and invokes `space_reveal_path` with `entry.rel_path`.
- Validate `space_reveal_path` reveals existing directories and files, and still rejects non-existent or out-of-space paths.
- Finder should select the folder; breadcrumb folder menus intentionally still omit Show in Finder.
- `tauri.conf.json` version bumped to `0.8.15-alpha.1`; verify build and dev flows remain stable.

<sup>Written for commit 10377b3d7cc7a3a6dd70e32e24c7c9ea42633adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Show in Finder" context menu action to file tree directories
> - Adds a "Show in Finder" option to the directory context menu in [FileTreeDirItem.tsx](https://github.com/SidhuK/Glyph/pull/506/files#diff-f1399e164824dab69cfd8062254cafe1688cf8d2db48bc081b248f92257d1ef1), invoking the `space_reveal_path` Tauri command with the directory's relative path.
> - Relaxes the `space_reveal_path` handler in [paths.rs](https://github.com/SidhuK/Glyph/pull/506/files#diff-4589389b6e5caaab7f320d6a6a2819044d4e7e5a44b5eaedb9148a4f2d963c1b) to accept directories in addition to files — previously it rejected any path that was not a file.
> - Bumps the app version to `0.8.15-alpha.1` in [tauri.conf.json](https://github.com/SidhuK/Glyph/pull/506/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10377b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Show in Finder” option to directory context menus.
  - Directories and other filesystem paths can now be revealed in the system file manager.

- **Bug Fixes**
  - Improved path reveal support beyond regular files.

- **Chores**
  - Updated the application version to 0.8.15-alpha.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->