### PR TITLE
Add heading-level wiki links with autocomplete and scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Repo extras: agents may read `docs/agents/` and `docs/architecture/adr/`. All ot
 
 Agents and reviewers should flag these patterns unless the change includes a clear justification and there is no simpler React/Tauri-safe alternative:
 
-- `useEffect`: avoid unless synchronizing with an external system. Prefer deriving values during render, event handlers for user actions, keys for reset behavior, and React Query for async server/IPC/filesystem state. See https://react.dev/learn/you-might-not-need-an-effect.
+- `useEffect`: UseEffect is completely banned. UseEffect is a code smell and should be avoided at all costs. Use derived values during render, event handlers for user actions, keys for reset behavior, and React Query for async server/IPC/filesystem state. See https://react.dev/learn/you-might-not-need-an-effect.
 - TanStack Query: prefer queries/mutations for async server, IPC, filesystem, loading, error, retry, cache, and invalidation flows instead of hand-rolled `useState`/`useEffect` state machines.
 - TanStack Virtual: use the existing virtualizer patterns for large lists, tables, boards, timelines, and scroll-heavy surfaces instead of rendering everything or inventing custom windowing logic.
 - `setTimeout`: do not use to sequence React state, paper over races, or wait for rendering. If used for debounce, retry, focus, or transient UI, use cleanup, a named delay constant, and explain why the delay is needed.

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -825,6 +825,7 @@ export function AppShell() {
 	useWorkspaceLinkEvents({
 		activeMarkdownTabPath,
 		fileTree,
+		noteSidePeekEnabled,
 		openPalette,
 		openWorkspaceFile,
 		openBrowseNote,

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -127,7 +127,9 @@ export function useWorkspaceLinkEvents({
 			if (!detail.target) return;
 			void (async () => {
 				try {
-					const normalizedTarget = normalizeRelPath(detail.target);
+					const targetWithoutAnchor =
+						detail.target.split("#", 1)[0] ?? detail.target;
+					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 					if (!normalizedTarget) return;
 
 					if (detail.embed || isImagePath(normalizedTarget)) {

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -27,6 +27,7 @@ import { requestHeadingNavigation } from "../editor/markdown/headingAnchor";
 interface UseWorkspaceLinkEventsArgs {
 	activeMarkdownTabPath: string | null;
 	fileTree: UseFileTreeResult;
+	noteSidePeekEnabled: boolean;
 	openPalette: (mode: "commands" | "search", query?: string) => void;
 	openWorkspaceFile: (path: string) => Promise<void>;
 	openBrowseNote: (path: string) => Promise<void>;
@@ -36,6 +37,7 @@ interface UseWorkspaceLinkEventsArgs {
 export function useWorkspaceLinkEvents({
 	activeMarkdownTabPath,
 	fileTree,
+	noteSidePeekEnabled,
 	openPalette,
 	openWorkspaceFile,
 	openBrowseNote,
@@ -47,7 +49,7 @@ export function useWorkspaceLinkEvents({
 			sourcePath: string | null,
 			headingAnchor?: string | null,
 		): Promise<string | null> => {
-			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
+			const targetWithoutAnchor = rawTarget.split("#", 1)[0];
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 			if (!normalizedTarget) return null;
 			if (isPdfPath(normalizedTarget)) {
@@ -127,8 +129,7 @@ export function useWorkspaceLinkEvents({
 			if (!detail.target) return;
 			void (async () => {
 				try {
-					const targetWithoutAnchor =
-						detail.target.split("#", 1)[0] ?? detail.target;
+					const targetWithoutAnchor = detail.target.split("#", 1)[0];
 					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
 					if (!normalizedTarget) return;
 
@@ -163,7 +164,7 @@ export function useWorkspaceLinkEvents({
 						sourcePath,
 						headingAnchor,
 					);
-					if (openedPath && headingAnchor) {
+					if (openedPath && headingAnchor && !noteSidePeekEnabled) {
 						dispatchInternalAnchorClick({
 							anchor: `#${headingAnchor}`,
 							sourcePath: openedPath,
@@ -237,6 +238,7 @@ export function useWorkspaceLinkEvents({
 		};
 	}, [
 		activeMarkdownTabPath,
+		noteSidePeekEnabled,
 		openBrowseNote,
 		openOrCreateWikiLinkTarget,
 		openPalette,

--- a/src/components/app/useWorkspaceLinkEvents.ts
+++ b/src/components/app/useWorkspaceLinkEvents.ts
@@ -19,8 +19,10 @@ import {
 	TAG_CLICK_EVENT,
 	type TagClickDetail,
 	WIKI_LINK_CLICK_EVENT,
-	type WikiLinkClickDetail,
+	dispatchInternalAnchorClick,
+	isWikiLinkClickEvent,
 } from "../editor/markdown/editorEvents";
+import { requestHeadingNavigation } from "../editor/markdown/headingAnchor";
 
 interface UseWorkspaceLinkEventsArgs {
 	activeMarkdownTabPath: string | null;
@@ -40,32 +42,42 @@ export function useWorkspaceLinkEvents({
 	setError,
 }: UseWorkspaceLinkEventsArgs) {
 	const openOrCreateWikiLinkTarget = useCallback(
-		async (rawTarget: string, sourcePath: string | null) => {
+		async (
+			rawTarget: string,
+			sourcePath: string | null,
+			headingAnchor?: string | null,
+		): Promise<string | null> => {
 			const targetWithoutAnchor = rawTarget.split("#", 1)[0] ?? rawTarget;
 			const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
-			if (!normalizedTarget) return;
+			if (!normalizedTarget) return null;
 			if (isPdfPath(normalizedTarget)) {
 				const resolved = await invoke("space_resolve_wikilink", {
 					target: normalizedTarget,
 				});
 				if (resolved) {
 					await openWorkspaceFile(resolved);
-					return;
+					return resolved;
 				}
 				setError(`Could not resolve PDF wikilink: ${rawTarget}`);
-				return;
+				return null;
 			}
 			if (!isMarkdownCreatablePath(normalizedTarget)) {
 				setError(`Only markdown notes are creatable via [[...]]: ${rawTarget}`);
-				return;
+				return null;
 			}
 
 			const resolved = await invoke("space_resolve_wikilink", {
 				target: normalizedTarget,
 			});
 			if (resolved) {
+				if (headingAnchor) {
+					requestHeadingNavigation({
+						path: resolved,
+						anchor: headingAnchor,
+					});
+				}
 				await openBrowseNote(resolved);
-				return;
+				return resolved;
 			}
 
 			const sourceDir = sourcePath ? parentDir(sourcePath) : "";
@@ -84,7 +96,7 @@ export function useWorkspaceLinkEvents({
 			});
 			if (createdPath) {
 				await openWorkspaceFile(createdPath);
-				return;
+				return createdPath;
 			}
 
 			setError("");
@@ -92,24 +104,30 @@ export function useWorkspaceLinkEvents({
 				target: normalizedTarget,
 			});
 			if (fallbackResolved) {
+				if (headingAnchor) {
+					requestHeadingNavigation({
+						path: fallbackResolved,
+						anchor: headingAnchor,
+					});
+				}
 				await openBrowseNote(fallbackResolved);
-				return;
+				return fallbackResolved;
 			}
 
 			setError(`Could not resolve wikilink: ${rawTarget}`);
+			return null;
 		},
 		[fileTree, openBrowseNote, openWorkspaceFile, setError],
 	);
 
 	useEffect(() => {
 		const onWikiLinkClick = (event: Event) => {
-			const detail = (event as CustomEvent<WikiLinkClickDetail>).detail;
-			if (!detail?.target) return;
+			if (!isWikiLinkClickEvent(event)) return;
+			const detail = event.detail;
+			if (!detail.target) return;
 			void (async () => {
 				try {
-					const targetWithoutAnchor =
-						detail.target.split("#", 1)[0] ?? detail.target;
-					const normalizedTarget = normalizeRelPath(targetWithoutAnchor);
+					const normalizedTarget = normalizeRelPath(detail.target);
 					if (!normalizedTarget) return;
 
 					if (detail.embed || isImagePath(normalizedTarget)) {
@@ -136,7 +154,19 @@ export function useWorkspaceLinkEvents({
 						);
 						return;
 					}
-					await openOrCreateWikiLinkTarget(detail.target, sourcePath);
+					const headingAnchor =
+						detail.anchorKind === "heading" ? detail.anchor : null;
+					const openedPath = await openOrCreateWikiLinkTarget(
+						detail.target,
+						sourcePath,
+						headingAnchor,
+					);
+					if (openedPath && headingAnchor) {
+						dispatchInternalAnchorClick({
+							anchor: `#${headingAnchor}`,
+							sourcePath: openedPath,
+						});
+					}
 				} catch (e) {
 					setError(
 						`Failed to open wikilink: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/components/database/DatabaseCell.tsx
+++ b/src/components/database/DatabaseCell.tsx
@@ -830,7 +830,11 @@ function DatabaseCellEditor({
 					<div className="wikiLinkSuggestionMenu databaseWikiLinkSuggestions">
 						{linkedNoteListAutocomplete.items.map((item, index) => (
 							<button
-								key={item.path}
+								key={
+									item.kind === "heading"
+										? `${item.kind}:${item.path}#${item.slug}`
+										: `${item.kind}:${item.path}`
+								}
 								type="button"
 								className={[
 									"wikiLinkSuggestionItem",
@@ -932,7 +936,11 @@ function DatabaseCellEditor({
 				<div className="wikiLinkSuggestionMenu databaseWikiLinkSuggestions">
 					{wikiLinkAutocomplete.items.map((item, index) => (
 						<button
-							key={item.path}
+							key={
+								item.kind === "heading"
+									? `${item.kind}:${item.path}#${item.slug}`
+									: `${item.kind}:${item.path}`
+							}
 							type="button"
 							className={[
 								"wikiLinkSuggestionItem",

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -781,11 +781,12 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		setTiptapHostNode(node);
 	}, []);
 	useEffect(() => {
+		void relPath;
 		const contentRoot = getMountedEditorContentRoot(tiptapHostNode);
 		const mountedEditor = liveEditor && contentRoot ? liveEditor : null;
 		onEditorReady?.(mountedEditor, mountedEditor ? contentRoot : null);
 		return () => onEditorReady?.(null, null);
-	}, [liveEditor, onEditorReady, tiptapHostNode]);
+	}, [liveEditor, onEditorReady, relPath, tiptapHostNode]);
 
 	const copySelectedCodeBlock = useCallback(() => {
 		if (!selectedCodeBlock) return;

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -123,18 +123,32 @@ export function handleEditorClick(
 			return true;
 		}
 		event.preventDefault();
+		const unresolved = wikiLink.getAttribute("data-unresolved") === "true";
+		const anchorKindAttr = wikiLink.getAttribute("data-anchor-kind");
+		const anchorKind =
+			anchorKindAttr === "heading" || anchorKindAttr === "block"
+				? anchorKindAttr
+				: "none";
+		const anchorAttr = wikiLink.getAttribute("data-anchor");
+		const anchor = anchorAttr ? anchorAttr : null;
 		const parsed = parseWikiLink(wikiLink.getAttribute("data-raw") ?? "");
 		if (parsed) {
-			dispatchWikiLinkClick({ ...parsed, sourcePath: relPath });
+			dispatchWikiLinkClick({
+				...parsed,
+				anchorKind,
+				anchor,
+				unresolved,
+				sourcePath: relPath,
+			});
 			return true;
 		}
 		dispatchWikiLinkClick({
 			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
 			target: wikiLink.getAttribute("data-target") ?? "",
 			alias: wikiLink.getAttribute("data-alias") || null,
-			anchorKind: "none",
-			anchor: null,
-			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
+			anchorKind,
+			anchor,
+			unresolved,
 			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
 			sourcePath: relPath,
 		});

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -11,6 +11,7 @@ import {
 	dispatchTagClick,
 	dispatchWikiLinkClick,
 } from "./markdown/editorEvents";
+import { parseWikiLink } from "./markdown/wikiLinkCodec";
 
 function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
 	const href = link.getAttribute("href")?.trim() ?? "";
@@ -122,16 +123,17 @@ export function handleEditorClick(
 			return true;
 		}
 		event.preventDefault();
+		const parsed = parseWikiLink(wikiLink.getAttribute("data-raw") ?? "");
+		if (parsed) {
+			dispatchWikiLinkClick({ ...parsed, sourcePath: relPath });
+			return true;
+		}
 		dispatchWikiLinkClick({
 			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
 			target: wikiLink.getAttribute("data-target") ?? "",
 			alias: wikiLink.getAttribute("data-alias") || null,
-			anchorKind:
-				(wikiLink.getAttribute("data-anchor-kind") as
-					| "none"
-					| "heading"
-					| "block") ?? "none",
-			anchor: wikiLink.getAttribute("data-anchor") || null,
+			anchorKind: "none",
+			anchor: null,
 			unresolved: wikiLink.getAttribute("data-unresolved") === "true",
 			embed: wikiLink.getAttribute("data-wikilink-embed") === "true",
 			sourcePath: relPath,

--- a/src/components/editor/editorClickHandlers.ts
+++ b/src/components/editor/editorClickHandlers.ts
@@ -11,7 +11,6 @@ import {
 	dispatchTagClick,
 	dispatchWikiLinkClick,
 } from "./markdown/editorEvents";
-import { parseWikiLink } from "./markdown/wikiLinkCodec";
 
 function isExpandedMarkdownUrlLink(link: HTMLAnchorElement): boolean {
 	const href = link.getAttribute("href")?.trim() ?? "";
@@ -131,17 +130,6 @@ export function handleEditorClick(
 				: "none";
 		const anchorAttr = wikiLink.getAttribute("data-anchor");
 		const anchor = anchorAttr ? anchorAttr : null;
-		const parsed = parseWikiLink(wikiLink.getAttribute("data-raw") ?? "");
-		if (parsed) {
-			dispatchWikiLinkClick({
-				...parsed,
-				anchorKind,
-				anchor,
-				unresolved,
-				sourcePath: relPath,
-			});
-			return true;
-		}
 		dispatchWikiLinkClick({
 			raw: wikiLink.getAttribute("data-raw") ?? wikiLink.textContent ?? "",
 			target: wikiLink.getAttribute("data-target") ?? "",

--- a/src/components/editor/extensions/wikiLink.integration.test.ts
+++ b/src/components/editor/extensions/wikiLink.integration.test.ts
@@ -22,6 +22,20 @@ describe("WikiLink markdown manager integration", () => {
 		return null;
 	}
 
+	it("round-trips heading-anchored wikilinks", () => {
+		const manager = new MarkdownManager({
+			extensions: [StarterKit, WikiLink],
+		});
+		const json = manager.parse("See [[Home#reference-library]]");
+		const wikiLinkNode = findWikiLinkNode(json);
+		expect(wikiLinkNode?.attrs).toMatchObject({
+			target: "Home",
+			anchorKind: "heading",
+			anchor: "reference-library",
+		});
+		expect(manager.serialize(json)).toContain("[[Home#reference-library]]");
+	});
+
 	it("round-trips wikilinks through parse/serialize", () => {
 		const manager = new MarkdownManager({
 			extensions: [StarterKit, WikiLink],

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -10,12 +10,14 @@ import Suggestion, { type SuggestionProps } from "@tiptap/suggestion";
 import {
 	type EditorLinkSuggestion,
 	isImageTarget,
-	suggestWikiLinks,
 } from "../../../lib/linkSuggestions";
 import {
 	parseWikiLink,
+	splitWikiLinkQuery,
 	wikiLinkAttrsToMarkdown,
+	wikiLinkDisplayName,
 } from "../markdown/wikiLinkCodec";
+import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
 import type { WikiLinkAttrs } from "../markdown/wikiLinkTypes";
 import { createTipTapTextSuggestionMenu } from "../suggestions/tiptapSuggestionMenu";
 
@@ -71,6 +73,97 @@ function isEmbedSuggestionContextFromQuery(
 	const cursor = editor.state.selection.from;
 	const startOfOpenBrackets = cursor - query.length - 2;
 	return isEmbedSuggestionContext(editor, startOfOpenBrackets);
+}
+
+function insertWikiLinkNode(
+	editor: SuggestionProps<EditorLinkSuggestion>["editor"],
+	range: { from: number; to: number },
+	inner: string,
+	asEmbed: boolean,
+): boolean {
+	const replaceFrom = asEmbed
+		? getEmbedReplacementFrom(editor, range.from)
+		: range.from;
+	const raw = asEmbed ? `![[${inner}]]` : `[[${inner}]]`;
+	const parsed = parseWikiLink(raw);
+	if (!parsed) return false;
+	editor
+		.chain()
+		.focus()
+		.deleteRange({
+			from: replaceFrom,
+			to: range.to,
+		})
+		.insertContent({
+			type: "wikiLink",
+			attrs: parsed,
+		})
+		.insertContent(" ")
+		.run();
+	return true;
+}
+
+function completeWikiLinkTarget(
+	editor: SuggestionProps<EditorLinkSuggestion>["editor"],
+	range: { from: number; to: number },
+	insertText: string,
+	asEmbed: boolean,
+): void {
+	const replaceFrom = asEmbed
+		? getEmbedReplacementFrom(editor, range.from)
+		: range.from;
+	const next = `${asEmbed ? "![[" : "[["}${insertText}`;
+	editor
+		.chain()
+		.focus()
+		.deleteRange({
+			from: replaceFrom,
+			to: range.to,
+		})
+		.insertContent(next)
+		.run();
+}
+
+function commitWikiLinkQuery(
+	editor: SuggestionProps<EditorLinkSuggestion>["editor"],
+	range: { from: number; to: number },
+	query: string,
+	asEmbed: boolean,
+): boolean {
+	const parsed = splitWikiLinkQuery(query);
+	if (!parsed.target) return false;
+	switch (parsed.kind) {
+		case "file":
+			return insertWikiLinkNode(editor, range, parsed.target, asEmbed);
+		case "heading": {
+			const heading = parsed.headingQuery.trim();
+			const inner =
+				heading && !heading.startsWith("^")
+					? `${parsed.target}#${heading}`
+					: parsed.target;
+			return insertWikiLinkNode(editor, range, inner, asEmbed);
+		}
+		default: {
+			const _exhaustive: never = parsed;
+			return _exhaustive;
+		}
+	}
+}
+
+function acceptWikiLinkSuggestion(
+	item: EditorLinkSuggestion,
+	props: SuggestionProps<EditorLinkSuggestion>,
+): void {
+	if (item.kind === "heading") {
+		props.command(item);
+		return;
+	}
+	completeWikiLinkTarget(
+		props.editor,
+		props.range,
+		item.insertText,
+		isEmbedSuggestionContext(props.editor, props.range.from),
+	);
 }
 
 declare module "@tiptap/core" {
@@ -154,8 +247,12 @@ export const WikiLink = Node.create({
 			];
 		}
 
-		const targetName = target.split("/").pop()?.replace(/\.md$/i, "") || target;
-		const displayName = alias || targetName;
+		const displayName = wikiLinkDisplayName({
+			target: node.attrs.target,
+			alias: node.attrs.alias,
+			anchor: node.attrs.anchor,
+			anchorKind: node.attrs.anchorKind,
+		});
 		return [
 			"span",
 			mergeAttributes(HTMLAttributes, {
@@ -164,6 +261,7 @@ export const WikiLink = Node.create({
 				"data-anchor-kind": node.attrs.anchorKind,
 				"data-anchor": node.attrs.anchor ?? "",
 				"data-alias": node.attrs.alias ?? "",
+				"data-raw": node.attrs.raw ?? "",
 				"data-unresolved": String(Boolean(node.attrs.unresolved)),
 				class: "wikiLink",
 			}),
@@ -248,17 +346,6 @@ export const WikiLink = Node.create({
 		];
 	},
 	addProseMirrorPlugins() {
-		const getSuggestions = async (
-			query: string,
-			includeImagesOnly: boolean,
-		): Promise<EditorLinkSuggestion[]> => {
-			return suggestWikiLinks({
-				query,
-				embedOnly: includeImagesOnly,
-				limit: this.options.suggestionLimit,
-			});
-		};
-
 		return [
 			Suggestion<EditorLinkSuggestion>({
 				editor: this.editor,
@@ -283,39 +370,32 @@ export const WikiLink = Node.create({
 				},
 				items: async ({ editor, query }) => {
 					const asEmbed = isEmbedSuggestionContextFromQuery(editor, query);
-					return getSuggestions(query, asEmbed);
+					return suggestWikiLinkItems({
+						query,
+						embedOnly: asEmbed,
+						limit: this.options.suggestionLimit,
+					});
 				},
 				command: ({ editor, range, props }) => {
 					const asEmbed = isEmbedSuggestionContext(editor, range.from);
-					const replaceFrom = asEmbed
-						? getEmbedReplacementFrom(editor, range.from)
-						: range.from;
-					const raw = asEmbed
-						? `![[${props.insertText}]]`
-						: `[[${props.insertText}]]`;
-					const parsed = parseWikiLink(raw);
-					if (!parsed) return;
-					editor
-						.chain()
-						.focus()
-						.deleteRange({
-							from: replaceFrom,
-							to: range.to,
-						})
-						.insertContent({
-							type: "wikiLink",
-							attrs: parsed,
-						})
-						.insertContent(" ")
-						.run();
+					insertWikiLinkNode(editor, range, props.insertText, asEmbed);
 				},
 				render: () =>
 					createTipTapTextSuggestionMenu<EditorLinkSuggestion>({
 						menuClassName: "wikiLinkSuggestionMenu",
 						itemContent: (item) => ({
 							title: item.title,
-							description: item.path,
+							description:
+								item.kind === "heading" ? `#${item.slug}` : item.path,
 						}),
+						onTab: acceptWikiLinkSuggestion,
+						onEmptyEnter: (props) =>
+							commitWikiLinkQuery(
+								props.editor,
+								props.range,
+								props.query,
+								isEmbedSuggestionContextFromQuery(props.editor, props.query),
+							),
 					}),
 			}),
 		];

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -137,10 +137,7 @@ function commitWikiLinkQuery(
 			return insertWikiLinkNode(editor, range, parsed.target, asEmbed);
 		case "heading": {
 			const heading = parsed.headingQuery.trim();
-			const inner =
-				heading && !heading.startsWith("^")
-					? `${parsed.target}#${heading}`
-					: parsed.target;
+			const inner = heading ? `${parsed.target}#${heading}` : parsed.target;
 			return insertWikiLinkNode(editor, range, inner, asEmbed);
 		}
 		default: {

--- a/src/components/editor/extensions/wikiLink.ts
+++ b/src/components/editor/extensions/wikiLink.ts
@@ -254,6 +254,7 @@ export const WikiLink = Node.create({
 			"span",
 			mergeAttributes(HTMLAttributes, {
 				"data-wikilink": "true",
+				"data-wikilink-embed": String(Boolean(node.attrs.embed)),
 				"data-target": node.attrs.target,
 				"data-anchor-kind": node.attrs.anchorKind,
 				"data-anchor": node.attrs.anchor ?? "",

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -336,22 +336,8 @@ export function useTableOfContents(
 	const scrollToHeading = useCallback(
 		(heading: TOCHeading) => {
 			if (!editor) return;
-			editor.commands.expandHeadingAncestors(heading.pos);
-			window.requestAnimationFrame(() => {
-				const el = getHeadingElement(editor, heading);
-				if (!el) return;
-				const scrollContainer = findScrollParent(el);
-				if (scrollContainer) {
-					const containerRect = scrollContainer.getBoundingClientRect();
-					const elRect = el.getBoundingClientRect();
-					const offset =
-						elRect.top - containerRect.top + scrollContainer.scrollTop - 20;
-					scrollContainer.scrollTo({ top: offset, behavior: "smooth" });
-				} else {
-					el.scrollIntoView({ behavior: "smooth", block: "start" });
-				}
-				setActiveId(heading.id);
-			});
+			scrollEditorToHeading(editor, heading);
+			setActiveId(heading.id);
 		},
 		[editor],
 	);
@@ -372,4 +358,25 @@ export function useTableOfContents(
 	);
 
 	return { headings, activeId, scrollToHeading, getPreviewForHeading };
+}
+
+export function scrollEditorToHeading(
+	editor: Editor,
+	heading: TOCHeading,
+): void {
+	editor.commands.expandHeadingAncestors(heading.pos);
+	window.requestAnimationFrame(() => {
+		const el = getHeadingElement(editor, heading);
+		if (!el) return;
+		const scrollContainer = findScrollParent(el);
+		if (scrollContainer) {
+			const containerRect = scrollContainer.getBoundingClientRect();
+			const elRect = el.getBoundingClientRect();
+			const offset =
+				elRect.top - containerRect.top + scrollContainer.scrollTop - 20;
+			scrollContainer.scrollTo({ top: offset, behavior: "smooth" });
+			return;
+		}
+		el.scrollIntoView({ behavior: "smooth", block: "start" });
+	});
 }

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -238,6 +238,15 @@ export function useTableOfContents(
 	const activeFrameRef = useRef<number | null>(null);
 	const headingsRef = useRef<TOCHeading[]>([]);
 	const headingsFrameRef = useRef<number | null>(null);
+	const headingsEditorRef = useRef<Editor | null>(editor);
+
+	if (headingsEditorRef.current !== editor) {
+		headingsEditorRef.current = editor;
+		const next = editor ? extractHeadingsFromDoc(editor.state.doc) : [];
+		headingsRef.current = next;
+		setHeadings((prev) => (isSameHeadingList(prev, next) ? prev : next));
+		if (!editor) setActiveId(null);
+	}
 
 	const publishHeadings = useCallback(() => {
 		if (headingsFrameRef.current !== null) return;
@@ -336,8 +345,7 @@ export function useTableOfContents(
 	const scrollToHeading = useCallback(
 		(heading: TOCHeading) => {
 			if (!editor) return;
-			scrollEditorToHeading(editor, heading);
-			setActiveId(heading.id);
+			scrollEditorToHeading(editor, heading, () => setActiveId(heading.id));
 		},
 		[editor],
 	);
@@ -363,11 +371,13 @@ export function useTableOfContents(
 export function scrollEditorToHeading(
 	editor: Editor,
 	heading: TOCHeading,
+	onVisible?: () => void,
 ): void {
 	editor.commands.expandHeadingAncestors(heading.pos);
 	window.requestAnimationFrame(() => {
 		const el = getHeadingElement(editor, heading);
 		if (!el) return;
+		onVisible?.();
 		const scrollContainer = findScrollParent(el);
 		if (scrollContainer) {
 			const containerRect = scrollContainer.getBoundingClientRect();

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -5,6 +5,7 @@ import { splitWikiLinkQuery } from "../markdown/wikiLinkCodec";
 import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
 import {
 	type SuggestionRange,
+	type SuggestionSelectCause,
 	useInputSuggestionEngine,
 } from "../suggestions/suggestionEngine";
 
@@ -77,14 +78,21 @@ export function useWikiLinkAutocomplete({
 		[inputRef, onChange],
 	);
 	const handleSelect = useCallback(
-		(item: EditorLinkSuggestion, range: SuggestionRange) => {
+		(
+			item: EditorLinkSuggestion,
+			range: SuggestionRange,
+			cause: SuggestionSelectCause,
+		) => {
 			if (onSelectItem) {
 				onSelectItem(item);
 				return;
 			}
 			const opening = wikiLinkOpening(value, range.from);
 			const replaceFrom = opening === "![[" ? range.from - 1 : range.from;
-			const markdown = `${opening}${item.insertText}]]`;
+			const commit = cause === "enter" || item.kind === "heading";
+			const markdown = commit
+				? `${opening}${item.insertText}]]`
+				: `${opening}${item.insertText}`;
 			const nextValue = `${value.slice(0, replaceFrom)}${markdown}${value.slice(
 				range.to,
 			)}`;
@@ -99,5 +107,7 @@ export function useWikiLinkAutocomplete({
 		provider,
 		findRange: findActiveWikiLinkRange,
 		onSelect: handleSelect,
+		closeAfterSelect: (item, cause) =>
+			Boolean(onSelectItem) || cause === "enter" || item.kind === "heading",
 	});
 }

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -1,11 +1,11 @@
 import type { RefObject } from "react";
 import { useCallback, useMemo } from "react";
-import {
-	type EditorLinkSuggestion,
-	suggestWikiLinks,
-} from "../../../lib/linkSuggestions";
+import type { EditorLinkSuggestion } from "../../../lib/linkSuggestions";
+import { splitWikiLinkQuery } from "../markdown/wikiLinkCodec";
+import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
 import {
 	type SuggestionRange,
+	type SuggestionSelectCause,
 	useInputSuggestionEngine,
 } from "../suggestions/suggestionEngine";
 
@@ -39,6 +39,10 @@ function findActiveWikiLinkRange(
 	};
 }
 
+function wikiLinkOpening(value: string, from: number): "![[" | "[[" {
+	return from > 0 && value[from - 1] === "!" ? "![[" : "[[";
+}
+
 export function useWikiLinkAutocomplete({
 	enabled,
 	inputRef,
@@ -50,26 +54,19 @@ export function useWikiLinkAutocomplete({
 		() => ({
 			id: "wiki-link",
 			limit: WIKI_LINK_SUGGESTION_LIMIT,
-			getItems: (query: string) =>
-				suggestWikiLinks({
-					query,
+			getItems: (query: string) => {
+				const parsed = splitWikiLinkQuery(query);
+				return suggestWikiLinkItems({
+					query: onSelectItem ? parsed.target : query,
 					includeAttachments: false,
 					limit: WIKI_LINK_SUGGESTION_LIMIT,
-				}),
+				});
+			},
 		}),
-		[],
+		[onSelectItem],
 	);
-	const handleSelect = useCallback(
-		(item: EditorLinkSuggestion, range: SuggestionRange) => {
-			if (onSelectItem) {
-				onSelectItem(item);
-				return;
-			}
-			const markdown = `[[${item.insertText}]]`;
-			const nextValue = `${value.slice(0, range.from)}${markdown}${value.slice(
-				range.to,
-			)}`;
-			const nextCursor = range.from + markdown.length;
+	const applyMarkdown = useCallback(
+		(nextValue: string, nextCursor: number) => {
 			onChange(nextValue);
 			requestAnimationFrame(() => {
 				const input = inputRef.current;
@@ -78,7 +75,30 @@ export function useWikiLinkAutocomplete({
 				input.setSelectionRange(nextCursor, nextCursor);
 			});
 		},
-		[inputRef, onChange, onSelectItem, value],
+		[inputRef, onChange],
+	);
+	const handleSelect = useCallback(
+		(
+			item: EditorLinkSuggestion,
+			range: SuggestionRange,
+			cause: SuggestionSelectCause,
+		) => {
+			if (onSelectItem) {
+				onSelectItem(item);
+				return;
+			}
+			const opening = wikiLinkOpening(value, range.from);
+			const replaceFrom = opening === "![[" ? range.from - 1 : range.from;
+			const commit = cause === "enter" || item.kind === "heading";
+			const markdown = commit
+				? `${opening}${item.insertText}]]`
+				: `${opening}${item.insertText}`;
+			const nextValue = `${value.slice(0, replaceFrom)}${markdown}${value.slice(
+				range.to,
+			)}`;
+			applyMarkdown(nextValue, replaceFrom + markdown.length);
+		},
+		[applyMarkdown, onSelectItem, value],
 	);
 	return useInputSuggestionEngine({
 		enabled,
@@ -87,5 +107,7 @@ export function useWikiLinkAutocomplete({
 		provider,
 		findRange: findActiveWikiLinkRange,
 		onSelect: handleSelect,
+		closeAfterSelect: (item, cause) =>
+			Boolean(onSelectItem) || cause === "enter" || item.kind === "heading",
 	});
 }

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -89,7 +89,7 @@ export function useWikiLinkAutocomplete({
 			}
 			const opening = wikiLinkOpening(value, range.from);
 			const replaceFrom = opening === "![[" ? range.from - 1 : range.from;
-			const commit = cause === "enter" || item.kind === "heading";
+			const commit = cause !== "tab" || item.kind === "heading";
 			const markdown = commit
 				? `${opening}${item.insertText}]]`
 				: `${opening}${item.insertText}`;
@@ -108,6 +108,6 @@ export function useWikiLinkAutocomplete({
 		findRange: findActiveWikiLinkRange,
 		onSelect: handleSelect,
 		closeAfterSelect: (item, cause) =>
-			Boolean(onSelectItem) || cause === "enter" || item.kind === "heading",
+			Boolean(onSelectItem) || cause !== "tab" || item.kind === "heading",
 	});
 }

--- a/src/components/editor/hooks/useWikiLinkAutocomplete.ts
+++ b/src/components/editor/hooks/useWikiLinkAutocomplete.ts
@@ -5,7 +5,6 @@ import { splitWikiLinkQuery } from "../markdown/wikiLinkCodec";
 import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
 import {
 	type SuggestionRange,
-	type SuggestionSelectCause,
 	useInputSuggestionEngine,
 } from "../suggestions/suggestionEngine";
 
@@ -78,21 +77,14 @@ export function useWikiLinkAutocomplete({
 		[inputRef, onChange],
 	);
 	const handleSelect = useCallback(
-		(
-			item: EditorLinkSuggestion,
-			range: SuggestionRange,
-			cause: SuggestionSelectCause,
-		) => {
+		(item: EditorLinkSuggestion, range: SuggestionRange) => {
 			if (onSelectItem) {
 				onSelectItem(item);
 				return;
 			}
 			const opening = wikiLinkOpening(value, range.from);
 			const replaceFrom = opening === "![[" ? range.from - 1 : range.from;
-			const commit = cause === "enter" || item.kind === "heading";
-			const markdown = commit
-				? `${opening}${item.insertText}]]`
-				: `${opening}${item.insertText}`;
+			const markdown = `${opening}${item.insertText}]]`;
 			const nextValue = `${value.slice(0, replaceFrom)}${markdown}${value.slice(
 				range.to,
 			)}`;
@@ -107,7 +99,5 @@ export function useWikiLinkAutocomplete({
 		provider,
 		findRange: findActiveWikiLinkRange,
 		onSelect: handleSelect,
-		closeAfterSelect: (item, cause) =>
-			Boolean(onSelectItem) || cause === "enter" || item.kind === "heading",
 	});
 }

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -57,14 +57,27 @@ export function isInternalAnchorClickEvent(
 function isWikiLinkClickDetail(value: unknown): value is WikiLinkClickDetail {
 	if (typeof value !== "object" || value === null) return false;
 	if (!("target" in value) || typeof value.target !== "string") return false;
+	if (!("raw" in value) || typeof value.raw !== "string") return false;
+	if (!("unresolved" in value) || typeof value.unresolved !== "boolean") {
+		return false;
+	}
+	if (
+		!("alias" in value) ||
+		(value.alias !== null && typeof value.alias !== "string")
+	) {
+		return false;
+	}
 	if (!("anchorKind" in value)) return false;
 	const kind = value.anchorKind;
 	if (kind !== "none" && kind !== "heading" && kind !== "block") return false;
 	if (
-		"anchor" in value &&
-		value.anchor !== null &&
-		typeof value.anchor !== "string"
+		!("anchor" in value) ||
+		(value.anchor !== null && typeof value.anchor !== "string")
 	) {
+		return false;
+	}
+	if ("embed" in value && typeof value.embed !== "boolean") return false;
+	if ("sourcePath" in value && typeof value.sourcePath !== "string") {
 		return false;
 	}
 	return true;

--- a/src/components/editor/markdown/editorEvents.ts
+++ b/src/components/editor/markdown/editorEvents.ts
@@ -34,6 +34,52 @@ export interface InternalAnchorClickDetail {
 	sourcePath: string;
 }
 
+function isInternalAnchorClickDetail(
+	value: unknown,
+): value is InternalAnchorClickDetail {
+	if (typeof value !== "object" || value === null) return false;
+	if (!("anchor" in value) || !("sourcePath" in value)) return false;
+	return (
+		typeof value.anchor === "string" && typeof value.sourcePath === "string"
+	);
+}
+
+export function isInternalAnchorClickEvent(
+	event: Event,
+): event is CustomEvent<InternalAnchorClickDetail> {
+	return (
+		event.type === INTERNAL_ANCHOR_CLICK_EVENT &&
+		event instanceof CustomEvent &&
+		isInternalAnchorClickDetail(event.detail)
+	);
+}
+
+function isWikiLinkClickDetail(value: unknown): value is WikiLinkClickDetail {
+	if (typeof value !== "object" || value === null) return false;
+	if (!("target" in value) || typeof value.target !== "string") return false;
+	if (!("anchorKind" in value)) return false;
+	const kind = value.anchorKind;
+	if (kind !== "none" && kind !== "heading" && kind !== "block") return false;
+	if (
+		"anchor" in value &&
+		value.anchor !== null &&
+		typeof value.anchor !== "string"
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function isWikiLinkClickEvent(
+	event: Event,
+): event is CustomEvent<WikiLinkClickDetail> {
+	return (
+		event.type === WIKI_LINK_CLICK_EVENT &&
+		event instanceof CustomEvent &&
+		isWikiLinkClickDetail(event.detail)
+	);
+}
+
 export function dispatchWikiLinkClick(detail: WikiLinkClickDetail): void {
 	window.dispatchEvent(
 		new CustomEvent<WikiLinkClickDetail>(WIKI_LINK_CLICK_EVENT, { detail }),

--- a/src/components/editor/markdown/headingAnchor.ts
+++ b/src/components/editor/markdown/headingAnchor.ts
@@ -1,3 +1,4 @@
+import { normalizeRelPath } from "../../../utils/path";
 import type { TOCHeading } from "../hooks/useTableOfContents";
 
 /**
@@ -67,4 +68,40 @@ export function resolveAnchorHeading(
 			(heading) => heading.text.trim().toLowerCase() === normalized,
 		) ?? null
 	);
+}
+
+type PendingHeadingJump = {
+	path: string;
+	anchor: string;
+};
+
+let pendingHeadingJump: PendingHeadingJump | null = null;
+
+export function requestHeadingNavigation(jump: PendingHeadingJump): void {
+	const path = normalizeRelPath(jump.path);
+	const anchor = jump.anchor.trim();
+	if (!path || !anchor) return;
+	pendingHeadingJump = { path, anchor };
+}
+
+export function discardPendingHeadingJump(path: string): void {
+	const normalized = normalizeRelPath(path);
+	if (pendingHeadingJump?.path === normalized) pendingHeadingJump = null;
+}
+
+export function applyPendingHeadingJump(options: {
+	path: string;
+	headings: readonly TOCHeading[];
+	selectHeading: (heading: TOCHeading) => void;
+}): boolean {
+	const path = normalizeRelPath(options.path);
+	if (!pendingHeadingJump || pendingHeadingJump.path !== path) return false;
+	const heading = resolveAnchorHeading(
+		options.headings,
+		pendingHeadingJump.anchor,
+	);
+	if (!heading) return false;
+	pendingHeadingJump = null;
+	options.selectHeading(heading);
+	return true;
 }

--- a/src/components/editor/markdown/wikiLinkCodec.test.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
 	findWikiLinkSpans,
 	parseWikiLink,
+	splitWikiLinkQuery,
 	wikiLinkAttrsToMarkdown,
+	wikiLinkDisplayName,
 } from "./wikiLinkCodec";
 
 describe("wikiLinkCodec", () => {
@@ -35,6 +37,39 @@ describe("wikiLinkCodec", () => {
 			anchorKind: "block",
 			anchor: "abc123",
 		});
+		expect(parseWikiLink("[[link#heading-3]]")).toMatchObject({
+			target: "link",
+			anchorKind: "heading",
+			anchor: "heading-3",
+		});
+	});
+
+	it("splits an in-progress wikilink query at the heading hash", () => {
+		expect(splitWikiLinkQuery("Daily Note")).toEqual({
+			kind: "file",
+			target: "Daily Note",
+		});
+		expect(splitWikiLinkQuery("Daily Note#")).toEqual({
+			kind: "heading",
+			target: "Daily Note",
+			headingQuery: "",
+		});
+		expect(splitWikiLinkQuery("link#heading-3")).toEqual({
+			kind: "heading",
+			target: "link",
+			headingQuery: "heading-3",
+		});
+	});
+
+	it("includes heading anchors in the display name", () => {
+		expect(
+			wikiLinkDisplayName({
+				target: "link.md",
+				alias: null,
+				anchorKind: "heading",
+				anchor: "heading-3",
+			}),
+		).toBe("link#heading-3");
 	});
 
 	it("rejects malformed wikilinks", () => {

--- a/src/components/editor/markdown/wikiLinkCodec.ts
+++ b/src/components/editor/markdown/wikiLinkCodec.ts
@@ -57,6 +57,36 @@ export function parseWikiLink(raw: string): WikiLinkAttrs | null {
 	};
 }
 
+export type WikiLinkQuery =
+	| { kind: "file"; target: string }
+	| { kind: "heading"; target: string; headingQuery: string };
+
+export function splitWikiLinkQuery(query: string): WikiLinkQuery {
+	const hashIdx = findUnescapedIndex(query, "#");
+	if (hashIdx < 0) {
+		return { kind: "file", target: query.trim() };
+	}
+	return {
+		kind: "heading",
+		target: query.slice(0, hashIdx).trim(),
+		headingQuery: query.slice(hashIdx + 1),
+	};
+}
+
+export function wikiLinkDisplayName(
+	attrs: Pick<WikiLinkAttrs, "target" | "alias" | "anchor" | "anchorKind">,
+): string {
+	const alias = typeof attrs.alias === "string" ? attrs.alias.trim() : "";
+	if (alias) return alias;
+	const target = typeof attrs.target === "string" ? attrs.target.trim() : "";
+	const targetName = target.split("/").pop()?.replace(/\.md$/i, "") || target;
+	const anchor = typeof attrs.anchor === "string" ? attrs.anchor.trim() : "";
+	if (attrs.anchorKind === "heading" && anchor)
+		return `${targetName}#${anchor}`;
+	if (attrs.anchorKind === "block" && anchor) return `${targetName}#^${anchor}`;
+	return targetName;
+}
+
 export function wikiLinkAttrsToMarkdown(attrs: Partial<WikiLinkAttrs>): string {
 	const raw = typeof attrs.raw === "string" ? attrs.raw : "";
 	const target = typeof attrs.target === "string" ? attrs.target.trim() : "";

--- a/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
+++ b/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
@@ -5,7 +5,6 @@ import {
 import { splitYamlFrontmatter } from "../../../lib/notePreview";
 import { invoke } from "../../../lib/tauri";
 import { isMarkdownPath } from "../../../utils/path";
-import { peekCachedMarkdownDoc } from "../../preview/markdownCache";
 import { analyzeNoteInfo } from "../../preview/noteInfoAnalysis";
 import { queryMatchesText } from "../suggestions/suggestionEngine";
 import { splitWikiLinkQuery } from "./wikiLinkCodec";
@@ -35,9 +34,7 @@ async function suggestWikiLinkHeadings(options: {
 	const path = await resolveWikiLinkPath(options.target);
 	if (!path) return [];
 	try {
-		const text =
-			peekCachedMarkdownDoc(path) ??
-			(await invoke("space_read_text", { path })).text;
+		const text = (await invoke("space_read_text", { path })).text;
 		const { body } = splitYamlFrontmatter(text);
 		const headings = analyzeNoteInfo(body, body, true).headings;
 		return headings

--- a/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
+++ b/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
@@ -1,0 +1,89 @@
+import {
+	type EditorLinkSuggestion,
+	suggestWikiLinks,
+} from "../../../lib/linkSuggestions";
+import { splitYamlFrontmatter } from "../../../lib/notePreview";
+import { invoke } from "../../../lib/tauri";
+import { isMarkdownPath } from "../../../utils/path";
+import { analyzeNoteInfo } from "../../preview/noteInfoAnalysis";
+import { queryMatchesText } from "../suggestions/suggestionEngine";
+import { splitWikiLinkQuery } from "./wikiLinkCodec";
+
+interface SuggestWikiLinkItemsOptions {
+	embedOnly?: boolean;
+	includeAttachments?: boolean;
+	limit: number;
+	query: string;
+}
+
+async function resolveWikiLinkPath(target: string): Promise<string | null> {
+	const resolved = await invoke("space_resolve_wikilink", { target });
+	return resolved && isMarkdownPath(resolved) ? resolved : null;
+}
+
+async function suggestWikiLinkHeadings(options: {
+	target: string;
+	headingQuery: string;
+	limit: number;
+}): Promise<EditorLinkSuggestion[]> {
+	if (options.headingQuery.trim().startsWith("^")) return [];
+	const path = await resolveWikiLinkPath(options.target);
+	if (!path) return [];
+	const doc = await invoke("space_read_text", { path });
+	const { body } = splitYamlFrontmatter(doc.text);
+	const headings = analyzeNoteInfo(doc.text, body, true).headings;
+	return headings
+		.filter((heading) =>
+			queryMatchesText(
+				options.headingQuery,
+				`${heading.text} ${heading.slug ?? ""}`,
+			),
+		)
+		.slice(0, options.limit)
+		.map((heading) => {
+			const slug = heading.slug ?? heading.text;
+			return {
+				kind: "heading",
+				path,
+				title: heading.text,
+				insertText: `${options.target}#${slug}`,
+				slug,
+			};
+		});
+}
+
+export async function suggestWikiLinkItems({
+	embedOnly = false,
+	includeAttachments = true,
+	limit,
+	query,
+}: SuggestWikiLinkItemsOptions): Promise<EditorLinkSuggestion[]> {
+	const parsed = splitWikiLinkQuery(query);
+	if (embedOnly) {
+		return suggestWikiLinks({
+			query: parsed.target || query,
+			embedOnly: true,
+			includeAttachments,
+			limit,
+		});
+	}
+	switch (parsed.kind) {
+		case "file":
+			return suggestWikiLinks({
+				query,
+				includeAttachments,
+				limit,
+			});
+		case "heading":
+			if (!parsed.target) return [];
+			return suggestWikiLinkHeadings({
+				target: parsed.target,
+				headingQuery: parsed.headingQuery,
+				limit,
+			});
+		default: {
+			const _exhaustive: never = parsed;
+			return _exhaustive;
+		}
+	}
+}

--- a/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
+++ b/src/components/editor/markdown/wikiLinkHeadingSuggest.ts
@@ -5,6 +5,7 @@ import {
 import { splitYamlFrontmatter } from "../../../lib/notePreview";
 import { invoke } from "../../../lib/tauri";
 import { isMarkdownPath } from "../../../utils/path";
+import { peekCachedMarkdownDoc } from "../../preview/markdownCache";
 import { analyzeNoteInfo } from "../../preview/noteInfoAnalysis";
 import { queryMatchesText } from "../suggestions/suggestionEngine";
 import { splitWikiLinkQuery } from "./wikiLinkCodec";
@@ -17,8 +18,12 @@ interface SuggestWikiLinkItemsOptions {
 }
 
 async function resolveWikiLinkPath(target: string): Promise<string | null> {
-	const resolved = await invoke("space_resolve_wikilink", { target });
-	return resolved && isMarkdownPath(resolved) ? resolved : null;
+	try {
+		const resolved = await invoke("space_resolve_wikilink", { target });
+		return resolved && isMarkdownPath(resolved) ? resolved : null;
+	} catch {
+		return null;
+	}
 }
 
 async function suggestWikiLinkHeadings(options: {
@@ -29,27 +34,33 @@ async function suggestWikiLinkHeadings(options: {
 	if (options.headingQuery.trim().startsWith("^")) return [];
 	const path = await resolveWikiLinkPath(options.target);
 	if (!path) return [];
-	const doc = await invoke("space_read_text", { path });
-	const { body } = splitYamlFrontmatter(doc.text);
-	const headings = analyzeNoteInfo(doc.text, body, true).headings;
-	return headings
-		.filter((heading) =>
-			queryMatchesText(
-				options.headingQuery,
-				`${heading.text} ${heading.slug ?? ""}`,
-			),
-		)
-		.slice(0, options.limit)
-		.map((heading) => {
-			const slug = heading.slug ?? heading.text;
-			return {
-				kind: "heading",
-				path,
-				title: heading.text,
-				insertText: `${options.target}#${slug}`,
-				slug,
-			};
-		});
+	try {
+		const text =
+			peekCachedMarkdownDoc(path) ??
+			(await invoke("space_read_text", { path })).text;
+		const { body } = splitYamlFrontmatter(text);
+		const headings = analyzeNoteInfo(body, body, true).headings;
+		return headings
+			.filter((heading) =>
+				queryMatchesText(
+					options.headingQuery,
+					`${heading.text} ${heading.slug ?? ""}`,
+				),
+			)
+			.slice(0, options.limit)
+			.map((heading) => {
+				const slug = heading.slug ?? heading.text;
+				return {
+					kind: "heading" as const,
+					path,
+					title: heading.text,
+					insertText: `${options.target}#${slug}`,
+					slug,
+				};
+			});
+	} catch {
+		return [];
+	}
 }
 
 export async function suggestWikiLinkItems({

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -340,7 +340,11 @@ export function NotePropertyValueField({
 				<div className="wikiLinkSuggestionMenu notePropertyWikiLinkSuggestions">
 					{wikiLinkAutocomplete.items.map((item, itemIndex) => (
 						<button
-							key={item.path}
+							key={
+								item.kind === "heading"
+									? `${item.kind}:${item.path}#${item.slug}`
+									: `${item.kind}:${item.path}`
+							}
 							type="button"
 							className={[
 								"wikiLinkSuggestionItem",

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -29,7 +29,7 @@ export function WikiLinkedText({ value }: { value: string }) {
 					data-target={detail.target}
 					data-unresolved={String(detail.unresolved)}
 					onClick={() => dispatchWikiLinkClick(detail)}
-					title={detail.target}
+					title={label}
 				>
 					<span className="wikiLinkIcon" aria-hidden="true" />
 					<span className="wikiLinkLabel">{label}</span>

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -1,27 +1,10 @@
 import type { ReactNode } from "react";
+import { dispatchWikiLinkClick } from "../markdown/editorEvents";
 import {
-	type WikiLinkClickDetail,
-	dispatchWikiLinkClick,
-} from "../markdown/editorEvents";
-import { findWikiLinkSpans, parseWikiLink } from "../markdown/wikiLinkCodec";
-
-function displayNameForTarget(target: string): string {
-	return target.split("/").pop()?.replace(/\.md$/i, "") || target;
-}
-
-function clickDetailFromRaw(raw: string): WikiLinkClickDetail | null {
-	const parsed = parseWikiLink(raw);
-	if (!parsed) return null;
-	return {
-		raw: parsed.raw,
-		target: parsed.target,
-		alias: parsed.alias,
-		anchorKind: parsed.anchorKind,
-		anchor: parsed.anchor,
-		unresolved: parsed.unresolved,
-		embed: parsed.embed,
-	};
-}
+	findWikiLinkSpans,
+	parseWikiLink,
+	wikiLinkDisplayName,
+} from "../markdown/wikiLinkCodec";
 
 export function WikiLinkedText({ value }: { value: string }) {
 	const spans = findWikiLinkSpans(value);
@@ -33,10 +16,11 @@ export function WikiLinkedText({ value }: { value: string }) {
 		if (cursor < span.start) {
 			nodes.push(value.slice(cursor, span.start));
 		}
-		const detail = clickDetailFromRaw(span.raw);
+		const detail = parseWikiLink(span.raw);
 		if (!detail) {
 			nodes.push(span.raw);
 		} else {
+			const label = wikiLinkDisplayName(detail);
 			nodes.push(
 				<button
 					key={`${span.start}:${span.end}`}
@@ -45,12 +29,10 @@ export function WikiLinkedText({ value }: { value: string }) {
 					data-target={detail.target}
 					data-unresolved={String(detail.unresolved)}
 					onClick={() => dispatchWikiLinkClick(detail)}
-					title={detail.target}
+					title={label}
 				>
 					<span className="wikiLinkIcon" aria-hidden="true" />
-					<span className="wikiLinkLabel">
-						{detail.alias || displayNameForTarget(detail.target)}
-					</span>
+					<span className="wikiLinkLabel">{label}</span>
 				</button>,
 			);
 		}

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -29,7 +29,7 @@ export function WikiLinkedText({ value }: { value: string }) {
 					data-target={detail.target}
 					data-unresolved={String(detail.unresolved)}
 					onClick={() => dispatchWikiLinkClick(detail)}
-					title={label}
+					title={detail.target}
 				>
 					<span className="wikiLinkIcon" aria-hidden="true" />
 					<span className="wikiLinkLabel">{label}</span>

--- a/src/components/editor/raw/extensions.ts
+++ b/src/components/editor/raw/extensions.ts
@@ -49,7 +49,10 @@ import {
 	embeddedLatexCompletionSource,
 	latexSnippetCompletionSource,
 } from "./latexCompletions";
-import { createRawLinkCompletionSource } from "./linkCompletions";
+import {
+	acceptWikiLinkCompletion,
+	createRawLinkCompletionSource,
+} from "./linkCompletions";
 import {
 	embeddedMathLinter,
 	markdownMathExtension,
@@ -278,6 +281,14 @@ export function createRawMarkdownExtensions(
 			}
 		}),
 		keymap.of([
+			{
+				key: "Tab",
+				run: acceptWikiLinkCompletion("tab"),
+			},
+			{
+				key: "Enter",
+				run: acceptWikiLinkCompletion("enter"),
+			},
 			...completionKeymap,
 			{ key: "Mod-b", run: wrapSelection("**") },
 			{ key: "Mod-i", run: wrapSelection("*") },

--- a/src/components/editor/raw/linkCompletions.ts
+++ b/src/components/editor/raw/linkCompletions.ts
@@ -2,10 +2,10 @@ import {
 	type Completion,
 	type CompletionContext,
 	type CompletionResult,
-	acceptCompletion,
 	pickedCompletion,
 	selectedCompletion,
 } from "@codemirror/autocomplete";
+import { syntaxTree } from "@codemirror/language";
 import type { EditorView } from "@codemirror/view";
 import { suggestMarkdownLinks } from "../../../lib/linkSuggestions";
 import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
@@ -97,17 +97,38 @@ function wikiLinkApply(meta: WikiLinkCompletionMeta) {
 	};
 }
 
+function isInTableOrCode(view: EditorView, pos: number): boolean {
+	let node = syntaxTree(view.state).resolveInner(pos, -1);
+	while (node) {
+		if (node.name === "Table") return true;
+		if (
+			node.name === "FencedCode" ||
+			node.name === "CodeBlock" ||
+			node.name === "InlineCode"
+		) {
+			return true;
+		}
+		if (!node.parent) return false;
+		node = node.parent;
+	}
+	return false;
+}
+
 function closeOpenWikiLink(view: EditorView): boolean {
 	const pos = view.state.selection.main.head;
-	const doc = view.state.doc.toString();
-	const before = doc.slice(0, pos);
+	if (isInTableOrCode(view, pos)) return false;
+	const line = view.state.doc.lineAt(pos);
+	const before = line.text.slice(0, pos - line.from);
 	const openIndex = before.lastIndexOf("[[");
 	if (openIndex < 0) return false;
+	const tokenStart = before[openIndex - 1] === "!" ? openIndex - 1 : openIndex;
+	const charBefore = tokenStart > 0 ? before[tokenStart - 1] : "";
+	if (charBefore && /[A-Za-z0-9]/.test(charBefore)) return false;
 	const afterOpen = before.slice(openIndex + 2);
 	if (afterOpen.includes("]]") || afterOpen.includes("\n")) return false;
 	if (afterOpen.includes("[") || afterOpen.includes("]")) return false;
 	if (!afterOpen.trim()) return false;
-	const existingClosing = doc.slice(pos, pos + 2);
+	const existingClosing = view.state.doc.sliceString(pos, pos + 2);
 	if (existingClosing === "]]") {
 		view.dispatch({ selection: { anchor: pos + 2 } });
 		return true;
@@ -214,7 +235,7 @@ export function acceptWikiLinkCompletion(cause: "tab" | "enter") {
 			});
 			return true;
 		}
-		if (acceptCompletion(view)) return true;
+		if (completion) return false;
 		if (cause === "enter") return closeOpenWikiLink(view);
 		return false;
 	};

--- a/src/components/editor/raw/linkCompletions.ts
+++ b/src/components/editor/raw/linkCompletions.ts
@@ -2,15 +2,32 @@ import {
 	type Completion,
 	type CompletionContext,
 	type CompletionResult,
+	acceptCompletion,
 	pickedCompletion,
+	selectedCompletion,
 } from "@codemirror/autocomplete";
 import type { EditorView } from "@codemirror/view";
-import {
-	suggestMarkdownLinks,
-	suggestWikiLinks,
-} from "../../../lib/linkSuggestions";
+import { suggestMarkdownLinks } from "../../../lib/linkSuggestions";
+import { suggestWikiLinkItems } from "../markdown/wikiLinkHeadingSuggest";
 
 const COMPLETION_LIMIT = 8;
+const WIKI_LINK_COMPLETION = Symbol("wikiLinkCompletion");
+
+type WikiLinkCompletionMeta = {
+	opening: "![[" | "[[";
+	insertText: string;
+	isHeading: boolean;
+};
+
+type WikiLinkCompletion = Completion & {
+	[WIKI_LINK_COMPLETION]: WikiLinkCompletionMeta;
+};
+
+function isWikiLinkCompletion(
+	completion: Completion | null,
+): completion is WikiLinkCompletion {
+	return Boolean(completion && WIKI_LINK_COMPLETION in completion);
+}
 
 function completionApply(
 	markdown: string,
@@ -34,6 +51,74 @@ function completionApply(
 	};
 }
 
+function applyWikiLinkCompletion(options: {
+	view: EditorView;
+	completion: Completion;
+	from: number;
+	to: number;
+	opening: "![[" | "[[";
+	insertText: string;
+	closeLink: boolean;
+}): void {
+	const current = options.view.state.doc.sliceString(options.from, options.to);
+	if (!current.startsWith(options.opening) || current.includes("\n")) return;
+	const markdown = options.closeLink
+		? `${options.opening}${options.insertText}]]`
+		: `${options.opening}${options.insertText}`;
+	const existingClosing = options.view.state.doc.sliceString(
+		options.to,
+		options.to + 2,
+	);
+	const replaceTo =
+		options.closeLink && existingClosing === "]]" ? options.to + 2 : options.to;
+	options.view.dispatch({
+		changes: { from: options.from, to: replaceTo, insert: markdown },
+		selection: { anchor: options.from + markdown.length },
+		annotations: pickedCompletion.of(options.completion),
+	});
+}
+
+function wikiLinkApply(meta: WikiLinkCompletionMeta) {
+	return (
+		view: EditorView,
+		completion: Completion,
+		from: number,
+		to: number,
+	) => {
+		applyWikiLinkCompletion({
+			view,
+			completion,
+			from,
+			to,
+			opening: meta.opening,
+			insertText: meta.insertText,
+			closeLink: meta.isHeading,
+		});
+	};
+}
+
+function closeOpenWikiLink(view: EditorView): boolean {
+	const pos = view.state.selection.main.head;
+	const doc = view.state.doc.toString();
+	const before = doc.slice(0, pos);
+	const openIndex = before.lastIndexOf("[[");
+	if (openIndex < 0) return false;
+	const afterOpen = before.slice(openIndex + 2);
+	if (afterOpen.includes("]]") || afterOpen.includes("\n")) return false;
+	if (afterOpen.includes("[") || afterOpen.includes("]")) return false;
+	if (!afterOpen.trim()) return false;
+	const existingClosing = doc.slice(pos, pos + 2);
+	if (existingClosing === "]]") {
+		view.dispatch({ selection: { anchor: pos + 2 } });
+		return true;
+	}
+	view.dispatch({
+		changes: { from: pos, insert: "]]" },
+		selection: { anchor: pos + 2 },
+	});
+	return true;
+}
+
 async function wikiLinkCompletions(
 	context: CompletionContext,
 ): Promise<CompletionResult | null> {
@@ -41,26 +126,28 @@ async function wikiLinkCompletions(
 	if (!match) return null;
 	const asEmbed = match.text.startsWith("![[");
 	const query = match.text.slice(asEmbed ? 3 : 2).trim();
-	const results = await suggestWikiLinks({
+	const results = await suggestWikiLinkItems({
 		query,
 		embedOnly: asEmbed,
 		limit: COMPLETION_LIMIT,
 	});
 	if (context.aborted) return null;
 	const opening = asEmbed ? "![[" : "[[";
-	const options = results.map(
-		(item): Completion => ({
+	const options = results.map((item): WikiLinkCompletion => {
+		const meta: WikiLinkCompletionMeta = {
+			opening,
+			insertText: item.insertText,
+			isHeading: item.kind === "heading",
+		};
+		return {
 			label: item.title,
-			detail: item.path,
-			apply: completionApply(
-				`${opening}${item.insertText}]]`,
-				"]]",
-				(text) => text.startsWith(opening) && !text.includes("\n"),
-			),
+			detail: item.kind === "heading" ? `#${item.slug}` : item.path,
+			apply: wikiLinkApply(meta),
 			type: asEmbed ? "keyword" : "text",
 			boost: item.title ? 1 : 0,
-		}),
-	);
+			[WIKI_LINK_COMPLETION]: meta,
+		};
+	});
 	return { from: match.from, options, filter: false };
 }
 
@@ -80,7 +167,7 @@ async function markdownLinkCompletions(
 	const options = results.map(
 		(item): Completion => ({
 			label: item.title,
-			detail: item.path,
+			detail: item.insertText,
 			apply: completionApply(
 				`](${item.insertText})`,
 				")",
@@ -103,5 +190,32 @@ export function createRawLinkCompletionSource(getRelPath: () => string) {
 			console.warn("Failed to load raw editor link suggestions", error);
 			return null;
 		}
+	};
+}
+
+export function acceptWikiLinkCompletion(cause: "tab" | "enter") {
+	return (view: EditorView) => {
+		const completion = selectedCompletion(view.state);
+		if (isWikiLinkCompletion(completion)) {
+			const meta = completion[WIKI_LINK_COMPLETION];
+			const match = view.state.doc
+				.sliceString(0, view.state.selection.main.head)
+				.match(/!?\[\[[^\]\n]*$/);
+			if (!match) return false;
+			const from = view.state.selection.main.head - match[0].length;
+			applyWikiLinkCompletion({
+				view,
+				completion,
+				from,
+				to: view.state.selection.main.head,
+				opening: meta.opening,
+				insertText: meta.insertText,
+				closeLink: cause === "enter" || meta.isHeading,
+			});
+			return true;
+		}
+		if (acceptCompletion(view)) return true;
+		if (cause === "enter") return closeOpenWikiLink(view);
+		return false;
 	};
 }

--- a/src/components/editor/suggestions/suggestionEngine.ts
+++ b/src/components/editor/suggestions/suggestionEngine.ts
@@ -17,6 +17,8 @@ export interface SuggestionRange {
 	query: string;
 }
 
+export type SuggestionSelectCause = "enter" | "tab" | "pointer";
+
 export interface UseInputSuggestionEngineOptions<T> {
 	enabled: boolean;
 	inputRef: RefObject<HTMLInputElement | null>;
@@ -26,7 +28,12 @@ export interface UseInputSuggestionEngineOptions<T> {
 		value: string,
 		selectionStart: number | null,
 	) => SuggestionRange | null;
-	onSelect: (item: T, range: SuggestionRange) => void;
+	onSelect: (
+		item: T,
+		range: SuggestionRange,
+		cause: SuggestionSelectCause,
+	) => void;
+	closeAfterSelect?: (item: T, cause: SuggestionSelectCause) => boolean;
 }
 
 export function clampSuggestionIndex(index: number, itemCount: number): number {
@@ -82,6 +89,7 @@ export function useInputSuggestionEngine<T>({
 	provider,
 	findRange,
 	onSelect,
+	closeAfterSelect,
 }: UseInputSuggestionEngineOptions<T>) {
 	const requestIdRef = useRef(0);
 	const [range, setRange] = useState<SuggestionRange | null>(null);
@@ -135,12 +143,12 @@ export function useInputSuggestionEngine<T>({
 	}, [inputRef, refresh, value]);
 
 	const select = useCallback(
-		(item: T) => {
+		(item: T, cause: SuggestionSelectCause = "pointer") => {
 			if (!range) return;
-			onSelect(item, range);
-			close();
+			onSelect(item, range, cause);
+			if (closeAfterSelect?.(item, cause) ?? true) close();
 		},
-		[close, onSelect, range],
+		[close, closeAfterSelect, onSelect, range],
 	);
 
 	const handleKeyDown = useCallback(
@@ -165,9 +173,14 @@ export function useInputSuggestionEngine<T>({
 				);
 				return true;
 			}
-			if (event.key === "Enter" || event.key === "Tab") {
+			if (event.key === "Enter") {
 				event.preventDefault();
-				select(items[activeIndex] ?? items[0]);
+				select(items[activeIndex] ?? items[0], "enter");
+				return true;
+			}
+			if (event.key === "Tab") {
+				event.preventDefault();
+				select(items[activeIndex] ?? items[0], "tab");
 				return true;
 			}
 			return false;

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -183,8 +183,11 @@ export function createTipTapSuggestionMenu<T>({
 				return true;
 			}
 			if (event.key === "Enter" && !items.length) {
+				if (!current || !onEmptyEnter) return false;
+				const handled = onEmptyEnter(current);
+				if (!handled) return false;
 				event.preventDefault();
-				return current ? (onEmptyEnter?.(current) ?? false) : false;
+				return true;
 			}
 			if (!items.length) return false;
 			if (event.key === "ArrowDown") {

--- a/src/components/editor/suggestions/tiptapSuggestionMenu.ts
+++ b/src/components/editor/suggestions/tiptapSuggestionMenu.ts
@@ -22,6 +22,8 @@ interface TipTapSuggestionMenuOptions<T> {
 	lockEditorScroll?: boolean;
 	resetSelectionOnUpdate?: boolean;
 	onEscape?: (view: EditorView) => void;
+	onTab?: (item: T, props: SuggestionProps<T>) => void;
+	onEmptyEnter?: (props: SuggestionProps<T>) => boolean;
 }
 
 interface TipTapTextSuggestionMenuOptions<T>
@@ -88,6 +90,8 @@ export function createTipTapSuggestionMenu<T>({
 	lockEditorScroll = true,
 	resetSelectionOnUpdate = false,
 	onEscape,
+	onTab,
+	onEmptyEnter,
 }: TipTapSuggestionMenuOptions<T>) {
 	let menu: HTMLDivElement | null = null;
 	let selectedIndex = 0;
@@ -125,7 +129,13 @@ export function createTipTapSuggestionMenu<T>({
 					item,
 					index,
 					isActive: index === selectedIndex,
-					select: (nextItem) => props.command(nextItem),
+					select: (nextItem) => {
+						if (onTab) {
+							onTab(nextItem, props);
+							return;
+						}
+						props.command(nextItem);
+					},
 				}),
 			);
 		}
@@ -172,6 +182,10 @@ export function createTipTapSuggestionMenu<T>({
 				}
 				return true;
 			}
+			if (event.key === "Enter" && !items.length) {
+				event.preventDefault();
+				return current ? (onEmptyEnter?.(current) ?? false) : false;
+			}
 			if (!items.length) return false;
 			if (event.key === "ArrowDown") {
 				event.preventDefault();
@@ -185,9 +199,21 @@ export function createTipTapSuggestionMenu<T>({
 				updateSelection(items);
 				return true;
 			}
-			if (event.key === "Enter" || event.key === "Tab") {
+			if (event.key === "Enter") {
 				event.preventDefault();
 				current?.command(items[selectedIndex] ?? items[0]);
+				return true;
+			}
+			if (event.key === "Tab") {
+				event.preventDefault();
+				if (!items.length) return false;
+				const item = items[selectedIndex] ?? items[0];
+				if (!item || !current) return false;
+				if (onTab) {
+					onTab(item, current);
+					return true;
+				}
+				current.command(item);
 				return true;
 			}
 			return false;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -194,7 +194,7 @@ export function MarkdownEditorPane({
 	const activeNoteKeyRef = useRef(activeNoteKey);
 	activeNoteKeyRef.current = activeNoteKey;
 	const { tocSource, handleEditorReady: handleTocEditorReady } =
-		useDeferredTocSource();
+		useDeferredTocSource(activeNoteKey);
 	const handleDocumentTextReplaced = useCallback((nextText: string) => {
 		if (infoPanelOpenRef.current) setInfoPanelText(nextText);
 	}, []);
@@ -213,6 +213,8 @@ export function MarkdownEditorPane({
 		saveLabel,
 		text,
 		textRef,
+		loadedRelPath,
+		rawEditorReady,
 	} = useMarkdownDocumentSession({
 		initialDoc,
 		initialError,
@@ -379,6 +381,9 @@ export function MarkdownEditorPane({
 		relPath,
 		headings: navigationHeadings,
 		selectVisibleHeading,
+		headingsReady:
+			loadedRelPath === relPath &&
+			(mode === "plain" ? rawEditorReady : tocSource !== null),
 	});
 	const handleEditorReady = useCallback(
 		(editor: Editor | null, contentRoot: HTMLElement | null) => {

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -3,6 +3,7 @@ import {
 	AiBrain04Icon,
 	LayoutAlignRightIcon,
 } from "@hugeicons/core-free-icons";
+import type { Editor } from "@tiptap/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -192,7 +193,8 @@ export function MarkdownEditorPane({
 	const activeNoteKey = `${spacePath ?? ""}\0${relPath}`;
 	const activeNoteKeyRef = useRef(activeNoteKey);
 	activeNoteKeyRef.current = activeNoteKey;
-	const { tocSource, handleEditorReady } = useDeferredTocSource();
+	const { tocSource, handleEditorReady: handleTocEditorReady } =
+		useDeferredTocSource();
 	const handleDocumentTextReplaced = useCallback((nextText: string) => {
 		if (infoPanelOpenRef.current) setInfoPanelText(nextText);
 	}, []);
@@ -366,14 +368,24 @@ export function MarkdownEditorPane({
 		[mode, rawEditorRef, scrollToHeading],
 	);
 
-	const getPlainText = useCallback(() => textRef.current, [textRef]);
+	const navigationHeadings = useMemo(
+		() =>
+			mode === "plain"
+				? analyzeNoteInfo(text, text, true).headings
+				: tocHeadings,
+		[mode, text, tocHeadings],
+	);
 	useInternalAnchorNavigation({
 		relPath,
-		mode,
-		getPlainText,
-		tocHeadings,
+		headings: navigationHeadings,
 		selectVisibleHeading,
 	});
+	const handleEditorReady = useCallback(
+		(editor: Editor | null, contentRoot: HTMLElement | null) => {
+			handleTocEditorReady(editor, contentRoot);
+		},
+		[handleTocEditorReady],
+	);
 
 	useEffect(() => {
 		if (!infoPanelOpen) return;

--- a/src/components/preview/NoteSidePeek.tsx
+++ b/src/components/preview/NoteSidePeek.tsx
@@ -5,13 +5,19 @@ import {
 	NoteIcon,
 } from "@hugeicons/core-free-icons";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
+import type { Editor } from "@tiptap/react";
+import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { noteDocumentQueryOptions } from "../../lib/navigationPrefetch";
 import { parseNotePreview } from "../../lib/notePreview";
 import { displayNameFromPath, parentDir } from "../../utils/path";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
+import {
+	extractHeadingsFromDoc,
+	scrollEditorToHeading,
+} from "../editor/hooks/useTableOfContents";
+import { applyPendingHeadingJump } from "../editor/markdown/headingAnchor";
 
 interface NoteSidePeekProps {
 	relPath: string;
@@ -32,6 +38,17 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 	const folder = parentDir(relPath);
 	const error = noteQuery.error ? extractErrorMessage(noteQuery.error) : "";
 	const isPending = noteQuery.isPending;
+	const handleEditorReady = useCallback(
+		(editor: Editor | null) => {
+			if (!editor) return;
+			applyPendingHeadingJump({
+				path: relPath,
+				headings: extractHeadingsFromDoc(editor.state.doc),
+				selectHeading: (heading) => scrollEditorToHeading(editor, heading),
+			});
+		},
+		[relPath],
+	);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
@@ -110,6 +127,7 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 							onChange={() => {}}
 							interactive
 							acceptSearchJumps={false}
+							onEditorReady={handleEditorReady}
 							deferHeavyFeatures
 						/>
 					</div>

--- a/src/components/preview/NoteSidePeek.tsx
+++ b/src/components/preview/NoteSidePeek.tsx
@@ -6,28 +6,24 @@ import {
 } from "@hugeicons/core-free-icons";
 import { useQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
-import { useCallback, useEffect, useRef } from "react";
+import {
+	type MouseEvent as ReactMouseEvent,
+	useCallback,
+	useEffect,
+	useRef,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { noteDocumentQueryOptions } from "../../lib/navigationPrefetch";
 import { parseNotePreview } from "../../lib/notePreview";
-import {
-	displayNameFromPath,
-	normalizeRelPath,
-	parentDir,
-} from "../../utils/path";
+import { displayNameFromPath, parentDir } from "../../utils/path";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import {
 	extractHeadingsFromDoc,
 	scrollEditorToHeading,
 } from "../editor/hooks/useTableOfContents";
 import {
-	INTERNAL_ANCHOR_CLICK_EVENT,
-	isInternalAnchorClickEvent,
-} from "../editor/markdown/editorEvents";
-import {
 	applyPendingHeadingJump,
-	discardPendingHeadingJump,
 	resolveAnchorHeading,
 } from "../editor/markdown/headingAnchor";
 
@@ -64,32 +60,22 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 		[relPath],
 	);
 
-	useEffect(() => {
-		const onInternalAnchorClick = (event: Event) => {
-			if (!isInternalAnchorClickEvent(event)) return;
-			if (
-				normalizeRelPath(event.detail.sourcePath) !== normalizeRelPath(relPath)
-			) {
-				return;
-			}
+	const handleInternalAnchorClick = useCallback(
+		(event: ReactMouseEvent<HTMLElement>) => {
+			const target = event.target instanceof Element ? event.target : null;
+			const anchor = target?.closest("a")?.getAttribute("href");
+			if (!anchor?.startsWith("#")) return;
 			const editor = editorRef.current;
 			if (!editor || editor.isDestroyed) return;
 			const heading = resolveAnchorHeading(
 				extractHeadingsFromDoc(editor.state.doc),
-				event.detail.anchor,
+				anchor,
 			);
 			if (!heading) return;
-			discardPendingHeadingJump(relPath);
 			scrollEditorToHeading(editor, heading);
-		};
-		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
-		return () => {
-			window.removeEventListener(
-				INTERNAL_ANCHOR_CLICK_EVENT,
-				onInternalAnchorClick,
-			);
-		};
-	}, [relPath]);
+		},
+		[],
+	);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
@@ -147,7 +133,10 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 					</button>
 				</div>
 			</header>
-			<div className="noteSidePeekBody">
+			<div
+				className="noteSidePeekBody"
+				onClickCapture={handleInternalAnchorClick}
+			>
 				{error ? (
 					<div className="noteSidePeekStatus">{error}</div>
 				) : isPending ? (

--- a/src/components/preview/NoteSidePeek.tsx
+++ b/src/components/preview/NoteSidePeek.tsx
@@ -6,18 +6,30 @@ import {
 } from "@hugeicons/core-free-icons";
 import { useQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { noteDocumentQueryOptions } from "../../lib/navigationPrefetch";
 import { parseNotePreview } from "../../lib/notePreview";
-import { displayNameFromPath, parentDir } from "../../utils/path";
+import {
+	displayNameFromPath,
+	normalizeRelPath,
+	parentDir,
+} from "../../utils/path";
 import { NoteInlineEditor } from "../editor/NoteInlineEditor";
 import {
 	extractHeadingsFromDoc,
 	scrollEditorToHeading,
 } from "../editor/hooks/useTableOfContents";
-import { applyPendingHeadingJump } from "../editor/markdown/headingAnchor";
+import {
+	INTERNAL_ANCHOR_CLICK_EVENT,
+	isInternalAnchorClickEvent,
+} from "../editor/markdown/editorEvents";
+import {
+	applyPendingHeadingJump,
+	discardPendingHeadingJump,
+	resolveAnchorHeading,
+} from "../editor/markdown/headingAnchor";
 
 interface NoteSidePeekProps {
 	relPath: string;
@@ -38,8 +50,10 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 	const folder = parentDir(relPath);
 	const error = noteQuery.error ? extractErrorMessage(noteQuery.error) : "";
 	const isPending = noteQuery.isPending;
+	const editorRef = useRef<Editor | null>(null);
 	const handleEditorReady = useCallback(
 		(editor: Editor | null) => {
+			editorRef.current = editor;
 			if (!editor) return;
 			applyPendingHeadingJump({
 				path: relPath,
@@ -49,6 +63,33 @@ export function NoteSidePeek({ relPath, onClose, onOpen }: NoteSidePeekProps) {
 		},
 		[relPath],
 	);
+
+	useEffect(() => {
+		const onInternalAnchorClick = (event: Event) => {
+			if (!isInternalAnchorClickEvent(event)) return;
+			if (
+				normalizeRelPath(event.detail.sourcePath) !== normalizeRelPath(relPath)
+			) {
+				return;
+			}
+			const editor = editorRef.current;
+			if (!editor || editor.isDestroyed) return;
+			const heading = resolveAnchorHeading(
+				extractHeadingsFromDoc(editor.state.doc),
+				event.detail.anchor,
+			);
+			if (!heading) return;
+			discardPendingHeadingJump(relPath);
+			scrollEditorToHeading(editor, heading);
+		};
+		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
+		return () => {
+			window.removeEventListener(
+				INTERNAL_ANCHOR_CLICK_EVENT,
+				onInternalAnchorClick,
+			);
+		};
+	}, [relPath]);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {

--- a/src/components/preview/useDeferredTocSource.ts
+++ b/src/components/preview/useDeferredTocSource.ts
@@ -9,8 +9,9 @@ interface TocSource {
 	contentRoot: HTMLElement;
 }
 
-export function useDeferredTocSource() {
+export function useDeferredTocSource(noteKey: string) {
 	const [tocSource, setTocSource] = useState<TocSource | null>(null);
+	const appliedNoteKeyRef = useRef(noteKey);
 	const tocReadyFrameRef = useRef<number | null>(null);
 	const tocReadyResizeObserverRef = useRef<ResizeObserver | null>(null);
 	const tocReadyGenerationRef = useRef(0);
@@ -31,6 +32,12 @@ export function useDeferredTocSource() {
 		cancelPendingTocReady();
 		disconnectPendingTocResizeObserver();
 	}, [cancelPendingTocReady, disconnectPendingTocResizeObserver]);
+
+	if (appliedNoteKeyRef.current !== noteKey) {
+		appliedNoteKeyRef.current = noteKey;
+		resetPendingTocReady();
+		setTocSource(null);
+	}
 
 	const handleEditorReady = useCallback(
 		(editor: Editor | null, contentRoot: HTMLElement | null) => {

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -1,42 +1,53 @@
 import { useEffect, useRef } from "react";
-import type { EditorViewMode } from "../../lib/editorMode";
+import { normalizeRelPath } from "../../utils/path";
 import type { TOCHeading } from "../editor/hooks/useTableOfContents";
 import {
 	INTERNAL_ANCHOR_CLICK_EVENT,
-	type InternalAnchorClickDetail,
+	isInternalAnchorClickEvent,
 } from "../editor/markdown/editorEvents";
-import { resolveAnchorHeading } from "../editor/markdown/headingAnchor";
-import { analyzeNoteInfo } from "./noteInfoAnalysis";
+import {
+	applyPendingHeadingJump,
+	discardPendingHeadingJump,
+	resolveAnchorHeading,
+} from "../editor/markdown/headingAnchor";
 
 interface UseInternalAnchorNavigationArgs {
 	relPath: string;
-	mode: EditorViewMode;
-	getPlainText: () => string;
-	tocHeadings: readonly TOCHeading[];
+	headings: readonly TOCHeading[];
 	selectVisibleHeading: (heading: TOCHeading) => void;
 }
 
 export function useInternalAnchorNavigation({
 	relPath,
-	mode,
-	getPlainText,
-	tocHeadings,
+	headings,
 	selectVisibleHeading,
 }: UseInternalAnchorNavigationArgs) {
-	const tocHeadingsRef = useRef(tocHeadings);
-	tocHeadingsRef.current = tocHeadings;
+	const selectVisibleHeadingRef = useRef(selectVisibleHeading);
+	selectVisibleHeadingRef.current = selectVisibleHeading;
+	const headingsRef = useRef(headings);
+	headingsRef.current = headings;
 
 	useEffect(() => {
-		const onInternalAnchorClick = (event: Event) => {
-			const detail = (event as CustomEvent<InternalAnchorClickDetail>).detail;
-			if (!detail || detail.sourcePath !== relPath) return;
+		applyPendingHeadingJump({
+			path: relPath,
+			headings,
+			selectHeading: (heading) => selectVisibleHeadingRef.current(heading),
+		});
 
-			const headings =
-				mode === "plain"
-					? analyzeNoteInfo(getPlainText(), getPlainText(), true).headings
-					: tocHeadingsRef.current;
-			const heading = resolveAnchorHeading(headings, detail.anchor);
-			if (heading) selectVisibleHeading(heading);
+		const onInternalAnchorClick = (event: Event) => {
+			if (!isInternalAnchorClickEvent(event)) return;
+			if (
+				normalizeRelPath(event.detail.sourcePath) !== normalizeRelPath(relPath)
+			) {
+				return;
+			}
+			const heading = resolveAnchorHeading(
+				headingsRef.current,
+				event.detail.anchor,
+			);
+			if (!heading) return;
+			discardPendingHeadingJump(relPath);
+			selectVisibleHeadingRef.current(heading);
 		};
 
 		window.addEventListener(INTERNAL_ANCHOR_CLICK_EVENT, onInternalAnchorClick);
@@ -46,5 +57,5 @@ export function useInternalAnchorNavigation({
 				onInternalAnchorClick,
 			);
 		};
-	}, [getPlainText, mode, relPath, selectVisibleHeading]);
+	}, [headings, relPath]);
 }

--- a/src/components/preview/useInternalAnchorNavigation.ts
+++ b/src/components/preview/useInternalAnchorNavigation.ts
@@ -15,12 +15,14 @@ interface UseInternalAnchorNavigationArgs {
 	relPath: string;
 	headings: readonly TOCHeading[];
 	selectVisibleHeading: (heading: TOCHeading) => void;
+	headingsReady: boolean;
 }
 
 export function useInternalAnchorNavigation({
 	relPath,
 	headings,
 	selectVisibleHeading,
+	headingsReady,
 }: UseInternalAnchorNavigationArgs) {
 	const selectVisibleHeadingRef = useRef(selectVisibleHeading);
 	selectVisibleHeadingRef.current = selectVisibleHeading;
@@ -28,11 +30,13 @@ export function useInternalAnchorNavigation({
 	headingsRef.current = headings;
 
 	useEffect(() => {
-		applyPendingHeadingJump({
-			path: relPath,
-			headings,
-			selectHeading: (heading) => selectVisibleHeadingRef.current(heading),
-		});
+		if (headingsReady) {
+			applyPendingHeadingJump({
+				path: relPath,
+				headings,
+				selectHeading: (heading) => selectVisibleHeadingRef.current(heading),
+			});
+		}
 
 		const onInternalAnchorClick = (event: Event) => {
 			if (!isInternalAnchorClickEvent(event)) return;
@@ -57,5 +61,5 @@ export function useInternalAnchorNavigation({
 				onInternalAnchorClick,
 			);
 		};
-	}, [headings, relPath]);
+	}, [headings, headingsReady, relPath]);
 }

--- a/src/components/preview/useMarkdownDocumentSession.ts
+++ b/src/components/preview/useMarkdownDocumentSession.ts
@@ -43,6 +43,8 @@ export function useMarkdownDocumentSession({
 	const [saving, setSaving] = useState(false);
 	const [autosaveBusy, setAutosaveBusy] = useState(false);
 	const [error, setError] = useState(() => initialError || "");
+	const [loadedRelPath, setLoadedRelPath] = useState(relPath);
+	const [rawEditorReady, setRawEditorReady] = useState(false);
 	const [lastSavedMtimeMs, setLastSavedMtimeMs] = useState<number | null>(
 		initialDoc?.mtime_ms ?? null,
 	);
@@ -82,6 +84,7 @@ export function useMarkdownDocumentSession({
 	const handleRawEditorReady = useCallback(
 		(editor: RawMarkdownEditorHandle | null) => {
 			rawEditorRef.current = editor;
+			setRawEditorReady(editor !== null);
 		},
 		[],
 	);
@@ -154,6 +157,8 @@ export function useMarkdownDocumentSession({
 		hasUserEditsRef.current = false;
 		setError(initialError);
 		setEditorMode(resolveEditorModeForNote(cached));
+		setLoadedRelPath(relPath);
+		setRawEditorReady(false);
 		activeRelPathRef.current = relPath;
 		if (initialDoc) {
 			setPrefetchedNote(relPath, initialDoc);
@@ -555,5 +560,7 @@ export function useMarkdownDocumentSession({
 		saveLabel,
 		text,
 		textRef,
+		loadedRelPath,
+		rawEditorReady,
 	};
 }

--- a/src/components/preview/useMarkdownDocumentSession.ts
+++ b/src/components/preview/useMarkdownDocumentSession.ts
@@ -197,6 +197,7 @@ export function useMarkdownDocumentSession({
 		setAutosaveBusy(false);
 		clearPulse();
 		clearMarkdownDocCache();
+		setLoadedRelPath("");
 	}, [clearPulse, spacePath]);
 
 	const loadDoc = useCallback(
@@ -225,6 +226,7 @@ export function useMarkdownDocumentSession({
 				mtimeRef.current = doc.mtime_ms;
 				setSavedText(doc.text);
 				setLastSavedMtimeMs(doc.mtime_ms);
+				setLoadedRelPath(relPath);
 				setPrefetchedNote(relPath, doc);
 				if (showRefreshFeedback) {
 					flashPulse("reloaded");

--- a/src/lib/linkSuggestions.ts
+++ b/src/lib/linkSuggestions.ts
@@ -1,11 +1,20 @@
-import { isImagePath, isPdfPath } from "../utils/path";
+import { isImagePath } from "../utils/path";
 import { invoke } from "./tauri";
 
-export interface EditorLinkSuggestion {
-	path: string;
-	title: string;
-	insertText: string;
-}
+export type EditorLinkSuggestion =
+	| {
+			kind: "file";
+			path: string;
+			title: string;
+			insertText: string;
+	  }
+	| {
+			kind: "heading";
+			path: string;
+			title: string;
+			insertText: string;
+			slug: string;
+	  };
 
 interface SuggestWikiLinksOptions {
 	embedOnly?: boolean;
@@ -24,10 +33,6 @@ export function isImageTarget(path: string): boolean {
 	return isImagePath(path);
 }
 
-export function isPdfTarget(path: string): boolean {
-	return isPdfPath(path);
-}
-
 function titleFromPath(path: string): string {
 	const name = path.split("/").pop() ?? path;
 	return name.replace(/\.md$/i, "") || name;
@@ -39,6 +44,7 @@ function toEditorSuggestion(item: {
 	insert_text: string;
 }): EditorLinkSuggestion {
 	return {
+		kind: "file",
 		path: item.path,
 		title: item.title || titleFromPath(item.path),
 		insertText: item.insert_text,


### PR DESCRIPTION
Closes 


## Description

Wiki links can now target a heading, e.g. `[[Home#reference-library]]`. Autocomplete stays in the `[[` flow so you can pick a note, then a heading; clicking the chip opens that note and scrolls to the heading.

- Tab (or clicking a file suggestion) completes the note name and stays inside `[[note`. Enter closes to `[[note]]`. After `#`, headings from that note are suggested as GitHub-style slugs.
- Clicking `[[note#heading]]` in rich, raw, preview, properties, and side peek opens the note and jumps to the heading. The jump waits until the opened note’s heading list is ready, so it isn’t applied against the previous document.
- Pending heading navigation lives on the existing heading-anchor helpers. Suggestion kinds are a `file | heading` union; pointer selection reuses Tab behavior so a file pick doesn’t close the link.

This commit also tightens `AGENTS.md` to treat `useEffect` as banned for new work. That’s bundled with this branch rather than a separate change.


## Screenshots

No new chrome; wiki chips now show `Note#heading` and scroll to that heading on click.


## Docs

Write `[[Note#heading-slug]]`. Slugs match GitHub-style heading anchors (`Reference Library` → `reference-library`). Tab keeps the wiki link open after picking a file so you can type `#` and pick a heading. Enter inserts the finished link.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Enable heading-targeted wiki links with staged autocomplete and reliable scroll-to-heading navigation across the application.

New Features:
- Support wiki links that target note headings using GitHub-style anchor slugs.
- Add staged file and heading autocomplete across rich text, raw Markdown, properties, and database editors.
- Navigate to linked headings when opening notes, including deferred navigation in preview and side peek views.

Bug Fixes:
- Prevent heading navigation from being applied before the destination note and its heading list are ready.
- Improve wiki-link click validation and prevent suggestion key collisions for files and headings.

Enhancements:
- Display heading anchors in wiki-link labels and preserve heading targets through parsing and serialization.
- Unify autocomplete selection behavior so Tab keeps file links open while Enter commits them.
- Centralize heading scrolling and pending navigation handling across editor and preview surfaces.

Tests:
- Add coverage for parsing, displaying, and round-tripping heading-anchored wiki links.

Chores:
- Update repository guidance to prohibit new use of useEffect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds heading-anchored wiki links with staged autocomplete and reliable scroll-to-heading across editors and preview. Previously wiki links only opened notes; now `[[Note#heading]]` is suggested and navigates to that heading. Tab stages the file target; Enter (or picking a heading) commits and auto-closes the link; navigation waits for headings before scrolling.

- Autocomplete: TipTap and raw (CodeMirror), properties, and database suggest files and headings. Tab keeps `[[` open while Enter commits; heading suggestions show `#slug`. Pressing Enter with no selection closes an open wiki link.
- Navigation: Clicking `[[note#heading]]` opens/creates the note, records a pending jump, and scrolls when headings are ready. The main pane dispatches an internal anchor click after open when side peek is off; side peek applies pending jumps on editor ready and intercepts in-panel `#anchor` clicks.
- Display and parsing: Wiki-link labels include anchors (for example, `Note#heading`). Parsing/serialize and tests cover heading anchors and in-progress `[[note#...]]` queries.
- Events and DOM: Uses `isWikiLinkClickEvent`/`isInternalAnchorClickEvent` guards. Wiki-link DOM includes `data-wikilink-embed`, `data-raw`, and anchor details.
- TOC and scrolling: `useDeferredTocSource(noteKey)` resets by note key. `useInternalAnchorNavigation` takes a `headings` list and a `headingsReady` flag and applies pending jumps when ready. Scrolling to headings is centralized.
- Minor: Suggestion keys include kind and `#slug` to avoid collisions. Team policy updated: `useEffect` is now fully banned.

**Migration**
- Update consumers of `EditorLinkSuggestion`: it is now a discriminated union with `kind: 'file' | 'heading'` (heading items include `slug`).
- Use `suggestWikiLinkItems()` to include heading suggestions; `suggestWikiLinks()` returns files only.
- Update `useInternalAnchorNavigation(relPath, { headings, headingsReady, selectVisibleHeading })`; remove `mode`, `getPlainText`, and `tocHeadings`.
- Call `useDeferredTocSource(noteKey)` with a stable per-note key.

<sup>Written for commit a0797b66e9e96fde41e68577b5721e42cf587b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add heading-level wiki link autocomplete and scroll-to-heading navigation
> - Wikilink autocomplete now suggests headings from the target note, enabling `[[Note#Heading]]` links in both the rich editor (TipTap) and raw markdown editor.
> - Pressing Tab in the suggestion menu performs a partial insert (file only, no closing `]]`), while Enter commits the full link including the anchor.
> - Clicking a `[[Note#Heading]]` link opens the note and scrolls to the target heading; navigation is queued via a pending-jump system so it works even before the editor is ready.
> - Side peek panel now handles heading anchor navigation through queued jumps and internal anchor click events.
> - `EditorLinkSuggestion` is refactored into a discriminated union with `'file'` and `'heading'` kinds; suggestion item keys are updated to avoid React collisions.
> - Risk: the new Tab keymap binding in the raw editor takes precedence over table-cell Tab navigation when a wikilink completion is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0797b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heading-aware wiki-link suggestions, including matching headings within notes.
  * Wiki links now support heading anchors such as `[[Note#Heading]]`.
  * Added Tab and Enter support for accepting wiki-link completions.
  * Improved displayed labels for wiki links and aliases.
* **Bug Fixes**
  * Fixed navigation to headings when opening linked notes, including preview and side-pane views.
  * Improved handling of invalid or unresolved wiki-link clicks and preserved anchor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->