### PR TITLE
Add default folder for new notes

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -157,6 +157,7 @@ export function AppShell() {
 		openMarkdownTabs,
 		activeMarkdownTabPath,
 		dailyNotesFolder,
+		defaultNewNoteFolder,
 		templateFolder,
 		periodNoteTemplates,
 		periodNotesEnabled,
@@ -877,14 +878,15 @@ export function AppShell() {
 		await attachContextFiles(tabs);
 	}, [attachContextFiles, openMarkdownTabs, setError]);
 
+	const newNoteFolder =
+		settingsSpacePath === spacePath && defaultNewNoteFolder
+			? defaultNewNoteFolder
+			: (activeDirPath ?? (activeFilePath ? parentDir(activeFilePath) : ""));
+
 	const createNoteInSelectedFolder = useCallback(async () => {
 		if (!spacePath) return null;
-		const nextDir =
-			dailyNotesFolder && activeDirPath === dailyNotesFolder
-				? ""
-				: (activeDirPath ?? "");
-		return fileTree.onNewFileInDir(nextDir);
-	}, [activeDirPath, dailyNotesFolder, fileTree, spacePath]);
+		return fileTree.onNewFileInDir(newNoteFolder);
+	}, [fileTree, newNoteFolder, spacePath]);
 
 	const handleNewNoteFromMenu = useCallback(() => {
 		if (!spacePath) return;
@@ -1419,6 +1421,7 @@ export function AppShell() {
 				onSelectDir={setActiveDirPath}
 				onOpenFile={(p) => void openWorkspaceFile(p)}
 				onNewNote={() => void createNoteInSelectedFolder()}
+				newNoteFolder={newNoteFolder}
 				onNewFileInDir={(p) => void fileTree.onNewFileInDir(p)}
 				onCreateFromTemplateInDir={(p) => void openTemplatePicker(p)}
 				onImportFilesInDir={importFilesInto}

--- a/src/components/app/Sidebar.tsx
+++ b/src/components/app/Sidebar.tsx
@@ -15,6 +15,7 @@ interface SidebarProps {
 	onSelectDir: (dirPath: string) => void;
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
+	newNoteFolder: string;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onImportFilesInDir: (dirPath: string) => void;
@@ -60,6 +61,7 @@ export const Sidebar = memo(function Sidebar({
 	onSelectDir,
 	onOpenFile,
 	onNewNote,
+	newNoteFolder,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
 	onImportFilesInDir,
@@ -139,6 +141,7 @@ export const Sidebar = memo(function Sidebar({
 									onSelectDir={onSelectDir}
 									onOpenFile={onOpenFile}
 									onNewNote={onNewNote}
+									newNoteFolder={newNoteFolder}
 									onNewFileInDir={onNewFileInDir}
 									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
 									onImportFilesInDir={onImportFilesInDir}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -43,6 +43,7 @@ interface SidebarContentProps {
 	onSelectDir: (dirPath: string) => void;
 	onOpenFile: (relPath: string) => void;
 	onNewNote: () => void;
+	newNoteFolder: string;
 	onNewFileInDir: (dirPath: string) => void;
 	onCreateFromTemplateInDir: (dirPath: string) => void;
 	onImportFilesInDir: (dirPath: string) => void;
@@ -141,6 +142,7 @@ export const SidebarContent = memo(function SidebarContent({
 	onSelectDir,
 	onOpenFile,
 	onNewNote,
+	newNoteFolder,
 	onNewFileInDir,
 	onCreateFromTemplateInDir,
 	onImportFilesInDir,
@@ -195,6 +197,9 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 	});
 	const newNoteShortcut = getBinding("new-note");
+	const newNoteTitle = newNoteFolder
+		? t("sidebar.newNoteInFolder", { folder: newNoteFolder })
+		: t("sidebar.newNoteInRoot");
 	const {
 		cancelHoverPrefetch: cancelAllDocsHoverPrefetch,
 		hoverPrefetchProps: allDocsHoverPrefetchProps,
@@ -376,7 +381,7 @@ export const SidebarContent = memo(function SidebarContent({
 							data-kind="new-note"
 							aria-label={t("sidebar.newNote")}
 							onClick={onNewNote}
-							title={`${t("sidebar.newNote")}${
+							title={`${newNoteTitle}${
 								newNoteShortcut
 									? ` (${formatShortcutForPlatform(newNoteShortcut)})`
 									: ""

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -119,31 +119,42 @@ export function SpaceSettingsPane() {
 		}
 	}, [currentSpacePath]);
 
-	const refresh = useCallback(async () => {
-		setError("");
-		try {
-			const currentSpace = spacePath ?? (await invoke("space_get_current"));
-			const settingsScope = { spacePath: currentSpace };
-			const settings = await loadSettings(settingsScope);
-			setCurrentSpacePath(currentSpace);
-			setDailyNotesFolderState(settings.dailyNotes.folder);
-			setDefaultNewNoteFolder(settings.noteCreation?.defaultFolder ?? null);
-			setPeriodNotesEnabled(
-				periodNotesEnabledFromSettings(settings.dailyNotes),
-			);
-			setQuickNotesFolderState(settings.quickNotes.folder);
-			setAttachmentStorageModeState(settings.editor.attachmentStorageMode);
-			setAttachmentFolderState(
-				settings.editor.attachmentFolder ?? DEFAULT_ATTACHMENT_FOLDER,
-			);
-			setEnablePeopleMentionsAsTags(settings.editor.enablePeopleMentionsAsTags);
-		} catch (e) {
-			setError(extractErrorMessage(e));
-		}
-	}, [spacePath]);
+	const refresh = useCallback(
+		async (isCurrent: () => boolean) => {
+			setError("");
+			try {
+				const currentSpace = spacePath ?? (await invoke("space_get_current"));
+				const settingsScope = { spacePath: currentSpace };
+				const settings = await loadSettings(settingsScope);
+				if (!isCurrent()) return;
+				setCurrentSpacePath(currentSpace);
+				setDailyNotesFolderState(settings.dailyNotes.folder);
+				setDefaultNewNoteFolder(settings.noteCreation?.defaultFolder ?? null);
+				setPeriodNotesEnabled(
+					periodNotesEnabledFromSettings(settings.dailyNotes),
+				);
+				setQuickNotesFolderState(settings.quickNotes.folder);
+				setAttachmentStorageModeState(settings.editor.attachmentStorageMode);
+				setAttachmentFolderState(
+					settings.editor.attachmentFolder ?? DEFAULT_ATTACHMENT_FOLDER,
+				);
+				setEnablePeopleMentionsAsTags(
+					settings.editor.enablePeopleMentionsAsTags,
+				);
+			} catch (e) {
+				if (!isCurrent()) return;
+				setError(extractErrorMessage(e));
+			}
+		},
+		[spacePath],
+	);
 
 	useEffect(() => {
-		void refresh();
+		let cancelled = false;
+		void refresh(() => !cancelled);
+		return () => {
+			cancelled = true;
+		};
 	}, [refresh]);
 
 	useTauriEvent("settings:updated", (payload) => {

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -74,6 +74,12 @@ export function SpaceSettingsPane() {
 		null,
 	);
 	const [dailyNotesError, setDailyNotesError] = useState<string | null>(null);
+	const [defaultNewNoteFolder, setDefaultNewNoteFolder] = useState<
+		string | null
+	>(null);
+	const [defaultNewNoteError, setDefaultNewNoteError] = useState<string | null>(
+		null,
+	);
 	const [periodNotesError, setPeriodNotesError] = useState<string | null>(null);
 	const [periodNotesEnabled, setPeriodNotesEnabled] = useState(
 		DEFAULT_PERIOD_NOTES_ENABLED,
@@ -121,6 +127,7 @@ export function SpaceSettingsPane() {
 			const settings = await loadSettings(settingsScope);
 			setCurrentSpacePath(currentSpace);
 			setDailyNotesFolderState(settings.dailyNotes.folder);
+			setDefaultNewNoteFolder(settings.noteCreation?.defaultFolder ?? null);
 			setPeriodNotesEnabled(
 				periodNotesEnabledFromSettings(settings.dailyNotes),
 			);
@@ -140,6 +147,9 @@ export function SpaceSettingsPane() {
 	}, [refresh]);
 
 	useTauriEvent("settings:updated", (payload) => {
+		if (payload.noteCreation && "defaultFolder" in payload.noteCreation) {
+			setDefaultNewNoteFolder(payload.noteCreation.defaultFolder ?? null);
+		}
 		if (typeof payload.editor?.enablePeopleMentionsAsTags === "boolean") {
 			setEnablePeopleMentionsAsTags(payload.editor.enablePeopleMentionsAsTags);
 		}
@@ -203,6 +213,36 @@ export function SpaceSettingsPane() {
 			setDailyNotesError(
 				cause instanceof Error ? cause.message : "Failed to clear folder",
 			);
+		}
+	}, [currentSpacePath]);
+
+	const handleBrowseDefaultNewNoteFolder = useCallback(async () => {
+		setDefaultNewNoteError(null);
+		try {
+			const selection = await selectFolderRelativeToSpace();
+			if (selection === null) return;
+			await writeSpaceSetting(
+				SPACE_SETTINGS.noteCreationDefaultFolder,
+				selection.relativePath || null,
+				{ spacePath: selection.spacePath },
+			);
+			setCurrentSpacePath(selection.spacePath);
+			setDefaultNewNoteFolder(selection.relativePath || null);
+		} catch (cause) {
+			setDefaultNewNoteError(extractErrorMessage(cause));
+		}
+	}, []);
+
+	const handleClearDefaultNewNoteFolder = useCallback(async () => {
+		setDefaultNewNoteError(null);
+		try {
+			const spacePath = requireSpacePath(currentSpacePath);
+			await writeSpaceSetting(SPACE_SETTINGS.noteCreationDefaultFolder, null, {
+				spacePath,
+			});
+			setDefaultNewNoteFolder(null);
+		} catch (cause) {
+			setDefaultNewNoteError(extractErrorMessage(cause));
 		}
 	}, [currentSpacePath]);
 
@@ -371,6 +411,32 @@ export function SpaceSettingsPane() {
 			{error ? <div className="settingsError">{error}</div> : null}
 
 			<div className="settingsGrid">
+				<SettingsSection
+					title={t("newNotes.sectionTitle")}
+					description={t("newNotes.sectionDescription")}
+				>
+					<SettingsRow
+						searchId="space-default-new-note-folder"
+						label={t("newNotes.defaultFolder.label")}
+						description={t("newNotes.defaultFolder.description")}
+						stacked
+						interactive={false}
+					>
+						<SettingsFolderPicker
+							path={defaultNewNoteFolder ?? t("newNotes.root")}
+							browseLabel={t("newNotes.browse")}
+							clearLabel={t("newNotes.clear")}
+							onBrowse={() => void handleBrowseDefaultNewNoteFolder()}
+							onClear={
+								defaultNewNoteFolder
+									? () => void handleClearDefaultNewNoteFolder()
+									: undefined
+							}
+							error={defaultNewNoteError}
+						/>
+					</SettingsRow>
+				</SettingsSection>
+
 				<SettingsSection
 					title="Daily Notes"
 					description="Choose where dated notes are created in the current space."

--- a/src/components/settings/SpaceSettingsPane.tsx
+++ b/src/components/settings/SpaceSettingsPane.tsx
@@ -100,7 +100,7 @@ export function SpaceSettingsPane() {
 	const [enablePeopleMentionsAsTags, setEnablePeopleMentionsAsTags] =
 		useState(false);
 	const [isSavingPeopleMentions, setIsSavingPeopleMentions] = useState(false);
-	const { startIndexRebuild } = useSpace();
+	const { spacePath, startIndexRebuild } = useSpace();
 
 	const onRebuildIndex = useCallback(async () => {
 		if (!currentSpacePath) {
@@ -122,7 +122,7 @@ export function SpaceSettingsPane() {
 	const refresh = useCallback(async () => {
 		setError("");
 		try {
-			const currentSpace = await invoke("space_get_current");
+			const currentSpace = spacePath ?? (await invoke("space_get_current"));
 			const settingsScope = { spacePath: currentSpace };
 			const settings = await loadSettings(settingsScope);
 			setCurrentSpacePath(currentSpace);
@@ -140,13 +140,14 @@ export function SpaceSettingsPane() {
 		} catch (e) {
 			setError(extractErrorMessage(e));
 		}
-	}, []);
+	}, [spacePath]);
 
 	useEffect(() => {
 		void refresh();
 	}, [refresh]);
 
 	useTauriEvent("settings:updated", (payload) => {
+		if (payload.spacePath && payload.spacePath !== spacePath) return;
 		if (payload.noteCreation && "defaultFolder" in payload.noteCreation) {
 			setDefaultNewNoteFolder(payload.noteCreation.defaultFolder ?? null);
 		}
@@ -236,15 +237,15 @@ export function SpaceSettingsPane() {
 	const handleClearDefaultNewNoteFolder = useCallback(async () => {
 		setDefaultNewNoteError(null);
 		try {
-			const spacePath = requireSpacePath(currentSpacePath);
+			const activeSpacePath = requireSpacePath(spacePath);
 			await writeSpaceSetting(SPACE_SETTINGS.noteCreationDefaultFolder, null, {
-				spacePath,
+				spacePath: activeSpacePath,
 			});
 			setDefaultNewNoteFolder(null);
 		} catch (cause) {
 			setDefaultNewNoteError(extractErrorMessage(cause));
 		}
-	}, [currentSpacePath]);
+	}, [spacePath]);
 
 	const handlePeriodNoteToggle = useCallback(
 		async (kind: OptionalPeriodKind, checked: boolean) => {

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -71,6 +71,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "space-monthly-notes", tab: "space" },
 	{ id: "space-quarterly-notes", tab: "space" },
 	{ id: "space-quick-notes-folder", tab: "space" },
+	{ id: "space-default-new-note-folder", tab: "space" },
 	{ id: "space-attachments-location", tab: "space" },
 	{ id: "space-template-folder", tab: "space" },
 	{ id: "space-default-daily-template", tab: "space" },

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -52,11 +52,12 @@ interface UILayoutContextValue {
 	activeMarkdownTabPath: string | null;
 	setActiveMarkdownTabPath: (path: string | null) => void;
 	dailyNotesFolder: string | null;
+	defaultNewNoteFolder: string | null;
 	templateFolder: string | null;
 	periodNoteTemplates: PeriodNoteTemplatePaths;
 	periodNotesEnabled: PeriodNotesEnabled;
 	/**
-	 * The space whose settings `dailyNotesFolder`, `templateFolder` and
+	 * The space whose folder and template settings
 	 * period note templates currently describe. Hydration is async, so after a
 	 * space switch those values lag until this matches the new space path.
 	 */
@@ -95,6 +96,7 @@ type UIState = {
 	openMarkdownTabs: string[];
 	activeMarkdownTabPath: string | null;
 	dailyNotesFolder: string | null;
+	defaultNewNoteFolder: string | null;
 	templateFolder: string | null;
 	periodNoteTemplates: PeriodNoteTemplatePaths;
 	periodNotesEnabled: PeriodNotesEnabled;
@@ -117,6 +119,7 @@ type UIAction =
 	| { type: "setOpenMarkdownTabs"; value: SetStateAction<string[]> }
 	| { type: "setActiveMarkdownTabPath"; value: string | null }
 	| { type: "setDailyNotesFolder"; value: string | null }
+	| { type: "setDefaultNewNoteFolder"; value: string | null }
 	| { type: "setTemplateFolder"; value: string | null }
 	| {
 			type: "setPeriodNoteEnabled";
@@ -145,6 +148,7 @@ type UIAction =
 			aiEnabled: boolean;
 			aiAssistantMode: AiAssistantMode;
 			dailyNotesFolder: string | null;
+			defaultNewNoteFolder: string | null;
 			templateFolder: string | null;
 			periodNoteTemplates: PeriodNoteTemplatePaths;
 			periodNotesEnabled: PeriodNotesEnabled;
@@ -156,6 +160,7 @@ type UIAction =
 			type: "hydrateSpaceSettings";
 			spacePath: string;
 			dailyNotesFolder: string | null;
+			defaultNewNoteFolder: string | null;
 			templateFolder: string | null;
 			periodNoteTemplates: PeriodNoteTemplatePaths;
 			periodNotesEnabled: PeriodNotesEnabled;
@@ -168,6 +173,7 @@ const initialUIState: UIState = {
 	openMarkdownTabs: [],
 	activeMarkdownTabPath: null,
 	dailyNotesFolder: null,
+	defaultNewNoteFolder: null,
 	templateFolder: null,
 	periodNoteTemplates: EMPTY_PERIOD_NOTE_TEMPLATES,
 	periodNotesEnabled: DEFAULT_PERIOD_NOTES_ENABLED,
@@ -203,6 +209,8 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 			return { ...state, activeMarkdownTabPath: action.value };
 		case "setDailyNotesFolder":
 			return { ...state, dailyNotesFolder: action.value };
+		case "setDefaultNewNoteFolder":
+			return { ...state, defaultNewNoteFolder: action.value };
 		case "setTemplateFolder":
 			return { ...state, templateFolder: action.value };
 		case "setPeriodNoteTemplate":
@@ -277,6 +285,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				...state,
 				settingsSpacePath: action.spacePath,
 				dailyNotesFolder: action.dailyNotesFolder,
+				defaultNewNoteFolder: action.defaultNewNoteFolder,
 				templateFolder: action.templateFolder,
 				periodNoteTemplates: action.periodNoteTemplates,
 				periodNotesEnabled: action.periodNotesEnabled,
@@ -289,6 +298,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				aiPanelOpen: action.aiEnabled ? state.aiPanelOpen : false,
 				aiAssistantMode: action.aiAssistantMode,
 				dailyNotesFolder: action.dailyNotesFolder,
+				defaultNewNoteFolder: action.defaultNewNoteFolder,
 				templateFolder: action.templateFolder,
 				periodNoteTemplates: action.periodNoteTemplates,
 				periodNotesEnabled: action.periodNotesEnabled,
@@ -312,6 +322,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		openMarkdownTabs,
 		activeMarkdownTabPath,
 		dailyNotesFolder,
+		defaultNewNoteFolder,
 		templateFolder,
 		periodNoteTemplates,
 		periodNotesEnabled,
@@ -360,6 +371,12 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			dispatch({
 				type: "setDailyNotesFolder",
 				value: payload.dailyNotes.folder ?? null,
+			});
+		}
+		if (payload.noteCreation && "defaultFolder" in payload.noteCreation) {
+			dispatch({
+				type: "setDefaultNewNoteFolder",
+				value: payload.noteCreation.defaultFolder ?? null,
 			});
 		}
 		if (typeof payload.dailyNotes?.weeklyNotes === "boolean") {
@@ -434,6 +451,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					aiEnabled: s.ui.aiEnabled,
 					aiAssistantMode: s.ui.aiAssistantMode,
 					dailyNotesFolder: s.dailyNotes?.folder ?? null,
+					defaultNewNoteFolder: s.noteCreation.defaultFolder,
 					templateFolder: s.templates?.folder ?? null,
 					periodNoteTemplates: periodNoteTemplatesFromSettings(s.templates),
 					periodNotesEnabled: periodNotesEnabledFromSettings(s.dailyNotes),
@@ -480,6 +498,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					type: "hydrateSpaceSettings",
 					spacePath,
 					dailyNotesFolder: s.dailyNotes?.folder ?? null,
+					defaultNewNoteFolder: s.noteCreation.defaultFolder,
 					templateFolder: s.templates?.folder ?? null,
 					periodNoteTemplates: periodNoteTemplatesFromSettings(s.templates),
 					periodNotesEnabled: periodNotesEnabledFromSettings(s.dailyNotes),
@@ -574,6 +593,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			activeMarkdownTabPath,
 			setActiveMarkdownTabPath,
 			dailyNotesFolder,
+			defaultNewNoteFolder,
 			templateFolder,
 			periodNoteTemplates,
 			periodNotesEnabled,
@@ -602,6 +622,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			activeMarkdownTabPath,
 			setActiveMarkdownTabPath,
 			dailyNotesFolder,
+			defaultNewNoteFolder,
 			templateFolder,
 			periodNoteTemplates,
 			periodNotesEnabled,

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -9,6 +9,17 @@
 		"searchAriaLabel": "Search settings",
 		"clearSearchAriaLabel": "Clear settings search"
 	},
+	"newNotes": {
+		"sectionTitle": "New notes",
+		"sectionDescription": "Choose where Glyph creates new notes in this space.",
+		"root": "Not configured",
+		"browse": "Browse",
+		"clear": "Clear default folder",
+		"defaultFolder": {
+			"label": "Default folder",
+			"description": "New Note and Cmd+N create notes here when a folder is set."
+		}
+	},
 	"usage": {
 		"loading": "Loading insights…",
 		"noSpace": "Open a space to view insights.",

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -352,6 +352,12 @@
 			"description": "Choose where quick notes are saved.",
 			"keywords": ["capture", "inbox"]
 		},
+		"space-default-new-note-folder": {
+			"title": "Default folder",
+			"section": "New notes",
+			"description": "Choose where new notes are created.",
+			"keywords": ["new note", "create", "folder", "location"]
+		},
 		"space-attachments-location": {
 			"title": "Location",
 			"section": "Attachments",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -4,6 +4,8 @@
 		"expand": "Expand sidebar",
 		"devBadge": "DEV",
 		"newNote": "New Note",
+		"newNoteInFolder": "Create new note in {{folder}}",
+		"newNoteInRoot": "Create new note in the workspace root",
 		"pinned": "Pinned",
 		"allNotes": "All Notes",
 		"collections": "Collections",

--- a/src/i18n/locales/fr/settings.general.json
+++ b/src/i18n/locales/fr/settings.general.json
@@ -9,6 +9,17 @@
 		"searchAriaLabel": "Rechercher dans les réglages",
 		"clearSearchAriaLabel": "Effacer la recherche des réglages"
 	},
+	"newNotes": {
+		"sectionTitle": "Nouvelles notes",
+		"sectionDescription": "Choisissez où Glyph crée les nouvelles notes dans cet espace.",
+		"root": "Non configuré",
+		"browse": "Parcourir",
+		"clear": "Effacer le dossier par défaut",
+		"defaultFolder": {
+			"label": "Dossier par défaut",
+			"description": "Nouvelle note et Cmd+N créent les notes ici lorsqu’un dossier est défini."
+		}
+	},
 	"usage": {
 		"loading": "Chargement des aperçus…",
 		"noSpace": "Ouvrez un espace pour voir les aperçus.",

--- a/src/i18n/locales/fr/settings.search.json
+++ b/src/i18n/locales/fr/settings.search.json
@@ -373,6 +373,12 @@
 			"description": "Choose where quick notes are saved.",
 			"keywords": ["capture", "inbox"]
 		},
+		"space-default-new-note-folder": {
+			"title": "Dossier par défaut",
+			"section": "Nouvelles notes",
+			"description": "Choisissez où les nouvelles notes sont créées.",
+			"keywords": ["nouvelle note", "créer", "dossier", "emplacement"]
+		},
 		"space-attachments-location": {
 			"title": "Location",
 			"section": "Attachments",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -4,6 +4,8 @@
 		"expand": "Développer la barre latérale",
 		"devBadge": "DEV",
 		"newNote": "Nouvelle note",
+		"newNoteInFolder": "Créer une note dans {{folder}}",
+		"newNoteInRoot": "Créer une note à la racine de l’espace",
 		"pinned": "Épinglées",
 		"allNotes": "Toutes les notes",
 		"collections": "Collections",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -262,10 +262,13 @@ function normalizeSpaceScopedSettings(value: unknown): SpaceScopedSettings {
 		);
 	}
 	if ("noteCreationDefaultFolder" in value) {
+		const folder = SPACE_SETTINGS.noteCreationDefaultFolder.normalize(
+			value.noteCreationDefaultFolder,
+		);
 		out.noteCreationDefaultFolder =
-			SPACE_SETTINGS.noteCreationDefaultFolder.normalize(
-				value.noteCreationDefaultFolder,
-			);
+			SPACE_SETTINGS.noteCreationDefaultFolder.validate?.(folder)
+				? null
+				: folder;
 	}
 	if ("templatesFolder" in value) {
 		out.templatesFolder =
@@ -433,7 +436,10 @@ function loadSpaceSettingValue<Value>(
 	const storedValue = hasActiveSpace
 		? activeSettings?.[definition.field]
 		: entries.get(definition.legacyKey);
-	return definition.normalize(storedValue);
+	const normalized = definition.normalize(storedValue);
+	return definition.validate?.(normalized)
+		? definition.defaultValue
+		: normalized;
 }
 
 export async function loadSettings(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -261,6 +261,12 @@ function normalizeSpaceScopedSettings(value: unknown): SpaceScopedSettings {
 			value.quickNotesFolder,
 		);
 	}
+	if ("noteCreationDefaultFolder" in value) {
+		out.noteCreationDefaultFolder =
+			SPACE_SETTINGS.noteCreationDefaultFolder.normalize(
+				value.noteCreationDefaultFolder,
+			);
+	}
 	if ("templatesFolder" in value) {
 		out.templatesFolder =
 			typeof value.templatesFolder === "string"
@@ -533,6 +539,12 @@ export async function loadSettings(
 		activeScopedSettings,
 		hasActiveSpace,
 	);
+	const noteCreationDefaultFolder = loadSpaceSettingValue(
+		SPACE_SETTINGS.noteCreationDefaultFolder,
+		entries,
+		activeScopedSettings,
+		hasActiveSpace,
+	);
 	const legacyTemplatesFolder = entries.get(
 		INTERNAL_SETTING_KEYS.templatesFolder,
 	);
@@ -650,6 +662,9 @@ export async function loadSettings(
 		},
 		quickNotes: {
 			folder: quickNotesFolder,
+		},
+		noteCreation: {
+			defaultFolder: noteCreationDefaultFolder,
 		},
 		templates: {
 			folder: templatesFolder,

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -200,6 +200,11 @@ function nullablePath(value: unknown): string | null {
 	return typeof value === "string" ? normalizeRelPath(value) || null : null;
 }
 
+function normalizeDefaultNewNoteFolder(value: unknown): string | null {
+	const path = nullablePath(value);
+	return path && !validateRelFolderPath(path) ? path : null;
+}
+
 function isThemeMode(value: unknown): value is ThemeMode {
 	return value === "system" || value === "light" || value === "dark";
 }
@@ -733,7 +738,7 @@ export const SPACE_SETTINGS = {
 		field: "noteCreationDefaultFolder",
 		defaultValue: null,
 		discovery: searchable("space-default-new-note-folder"),
-		normalize: nullablePath,
+		normalize: normalizeDefaultNewNoteFolder,
 		parse: (value) =>
 			typeof value === "string" || value === null
 				? parsed(value)

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -200,11 +200,6 @@ function nullablePath(value: unknown): string | null {
 	return typeof value === "string" ? normalizeRelPath(value) || null : null;
 }
 
-function normalizeDefaultNewNoteFolder(value: unknown): string | null {
-	const path = nullablePath(value);
-	return path && !validateRelFolderPath(path) ? path : null;
-}
-
 function isThemeMode(value: unknown): value is ThemeMode {
 	return value === "system" || value === "light" || value === "dark";
 }
@@ -738,7 +733,7 @@ export const SPACE_SETTINGS = {
 		field: "noteCreationDefaultFolder",
 		defaultValue: null,
 		discovery: searchable("space-default-new-note-folder"),
-		normalize: normalizeDefaultNewNoteFolder,
+		normalize: nullablePath,
 		parse: (value) =>
 			typeof value === "string" || value === null
 				? parsed(value)

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -728,6 +728,21 @@ export const SPACE_SETTINGS = {
 		patch: (value) => ({ quickNotesFolder: value }),
 		change: (value) => ({ quickNotes: { folder: value } }),
 	}),
+	noteCreationDefaultFolder: defineSpaceSetting({
+		legacyKey: "noteCreation.defaultFolder",
+		field: "noteCreationDefaultFolder",
+		defaultValue: null,
+		discovery: searchable("space-default-new-note-folder"),
+		normalize: nullablePath,
+		parse: (value) =>
+			typeof value === "string" || value === null
+				? parsed(value)
+				: INVALID_PARSE_RESULT,
+		read: (settings) => settings.noteCreation.defaultFolder,
+		patch: (value) => ({ noteCreationDefaultFolder: value }),
+		change: (value) => ({ noteCreation: { defaultFolder: value } }),
+		validate: (value) => (value === null ? null : validateRelFolderPath(value)),
+	}),
 	templatesDailyNoteTemplate: defineSpaceSetting({
 		legacyKey: "templates.dailyNoteTemplate",
 		field: "templatesDailyNoteTemplate",

--- a/src/lib/settings/model.ts
+++ b/src/lib/settings/model.ts
@@ -37,6 +37,10 @@ export interface QuickNotesSettings {
 	folder: string;
 }
 
+export interface NoteCreationSettings {
+	defaultFolder: string | null;
+}
+
 export interface EditorSettings {
 	showCollapsibleHeadings: boolean;
 	showCollapsibleLists: boolean;
@@ -117,6 +121,7 @@ export interface AppSettings {
 		quarterlyNotes: boolean;
 	};
 	quickNotes: QuickNotesSettings;
+	noteCreation: NoteCreationSettings;
 	templates: {
 		folder: string | null;
 		dailyNoteTemplate: string | null;
@@ -135,6 +140,7 @@ export interface SpaceScopedSettings {
 	dailyNotesMonthlyNotes?: boolean;
 	dailyNotesQuarterlyNotes?: boolean;
 	quickNotesFolder?: string;
+	noteCreationDefaultFolder?: string | null;
 	templatesFolder?: string | null;
 	templatesDailyNoteTemplate?: string | null;
 	templatesWeeklyNoteTemplate?: string | null;
@@ -150,6 +156,7 @@ interface SettingsChangeSections {
 	ui: AppSettings["ui"];
 	dailyNotes: AppSettings["dailyNotes"];
 	quickNotes: AppSettings["quickNotes"];
+	noteCreation: AppSettings["noteCreation"];
 	templates: AppSettings["templates"];
 	database: AppSettings["database"];
 	editor: AppSettings["editor"];


### PR DESCRIPTION
Closes

## Description

Adds a per-space default folder for new notes.

- Adds the Default folder picker in Settings > Space, with clear-to-unset behavior.
- Routes New Note and Cmd+N to the default folder when configured.
- Preserves selected-folder, current-note-folder, and workspace-root fallback behavior when unset.
- Shows the resolved destination in the New Note tooltip and registers the setting in settings search.

## Screenshots

Not captured.

## Docs

No documentation changes are needed.

## Ready?

- [ ] Documented what is new
- [ ] Added in-code documentation where needed
- [ ] Wrote tests for new components or features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Configure and apply a per-space default destination for new notes while retaining existing fallback behavior when it is unset.

New Features:
- Add a per-space setting to choose the default folder for newly created notes, with browse and clear controls.
- Create new notes in the configured folder and expose the resolved destination in the New Note tooltip.

Bug Fixes:
- Preserve sensible folder fallbacks for new notes when no default is configured, including the selected folder, current note folder, and workspace root.

Enhancements:
- Keep the default new-note folder synchronized across space settings, UI state, and settings update events.
- Validate configured folder paths and make the setting available through settings search.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-space default folder for New Note and Cmd+N so teams can centralize new content. Previously, creating a note while the Daily Notes folder was selected forced the workspace root; now we target a configured default or the selected/current folder, falling back to root.

- Adds “New notes > Default folder” in Space settings with browse/clear; persisted as `noteCreation.defaultFolder` and searchable as “space-default-new-note-folder”.
- Resolves the destination only when the setting’s space matches the active space; otherwise uses the selected folder or current note’s folder; sidebar tooltip shows “Create new note in …”.
- Hydrates and updates `defaultNewNoteFolder` via `UIContext`; listens to `settings:updated` scoped by space and ignores stale settings refreshes on space switches.
- Validates and normalizes relative folder paths; invalid paths are rejected and treated as unset. Adds en/fr strings for settings and sidebar tooltips.
- No migration required. Behavior change: removed the special-case redirect that sent New Note out of the Daily Notes folder to root when no default is set.

<sup>Written for commit 322a5ad604452aa6436a37ce10065882866f8eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable default folder for new note creation per space
> - Adds a new space-scoped setting `noteCreation.defaultFolder` configurable via a new "New notes" section in [SpaceSettingsPane.tsx](https://github.com/SidhuK/Glyph/pull/512/files#diff-4007f5875278144c68dd565a40ec69385835ac2359e21264fe18a1a7e394e4e0).
> - New notes are created in the configured default folder when set; otherwise they fall back to the active directory, parent of the active file, or workspace root.
> - The New Note button tooltip in [SidebarContent.tsx](https://github.com/SidhuK/Glyph/pull/512/files#diff-3353d28e4e1612b92e2095faa9dc64e7b38b0b4cfed251479b8c872e454b6804) dynamically reflects the target folder.
> - The `defaultNewNoteFolder` value is hydrated into [UIContext.tsx](https://github.com/SidhuK/Glyph/pull/512/files#diff-621870439bb5ad737936ff3a07d7939baa11bd9431b77c44453dc2a13d6eec40) and kept in sync with live `settings:updated` events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 322a5ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-space setting to choose the default folder for new notes.
  * New notes now open in the configured folder, or at the root when no folder is selected.
  * Added folder browsing and clearing controls in settings.
  * The new-note sidebar action now indicates its destination.
  * Added English and French translations and settings search support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->