### PR TITLE
Add Grok Build CLI as an Agents provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Repo extras: agents may read `docs/agents/` and `docs/architecture/adr/`. All ot
 
 ## Backend Overview (`src-tauri/src/`)
 
-- Tauri setup and command registration live in `lib.rs` / `main.rs`; native features are grouped by domain such as `space`, `space_fs`, `notes`, `index`, `databases`, `ai_*` (`ai_rig`, `ai_codex`, `ai_amp`, `ai_claude_code`, `ai_cursor`, `ai_opencode`, `ai_pi`), `git_sync`, `license`, and `external_markdown`.
+- Tauri setup and command registration live in `lib.rs` / `main.rs`; native features are grouped by domain such as `space`, `space_fs`, `notes`, `index`, `databases`, `ai_*` (`ai_rig`, `ai_codex`, `ai_amp`, `ai_claude_code`, `ai_cursor`, `ai_grok`, `ai_opencode`, `ai_pi`), `git_sync`, `license`, and `external_markdown`.
 - Use `paths::join_under()` for safe space paths, `io_atomic::write_atomic()` for durable writes, and `net.rs` checks for user-supplied URLs.
 
 ## Code Style & Safety

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
-    process::Command as StdCommand,
     time::Duration,
 };
 
@@ -27,6 +26,7 @@ use crate::ai_rig::{
 const RUN_TIMEOUT: Duration = Duration::from_secs(600);
 const EXIT_AFTER_RESULT_GRACE: Duration = Duration::from_secs(2);
 const STARTUP_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
+const LIST_MODELS_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_MODEL_ID: &str = "grok-build";
 const CHAT_TOOLS: &str = "read_file,grep,list_dir";
 const GROK_ALIAS_MODELS: &[(&str, &str, &str)] = &[
@@ -171,18 +171,24 @@ fn collect_models_from_config(models: &mut Vec<String>, seen: &mut HashSet<Strin
     }
 }
 
-fn collect_models_from_runtime(
+async fn collect_models_from_runtime(
     binary: &Path,
     models: &mut Vec<String>,
     seen: &mut HashSet<String>,
 ) {
-    if let Ok(output) = StdCommand::new(binary).arg("--help").output() {
-        collect_models_from_text(&String::from_utf8_lossy(&output.stdout), models, seen);
-        collect_models_from_text(&String::from_utf8_lossy(&output.stderr), models, seen);
+    let mut command = Command::new(binary);
+    command.arg("--help").kill_on_drop(true);
+    if let Some(path) = cli_runtime_path(binary) {
+        command.env("PATH", path);
     }
+    let Ok(Ok(output)) = tokio::time::timeout(LIST_MODELS_TIMEOUT, command.output()).await else {
+        return;
+    };
+    collect_models_from_text(&String::from_utf8_lossy(&output.stdout), models, seen);
+    collect_models_from_text(&String::from_utf8_lossy(&output.stderr), models, seen);
 }
 
-pub fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
+pub async fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
     let binary = find_grok_binary()?;
     let mut seen = HashSet::new();
     let mut ids = Vec::new();
@@ -190,7 +196,7 @@ pub fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
     for (id, _, _) in GROK_ALIAS_MODELS {
         push_model_id(&mut ids, &mut seen, id);
     }
-    collect_models_from_runtime(&binary, &mut ids, &mut seen);
+    collect_models_from_runtime(&binary, &mut ids, &mut seen).await;
     collect_models_from_config(&mut ids, &mut seen);
     push_model_id(&mut ids, &mut seen, &profile.model);
 

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -158,7 +158,7 @@ fn collect_models_from_config(models: &mut Vec<String>, seen: &mut HashSet<Strin
             let line = line.trim();
             if let Some(rest) = line.strip_prefix("[model.") {
                 let id = rest.trim_end_matches(']').trim_matches('"').trim();
-                if is_grok_model_id(id) || !id.is_empty() {
+                if is_grok_model_id(id) {
                     push_model_id(models, seen, id);
                 }
                 continue;

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -129,12 +129,31 @@ fn is_grok_model_id(id: &str) -> bool {
 }
 
 fn collect_models_from_text(text: &str, models: &mut Vec<String>, seen: &mut HashSet<String>) {
-    for token in
-        text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_'))
-    {
+    for line in text.lines() {
+        let Some(token) = line.split_whitespace().next() else {
+            continue;
+        };
         if is_grok_model_id(token) {
             push_model_id(models, seen, token);
         }
+    }
+}
+
+fn collect_default_model_from_config_line(
+    line: &str,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    let Some((key, value)) = line.split_once('=') else {
+        return;
+    };
+    if key.trim() != "default_model" {
+        return;
+    }
+    let value = value.split_once('#').map_or(value, |(value, _)| value).trim();
+    let value = value.trim_matches(['"', '\'']);
+    if is_grok_model_id(value) {
+        push_model_id(models, seen, value);
     }
 }
 
@@ -177,10 +196,7 @@ async fn collect_models_from_config(
                 }
                 continue;
             }
-            if line.starts_with('#') || !line.contains("default") {
-                continue;
-            }
-            collect_models_from_text(line, models, seen);
+            collect_default_model_from_config_line(line, models, seen);
         }
     }
     Ok(())
@@ -200,7 +216,6 @@ async fn collect_models_from_runtime(
         return;
     };
     collect_models_from_text(&String::from_utf8_lossy(&output.stdout), models, seen);
-    collect_models_from_text(&String::from_utf8_lossy(&output.stderr), models, seen);
 }
 
 pub async fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
@@ -304,7 +319,7 @@ fn event_text(value: &Value) -> Option<&str> {
         .or_else(|| value.get("message").and_then(|v| v.as_str()))
 }
 
-fn tool_name(value: &Value) -> &str {
+fn explicit_tool_name(value: &Value) -> Option<&str> {
     value
         .get("toolName")
         .or_else(|| value.get("tool_name"))
@@ -312,7 +327,6 @@ fn tool_name(value: &Value) -> &str {
         .or_else(|| value.get("kind"))
         .and_then(|v| v.as_str())
         .filter(|name| !name.is_empty())
-        .unwrap_or("tool")
 }
 
 fn tool_call_id(value: &Value) -> Option<String> {
@@ -342,15 +356,30 @@ fn handle_tool_call(
     job_id: &str,
     value: &Value,
     tool_events: &mut Vec<AiStoredToolEvent>,
+    active_tools: &mut HashMap<String, String>,
     phase: &str,
 ) {
+    let call_id = tool_call_id(value);
+    let explicit_name = explicit_tool_name(value);
+    let tool = explicit_name
+        .or_else(|| call_id.as_ref().and_then(|id| active_tools.get(id).map(String::as_str)))
+        .unwrap_or("tool")
+        .to_string();
+    if let Some(call_id) = &call_id {
+        if phase == "call" || explicit_name.is_some() {
+            active_tools.insert(call_id.clone(), tool.clone());
+        }
+        if matches!(phase, "result" | "error") {
+            active_tools.remove(call_id);
+        }
+    }
     emit_tool(
         app,
         job_id,
         tool_events,
-        tool_name(value),
+        &tool,
         phase,
-        tool_call_id(value),
+        call_id,
         Some(value.clone()),
         if phase == "error" {
             tool_error(value)
@@ -366,6 +395,7 @@ fn handle_event(
     value: &Value,
     full: &mut String,
     tool_events: &mut Vec<AiStoredToolEvent>,
+    active_tools: &mut HashMap<String, String>,
 ) -> Result<Option<bool>, String> {
     match value.get("type").and_then(|v| v.as_str()) {
         Some("text") => {
@@ -379,7 +409,7 @@ fn handle_event(
             Ok(None)
         }
         Some("tool_call") => {
-            handle_tool_call(app, job_id, value, tool_events, "call");
+            handle_tool_call(app, job_id, value, tool_events, active_tools, "call");
             Ok(None)
         }
         Some("tool_call_update") => {
@@ -389,7 +419,7 @@ fn handle_event(
                 "in_progress" | "pending" => return Ok(None),
                 _ => "result",
             };
-            handle_tool_call(app, job_id, value, tool_events, phase);
+            handle_tool_call(app, job_id, value, tool_events, active_tools, phase);
             Ok(None)
         }
         Some("end") => {
@@ -491,6 +521,7 @@ pub async fn run_with_grok(
     tokio::pin!(startup_timeout);
     let mut full = String::new();
     let mut tool_events = Vec::new();
+    let mut active_tools = HashMap::new();
     let mut last_stderr = String::new();
     let mut saw_stdout = false;
     let mut stderr_open = true;
@@ -560,7 +591,14 @@ pub async fn run_with_grok(
                         });
                     }
                 };
-                match handle_event(app, job_id, &value, &mut full, &mut tool_events) {
+                match handle_event(
+                    app,
+                    job_id,
+                    &value,
+                    &mut full,
+                    &mut tool_events,
+                    &mut active_tools,
+                ) {
                     Ok(Some(done)) => {
                         wait_after_result(&mut child, &last_stderr).await?;
                         return Ok((full, done, tool_events));

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -192,7 +192,7 @@ async fn collect_models_from_runtime(
     seen: &mut HashSet<String>,
 ) {
     let mut command = Command::new(binary);
-    command.arg("--help").kill_on_drop(true);
+    command.arg("models").kill_on_drop(true);
     if let Some(path) = cli_runtime_path(binary) {
         command.env("PATH", path);
     }
@@ -248,36 +248,6 @@ async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
 async fn stop_child(child: &mut Child) {
     let _ = child.kill().await;
     let _ = child.wait().await;
-}
-
-struct KillChildOnDrop {
-    child: Child,
-}
-
-impl KillChildOnDrop {
-    fn new(child: Child) -> Self {
-        Self { child }
-    }
-}
-
-impl Drop for KillChildOnDrop {
-    fn drop(&mut self) {
-        let _ = self.child.start_kill();
-    }
-}
-
-impl std::ops::Deref for KillChildOnDrop {
-    type Target = Child;
-
-    fn deref(&self) -> &Self::Target {
-        &self.child
-    }
-}
-
-impl std::ops::DerefMut for KillChildOnDrop {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.child
-    }
 }
 
 async fn wait_after_result(child: &mut Child, last_stderr: &str) -> Result<(), String> {
@@ -505,11 +475,9 @@ pub async fn run_with_grok(
     }
     command.kill_on_drop(true);
 
-    let mut child = KillChildOnDrop::new(
-        command
-            .spawn()
-            .map_err(|e| format!("failed to start Grok CLI: {e}"))?,
-    );
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to start Grok CLI: {e}"))?;
     let stdout = child
         .stdout
         .take()
@@ -583,7 +551,13 @@ pub async fn run_with_grok(
                     Ok(value) => value,
                     Err(e) => {
                         stop_child(&mut child).await;
-                        return Err(format!("failed to parse Grok CLI JSON output: {e}"));
+                        return Err(if last_stderr.trim().is_empty() {
+                            format!("failed to parse Grok CLI JSON output: {e}")
+                        } else {
+                            format!(
+                                "failed to parse Grok CLI JSON output: {e} (last stderr: {last_stderr})"
+                            )
+                        });
                     }
                 };
                 match handle_event(app, job_id, &value, &mut full, &mut tool_events) {

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -140,24 +140,38 @@ fn collect_models_from_text(text: &str, models: &mut Vec<String>, seen: &mut Has
 
 fn grok_config_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
+    if let Some(grok_home) = std::env::var_os("GROK_HOME").map(PathBuf::from) {
+        paths.push(grok_home.join("config.toml"));
+    }
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
-        if let Some(grok_home) = std::env::var_os("GROK_HOME").map(PathBuf::from) {
-            paths.push(grok_home.join("config.toml"));
-        }
         paths.push(home.join(".grok/config.toml"));
     }
     paths
 }
 
-fn collect_models_from_config(models: &mut Vec<String>, seen: &mut HashSet<String>) {
-    for path in grok_config_paths() {
-        let Ok(text) = std::fs::read_to_string(path) else {
-            continue;
-        };
+async fn collect_models_from_config(
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) -> Result<(), String> {
+    let texts = tauri::async_runtime::spawn_blocking(|| {
+        grok_config_paths()
+            .into_iter()
+            .filter_map(|path| std::fs::read_to_string(path).ok())
+            .collect::<Vec<_>>()
+    })
+    .await
+    .map_err(|error| format!("failed to read Grok config: {error}"))?;
+
+    for text in texts {
         for line in text.lines() {
             let line = line.trim();
             if let Some(rest) = line.strip_prefix("[model.") {
-                let id = rest.trim_end_matches(']').trim_matches('"').trim();
+                let id = rest
+                    .split_once(']')
+                    .map_or(rest, |(id, _)| id)
+                    .trim()
+                    .trim_matches('"')
+                    .trim();
                 if is_grok_model_id(id) {
                     push_model_id(models, seen, id);
                 }
@@ -169,6 +183,7 @@ fn collect_models_from_config(models: &mut Vec<String>, seen: &mut HashSet<Strin
             collect_models_from_text(line, models, seen);
         }
     }
+    Ok(())
 }
 
 async fn collect_models_from_runtime(
@@ -197,7 +212,7 @@ pub async fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
         push_model_id(&mut ids, &mut seen, id);
     }
     collect_models_from_runtime(&binary, &mut ids, &mut seen).await;
-    collect_models_from_config(&mut ids, &mut seen);
+    collect_models_from_config(&mut ids, &mut seen).await?;
     push_model_id(&mut ids, &mut seen, &profile.model);
 
     Ok(ids.into_iter().map(|id| model_entry_for_id(&id)).collect())
@@ -457,7 +472,6 @@ pub async fn run_with_grok(
         .arg(root)
         .arg("--output-format")
         .arg("streaming-json")
-        .arg("--verbatim")
         .current_dir(root)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());

--- a/src-tauri/src/ai_grok/mod.rs
+++ b/src-tauri/src/ai_grok/mod.rs
@@ -1,0 +1,583 @@
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    process::Command as StdCommand,
+    time::Duration,
+};
+
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, Command},
+    sync::mpsc,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::ai_rig::{
+    events::AiStatusEvent,
+    helpers::{cli_runtime_path, emit_tool, find_cli_binary},
+    providers::build_transcript,
+    types::{
+        AiAssistantMode, AiChunkEvent, AiMessage, AiModel, AiProfile, AiReasoningEffortOption,
+        AiStoredToolEvent,
+    },
+};
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(600);
+const EXIT_AFTER_RESULT_GRACE: Duration = Duration::from_secs(2);
+const STARTUP_OUTPUT_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_MODEL_ID: &str = "grok-build";
+const CHAT_TOOLS: &str = "read_file,grep,list_dir";
+const GROK_ALIAS_MODELS: &[(&str, &str, &str)] = &[
+    (
+        DEFAULT_MODEL_ID,
+        "Grok Build",
+        "Default Grok coding agent for the signed-in xAI account.",
+    ),
+    (
+        "grok-4.6",
+        "Grok 4.6",
+        "Latest general Grok model advertised by the Grok CLI.",
+    ),
+    (
+        "grok-4.5",
+        "Grok 4.5",
+        "Previous general Grok model advertised by the Grok CLI.",
+    ),
+    (
+        "grok-code-fast-1",
+        "Grok Code Fast",
+        "Faster coding alias for Grok Build.",
+    ),
+];
+
+fn find_grok_binary() -> Result<PathBuf, String> {
+    find_cli_binary("Grok", "GROK_CLI_PATH", "grok")
+}
+
+fn reasoning_options() -> Vec<AiReasoningEffortOption> {
+    ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+        .into_iter()
+        .map(|effort| AiReasoningEffortOption {
+            effort: effort.to_string(),
+            description: None,
+        })
+        .collect()
+}
+
+fn model_entry(id: &str, name: &str, description: &str) -> AiModel {
+    AiModel {
+        id: id.to_string(),
+        name: name.to_string(),
+        context_length: None,
+        description: Some(description.to_string()),
+        input_modalities: None,
+        output_modalities: None,
+        tokenizer: None,
+        prompt_pricing: None,
+        completion_pricing: None,
+        supported_parameters: Some(vec!["tools".to_string(), "reasoning".to_string()]),
+        max_completion_tokens: None,
+        reasoning_effort: Some(reasoning_options()),
+        default_reasoning_effort: None,
+    }
+}
+
+fn grok_model_name(id: &str) -> String {
+    id.split('-')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn model_entry_for_id(id: &str) -> AiModel {
+    if let Some((_, name, description)) =
+        GROK_ALIAS_MODELS.iter().find(|(alias, _, _)| *alias == id)
+    {
+        return model_entry(id, name, description);
+    }
+    model_entry(
+        id,
+        &grok_model_name(id),
+        "Grok model discovered from the installed Grok CLI.",
+    )
+}
+
+fn push_model_id(models: &mut Vec<String>, seen: &mut HashSet<String>, id: &str) {
+    let trimmed = id.trim();
+    if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+        return;
+    }
+    models.push(trimmed.to_string());
+}
+
+fn is_grok_model_id(id: &str) -> bool {
+    let id = id.trim();
+    id.len() >= 6
+        && id.starts_with("grok-")
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_')
+}
+
+fn collect_models_from_text(text: &str, models: &mut Vec<String>, seen: &mut HashSet<String>) {
+    for token in
+        text.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_'))
+    {
+        if is_grok_model_id(token) {
+            push_model_id(models, seen, token);
+        }
+    }
+}
+
+fn grok_config_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        if let Some(grok_home) = std::env::var_os("GROK_HOME").map(PathBuf::from) {
+            paths.push(grok_home.join("config.toml"));
+        }
+        paths.push(home.join(".grok/config.toml"));
+    }
+    paths
+}
+
+fn collect_models_from_config(models: &mut Vec<String>, seen: &mut HashSet<String>) {
+    for path in grok_config_paths() {
+        let Ok(text) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        for line in text.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("[model.") {
+                let id = rest.trim_end_matches(']').trim_matches('"').trim();
+                if is_grok_model_id(id) || !id.is_empty() {
+                    push_model_id(models, seen, id);
+                }
+                continue;
+            }
+            if line.starts_with('#') || !line.contains("default") {
+                continue;
+            }
+            collect_models_from_text(line, models, seen);
+        }
+    }
+}
+
+fn collect_models_from_runtime(
+    binary: &Path,
+    models: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    if let Ok(output) = StdCommand::new(binary).arg("--help").output() {
+        collect_models_from_text(&String::from_utf8_lossy(&output.stdout), models, seen);
+        collect_models_from_text(&String::from_utf8_lossy(&output.stderr), models, seen);
+    }
+}
+
+pub fn list_models(profile: &AiProfile) -> Result<Vec<AiModel>, String> {
+    let binary = find_grok_binary()?;
+    let mut seen = HashSet::new();
+    let mut ids = Vec::new();
+
+    for (id, _, _) in GROK_ALIAS_MODELS {
+        push_model_id(&mut ids, &mut seen, id);
+    }
+    collect_models_from_runtime(&binary, &mut ids, &mut seen);
+    collect_models_from_config(&mut ids, &mut seen);
+    push_model_id(&mut ids, &mut seen, &profile.model);
+
+    Ok(ids.into_iter().map(|id| model_entry_for_id(&id)).collect())
+}
+
+fn prompt_text(messages: &[AiMessage]) -> String {
+    let transcript = build_transcript("", messages);
+    if transcript.trim().is_empty() {
+        messages
+            .iter()
+            .rev()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.clone())
+            .unwrap_or_default()
+    } else {
+        transcript
+    }
+}
+
+async fn pipe_stderr(child: &mut Child) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>(64);
+    if let Some(stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = tx.send(line).await;
+            }
+        });
+    }
+    rx
+}
+
+async fn stop_child(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+}
+
+struct KillChildOnDrop {
+    child: Child,
+}
+
+impl KillChildOnDrop {
+    fn new(child: Child) -> Self {
+        Self { child }
+    }
+}
+
+impl Drop for KillChildOnDrop {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+impl std::ops::Deref for KillChildOnDrop {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl std::ops::DerefMut for KillChildOnDrop {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
+    }
+}
+
+async fn wait_after_result(child: &mut Child, last_stderr: &str) -> Result<(), String> {
+    match tokio::time::timeout(EXIT_AFTER_RESULT_GRACE, child.wait()).await {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(status)) => Err(grok_cli_failure("request", status, last_stderr)),
+        Ok(Err(e)) => Err(e.to_string()),
+        Err(_) => {
+            stop_child(child).await;
+            Ok(())
+        }
+    }
+}
+
+fn grok_cli_failure(action: &str, status: impl std::fmt::Display, stderr: &str) -> String {
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        format!("Grok CLI {action} exited with {status}")
+    } else {
+        format!("Grok CLI {action} exited with {status}: {stderr}")
+    }
+}
+
+fn emit_chunk(app: &AppHandle, job_id: &str, full: &mut String, delta: &str) {
+    if delta.is_empty() {
+        return;
+    }
+    full.push_str(delta);
+    let _ = app.emit(
+        "ai:chunk",
+        AiChunkEvent {
+            job_id: job_id.to_string(),
+            delta: delta.to_string(),
+        },
+    );
+}
+
+fn emit_status(app: &AppHandle, job_id: &str, status: &str, detail: Option<String>) {
+    let _ = app.emit(
+        "ai:status",
+        AiStatusEvent {
+            job_id: job_id.to_string(),
+            status: status.to_string(),
+            detail,
+        },
+    );
+}
+
+fn event_text(value: &Value) -> Option<&str> {
+    value
+        .get("data")
+        .and_then(|v| v.as_str())
+        .or_else(|| value.get("text").and_then(|v| v.as_str()))
+        .or_else(|| value.get("message").and_then(|v| v.as_str()))
+}
+
+fn tool_name(value: &Value) -> &str {
+    value
+        .get("toolName")
+        .or_else(|| value.get("tool_name"))
+        .or_else(|| value.get("title"))
+        .or_else(|| value.get("kind"))
+        .and_then(|v| v.as_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("tool")
+}
+
+fn tool_call_id(value: &Value) -> Option<String> {
+    value
+        .get("toolCallId")
+        .or_else(|| value.get("tool_call_id"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+fn tool_error(value: &Value) -> Option<String> {
+    value
+        .get("error")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            value
+                .get("rawOutput")
+                .and_then(|output| output.get("error").or_else(|| output.get("message")))
+                .and_then(|v| v.as_str())
+        })
+        .filter(|message| !message.is_empty())
+        .map(str::to_string)
+}
+
+fn handle_tool_call(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+    phase: &str,
+) {
+    emit_tool(
+        app,
+        job_id,
+        tool_events,
+        tool_name(value),
+        phase,
+        tool_call_id(value),
+        Some(value.clone()),
+        if phase == "error" {
+            tool_error(value)
+        } else {
+            None
+        },
+    );
+}
+
+fn handle_event(
+    app: &AppHandle,
+    job_id: &str,
+    value: &Value,
+    full: &mut String,
+    tool_events: &mut Vec<AiStoredToolEvent>,
+) -> Result<Option<bool>, String> {
+    match value.get("type").and_then(|v| v.as_str()) {
+        Some("text") => {
+            emit_chunk(app, job_id, full, event_text(value).unwrap_or(""));
+            Ok(None)
+        }
+        Some("thought") => {
+            if let Some(thought) = event_text(value).map(str::trim).filter(|s| !s.is_empty()) {
+                emit_status(app, job_id, "thinking", Some(thought.to_string()));
+            }
+            Ok(None)
+        }
+        Some("tool_call") => {
+            handle_tool_call(app, job_id, value, tool_events, "call");
+            Ok(None)
+        }
+        Some("tool_call_update") => {
+            let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("");
+            let phase = match status {
+                "failed" | "error" | "cancelled" => "error",
+                "in_progress" | "pending" => return Ok(None),
+                _ => "result",
+            };
+            handle_tool_call(app, job_id, value, tool_events, phase);
+            Ok(None)
+        }
+        Some("end") => {
+            if full.trim().is_empty() {
+                if let Some(text) = event_text(value) {
+                    emit_chunk(app, job_id, full, text);
+                }
+            }
+            Ok(Some(false))
+        }
+        Some("error") => Err(event_text(value)
+            .unwrap_or("Grok CLI request failed")
+            .to_string()),
+        _ => Ok(None),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_with_grok(
+    cancel: &CancellationToken,
+    app: &AppHandle,
+    job_id: &str,
+    profile: &AiProfile,
+    system: &str,
+    messages: &[AiMessage],
+    mode: &AiAssistantMode,
+    space_root: Option<&Path>,
+) -> Result<(String, bool, Vec<AiStoredToolEvent>), String> {
+    let root = space_root.ok_or_else(|| "No space is open".to_string())?;
+    let binary = find_grok_binary()?;
+    let prompt = prompt_text(messages);
+    if prompt.trim().is_empty() {
+        return Err("Grok CLI needs a prompt".to_string());
+    }
+
+    emit_status(
+        app,
+        job_id,
+        "thinking",
+        Some("Starting Grok CLI".to_string()),
+    );
+
+    let mut command = Command::new(&binary);
+    command
+        .arg("--no-auto-update")
+        .arg("--no-alt-screen")
+        .arg("-p")
+        .arg(&prompt)
+        .arg("--cwd")
+        .arg(root)
+        .arg("--output-format")
+        .arg("streaming-json")
+        .arg("--verbatim")
+        .current_dir(root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    if let Some(path) = cli_runtime_path(&binary) {
+        command.env("PATH", path);
+    }
+
+    match mode {
+        AiAssistantMode::Chat => {
+            command.arg("--tools").arg(CHAT_TOOLS);
+        }
+        AiAssistantMode::Create => {
+            command.arg("--yolo");
+        }
+    }
+
+    if !system.trim().is_empty() {
+        command.arg("--rules").arg(system.trim());
+    }
+    let model = profile.model.trim();
+    if !model.is_empty() && model != DEFAULT_MODEL_ID {
+        command.arg("-m").arg(model);
+    }
+    if let Some(effort) = profile
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        command.arg("--effort").arg(effort);
+    }
+    command.kill_on_drop(true);
+
+    let mut child = KillChildOnDrop::new(
+        command
+            .spawn()
+            .map_err(|e| format!("failed to start Grok CLI: {e}"))?,
+    );
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Grok CLI stdout".to_string())?;
+    let mut stdout_lines = BufReader::new(stdout).lines();
+    let mut stderr_lines = pipe_stderr(&mut child).await;
+
+    let timeout = tokio::time::sleep(RUN_TIMEOUT);
+    tokio::pin!(timeout);
+    let startup_timeout = tokio::time::sleep(STARTUP_OUTPUT_TIMEOUT);
+    tokio::pin!(startup_timeout);
+    let mut full = String::new();
+    let mut tool_events = Vec::new();
+    let mut last_stderr = String::new();
+    let mut saw_stdout = false;
+    let mut stderr_open = true;
+    let mut stdout_open = true;
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                stop_child(&mut child).await;
+                return Ok((String::new(), true, tool_events));
+            }
+            _ = &mut timeout => {
+                stop_child(&mut child).await;
+                return Err("Grok CLI request timed out".to_string());
+            }
+            _ = &mut startup_timeout, if !saw_stdout => {
+                stop_child(&mut child).await;
+                return Err(if last_stderr.trim().is_empty() {
+                    "Grok CLI produced no output after starting".to_string()
+                } else {
+                    format!("Grok CLI produced no output after starting: {last_stderr}")
+                });
+            }
+            maybe_err = stderr_lines.recv(), if stderr_open => {
+                match maybe_err {
+                    Some(line) => {
+                        if !line.trim().is_empty() {
+                            last_stderr = line;
+                        }
+                    }
+                    None => stderr_open = false,
+                }
+            }
+            status = child.wait(), if !stdout_open => {
+                let status = status.map_err(|e| e.to_string())?;
+                if status.success() && !full.trim().is_empty() {
+                    return Ok((full, false, tool_events));
+                }
+                return Err(grok_cli_failure("request", status, &last_stderr));
+            }
+            line = stdout_lines.next_line(), if stdout_open => {
+                let line = match line {
+                    Ok(line) => line,
+                    Err(e) => {
+                        stop_child(&mut child).await;
+                        return Err(format!("failed reading Grok CLI output: {e}"));
+                    }
+                };
+                let Some(line) = line else {
+                    stdout_open = false;
+                    continue;
+                };
+                if line.trim().is_empty() {
+                    continue;
+                }
+                saw_stdout = true;
+                let value = match serde_json::from_str::<Value>(&line) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        stop_child(&mut child).await;
+                        return Err(format!("failed to parse Grok CLI JSON output: {e}"));
+                    }
+                };
+                match handle_event(app, job_id, &value, &mut full, &mut tool_events) {
+                    Ok(Some(done)) => {
+                        wait_after_result(&mut child, &last_stderr).await?;
+                        return Ok((full, done, tool_events));
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        stop_child(&mut child).await;
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/ai_rig/commands.rs
+++ b/src-tauri/src/ai_rig/commands.rs
@@ -220,6 +220,7 @@ pub async fn ai_profile_delete(
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::ClaudeCode
                 | super::types::AiProviderKind::Cursor
+                | super::types::AiProviderKind::Grok
                 | super::types::AiProviderKind::Opencode
                 | super::types::AiProviderKind::Pi
         );
@@ -348,6 +349,7 @@ pub async fn ai_chat_start(
                 | super::types::AiProviderKind::Amp
                 | super::types::AiProviderKind::ClaudeCode
                 | super::types::AiProviderKind::Cursor
+                | super::types::AiProviderKind::Grok
                 | super::types::AiProviderKind::Opencode
                 | super::types::AiProviderKind::Pi
         )
@@ -517,6 +519,12 @@ pub async fn run_request(
         )
         .await;
     }
+    if matches!(profile.provider, super::types::AiProviderKind::Grok) {
+        return crate::ai_grok::run_with_grok(
+            cancel, app, job_id, profile, system, messages, mode, space_root,
+        )
+        .await;
+    }
     if matches!(profile.provider, super::types::AiProviderKind::Pi) {
         return crate::ai_pi::run_with_pi(
             cancel, app, job_id, profile, system, messages, mode, space_root,
@@ -525,7 +533,16 @@ pub async fn run_request(
     }
 
     runtime::run_with_rig(
-        cancel, app, job_id, profile, api_key, system, messages, mode, space_root, window_label,
+        cancel,
+        app,
+        job_id,
+        profile,
+        api_key,
+        system,
+        messages,
+        mode,
+        space_root,
+        window_label,
     )
     .await
 }

--- a/src-tauri/src/ai_rig/helpers.rs
+++ b/src-tauri/src/ai_rig/helpers.rs
@@ -31,6 +31,7 @@ pub fn default_base_url(provider: &AiProviderKind) -> &'static str {
         AiProviderKind::Amp => "https://ampcode.com/",
         AiProviderKind::ClaudeCode => "https://code.claude.com/",
         AiProviderKind::Cursor => "https://cursor.com/",
+        AiProviderKind::Grok => "https://x.ai/cli",
         AiProviderKind::Opencode => "http://127.0.0.1:4096",
         AiProviderKind::Pi => "https://pi.dev/",
     }

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -622,7 +622,7 @@ pub async fn ai_models_list(
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
         AiProviderKind::ClaudeCode => crate::ai_claude_code::list_models(&space_root, &profile),
         AiProviderKind::Cursor => crate::ai_cursor::list_models(&profile).await,
-        AiProviderKind::Grok => crate::ai_grok::list_models(&profile),
+        AiProviderKind::Grok => crate::ai_grok::list_models(&profile).await,
         AiProviderKind::Opencode => crate::ai_opencode::list_models(&space_root).await,
         AiProviderKind::Pi => crate::ai_pi::list_models(&space_root).await,
     }

--- a/src-tauri/src/ai_rig/models.rs
+++ b/src-tauri/src/ai_rig/models.rs
@@ -622,6 +622,7 @@ pub async fn ai_models_list(
         AiProviderKind::Amp => Ok(crate::ai_amp::list_models()),
         AiProviderKind::ClaudeCode => crate::ai_claude_code::list_models(&space_root, &profile),
         AiProviderKind::Cursor => crate::ai_cursor::list_models(&profile).await,
+        AiProviderKind::Grok => crate::ai_grok::list_models(&profile),
         AiProviderKind::Opencode => crate::ai_opencode::list_models(&space_root).await,
         AiProviderKind::Pi => crate::ai_pi::list_models(&space_root).await,
     }

--- a/src-tauri/src/ai_rig/providers.rs
+++ b/src-tauri/src/ai_rig/providers.rs
@@ -19,6 +19,7 @@ pub fn capabilities(provider: &AiProviderKind) -> ProviderCapabilities {
         | AiProviderKind::Amp
         | AiProviderKind::ClaudeCode
         | AiProviderKind::Cursor
+        | AiProviderKind::Grok
         | AiProviderKind::Opencode
         | AiProviderKind::Pi => ProviderCapabilities {
             requires_max_tokens: false,

--- a/src-tauri/src/ai_rig/runtime.rs
+++ b/src-tauri/src/ai_rig/runtime.rs
@@ -370,6 +370,7 @@ pub async fn run_with_rig(
         | AiProviderKind::Amp
         | AiProviderKind::ClaudeCode
         | AiProviderKind::Cursor
+        | AiProviderKind::Grok
         | AiProviderKind::Opencode
         | AiProviderKind::Pi => {
             return Err(
@@ -640,6 +641,9 @@ pub async fn generate_chat_title_with_rig(
         }
         AiProviderKind::Cursor => {
             return Ok("Cursor Chat".to_string());
+        }
+        AiProviderKind::Grok => {
+            return Ok("Grok Chat".to_string());
         }
         AiProviderKind::Opencode => {
             return Ok("OpenCode Chat".to_string());

--- a/src-tauri/src/ai_rig/store.rs
+++ b/src-tauri/src/ai_rig/store.rs
@@ -69,6 +69,7 @@ pub fn ensure_default_profiles(store: &mut AiStore) {
         (AiProviderKind::Amp, "smart", None, false),
         (AiProviderKind::ClaudeCode, "default", None, false),
         (AiProviderKind::Cursor, "auto", None, false),
+        (AiProviderKind::Grok, "grok-build", None, false),
         (AiProviderKind::Opencode, "", None, true),
         (AiProviderKind::Pi, "", None, true),
     ];

--- a/src-tauri/src/ai_rig/types.rs
+++ b/src-tauri/src/ai_rig/types.rs
@@ -14,6 +14,7 @@ pub enum AiProviderKind {
     Amp,
     ClaudeCode,
     Cursor,
+    Grok,
     Opencode,
     Pi,
 }
@@ -32,6 +33,7 @@ impl AiProviderKind {
             Self::Amp => "amp",
             Self::ClaudeCode => "claude_code",
             Self::Cursor => "cursor",
+            Self::Grok => "grok",
             Self::Opencode => "opencode",
             Self::Pi => "pi",
         }
@@ -50,6 +52,7 @@ impl AiProviderKind {
             Self::Amp => "Amp",
             Self::ClaudeCode => "Claude Code",
             Self::Cursor => "Cursor",
+            Self::Grok => "Grok",
             Self::Opencode => "OpenCode",
             Self::Pi => "PI",
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod ai_amp;
 mod ai_claude_code;
 mod ai_codex;
 mod ai_cursor;
+mod ai_grok;
 mod ai_opencode;
 mod ai_pi;
 mod ai_rig;

--- a/src/assets/provider-logos/grok-dark.svg
+++ b/src/assets/provider-logos/grok-dark.svg
@@ -1,0 +1,4 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Grok</title>
+  <path fill="#fff" d="M12 1.1 15.55 8.45 22.9 12 15.55 15.55 12 22.9 8.45 15.55 1.1 12 8.45 8.45z"/>
+</svg>

--- a/src/assets/provider-logos/grok-light.svg
+++ b/src/assets/provider-logos/grok-light.svg
@@ -1,0 +1,4 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <title>Grok</title>
+  <path fill="#111" d="M12 1.1 15.55 8.45 22.9 12 15.55 15.55 12 22.9 8.45 15.55 1.1 12 8.45 8.45z"/>
+</svg>

--- a/src/components/ai/modelSelectorConstants.tsx
+++ b/src/components/ai/modelSelectorConstants.tsx
@@ -48,6 +48,7 @@ export const providerSupportKeyMap: Record<AiProviderKind, string> = {
 	amp: "amp",
 	claude_code: "anthropic",
 	cursor: "cursor",
+	grok: "grok",
 	opencode: "opencode",
 	pi: "pi",
 };

--- a/src/components/ai/providerLogos.ts
+++ b/src/components/ai/providerLogos.ts
@@ -6,6 +6,8 @@ import codexLightThemeLogoUrl from "../../assets/provider-logos/codex-light.svg?
 import cursorDarkThemeLogoUrl from "../../assets/provider-logos/cursor-dark.svg?url";
 import cursorLightThemeLogoUrl from "../../assets/provider-logos/cursor-light.svg?url";
 import geminiLogoUrl from "../../assets/provider-logos/google-gemini.svg?url";
+import grokDarkThemeLogoUrl from "../../assets/provider-logos/grok-dark.svg?url";
+import grokLightThemeLogoUrl from "../../assets/provider-logos/grok-light.svg?url";
 import llamacppLogoUrl from "../../assets/provider-logos/llamacpp.svg?url";
 import ollamaLogoUrl from "../../assets/provider-logos/ollama.svg?url";
 import openrouterLogoUrl from "../../assets/provider-logos/open-router.svg?url";
@@ -46,6 +48,11 @@ export const providerLogoMeta: Record<
 		src: cursorLightThemeLogoUrl,
 		darkSrc: cursorDarkThemeLogoUrl,
 		label: "Cursor",
+	},
+	grok: {
+		src: grokLightThemeLogoUrl,
+		darkSrc: grokDarkThemeLogoUrl,
+		label: "Grok",
 	},
 	opencode: {
 		src: opencodeLightThemeLogoUrl,

--- a/src/components/settings/ai/AiConnectionPicker.tsx
+++ b/src/components/settings/ai/AiConnectionPicker.tsx
@@ -30,6 +30,7 @@ const CONNECTION_OPTIONS = [
 		providers: [
 			{ value: "codex_chatgpt", label: "Codex" },
 			{ value: "cursor", label: "Cursor" },
+			{ value: "grok", label: "Grok" },
 			{ value: "claude_code", label: "Claude Code" },
 			{ value: "amp", label: "Amp" },
 			{ value: "opencode", label: "OpenCode" },

--- a/src/components/settings/ai/AiProviderSection.tsx
+++ b/src/components/settings/ai/AiProviderSection.tsx
@@ -10,6 +10,14 @@ import { SettingsSelect } from "../SettingsSelect";
 import { AiConnectionPicker } from "./AiConnectionPicker";
 import { AiModelCombobox } from "./AiModelCombobox";
 
+function usesReasoningControl(provider: AiProviderKind): boolean {
+	return (
+		provider === "codex_chatgpt" ||
+		provider === "pi" ||
+		provider === "grok"
+	);
+}
+
 interface AiProviderSectionProps {
 	profileDraft: AiProfile;
 	availableModels: AiModel[] | null;
@@ -33,8 +41,7 @@ export function AiProviderSection({
 	const selectedModel =
 		availableModels?.find((model) => model.id === profileDraft.model) ?? null;
 	const reasoningOptions = selectedModel?.reasoning_effort ?? null;
-	const shouldShowReasoningSelect =
-		profileDraft.provider === "codex_chatgpt" || profileDraft.provider === "pi";
+	const shouldShowReasoningSelect = usesReasoningControl(profileDraft.provider);
 	const baseUrlPlaceholder =
 		profileDraft.provider === "llama_cpp"
 			? "http://localhost:8080/v1"
@@ -72,13 +79,11 @@ export function AiProviderSection({
 						void onPersistDraft({
 							...profileDraft,
 							model: nextModelId,
-							reasoning_effort:
-								profileDraft.provider === "codex_chatgpt" ||
-								profileDraft.provider === "pi"
-									? stillValid
-										? currentEffort
-										: (nextModel?.default_reasoning_effort ?? currentEffort)
-									: null,
+							reasoning_effort: usesReasoningControl(profileDraft.provider)
+								? stillValid
+									? currentEffort
+									: (nextModel?.default_reasoning_effort ?? currentEffort)
+								: null,
 						});
 					}}
 					onModelsChange={onModelsChange}

--- a/src/components/settings/ai/AiProviderSection.tsx
+++ b/src/components/settings/ai/AiProviderSection.tsx
@@ -12,9 +12,7 @@ import { AiModelCombobox } from "./AiModelCombobox";
 
 function usesReasoningControl(provider: AiProviderKind): boolean {
 	return (
-		provider === "codex_chatgpt" ||
-		provider === "pi" ||
-		provider === "grok"
+		provider === "codex_chatgpt" || provider === "pi" || provider === "grok"
 	);
 }
 

--- a/src/components/settings/ai/providerCapabilities.ts
+++ b/src/components/settings/ai/providerCapabilities.ts
@@ -7,6 +7,7 @@ const PROVIDERS_WITHOUT_API_KEY = new Set<AiProviderKind>([
 	"amp",
 	"claude_code",
 	"cursor",
+	"grok",
 	"opencode",
 	"pi",
 ]);

--- a/src/i18n/locales/de/settings.search.json
+++ b/src/i18n/locales/de/settings.search.json
@@ -292,7 +292,7 @@
 		"ai-provider-service": {
 			"title": "Anbieter",
 			"section": "Verbindung",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -272,7 +272,7 @@
 		"ai-provider-service": {
 			"title": "Provider",
 			"section": "Connection",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/es/settings.search.json
+++ b/src/i18n/locales/es/settings.search.json
@@ -302,7 +302,7 @@
 		"ai-provider-service": {
 			"title": "Proveedor",
 			"section": "Conexión",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/fr/settings.search.json
+++ b/src/i18n/locales/fr/settings.search.json
@@ -293,7 +293,7 @@
 		"ai-provider-service": {
 			"title": "Fournisseur",
 			"section": "Connexion",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/ja/settings.search.json
+++ b/src/i18n/locales/ja/settings.search.json
@@ -303,7 +303,7 @@
 		"ai-provider-service": {
 			"title": "プロバイダー",
 			"section": "接続",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/ko/settings.search.json
+++ b/src/i18n/locales/ko/settings.search.json
@@ -296,7 +296,7 @@
 		"ai-provider-service": {
 			"title": "공급자",
 			"section": "연결",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/pl/settings.search.json
+++ b/src/i18n/locales/pl/settings.search.json
@@ -272,7 +272,14 @@
 		"ai-provider-service": {
 			"title": "Usługa",
 			"section": "Dostawca",
-			"keywords": ["dostawca", "cursor", "grok", "openai", "anthropic", "ollama"]
+			"keywords": [
+				"dostawca",
+				"cursor",
+				"grok",
+				"openai",
+				"anthropic",
+				"ollama"
+			]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/pl/settings.search.json
+++ b/src/i18n/locales/pl/settings.search.json
@@ -272,7 +272,7 @@
 		"ai-provider-service": {
 			"title": "Usługa",
 			"section": "Dostawca",
-			"keywords": ["dostawca", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["dostawca", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/i18n/locales/pt-BR/settings.search.json
+++ b/src/i18n/locales/pt-BR/settings.search.json
@@ -303,7 +303,7 @@
 		"ai-provider-service": {
 			"title": "Provedor",
 			"section": "Conexão",
-			"keywords": ["codex", "cursor", "openai", "anthropic", "ollama"]
+			"keywords": ["codex", "cursor", "grok", "openai", "anthropic", "ollama"]
 		},
 		"ai-provider-model": {
 			"title": "Model",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -750,6 +750,7 @@ export type AiProviderKind =
 	| "amp"
 	| "claude_code"
 	| "cursor"
+	| "grok"
 	| "opencode"
 	| "pi";
 


### PR DESCRIPTION
## Summary

Adds Grok (Grok Build CLI) as a dedicated Agents provider, following the same CLI-runtime pattern as Claude Code and Cursor.

Users who already have `grok` installed can pick **Grok** under Settings → AI → Agents and chat against the open space using their existing `grok login` / `XAI_API_KEY`. Glyph does not store an xAI token.

Headless invocation:

* Finds `grok` via `GROK_CLI_PATH` or the usual macOS CLI search paths (including `~/.local/bin` and `~/.grok/bin`)
* Runs `grok -p` with `--cwd` set to the space root, `--no-auto-update`, and `--output-format streaming-json`
* Chat mode allowlists `read_file,grep,list_dir` (no `--yolo`)
* Create mode uses `--yolo` so writes can proceed without a TTY
* Streams `text` / `thought` / `tool_call` / `tool_call_update` / `end` / `error` into `ai:chunk`, `ai:tool`, and status events
* Follow-ups replay the transcript; no ACP client

Note index freshness after Create-mode writes still goes through the existing space filesystem watcher, same as the other agent CLIs.

## Related Issues

Closes SidhuK/Glyph#492

## Testing

- [X] `pnpm check`
- [X] `pnpm build`
- [X] `cd src-tauri && cargo check` (GitHub Actions Rust / Check)
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

N/A (cloud agent; Grok appears in the Agents provider picker with a logo and no API-key field)

## Contributor Checklist

- [X] This PR is focused and avoids unrelated refactors
- [X] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [X] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [X] This change does not add or require Windows-specific support
- [X] I am not introducing backward-compatibility code for deprecated behavior

<img src="https://camo.githubusercontent.com/ae5336cc4565ed7dd126cd5bfcb9f6a53979c32e32819e23ffd98524f0526bc9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d7765622d6461726b2e706e67 " alt="Open in Web" width="114" data-linear-height="28" /> <img src="https://camo.githubusercontent.com/583722e75417432aa96019715ba989e7851c00ce91b7725e7246cf7c45b1dae9/68747470733a2f2f637572736f722e636f6d2f6173736574732f696d616765732f6f70656e2d696e2d637572736f722d6461726b2e706e67 " alt="Open in Cursor" width="131" data-linear-height="28" />

## Summary by Sourcery

Enable users to select Grok for agent chats and workspace changes through their authenticated local Grok CLI without storing an xAI token.

New Features:
- Add Grok as an Agents provider backed by the locally installed Grok Build CLI.
- Support streaming Grok chat and create runs with model discovery, tool events, cancellation, and reasoning controls.

Enhancements:
- Register Grok throughout provider capabilities, profile management, request routing, model selection, and chat title generation.
- Add Grok to the AI settings picker with branding and no API-key configuration.

Documentation:
- Document the new native ai_grok backend module.

New Features:

* Introduce Grok as a new AI provider with default profile and model selection metadata, including reasoning-effort controls.
* Add a Grok-specific CLI runtime that discovers installed Grok models and runs chat/create requests with streaming JSON output and tool-call handling.

Enhancements:

* Align reasoning-effort handling behind a shared helper so Grok, Codex ChatGPT, and Pi all use the same UI logic.
* Expand provider capabilities, titles, and default base URLs to recognize Grok as a CLI-based agent alongside Cursor and Claude Code.

Documentation:

* Update agent backend documentation to reference the new ai_grok module in the native Tauri architecture.

---

## Summary by cubic

Adds Grok Build CLI as an Agents provider, running the local `grok` binary headless against the open space with streaming events. Users can select Grok without storing an API key; behavior mirrors Cursor/Claude Code and chat titles are “Grok Chat.”

* Registers the `Grok` provider with default profile (`model: "grok-build"`) and base URL `https://x.ai/cli`; adds picker entry, logos, and hides the API key field.
* Routes runs to a native Grok runtime: starts `grok` with streaming JSON, `--no-auto-update`, `--no-alt-screen`, `--verbatim`, and `--cwd` at the space root; maps `text/thought/tool_call/tool_call_update/end/error` into `ai:chunk`, tool events, and status; Chat allowlists `read_file,grep,list_dir`, Create uses `--yolo`; supports cooperative cancellation, a 600s run timeout, 30s startup timeout, and a 2s exit grace.
* Models: preloads aliases and discovers models from `grok --help` and `~/.grok/config.toml`, ignoring non-`[model.*]` tables; bounded by a 30s timeout; exposes reasoning-effort options in the UI.
* Store/runtime: adds `Grok` to provider capabilities and inserts a default profile on next launch; generates “Grok Chat” titles; no token is stored.

**Rollout**

* Users must install `grok` and be signed in (`grok login`) or set `XAI_API_KEY`; optionally set `GROK_CLI_PATH`.
* A default Grok profile is added to existing stores on next launch.

Written for commit 96bc4f05c44cd6e1e6593b41bbe0dd279b6d46c8. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

> [!NOTE]
> ### Add Grok Build CLI as a native Agents provider
>
> * Adds a new `ai_grok` Rust module that discovers the Grok CLI binary, lists available models by parsing CLI output and config files, and executes chat turns by spawning the CLI with `--output-format streaming-json`, emitting `ai:chunk` and `ai:status` events.
> * Registers `Grok` as a first-class `AiProviderKind` in both Rust and TypeScript, with routing in `run_request` delegating to the new native runtime instead of Rig.
> * Adds a default Grok profile (`grok-build` model, `allow_private_hosts: false`) created on new installs, and surfaces Grok in the agent connection picker with light/dark logos and reasoning-level UI.
> * No API key is required; the provider relies entirely on the locally installed Grok CLI.
>
> [Macroscope](<https://app.macroscope.com>) summarized 96bc4f0.

## Summary by CodeRabbit

* **New Features**
  * Added Grok as an AI provider for agent connections.
  * Added Grok model discovery, configuration, and reasoning controls.
  * Added Grok chat execution with streaming responses, tool events, cancellation, and error handling.
  * Added Grok branding, provider selection, default profile support, and settings search keywords.
* **Documentation**
  * Updated the backend overview to include Grok support.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grok Build CLI as an Agents provider
> - Adds the [ai_grok module](https://github.com/SidhuK/Glyph/pull/514/files#diff-d4e050ad517dd4d18dd40f96696227fe13b059eb37d1f9479cdc1cb0c6b0db68) to run requests via the Grok CLI with streaming, tool events, cancellation, and timeouts.
> - Routes Grok requests to `ai_grok::run_with_grok` and rejects them in the generic `run_with_rig` runtime in [runtime.rs](https://github.com/SidhuK/Glyph/pull/514/files#diff-f45d42663e16e1d2ccf0bb7d6c72eddf3b29a8f5b512887c7079c760b9bfc2f1).
> - Adds a default Grok profile and updates provider capabilities to skip API keys and `max_tokens`.
> - Adds UI support for Grok in the connection picker, reasoning controls, provider logos, and search keywords.
> - Risk: `run_with_rig` rejects Grok requests; callers in [commands.rs](https://github.com/SidhuK/Glyph/pull/514/files#diff-021eb8f37fb12aa395fa1fc1bc318149321fa6be38dc9e1c62bc6e57de3bc489) are updated to route to the dedicated runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67e0e24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Grok Build CLI as an Agents provider via the local `grok` binary so users can chat/create without storing an xAI token. Previously unavailable, Grok is now selectable and runs through a native runtime (not Rig), with streaming responses, robust tool events, and shared reasoning controls.

- Introduces `ai_grok` runtime: spawns `grok` with `--output-format streaming-json`, `--no-auto-update`, and `--cwd` at the space root; Chat allowlists `read_file,grep,list_dir`, Create uses `--yolo`; supports cooperative cancellation, a 600s run timeout, a 30s startup-output timeout, and a 2s exit grace. Improves event parsing for `text`, `thought`, `tool_call`, and `tool_call_update` (names, call IDs, and errors).
- Discovers models from `grok models` and `~/.grok/config.toml`/`$GROK_HOME/config.toml` with a 30s timeout; filters non-`[model.*]` tables; honors `default_model`; augments with alias models; exposes reasoning-effort options aligned with Codex and Pi.
- Wires `Grok` across Rust/TypeScript: marks it no-API-key, sets default profile (`model: "grok-build"`), routes Grok away from `run_with_rig`, uses `https://x.ai/cli` as the base URL, generates “Grok Chat” titles, and adds logos and settings search keywords.

Rollout
- Require `grok` installation and auth (`grok login` or `XAI_API_KEY`); optionally set `GROK_CLI_PATH`.
- Auto-add a default Grok profile on next launch.

<sup>Written for commit 67e0e24fba301cf296a4f6b8cc1baf42db8bc607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

