### PR TITLE
Align side peek with workspace edges

### DIFF
--- a/src/styles/app/16-main-workspace-layout.css
+++ b/src/styles/app/16-main-workspace-layout.css
@@ -150,9 +150,9 @@
 
 .noteSidePeek {
 	position: absolute;
-	top: 10px;
+	top: 0;
 	right: 10px;
-	bottom: 10px;
+	bottom: 0;
 	z-index: 40;
 	width: min(520px, 48%);
 	display: flex;


### PR DESCRIPTION
## Summary

Align the note side peek with the workspace's top and bottom edges by removing its vertical inset.

## Related Issues

Closes #

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

If the change affects the UI, add screenshots or a short video.

## Contributor Checklist

- [ ] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [ ] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [ ] This change does not add or require Windows-specific support
- [ ] I am not introducing backward-compatibility code for deprecated behavior

## Summary by Sourcery

Enhancements:
- Align the note side peek with the workspace’s top and bottom edges by removing its vertical inset.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `.noteSidePeek` with workspace edges by removing 10px insets
> Updates the `.noteSidePeek` CSS rule in [16-main-workspace-layout.css](https://github.com/SidhuK/Glyph/pull/517/files#diff-a376d7bf2c7bd279948dbc4de6c6b0eb88185fe1f81efdd61d656fe641581ba4) to set `top` and `bottom` from `10px` to `0`. The panel now spans flush to the top and bottom of its container.
> - Behavioral Change: the side peek panel loses its 10px vertical gaps, increasing usable vertical space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4770c33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the note side peek with the workspace edges by removing the vertical inset. Previously there were 10px gaps at the top and bottom; now the panel is flush to increase usable height and match layout edges.

- Sets `.noteSidePeek` `top: 0` and `bottom: 0` (was `10px`).
- Confirm no clipping or awkward overlap with rounded corners/title bar, and that scroll/resize remain accessible at small heights.

<sup>Written for commit 4770c330f8d7d5762a2b2b0a6250f837d71f38fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the note side panel layout to extend across the full height of its containing area.
  * Preserved the existing right-side spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->