### PR TITLE
Cut RAM from inline images, closed AI panel, and graph cache

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod pinned_files;
 mod print;
 mod release_channels;
 mod space;
+mod space_asset_protocol;
 mod space_fs;
 mod system_fonts;
 mod tag_appearance;
@@ -1612,6 +1613,9 @@ pub fn run() {
                 warn!("Failed to focus main window for second instance: {error}");
             }
         }))
+        .register_asynchronous_uri_scheme_protocol("glyphasset", |ctx, request, responder| {
+            space_asset_protocol::handle(ctx, request, responder);
+        })
         .menu(|app| build_main_menu(app, false, false, &[], &HashMap::new(), &HashMap::new()))
         .on_menu_event(|app, event| match event.id().as_ref() {
             id if id.starts_with("space.recent.") => {

--- a/src-tauri/src/space/state.rs
+++ b/src-tauri/src/space/state.rs
@@ -152,11 +152,15 @@ impl SpaceState {
     }
 
     pub fn root_for_window(&self, window: &tauri::WebviewWindow) -> Result<PathBuf, String> {
-        match self.root_for_window_label(window.label()) {
+        self.root_for_webview_label(window.label())
+    }
+
+    pub(crate) fn root_for_webview_label(&self, window_label: &str) -> Result<PathBuf, String> {
+        match self.root_for_window_label(window_label) {
             Ok(root) => Ok(root),
             Err(error)
                 if is_no_space_session_error(&error)
-                    && shares_main_space_session(window.label()) =>
+                    && shares_main_space_session(window_label) =>
             {
                 // Auxiliary editor windows (quick note, external markdown, …)
                 // inherit the main window's active space rather than owning one.

--- a/src-tauri/src/space_asset_protocol.rs
+++ b/src-tauri/src/space_asset_protocol.rs
@@ -1,0 +1,161 @@
+use std::path::PathBuf;
+
+use tauri::http::{header, StatusCode};
+use tauri::{Manager, Runtime, UriSchemeContext, UriSchemeResponder};
+use tracing::warn;
+
+use crate::paths;
+use crate::space::SpaceState;
+use crate::space_fs::helpers::deny_hidden_rel_path;
+
+pub fn handle<R: Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: tauri::http::Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+) {
+    let app = ctx.app_handle().clone();
+    let webview_label = ctx.webview_label().to_string();
+    let uri = request.uri().clone();
+    std::thread::spawn(move || {
+        responder.respond(response_for_request(&app, &webview_label, &uri));
+    });
+}
+
+fn response_for_request<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    webview_label: &str,
+    uri: &tauri::http::Uri,
+) -> tauri::http::Response<Vec<u8>> {
+    match load_image(app, webview_label, uri) {
+        Ok((mime, bytes)) => http_response(
+            StatusCode::OK,
+            &[
+                (header::CONTENT_TYPE, mime),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            bytes,
+        ),
+        Err(status) => {
+            if status != StatusCode::NOT_FOUND {
+                warn!(
+                    webview = webview_label,
+                    status = status.as_u16(),
+                    "glyphasset request failed"
+                );
+            }
+            http_response(status, &[], Vec::new())
+        }
+    }
+}
+
+fn load_image<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    webview_label: &str,
+    uri: &tauri::http::Uri,
+) -> Result<(&'static str, Vec<u8>), StatusCode> {
+    let host = uri.host().unwrap_or("localhost");
+    if host != "localhost" {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let rel = decode_rel_path(uri.path()).ok_or(StatusCode::NOT_FOUND)?;
+    deny_hidden_rel_path(&rel).map_err(|_| StatusCode::NOT_FOUND)?;
+
+    let ext = rel
+        .extension()
+        .and_then(|value| value.to_str())
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_default();
+    let mime = mime_for_image_ext(&ext).ok_or(StatusCode::NOT_FOUND)?;
+
+    let space_state = app.try_state::<SpaceState>().ok_or(StatusCode::NOT_FOUND)?;
+    let root = space_state
+        .root_for_webview_label(webview_label)
+        .map_err(|_| StatusCode::NOT_FOUND)?;
+    let abs = paths::join_under(&root, &rel).map_err(|_| StatusCode::NOT_FOUND)?;
+    if !abs.is_file() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
+    let bytes = std::fs::read(&abs).map_err(|_| StatusCode::NOT_FOUND)?;
+    Ok((mime, bytes))
+}
+
+fn decode_rel_path(uri_path: &str) -> Option<PathBuf> {
+    let trimmed = uri_path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let decoded = percent_decode_utf8(trimmed)?;
+    let rel = PathBuf::from(decoded.replace('\\', "/"));
+    if rel.as_os_str().is_empty() || rel.is_absolute() {
+        return None;
+    }
+    Some(rel)
+}
+
+fn percent_decode_utf8(value: &str) -> Option<String> {
+    if !value.as_bytes().contains(&b'%') {
+        return Some(value.to_string());
+    }
+
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let Some(high) = hex_value(bytes[index + 1]) else {
+                return None;
+            };
+            let Some(low) = hex_value(bytes[index + 2]) else {
+                return None;
+            };
+            decoded.push((high << 4) | low);
+            index += 3;
+            continue;
+        }
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn mime_for_image_ext(ext: &str) -> Option<&'static str> {
+    match ext {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "gif" => Some("image/gif"),
+        "svg" => Some("image/svg+xml"),
+        "bmp" => Some("image/bmp"),
+        "avif" => Some("image/avif"),
+        "tif" | "tiff" => Some("image/tiff"),
+        _ => None,
+    }
+}
+
+fn http_response(
+    status: StatusCode,
+    headers: &[(header::HeaderName, &'static str)],
+    body: Vec<u8>,
+) -> tauri::http::Response<Vec<u8>> {
+    let mut builder = tauri::http::Response::builder().status(status);
+    for (name, value) in headers {
+        builder = builder.header(name, *value);
+    }
+    builder.body(body).unwrap_or_else(|_| {
+        tauri::http::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Vec::new())
+            .unwrap_or_else(|_| tauri::http::Response::new(Vec::new()))
+    })
+}

--- a/src-tauri/src/space_asset_protocol.rs
+++ b/src-tauri/src/space_asset_protocol.rs
@@ -73,11 +73,13 @@ fn load_image<R: Runtime>(
         .root_for_webview_label(webview_label)
         .map_err(|_| StatusCode::NOT_FOUND)?;
     let abs = paths::join_under(&root, &rel).map_err(|_| StatusCode::NOT_FOUND)?;
-    if !abs.is_file() {
+    let canonical_root = root.canonicalize().map_err(|_| StatusCode::NOT_FOUND)?;
+    let canonical_path = abs.canonicalize().map_err(|_| StatusCode::NOT_FOUND)?;
+    if !canonical_path.starts_with(&canonical_root) || !canonical_path.is_file() {
         return Err(StatusCode::NOT_FOUND);
     }
 
-    let bytes = std::fs::read(&abs).map_err(|_| StatusCode::NOT_FOUND)?;
+    let bytes = std::fs::read(&canonical_path).map_err(|_| StatusCode::NOT_FOUND)?;
     Ok((mime, bytes))
 }
 

--- a/src-tauri/src/space_asset_protocol.rs
+++ b/src-tauri/src/space_asset_protocol.rs
@@ -73,9 +73,8 @@ fn load_image<R: Runtime>(
         .root_for_webview_label(webview_label)
         .map_err(|_| StatusCode::NOT_FOUND)?;
     let abs = paths::join_under(&root, &rel).map_err(|_| StatusCode::NOT_FOUND)?;
-    let canonical_root = root.canonicalize().map_err(|_| StatusCode::NOT_FOUND)?;
     let canonical_path = abs.canonicalize().map_err(|_| StatusCode::NOT_FOUND)?;
-    if !canonical_path.starts_with(&canonical_root) || !canonical_path.is_file() {
+    if !canonical_path.starts_with(&root) || !canonical_path.is_file() {
         return Err(StatusCode::NOT_FOUND);
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.15-alpha.3",
+	"version": "0.8.15-alpha.4",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/ai/AIFloatingHost.tsx
+++ b/src/components/ai/AIFloatingHost.tsx
@@ -10,13 +10,18 @@ const LazyAIPanel = lazy(loadAIPanel);
 
 interface AIFloatingHostProps {
 	onToggle: () => void;
+	hidden?: boolean;
 }
 
-export function AIFloatingHost({ onToggle }: AIFloatingHostProps) {
+export function AIFloatingHost({ onToggle, hidden }: AIFloatingHostProps) {
 	const shouldReduceMotion = useReducedMotion();
 
 	return (
-		<div className="aiFloatingWindowHost" data-window-drag-ignore>
+		<div
+			className="aiFloatingWindowHost"
+			data-window-drag-ignore
+			hidden={hidden}
+		>
 			<m.div
 				className="aiFloatingWindow"
 				initial={shouldReduceMotion ? false : { opacity: 0, x: 8, scale: 0.99 }}

--- a/src/components/ai/AIFloatingHost.tsx
+++ b/src/components/ai/AIFloatingHost.tsx
@@ -20,7 +20,7 @@ export function AIFloatingHost({ onToggle, hidden }: AIFloatingHostProps) {
 		<div
 			className="aiFloatingWindowHost"
 			data-window-drag-ignore
-			hidden={hidden}
+			style={hidden ? { display: "none" } : undefined}
 		>
 			<m.div
 				className="aiFloatingWindow"

--- a/src/components/ai/AIFloatingHost.tsx
+++ b/src/components/ai/AIFloatingHost.tsx
@@ -1,10 +1,8 @@
 import { m, useReducedMotion } from "motion/react";
-import { Suspense, lazy, useEffect } from "react";
-
-const importAIPanel = () => import("./AIPanel");
+import { Suspense, lazy } from "react";
 
 const loadAIPanel = () =>
-	importAIPanel().then((module) => ({
+	import("./AIPanel").then((module) => ({
 		default: module.AIPanel,
 	}));
 
@@ -16,21 +14,6 @@ interface AIFloatingHostProps {
 
 export function AIFloatingHost({ onToggle }: AIFloatingHostProps) {
 	const shouldReduceMotion = useReducedMotion();
-
-	useEffect(() => {
-		let cancelled = false;
-		void importAIPanel()
-			.then((module) => {
-				if (cancelled) return;
-				void module.prefetchAIPanelData();
-			})
-			.catch((error) => {
-				console.error("Failed to preload AI panel data", error);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
 
 	return (
 		<div className="aiFloatingWindowHost" data-window-drag-ignore>

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAISidebarContext, useUILayoutContext } from "../../contexts";
 import { extractErrorMessage } from "../../lib/errorUtils";
+import type { AiStoredToolEvent } from "../../lib/tauri";
 import { onWindowDragMouseDown } from "../../utils/window";
 import { ChevronDown, Settings as SettingsIcon, X } from "../Icons";
 import { Button } from "../ui/shadcn/button";
@@ -19,12 +20,21 @@ import {
 	consumePendingAiSelectionContext,
 } from "./aiContextEvents";
 import { messageText, parseAddTrigger } from "./aiPanelConstants";
+import {
+	endAiPanelKeepMounted,
+	setActiveAiHistoryJobId,
+	useAiPanelSession,
+} from "./aiPanelSession";
 import { useAiActions } from "./hooks/useAiActions";
 import { useAiToolEvents } from "./hooks/useAiToolEvents";
 import { useRigChat } from "./hooks/useRigChat";
-import { preloadAiContextIndex, useAiContext } from "./useAiContext";
-import { preloadAiHistorySummaries, useAiHistory } from "./useAiHistory";
-import { preloadAiProfilesData, useAiProfiles } from "./useAiProfiles";
+import { useAiContext } from "./useAiContext";
+import {
+	fetchAiHistoryDetail,
+	useAiHistory,
+	useRestoredAiChat,
+} from "./useAiHistory";
+import { useAiProfiles } from "./useAiProfiles";
 
 const CHIP_MARKER_RE = /\uE000[^\uE001]*\uE001|\uE000|\uE001/g;
 
@@ -32,12 +42,15 @@ interface AIPanelProps {
 	onClose: () => void;
 }
 
-export async function prefetchAIPanelData(): Promise<void> {
-	await Promise.all([
-		preloadAiProfilesData(),
-		preloadAiHistorySummaries(14),
-		preloadAiContextIndex(),
-	]);
+function timelineFromStoredToolEvents(
+	toolEvents: AiStoredToolEvent[],
+): AIActivityTimelineEvent[] {
+	return toolEvents
+		.filter((event) => event.phase === "result")
+		.map((event) => ({
+			kind: "citation",
+			payload: event.payload,
+		}));
 }
 
 function stripChipMarkers(text: string): string {
@@ -58,11 +71,26 @@ export function AIPanel({ onClose }: AIPanelProps) {
 	const [selectionContext, setSelectionContext] =
 		useState<AiSelectionContext | null>(null);
 	const [selectionMessageBaseline, setSelectionMessageBaseline] = useState(0);
+	const [hydratedJobId, setHydratedJobId] = useState<string | null>(null);
 
+	const session = useAiPanelSession();
 	const history = useAiHistory(14, { enabled: historyExpanded });
 	const chat = useRigChat({
-		onComplete: () => void history.refresh(),
+		onComplete: (historyId, keepAliveEpoch) => {
+			setActiveAiHistoryJobId(historyId);
+			setHydratedJobId(historyId);
+			void history.refresh();
+			void fetchAiHistoryDetail(historyId).finally(() => {
+				endAiPanelKeepMounted(keepAliveEpoch);
+			});
+		},
 	});
+	const shouldRestore =
+		Boolean(session.jobId) &&
+		chat.messages.length === 0 &&
+		chat.status === "ready" &&
+		hydratedJobId !== session.jobId;
+	const restored = useRestoredAiChat(shouldRestore ? session.jobId : null);
 	const profiles = useAiProfiles();
 	const trigger = parseAddTrigger(input);
 	const showAddPanel = addPanelOpen || Boolean(trigger);
@@ -70,6 +98,18 @@ export function AIPanel({ onClose }: AIPanelProps) {
 	const context = useAiContext(panelQuery);
 	const toolEvents = useAiToolEvents({ isChatMode, chatStatus: chat.status });
 	const actions = useAiActions(chat);
+
+	if (restored && session.jobId && hydratedJobId !== session.jobId) {
+		setHydratedJobId(session.jobId);
+		chat.setThreadId(session.jobId);
+		chat.setMessages(restored.messages);
+		toolEvents.resetToolState();
+		toolEvents.setResponsePhase("idle");
+		toolEvents.setActivityTimeline(
+			timelineFromStoredToolEvents(restored.toolEvents),
+		);
+		chat.clearError();
+	}
 
 	const composerInputRef = useRef<HTMLDivElement | null>(null);
 	const scheduleResize = useCallback(() => {
@@ -275,15 +315,14 @@ export function AIPanel({ onClose }: AIPanelProps) {
 			}
 			const loaded = await history.loadChatMessages(jobId);
 			if (!loaded) return;
+			setActiveAiHistoryJobId(jobId);
+			setHydratedJobId(jobId);
 			toolEvents.resetToolState();
 			toolEvents.setResponsePhase("idle");
-			const restoredTimeline: AIActivityTimelineEvent[] = loaded.toolEvents
-				.filter((event) => event.phase === "result")
-				.map((event) => ({
-					kind: "citation",
-					payload: event.payload,
-				}));
-			toolEvents.setActivityTimeline(restoredTimeline);
+			toolEvents.setActivityTimeline(
+				timelineFromStoredToolEvents(loaded.toolEvents),
+			);
+			chat.setThreadId(jobId);
 			chat.setMessages(loaded.messages);
 			chat.clearError();
 			setSelectionContext(null);
@@ -310,6 +349,8 @@ export function AIPanel({ onClose }: AIPanelProps) {
 		chat.setMessages([]);
 		chat.clearError();
 		setSelectionMessageBaseline(0);
+		setHydratedJobId(null);
+		setActiveAiHistoryJobId(null);
 	}, [actions, chat, scheduleResize, toolEvents]);
 
 	const latestSelectionAssistantText = useMemo(() => {

--- a/src/components/ai/AIPanel.tsx
+++ b/src/components/ai/AIPanel.tsx
@@ -80,9 +80,11 @@ export function AIPanel({ onClose }: AIPanelProps) {
 			setActiveAiHistoryJobId(historyId);
 			setHydratedJobId(historyId);
 			void history.refresh();
-			void fetchAiHistoryDetail(historyId).finally(() => {
-				endAiPanelKeepMounted(keepAliveEpoch);
-			});
+			void fetchAiHistoryDetail(historyId)
+				.catch(() => {})
+				.finally(() => {
+					endAiPanelKeepMounted(keepAliveEpoch);
+				});
 		},
 	});
 	const shouldRestore =

--- a/src/components/ai/aiPanelSession.ts
+++ b/src/components/ai/aiPanelSession.ts
@@ -1,0 +1,56 @@
+import { useSyncExternalStore } from "react";
+
+type AiPanelSessionSnapshot = {
+	jobId: string | null;
+	keepMounted: boolean;
+};
+
+let jobId: string | null = null;
+let keepMounted = false;
+let keepAliveEpoch = 0;
+let snapshot: AiPanelSessionSnapshot = { jobId: null, keepMounted: false };
+const listeners = new Set<() => void>();
+
+function emit(): void {
+	snapshot = { jobId, keepMounted };
+	for (const listener of listeners) {
+		listener();
+	}
+}
+
+export function setActiveAiHistoryJobId(next: string | null): void {
+	const normalized = next?.trim() || null;
+	if (jobId === normalized) return;
+	jobId = normalized;
+	emit();
+}
+
+export function beginAiPanelKeepMounted(): number {
+	keepAliveEpoch += 1;
+	if (!keepMounted) {
+		keepMounted = true;
+		emit();
+	}
+	return keepAliveEpoch;
+}
+
+export function endAiPanelKeepMounted(epoch: number): void {
+	if (epoch !== keepAliveEpoch || !keepMounted) return;
+	keepMounted = false;
+	emit();
+}
+
+function subscribe(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+function getSnapshot(): AiPanelSessionSnapshot {
+	return snapshot;
+}
+
+export function useAiPanelSession(): AiPanelSessionSnapshot {
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/src/components/ai/aiPanelSession.ts
+++ b/src/components/ai/aiPanelSession.ts
@@ -40,6 +40,14 @@ export function endAiPanelKeepMounted(epoch: number): void {
 	emit();
 }
 
+export function clearAiPanelSession(): void {
+	keepAliveEpoch += 1;
+	if (!jobId && !keepMounted) return;
+	jobId = null;
+	keepMounted = false;
+	emit();
+}
+
 function subscribe(listener: () => void): () => void {
 	listeners.add(listener);
 	return () => {

--- a/src/components/ai/aiPanelSession.ts
+++ b/src/components/ai/aiPanelSession.ts
@@ -40,6 +40,10 @@ export function endAiPanelKeepMounted(epoch: number): void {
 	emit();
 }
 
+export function isAiPanelKeepMounted(epoch: number): boolean {
+	return epoch === keepAliveEpoch && keepMounted;
+}
+
 export function clearAiPanelSession(): void {
 	keepAliveEpoch += 1;
 	if (!jobId && !keepMounted) return;

--- a/src/components/ai/cache.ts
+++ b/src/components/ai/cache.ts
@@ -1,8 +1,10 @@
+import { clearAiPanelSession } from "./aiPanelSession";
 import { clearAiContextCache } from "./useAiContext";
 import { clearAiHistoryCache } from "./useAiHistory";
 import { clearAiProfilesCache } from "./useAiProfiles";
 
 export function clearAiPanelCaches() {
+	clearAiPanelSession();
 	clearAiContextCache();
 	clearAiHistoryCache();
 	clearAiProfilesCache();

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -7,6 +7,10 @@ import {
 	invoke,
 } from "../../../lib/tauri";
 import { listenTauriEvent } from "../../../lib/tauriEvents";
+import {
+	beginAiPanelKeepMounted,
+	endAiPanelKeepMounted,
+} from "../aiPanelSession";
 
 type UIMessagePart = { type: "text"; text: string };
 
@@ -41,7 +45,7 @@ type SendMessageOptions = {
 };
 
 interface UseRigChatOptions {
-	onComplete?: () => void;
+	onComplete?: (historyId: string, keepAliveEpoch: number) => void;
 }
 
 export type RigChatStatus = "ready" | "submitted" | "streaming" | "error";
@@ -69,6 +73,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	const messagesRef = useRef<UIMessage[]>([]);
 	const activeJobIdRef = useRef<string | null>(null);
 	const activeThreadIdRef = useRef<string | null>(null);
+	const keepAliveEpochRef = useRef(0);
 	const awaitingStartRef = useRef(false);
 	const stopListenersRef = useRef<Array<() => void>>([]);
 	const doneTimerRef = useRef<number | null>(null);
@@ -99,6 +104,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	}, []);
 
 	const completeActiveJob = useCallback(() => {
+		const historyId = activeThreadIdRef.current || activeJobIdRef.current;
+		const keepAliveEpoch = keepAliveEpochRef.current;
 		flushStreamingRef.current?.();
 		flushStreamingRef.current = null;
 		clearDoneTimer();
@@ -106,7 +113,12 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 		awaitingStartRef.current = false;
 		cleanupListeners();
 		setStatus("ready");
-		onComplete?.();
+		if (historyId && onComplete) {
+			activeThreadIdRef.current = historyId;
+			onComplete(historyId, keepAliveEpoch);
+			return;
+		}
+		endAiPanelKeepMounted(keepAliveEpoch);
 	}, [cleanupListeners, clearDoneTimer, onComplete]);
 
 	const clearError = useCallback(() => {
@@ -125,6 +137,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 		activeJobIdRef.current = null;
 		awaitingStartRef.current = false;
 		cleanupListeners();
+		endAiPanelKeepMounted(keepAliveEpochRef.current);
 		setStatus("ready");
 	}, [cleanupListeners, clearDoneTimer]);
 
@@ -163,6 +176,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 			updateMessages(nextMessages);
 			setStatus("submitted");
 			awaitingStartRef.current = true;
+			keepAliveEpochRef.current = beginAiPanelKeepMounted();
 
 			try {
 				clearDoneTimer();
@@ -244,6 +258,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					activeJobIdRef.current = null;
 					awaitingStartRef.current = false;
 					cleanupListeners();
+					endAiPanelKeepMounted(keepAliveEpochRef.current);
 					setError(new Error(payload.message));
 					setStatus("error");
 				};
@@ -298,6 +313,9 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				});
 
 				activeJobIdRef.current = jobId;
+				if (!activeThreadIdRef.current) {
+					activeThreadIdRef.current = jobId;
+				}
 				awaitingStartRef.current = false;
 				for (const payload of pendingChunks) {
 					handleChunk(payload);
@@ -313,6 +331,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				activeJobIdRef.current = null;
 				awaitingStartRef.current = false;
 				cleanupListeners();
+				endAiPanelKeepMounted(keepAliveEpochRef.current);
 				setError(err instanceof Error ? err : new Error(String(err)));
 				setStatus("error");
 			}

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -10,6 +10,7 @@ import { listenTauriEvent } from "../../../lib/tauriEvents";
 import {
 	beginAiPanelKeepMounted,
 	endAiPanelKeepMounted,
+	isAiPanelKeepMounted,
 } from "../aiPanelSession";
 
 type UIMessagePart = { type: "text"; text: string };
@@ -127,6 +128,8 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 	}, []);
 
 	const stop = useCallback(() => {
+		const keepAliveEpoch = keepAliveEpochRef.current;
+		keepAliveEpochRef.current = 0;
 		const jobId = activeJobIdRef.current;
 		if (jobId) {
 			void invoke("ai_chat_cancel", { job_id: jobId }).catch(() => {});
@@ -137,7 +140,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 		activeJobIdRef.current = null;
 		awaitingStartRef.current = false;
 		cleanupListeners();
-		endAiPanelKeepMounted(keepAliveEpochRef.current);
+		endAiPanelKeepMounted(keepAliveEpoch);
 		setStatus("ready");
 	}, [cleanupListeners, clearDoneTimer]);
 
@@ -178,7 +181,9 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 			awaitingStartRef.current = true;
 			const keepAliveEpoch = beginAiPanelKeepMounted();
 			keepAliveEpochRef.current = keepAliveEpoch;
-			const isCurrentSend = () => keepAliveEpochRef.current === keepAliveEpoch;
+			const isCurrentSend = () =>
+				keepAliveEpochRef.current === keepAliveEpoch &&
+				isAiPanelKeepMounted(keepAliveEpoch);
 
 			try {
 				clearDoneTimer();

--- a/src/components/ai/hooks/useRigChat.ts
+++ b/src/components/ai/hooks/useRigChat.ts
@@ -176,7 +176,9 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 			updateMessages(nextMessages);
 			setStatus("submitted");
 			awaitingStartRef.current = true;
-			keepAliveEpochRef.current = beginAiPanelKeepMounted();
+			const keepAliveEpoch = beginAiPanelKeepMounted();
+			keepAliveEpochRef.current = keepAliveEpoch;
+			const isCurrentSend = () => keepAliveEpochRef.current === keepAliveEpoch;
 
 			try {
 				clearDoneTimer();
@@ -201,8 +203,12 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 				let chunkFrame: number | null = null;
 				let streamingStarted = false;
 				const shouldBufferEvent = (jobId: string) =>
-					awaitingStartRef.current && !activeJobIdRef.current && !!jobId;
-				const isActiveJob = (jobId: string) => jobId === activeJobIdRef.current;
+					isCurrentSend() &&
+					awaitingStartRef.current &&
+					!activeJobIdRef.current &&
+					!!jobId;
+				const isActiveJob = (jobId: string) =>
+					isCurrentSend() && jobId === activeJobIdRef.current;
 				const flushChunks = () => {
 					if (chunkFrame !== null) {
 						window.cancelAnimationFrame(chunkFrame);
@@ -258,7 +264,7 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					activeJobIdRef.current = null;
 					awaitingStartRef.current = false;
 					cleanupListeners();
-					endAiPanelKeepMounted(keepAliveEpochRef.current);
+					endAiPanelKeepMounted(keepAliveEpoch);
 					setError(new Error(payload.message));
 					setStatus("error");
 				};
@@ -286,6 +292,12 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					}
 					handleError(payload);
 				});
+				if (!isCurrentSend()) {
+					onChunk();
+					onDone();
+					onError();
+					return;
+				}
 
 				stopListenersRef.current = [
 					onChunk,
@@ -311,6 +323,10 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 						audit: options?.body?.audit ?? true,
 					},
 				});
+				if (!isCurrentSend()) {
+					void invoke("ai_chat_cancel", { job_id: jobId }).catch(() => {});
+					return;
+				}
 
 				activeJobIdRef.current = jobId;
 				if (!activeThreadIdRef.current) {
@@ -326,12 +342,13 @@ export function useRigChat(options: UseRigChatOptions = {}) {
 					handleDone(pendingDone);
 				}
 			} catch (err) {
+				if (!isCurrentSend()) return;
 				flushStreamingRef.current = null;
 				clearDoneTimer();
 				activeJobIdRef.current = null;
 				awaitingStartRef.current = false;
 				cleanupListeners();
-				endAiPanelKeepMounted(keepAliveEpochRef.current);
+				endAiPanelKeepMounted(keepAliveEpoch);
 				setError(err instanceof Error ? err : new Error(String(err)));
 				setStatus("error");
 			}

--- a/src/components/ai/useAiContext.ts
+++ b/src/components/ai/useAiContext.ts
@@ -59,19 +59,6 @@ function contextKey(kind: ContextEntryKind, path: string): string {
 	return `${kind}:${path}`;
 }
 
-export async function preloadAiContextIndex(): Promise<AiContextIndexData | null> {
-	return queryClient.fetchQuery({
-		queryKey: aiContextIndexQueryKey,
-		queryFn: async () => {
-			const index = await invoke("ai_context_index");
-			return {
-				folders: index.folders,
-				files: index.files,
-			};
-		},
-	});
-}
-
 export function useAiContext(contextSearch = "") {
 	const [attachedContext, setAttachedContext] = useState<ContextEntry[]>([]);
 	const attachedContextRef = useRef<ContextEntry[]>([]);

--- a/src/components/ai/useAiHistory.ts
+++ b/src/components/ai/useAiHistory.ts
@@ -53,6 +53,8 @@ export function fetchAiHistoryDetail(
 	return queryClient.fetchQuery({
 		queryKey: aiHistoryQueryKeys.detail(jobId),
 		queryFn: () => invoke("ai_chat_history_get", { job_id: jobId }),
+		gcTime: 0,
+		staleTime: 0,
 		retry: HISTORY_WRITE_RETRY,
 		retryDelay: HISTORY_WRITE_RETRY_MS,
 	});
@@ -63,6 +65,7 @@ export function useRestoredAiChat(jobId: string | null): LoadedAiChat | null {
 		queryKey: aiHistoryQueryKeys.detail(jobId ?? ""),
 		queryFn: () => invoke("ai_chat_history_get", { job_id: jobId ?? "" }),
 		enabled: Boolean(jobId),
+		gcTime: 0,
 	});
 	if (!jobId || !query.data) return null;
 	return {
@@ -92,6 +95,8 @@ export function useAiHistory(limit = 20, options?: UseAiHistoryOptions) {
 			const detail = await localQueryClient.fetchQuery({
 				queryKey: aiHistoryQueryKeys.detail(jobId),
 				queryFn: () => invoke("ai_chat_history_get", { job_id: jobId }),
+				gcTime: 0,
+				staleTime: 0,
 			});
 			return {
 				messages: toUIMessages(jobId, detail.messages),

--- a/src/components/ai/useAiHistory.ts
+++ b/src/components/ai/useAiHistory.ts
@@ -4,7 +4,6 @@ import { extractErrorMessage } from "../../lib/errorUtils";
 import { queryClient } from "../../lib/queryClient";
 import {
 	type AiChatHistoryDetail,
-	type AiChatHistorySummary,
 	type AiStoredToolEvent,
 	invoke,
 } from "../../lib/tauri";
@@ -45,13 +44,31 @@ interface LoadedAiChat {
 	toolEvents: AiStoredToolEvent[];
 }
 
-export function preloadAiHistorySummaries(
-	limit = 20,
-): Promise<AiChatHistorySummary[]> {
+const HISTORY_WRITE_RETRY = 30;
+const HISTORY_WRITE_RETRY_MS = 500;
+
+export function fetchAiHistoryDetail(
+	jobId: string,
+): Promise<AiChatHistoryDetail> {
 	return queryClient.fetchQuery({
-		queryKey: aiHistoryQueryKeys.summaries(limit),
-		queryFn: () => invoke("ai_chat_history_list", { limit }),
+		queryKey: aiHistoryQueryKeys.detail(jobId),
+		queryFn: () => invoke("ai_chat_history_get", { job_id: jobId }),
+		retry: HISTORY_WRITE_RETRY,
+		retryDelay: HISTORY_WRITE_RETRY_MS,
 	});
+}
+
+export function useRestoredAiChat(jobId: string | null): LoadedAiChat | null {
+	const query = useQuery({
+		queryKey: aiHistoryQueryKeys.detail(jobId ?? ""),
+		queryFn: () => invoke("ai_chat_history_get", { job_id: jobId ?? "" }),
+		enabled: Boolean(jobId),
+	});
+	if (!jobId || !query.data) return null;
+	return {
+		messages: toUIMessages(jobId, query.data.messages),
+		toolEvents: query.data.tool_events ?? [],
+	};
 }
 
 interface UseAiHistoryOptions {

--- a/src/components/ai/useAiProfiles.ts
+++ b/src/components/ai/useAiProfiles.ts
@@ -39,13 +39,6 @@ export function clearAiProfilesCache() {
 	queryClient.removeQueries({ queryKey: aiProfilesQueryKey });
 }
 
-export function preloadAiProfilesData(): Promise<AiProfilesBootstrap> {
-	return queryClient.fetchQuery({
-		queryKey: aiProfilesQueryKey,
-		queryFn: fetchAiProfilesBootstrap,
-	});
-}
-
 function updateProfilesCache(
 	updater: (current: AiProfilesBootstrap) => AiProfilesBootstrap,
 ) {

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -468,7 +468,7 @@ export const MainContent = memo(function MainContent({
 			>
 				{aiSidebarMounted ? (
 					<AIFloatingHost
-						hidden={!aiSidebarVisible}
+						hidden={!rightSidebarOpen || !aiSidebarVisible}
 						onToggle={() => setAiPanelOpen((open) => !open)}
 					/>
 				) : null}

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -1,6 +1,5 @@
 import { m } from "motion/react";
 import {
-	Activity,
 	type CSSProperties,
 	type Dispatch,
 	type SetStateAction,
@@ -32,6 +31,7 @@ import type { FsEntry } from "../../lib/tauri";
 import { toast } from "../../lib/toast";
 import { cn } from "../../lib/utils";
 import { AIFloatingHost } from "../ai/AIFloatingHost";
+import { useAiPanelSession } from "../ai/aiPanelSession";
 import type { CreateMarkdownFileOptions } from "../editor/types";
 import { FolioWorkspace } from "../folio/FolioWorkspace";
 import { NoteSidePeek } from "../preview/NoteSidePeek";
@@ -262,11 +262,14 @@ export const MainContent = memo(function MainContent({
 	const { spacePath, settingsLoaded, onOpenSpace } = useSpace();
 	const { folioMode, settingsMode, settingsTab } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
+	const { keepMounted: aiPanelKeepMounted } = useAiPanelSession();
 	const [infoSidebarWidth, setInfoSidebarWidth] = useState(340);
 	const [infoSidebarOpen, setInfoSidebarOpen] = useState(false);
 	const handledDailyNoteSetupNoticeRequestRef = useRef(0);
 
 	const aiSidebarVisible = aiEnabled && aiPanelOpen && !infoSidebarOpen;
+	const aiSidebarMounted =
+		aiEnabled && (aiSidebarVisible || aiPanelKeepMounted);
 	const rightSidebarOpen =
 		Boolean(spacePath) &&
 		!settingsMode &&
@@ -464,9 +467,9 @@ export const MainContent = memo(function MainContent({
 				data-open={rightSidebarOpen ? "true" : undefined}
 				style={notesInfoSidebarHostStyle}
 			>
-				<Activity mode={aiSidebarVisible ? "visible" : "hidden"}>
+				{aiSidebarMounted ? (
 					<AIFloatingHost onToggle={() => setAiPanelOpen((open) => !open)} />
-				</Activity>
+				) : null}
 			</div>
 		</>
 	);

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -268,8 +268,7 @@ export const MainContent = memo(function MainContent({
 	const handledDailyNoteSetupNoticeRequestRef = useRef(0);
 
 	const aiSidebarVisible = aiEnabled && aiPanelOpen && !infoSidebarOpen;
-	const aiSidebarMounted =
-		aiEnabled && (aiSidebarVisible || aiPanelKeepMounted);
+	const aiSidebarMounted = aiSidebarVisible || aiPanelKeepMounted;
 	const rightSidebarOpen =
 		Boolean(spacePath) &&
 		!settingsMode &&
@@ -468,7 +467,10 @@ export const MainContent = memo(function MainContent({
 				style={notesInfoSidebarHostStyle}
 			>
 				{aiSidebarMounted ? (
-					<AIFloatingHost onToggle={() => setAiPanelOpen((open) => !open)} />
+					<AIFloatingHost
+						hidden={!aiSidebarVisible}
+						onToggle={() => setAiPanelOpen((open) => !open)}
+					/>
 				) : null}
 			</div>
 		</>
@@ -476,16 +478,19 @@ export const MainContent = memo(function MainContent({
 
 	if (settingsMode) {
 		return (
-			<main className="mainArea">
-				<div className="settingsTabPanel">
-					<header className="settingsPanelHeader">
-						<div className="settingsPanelTitleRow">
-							<h2 className="settingsPanelTitle">{settingsPanelTitle}</h2>
-						</div>
-					</header>
-					<SettingsTabContent tab={settingsTab} />
-				</div>
-			</main>
+			<>
+				<main className="mainArea">
+					<div className="settingsTabPanel">
+						<header className="settingsPanelHeader">
+							<div className="settingsPanelTitleRow">
+								<h2 className="settingsPanelTitle">{settingsPanelTitle}</h2>
+							</div>
+						</header>
+						<SettingsTabContent tab={settingsTab} />
+					</div>
+				</main>
+				{aiPanelKeepMounted ? rightSidebarSurface : null}
+			</>
 		);
 	}
 

--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -36,6 +36,7 @@ import { useSpaceConnectionsGraph } from "./useSpaceConnectionsGraph";
 const LARGE_GRAPH_NOTE_THRESHOLD = 5_000;
 const CONNECTIONS_QUERY_ROOT = "space-connections";
 const CONNECTIONS_SETTINGS_QUERY_ROOT = "space-connections-settings";
+const warnedLargeGraphSpaces = new Set<string>();
 
 async function warnAboutLargeGraph(payload: SpaceConnections) {
 	const noteCount = payload.nodes.length;
@@ -160,14 +161,13 @@ export function SpaceConnectionsView() {
 		gcTime: 0,
 		queryFn: async () => {
 			const payload = await invoke("space_connections");
-			const existing = queryClient.getQueryData<SpaceConnections>([
-				CONNECTIONS_QUERY_ROOT,
-				scopedSpacePath,
-			]);
-			const alreadyWarned =
-				existing !== undefined &&
-				existing.nodes.length > LARGE_GRAPH_NOTE_THRESHOLD;
-			if (!alreadyWarned) await warnAboutLargeGraph(payload);
+			if (
+				payload.nodes.length > LARGE_GRAPH_NOTE_THRESHOLD &&
+				!warnedLargeGraphSpaces.has(scopedSpacePath)
+			) {
+				warnedLargeGraphSpaces.add(scopedSpacePath);
+				await warnAboutLargeGraph(payload);
+			}
 			return payload;
 		},
 	});

--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -157,6 +157,7 @@ export function SpaceConnectionsView() {
 	const connectionsQuery = useQuery({
 		queryKey: [CONNECTIONS_QUERY_ROOT, scopedSpacePath],
 		enabled: Boolean(spacePath),
+		gcTime: 0,
 		queryFn: async () => {
 			const payload = await invoke("space_connections");
 			const existing = queryClient.getQueryData<SpaceConnections>([

--- a/src/components/connections/useSpaceConnectionsGraph.ts
+++ b/src/components/connections/useSpaceConnectionsGraph.ts
@@ -148,6 +148,7 @@ export function useSpaceConnectionsGraph(
 		queryKey: ["space-connections-layout", spacePath, layoutFingerprint],
 		enabled: Boolean(filteredPayload && filteredPayload.nodes.length > 0),
 		staleTime: Number.POSITIVE_INFINITY,
+		gcTime: 0,
 		retry: false,
 		queryFn: ({ signal }) => {
 			if (!filteredPayload) {

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -2,18 +2,29 @@ import type { Editor } from "@tiptap/core";
 import { useEffect } from "react";
 import { invoke } from "../../../lib/tauri";
 
-const INLINE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 const INLINE_IMAGE_CACHE_MAX = 64;
-const INLINE_IMAGE_CACHE_MAX_BYTES = 24 * 1024 * 1024;
 const INLINE_IMAGE_HYDRATION_ROOT_MARGIN = "720px 0px";
+const GLYPH_ASSET_SCHEME = "glyphasset";
 
-const dataUrlCache = new Map<string, string>();
+const urlCache = new Map<string, string>();
 const missCache = new Set<string>();
 const inFlightCache = new Map<string, Promise<string | null>>();
 const sourceGeneration = new Map<string, number>();
 const sourceConsumers = new Map<string, number>();
 let globalGeneration = 0;
 let nextSourceGeneration = 1;
+
+export function spaceAssetUrl(relPath: string): string {
+	const encoded = relPath
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/^\/+/, "")
+		.split("/")
+		.filter((segment) => segment.length > 0)
+		.map((segment) => encodeURIComponent(segment))
+		.join("/");
+	return `${GLYPH_ASSET_SCHEME}://localhost/${encoded}`;
+}
 
 function getSourceGeneration(sourcePath: string): number {
 	const existing = sourceGeneration.get(sourcePath);
@@ -34,24 +45,11 @@ function matchesGeneration(
 	);
 }
 
-function getCacheBytes(): number {
-	let total = 0;
-	for (const value of dataUrlCache.values()) {
-		total += value.length;
-	}
-	return total;
-}
-
 function trimOldestCacheEntries() {
-	while (dataUrlCache.size > INLINE_IMAGE_CACHE_MAX) {
-		const oldestKey = dataUrlCache.keys().next().value;
+	while (urlCache.size > INLINE_IMAGE_CACHE_MAX) {
+		const oldestKey = urlCache.keys().next().value;
 		if (!oldestKey) break;
-		dataUrlCache.delete(oldestKey);
-	}
-	while (getCacheBytes() > INLINE_IMAGE_CACHE_MAX_BYTES) {
-		const oldestKey = dataUrlCache.keys().next().value;
-		if (!oldestKey) break;
-		dataUrlCache.delete(oldestKey);
+		urlCache.delete(oldestKey);
 	}
 	while (missCache.size > INLINE_IMAGE_CACHE_MAX) {
 		const oldestKey = missCache.values().next().value;
@@ -64,7 +62,7 @@ export function clearInlineImageHydrationCache() {
 	globalGeneration += 1;
 	sourceGeneration.clear();
 	sourceConsumers.clear();
-	dataUrlCache.clear();
+	urlCache.clear();
 	missCache.clear();
 	inFlightCache.clear();
 }
@@ -72,7 +70,7 @@ export function clearInlineImageHydrationCache() {
 function maybeDeleteSourceGeneration(sourcePath: string) {
 	const prefix = `${sourcePath}::`;
 	const hasEntries =
-		[...dataUrlCache.keys()].some((key) => key.startsWith(prefix)) ||
+		[...urlCache.keys()].some((key) => key.startsWith(prefix)) ||
 		[...missCache].some((key) => key.startsWith(prefix)) ||
 		[...inFlightCache.keys()].some((key) => key.startsWith(prefix));
 	if (!hasEntries && (sourceConsumers.get(sourcePath) ?? 0) === 0) {
@@ -85,8 +83,8 @@ function clearInlineImageHydrationCacheForSource(sourcePath: string) {
 	const prefix = `${sourcePath}::`;
 	// Wiki image-link keys are global (`wiki-image-link::...`) and intentionally
 	// survive per-source invalidation because they do not depend on sourcePath.
-	for (const key of [...dataUrlCache.keys()]) {
-		if (key.startsWith(prefix)) dataUrlCache.delete(key);
+	for (const key of [...urlCache.keys()]) {
+		if (key.startsWith(prefix)) urlCache.delete(key);
 	}
 	for (const key of [...missCache]) {
 		if (key.startsWith(prefix)) missCache.delete(key);
@@ -113,7 +111,9 @@ function decrementInlineImageHydrationConsumers(sourcePath: string) {
 }
 
 function isDirectImageUrl(src: string): boolean {
-	return /^(https?:|data:|blob:|asset:|tauri:|file:|\/\/)/i.test(src);
+	return /^(https?:|data:|blob:|asset:|tauri:|file:|glyphasset:|\/\/)/i.test(
+		src,
+	);
 }
 
 function dedupeCandidates(href: string): string[] {
@@ -172,13 +172,13 @@ async function resolveSpaceImagePath(
 	return null;
 }
 
-async function resolveInlineImageDataUrl(
+async function resolveInlineImageSrc(
 	sourcePath: string,
 	rawSrc: string,
 	kind: InlineImageResolverKind,
 ): Promise<string | null> {
 	const key = getInlineImageCacheKey(sourcePath, rawSrc, kind);
-	if (dataUrlCache.has(key)) return dataUrlCache.get(key) ?? null;
+	if (urlCache.has(key)) return urlCache.get(key) ?? null;
 	if (missCache.has(key)) return null;
 	if (inFlightCache.has(key)) return inFlightCache.get(key) ?? null;
 	const expectedGlobalGeneration = globalGeneration;
@@ -202,27 +202,10 @@ async function resolveInlineImageDataUrl(
 				trimOldestCacheEntries();
 				return null;
 			}
-			const preview = await invoke("space_read_binary_preview", {
-				path: relPath,
-				max_bytes: INLINE_IMAGE_MAX_BYTES,
-			});
-			if (
-				!matchesGeneration(
-					sourcePath,
-					expectedGlobalGeneration,
-					expectedSourceGeneration,
-				)
-			) {
-				return null;
-			}
-			if (preview.truncated) {
-				missCache.add(key);
-				trimOldestCacheEntries();
-				return null;
-			}
-			dataUrlCache.set(key, preview.data_url);
+			const src = spaceAssetUrl(relPath);
+			urlCache.set(key, src);
 			trimOldestCacheEntries();
-			return preview.data_url;
+			return src;
 		} catch {
 			if (
 				matchesGeneration(
@@ -261,7 +244,7 @@ function hydrateImageNodesInDocument(
 	editor: Editor,
 	image: HTMLImageElement,
 	originalSrc: string,
-	dataUrl: string,
+	src: string,
 ) {
 	if (editor.isDestroyed) return;
 	let domPos: number;
@@ -280,10 +263,10 @@ function hydrateImageNodesInDocument(
 				? node.attrs.originSrc
 				: currentSrc;
 		if (currentOrigin !== originalSrc) continue;
-		if (currentSrc === dataUrl && node.attrs.originSrc === originalSrc) return;
+		if (currentSrc === src && node.attrs.originSrc === originalSrc) return;
 		tr.setNodeMarkup(pos, undefined, {
 			...node.attrs,
-			src: dataUrl,
+			src,
 			originSrc: originalSrc,
 		});
 		editor.view.dispatch(tr);
@@ -319,31 +302,29 @@ export function useHydrateInlineImages(
 			const key = getInlineImageCacheKey(sourcePath, originalSrc, resolverKind);
 			if (image.getAttribute("data-glyph-hydrated-key") === key) return;
 			image.dataset.glyphHydrationState = "loading";
-			void resolveInlineImageDataUrl(
-				sourcePath,
-				originalSrc,
-				resolverKind,
-			).then((dataUrl) => {
-				if (cancelled || editor.isDestroyed || !image.isConnected) return;
-				const currentOrigin =
-					image.getAttribute("data-glyph-origin-src")?.trim() ?? "";
-				const currentKey = currentOrigin
-					? getInlineImageCacheKey(
-							sourcePath,
-							currentOrigin,
-							getResolverKindForImage(image),
-						)
-					: "";
-				if (currentKey !== key) return;
-				if (!dataUrl) {
-					image.dataset.glyphHydrationState = "failed";
-					return;
-				}
-				hydrateImageNodesInDocument(editor, image, originalSrc, dataUrl);
-				image.setAttribute("data-glyph-hydrated-key", key);
-				image.setAttribute("src", dataUrl);
-				image.dataset.glyphHydrationState = "ready";
-			});
+			void resolveInlineImageSrc(sourcePath, originalSrc, resolverKind).then(
+				(src) => {
+					if (cancelled || editor.isDestroyed || !image.isConnected) return;
+					const currentOrigin =
+						image.getAttribute("data-glyph-origin-src")?.trim() ?? "";
+					const currentKey = currentOrigin
+						? getInlineImageCacheKey(
+								sourcePath,
+								currentOrigin,
+								getResolverKindForImage(image),
+							)
+						: "";
+					if (currentKey !== key) return;
+					if (!src) {
+						image.dataset.glyphHydrationState = "failed";
+						return;
+					}
+					hydrateImageNodesInDocument(editor, image, originalSrc, src);
+					image.setAttribute("data-glyph-hydrated-key", key);
+					image.setAttribute("src", src);
+					image.dataset.glyphHydrationState = "ready";
+				},
+			);
 		};
 
 		const hydrateImages = () => {

--- a/src/components/editor/hooks/useHydrateInlineImages.ts
+++ b/src/components/editor/hooks/useHydrateInlineImages.ts
@@ -16,7 +16,6 @@ let nextSourceGeneration = 1;
 
 export function spaceAssetUrl(relPath: string): string {
 	const encoded = relPath
-		.trim()
 		.replace(/\\/g, "/")
 		.replace(/^\/+/, "")
 		.split("/")

--- a/src/components/editor/hooks/useNoteEditor.test.tsx
+++ b/src/components/editor/hooks/useNoteEditor.test.tsx
@@ -240,7 +240,8 @@ vi.mock("../../../lib/tauriEvents", () => ({
 	},
 }));
 
-vi.mock("./useHydrateInlineImages", () => ({
+vi.mock("./useHydrateInlineImages", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./useHydrateInlineImages")>()),
 	useHydrateInlineImages: () => {},
 }));
 
@@ -1214,7 +1215,7 @@ describe("useNoteEditor", () => {
 			6,
 			undefined,
 			expect.objectContaining({
-				src: "data:image/png;base64,abc",
+				src: "glyphasset://localhost/assets/image.png",
 				alt: "paste.png",
 				title: "",
 				originSrc: "../assets/image.png",

--- a/src/components/editor/hooks/useNoteEditor.ts
+++ b/src/components/editor/hooks/useNoteEditor.ts
@@ -30,7 +30,10 @@ import {
 	applyEditorSpellCheck,
 	useEditorSpellCheck,
 } from "./useEditorSpellCheck";
-import { useHydrateInlineImages } from "./useHydrateInlineImages";
+import {
+	spaceAssetUrl,
+	useHydrateInlineImages,
+} from "./useHydrateInlineImages";
 import { useNoteEditorSettings } from "./useNoteEditorSettings";
 
 const PASTE_FAILURE_PREFIX = "Image paste failed";
@@ -630,7 +633,7 @@ export function useNoteEditor({
 											continue;
 										}
 										replacePlaceholderWithImage(editorInstance, item.uploadId, {
-											src: dataUrl,
+											src: spaceAssetUrl(saved.asset_rel_path),
 											alt: item.file.name || "",
 											title: "",
 											originSrc: saved.href,


### PR DESCRIPTION
Closes 

## Description

Three memory cuts that should show up in Activity Monitor. The megabyte ranges are from a code audit, not heap snapshots.

- Space images used to go through IPC as base64 and sit in a 24 MB JS cache. They now load over a `glyphasset://` URI scheme. Markdown on disk still stores relative paths. Images over 5 MB now render, because the old preview cutoff is gone.
- Closing the AI panel used to leave the tree mounted (`Activity hidden`) and preloaded on app start. It now unmounts. Reopen restores the last job from disk. A live stream keeps the panel mounted until history is written, so the Rust job is not cancelled.
- Closing the connections graph already tore down Sigma. Payload and layout queries still lingered for the default gc window. Both now use `gcTime: 0`.

Undo depth and unbounded file-preview maps were left alone.

## Screenshots

## Docs

Custom protocol `glyphasset` is registered in `lib.rs` and handled in `space_asset_protocol.rs`. It resolves the space for the requesting webview, joins under the space root, and only serves image extensions.

AI session job id and keep-mounted live in `aiPanelSession.ts`. Graph eviction is the two `gcTime: 0` lines on the connections payload and layout queries.

No user-facing copy or docs files changed.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Reduce application memory usage by streaming inline images, unmounting inactive AI sessions, and immediately evicting unused graph data.

New Features:
- Serve space images through a secure glyphasset:// URI scheme, allowing large inline images to render without embedding image data in the editor.

Bug Fixes:
- Unmount the AI panel when closed while preserving active streams and restoring completed conversations when reopened.
- Evict connections graph payload and layout query caches immediately after they become unused.

Enhancements:
- Reduce AI memory usage by removing startup data preloading and improving session and history lifecycle handling.
- Deduplicate large-graph warnings per space.

Tests:
- Update editor tests to verify glyphasset:// URLs are used for pasted images.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams inline images from disk over `glyphasset://`, unmounts the panel when closed, and evicts graph caches immediately to cut RAM. Also prevents stale chat updates when the panel is stopped or hidden and hardens asset path validation.

- Image streaming: registers an async `glyphasset` handler that serves only image files under the requesting webview’s space root, denies hidden/absolute segments, validates canonical paths, and sets Cache-Control: no-store; Markdown keeps relative paths and editor hydration/paste now write `glyphasset://` URLs so large images render.
- Panel lifecycle: removes preloading; closing unmounts the tree; a live stream keeps it mounted only until history persistence finishes; restores the last job by history ID; per-send epochs gate events to prevent stale updates after stop/hide; clearing caches resets the session; the floating host hides with display: none and only mounts when visible or keep-mounted.
- Graph caching: sets `gcTime: 0` on connections payload and layout queries; large-graph warnings dedupe per space.
- Migration: removes `preloadAiContextIndex`, `preloadAiProfilesData`, and `preloadAiHistorySummaries`; update any external callers.

<sup>Written for commit 3af0eb66f785db50e9ee1db086aae36d4ce5c0ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cut RAM from inline image data URLs, closed AI panel, and graph cache
> - Inline images now reference a custom `glyphasset://localhost/...` URI instead of embedding base64 data URLs in the DOM. A new async protocol handler in [space_asset_protocol.rs](https://github.com/SidhuK/Glyph/pull/519/files#diff-fc5a1ac3e637d0c4a0f24c1f839213cab7c79c9a0c7cced39eb5dd979c5bb4d2) validates paths, restricts file extensions to known image types, resolves the correct space root per webview via `SpaceState::root_for_webview_label`, and serves file bytes with `Cache-Control: no-store`.
> - The AI panel no longer prefetches context/history/profiles on mount. Instead it stays mounted but hidden via a `hidden` prop when `keepMounted` is set in [aiPanelSession.ts](https://github.com/SidhuK/Glyph/pull/519/files#diff-eef2986aab69bb18ef63069fe675727af8825ede554979c6efd9bf9b7d35a79c), and restores prior chat state (thread, messages, tool events) on reopen using `useRestoredAiChat`.
> - Graph connections and layout queries set `gcTime: 0` in [SpaceConnectionsView.tsx](https://github.com/SidhuK/Glyph/pull/519/files#diff-6e9170a5cc1ea42979922a512b3590d624c9664087d08d7dca630dd5bb81dba8) and [useSpaceConnectionsGraph.ts](https://github.com/SidhuK/Glyph/pull/519/files#diff-fdbf676f45ea9be747a57e6f8d63e9ebaeecfd5f6d09eece2c60c2d5eea03cdf) to prevent automatic garbage collection. Large-graph warnings now fire once per space path.
> - Risk: `load_image` in [space_asset_protocol.rs](https://github.com/SidhuK/Glyph/pull/519/files#diff-fc5a1ac3e637d0c4a0f24c1f839213cab7c79c9a0c7cced39eb5dd979c5bb4d2) requires host `localhost` and canonicalizes under the webview's space root; misconfigured spaces or symlinked roots that canonicalize outside the root will return 404. `Cache-Control: no-store` on glyphasset responses means images are re-fetched on every render.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3af0eb6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AI conversations now remain available while completing tasks and can be restored with messages, tool activity, and citations.
  - Pasted and inline images now load through dedicated asset URLs for improved handling and consistency.
  - Added secure loading for supported space image assets.

- **Bug Fixes**
  - Improved AI panel state handling during chat completion, errors, stopping, and new conversations.
  - Improved restoration of chat history and associated activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->