### PR TITLE
Make frontmatter wikilinks clickable

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.15",
+	"version": "0.8.16-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -934,6 +934,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					<div className="frontmatterPreview mono">
 						<NotePropertiesPanel
 							frontmatter={frontmatterDraft}
+							sourcePath={relPath}
 							onChange={handleFrontmatterChange}
 						/>
 					</div>

--- a/src/components/editor/NotePropertiesPanel.tsx
+++ b/src/components/editor/NotePropertiesPanel.tsx
@@ -22,6 +22,7 @@ function normalizeFrontmatter(fm: string | null): string | null {
 interface NotePropertiesPanelProps {
 	frontmatter: string | null;
 	readOnly?: boolean;
+	sourcePath?: string | null;
 	onChange: (frontmatter: string | null) => void;
 	onErrorChange?: (message: string) => void;
 }
@@ -35,6 +36,7 @@ interface NotePropertiesEditorState {
 export function NotePropertiesPanel({
 	frontmatter,
 	readOnly = false,
+	sourcePath,
 	onChange,
 	onErrorChange,
 }: NotePropertiesPanelProps) {
@@ -207,6 +209,7 @@ export function NotePropertiesPanel({
 								index={index}
 								property={property}
 								readOnly={readOnly}
+								sourcePath={sourcePath}
 								availableTags={availableTags}
 								tagDraft={tagDrafts[rowId] ?? ""}
 								statusColors={statusColors}

--- a/src/components/editor/noteProperties/NotePropertyRow.tsx
+++ b/src/components/editor/noteProperties/NotePropertyRow.tsx
@@ -13,6 +13,7 @@ interface NotePropertyRowProps {
 	index: number;
 	property: NoteProperty;
 	readOnly: boolean;
+	sourcePath?: string | null;
 	availableTags: TagCount[];
 	tagDraft: string;
 	statusColors: Record<string, EditorTextColor>;
@@ -31,6 +32,7 @@ export function NotePropertyRow({
 	index,
 	property,
 	readOnly,
+	sourcePath,
 	availableTags,
 	tagDraft,
 	statusColors,
@@ -102,6 +104,7 @@ export function NotePropertyRow({
 					index={index}
 					property={property}
 					readOnly={readOnly}
+					sourcePath={sourcePath}
 					availableTags={availableTags}
 					tagDraft={tagDraft}
 					statusColors={statusColors}

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useState } from "react";
 import { useDateDisplayFormat } from "../../../contexts";
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 import { X } from "../../Icons";
@@ -21,6 +20,7 @@ interface NotePropertyValueFieldProps {
 	index: number;
 	property: NoteProperty;
 	readOnly: boolean;
+	sourcePath?: string | null;
 	availableTags: TagCount[];
 	tagDraft: string;
 	statusColors: Record<string, EditorTextColor>;
@@ -38,6 +38,7 @@ export function NotePropertyValueField({
 	index,
 	property,
 	readOnly,
+	sourcePath,
 	availableTags,
 	tagDraft,
 	statusColors,
@@ -134,7 +135,7 @@ export function NotePropertyValueField({
 		}
 		return (
 			<span className="notePropertyTextValue">
-				<WikiLinkedText value={text} />
+				<WikiLinkedText value={text} sourcePath={sourcePath} />
 			</span>
 		);
 	}
@@ -274,6 +275,7 @@ export function NotePropertyValueField({
 		<TextPropertyValueField
 			key={property.value_text ?? ""}
 			property={property}
+			sourcePath={sourcePath}
 			onUpdate={(patch) => onUpdate(index, patch)}
 		/>
 	);

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -274,7 +274,7 @@ export function NotePropertyValueField({
 
 	return (
 		<TextPropertyValueField
-			key={property.value_text ?? ""}
+			key={`${property.kind}:${property.value_text ?? ""}`}
 			property={property}
 			sourcePath={sourcePath}
 			onUpdate={(patch) => onUpdate(index, patch)}

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -8,6 +8,7 @@ import { PropertyOptionPicker } from "../../status/PropertyOptionPicker";
 import { StatusPropertyPill } from "../../status/StatusPropertyPill";
 import type { EditorTextColor } from "../textColors";
 import { TextPropertyValueField } from "./TextPropertyValueField";
+import { WikiLinkedText } from "./WikiLinkedText";
 import {
 	buildTagSuggestions,
 	formatPropertyDate,

--- a/src/components/editor/noteProperties/NotePropertyValueField.tsx
+++ b/src/components/editor/noteProperties/NotePropertyValueField.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useDateDisplayFormat } from "../../../contexts";
 import type { NoteProperty, TagCount } from "../../../lib/tauri";
 import { X } from "../../Icons";
@@ -7,10 +7,8 @@ import { Toggle } from "../../base/toggle/toggle";
 import { PriorityPropertyPill } from "../../status/PriorityPropertyPill";
 import { PropertyOptionPicker } from "../../status/PropertyOptionPicker";
 import { StatusPropertyPill } from "../../status/StatusPropertyPill";
-import { Input } from "../../ui/shadcn/input";
-import { useWikiLinkAutocomplete } from "../hooks/useWikiLinkAutocomplete";
 import type { EditorTextColor } from "../textColors";
-import { WikiLinkedText } from "./WikiLinkedText";
+import { TextPropertyValueField } from "./TextPropertyValueField";
 import {
 	buildTagSuggestions,
 	formatPropertyDate,
@@ -52,24 +50,6 @@ export function NotePropertyValueField({
 	tagInputRef,
 }: NotePropertyValueFieldProps) {
 	const dateDisplayFormat = useDateDisplayFormat();
-	const textValue = property.value_text ?? "";
-	const [textDraft, setTextDraft] = useState(textValue);
-	const textInputRef = useRef<HTMLInputElement | null>(null);
-	const wikiLinkAutocomplete = useWikiLinkAutocomplete({
-		enabled: property.kind === "text" && !readOnly,
-		inputRef: textInputRef,
-		value: textDraft,
-		onChange: setTextDraft,
-	});
-
-	useEffect(() => {
-		setTextDraft(textValue);
-	}, [textValue]);
-
-	const commitTextDraft = () => {
-		if (textDraft === textValue) return;
-		onUpdate(index, { value_text: textDraft });
-	};
 
 	if (readOnly) {
 		if (property.kind === "status") {
@@ -291,78 +271,10 @@ export function NotePropertyValueField({
 	}
 
 	return (
-		<div className="notePropertyTextEditor">
-			<Input
-				ref={(node) => {
-					textInputRef.current = node;
-				}}
-				className="plainTextInput notePropertyFieldInput"
-				style={{ color: "var(--text-primary)" }}
-				type={
-					property.kind === "date"
-						? "date"
-						: property.kind === "url"
-							? "url"
-							: "text"
-				}
-				value={textDraft}
-				placeholder={textDraft ? "" : "—"}
-				aria-label={`${property.key || "Property"} value`}
-				onChange={(event) => {
-					const nextValue = event.target.value;
-					setTextDraft(nextValue);
-					wikiLinkAutocomplete.refresh(
-						nextValue,
-						event.currentTarget.selectionStart,
-					);
-				}}
-				onBlur={commitTextDraft}
-				onFocus={(event) => {
-					wikiLinkAutocomplete.refresh(
-						event.currentTarget.value,
-						event.currentTarget.selectionStart,
-					);
-				}}
-				onClick={(event) => {
-					wikiLinkAutocomplete.refresh(
-						event.currentTarget.value,
-						event.currentTarget.selectionStart,
-					);
-				}}
-				onKeyDown={(event) => {
-					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
-					if (event.key !== "Enter") return;
-					event.preventDefault();
-					event.currentTarget.blur();
-				}}
-			/>
-			{wikiLinkAutocomplete.items.length > 0 ? (
-				<div className="wikiLinkSuggestionMenu notePropertyWikiLinkSuggestions">
-					{wikiLinkAutocomplete.items.map((item, itemIndex) => (
-						<button
-							key={
-								item.kind === "heading"
-									? `${item.kind}:${item.path}#${item.slug}`
-									: `${item.kind}:${item.path}`
-							}
-							type="button"
-							className={[
-								"wikiLinkSuggestionItem",
-								itemIndex === wikiLinkAutocomplete.activeIndex ? "active" : "",
-							]
-								.filter(Boolean)
-								.join(" ")}
-							onMouseDown={(event) => {
-								event.preventDefault();
-								wikiLinkAutocomplete.select(item);
-							}}
-						>
-							<span className="wikiLinkSuggestionTitle">{item.title}</span>
-							<span className="wikiLinkSuggestionPath">{item.path}</span>
-						</button>
-					))}
-				</div>
-			) : null}
-		</div>
+		<TextPropertyValueField
+			key={property.value_text ?? ""}
+			property={property}
+			onUpdate={(patch) => onUpdate(index, patch)}
+		/>
 	);
 }

--- a/src/components/editor/noteProperties/TextPropertyValueField.tsx
+++ b/src/components/editor/noteProperties/TextPropertyValueField.tsx
@@ -1,0 +1,139 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { NoteProperty } from "../../../lib/tauri";
+import { Edit } from "../../Icons";
+import { Button } from "../../ui/shadcn/button";
+import { Input } from "../../ui/shadcn/input";
+import { useWikiLinkAutocomplete } from "../hooks/useWikiLinkAutocomplete";
+import { findWikiLinkSpans } from "../markdown/wikiLinkCodec";
+import { WikiLinkedText } from "./WikiLinkedText";
+
+interface TextPropertyValueFieldProps {
+	property: NoteProperty;
+	onUpdate: (patch: Partial<NoteProperty>) => void;
+}
+
+export function TextPropertyValueField({
+	property,
+	onUpdate,
+}: TextPropertyValueFieldProps) {
+	const { t } = useTranslation("menu");
+	const value = property.value_text ?? "";
+	const [draft, setDraft] = useState(value);
+	const [isEditing, setIsEditing] = useState(
+		() => findWikiLinkSpans(value).length === 0,
+	);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const wikiLinkAutocomplete = useWikiLinkAutocomplete({
+		enabled: property.kind === "text" && isEditing,
+		inputRef,
+		value: draft,
+		onChange: setDraft,
+	});
+	const hasWikiLinks = findWikiLinkSpans(draft).length > 0;
+
+	const commitDraft = () => {
+		if (draft !== value) onUpdate({ value_text: draft });
+		setIsEditing(false);
+	};
+
+	if (!isEditing && hasWikiLinks) {
+		return (
+			<div className="notePropertyWikiLinkDisplay">
+				<WikiLinkedText value={draft} />
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					className="notePropertyWikiLinkEdit"
+					aria-label={t("submenus.edit")}
+					title={t("submenus.edit")}
+					onClick={() => setIsEditing(true)}
+				>
+					<Edit size="var(--icon-xs)" />
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="notePropertyTextEditor">
+			<Input
+				ref={inputRef}
+				autoFocus={hasWikiLinks}
+				className="plainTextInput notePropertyFieldInput"
+				style={{ color: "var(--text-primary)" }}
+				type={
+					property.kind === "date"
+						? "date"
+						: property.kind === "url"
+							? "url"
+							: "text"
+				}
+				value={draft}
+				placeholder={draft ? "" : "—"}
+				aria-label={`${property.key || "Property"} value`}
+				onChange={(event) => {
+					const nextValue = event.target.value;
+					setDraft(nextValue);
+					wikiLinkAutocomplete.refresh(
+						nextValue,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onBlur={commitDraft}
+				onFocus={(event) => {
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onClick={(event) => {
+					wikiLinkAutocomplete.refresh(
+						event.currentTarget.value,
+						event.currentTarget.selectionStart,
+					);
+				}}
+				onKeyDown={(event) => {
+					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
+					if (event.key === "Escape") {
+						event.preventDefault();
+						setDraft(value);
+						setIsEditing(false);
+						return;
+					}
+					if (event.key !== "Enter") return;
+					event.preventDefault();
+					event.currentTarget.blur();
+				}}
+			/>
+			{wikiLinkAutocomplete.items.length > 0 ? (
+				<div className="wikiLinkSuggestionMenu notePropertyWikiLinkSuggestions">
+					{wikiLinkAutocomplete.items.map((item, itemIndex) => (
+						<button
+							key={
+								item.kind === "heading"
+									? `${item.kind}:${item.path}#${item.slug}`
+									: `${item.kind}:${item.path}`
+							}
+							type="button"
+							className={[
+								"wikiLinkSuggestionItem",
+								itemIndex === wikiLinkAutocomplete.activeIndex ? "active" : "",
+							]
+								.filter(Boolean)
+								.join(" ")}
+							onMouseDown={(event) => {
+								event.preventDefault();
+								wikiLinkAutocomplete.select(item);
+							}}
+						>
+							<span className="wikiLinkSuggestionTitle">{item.title}</span>
+							<span className="wikiLinkSuggestionPath">{item.path}</span>
+						</button>
+					))}
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/src/components/editor/noteProperties/TextPropertyValueField.tsx
+++ b/src/components/editor/noteProperties/TextPropertyValueField.tsx
@@ -33,8 +33,7 @@ export function TextPropertyValueField({
 		value: draft,
 		onChange: setDraft,
 	});
-	const hasWikiLinks =
-		isTextProperty && findWikiLinkSpans(draft).length > 0;
+	const hasWikiLinks = isTextProperty && findWikiLinkSpans(draft).length > 0;
 
 	const commitDraft = () => {
 		wikiLinkAutocomplete.close();

--- a/src/components/editor/noteProperties/TextPropertyValueField.tsx
+++ b/src/components/editor/noteProperties/TextPropertyValueField.tsx
@@ -10,37 +10,42 @@ import { WikiLinkedText } from "./WikiLinkedText";
 
 interface TextPropertyValueFieldProps {
 	property: NoteProperty;
+	sourcePath?: string | null;
 	onUpdate: (patch: Partial<NoteProperty>) => void;
 }
 
 export function TextPropertyValueField({
 	property,
+	sourcePath,
 	onUpdate,
 }: TextPropertyValueFieldProps) {
 	const { t } = useTranslation("menu");
 	const value = property.value_text ?? "";
+	const isTextProperty = property.kind === "text";
+	const containsWikiLinks =
+		isTextProperty && findWikiLinkSpans(value).length > 0;
 	const [draft, setDraft] = useState(value);
-	const [isEditing, setIsEditing] = useState(
-		() => findWikiLinkSpans(value).length === 0,
-	);
+	const [isEditing, setIsEditing] = useState(() => !containsWikiLinks);
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const wikiLinkAutocomplete = useWikiLinkAutocomplete({
-		enabled: property.kind === "text" && isEditing,
+		enabled: isTextProperty && isEditing,
 		inputRef,
 		value: draft,
 		onChange: setDraft,
 	});
-	const hasWikiLinks = findWikiLinkSpans(draft).length > 0;
+	const hasWikiLinks =
+		isTextProperty && findWikiLinkSpans(draft).length > 0;
 
 	const commitDraft = () => {
+		wikiLinkAutocomplete.close();
 		if (draft !== value) onUpdate({ value_text: draft });
-		setIsEditing(false);
+		setIsEditing(!hasWikiLinks);
 	};
 
 	if (!isEditing && hasWikiLinks) {
 		return (
 			<div className="notePropertyWikiLinkDisplay">
-				<WikiLinkedText value={draft} />
+				<WikiLinkedText value={draft} sourcePath={sourcePath} />
 				<Button
 					type="button"
 					variant="ghost"
@@ -95,13 +100,14 @@ export function TextPropertyValueField({
 					);
 				}}
 				onKeyDown={(event) => {
-					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
 					if (event.key === "Escape") {
 						event.preventDefault();
+						wikiLinkAutocomplete.close();
 						setDraft(value);
-						setIsEditing(false);
+						setIsEditing(!containsWikiLinks);
 						return;
 					}
+					if (wikiLinkAutocomplete.handleKeyDown(event)) return;
 					if (event.key !== "Enter") return;
 					event.preventDefault();
 					event.currentTarget.blur();

--- a/src/components/editor/noteProperties/WikiLinkedText.tsx
+++ b/src/components/editor/noteProperties/WikiLinkedText.tsx
@@ -6,7 +6,12 @@ import {
 	wikiLinkDisplayName,
 } from "../markdown/wikiLinkCodec";
 
-export function WikiLinkedText({ value }: { value: string }) {
+interface WikiLinkedTextProps {
+	value: string;
+	sourcePath?: string | null;
+}
+
+export function WikiLinkedText({ value, sourcePath }: WikiLinkedTextProps) {
 	const spans = findWikiLinkSpans(value);
 	if (!spans.length) return <>{value}</>;
 
@@ -28,7 +33,11 @@ export function WikiLinkedText({ value }: { value: string }) {
 					className="wikiLink notePropertyWikiLink"
 					data-target={detail.target}
 					data-unresolved={String(detail.unresolved)}
-					onClick={() => dispatchWikiLinkClick(detail)}
+					onClick={() =>
+						dispatchWikiLinkClick(
+							sourcePath == null ? detail : { ...detail, sourcePath },
+						)
+					}
 					title={label}
 				>
 					<span className="wikiLinkIcon" aria-hidden="true" />

--- a/src/components/preview/NotesInfoSidebar.tsx
+++ b/src/components/preview/NotesInfoSidebar.tsx
@@ -351,6 +351,7 @@ export const NotesInfoSidebar = memo(function NotesInfoSidebar({
 						<section className="markdownEditorInfoSection markdownEditorInfoSectionFrontmatter">
 							<NotePropertiesPanel
 								frontmatter={frontmatter}
+								sourcePath={relPath}
 								onChange={onFrontmatterChange}
 							/>
 						</section>

--- a/src/styles/app/24-node-note-properties.css
+++ b/src/styles/app/24-node-note-properties.css
@@ -312,6 +312,23 @@ input.notePropertyValue {
 	vertical-align: baseline;
 }
 
+.notePropertyWikiLinkDisplay {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	min-height: 30px;
+}
+
+.notePropertyWikiLinkEdit {
+	color: var(--text-tertiary);
+	margin-left: 2px;
+}
+
+.notePropertyWikiLinkEdit:hover,
+.notePropertyWikiLinkEdit:focus-visible {
+	color: var(--text-primary);
+}
+
 .notePropertyRow:has(.notePropertyWikiLinkSuggestions) {
 	z-index: 5;
 }


### PR DESCRIPTION
Closes


## Description

Renders committed wikilinks in editable frontmatter properties as clickable note links, while preserving the existing raw input and autocomplete for editing. Adds a compact edit action, escape-to-cancel behavior, and the 0.8.16-alpha.1 version bump.

- Reuses the shared wikilink parser and navigation event
- Keeps raw frontmatter YAML unchanged

## Screenshots

No screenshots recorded.

## Docs

No documentation changes needed.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Make wikilinks in frontmatter properties clickable while preserving editable raw values and existing autocomplete behavior.

New Features:
- Render wikilinks in frontmatter text properties as clickable note links with context-aware navigation.
- Provide a compact edit mode for linked values while retaining autocomplete and raw-value editing, including Enter-to-commit and Escape-to-cancel behavior.

Enhancements:
- Propagate the containing note path through frontmatter property rendering so relative wikilinks resolve correctly.
- Separate text-property editing from general property value rendering.

Build:
- Bump the application version to 0.8.16-alpha.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes wikilinks in frontmatter text properties clickable in display mode. Previously these values rendered as plain text; now committed [[links]] navigate, editing still uses raw input with autocomplete, and no YAML/frontmatter serialization changes.

**Review notes**
- Resolves relative link clicks with the note’s path by passing `sourcePath` from editors to `WikiLinkedText`.
- Moves text/url/date editing into a new `TextPropertyValueField`; `NotePropertyValueField` now delegates. Linked values show a compact Edit button; Enter or blur commits, Escape cancels. Resets display/edit state when the property kind or value changes to avoid stale UI.
- Migration: Code relying on `NotePropertyValueField`’s inline text input should use `TextPropertyValueField`.

<sup>Written for commit 2e41d4d5b29b6a5c886aed7eaa242f644836a042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make frontmatter wiki links clickable via `TextPropertyValueField`
> - Adds `TextPropertyValueField` to manage text-like properties, rendering wiki links as clickable text with an edit button, autocomplete, and Escape-to-cancel behavior.
> - Threads `sourcePath` from `NoteInlineEditor` and `NotesInfoSidebar` through `NotePropertiesPanel` and `NotePropertyRow` to `WikiLinkedText` so wiki link clicks include note context.
> - Adds CSS for the wiki link display container and edit button in [24-node-note-properties.css](https://github.com/SidhuK/Glyph/pull/520/files#diff-7aedbfe25f5d592b4abbfb7fe3c13f2324153f6958f89a4f0aa44cee94b88a69).
> - Behavioral Change: `NotePropertyValueField` no longer manages inline text input and draft state for non-status properties; it delegates to `TextPropertyValueField`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e41d4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editing support for text, date, and URL note properties.
  * Added wiki-link autocomplete while editing note properties.
  * Added display and edit controls for wiki-linked values, including keyboard-focus and hover states.

* **Bug Fixes**
  * Improved property editing with commit on blur or Enter and cancellation with Escape.

* **Chores**
  * Updated the application version to 0.8.16-alpha.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->