### PR TITLE
Add manual commit message prompts for Git sync (#521) [Release]

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,14 @@ tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 core-text = "20"
 objc2-app-kit = { version = "0.3", default-features = false, features = [
   "std",
+  "NSAlert",
+  "NSApplication",
+  "NSButton",
+  "NSControl",
+  "NSResponder",
+  "NSTextField",
+  "NSView",
+  "NSWindow",
   "NSPasteboard",
 ] }
 objc2-foundation = { version = "0.3", default-features = false, features = [

--- a/src-tauri/src/git_sync/commands.rs
+++ b/src-tauri/src/git_sync/commands.rs
@@ -4,8 +4,8 @@ use crate::space::state::SpaceState;
 
 use super::service;
 use super::types::{
-    GitCommitDiff, GitHistoryCommit, GitSyncConfig, GitSyncConfigPatch, GitSyncRunRequest,
-    GitSyncStatus,
+    GitCommitDiff, GitHistoryCommit, GitSyncCommitMessagePromptRequest, GitSyncConfig,
+    GitSyncConfigPatch, GitSyncRunRequest, GitSyncStatus,
 };
 use super::GitSyncState;
 
@@ -46,6 +46,36 @@ pub async fn git_sync_run(
     request: GitSyncRunRequest,
 ) -> Result<GitSyncStatus, String> {
     service::run_git_sync(app, &git_state, &space_state, window.label(), request)
+}
+
+#[tauri::command]
+pub async fn git_sync_commit_message_prompt(
+    app: AppHandle,
+    request: GitSyncCommitMessagePromptRequest,
+) -> Result<Option<String>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        app.run_on_main_thread(move || {
+            let result = super::native::prompt_commit_message(request);
+            let _ = sender.send(result);
+        })
+        .map_err(|error| format!("failed to open commit message prompt: {error}"))?;
+
+        return tauri::async_runtime::spawn_blocking(move || {
+            receiver
+                .recv()
+                .map_err(|error| format!("commit message prompt failed: {error}"))?
+        })
+        .await
+        .map_err(|error| format!("commit message prompt failed: {error}"))?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, request);
+        Err("commit message prompts are only available on macOS".to_string())
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/git_sync/mod.rs
+++ b/src-tauri/src/git_sync/mod.rs
@@ -1,5 +1,7 @@
 pub mod commands;
 mod git;
+#[cfg(target_os = "macos")]
+mod native;
 mod service;
 mod store;
 pub mod types;

--- a/src-tauri/src/git_sync/native.rs
+++ b/src-tauri/src/git_sync/native.rs
@@ -1,0 +1,40 @@
+use objc2_app_kit::{NSAlert, NSAlertFirstButtonReturn, NSTextField};
+use objc2_foundation::{MainThreadMarker, NSPoint, NSRect, NSSize, NSString};
+
+use super::types::GitSyncCommitMessagePromptRequest;
+
+pub fn prompt_commit_message(
+    request: GitSyncCommitMessagePromptRequest,
+) -> Result<Option<String>, String> {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return Err("commit message prompt must run on the macOS main thread".to_string());
+    };
+
+    let alert = NSAlert::new(mtm);
+    let title = NSString::from_str(&request.title);
+    let description = NSString::from_str(&request.description);
+    let placeholder = NSString::from_str(&request.placeholder);
+    let confirm_label = NSString::from_str(&request.confirm_label);
+    let cancel_label = NSString::from_str(&request.cancel_label);
+
+    alert.setMessageText(&title);
+    alert.setInformativeText(&description);
+
+    let input = NSTextField::initWithFrame(
+        mtm.alloc(),
+        NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(360.0, 24.0)),
+    );
+    input.setPlaceholderString(Some(&placeholder));
+    input.setStringValue(&NSString::from_str(""));
+    alert.setAccessoryView(Some(&input));
+    alert.addButtonWithTitle(&confirm_label);
+    alert.addButtonWithTitle(&cancel_label);
+    alert.layout();
+    let _ = alert.window().makeFirstResponder(Some(&input));
+
+    if alert.runModal() != NSAlertFirstButtonReturn {
+        return Ok(None);
+    }
+
+    Ok(Some(input.stringValue().to_string()))
+}

--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -445,12 +445,16 @@ fn run_git_sync_background(
     let _sync_guard = SyncResetGuard::new(Arc::clone(&git_state.runtime), runtime_key(&space_root));
     let mut config = load_config(&space_root)?;
     let is_auto = request.mode == GitSyncRunMode::Auto;
-    let commit_message = request
-        .commit_message
-        .as_deref()
-        .map(str::trim)
-        .filter(|message| !message.is_empty())
-        .unwrap_or("Glyph sync");
+    let commit_message = if !is_auto && config.prompt_for_commit_message {
+        request
+            .commit_message
+            .as_deref()
+            .map(str::trim)
+            .filter(|message| !message.is_empty())
+            .unwrap_or("Glyph sync")
+    } else {
+        "Glyph sync"
+    };
 
     let run_result = (|| -> Result<(), String> {
         let inspection = inspect_repo(&space_root)?;

--- a/src-tauri/src/git_sync/service.rs
+++ b/src-tauri/src/git_sync/service.rs
@@ -219,6 +219,7 @@ fn config_to_status(
         status.enabled = config.enabled;
         status.paused = config.paused;
         status.auto_sync_prompted = config.auto_sync_prompted;
+        status.prompt_for_commit_message = config.prompt_for_commit_message;
         status.interval_minutes = config.interval_minutes;
         status.conflict_policy = config.conflict_policy;
         status.inclusions = config.inclusions;
@@ -357,6 +358,9 @@ pub fn update_git_sync_config(
     if let Some(auto_sync_prompted) = patch.auto_sync_prompted {
         config.auto_sync_prompted = auto_sync_prompted;
     }
+    if let Some(prompt_for_commit_message) = patch.prompt_for_commit_message {
+        config.prompt_for_commit_message = prompt_for_commit_message;
+    }
     if patch.enabled.is_some() || patch.paused.is_some() {
         config.auto_sync_prompted = true;
     }
@@ -441,6 +445,12 @@ fn run_git_sync_background(
     let _sync_guard = SyncResetGuard::new(Arc::clone(&git_state.runtime), runtime_key(&space_root));
     let mut config = load_config(&space_root)?;
     let is_auto = request.mode == GitSyncRunMode::Auto;
+    let commit_message = request
+        .commit_message
+        .as_deref()
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .unwrap_or("Glyph sync");
 
     let run_result = (|| -> Result<(), String> {
         let inspection = inspect_repo(&space_root)?;
@@ -495,7 +505,7 @@ fn run_git_sync_background(
         )?;
         stage_for_sync(&space_root)?;
         if working_tree_dirty(&space_root)? {
-            commit_all(&space_root, "Glyph sync")?;
+            commit_all(&space_root, commit_message)?;
         }
 
         if remote_branch_exists(&space_root, remote_name, &branch)? {

--- a/src-tauri/src/git_sync/types.rs
+++ b/src-tauri/src/git_sync/types.rs
@@ -81,6 +81,8 @@ pub struct GitSyncConfig {
     pub paused: bool,
     #[serde(default)]
     pub auto_sync_prompted: bool,
+    #[serde(default)]
+    pub prompt_for_commit_message: bool,
 }
 
 impl GitSyncConfig {
@@ -99,6 +101,7 @@ impl GitSyncConfig {
             consecutive_auto_sync_failures: 0,
             paused: false,
             auto_sync_prompted: false,
+            prompt_for_commit_message: false,
         }
     }
 }
@@ -122,6 +125,17 @@ pub struct GitSyncRunRequest {
     pub mode: GitSyncRunMode,
     #[serde(default)]
     pub context: GitSyncContext,
+    #[serde(default)]
+    pub commit_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GitSyncCommitMessagePromptRequest {
+    pub title: String,
+    pub description: String,
+    pub placeholder: String,
+    pub confirm_label: String,
+    pub cancel_label: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -132,6 +146,7 @@ pub struct GitSyncConfigPatch {
     pub inclusions: Option<GitSyncInclusionSettings>,
     pub paused: Option<bool>,
     pub auto_sync_prompted: Option<bool>,
+    pub prompt_for_commit_message: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -147,6 +162,7 @@ pub struct GitSyncStatus {
     pub enabled: bool,
     pub paused: bool,
     pub auto_sync_prompted: bool,
+    pub prompt_for_commit_message: bool,
     pub phase: GitSyncPhase,
     pub is_syncing: bool,
     pub interval_minutes: u32,
@@ -180,6 +196,7 @@ impl Default for GitSyncStatus {
             enabled: false,
             paused: false,
             auto_sync_prompted: false,
+            prompt_for_commit_message: false,
             phase: GitSyncPhase::Idle,
             is_syncing: false,
             interval_minutes: DEFAULT_GIT_SYNC_INTERVAL_MINUTES,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1938,6 +1938,7 @@ pub fn run() {
             git_sync::commands::git_sync_config_read,
             git_sync::commands::git_sync_config_update,
             git_sync::commands::git_sync_run,
+            git_sync::commands::git_sync_commit_message_prompt,
             git_sync::commands::git_sync_disconnect,
             git_sync::commands::git_history_list,
             git_sync::commands::git_history_diff,

--- a/src/components/settings/GitSettingsPane.tsx
+++ b/src/components/settings/GitSettingsPane.tsx
@@ -6,6 +6,8 @@ import {
 	Link01Icon,
 } from "@hugeicons/core-free-icons";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useGitSyncContext } from "../../contexts/GitSyncContext";
 import { ATTACHMENT_LOCATION_OPTIONS } from "../../lib/attachmentStorage";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
@@ -53,6 +55,8 @@ const CONFLICT_POLICY_OPTIONS = [
 }[];
 
 export function GitSettingsPane() {
+	const gitSync = useGitSyncContext();
+	const { t } = useTranslation();
 	const [status, setStatus] = useState<GitSyncStatus | null>(null);
 	const [config, setConfig] = useState<GitSyncConfig | null>(null);
 	const [attachmentStorageMode, setAttachmentStorageMode] =
@@ -92,6 +96,7 @@ export function GitSettingsPane() {
 	const updatePatch = useCallback(
 		async (patch: {
 			enabled?: boolean;
+			prompt_for_commit_message?: boolean;
 			conflict_policy?: GitSyncConflictPolicy;
 			interval_minutes?: number;
 			inclusions?: GitSyncInclusionSettings;
@@ -117,27 +122,14 @@ export function GitSettingsPane() {
 		setBusy(true);
 		setError("");
 		try {
-			const settings = await loadSettings();
-			const nextStatus = await invoke("git_sync_run", {
-				request: {
-					mode: "manual",
-					context: {
-						templates_folder: settings.templates.folder,
-						attachment_storage_mode: settings.editor.attachmentStorageMode,
-						attachment_folder:
-							settings.editor.attachmentStorageMode === "specific-folder"
-								? settings.editor.attachmentFolder
-								: null,
-					},
-				},
-			});
-			setStatus(nextStatus);
+			const nextStatus = await gitSync.syncNow();
+			if (nextStatus) setStatus(nextStatus);
 		} catch (cause) {
 			setError(extractErrorMessage(cause));
 		} finally {
 			setBusy(false);
 		}
-	}, []);
+	}, [gitSync]);
 
 	const inclusions = config?.inclusions ?? DEFAULT_INCLUSIONS;
 	const gitEnabledForSpace =
@@ -250,6 +242,19 @@ export function GitSettingsPane() {
 							disabled={!gitEnabledForSpace || busy}
 							onCheckedChange={(checked) => {
 								void updatePatch({ enabled: checked });
+							}}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label={t("gitSync.manualCommitMessages")}
+						description={t("gitSync.manualCommitMessagesDescription")}
+					>
+						<SettingsToggle
+							ariaLabel={t("gitSync.manualCommitMessages")}
+							checked={config?.prompt_for_commit_message ?? false}
+							disabled={!gitEnabledForSpace || busy}
+							onCheckedChange={(checked) => {
+								void updatePatch({ prompt_for_commit_message: checked });
 							}}
 						/>
 					</SettingsRow>

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -85,6 +85,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "git-how-it-works", tab: "git" },
 	{ id: "git-branch", tab: "git" },
 	{ id: "git-automatic-sync", tab: "git" },
+	{ id: "git-manual-commit-messages", tab: "git" },
 	{ id: "git-sync-interval", tab: "git" },
 	{ id: "git-sync-actions", tab: "git" },
 	{ id: "git-conflict-policy", tab: "git" },

--- a/src/contexts/GitSyncContext.tsx
+++ b/src/contexts/GitSyncContext.tsx
@@ -1,18 +1,7 @@
 import { type ReactNode, createContext, useContext } from "react";
-import { useGitSync } from "../hooks/useGitSync";
-import type { GitSyncStatus } from "../lib/tauri";
+import { type GitSyncController, useGitSync } from "../hooks/useGitSync";
 import { useEditorContext } from "./EditorContext";
 import { useSpace } from "./SpaceContext";
-
-interface GitSyncController {
-	status: GitSyncStatus | null;
-	loading: boolean;
-	error: string;
-	refreshStatus: () => Promise<void>;
-	syncNow: () => Promise<GitSyncStatus>;
-	resumeAutoSync: () => Promise<void>;
-	openGitSettings: () => void;
-}
 
 const GitSyncContext = createContext<GitSyncController | null>(null);
 

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -104,7 +104,9 @@ export function useGitSync({
 	const syncNow = useCallback(async () => {
 		const syncSpacePath = activeSpacePathRef.current;
 		const promptForCommitMessage =
-			status?.prompt_for_commit_message ??
+			(statusSpaceRef.current === syncSpacePath
+				? status?.prompt_for_commit_message
+				: undefined) ??
 			(await invoke("git_sync_config_read"))?.prompt_for_commit_message ??
 			false;
 		if (activeSpacePathRef.current !== syncSpacePath) return null;

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useUILayoutContext } from "../contexts";
 import {
 	completeAutoSyncPrompt,
@@ -15,12 +16,12 @@ interface UseGitSyncOptions {
 	saveEditors: () => Promise<boolean>;
 }
 
-interface GitSyncController {
+export interface GitSyncController {
 	status: GitSyncStatus | null;
 	loading: boolean;
 	error: string;
 	refreshStatus: () => Promise<void>;
-	syncNow: () => Promise<GitSyncStatus>;
+	syncNow: () => Promise<GitSyncStatus | null>;
 	resumeAutoSync: () => Promise<void>;
 	openGitSettings: () => void;
 }
@@ -42,6 +43,7 @@ export function useGitSync({
 	saveEditors,
 }: UseGitSyncOptions): GitSyncController {
 	const { openSettings } = useUILayoutContext();
+	const { t } = useTranslation();
 	const [status, setStatus] = useState<GitSyncStatus | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
@@ -83,12 +85,12 @@ export function useGitSync({
 	}, [spacePath]);
 
 	const runSync = useCallback(
-		async (mode: GitSyncRunMode) => {
+		async (mode: GitSyncRunMode, commitMessage?: string) => {
 			const runSpacePath = activeSpacePathRef.current;
 			await saveEditors();
 			const context = await buildRunContext();
 			const nextStatus = await invoke("git_sync_run", {
-				request: { mode, context },
+				request: { mode, context, commit_message: commitMessage },
 			});
 			if (runSpacePath && activeSpacePathRef.current === runSpacePath) {
 				statusSpaceRef.current = runSpacePath;
@@ -99,7 +101,22 @@ export function useGitSync({
 		[saveEditors],
 	);
 
-	const syncNow = useCallback(async () => runSync("manual"), [runSync]);
+	const syncNow = useCallback(async () => {
+		if (!status?.prompt_for_commit_message) {
+			return runSync("manual");
+		}
+		const commitMessage = await invoke("git_sync_commit_message_prompt", {
+			request: {
+				title: t("gitSync.commitTitle"),
+				description: t("gitSync.commitDescription"),
+				placeholder: t("gitSync.commitMessagePlaceholder"),
+				confirm_label: t("gitSync.sync"),
+				cancel_label: t("gitSync.cancel"),
+			},
+		});
+		if (commitMessage === null) return null;
+		return runSync("manual", commitMessage.trim());
+	}, [runSync, status?.prompt_for_commit_message, t]);
 
 	const resumeAutoSync = useCallback(async () => {
 		const resumeSpacePath = activeSpacePathRef.current;

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -102,7 +102,13 @@ export function useGitSync({
 	);
 
 	const syncNow = useCallback(async () => {
-		if (!status?.prompt_for_commit_message) {
+		const syncSpacePath = activeSpacePathRef.current;
+		const promptForCommitMessage =
+			status?.prompt_for_commit_message ??
+			(await invoke("git_sync_config_read"))?.prompt_for_commit_message ??
+			false;
+		if (activeSpacePathRef.current !== syncSpacePath) return null;
+		if (!promptForCommitMessage) {
 			return runSync("manual");
 		}
 		const commitMessage = await invoke("git_sync_commit_message_prompt", {
@@ -114,7 +120,12 @@ export function useGitSync({
 				cancel_label: t("gitSync.cancel"),
 			},
 		});
-		if (commitMessage === null) return null;
+		if (
+			commitMessage === null ||
+			activeSpacePathRef.current !== syncSpacePath
+		) {
+			return null;
+		}
 		return runSync("manual", commitMessage.trim());
 	}, [runSync, status?.prompt_for_commit_message, t]);
 

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -425,6 +425,11 @@
 			"section": "Sync",
 			"keywords": ["auto", "git"]
 		},
+		"git-manual-commit-messages": {
+			"title": "Manual commit messages",
+			"section": "Sync",
+			"keywords": ["commit", "message", "manual", "git"]
+		},
 		"git-sync-interval": {
 			"title": "Interval",
 			"section": "Sync",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -174,6 +174,15 @@
 		"openAnotherSpace": "Open another space",
 		"switchSaveFailed": "The current space could not be saved. Please try again."
 	},
+	"gitSync": {
+		"commitTitle": "Sync with Git",
+		"commitDescription": "Optionally add a message to the local commit created by this manual sync.",
+		"commitMessagePlaceholder": "Optional. Defaults to Glyph sync",
+		"cancel": "Cancel",
+		"sync": "Sync Now",
+		"manualCommitMessages": "Manual commit messages",
+		"manualCommitMessagesDescription": "Ask for a message before each manual sync. When off, Glyph uses \"Glyph sync\"."
+	},
 	"ai": {
 		"toolFailed": "{{tool}} failed"
 	},

--- a/src/lib/gitSyncUi.test.ts
+++ b/src/lib/gitSyncUi.test.ts
@@ -15,6 +15,7 @@ function makeStatus(overrides: Partial<GitSyncStatus> = {}): GitSyncStatus {
 		enabled: true,
 		paused: false,
 		auto_sync_prompted: true,
+		prompt_for_commit_message: false,
 		phase: "idle",
 		is_syncing: false,
 		interval_minutes: 10,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -642,6 +642,7 @@ export interface GitSyncConfig {
 	consecutive_auto_sync_failures: number;
 	paused: boolean;
 	auto_sync_prompted: boolean;
+	prompt_for_commit_message: boolean;
 }
 
 export interface GitSyncStatus {
@@ -656,6 +657,7 @@ export interface GitSyncStatus {
 	enabled: boolean;
 	paused: boolean;
 	auto_sync_prompted: boolean;
+	prompt_for_commit_message: boolean;
 	phase: GitSyncPhase;
 	is_syncing: boolean;
 	interval_minutes: number;
@@ -702,6 +704,15 @@ interface GitSyncContext {
 interface GitSyncRunRequest {
 	mode: GitSyncRunMode;
 	context: GitSyncContext;
+	commit_message?: string | null;
+}
+
+interface GitSyncCommitMessagePromptRequest {
+	title: string;
+	description: string;
+	placeholder: string;
+	confirm_label: string;
+	cancel_label: string;
 }
 
 interface GitSyncConfigPatch {
@@ -711,6 +722,7 @@ interface GitSyncConfigPatch {
 	inclusions?: GitSyncInclusionSettings;
 	paused?: boolean;
 	auto_sync_prompted?: boolean;
+	prompt_for_commit_message?: boolean;
 }
 
 type LicenseMode =
@@ -1220,6 +1232,10 @@ interface TauriCommands {
 		GitSyncConfig
 	>;
 	git_sync_run: CommandDef<{ request: GitSyncRunRequest }, GitSyncStatus>;
+	git_sync_commit_message_prompt: CommandDef<
+		{ request: GitSyncCommitMessagePromptRequest },
+		string | null
+	>;
 	git_sync_disconnect: CommandDef<void, GitSyncStatus>;
 	git_history_list: CommandDef<
 		{ path: string; limit?: number | null },


### PR DESCRIPTION
## Summary

- Add an optional macOS prompt for custom commit messages during manual Git sync.
- Persist the setting and use `Glyph sync` when prompts are disabled or left blank.
- Expose the option in Git settings, search, translations, and typed Tauri commands.

## Testing

- Updated the Git sync UI test fixture for the new status field.
- Not run (not requested)

## Summary by Sourcery

Allow manual Git syncs to optionally use a user-provided commit message through a persisted macOS prompt, while retaining the existing default behavior.

New Features:
- Add an optional macOS commit-message prompt for manual Git synchronization, allowing users to confirm, customize, or cancel the sync commit.
- Expose the manual commit-message preference through Git settings, settings search, localized UI text, and typed Tauri commands.

Bug Fixes:
- Prevent manual sync from proceeding when the user cancels the commit prompt or changes spaces while the prompt is active.

Enhancements:
- Use the default "Glyph sync" commit message when prompting is disabled or the submitted message is blank, while preserving custom messages when provided.

Build:
- Enable the macOS AppKit and Foundation APIs required for the native commit-message prompt.

Tests:
- Update Git sync UI test fixtures for the new commit-message prompt status field.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional commit-message prompt for manual Git sync on macOS so users can label commits. Previously manual sync always used "Glyph sync"; now you can enter a message, cancel to abort, or leave it blank to keep the default.

- Adds `prompt_for_commit_message` to Git sync config/status with a "Manual commit messages" toggle and settings search entry `git-manual-commit-messages`.
- Introduces `git_sync_commit_message_prompt` to show a native `NSAlert` on the main thread; non-macOS targets return an error.
- Manual sync sends a trimmed `commit_message` to the backend; auto sync remains unchanged.
- Aborts the prompt/sync if the active space changes before or after prompting.
- Extends `GitSyncRunRequest`, `GitSyncConfigPatch`, and `GitSyncStatus` with serde-defaulted fields; no migration required.
- Enables required AppKit/Foundation features in `objc2-app-kit` and `objc2-foundation`.

<sup>Written for commit f4c550d4c32a20a99dfc679500258f530b052bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual commit message prompt for Git sync on macOS
> - Adds a macOS native `NSAlert` with an `NSTextField` to collect an optional commit message, exposed via the new `git_sync_commit_message_prompt` Tauri command; non-macOS targets return an error.
> - Adds `prompt_for_commit_message` to `GitSyncConfig`, `GitSyncStatus`, and `GitSyncConfigPatch`, and an optional `commit_message` to `GitSyncRunRequest`; manual syncs use the custom message when enabled, otherwise default to `"Glyph sync"`.
> - Integrates the prompt into the `useGitSync` hook and `GitSettingsPane` with a settings toggle, search indexing, and English localization.
> - Behavioral Change: the Sync Now action in `GitSettingsPane` now routes through `gitSync.syncNow()` instead of a direct `invoke`, and manual syncs abort when the prompt is cancelled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4c550d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to request a custom commit message during Git sync.
  * Added a native macOS commit message dialog with customizable labels and cancellation.
  * Added the manual commit message setting to Git settings and settings search.
  * Sync operations now use the entered message, with a default message when none is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->