### PR TITLE
Hide the AI toolbar button when AI is disabled

### DIFF
--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -256,7 +256,7 @@ export function MarkdownEditorPane({
 	const [previewContext, setPreviewContext] =
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const [linkRefreshKey, setLinkRefreshKey] = useState(0);
-	const { openSettings, showToc } = useUILayoutContext();
+	const { showToc } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
 	const { status: gitSyncStatus } = useGitSyncContext();
 	const hasSupportedGit = canShowGitHistory(gitSyncStatus);
@@ -559,24 +559,22 @@ export function MarkdownEditorPane({
 						onModeChange={requestEditorMode}
 					/>
 					<div className="markdownEditorToolbarActions">
-						<button
-							type="button"
-							className="markdownEditorToolbarBtn"
-							data-active={isAiPanelActive || undefined}
-							onClick={() => {
-								if (!aiEnabled) {
-									openSettings("ai");
-									return;
-								}
-								setInfoPanelOpen(() => false);
-								setAiPanelOpen((open) => !open);
-							}}
-							aria-label={t("toolbar.aiPanel")}
-							title={t("toolbar.aiPanel")}
-							aria-pressed={aiEnabled ? aiPanelOpen : undefined}
-						>
-							<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
-						</button>
+						{aiEnabled ? (
+							<button
+								type="button"
+								className="markdownEditorToolbarBtn"
+								data-active={isAiPanelActive || undefined}
+								onClick={() => {
+									setInfoPanelOpen(() => false);
+									setAiPanelOpen((open) => !open);
+								}}
+								aria-label={t("toolbar.aiPanel")}
+								title={t("toolbar.aiPanel")}
+								aria-pressed={aiPanelOpen}
+							>
+								<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
+							</button>
+						) : null}
 						<button
 							type="button"
 							className="markdownEditorToolbarBtn"


### PR DESCRIPTION
## Summary

- Hide the AI toolbar button when AI is disabled
- Remove the unused settings navigation dependency from the editor pane
- Keep the button focused on toggling the AI panel when enabled

## Testing

Not run (not requested)

## Summary by Sourcery

Hide the AI toolbar action when AI is unavailable and keep its enabled behavior focused on toggling the AI panel.

Bug Fixes:
- Hide the AI toolbar button when AI is disabled so unavailable functionality is not presented.
- Ensure the AI toolbar button only toggles the AI panel when AI is enabled.

Enhancements:
- Remove the unused settings navigation dependency from the editor pane.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide AI toolbar button in `MarkdownEditorPane` when AI is disabled
> The AI panel toolbar button in [MarkdownEditorPane.tsx](https://github.com/SidhuK/Glyph/pull/522/files#diff-db5b61c6611a5998ee760a3301783d01d7e787fa0d3232c9f01dca73ba7b615d) is now conditionally rendered only when `aiEnabled` is true. Previously the button always rendered and redirected to AI settings when clicked. The `onClick` handler no longer calls `openSettings("ai")`; it only toggles the AI panel and closes the info panel. `aria-pressed` now reflects `aiPanelOpen` directly since the button only exists when AI is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44f2d7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The AI toolbar button now appears only when AI features are enabled.
  * Disabled AI controls no longer open AI settings.
  * Improved accessibility by keeping the button’s pressed state synchronized with the AI panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->