### PR TITLE
Improve main tab close button styling

### DIFF
--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -537,10 +537,11 @@
 }
 
 button.mainTabClose {
-	left: 10px;
-	width: 10px;
-	height: 10px;
-	background: var(--text-primary);
+	background: radial-gradient(
+		circle,
+		var(--text-primary) 0 5px,
+		transparent 5px
+	);
 	color: var(--bg-primary);
 }
 

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -536,9 +536,16 @@
 		var(--transition-fast);
 }
 
+button.mainTabClose {
+	left: 10px;
+	width: 10px;
+	height: 10px;
+	background: var(--text-primary);
+	color: var(--bg-primary);
+}
+
 .mainTabWrap:hover .mainTabClose {
-	opacity: 0.9;
-	color: var(--text-primary);
+	opacity: 1;
 }
 
 .mainTabPin {
@@ -546,7 +553,13 @@
 	color: var(--text-secondary);
 }
 
-.mainTabClose > svg,
+.mainTabClose > svg {
+	display: block;
+	width: 6px;
+	height: 6px;
+	flex: 0 0 auto;
+}
+
 .mainTabPin > .mainTabPinIcon {
 	display: block;
 	width: 14px;
@@ -573,18 +586,6 @@
 	opacity: 1;
 	box-shadow: none;
 	transform: translateY(-50%);
-}
-
-.mainTabClose:hover {
-	background: transparent;
-	border-color: transparent;
-	color: var(--text-primary);
-	opacity: 1;
-	box-shadow: none;
-}
-
-.mainTabClose:active {
-	background: color-mix(in srgb, var(--bg-hover) 94%, transparent);
 }
 
 .mainTabAdd {


### PR DESCRIPTION
Closes 


## Description

Improve the main tab close button styling for a smaller, more consistent visual treatment.

- Add compact sizing and contrasting colors to the close button.
- Normalize the close icon dimensions and layout.
- Simplify hover behavior and remove obsolete hover/active overrides.
- This is a CSS-only visual refinement.


## Screenshots

No screenshots included; the change is a CSS-only refinement to the main tab close button.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Improve the main tab close button styling for a smaller and more consistent visual treatment.

Enhancements:
- Refine the main tab close button with a compact, contrasting design and consistently sized icon.
- Simplify close-button interaction styling by retaining parent hover opacity behavior and removing obsolete hover and active overrides.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restyle `button.mainTabClose` with radial gradient and fixed 6px SVG icon
> Restyles the main tab close button in [17-main-tabs.css](https://github.com/SidhuK/Glyph/pull/523/files#diff-5a8854af0ae24051bf6370e54a98038a64f792cc2d76b424d7e993ac7a881843). The button now uses a radial-gradient background with primary background text color, and the close icon renders at a fixed 6px block size.
> - On parent tab hover, the close button becomes fully opaque without a separate color change
> - Removes the close button's own hover and active state overrides, relying on base and parent-hover styles instead
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b072a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->