### PR TITLE
Add Zen mode for focused note editing

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -169,6 +169,8 @@ export function AppShell() {
 		openSettings,
 		closeSettings,
 	} = useUILayoutContext();
+	const zenModeRef = useRef(zenMode);
+	zenModeRef.current = zenMode;
 	const { aiEnabled, setAiPanelOpen } = useAISidebarContext();
 	const {
 		getCurrentMarkdown,
@@ -294,7 +296,10 @@ export function AppShell() {
 		"settings:updated",
 		useCallback(
 			(payload: {
-				editor?: { showCollapsibleHeadings?: boolean };
+				editor?: {
+					showCollapsibleHeadings?: boolean;
+					zenMode?: boolean;
+				};
 				ui?: {
 					noteSidePeek?: boolean;
 					resumeLastSession?: boolean;
@@ -302,6 +307,11 @@ export function AppShell() {
 			}) => {
 				if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 					setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+				}
+				if (payload.editor?.zenMode) {
+					setPaletteOpen(false);
+					setCalendarOpen(false);
+					setTemplatePickerOpen(false);
 				}
 				if (typeof payload.ui?.noteSidePeek === "boolean") {
 					setNoteSidePeekEnabled(payload.ui.noteSidePeek);
@@ -311,7 +321,7 @@ export function AppShell() {
 					setResumeLastSession(payload.ui.resumeLastSession);
 				}
 			},
-			[],
+			[setPaletteOpen],
 		),
 	);
 
@@ -620,6 +630,7 @@ export function AppShell() {
 
 	const openTemplatePicker = useCallback(
 		async (dirPath?: string) => {
+			if (zenModeRef.current) return;
 			if (!spacePath) return;
 			if (templateFolder === null) {
 				setError("Set a template folder in Settings -> Space first.");
@@ -628,6 +639,7 @@ export function AppShell() {
 			}
 			try {
 				const templates = await listTemplates(templateFolder);
+				if (zenModeRef.current) return;
 				if (!templates.length) {
 					setError("No markdown templates were found in the template folder.");
 					openTemplatesSettings();
@@ -746,6 +758,7 @@ export function AppShell() {
 	}, [requestOpenPeriodNote]);
 
 	const openCalendar = useCallback(() => {
+		if (zenModeRef.current) return;
 		if (!spacePath) return;
 		setCalendarOpen(true);
 	}, [spacePath]);
@@ -775,6 +788,7 @@ export function AppShell() {
 
 	const openPalette = useCallback(
 		(mode: "commands" | "search", query = "") => {
+			if (zenModeRef.current) return;
 			setPaletteLaunchMode(mode);
 			setPaletteInitialQuery(query);
 			setCommandPaletteSessionId((value) => value + 1);

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -165,6 +165,7 @@ export function AppShell() {
 		sidebarWidth,
 		setSidebarWidth,
 		settingsMode,
+		zenMode,
 		openSettings,
 		closeSettings,
 	} = useUILayoutContext();
@@ -1380,14 +1381,14 @@ export function AppShell() {
 				rightSidebarOpen && "appShellRightSidebarOpen",
 			)}
 		>
-			{isIndexing ? <IndexingNotice /> : null}
+			{!zenMode && isIndexing ? <IndexingNotice /> : null}
 			<div
 				aria-hidden="true"
 				className="windowDragStrip"
 				data-tauri-drag-region
 				onMouseDown={onWindowDragMouseDown}
 			/>
-			{sidebarCollapsed && (
+			{(!zenMode || settingsMode) && sidebarCollapsed ? (
 				<div className="sidebarCollapsedToggle">
 					<WindowChromeIconButton
 						ariaLabel={
@@ -1416,52 +1417,56 @@ export function AppShell() {
 						onInstallUpdate={autoUpdater.installAndRelaunch}
 					/>
 				</div>
-			)}
-			<Sidebar
-				onSelectDir={setActiveDirPath}
-				onOpenFile={(p) => void openWorkspaceFile(p)}
-				onNewNote={() => void createNoteInSelectedFolder()}
-				newNoteFolder={newNoteFolder}
-				onNewFileInDir={(p) => void fileTree.onNewFileInDir(p)}
-				onCreateFromTemplateInDir={(p) => void openTemplatePicker(p)}
-				onImportFilesInDir={importFilesInto}
-				onImportFolderInDir={importFolderInto}
-				onImportPathsInDir={importPathsInto}
-				onRequestCreateFolder={(dirPath) =>
-					fileTree.requestCreateFolder(dirPath)
-				}
-				onDuplicateFile={(p) => duplicateFileWithActiveEditorFlush(p)}
-				onRenameDir={(p, name, kind) => fileTree.onRenameDir(p, name, kind)}
-				onDeletePath={(p, kind) => fileTree.onDeletePath(p, kind)}
-				onMovePath={(fromPath, toDirPath, kind) =>
-					fileTree.onMovePath(fromPath, toDirPath, kind)
-				}
-				onToggleDir={fileTree.toggleDir}
-				onLoadDir={fileTree.loadDir}
-				onExpandAllDirs={fileTree.expandAllDirs}
-				onCollapseAllDirs={fileTree.collapseAllDirs}
-				onSelectTag={(t) => openTagSearchPalette(t)}
-				sidebarCollapsed={sidebarCollapsed}
-				onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
-				spacePath={spacePath}
-				onOpenAllDocs={openAllDocsTab}
-				onOpenPinnedDocs={openPinnedDocsTab}
-				onOpenConnections={openConnectionsView}
-				onOpenDatabases={(databaseId) => openDatabasesTab(databaseId)}
-				activeTopSection={activeTopSection}
-				onPrefetchDatabases={prefetchDatabasesTab}
-				onPrefetchAllDocs={prefetchAllDocsTab}
-				onPrefetchFile={prefetchWorkspaceFile}
-			/>
-			<div
-				ref={sidebarResize.resizeRef}
-				className="sidebarResizeHandle"
-				onPointerDown={sidebarResize.handlePointerDown}
-				onPointerMove={sidebarResize.handlePointerMove}
-				onPointerUp={sidebarResize.handlePointerUp}
-				data-window-drag-ignore
-				style={{ cursor: sidebarCollapsed ? "default" : "col-resize" }}
-			/>
+			) : null}
+			{!zenMode || settingsMode ? (
+				<>
+					<Sidebar
+						onSelectDir={setActiveDirPath}
+						onOpenFile={(p) => void openWorkspaceFile(p)}
+						onNewNote={() => void createNoteInSelectedFolder()}
+						newNoteFolder={newNoteFolder}
+						onNewFileInDir={(p) => void fileTree.onNewFileInDir(p)}
+						onCreateFromTemplateInDir={(p) => void openTemplatePicker(p)}
+						onImportFilesInDir={importFilesInto}
+						onImportFolderInDir={importFolderInto}
+						onImportPathsInDir={importPathsInto}
+						onRequestCreateFolder={(dirPath) =>
+							fileTree.requestCreateFolder(dirPath)
+						}
+						onDuplicateFile={(p) => duplicateFileWithActiveEditorFlush(p)}
+						onRenameDir={(p, name, kind) => fileTree.onRenameDir(p, name, kind)}
+						onDeletePath={(p, kind) => fileTree.onDeletePath(p, kind)}
+						onMovePath={(fromPath, toDirPath, kind) =>
+							fileTree.onMovePath(fromPath, toDirPath, kind)
+						}
+						onToggleDir={fileTree.toggleDir}
+						onLoadDir={fileTree.loadDir}
+						onExpandAllDirs={fileTree.expandAllDirs}
+						onCollapseAllDirs={fileTree.collapseAllDirs}
+						onSelectTag={(t) => openTagSearchPalette(t)}
+						sidebarCollapsed={sidebarCollapsed}
+						onToggleSidebar={() => setSidebarCollapsed(!sidebarCollapsed)}
+						spacePath={spacePath}
+						onOpenAllDocs={openAllDocsTab}
+						onOpenPinnedDocs={openPinnedDocsTab}
+						onOpenConnections={openConnectionsView}
+						onOpenDatabases={(databaseId) => openDatabasesTab(databaseId)}
+						activeTopSection={activeTopSection}
+						onPrefetchDatabases={prefetchDatabasesTab}
+						onPrefetchAllDocs={prefetchAllDocsTab}
+						onPrefetchFile={prefetchWorkspaceFile}
+					/>
+					<div
+						ref={sidebarResize.resizeRef}
+						className="sidebarResizeHandle"
+						onPointerDown={sidebarResize.handlePointerDown}
+						onPointerMove={sidebarResize.handlePointerMove}
+						onPointerUp={sidebarResize.handlePointerUp}
+						data-window-drag-ignore
+						style={{ cursor: sidebarCollapsed ? "default" : "col-resize" }}
+					/>
+				</>
+			) : null}
 			<MainContent
 				fileTree={{
 					createMarkdownFileAtPath: fileTree.createMarkdownFileAtPath,
@@ -1511,7 +1516,7 @@ export function AppShell() {
 					void openPeekedNote();
 				}}
 			/>
-			{commandPaletteMounted ? (
+			{!zenMode && commandPaletteMounted ? (
 				<Suspense fallback={null}>
 					<LazyCommandPalette
 						key={`${commandPaletteSessionId}:${paletteLaunchMode}:${paletteInitialQuery}`}
@@ -1548,23 +1553,27 @@ export function AppShell() {
 					/>
 				</Suspense>
 			) : null}
-			<CalendarPaletteController
-				open={calendarOpen}
-				onClose={closeCalendar}
-				spacePath={spacePath}
-				dailyNoteFolder={dailyNotesFolder}
-				onOpenNote={(path) => void openWorkspaceFile(path)}
-				onOpenPeriodNoteAtDate={(kind, date) =>
-					void handleOpenPeriodNoteAtDate(kind, date)
-				}
-			/>
-			<TemplatePickerDialog
-				open={templatePickerOpen}
-				templates={templatePickerItems}
-				onClose={() => setTemplatePickerOpen(false)}
-				onPick={(template) => void handlePickTemplate(template)}
-				onOpenSettings={openTemplatesSettings}
-			/>
+			{!zenMode ? (
+				<>
+					<CalendarPaletteController
+						open={calendarOpen}
+						onClose={closeCalendar}
+						spacePath={spacePath}
+						dailyNoteFolder={dailyNotesFolder}
+						onOpenNote={(path) => void openWorkspaceFile(path)}
+						onOpenPeriodNoteAtDate={(kind, date) =>
+							void handleOpenPeriodNoteAtDate(kind, date)
+						}
+					/>
+					<TemplatePickerDialog
+						open={templatePickerOpen}
+						templates={templatePickerItems}
+						onClose={() => setTemplatePickerOpen(false)}
+						onPick={(template) => void handlePickTemplate(template)}
+						onOpenSettings={openTemplatesSettings}
+					/>
+				</>
+			) : null}
 		</div>
 	);
 }

--- a/src/components/app/EditorPaneCanvas.tsx
+++ b/src/components/app/EditorPaneCanvas.tsx
@@ -8,6 +8,7 @@ import {
 	useCallback,
 	useState,
 } from "react";
+import { useUILayoutContext } from "../../contexts";
 import { ACTIVITY_TIMELINE_TAB_ID } from "../../lib/activityTimeline";
 import type { DatabasesOpenRequest } from "../../lib/database/openDatabasesRequest";
 import { DATABASES_TAB_ID } from "../../lib/databases";
@@ -108,6 +109,7 @@ export const EditorPaneCanvas = memo(function EditorPaneCanvas({
 	databasesOpenRequest,
 	onConsumeDatabasesOpenRequest,
 }: EditorPaneCanvasProps) {
+	const { zenMode } = useUILayoutContext();
 	const handlePrefetchTab = useCallback(
 		(target: string | null) => {
 			if (!target) return;
@@ -155,7 +157,7 @@ export const EditorPaneCanvas = memo(function EditorPaneCanvas({
 			}
 			data-databases={viewerPath === DATABASES_TAB_ID ? "true" : undefined}
 		>
-			{pane.tabs.length > 0 ? (
+			{!zenMode && pane.tabs.length > 0 ? (
 				<div className="mainTabBarTransition">
 					<TabBar
 						paneId={pane.id}
@@ -187,6 +189,7 @@ export const EditorPaneCanvas = memo(function EditorPaneCanvas({
 				<div
 					aria-hidden="true"
 					className="mainTabsEmptyDragRegion"
+					data-zen-mode={zenMode ? "true" : undefined}
 					data-tauri-drag-region={allowWindowDrag ? "" : undefined}
 					onMouseDown={allowWindowDrag ? onWindowDragMouseDown : undefined}
 				/>

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -491,7 +491,7 @@ export const MainContent = memo(function MainContent({
 						<SettingsTabContent tab={settingsTab} />
 					</div>
 				</main>
-				{!zenMode && aiPanelKeepMounted ? rightSidebarSurface : null}
+				{aiPanelKeepMounted ? rightSidebarSurface : null}
 			</>
 		);
 	}
@@ -546,7 +546,7 @@ export const MainContent = memo(function MainContent({
 					) : null}
 				</div>
 			</main>
-			{!zenMode ? rightSidebarSurface : null}
+			{rightSidebarSurface}
 		</>
 	);
 });

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -260,19 +260,21 @@ export const MainContent = memo(function MainContent({
 	onOpenPeekedNote,
 }: MainContentProps) {
 	const { spacePath, settingsLoaded, onOpenSpace } = useSpace();
-	const { folioMode, settingsMode, settingsTab } = useUILayoutContext();
+	const { folioMode, settingsMode, settingsTab, zenMode } =
+		useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
 	const { keepMounted: aiPanelKeepMounted } = useAiPanelSession();
 	const [infoSidebarWidth, setInfoSidebarWidth] = useState(340);
 	const [infoSidebarOpen, setInfoSidebarOpen] = useState(false);
 	const handledDailyNoteSetupNoticeRequestRef = useRef(0);
 
-	const aiSidebarVisible = aiEnabled && aiPanelOpen && !infoSidebarOpen;
+	const aiSidebarVisible =
+		!zenMode && aiEnabled && aiPanelOpen && !infoSidebarOpen;
 	const aiSidebarMounted = aiSidebarVisible || aiPanelKeepMounted;
 	const rightSidebarOpen =
 		Boolean(spacePath) &&
 		!settingsMode &&
-		(aiSidebarVisible || infoSidebarOpen);
+		(aiSidebarVisible || (!zenMode && infoSidebarOpen));
 	const infoSidebarResize = useResizablePanel({
 		min: 260,
 		max: 620,
@@ -489,7 +491,7 @@ export const MainContent = memo(function MainContent({
 						<SettingsTabContent tab={settingsTab} />
 					</div>
 				</main>
-				{aiPanelKeepMounted ? rightSidebarSurface : null}
+				{!zenMode && aiPanelKeepMounted ? rightSidebarSurface : null}
 			</>
 		);
 	}
@@ -535,7 +537,7 @@ export const MainContent = memo(function MainContent({
 					) : (
 						editorCanvas
 					)}
-					{peekNotePath ? (
+					{!zenMode && peekNotePath ? (
 						<NoteSidePeek
 							relPath={peekNotePath}
 							onClose={onCloseNotePeek}
@@ -544,7 +546,7 @@ export const MainContent = memo(function MainContent({
 					) : null}
 				</div>
 			</main>
-			{rightSidebarSurface}
+			{!zenMode ? rightSidebarSurface : null}
 		</>
 	);
 });

--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NoteInlineEditor } from "./NoteInlineEditor";
+import { loadMathExtensionFactory } from "./math/loadMathExtensions";
 
 vi.mock("react-i18next", () => ({
 	useTranslation: () => ({
@@ -331,14 +332,23 @@ describe("NoteInlineEditor table controls", () => {
 		vi.unstubAllGlobals();
 	});
 
-	function render(mode: "plain" | "rich" | "preview" = "rich") {
+	function render(
+		mode: "plain" | "rich" | "preview" = "rich",
+		options: {
+			chrome?: "full" | "minimal";
+			enableMath?: boolean;
+			markdown?: string;
+		} = {},
+	) {
 		act(() => {
 			root.render(
 				<NoteInlineEditor
-					markdown=""
+					markdown={options.markdown ?? ""}
 					mode={mode}
 					onChange={() => {}}
 					relPath=""
+					chrome={options.chrome}
+					enableMath={options.enableMath}
 				/>,
 			);
 		});
@@ -383,6 +393,24 @@ describe("NoteInlineEditor table controls", () => {
 		expect(container.querySelector('[data-axis="column"]')).toBeInstanceOf(
 			HTMLButtonElement,
 		);
+	});
+
+	it("loads equations in minimal chrome only when the caller opts in", async () => {
+		const loadMathExtensions = vi.mocked(loadMathExtensionFactory);
+		render("rich", { chrome: "minimal", markdown: "$x$" });
+
+		expect(loadMathExtensions).not.toHaveBeenCalled();
+
+		render("rich", {
+			chrome: "minimal",
+			enableMath: true,
+			markdown: "$x$",
+		});
+		await act(async () => {
+			await Promise.resolve();
+		});
+
+		expect(loadMathExtensions).toHaveBeenCalledOnce();
 	});
 
 	it("hides table controls when selection moves outside the table", async () => {

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -215,6 +215,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 	acceptSearchJumps = true,
 	deferHeavyFeatures = false,
 	chrome = "full",
+	enableMath = chrome === "full",
 	additionalExtensions: additionalExtensionsProp = EMPTY_ADDITIONAL_EXTENSIONS,
 	placeholder,
 	pasteMarkdownBehavior = "plain-text",
@@ -237,10 +238,10 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		import("@tiptap/core").AnyExtension[]
 	>([]);
 	const [mathExtensionsReady, setMathExtensionsReady] = useState(
-		mode === "plain",
+		mode === "plain" || !enableMath,
 	);
 	useEffect(() => {
-		if (mode === "plain" || mathExtensions.length > 0) {
+		if (!enableMath || mode === "plain" || mathExtensions.length > 0) {
 			setMathExtensionsReady(true);
 			return;
 		}
@@ -262,7 +263,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		return () => {
 			cancelled = true;
 		};
-	}, [mathExtensions.length, mathNodeEditor.open, mode]);
+	}, [enableMath, mathExtensions.length, mathNodeEditor.open, mode]);
 
 	const mergedAdditionalExtensions = useMemo(
 		() => [...mathExtensions, ...additionalExtensionsProp],
@@ -944,7 +945,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 					</div>
 				) : null}
 				{mode !== "plain" &&
-				(mathExtensionsReady || !markdown.includes("$")) ? (
+				(!enableMath || mathExtensionsReady || !markdown.includes("$")) ? (
 					<NoteEditorSurface
 						editor={liveEditor}
 						mode={mode}

--- a/src/components/editor/NoteInlineEditor.tsx
+++ b/src/components/editor/NoteInlineEditor.tsx
@@ -240,7 +240,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		mode === "plain",
 	);
 	useEffect(() => {
-		if (chromeMinimal || mode === "plain" || mathExtensions.length > 0) {
+		if (mode === "plain" || mathExtensions.length > 0) {
 			setMathExtensionsReady(true);
 			return;
 		}
@@ -262,7 +262,7 @@ export const NoteInlineEditor = memo(function NoteInlineEditor({
 		return () => {
 			cancelled = true;
 		};
-	}, [chromeMinimal, mathExtensions.length, mathNodeEditor.open, mode]);
+	}, [mathExtensions.length, mathNodeEditor.open, mode]);
 
 	const mergedAdditionalExtensions = useMemo(
 		() => [...mathExtensions, ...additionalExtensionsProp],

--- a/src/components/editor/rollover/DailyNoteRollover.tsx
+++ b/src/components/editor/rollover/DailyNoteRollover.tsx
@@ -40,12 +40,14 @@ export function DailyNoteRollover({
 	const { t } = useTranslation("editor");
 	const [summaryOpen, setSummaryOpen] = useState(false);
 	const { spacePath } = useSpace();
-	const { dailyNotesFolder, periodNoteTemplates } = useUILayoutContext();
+	const { dailyNotesFolder, periodNoteTemplates, zenMode } =
+		useUILayoutContext();
 	const today = getTodayDateString();
 	const noteDate = dailyNotesFolder
 		? getDailyNoteDateFromPath(relPath, dailyNotesFolder)
 		: null;
-	const enabled =
+	const rolloverEnabled =
+		!zenMode &&
 		mode === "rich" &&
 		Boolean(dailyNotesFolder && noteDate && noteDate <= today);
 	const overdueQuery = useQuery({
@@ -55,7 +57,7 @@ export function DailyNoteRollover({
 				folder: dailyNotesFolder ?? "",
 				before_date: today,
 			}),
-		enabled: enabled && noteDate === today,
+		enabled: rolloverEnabled && noteDate === today,
 	});
 	const noteQuery = useQuery({
 		queryKey: ["daily-note-rollover-note", dailyNotesFolder, noteDate],
@@ -65,7 +67,7 @@ export function DailyNoteRollover({
 				before_date: today,
 				source_date: noteDate,
 			}),
-		enabled,
+		enabled: rolloverEnabled,
 	});
 
 	const moveMutation = useMutation({
@@ -237,7 +239,7 @@ export function DailyNoteRollover({
 		});
 	};
 
-	if (!enabled) return children(null);
+	if (!rolloverEnabled) return children(null);
 	const overdue = overdueQuery.data ?? [];
 	const taskActions: RolloverTaskActions = {
 		targets: noteDate === today ? ["tomorrow"] : ["today", "tomorrow"],

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -48,6 +48,8 @@ export interface NoteInlineEditorProps {
 	acceptSearchJumps?: boolean;
 	deferHeavyFeatures?: boolean;
 	chrome?: NoteInlineEditorChrome;
+	/** Loads equation extensions even when this surface uses minimal chrome. */
+	enableMath?: boolean;
 	additionalExtensions?: AnyExtension[];
 	placeholder?: string;
 	pasteMarkdownBehavior?: PasteMarkdownBehavior;

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -623,7 +623,7 @@ export function MarkdownEditorPane({
 										relPath={relPath}
 										mode={mode}
 										chrome={zenMode ? "minimal" : "full"}
-										enableMath={zenMode}
+										enableMath
 										enableFocusMode
 										aiEnabled={aiEnabled && !zenMode}
 										onOpenAiPanel={() => setAiPanelOpen(true)}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -623,6 +623,7 @@ export function MarkdownEditorPane({
 										relPath={relPath}
 										mode={mode}
 										chrome={zenMode ? "minimal" : "full"}
+										enableMath={zenMode}
 										enableFocusMode
 										aiEnabled={aiEnabled && !zenMode}
 										onOpenAiPanel={() => setAiPanelOpen(true)}

--- a/src/components/preview/MarkdownEditorPane.tsx
+++ b/src/components/preview/MarkdownEditorPane.tsx
@@ -256,7 +256,7 @@ export function MarkdownEditorPane({
 	const [previewContext, setPreviewContext] =
 		useState<WorkspaceDatabasePreviewContext | null>(null);
 	const [linkRefreshKey, setLinkRefreshKey] = useState(0);
-	const { showToc } = useUILayoutContext();
+	const { showToc, zenMode } = useUILayoutContext();
 	const { aiEnabled, aiPanelOpen, setAiPanelOpen } = useAISidebarContext();
 	const { status: gitSyncStatus } = useGitSyncContext();
 	const hasSupportedGit = canShowGitHistory(gitSyncStatus);
@@ -551,47 +551,49 @@ export function MarkdownEditorPane({
 
 	return (
 		<section className="filePreviewPane markdownEditorPane" ref={paneRef}>
-			<div className="markdownEditorFloatActions">
-				<div className="markdownEditorToolbar">
-					<EditorViewModeSwitch
-						mode={mode}
-						largeNote={isLargeNote}
-						onModeChange={requestEditorMode}
-					/>
-					<div className="markdownEditorToolbarActions">
-						{aiEnabled ? (
+			{!zenMode ? (
+				<div className="markdownEditorFloatActions">
+					<div className="markdownEditorToolbar">
+						<EditorViewModeSwitch
+							mode={mode}
+							largeNote={isLargeNote}
+							onModeChange={requestEditorMode}
+						/>
+						<div className="markdownEditorToolbarActions">
+							{aiEnabled ? (
+								<button
+									type="button"
+									className="markdownEditorToolbarBtn"
+									data-active={isAiPanelActive || undefined}
+									onClick={() => {
+										setInfoPanelOpen(() => false);
+										setAiPanelOpen((open) => !open);
+									}}
+									aria-label={t("toolbar.aiPanel")}
+									title={t("toolbar.aiPanel")}
+									aria-pressed={aiPanelOpen}
+								>
+									<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
+								</button>
+							) : null}
 							<button
 								type="button"
 								className="markdownEditorToolbarBtn"
-								data-active={isAiPanelActive || undefined}
-								onClick={() => {
-									setInfoPanelOpen(() => false);
-									setAiPanelOpen((open) => !open);
-								}}
-								aria-label={t("toolbar.aiPanel")}
-								title={t("toolbar.aiPanel")}
-								aria-pressed={aiPanelOpen}
+								data-active={infoPanelOpen || undefined}
+								onClick={toggleInfoPanel}
+								aria-label={t("toolbar.info")}
+								title={t("toolbar.info")}
+								aria-pressed={infoPanelOpen}
 							>
-								<HugeiconsIcon icon={AiBrain04Icon} size="var(--icon-md)" />
+								<HugeiconsIcon
+									icon={LayoutAlignRightIcon}
+									size="var(--icon-md)"
+								/>
 							</button>
-						) : null}
-						<button
-							type="button"
-							className="markdownEditorToolbarBtn"
-							data-active={infoPanelOpen || undefined}
-							onClick={toggleInfoPanel}
-							aria-label={t("toolbar.info")}
-							title={t("toolbar.info")}
-							aria-pressed={infoPanelOpen}
-						>
-							<HugeiconsIcon
-								icon={LayoutAlignRightIcon}
-								size="var(--icon-md)"
-							/>
-						</button>
+						</div>
 					</div>
 				</div>
-			</div>
+			) : null}
 			{error ? (
 				<div className="filePreviewMeta">
 					<div className="filePreviewHint">{error}</div>
@@ -620,8 +622,9 @@ export function MarkdownEditorPane({
 										markdown={text}
 										relPath={relPath}
 										mode={mode}
+										chrome={zenMode ? "minimal" : "full"}
 										enableFocusMode
-										aiEnabled={aiEnabled}
+										aiEnabled={aiEnabled && !zenMode}
 										onOpenAiPanel={() => setAiPanelOpen(true)}
 										pasteMarkdownBehavior="smart-markdown"
 										onChange={(nextText) => {
@@ -646,47 +649,55 @@ export function MarkdownEditorPane({
 				getHeadingPreview={getPreviewForHeading}
 				onSelectHeading={scrollToHeading}
 				visible={
-					showToc && !infoPanelOpen && !gitDiff && !error && mode !== "plain"
+					!zenMode &&
+					showToc &&
+					!infoPanelOpen &&
+					!gitDiff &&
+					!error &&
+					mode !== "plain"
 				}
 			/>
 
-			<NotesInfoSidebar
-				open={infoPanelOpen}
-				hasError={Boolean(error)}
-				relPath={relPath}
-				frontmatter={currentFrontmatter}
-				onFrontmatterChange={handleInfoFrontmatterChange}
-				stats={infoAnalysis.stats}
-				taskSummary={infoAnalysis.taskSummary}
-				tocHeadings={visibleHeadings}
-				tocActiveId={visibleActiveHeadingId}
-				onSelectHeading={selectVisibleHeading}
-				backlinks={sidebarBacklinks}
-				unlinkedMentions={{
-					...unlinkedMentions,
-					onLink: unlinkedMentions.linkMention,
-					onLinkAll: unlinkedMentions.linkAll,
-				}}
-				linkedNotes={linkedNotes}
-				relationshipGroups={relationshipGroups}
-				previewContext={previewContext}
-				lastSavedMtimeMs={lastSavedMtimeMs}
-				lineCount={infoAnalysis.lineCount}
-				utf8SizeBytes={utf8SizeBytes}
-				saveLabel={saveLabel}
-				gitSyncStatus={gitSyncStatus}
-				selectedGitCommitHash={gitDiff?.commit.hash ?? null}
-				onSelectGitDiff={onGitDiffChange ?? undefined}
-				onClose={closeInfoPanel}
-			/>
-			<LinkedNotePreviewSheet />
-
-			<LocalNoteConnectionsDialog
-				open={localConnectionsOpen}
-				onOpenChange={setLocalConnectionsOpen}
-				noteId={relPath}
-				connectionsRefreshKey={(lastSavedMtimeMs ?? 0) + linkRefreshKey}
-			/>
+			{!zenMode ? (
+				<>
+					<NotesInfoSidebar
+						open={infoPanelOpen}
+						hasError={Boolean(error)}
+						relPath={relPath}
+						frontmatter={currentFrontmatter}
+						onFrontmatterChange={handleInfoFrontmatterChange}
+						stats={infoAnalysis.stats}
+						taskSummary={infoAnalysis.taskSummary}
+						tocHeadings={visibleHeadings}
+						tocActiveId={visibleActiveHeadingId}
+						onSelectHeading={selectVisibleHeading}
+						backlinks={sidebarBacklinks}
+						unlinkedMentions={{
+							...unlinkedMentions,
+							onLink: unlinkedMentions.linkMention,
+							onLinkAll: unlinkedMentions.linkAll,
+						}}
+						linkedNotes={linkedNotes}
+						relationshipGroups={relationshipGroups}
+						previewContext={previewContext}
+						lastSavedMtimeMs={lastSavedMtimeMs}
+						lineCount={infoAnalysis.lineCount}
+						utf8SizeBytes={utf8SizeBytes}
+						saveLabel={saveLabel}
+						gitSyncStatus={gitSyncStatus}
+						selectedGitCommitHash={gitDiff?.commit.hash ?? null}
+						onSelectGitDiff={onGitDiffChange ?? undefined}
+						onClose={closeInfoPanel}
+					/>
+					<LinkedNotePreviewSheet />
+					<LocalNoteConnectionsDialog
+						open={localConnectionsOpen}
+						onOpenChange={setLocalConnectionsOpen}
+						noteId={relPath}
+						connectionsRefreshKey={(lastSavedMtimeMs ?? 0) + linkRefreshKey}
+					/>
+				</>
+			) : null}
 		</section>
 	);
 }

--- a/src/components/settings/ExperimentalSettingsPane.tsx
+++ b/src/components/settings/ExperimentalSettingsPane.tsx
@@ -61,6 +61,11 @@ export function ExperimentalSettingsPane() {
 		DURABLE_SETTINGS.editorShowFormatBar.write,
 		setError,
 	);
+	const zenMode = useSettingsBoolean(
+		false,
+		DURABLE_SETTINGS.editorZenMode.write,
+		setError,
+	);
 	const rawMarkdownVimMode = useSettingsBoolean(
 		false,
 		DURABLE_SETTINGS.editorRawMarkdownVimMode.write,
@@ -81,6 +86,7 @@ export function ExperimentalSettingsPane() {
 	const setInitialNoteSidePeek = noteSidePeek.setInitialChecked;
 	const setInitialExternalLinkPreviews = externalLinkPreviews.setInitialChecked;
 	const setInitialFormatBar = formatBar.setInitialChecked;
+	const setInitialZenMode = zenMode.setInitialChecked;
 	const setInitialRawMarkdownVimMode = rawMarkdownVimMode.setInitialChecked;
 	const setInitialFocusMode = focusMode.setInitialValue;
 	const setInitialNonMarkdownFiles = nonMarkdownFiles.setInitialChecked;
@@ -92,6 +98,7 @@ export function ExperimentalSettingsPane() {
 		setInitialNoteSidePeek(settings.ui.noteSidePeek);
 		setInitialExternalLinkPreviews(settings.editor.showExternalLinkPreviews);
 		setInitialFormatBar(settings.editor.showFormatBar);
+		setInitialZenMode(settings.editor.zenMode);
 		setInitialRawMarkdownVimMode(settings.editor.rawMarkdownVimMode);
 		setInitialFocusMode(settings.editor.focusMode);
 		setInitialNonMarkdownFiles(settings.ui.showNonMarkdownFiles);
@@ -100,6 +107,7 @@ export function ExperimentalSettingsPane() {
 		setInitialExternalLinkPreviews,
 		setInitialFolioMode,
 		setInitialFormatBar,
+		setInitialZenMode,
 		setInitialNoteSidePeek,
 		setInitialFocusMode,
 		setInitialNonMarkdownFiles,
@@ -174,6 +182,18 @@ export function ExperimentalSettingsPane() {
 							disabled={externalLinkPreviews.isSaving}
 							ariaLabel={t("editor.externalLinkPreviews.ariaLabel")}
 							onCheckedChange={externalLinkPreviews.onCheckedChange}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label={t("experimental.zenMode.label")}
+						description={t("experimental.zenMode.description")}
+						searchId="general-editor-zen-mode"
+					>
+						<SettingsToggle
+							checked={zenMode.checked}
+							disabled={zenMode.isSaving}
+							ariaLabel={t("experimental.zenMode.ariaLabel")}
+							onCheckedChange={zenMode.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -104,6 +104,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "general-editor-spell-check", tab: "editor" },
 	{ id: "general-editor-external-link-previews", tab: "experimental" },
 	{ id: "general-editor-format-bar", tab: "experimental" },
+	{ id: "general-editor-zen-mode", tab: "experimental" },
 	{ id: "general-editor-vim-mode", tab: "experimental" },
 	{ id: "ai-assistant-behavior-tools", tab: "ai" },
 	{ id: "appearance-layout-folio-mode", tab: "experimental" },

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -323,6 +323,8 @@ export function UIProvider({ children }: { children: ReactNode }) {
 	const { spacePath } = useSpace();
 	const [state, dispatch] = useReducer(uiReducer, initialUIState);
 	const spacePathRef = useRef(spacePath);
+	const zenModeRef = useRef(initialUIState.zenMode);
+	const zenModeRevisionRef = useRef(0);
 	const {
 		sidebarCollapsed,
 		sidebarWidth,
@@ -368,6 +370,8 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		}
 		const nextZenMode = payload.editor?.zenMode;
 		if (typeof nextZenMode === "boolean") {
+			zenModeRevisionRef.current += 1;
+			zenModeRef.current = nextZenMode;
 			dispatch({ type: "setZenMode", value: nextZenMode });
 		}
 		const nextFolioMode = payload.ui?.folioMode;
@@ -454,10 +458,16 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		const loadAndApplySettings = async () => {
 			try {
 				const requestedSpacePath = spacePathRef.current;
+				const zenModeRevision = zenModeRevisionRef.current;
 				const s = await loadSettings({ spacePath: requestedSpacePath });
 				// Discard if unmounted or the active space changed mid-load so we
 				// never stamp the previous space's folders/template as the new one.
 				if (cancelled || requestedSpacePath !== spacePathRef.current) return;
+				const nextZenMode =
+					zenModeRevision === zenModeRevisionRef.current
+						? s.editor.zenMode
+						: zenModeRef.current;
+				zenModeRef.current = nextZenMode;
 				dispatch({
 					type: "hydrateSettings",
 					spacePath: requestedSpacePath,
@@ -469,7 +479,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					periodNoteTemplates: periodNoteTemplatesFromSettings(s.templates),
 					periodNotesEnabled: periodNotesEnabledFromSettings(s.dailyNotes),
 					showToc: s.ui.showToc,
-					zenMode: s.editor.zenMode,
+					zenMode: nextZenMode,
 					folioMode: s.ui.folioMode,
 					dateDisplayFormat: s.ui.dateDisplayFormat,
 				});

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -64,6 +64,7 @@ interface UILayoutContextValue {
 	settingsSpacePath: string | null;
 	showToc: boolean;
 	setShowToc: (show: boolean) => void;
+	zenMode: boolean;
 	folioMode: boolean;
 	setFolioMode: (enabled: boolean) => void;
 	folioScope: FolioScope;
@@ -102,6 +103,7 @@ type UIState = {
 	periodNotesEnabled: PeriodNotesEnabled;
 	settingsSpacePath: string | null;
 	showToc: boolean;
+	zenMode: boolean;
 	folioMode: boolean;
 	folioScope: FolioScope;
 	settingsMode: boolean;
@@ -132,6 +134,7 @@ type UIAction =
 			value: string | null;
 	  }
 	| { type: "setShowToc"; value: boolean }
+	| { type: "setZenMode"; value: boolean }
 	| { type: "setFolioMode"; value: boolean }
 	| { type: "setFolioScope"; value: FolioScope }
 	| { type: "setAiEnabled"; value: boolean }
@@ -153,6 +156,7 @@ type UIAction =
 			periodNoteTemplates: PeriodNoteTemplatePaths;
 			periodNotesEnabled: PeriodNotesEnabled;
 			showToc: boolean;
+			zenMode: boolean;
 			folioMode: boolean;
 			dateDisplayFormat: DateDisplayFormat;
 	  }
@@ -179,6 +183,7 @@ const initialUIState: UIState = {
 	periodNotesEnabled: DEFAULT_PERIOD_NOTES_ENABLED,
 	settingsSpacePath: null,
 	showToc: true,
+	zenMode: false,
 	folioMode: false,
 	folioScope: DEFAULT_FOLIO_SCOPE,
 	settingsMode: false,
@@ -231,6 +236,8 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 			};
 		case "setShowToc":
 			return { ...state, showToc: action.value };
+		case "setZenMode":
+			return { ...state, zenMode: action.value };
 		case "setFolioMode":
 			return {
 				...state,
@@ -303,6 +310,7 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 				periodNoteTemplates: action.periodNoteTemplates,
 				periodNotesEnabled: action.periodNotesEnabled,
 				showToc: action.showToc,
+				zenMode: action.zenMode,
 				folioMode: action.folioMode,
 				dateDisplayFormat: action.dateDisplayFormat,
 			};
@@ -328,6 +336,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		periodNotesEnabled,
 		settingsSpacePath,
 		showToc,
+		zenMode,
 		folioMode,
 		folioScope,
 		settingsMode,
@@ -356,6 +365,10 @@ export function UIProvider({ children }: { children: ReactNode }) {
 		const nextShowToc = payload.ui?.showToc;
 		if (typeof nextShowToc === "boolean") {
 			dispatch({ type: "setShowToc", value: nextShowToc });
+		}
+		const nextZenMode = payload.editor?.zenMode;
+		if (typeof nextZenMode === "boolean") {
+			dispatch({ type: "setZenMode", value: nextZenMode });
 		}
 		const nextFolioMode = payload.ui?.folioMode;
 		if (typeof nextFolioMode === "boolean") {
@@ -456,6 +469,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 					periodNoteTemplates: periodNoteTemplatesFromSettings(s.templates),
 					periodNotesEnabled: periodNotesEnabledFromSettings(s.dailyNotes),
 					showToc: s.ui.showToc,
+					zenMode: s.editor.zenMode,
 					folioMode: s.ui.folioMode,
 					dateDisplayFormat: s.ui.dateDisplayFormat,
 				});
@@ -600,6 +614,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			settingsSpacePath,
 			showToc,
 			setShowToc,
+			zenMode,
 			folioMode,
 			setFolioMode,
 			folioScope,
@@ -629,6 +644,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
 			settingsSpacePath,
 			showToc,
 			setShowToc,
+			zenMode,
 			folioMode,
 			setFolioMode,
 			folioScope,

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -93,6 +93,11 @@
 			"label": "Note peek",
 			"description": "Wiki links and All Notes open as a Peek over the current tab instead of replacing it. Expand the Peek to go to that note, or close it to stay where you were. The file tree and command palette still open tabs.",
 			"ariaLabel": "Note peek"
+		},
+		"zenMode": {
+			"label": "Zen mode",
+			"description": "Hide the sidebars, tabs, editor controls, and formatting ribbon so only your note remains.",
+			"ariaLabel": "Zen mode"
 		}
 	},
 	"editor": {

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -525,6 +525,18 @@
 			"section": "Experimental",
 			"keywords": ["format", "toolbar", "ribbon", "rich", "editor", "hide"]
 		},
+		"general-editor-zen-mode": {
+			"title": "Zen mode",
+			"section": "Experimental",
+			"keywords": [
+				"focus",
+				"distraction",
+				"minimal",
+				"sidebar",
+				"tabs",
+				"editor"
+			]
+		},
 		"ai-assistant-behavior-tools": {
 			"title": "AI chat has access to tools",
 			"section": "Assistant behavior",

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -635,6 +635,7 @@ export async function loadSettings(
 		showExternalLinkPreviews:
 			DURABLE_SETTINGS.editorShowExternalLinkPreviews.load(entries),
 		showFormatBar: DURABLE_SETTINGS.editorShowFormatBar.load(entries),
+		zenMode: DURABLE_SETTINGS.editorZenMode.load(entries),
 		focusMode: DURABLE_SETTINGS.editorFocusMode.load(entries),
 	};
 	const database: AppSettings["database"] = {

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -663,6 +663,13 @@ export const DURABLE_SETTINGS = {
 		read: (settings) => settings.editor.showFormatBar,
 		change: (value) => ({ editor: { showFormatBar: value } }),
 	}),
+	editorZenMode: booleanSetting({
+		key: "editor.zenMode",
+		defaultValue: false,
+		discovery: searchable("general-editor-zen-mode"),
+		read: (settings) => settings.editor.zenMode,
+		change: (value) => ({ editor: { zenMode: value } }),
+	}),
 	editorFocusMode: defineApplicationSetting({
 		key: "editor.focusMode",
 		defaultValue: DEFAULT_FOCUS_MODE,

--- a/src/lib/settings/model.ts
+++ b/src/lib/settings/model.ts
@@ -59,6 +59,7 @@ export interface EditorSettings {
 	spellCheck: boolean;
 	showExternalLinkPreviews: boolean;
 	showFormatBar: boolean;
+	zenMode: boolean;
 	focusMode: FocusMode;
 }
 

--- a/src/styles/app/17-main-tabs.css
+++ b/src/styles/app/17-main-tabs.css
@@ -13,6 +13,10 @@
 	background: var(--bg-canvas, var(--bg-primary));
 }
 
+.mainTabsEmptyDragRegion[data-zen-mode="true"] {
+	background: var(--bg-primary);
+}
+
 .mainTabsBar {
 	--main-tabs-right-reserve: 168px;
 	--main-tabs-left-reserve: var(--space-3);


### PR DESCRIPTION
Closes 


## Description

Adds a persisted Zen mode setting for distraction-free note editing.

- Hides the sidebar, tabs, command palette, editor toolbar, note info panels, side peek, table of contents, AI panel, and daily-note rollover UI while Zen mode is active.
- Keeps the settings surface available so users can turn Zen mode off.
- Adds the setting to Experimental settings, settings search, and English translations.

## Screenshots

No screenshots or screen recording were captured for this PR.

## Docs

No documentation changes are needed. The setting description and search keywords are included in the Experimental settings UI.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Zen mode for focused note editing controlled by `editor.zenMode`
> - Adds a durable `editor.zenMode` setting, toggled via Experimental Settings, and managed by `UIContext` to propagate state across the app.
> - When active, components like `AppShell`, `MainContent`, and `MarkdownEditorPane` hide sidebars, tab bars, floating toolbars, and dialogs. `DailyNoteRollover` suspends prompts.
> - Adds an `enableMath` prop to `NoteInlineEditor` to prevent loading math extensions in minimal chrome unless explicitly requested, which is used during Zen mode.
> - Risk: `UIProvider` handles `zenMode` across async settings hydration using refs; check `src/contexts/UIContext.tsx` if state desyncs from settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 641ea97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Summary by Sourcery

Add persisted Zen mode to provide focused note editing with nonessential workspace UI hidden.

New Features:
- Add a persisted Zen mode setting for distraction-free note editing, configurable from Experimental settings and available through settings search.

Enhancements:
- Hide editor and workspace UI chrome, including navigation, tabs, toolbars, panels, previews, and daily-note rollover controls while Zen mode is active, while keeping settings accessible.
- Preserve live Zen mode changes during asynchronous settings loading and allow math rendering in minimal-chrome editors when enabled.

Tests:
- Add coverage for opt-in equation loading in minimal editor chrome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zen Mode for a distraction-free editing experience.
  * Hides sidebars, tabs, toolbars, palettes, previews, and other interface elements while active.
  * Disables AI integrations and daily note rollover in Zen Mode.
  * Added a persistent Zen Mode toggle under Experimental settings, with settings search support.
  * Settings remain accessible while Zen Mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->