### PR TITLE
Fix AI composer active file suggestion box layout (#526) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.16-alpha.1",
+	"version": "0.8.16-alpha.2",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -12,6 +12,7 @@ import {
 	useMemo,
 	useRef,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useIsDarkTheme } from "../../hooks/useIsDarkTheme";
 import { APP_TAGLINE } from "../../lib/copy";
 import { normalizeRelPath } from "../../utils/path";
@@ -250,6 +251,7 @@ export function AIComposer({
 	onRemoveContext,
 }: AIComposerProps) {
 	const isDarkTheme = useIsDarkTheme();
+	const { t } = useTranslation("shell");
 	const hasDraftText = Boolean(input.replace(CHIP_RE, "").trim());
 	const beamSize = isStreamingResponse ? "pulse-inner" : "md";
 	const beamStrength = isStreamingResponse ? 0.3 : hasDraftText ? 0.28 : 0.7;
@@ -480,13 +482,18 @@ export function AIComposer({
 			) : null}
 			<div className="aiComposer">
 				{showActiveFileSuggestion ? (
-					<div className="aiComposerSuggestionHint" aria-label="Active file">
+					<div
+						className="aiComposerSuggestionHint"
+						aria-label={t("ai.activeFile")}
+					>
 						<button
 							type="button"
 							className="aiComposerSuggestionButton"
 							onClick={() => onAddContext("file", suggestedFilePath)}
-							aria-label={`Add ${fileNameFromPath(suggestedFilePath)} to context`}
-							title={`Add ${suggestedFilePath} to context`}
+							aria-label={t("ai.addToContext", {
+								name: fileNameFromPath(suggestedFilePath),
+							})}
+							title={t("ai.addToContext", { name: suggestedFilePath })}
 							disabled={isAwaitingResponse}
 						>
 							<span className="aiComposerSuggestionIcon">

--- a/src/components/ai/AIComposer.tsx
+++ b/src/components/ai/AIComposer.tsx
@@ -15,7 +15,7 @@ import {
 import { useIsDarkTheme } from "../../hooks/useIsDarkTheme";
 import { APP_TAGLINE } from "../../lib/copy";
 import { normalizeRelPath } from "../../utils/path";
-import { File, X } from "../Icons";
+import { File, Plus, X } from "../Icons";
 import { Button } from "../ui/shadcn/button";
 import { ModelSelector } from "./ModelSelector";
 import { truncateLabel } from "./modelSelectorConstants";
@@ -479,6 +479,28 @@ export function AIComposer({
 				</div>
 			) : null}
 			<div className="aiComposer">
+				{showActiveFileSuggestion ? (
+					<div className="aiComposerSuggestionHint" aria-label="Active file">
+						<button
+							type="button"
+							className="aiComposerSuggestionButton"
+							onClick={() => onAddContext("file", suggestedFilePath)}
+							aria-label={`Add ${fileNameFromPath(suggestedFilePath)} to context`}
+							title={`Add ${suggestedFilePath} to context`}
+							disabled={isAwaitingResponse}
+						>
+							<span className="aiComposerSuggestionIcon">
+								<File size="var(--icon-sm)" />
+							</span>
+							<span className="aiComposerSuggestionLabel">
+								{truncateLabel(fileNameFromPath(suggestedFilePath), 28)}
+							</span>
+							<span className="aiComposerSuggestionAddIcon">
+								<Plus size="var(--icon-sm)" aria-hidden="true" />
+							</span>
+						</button>
+					</div>
+				) : null}
 				<BorderBeam
 					className="aiComposerBeam"
 					size={beamSize}
@@ -488,28 +510,6 @@ export function AIComposer({
 					duration={isStreamingResponse ? 3.4 : 5.2}
 				>
 					<div className="aiComposerInputShell">
-						{showActiveFileSuggestion ? (
-							<div
-								className="aiComposerSuggestionHint"
-								aria-label="Active file"
-							>
-								<button
-									type="button"
-									className="aiComposerSuggestionButton"
-									onClick={() => onAddContext("file", suggestedFilePath)}
-									aria-label={`Add ${fileNameFromPath(suggestedFilePath)} to context`}
-									title={`Add ${suggestedFilePath} to context`}
-									disabled={isAwaitingResponse}
-								>
-									<span className="aiComposerSuggestionIcon">
-										<File size="var(--icon-sm)" />
-									</span>
-									<span className="aiComposerSuggestionLabel">
-										{truncateLabel(fileNameFromPath(suggestedFilePath), 28)}
-									</span>
-								</button>
-							</div>
-						) : null}
 						<div
 							ref={composerInputRef}
 							className="aiComposerInput"

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -148,7 +148,9 @@
 		"pinned": "Angeheftet"
 	},
 	"ai": {
-		"toolFailed": "{{tool}} ist fehlgeschlagen"
+		"toolFailed": "{{tool}} ist fehlgeschlagen",
+		"activeFile": "Aktive Datei",
+		"addToContext": "{{name}} zum Kontext hinzufügen"
 	},
 	"connections": {
 		"loading": "Notizen und Verknüpfungen werden geladen…",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -184,7 +184,9 @@
 		"manualCommitMessagesDescription": "Ask for a message before each manual sync. When off, Glyph uses \"Glyph sync\"."
 	},
 	"ai": {
-		"toolFailed": "{{tool}} failed"
+		"toolFailed": "{{tool}} failed",
+		"activeFile": "Active file",
+		"addToContext": "Add {{name}} to context"
 	},
 	"connections": {
 		"loading": "Loading notes and links…",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -148,7 +148,9 @@
 		"pinned": "Fijadas"
 	},
 	"ai": {
-		"toolFailed": "Falló {{tool}}"
+		"toolFailed": "Falló {{tool}}",
+		"activeFile": "Archivo activo",
+		"addToContext": "Añadir {{name}} al contexto"
 	},
 	"connections": {
 		"loading": "Cargando notas y enlaces…",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -150,7 +150,9 @@
 		"pinned": "Épinglées"
 	},
 	"ai": {
-		"toolFailed": "Échec de {{tool}}"
+		"toolFailed": "Échec de {{tool}}",
+		"activeFile": "Fichier actif",
+		"addToContext": "Ajouter {{name}} au contexte"
 	},
 	"connections": {
 		"loading": "Chargement des notes et des liens…",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -147,7 +147,9 @@
 		"pinned": "ピン留め"
 	},
 	"ai": {
-		"toolFailed": "{{tool}} に失敗しました"
+		"toolFailed": "{{tool}} に失敗しました",
+		"activeFile": "アクティブなファイル",
+		"addToContext": "{{name}} をコンテキストに追加"
 	},
 	"connections": {
 		"loading": "ノートとリンクを読み込み中…",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -147,7 +147,9 @@
 		"pinned": "고정됨"
 	},
 	"ai": {
-		"toolFailed": "{{tool}} 실패"
+		"toolFailed": "{{tool}} 실패",
+		"activeFile": "활성 파일",
+		"addToContext": "{{name}}을(를) 컨텍스트에 추가"
 	},
 	"connections": {
 		"loading": "노트와 링크를 불러오는 중…",

--- a/src/i18n/locales/pl/shell.json
+++ b/src/i18n/locales/pl/shell.json
@@ -182,7 +182,9 @@
 		"switchSaveFailed": "Nie udało się zapisać bieżącej przestrzeni. Spróbuj ponownie."
 	},
 	"ai": {
-		"toolFailed": "Narzędzie {{tool}} nie powiodło się"
+		"toolFailed": "Narzędzie {{tool}} nie powiodło się",
+		"activeFile": "Aktywny plik",
+		"addToContext": "Dodaj {{name}} do kontekstu"
 	},
 	"connections": {
 		"loading": "Wczytywanie notatek i łączy…",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -148,7 +148,9 @@
 		"pinned": "Fixadas"
 	},
 	"ai": {
-		"toolFailed": "Falha em {{tool}}"
+		"toolFailed": "Falha em {{tool}}",
+		"activeFile": "Arquivo ativo",
+		"addToContext": "Adicionar {{name}} ao contexto"
 	},
 	"connections": {
 		"loading": "Carregando notas e links…",

--- a/src/styles/app/21-ai-composer-context.css
+++ b/src/styles/app/21-ai-composer-context.css
@@ -118,26 +118,34 @@
 }
 
 .aiComposerSuggestionHint {
-	position: absolute;
-	top: 6px;
-	left: 12px;
-	z-index: 3;
-	pointer-events: auto;
+	position: relative;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: calc(100% - 20px);
+	min-height: 28px;
+	margin: 0 auto -1px;
+	padding: 3px 8px 0;
+	border: 1px solid color-mix(in srgb, var(--border-default) 30%, transparent);
+	border-bottom: 0;
+	border-radius: var(--radius-md) var(--radius-md) 0 0;
+	background: color-mix(in srgb, var(--bg-secondary) 55%, transparent);
 }
 
 .aiComposerSuggestionButton {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	height: 20px;
+	height: 24px;
 	padding: 0 6px 0 4px;
 	border-radius: var(--radius-sm);
 	font-size: calc(var(--text-base) * 0.8);
 	font-weight: 500;
 	line-height: 1;
-	background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
+	background: transparent;
 	color: var(--text-tertiary);
-	border: 1px solid color-mix(in srgb, var(--border-default) 30%, transparent);
+	border: none;
 	cursor: pointer;
 	opacity: 0.7;
 	transition: opacity var(--transition-fast), background var(--transition-fast);
@@ -156,6 +164,12 @@
 .aiComposerSuggestionIcon {
 	display: inline-flex;
 	align-items: center;
+}
+
+.aiComposerSuggestionAddIcon {
+	display: inline-flex;
+	align-items: center;
+	color: var(--text-secondary);
 }
 
 .aiComposerSuggestionLabel {


### PR DESCRIPTION
Closes 


## Description

Fixes the AI composer active file suggestion chip that was absolutely positioned inside the input shell, causing overlap and clipping.

- Moves `aiComposerSuggestionHint` outside `BorderBeam`/`aiComposerInputShell` to render as a full-width top bar above the composer input
- Restyles `.aiComposerSuggestionHint` from `position: absolute` to centered relative container with top border (`border-bottom: 0`, rounded top corners, `width: calc(100% - 20px)`)
- Increases suggestion button height and cleans up styling (transparent background, no border)
- Adds `Plus` icon affordance to suggestion button for clearer add-to-context action
- Bumps version to `0.8.16-alpha.2`

Reasoning: the previous absolute positioning inside the input shell made the suggestion overlap the input area and depend on the shell's layout. Extracting it as a dedicated top bar gives it proper spacing, centering, and visual separation.

## Screenshots

Visual change — suggestion hint now appears as a centered bar attached to the top of the composer instead of floating inside the input.

(Screenshots not attached — verify in `AIComposer` with an active file open.)

## Docs

No docs changes needed. Visual/behavioral fix only for `src/components/ai/AIComposer.tsx` and `src/styles/app/21-ai-composer-context.css`.

## Ready?

- [x] Ran the linter to ensure style guidelines were followed
- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Created a demo

## Summary by Sourcery

Fix the AI composer active-file suggestion layout by separating it from the input shell and presenting it as a dedicated top bar.

Bug Fixes:
- Prevent active-file suggestions in the AI composer from overlapping or clipping the input area.

Enhancements:
- Present active-file suggestions as a centered bar above the composer with clearer add-to-context affordance and localized accessibility labels.

Build:
- Bump the application version to 0.8.16-alpha.2.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `AIComposer` active file suggestion box layout
> - Moves the active-file suggestion hint from inside the composer input to a full-width bar above the `BorderBeam` container, and adds a trailing `Plus` icon to the suggestion button.
> - Replaces hardcoded English strings with i18n keys `ai.activeFile` and `ai.addToContext` across nine locales (de, en, es, fr, ja, ko, pl, pt-BR) in [shell.json](https://github.com/SidhuK/Glyph/pull/526/files#diff-d051b7529e4bff0433762079f41cc33a48396dec763064880e01d7228a08e978).
> - Restyles `.aiComposerSuggestionHint` and `.aiComposerSuggestionButton` in [21-ai-composer-context.css](https://github.com/SidhuK/Glyph/pull/526/files#diff-14f6bac963af9c293a55e409ac31bd74e48c5e7ce2340baa361d3482be73cd64) with updated sizing, borders, and hover behaviors.
> - Bumps version to `0.8.16-alpha.2` in [tauri.conf.json](https://github.com/SidhuK/Glyph/pull/526/files#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9110a68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the active-file suggestion control in the AI composer with a clearer layout and an added plus icon.

- **Style**
  - Refined suggestion hint spacing, alignment, borders, background, and button appearance for improved visibility and consistency.

- **Chores**
  - Updated the application version to 0.8.16-alpha.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->