### PR TITLE
Show folder file counts on hover

### DIFF
--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -29,6 +29,7 @@ import {
 	filterVisibleFileTreeEntries,
 	hasVisibleFileTreeEntries,
 } from "../../hooks/fileTreeHelpers";
+import { useFolderFileCounts } from "../../hooks/useFolderFileCounts";
 import { useTaskSummariesForPaths } from "../../hooks/useTaskSummariesForPaths";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import { spaceLabelFromAbsPath } from "../../lib/fileTreeFolderName";
@@ -40,7 +41,6 @@ import type {
 	FsEntry,
 	NoteTaskSummary,
 } from "../../lib/tauri";
-import { invoke } from "../../lib/tauri";
 import { useTauriEvent } from "../../lib/tauriEvents";
 import { isDeleteKey } from "../../utils/keyboard";
 import { parentDir } from "../../utils/path";
@@ -625,9 +625,6 @@ export const FileTreePane = memo(function FileTreePane({
 	const [showNonMarkdownFiles, setShowNonMarkdownFiles] = useState<
 		boolean | null
 	>(null);
-	const [folderFileCounts, setFolderFileCounts] = useState<
-		Record<string, number>
-	>({});
 	const [focusedDirPath, setFocusedDirPath] = useState<string | null>(
 		activeDirPath,
 	);
@@ -731,49 +728,12 @@ export const FileTreePane = memo(function FileTreePane({
 			.join("||");
 	}, [childrenByDir, rootEntries, summaryParentDirs]);
 
-	useEffect(() => {
-		if (!spacePath || showNonMarkdownFiles === null) {
-			setFolderFileCounts({});
-			return;
-		}
-
-		const requestRevision = folderCountTreeRevision;
-		if (!requestRevision) {
-			setFolderFileCounts({});
-			return;
-		}
-
-		let cancelled = false;
-		void invoke("space_dir_children_summary", {
-			dirs: summaryParentDirs,
-		})
-			.then((summaries) => {
-				if (cancelled) return;
-				const nextCounts: Record<string, number> = {};
-				for (const summary of summaries) {
-					nextCounts[summary.dir_rel_path] = showNonMarkdownFiles
-						? summary.total_files_recursive
-						: summary.total_markdown_recursive;
-				}
-				setFolderFileCounts((prev) => ({
-					...prev,
-					...nextCounts,
-				}));
-			})
-			.catch((error: unknown) => {
-				if (cancelled) return;
-				console.warn("Failed to load folder file counts", error);
-			});
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
+	const folderFileCounts = useFolderFileCounts({
 		spacePath,
-		showNonMarkdownFiles,
-		summaryParentDirs,
-		folderCountTreeRevision,
-	]);
+		includeNonMarkdown: showNonMarkdownFiles,
+		parentDirs: summaryParentDirs,
+		treeRevision: folderCountTreeRevision,
+	});
 
 	const taskSummaryPaths = useMemo(() => {
 		const paths = new Set<string>();

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -289,7 +289,6 @@ interface TreeEntriesProps {
 	onCancelRename: () => void;
 	itemAppearance: Record<string, FileTreeAppearance>;
 	folderFileCounts: Record<string, number>;
-	showFolderFileCounts: boolean;
 	showNonMarkdownFiles: boolean;
 	externalDropTargetPath: string | null;
 	onOpenAppearancePicker: (entry: FsEntry) => void;
@@ -376,7 +375,6 @@ function TreeEntries({
 	onCancelRename,
 	itemAppearance,
 	folderFileCounts,
-	showFolderFileCounts,
 	showNonMarkdownFiles,
 	externalDropTargetPath,
 	onOpenAppearancePicker,
@@ -536,11 +534,7 @@ function TreeEntries({
 							onRequestCreateFolder={onRequestCreateFolder}
 							onDeletePath={onDeletePath}
 							appearance={itemAppearance[entry.rel_path] ?? null}
-							fileCount={
-								showFolderFileCounts
-									? (folderFileCounts[entry.rel_path] ?? null)
-									: null
-							}
+							fileCount={folderFileCounts[entry.rel_path] ?? null}
 							isExternalDropTarget={externalDropTargetPath === entry.rel_path}
 							onOpenAppearancePicker={() => onOpenAppearancePicker(entry)}
 							onStartRename={() => onStartRename(entry.rel_path)}
@@ -738,7 +732,7 @@ export const FileTreePane = memo(function FileTreePane({
 	}, [childrenByDir, rootEntries, summaryParentDirs]);
 
 	useEffect(() => {
-		if (!spacePath || !showFolderFileCounts || showNonMarkdownFiles === null) {
+		if (!spacePath || showNonMarkdownFiles === null) {
 			setFolderFileCounts({});
 			return;
 		}
@@ -776,7 +770,6 @@ export const FileTreePane = memo(function FileTreePane({
 		};
 	}, [
 		spacePath,
-		showFolderFileCounts,
 		showNonMarkdownFiles,
 		summaryParentDirs,
 		folderCountTreeRevision,
@@ -1072,6 +1065,7 @@ export const FileTreePane = memo(function FileTreePane({
 		<m.aside
 			ref={paneRef}
 			className="fileTreePane"
+			data-folder-counts={showFolderFileCounts ? undefined : "hover"}
 			initial={{ y: 10 }}
 			animate={{ y: 0 }}
 			transition={springTransition}
@@ -1140,7 +1134,6 @@ export const FileTreePane = memo(function FileTreePane({
 							onCancelRename={onCancelRename}
 							itemAppearance={itemAppearance}
 							folderFileCounts={folderFileCounts}
-							showFolderFileCounts={showFolderFileCounts}
 							showNonMarkdownFiles={showNonMarkdownFilesSetting}
 							externalDropTargetPath={externalDropTargetPath}
 							onOpenAppearancePicker={handleOpenAppearancePicker}
@@ -1191,7 +1184,6 @@ export const FileTreePane = memo(function FileTreePane({
 						onCancelRename={onCancelRename}
 						itemAppearance={itemAppearance}
 						folderFileCounts={folderFileCounts}
-						showFolderFileCounts={showFolderFileCounts}
 						showNonMarkdownFiles={showNonMarkdownFilesSetting}
 						externalDropTargetPath={externalDropTargetPath}
 						onOpenAppearancePicker={handleOpenAppearancePicker}

--- a/src/hooks/useFolderFileCounts.ts
+++ b/src/hooks/useFolderFileCounts.ts
@@ -50,7 +50,11 @@ export function useFolderFileCounts({
 			treeRevision,
 		],
 		enabled,
-		placeholderData: (previousData) => previousData,
+		placeholderData: (previousData, previousQuery) =>
+			previousQuery?.queryKey[1] === spacePath &&
+			previousQuery.queryKey[2] === includeNonMarkdown
+				? previousData
+				: undefined,
 		queryFn: async () => {
 			const summaries = await invoke("space_dir_children_summary", {
 				dirs,

--- a/src/hooks/useFolderFileCounts.ts
+++ b/src/hooks/useFolderFileCounts.ts
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { DirChildSummary } from "../lib/tauri";
+import { invoke } from "../lib/tauri";
+
+const EMPTY_FOLDER_FILE_COUNTS: Record<string, number> = {};
+
+type FolderFileCountsArgs = {
+	spacePath: string | null;
+	includeNonMarkdown: boolean | null;
+	parentDirs: string[];
+	treeRevision: string;
+};
+
+function countsFromSummaries(
+	summaries: DirChildSummary[],
+	includeNonMarkdown: boolean,
+): Record<string, number> {
+	const next: Record<string, number> = {};
+	for (const summary of summaries) {
+		next[summary.dir_rel_path] = includeNonMarkdown
+			? summary.total_files_recursive
+			: summary.total_markdown_recursive;
+	}
+	return next;
+}
+
+export function useFolderFileCounts({
+	spacePath,
+	includeNonMarkdown,
+	parentDirs,
+	treeRevision,
+}: FolderFileCountsArgs): Record<string, number> {
+	const dirs = useMemo(
+		() => Array.from(new Set(parentDirs)).sort(),
+		[parentDirs],
+	);
+	const enabled =
+		Boolean(spacePath) &&
+		includeNonMarkdown !== null &&
+		dirs.length > 0 &&
+		Boolean(treeRevision);
+
+	const countsQuery = useQuery({
+		queryKey: [
+			"folder-file-counts",
+			spacePath,
+			includeNonMarkdown,
+			dirs,
+			treeRevision,
+		],
+		enabled,
+		placeholderData: (previousData) => previousData,
+		queryFn: async () => {
+			const summaries = await invoke("space_dir_children_summary", {
+				dirs,
+			});
+			return countsFromSummaries(summaries, includeNonMarkdown === true);
+		},
+	});
+
+	if (!enabled) {
+		return EMPTY_FOLDER_FILE_COUNTS;
+	}
+	return countsQuery.data ?? EMPTY_FOLDER_FILE_COUNTS;
+}

--- a/src/styles/app/18-filetree-body.css
+++ b/src/styles/app/18-filetree-body.css
@@ -396,6 +396,21 @@
 	margin-left: auto;
 }
 
+.fileTreePane[data-folder-counts="hover"] .fileTreeCounts {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity var(--transition-fast);
+}
+
+.fileTreePane[data-folder-counts="hover"]
+	.fileTreeRowShell:hover
+	.fileTreeCounts,
+.fileTreePane[data-folder-counts="hover"]
+	.fileTreeRowShell:focus-within
+	.fileTreeCounts {
+	opacity: 1;
+}
+
 .fileTreeExtBadge {
 	flex-shrink: 0;
 	font-size: calc(var(--text-base) * 0.8);


### PR DESCRIPTION
## Summary

Folder file counts still show at the end of each row when the always-visible setting is on. When it is off, the same recursive total now appears on hover or keyboard focus, so you can peek without permanently cluttering the tree.

Counts load through a TanStack Query hook (`useFolderFileCounts`) instead of a `useEffect` plus local state. The query key includes the space, markdown vs all-files setting, expanded parent folders, and a tree revision so add/delete still refreshes the numbers. The last counts stay on screen while the next fetch is in flight.

## Related Issues

## Testing

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`
- [x] `FileTreePane.test.tsx`
- [ ] Relevant manual testing completed on macOS

## Screenshots or Recordings

## Contributor Checklist

- [x] This PR is focused and avoids unrelated refactors
- [ ] I updated docs, copy, or templates if behavior changed
- [ ] I added or updated tests where it made sense
- [x] I used `src/lib/tauri.ts` for frontend Tauri invokes when applicable
- [x] This change does not add or require Windows-specific support
- [x] I am not introducing backward-compatibility code for deprecated behavior

## Summary by Sourcery

Show folder file counts on demand while keeping persistent display available and ensuring counts stay current.

New Features:
- Show recursive folder file counts on row hover or keyboard focus when persistent counts are disabled.

Enhancements:
- Manage folder file count loading with a TanStack Query hook that refreshes for tree, display-setting, space, and expanded-folder changes while retaining previous counts during refetches.