### PR TITLE
Add heading and nested list collapse command

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -200,6 +200,7 @@ export function AppShell() {
 		TemplatePickerItem[]
 	>([]);
 	const [showCollapsibleHeadings, setShowCollapsibleHeadings] = useState(false);
+	const [showCollapsibleLists, setShowCollapsibleLists] = useState(false);
 	const [noteSidePeekEnabled, setNoteSidePeekEnabled] = useState(false);
 	const [notePeek, setNotePeek] = useState<{
 		spacePath: string;
@@ -280,6 +281,7 @@ export function AppShell() {
 			.then((settings) => {
 				if (cancelled) return;
 				setShowCollapsibleHeadings(settings.editor.showCollapsibleHeadings);
+				setShowCollapsibleLists(settings.editor.showCollapsibleLists);
 				setNoteSidePeekEnabled(settings.ui.noteSidePeek);
 				setResumeLastSession(settings.ui.resumeLastSession);
 			})
@@ -298,6 +300,7 @@ export function AppShell() {
 			(payload: {
 				editor?: {
 					showCollapsibleHeadings?: boolean;
+					showCollapsibleLists?: boolean;
 					zenMode?: boolean;
 				};
 				ui?: {
@@ -307,6 +310,9 @@ export function AppShell() {
 			}) => {
 				if (typeof payload.editor?.showCollapsibleHeadings === "boolean") {
 					setShowCollapsibleHeadings(payload.editor.showCollapsibleHeadings);
+				}
+				if (typeof payload.editor?.showCollapsibleLists === "boolean") {
+					setShowCollapsibleLists(payload.editor.showCollapsibleLists);
 				}
 				if (payload.editor?.zenMode) {
 					setPaletteOpen(false);
@@ -1285,6 +1291,7 @@ export function AppShell() {
 		setMovePickerSourcePath,
 		setSidebarCollapsed,
 		showCollapsibleHeadings,
+		showCollapsibleLists,
 		sidebarCollapsed,
 		spacePath,
 		tabsLength: tabs.length,

--- a/src/components/app/editorCommands.tsx
+++ b/src/components/app/editorCommands.tsx
@@ -15,6 +15,7 @@ interface BuildEditorCommandsOptions {
 	aiEnabled: boolean;
 	setCurrentEditorMode: (mode: EditorViewMode) => boolean;
 	showCollapsibleHeadings: boolean;
+	showCollapsibleLists: boolean;
 }
 
 const VIEW_MODE_COMMANDS = [
@@ -40,6 +41,7 @@ export function buildEditorCommands({
 	aiEnabled,
 	setCurrentEditorMode,
 	showCollapsibleHeadings,
+	showCollapsibleLists,
 }: BuildEditorCommandsOptions): Command[] {
 	const enabled = Boolean(activeMarkdownTabPath);
 	const formattingCommands = EDITOR_ACTIONS.filter(
@@ -49,7 +51,11 @@ export function buildEditorCommands({
 			(aiEnabled || action !== "ai_selection_to_context"),
 	).map((action) => ({
 		id: action,
-		enabled,
+		enabled:
+			enabled &&
+			(action !== "toggle_heading_or_list_collapse" ||
+				showCollapsibleHeadings ||
+				showCollapsibleLists),
 		allowInEditable: true,
 		action: () => dispatchEditorMenuAction({ action }),
 	}));

--- a/src/components/app/useAppCommands.tsx
+++ b/src/components/app/useAppCommands.tsx
@@ -122,6 +122,7 @@ interface UseAppCommandsDeps {
 	setMovePickerSourcePath: (path: string | null) => void;
 	setSidebarCollapsed: (collapsed: boolean) => void;
 	showCollapsibleHeadings: boolean;
+	showCollapsibleLists: boolean;
 	sidebarCollapsed: boolean;
 	spacePath: string | null;
 	tabsLength: number;
@@ -269,6 +270,7 @@ export function useAppCommands({
 	setMovePickerSourcePath,
 	setSidebarCollapsed,
 	showCollapsibleHeadings,
+	showCollapsibleLists,
 	sidebarCollapsed,
 	spacePath,
 	tabsLength,
@@ -301,6 +303,7 @@ export function useAppCommands({
 			aiEnabled,
 			setCurrentEditorMode,
 			showCollapsibleHeadings,
+			showCollapsibleLists,
 		});
 		const baseCommands: Command[] = [
 			{
@@ -734,6 +737,7 @@ export function useAppCommands({
 		setSidebarCollapsed,
 		sidebarCollapsed,
 		showCollapsibleHeadings,
+		showCollapsibleLists,
 		spacePath,
 		openAllDocsTab,
 		openSearchPalette,

--- a/src/components/editor/editorActions.ts
+++ b/src/components/editor/editorActions.ts
@@ -22,6 +22,7 @@ const BASE_EDITOR_ACTION_IDS = [
 	"heading_3",
 	"collapse_all_headings",
 	"expand_all_headings",
+	"toggle_heading_or_list_collapse",
 	"bullet_list",
 	"numbered_list",
 	"todo_list",
@@ -114,6 +115,8 @@ export function executeEditorAction({
 			return chain.collapseAllHeadings().run();
 		case "expand_all_headings":
 			return chain.expandAllHeadings().run();
+		case "toggle_heading_or_list_collapse":
+			return editor.commands.toggleCurrentCollapse();
 		case "bullet_list":
 			return chain.toggleBulletList().run();
 		case "numbered_list":

--- a/src/components/editor/extensions/headingCollapse.ts
+++ b/src/components/editor/extensions/headingCollapse.ts
@@ -356,7 +356,7 @@ function findHeadingAtPosition(
 	pos: number,
 ): HeadingRange | null {
 	const containingHeadings = headings.filter(
-		(heading) => pos > heading.pos && pos < heading.end,
+		(heading) => pos >= heading.pos && pos < heading.end,
 	);
 	return containingHeadings[containingHeadings.length - 1] ?? null;
 }
@@ -408,9 +408,10 @@ export const HeadingCollapse = Extension.create<{
 							: null;
 
 					if (!meta) return false;
-					dispatch?.(state.tr.setMeta(headingCollapsePluginKey, meta));
+					const transaction = state.tr.setMeta(headingCollapsePluginKey, meta);
+					dispatch?.(transaction);
 					if (listBranch && dispatch) {
-						const nextState = this.editor.state;
+						const nextState = state.apply(transaction);
 						const nextCollapseState =
 							headingCollapsePluginKey.getState(nextState);
 						if (nextCollapseState) {

--- a/src/components/editor/extensions/headingCollapse.ts
+++ b/src/components/editor/extensions/headingCollapse.ts
@@ -333,9 +333,38 @@ function mapPositions(
 	return mapped;
 }
 
+function findListBranchAtPosition(
+	doc: ProseMirrorNode,
+	pos: number,
+): ListBranch | null {
+	const resolved = doc.resolve(pos);
+	const branches = extractListBranches(doc);
+
+	for (let depth = resolved.depth; depth > 0; depth -= 1) {
+		const node = resolved.node(depth);
+		if (!LIST_ITEM_NODE_NAMES.has(node.type.name)) continue;
+		const branchPos = resolved.before(depth);
+		const branch = branches.find((candidate) => candidate.pos === branchPos);
+		if (branch) return branch;
+	}
+
+	return null;
+}
+
+function findHeadingAtPosition(
+	headings: HeadingRange[],
+	pos: number,
+): HeadingRange | null {
+	const containingHeadings = headings.filter(
+		(heading) => pos > heading.pos && pos < heading.end,
+	);
+	return containingHeadings[containingHeadings.length - 1] ?? null;
+}
+
 declare module "@tiptap/core" {
 	interface Commands<ReturnType> {
 		headingCollapse: {
+			toggleCurrentCollapse: () => ReturnType;
 			toggleHeadingCollapse: (pos: number) => ReturnType;
 			expandHeadingAncestors: (pos: number) => ReturnType;
 			setHeadingCollapseEnabled: (enabled: boolean) => ReturnType;
@@ -355,7 +384,43 @@ export const HeadingCollapse = Extension.create<{
 		return { onListCollapseToggle: () => {} };
 	},
 	addCommands() {
+		const onListCollapseToggle = this.options.onListCollapseToggle;
 		return {
+			toggleCurrentCollapse:
+				() =>
+				({ state, dispatch }) => {
+					const collapseState = headingCollapsePluginKey.getState(state);
+					if (!collapseState) return false;
+
+					const listBranch = collapseState.listsEnabled
+						? findListBranchAtPosition(state.doc, state.selection.from)
+						: null;
+					const heading = collapseState.headingsEnabled
+						? findHeadingAtPosition(
+								extractHeadingRanges(state.doc),
+								state.selection.from,
+							)
+						: null;
+					const meta: HeadingCollapseMeta | null = listBranch
+						? { type: "list-toggle", pos: listBranch.pos }
+						: heading
+							? { type: "heading-toggle", pos: heading.pos }
+							: null;
+
+					if (!meta) return false;
+					dispatch?.(state.tr.setMeta(headingCollapsePluginKey, meta));
+					if (listBranch && dispatch) {
+						const nextState = this.editor.state;
+						const nextCollapseState =
+							headingCollapsePluginKey.getState(nextState);
+						if (nextCollapseState) {
+							onListCollapseToggle(
+								collapsedListBranchKeys(nextState.doc, nextCollapseState),
+							);
+						}
+					}
+					return true;
+				},
 			toggleHeadingCollapse:
 				(pos: number) =>
 				({ state, dispatch }) => {

--- a/src/i18n/locales/de/commands.json
+++ b/src/i18n/locales/de/commands.json
@@ -418,6 +418,10 @@
 			"label": "Aufgabenliste",
 			"description": "Eine Aufgabenliste umschalten."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Überschriften-/Listenbereich umschalten",
+			"description": "Den aktuellen Überschriftenbereich oder verschachtelten Listenbereich umschalten."
+		},
 		"toggle-ai": {
 			"label": "KI-Panel umschalten",
 			"description": "Das KI-Assistentenpanel ein- oder ausblenden."

--- a/src/i18n/locales/en/commands.json
+++ b/src/i18n/locales/en/commands.json
@@ -426,6 +426,10 @@
 			"label": "To-do List",
 			"description": "Toggle a task list."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Toggle Heading/List Collapse",
+			"description": "Toggle the current heading section or nested list branch."
+		},
 		"toggle-ai": {
 			"label": "Toggle AI Panel",
 			"description": "Show or hide the AI assistant panel."

--- a/src/i18n/locales/es/commands.json
+++ b/src/i18n/locales/es/commands.json
@@ -418,6 +418,10 @@
 			"label": "Lista de tareas",
 			"description": "Alternar una lista de tareas."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Alternar contraer/expandir encabezado o lista",
+			"description": "Alterna la sección de encabezado actual o la rama de lista anidada."
+		},
 		"toggle-ai": {
 			"label": "Mostrar u ocultar panel de IA",
 			"description": "Mostrar u ocultar el panel del asistente de IA."

--- a/src/i18n/locales/fr/commands.json
+++ b/src/i18n/locales/fr/commands.json
@@ -418,6 +418,10 @@
 			"label": "Liste de tâches",
 			"description": "Activer ou désactiver une liste de tâches."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Plier/déplier le titre ou la liste",
+			"description": "Plie ou déplie la section de titre actuelle ou la branche de liste imbriquée."
+		},
 		"toggle-ai": {
 			"label": "Afficher/masquer le panneau IA",
 			"description": "Afficher ou masquer le panneau de l’assistant IA."

--- a/src/i18n/locales/ja/commands.json
+++ b/src/i18n/locales/ja/commands.json
@@ -418,6 +418,10 @@
 			"label": "To-do リスト",
 			"description": "タスクリストを切り替えます。"
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "見出し／リストの折りたたみを切り替え",
+			"description": "現在の見出しセクションまたは入れ子のリストを折りたたむか展開します。"
+		},
 		"toggle-ai": {
 			"label": "AI パネルの表示切替",
 			"description": "AI アシスタントパネルの表示／非表示を切り替えます。"

--- a/src/i18n/locales/ko/commands.json
+++ b/src/i18n/locales/ko/commands.json
@@ -418,6 +418,10 @@
 			"label": "할 일 목록",
 			"description": "할 일 목록을 전환합니다."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "제목/목록 접기 전환",
+			"description": "현재 제목 섹션 또는 중첩 목록을 접거나 펼칩니다."
+		},
 		"toggle-ai": {
 			"label": "AI 패널 전환",
 			"description": "AI 어시스턴트 패널을 표시하거나 숨깁니다."

--- a/src/i18n/locales/pl/commands.json
+++ b/src/i18n/locales/pl/commands.json
@@ -426,6 +426,10 @@
 			"label": "Lista zadań",
 			"description": "Włącz lub wyłącz listę zadań."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Przełącz zwijanie nagłówka/listy",
+			"description": "Przełącz zwijanie bieżącej sekcji nagłówka lub zagnieżdżonej gałęzi listy."
+		},
 		"toggle-ai": {
 			"label": "Przełącz panel AI",
 			"description": "Pokaż lub ukryj panel asystenta AI."

--- a/src/i18n/locales/pt-BR/commands.json
+++ b/src/i18n/locales/pt-BR/commands.json
@@ -418,6 +418,10 @@
 			"label": "Lista de tarefas",
 			"description": "Alternar uma lista de tarefas."
 		},
+		"toggle_heading_or_list_collapse": {
+			"label": "Alternar recolhimento de título/lista",
+			"description": "Alterna o recolhimento da seção de título atual ou da ramificação de lista aninhada."
+		},
 		"toggle-ai": {
 			"label": "Alternar painel de IA",
 			"description": "Mostrar ou ocultar o painel do assistente de IA."

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -43,6 +43,32 @@ describe("shortcuts", () => {
 		expect(isShortcutMatch(keyEvent("K"), { key: "k" })).toBe(true);
 	});
 
+	it("matches shifted US bracket characters to [ and ] bindings", () => {
+		expect(
+			isShortcutMatch(keyEvent("{", { meta: true, shift: true }), {
+				key: "[",
+				meta: true,
+				shift: true,
+			}),
+		).toBe(true);
+		expect(
+			isShortcutMatch(keyEvent("}", { meta: true, shift: true }), {
+				key: "]",
+				meta: true,
+				shift: true,
+			}),
+		).toBe(true);
+	});
+
+	it("does not match unrelated characters produced by physical bracket keys", () => {
+		expect(
+			isShortcutMatch(keyEvent("ü", { meta: true, code: "BracketLeft" }), {
+				key: "[",
+				meta: true,
+			}),
+		).toBe(false);
+	});
+
 	it("normalizes shortcut keys before building signatures", () => {
 		expect(normalizeShortcutKey(" ")).toBe("Space");
 		const normalized = normalizeShortcut({

--- a/src/lib/shortcuts.test.ts
+++ b/src/lib/shortcuts.test.ts
@@ -43,32 +43,6 @@ describe("shortcuts", () => {
 		expect(isShortcutMatch(keyEvent("K"), { key: "k" })).toBe(true);
 	});
 
-	it("matches shifted US bracket characters to [ and ] bindings", () => {
-		expect(
-			isShortcutMatch(keyEvent("{", { meta: true, shift: true }), {
-				key: "[",
-				meta: true,
-				shift: true,
-			}),
-		).toBe(true);
-		expect(
-			isShortcutMatch(keyEvent("}", { meta: true, shift: true }), {
-				key: "]",
-				meta: true,
-				shift: true,
-			}),
-		).toBe(true);
-	});
-
-	it("does not match unrelated characters produced by physical bracket keys", () => {
-		expect(
-			isShortcutMatch(keyEvent("ü", { meta: true, code: "BracketLeft" }), {
-				key: "[",
-				meta: true,
-			}),
-		).toBe(false);
-	});
-
 	it("normalizes shortcut keys before building signatures", () => {
 		expect(normalizeShortcutKey(" ")).toBe("Space");
 		const normalized = normalizeShortcut({

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -113,8 +113,8 @@ export function isShortcutMatch(
 	const eventKey = normalizeShortcutKey(event.key);
 	return (
 		eventKey === normalized.key ||
-		(normalized.key === "[" && event.code === "BracketLeft") ||
-		(normalized.key === "]" && event.code === "BracketRight")
+		(normalized.key === "[" && eventKey === "{") ||
+		(normalized.key === "]" && eventKey === "}")
 	);
 }
 

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -110,7 +110,12 @@ export function isShortcutMatch(
 	if (!(normalized.meta && !isMac)) {
 		if (event.ctrlKey !== Boolean(normalized.ctrl)) return false;
 	}
-	return normalizeShortcutKey(event.key) === normalized.key;
+	const eventKey = normalizeShortcutKey(event.key);
+	return (
+		eventKey === normalized.key ||
+		(normalized.key === "[" && event.code === "BracketLeft") ||
+		(normalized.key === "]" && event.code === "BracketRight")
+	);
 }
 
 export function getShortcutTooltip(shortcut: Shortcut): string {

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -1227,6 +1227,20 @@
 			"commandPalette": true,
 			"menuId": "editor.todo_list"
 		},
+		"toggle_heading_or_list_collapse": {
+			"id": "toggle_heading_or_list_collapse",
+			"label": "Toggle Heading/List Collapse",
+			"description": "Toggle the current heading section or nested list branch.",
+			"category": "editor",
+			"context": "editor",
+			"defaultBinding": {
+				"meta": true,
+				"shift": true,
+				"key": "["
+			},
+			"allowInEditable": true,
+			"commandPalette": true
+		},
 		"toggle-ai": {
 			"id": "toggle-ai",
 			"label": "Toggle AI Panel",


### PR DESCRIPTION
Closes 


## Description

Adds a command-palette action and keyboard shortcut for toggling the collapse state at the current heading or nested list branch.

- Adds position-aware heading and nested-list collapse dispatching.
- Persists list collapse state after command-driven toggles.
- Makes the macOS shifted-bracket shortcut match physical bracket keys.
- Adds translations for all supported locales.

## Docs

No documentation changes are needed for this command addition.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it is really helpful.

- [ ] Documented what is new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Add position-aware heading and nested-list collapse toggling through the command palette and keyboard shortcuts.

New Features:
- Add a command-palette action and shortcut to toggle the heading section or nested-list branch at the current cursor position.
- Persist nested-list collapse state after command-driven toggles.
- Add localized command labels across supported locales.

Bug Fixes:
- Ensure macOS shifted-bracket shortcuts match the characters produced by the physical bracket keys.

Enhancements:
- Respect separate heading and list collapse settings when enabling the toggle command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a command-palette action and keyboard shortcut to toggle collapse state at the current heading section or nested list branch, and fixes the macOS shifted-bracket shortcut matching.

**New Features**
- The new `toggle_heading_or_list_collapse` command resolves the heading or nested list branch at the cursor position.
- The command stays disabled unless heading or list collapse is enabled in settings.
- List collapse state persists after command-driven toggles.

**Bug Fixes**
- macOS Shift+[ / Shift+] shortcuts now match the `{` and `}` characters those keys produce instead of relying on physical key codes.

<sup>Written for commit a20037b5efa2768e7c657a6a6d2a3a0fa816f1cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to collapse or expand the current heading section or nested list branch.
  * Added command palette support with the default shortcut `Meta+Shift+[`.
  * Added localized labels and descriptions across supported languages.

* **Bug Fixes**
  * Improved recognition of bracket-key shortcuts across keyboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->