### PR TITLE
docs: update architecture for recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Repo extras: agents may read `docs/agents/` and `docs/architecture/adr/`. All ot
 - Multi-window: resolve the space per window via `space_state.root_for_window(&window)` in commands; never assume a single global active space.
 - Never call `invoke()` in a loop over paths/notes; use the existing batch commands (`space_read_texts_batch`, `space_read_text_previews_batch`, `task_summaries_for_paths`) or add a batch command.
 - New settings require all of: default value, load-time normalization of legacy/invalid values, `settings:updated` emit, Rust runtime sync when native code consumes it, and a `settingsSearch.ts` entry.
-- Any Rust code path that writes a note must reindex it and emit the change event (`notes:external_changed` / `space:fs_changed`); the SQLite index is derived and must never go stale after a write.
+- Any Rust code path that writes a note must reindex it and emit a typed `space:fs_changed` change event; the SQLite index is derived and must never go stale after a write.
 - All user-facing strings go through the i18n translation layer (menu labels via `set_menu_labels`); no hardcoded UI text.
 - Make sure we don't over-engineer CSS and use default components as much as possible unless explicitly stated.
 - Hard subtraction pass: always attempt the fix by deleting or narrowing existing code first, and only add LOC when the existing code provably cannot support the fix. Never add new abstractions, command entries, shortcuts, files, or wiring as a patch around code that should have been narrowed.

--- a/docs/Glyph-translation-table.md
+++ b/docs/Glyph-translation-table.md
@@ -53,6 +53,8 @@ This is a simple worksheet for translating Glyph into any language. Leave the En
 | Attach the current note to AI. | |
 | AI: Use Selection as Context | |
 | Send the selected text to the AI panel as its main context. | |
+| Active file | |
+| Add {{name}} to context | |
 | Bold | |
 | Toggle bold formatting for the current selection. | |
 | Bullet List | |
@@ -585,6 +587,10 @@ This is a simple worksheet for translating Glyph into any language. Leave the En
 | Off | |
 | Paragraph | |
 | Sentence | |
+| Note peek | |
+| Wiki links and All Notes open as a Peek over the current tab instead of replacing it. Expand the Peek to go to that note, or close it to stay where you were. The file tree and command palette still open tabs. | |
+| Zen mode | |
+| Hide the sidebars, tabs, editor controls, and formatting ribbon so only your note remains. | |
 | Table of contents | |
 | Show a floating table of contents for each note. | |
 | Table of contents | |

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -130,7 +130,7 @@ See `02-spaces-storage-filesystem.md` for the details.
 3. `NoteInlineEditor` owns the TipTap editor instance.
 4. User edits update Markdown text in React state.
 5. Autosave calls `space_write_text` with the last known `mtime_ms`.
-6. Rust validates the path, checks conflicts, writes atomically, indexes the note, and emits `notes:external_changed`.
+6. Rust validates the path, checks conflicts, writes atomically, indexes the note, and emits a typed `space:fs_changed` payload.
 
 See `05-editor-markdown-autosave.md`.
 

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -43,6 +43,7 @@ Code ownership:
 - `src-tauri/src/space/helpers.rs`: create/open implementation and onboarding helpers
 - `src-tauri/src/space/state.rs`: active root, watcher handle, local-change tracking, store mutexes
 - `src-tauri/src/space/watcher.rs`: recursive filesystem watcher and index refresh
+- `src-tauri/src/note_mutation.rs`: centralized note commit, indexing, unindexing, rename handling, and change payload construction (introduced in `4aa71d69`)
 - `src-tauri/src/glyph_paths.rs`: `.glyph/` paths in the space folder
 - `src-tauri/src/index/paths.rs`: app-support SQLite index paths and space-key manifest
 - `src-tauri/src/space_fs/`: file tree, read/write, preview, rename, delete, link resolution
@@ -52,29 +53,30 @@ Code ownership:
 - `src/contexts/FileTreeContext.tsx`: frontend tree state tied to a space
 - `src/hooks/useFileTree.ts`: frontend filesystem operations and tree loading
 - `src/hooks/useFileTreeCRUD.ts`: create, rename, move, delete UI actions
+- `src/lib/spaceChange.ts`: renderer-side application of typed filesystem changes and derived-cache invalidation
 
 ## Space State
 
-Rust stores active space state in `SpaceState`:
+Rust stores per-window space sessions in `SpaceState`:
 
 ```rust
 pub struct SpaceState {
-    pub(crate) current: Mutex<Option<PathBuf>>,
-    pub(crate) notes_watcher: Mutex<Option<notify::RecommendedWatcher>>,
-    recent_local_changes: RecentLocalChanges,
+    pub(crate) sessions: Mutex<HashMap<String, SpaceSession>>,
     db_store_mutex: Arc<Mutex<()>>,
     file_tree_appearance_mutex: Arc<Mutex<()>>,
+    list_collapse_state_mutex: Arc<Mutex<()>>,
+    note_mutation_mutex: Arc<Mutex<()>>,
     pinned_files_mutex: Arc<Mutex<()>>,
 }
 ```
 
 The state has three jobs:
 
-1. Hold the active root path.
-2. Hold the watcher so it stays alive for the current space.
-3. Share mutexes for JSON stores that live under `.glyph/`.
+1. Map each window label to its space root, watcher, and recent-local-change set.
+2. Share mutexes for JSON stores and note mutations that live under `.glyph/` or the derived index.
+3. Resolve auxiliary editor windows against the main window's session when they share its space (`quick-note`, `quick-task`, and `external-markdown-*`).
 
-`current_root()` returns an error when no space is open. Most commands call it first, so the backend enforces "no active space, no workspace operation."
+Commands call `root_for_window(&window)`, so the backend enforces "no space session for this window, no workspace operation" while retaining independent sessions for windows that own their space.
 
 ## Opening a Space
 
@@ -93,7 +95,7 @@ Rust flow in `space_open` and `space_create`:
 3. Register the space in the app-support index manifest and remove any stale in-space `glyph.sqlite` sidecars.
 4. Create or open Glyph metadata in `.glyph/`.
 5. Reset the index schema cache with `index::db::reset_schema_cache()`.
-6. Store the canonical root in `SpaceState.current`.
+6. Store the canonical root and watcher in the calling window's `SpaceState` session.
 7. Install the notes watcher with `set_notes_watcher()`.
 8. Enable the native Close Space menu item.
 
@@ -154,15 +156,14 @@ Frontend loading uses `useFileTree()`:
 
 ## Writing Text
 
-`space_write_text` handles note and text writes:
+`space_write_text` handles note and text writes through the centralized mutation helpers in `src-tauri/src/note_mutation.rs`:
 
 1. Validates the relative path.
 2. Checks `base_mtime_ms` when the caller supplies it.
 3. Creates parent folders.
-4. Marks markdown writes as recent local changes.
-5. Writes bytes through `io_atomic::write_atomic()`.
-6. Reindexes markdown content with `index::index_note()`.
-7. Emits `notes:external_changed` for markdown files because the watcher suppresses local writes.
+4. Writes bytes through `io_atomic::write_atomic()` (or reserves a new path with the create-new mode).
+5. Reindexes markdown content and marks the local change together.
+6. Returns a typed `SpaceChange::create` or `SpaceChange::content` result for one propagation path.
 
 The `base_mtime_ms` check protects an open editor from silently overwriting a file changed outside the app. `MarkdownEditorPane` handles the conflict path by reading the latest file and retrying once with the new mtime.
 
@@ -178,10 +179,16 @@ Use `io_atomic::copy_atomic()` when duplicating a file. Use `OpenOptions::create
 
 `set_notes_watcher()` installs a recursive watcher with `notify`.
 
-The watcher emits two event types:
+The watcher and all backend writers now converge on one typed event, `space:fs_changed`. `SpaceChange` is defined in Rust in `src-tauri/src/note_mutation.rs` and mirrored in `src/lib/spaceChange.ts`:
 
-- `space:fs_changed`: any visible create, modify, or remove event
-- `notes:external_changed`: markdown events that should refresh note-backed UI
+- `content` and `create` identify one changed path
+- `remove` includes whether the removal is recursive
+- `rename` includes source, destination, and recursive state
+- `batch` groups changes from one operation
+
+The watcher emits this event type for visible filesystem changes:
+
+- `space:fs_changed`: any visible create, modify, remove, or rename event, with a `SpaceChange` payload
 
 The watcher also updates the SQLite index for markdown files. It debounces index work for 100ms and collapses repeated events by relative path.
 
@@ -190,14 +197,10 @@ Recent local changes prevent a loop:
 1. Local markdown writes call `mark_recent_local_change()`.
 2. The watcher sees the filesystem event.
 3. `has_recent_local_change()` returns true for about two seconds.
-4. The watcher skips the external note event and index work.
-5. The writer emits the needed `notes:external_changed` event after indexing.
+4. The watcher skips duplicate index work and change propagation for that recent local path.
+5. The mutation commit emits the needed `space:fs_changed` event after indexing. The renderer applies the same payload to the file tree, tabs, pinned paths, open-note content, and derived query/prefetch caches.
 
-Frontend consumers:
-
-- `FileTreeContext` refreshes pinned files after remove events.
-- `AppShell` queues changed paths, reloads affected file tree directories after 150ms, and invalidates prefetch caches.
-- `MarkdownEditorPane` reloads the active note after `notes:external_changed` when the editor is clean.
+Frontend application is centralized in `applySpaceChange()` and `useSpaceChangePropagation()` in `src/lib/spaceChange.ts`. It ignores changes for another space, recursively applies batches, reloads affected directories, retargets or closes tabs and pinned paths, refreshes tags, notifies open-note listeners, and invalidates note, calendar, All Notes/activity, database, usage, folio, and unlinked-mention data. The renderer event map in `src/lib/tauriEvents.ts` types `space:fs_changed` as `SpaceChange`.
 
 ## Rename, Duplicate, Delete
 
@@ -212,7 +215,7 @@ Frontend consumers:
 - uses case-insensitive sibling names to choose `Copy`, `Copy 2`, and so on
 - copies with `copy_atomic()`
 - indexes the duplicate if it is markdown
-- emits `notes:external_changed`
+- emits a typed `space:fs_changed` create payload
 
 ### Rename
 
@@ -286,7 +289,7 @@ When you change filesystem behavior:
 4. Mark local markdown changes before writes that the watcher will see.
 5. Reindex markdown changes before emitting UI refresh events.
 6. Update pinned files, appearance paths, and tabs for path moves.
-7. Add or adjust events when the frontend needs to refresh cached state.
+7. Return or emit a `SpaceChange` through `note_mutation.rs`; do not add a second note/filesystem event path.
 8. Keep `.glyph/` inaccessible through normal space file commands.
 
 ## Failure Modes

--- a/docs/architecture/02-spaces-storage-filesystem.md
+++ b/docs/architecture/02-spaces-storage-filesystem.md
@@ -99,7 +99,7 @@ Rust flow in `space_open` and `space_create`:
 7. Install the notes watcher with `set_notes_watcher()`.
 8. Enable the native Close Space menu item.
 
-`space_close` clears `current`, drops the watcher, resets the schema cache, and disables Close Space.
+`space_close` clears the calling window's session with `remove_window_session`, drops its watcher, resets the schema cache, and updates the Close Space menu through `update_close_space_menu`.
 
 ## Path Safety
 

--- a/docs/architecture/03-frontend-shell-state.md
+++ b/docs/architecture/03-frontend-shell-state.md
@@ -53,6 +53,7 @@ Do not move providers without checking their hooks. A provider that calls `useSp
 - onboarding note path
 - indexing flag
 - open/create/close actions
+- current window's space session; Rust resolves roots per window, and auxiliary note windows inherit the main window's space session
 
 On startup, it:
 
@@ -90,7 +91,7 @@ When `spacePath` changes, it clears file tree state, lists the root with `space_
 It listens for:
 
 - `settings:updated`: refresh tag behavior and tag rendering flags
-- `space:fs_changed`: refresh pinned files after removals
+- `space:fs_changed`: handled by centralized `useSpaceChangePropagation()` from `src/lib/spaceChange.ts`, which applies typed changes to directories, pinned paths, tabs, tags, and derived caches
 
 ## UI Provider
 
@@ -183,7 +184,7 @@ type WorkspaceTab = {
 
 Special tabs use stable ids such as:
 
-- all docs
+- activity timeline / All Notes
 - calendar
 - databases
 - templates
@@ -223,6 +224,8 @@ Responsibilities:
 
 The hook uses refs for request versions and loaded directories because those values must not retrigger renders on every filesystem load.
 
+Folder rows can display recursive counts from `useFolderFileCounts()` (`src/hooks/useFolderFileCounts.ts`). The hook queries `space_dir_children_summary` in `src-tauri/src/space_fs/summary.rs` for visible parent directories and selects either all-file or Markdown-only totals. When configured for hover display, `FileTreePane` marks the tree with `data-folder-counts="hover"`; counts remain query-backed derived data rather than file-tree state.
+
 ## Command Routing
 
 Global commands live in three layers:
@@ -245,13 +248,13 @@ When adding a command, update:
 `src/lib/navigationPrefetch.ts` caches expensive next-view data:
 
 - markdown note docs
-- all-docs data
+- activity timeline / All Notes data
 - calendar data
 - database landing and rows
 
 `AppShell` prefetches when users hover or navigate. It invalidates cache on:
 
-- `notes:external_changed`
+- `space:fs_changed`
 - space changes
 - explicit note path changes
 
@@ -261,6 +264,14 @@ This cache improves navigation but must not become a source of truth. Every pref
 
 Settings render inside the main app surface rather than as a separate route. `UIProvider` stores `settingsMode` and `settingsTab`. `AppShell` opens settings from menus, commands, and panes.
 
+`src/components/settings/settingsConfig.tsx` groups settings navigation into three categories:
+
+- `application`: general, appearance, editor, shortcuts, and about
+- `workspace`: space, Git, AI, and usage
+- `experimental`: the experimental settings pane
+
+The experimental pane currently contains Note Peek and Zen mode. Search routing in `src/components/settings/settingsSearch.ts` must continue to point each setting at its owning tab.
+
 Some settings change Rust behavior:
 
 - people mentions as tags call `index_set_people_mentions_as_tags_enabled`
@@ -269,6 +280,20 @@ Some settings change Rust behavior:
 - translucent app calls `set_window_vibrancy_theme`
 
 Keep UI settings and native runtime settings in sync when adding a preference.
+
+### Note Peek and Zen Mode
+
+When `ui.noteSidePeek` is enabled, browse navigation from wiki links, the activity timeline, and other preview-oriented surfaces calls `openBrowseNote()` in `AppShell`. Markdown notes are prefetched and shown in the interactive `NoteSidePeek` overlay; expanding it opens the note as a normal workspace tab, while closing it preserves the current tab. Explicit workspace opens from the file tree and command palette continue to open tabs. The overlay is rendered by `MainContent` and implemented in `src/components/preview/NoteSidePeek.tsx`.
+
+When `editor.zenMode` is active, `AppShell`, `MainContent`, `EditorPaneCanvas`, and `MarkdownEditorPane` suppress shell/editor chrome such as the sidebar, tabs, indexing notice, command palette, auxiliary panels, and editor toolbar surfaces as appropriate. The note remains editable; Zen mode is a layout state, not a separate editor or space.
+
+### Activity Timeline / All Notes
+
+The classic `AllDocsPane` grid was removed in `d7a8d49c`. The All Notes command and tab now render `ActivityTimelinePane`, which groups notes by activity date, includes a recent-activity summary and heatmap, and loads rows through query-backed paginated All Notes data. Browse clicks use the Note Peek behavior above when enabled.
+
+### Space-specific new-note folder
+
+`SpaceSettingsPane` stores `noteCreation.defaultFolder` as a space setting. `AppShell` uses it for sidebar and global new-note actions when it belongs to the currently open space; otherwise it falls back to the active directory or active file's parent. The setting is loaded and updated with the space path so a folder preference cannot leak between spaces (`src/components/settings/SpaceSettingsPane.tsx`, `src/lib/settings.ts`).
 
 ## AI Panel State
 

--- a/docs/architecture/03-frontend-shell-state.md
+++ b/docs/architecture/03-frontend-shell-state.md
@@ -270,7 +270,7 @@ Settings render inside the main app surface rather than as a separate route. `UI
 - `workspace`: space, Git, AI, and usage
 - `experimental`: the experimental settings pane
 
-The experimental pane currently contains Note Peek and Zen mode. Search routing in `src/components/settings/settingsSearch.ts` must continue to point each setting at its owning tab.
+The experimental pane includes Note Peek and Zen mode alongside Folio mode, raw Markdown Vim mode, external link previews, formatting-bar visibility, focus mode, and non-Markdown file visibility. Search routing in `src/components/settings/settingsSearch.ts` must continue to point each setting at its owning tab.
 
 Some settings change Rust behavior:
 

--- a/docs/architecture/04-ipc-and-native-runtime.md
+++ b/docs/architecture/04-ipc-and-native-runtime.md
@@ -8,6 +8,7 @@ Frontend:
 
 - `src/lib/tauri.ts`: typed `invoke()` wrapper and command result types
 - `src/lib/tauriEvents.ts`: typed event helpers
+- `src/lib/spaceChange.ts`: typed `space:fs_changed` propagation and cache invalidation
 - `src/hooks/useMenuListeners.ts`: native menu event consumers
 - `src/lib/shortcuts/`: shortcut normalization and registry
 - `src/shared/appCommandManifest.json`: app command metadata shared with native menu code
@@ -15,6 +16,7 @@ Frontend:
 Rust:
 
 - `src-tauri/src/lib.rs`: Tauri builder, command registration, menus, windows, plugins
+- `src-tauri/src/note_mutation.rs`: shared Markdown write, index, and change-event flow
 - `src-tauri/src/menu_manifest.rs`: native menu command lookup and accelerators
 - feature modules under `src-tauri/src/*/commands.rs`: command handlers
 
@@ -86,6 +88,12 @@ The command map covers these groups:
 - AI: profiles, secrets, models, chat, context, history, provider support, Codex account and rate limits
 
 Keep command names descriptive. Most existing commands use a module prefix: `space_`, `index_`-style index names, `databases_`, `ai_`, `codex_`, `git_sync_`, `git_history_`, `external_markdown_`.
+
+## Note mutation boundary
+
+Markdown writes use the shared helpers in `src-tauri/src/note_mutation.rs`. `commit_markdown()` validates the relative path, checks the expected mtime when replacing an existing note, writes atomically, and calls `index_written_markdown()` before returning. Commands emit the returned `SpaceChange` through `space:fs_changed` after the blocking work completes. Text writes, imports, database cell edits, and path operations use this boundary, so a successful note mutation updates the derived index before frontend consumers refresh. This boundary was introduced in the note mutation work that landed after `8f2d0446`.
+
+`SpaceChange` is a tagged, serialized enum with `content`, `create`, `remove`, `rename`, and `batch` variants. Each payload carries the canonical `space_path`; path-specific variants carry `rel_path`, or `from_path` and `to_path`, plus `recursive` where needed. Keep the Rust enum and `src/lib/spaceChange.ts` union in sync when adding a change kind.
 
 ## Tauri Builder
 
@@ -208,8 +216,7 @@ Backend-to-frontend events include:
 
 - `menu:open_recent_space`
 - `menu:app_command`
-- `space:fs_changed`
-- `notes:external_changed`
+- `space:fs_changed` with a typed `SpaceChange` payload. `useSpaceChangePropagation()` batches delivery for 50ms, refreshes affected directories and tags, invalidates derived query data, and reloads open-note content for `content` changes.
 - `settings:updated`
 - `index:progress`
 - `ai:chunk`

--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -237,9 +237,9 @@ This strategy favors the user's current editor text after one refresh. It does n
 
 ## External Changes
 
-Rust emits `space:fs_changed` with a typed content payload after external markdown changes and after backend writes that the watcher suppresses.
+Rust emits `space:fs_changed` with a typed content payload after external markdown changes and after backend writes that the watcher suppresses. `useSpaceChangePropagation()` batches that event for 50ms and passes affected open-note paths through `applySpaceChange()` and the open-note listener registry. `useMarkdownDocumentSession` subscribes to that registry and owns the 180ms `EXTERNAL_RELOAD_DEBOUNCE_MS` debounce and `pendingExternalReloadRef` handling. `MarkdownEditorPane` does not listen to `space:fs_changed` directly.
 
-`MarkdownEditorPane` handles it:
+`useMarkdownDocumentSession` handles the propagated change:
 
 1. Normalize the event path and current path.
 2. Ignore events for other notes.

--- a/docs/architecture/05-editor-markdown-autosave.md
+++ b/docs/architecture/05-editor-markdown-autosave.md
@@ -11,6 +11,9 @@ Frontend:
 - `src/components/editor/hooks/useNoteEditor.ts`: TipTap instance, Markdown conversion, paste handling, image paste
 - `src/components/editor/extensions/index.ts`: extension composition
 - `src/components/editor/markdown/`: wiki link and Markdown bridge helpers
+- `src/components/editor/markdown/wikiLinkCodec.ts`: parses and serializes file, heading, and block wiki-link anchors
+- `src/components/editor/markdown/wikiLinkHeadingSuggest.ts`: resolves a target note and suggests its headings
+- `src/components/editor/noteProperties/TextPropertyValueField.tsx`: source-aware text-property wiki-link display and editing
 - `src/components/editor/hooks/useHydrateInlineImages.ts`: image path hydration
 - `src/components/editor/hooks/useTaskInlineDates.ts`: inline task date editing
 - `src/components/editor/hooks/useExtractSelectionToNote.ts`: extract selection flow
@@ -64,6 +67,8 @@ It knows:
 - image upload placeholders
 - settings that change editor features
 
+Editor settings arrive through `settings:updated`, not only on the initial settings load. In particular, `showFormatBar` is applied live by `useNoteEditorSettings()` and controls the rich editor formatting bar while the note remains open. `NoteInlineEditor` renders the bar only when the editor is editable and the setting is enabled. The setting is defined and persisted as `editor.showFormatBar` in `src/lib/settings/definitions.ts`.
+
 Keep those roles separate. File persistence should stay in `MarkdownEditorPane`. TipTap transaction logic should stay in `useNoteEditor`.
 
 ## Document Load Flow
@@ -103,6 +108,8 @@ The durable file includes optional YAML frontmatter and Markdown body.
 
 Wiki links need bridge logic because TipTap and Markdown need different representations for editing and serialization.
 
+`parseWikiLink()` splits the target from an optional `#heading` or `#^block` anchor and preserves aliases and embeds. Heading links such as `[[Note#heading]]` use the target note's heading slug for insertion and navigation. Rich mode uses the TipTap wiki-link extension and `wikiLinkHeadingSuggest.ts`; raw mode uses CodeMirror decorations and `raw/interactions.ts`. Both modes pass the current note as `sourcePath` when dispatching a click so relative links resolve from the note that contains them. `headingAnchor.ts` and `useInternalAnchorNavigation.ts` apply the anchor after the target note loads. This behavior was added in `e3ccf8cb` and its follow-up link handling commits.
+
 Use the bridge helpers rather than ad hoc string replacement when changing wiki-link Markdown behavior.
 
 ## TipTap Extensions
@@ -136,6 +143,8 @@ Feature settings can enable or disable parts of this list:
 - people mentions as tags
 - markdown link autocomplete
 - collapsible headings
+
+The AI toolbar action is conditional as well. `MarkdownEditorPane` renders the AI toolbar button only when `aiEnabled` is true and passes the same gate to `NoteInlineEditor`; the AI sidebar and AI command group use the setting too. Disabling AI therefore removes the editor entry point instead of leaving a button that cannot open a panel.
 
 The extension list should stay centralized. Adding extensions from a component creates inconsistent editor behavior across rich editor surfaces.
 
@@ -228,7 +237,7 @@ This strategy favors the user's current editor text after one refresh. It does n
 
 ## External Changes
 
-Rust emits `notes:external_changed` after external markdown changes and after local writes that the watcher suppresses.
+Rust emits `space:fs_changed` with a typed content payload after external markdown changes and after backend writes that the watcher suppresses.
 
 `MarkdownEditorPane` handles it:
 
@@ -279,6 +288,8 @@ Frontmatter appears in two ways:
 
 `NoteInlineEditor` keeps a frontmatter draft. Property tools call frontmatter render/parse commands or local helpers depending on the path. On frontmatter commit, `MarkdownEditorPane` runs autosave immediately.
 
+Text properties can contain wiki links. `TextPropertyValueField` detects links in text-valued properties, shows them through `WikiLinkedText` when not editing, and passes the containing note's `sourcePath` so relative targets resolve correctly. While editing, the same wiki-link autocomplete supports file and heading suggestions. This path is separate from body editing but uses the same codec and click event shape. The interactive behavior was added in `1e5525f6` and the follow-up fixes `2e41d4d5` and `86f507a4`.
+
 Database cell edits also update note frontmatter from the backend. See `07-databases-frontmatter.md`.
 
 ## Links and Navigation
@@ -297,6 +308,8 @@ It dispatches app events:
 - `dispatchPersonClick()`
 - `dispatchWikiLinkClick()`
 - `dispatchMarkdownLinkClick()`
+
+Wiki-link clicks carry the parsed anchor kind and anchor when present. Rich and raw modes both support heading-addressed links and use the source path for resolution. Frontmatter text-property links follow the same source-aware dispatch through `WikiLinkedText`.
 
 `AppShell` listens through `useWorkspaceLinkEvents()` and decides whether to open a note, open search, or open an external URL.
 
@@ -348,7 +361,7 @@ When changing editor behavior:
 3. Use Markdown bridge helpers for wiki-link serialization.
 4. Preserve `base_mtime_ms` conflict checks.
 5. Reindex notes after backend writes.
-6. Emit or handle `notes:external_changed` when note-derived UI must refresh.
+6. Emit or handle `space:fs_changed` when note-derived UI must refresh.
 7. Avoid programmatic content replacement loops by using suppression refs.
 8. Flush the editor before operations that duplicate, sync, or export the current note.
 9. Keep image paste storage tied to a real space file.
@@ -400,7 +413,7 @@ The failure sequence:
   `requestAnimationFrame`. macOS suspends rAF for occluded windows, which
   could strand a pending sync — and the text it carried — indefinitely.
 
-A considered-and-rejected change: tagging the self-emitted
+A considered-and-rejected change was tagging the self-emitted legacy
 `notes:external_changed` event from `space_write_text` so the session could
 ignore its own saves. AI actions and quick notes also write the open note
 via `space_write_text` in the same window, and the session must keep

--- a/docs/architecture/06-index-search-graph-tasks.md
+++ b/docs/architecture/06-index-search-graph-tasks.md
@@ -21,10 +21,11 @@ Backend:
 - `src-tauri/src/index/search_advanced.rs`: structured search
 - `src-tauri/src/index/search_hybrid.rs`: FTS plus local semantic-ish ranking
 - `src-tauri/src/index/checklists/`: markdown checklist parsing and summary queries
+- `src-tauri/src/index/insights.rs`: usage metrics, folder summaries, creation streams, and visible-space byte totals
 
 Frontend consumers:
 
-- `src/components/app/AllDocsPane.tsx`
+- `src/components/app/ActivityTimelinePane.tsx`: activity timeline / All Notes view
 - `src/components/checklists/TaskProgressIndicator.tsx`
 - `src/components/TagsPane.tsx`
 - `src/components/connections/SpaceConnectionsView.tsx`
@@ -161,10 +162,12 @@ The indexer:
 10. Reindexes frontmatter properties.
 11. Reindexes relationships.
 12. Stores checklist total/completed counts on the `notes` row.
-13. Parses outgoing links.
+13. Parses outgoing links. File links with `#heading` or `#^block` are indexed against the file target; the anchor is resolved by the editor/navigation layer.
 14. Resolves wiki titles to note ids when the title is unique.
 15. Inserts link rows.
 16. Commits the transaction.
+
+Frontmatter relationship extraction also recognizes wiki links inside scalar text properties and sequences. It strips the optional heading or block anchor for relationship target resolution while retaining the property's field key and ordinal.
 
 The etag short path matters. If content did not change, derived rows are skipped while note updated time can refresh.
 
@@ -292,6 +295,17 @@ Markdown remains the source of truth. The index only caches counts for progress 
 `all_docs_count` uses the same folder prefix logic.
 
 All-docs UI should treat this as an index view. If a note is missing, run or inspect `index_rebuild`.
+
+## Usage insights
+
+`usage_insights` returns aggregate metrics for the active space through `src-tauri/src/index/insights.rs`. The expanded folder and byte accounting landed in `06fb5a24`. In addition to note, task, link, tag, activity, and daily-note counts, the result includes:
+
+- `isolatedNoteCount`, counting notes with no link or relationship edge
+- `folders`, grouped by the first path component, with note, task, completed-task, and isolated-note counts
+- `folderWeeks`, a 12-week creation stream by first-level folder. The seven busiest folders are kept and the rest are grouped under `__other__`.
+- `totalFileBytes`, computed by walking visible regular files under the space root. Hidden entries and symlinks do not contribute.
+
+The Rust response uses camelCase through `src-tauri/src/index/types.rs`; the matching frontend types live in `src/lib/tauri.ts`. The usage settings UI renders the folder stream and folder summary from these fields. These values are space-scoped and the frontend invalidates the `usage-insights` query when it receives `space:fs_changed`.
 
 ## Index Consumers
 

--- a/docs/architecture/08-ai-runtime-tools-history.md
+++ b/docs/architecture/08-ai-runtime-tools-history.md
@@ -29,7 +29,7 @@ Backend:
 - `src-tauri/src/ai_rig/history.rs`: chat history readers
 - `src-tauri/src/ai_rig/audit.rs`: audit/history writes
 - `src-tauri/src/ai_codex/`: Codex account and chat runtime
-- `src-tauri/src/ai_amp/`, `ai_claude_code/`, `ai_opencode/`, `ai_pi/`: dedicated provider runtimes
+- `src-tauri/src/ai_amp/`, `ai_claude_code/`, `ai_cursor/`, `ai_grok/`, `ai_opencode/`, `ai_pi/`: dedicated provider runtimes
 
 ## Provider Model
 
@@ -47,6 +47,8 @@ Backend:
 - Claude Code
 - OpenCode
 - Pi
+- Cursor
+- Grok
 
 Profiles store:
 
@@ -59,7 +61,7 @@ Profiles store:
 
 Profiles live in app config at `ai.json`, not in the space. API keys live per space through `local_secrets.rs` so each space can have separate credentials.
 
-Default profiles are generated in `ensure_default_profiles()`. Provider ids are stable provider keys such as `openai`, `anthropic`, and `codex_chatgpt`.
+Default profiles are generated in `ensure_default_profiles()`. Provider ids are stable provider keys such as `openai`, `anthropic`, `codex_chatgpt`, `cursor`, and `grok`. Cursor defaults to `auto`; Grok defaults to `grok-build`.
 
 ## Profile Store
 
@@ -143,6 +145,8 @@ Cancellation calls `ai_chat_cancel`, which cancels the token by job id.
 - `Amp`: `ai_amp::run_with_amp`
 - `ClaudeCode`: `ai_claude_code::run_with_claude_code`
 - `Pi`: `ai_pi::run_with_pi`
+- `Cursor`: `ai_cursor::run_with_cursor`
+- `Grok`: `ai_grok::run_with_grok`
 - everything else: `runtime::run_with_rig`
 
 Dedicated runtimes return the same tuple as Rig:
@@ -152,6 +156,10 @@ Dedicated runtimes return the same tuple as Rig:
 ```
 
 That keeps the command and history path shared even when provider internals differ.
+
+Cursor and Grok run their installed CLIs as child processes. Both require an open space, use that space as the process working directory, parse JSON lines from stdout, forward text and tool events through the shared `ai:*` events, and kill the child on cancellation. Requests have a 30-second startup limit and a 10-minute run limit. Cursor discovers models with `agent --list-models`, always including `auto`. Grok combines models from `grok models`, Grok config files, and built-in aliases such as `grok-build`, `grok-4.6`, `grok-4.5`, and `grok-code-fast-1`.
+
+Cursor chat uses ask mode; create mode passes `--force --sandbox disabled`. Grok chat allows `read_file,grep,list_dir`; create mode passes `--yolo`. Grok also forwards the profile reasoning effort. CLI paths can be overridden with `CURSOR_CLI_PATH` or `GROK_CLI_PATH`.
 
 ## Rig Runtime
 

--- a/docs/architecture/09-settings-menus-git-sync-native-windows.md
+++ b/docs/architecture/09-settings-menus-git-sync-native-windows.md
@@ -6,7 +6,10 @@ Glyph keeps most preferences in a Tauri store, mirrors live changes through even
 
 Settings and shortcuts:
 
-- `src/lib/settings.ts`: settings store, defaults, migrations, update helpers
+- `src/lib/settings.ts`: settings loading, normalization, persistence, and update helpers
+- `src/lib/settings/definitions.ts`: centralized application and space setting definitions
+- `src/lib/settings/model.ts`: persisted settings types, including `SpaceScopedSettingsMap`
+- `src/components/settings/settingsSearch.ts`: searchable settings tabs and entries
 - `src/components/settings/`: settings panes
 - `src/components/settings/ai/`: AI settings sections
 - `src/lib/shortcuts/`: shortcut types, registry, platform normalization
@@ -50,13 +53,13 @@ Settings include:
 - template folder and daily note template
 - attachment folder and attachment storage mode
 - date display format
-- editor settings: default editor mode, focus mode, spell check, editor width, raw Markdown Vim mode, frontmatter visibility, collapsible headings, TOC
+- editor settings: default editor mode, focus mode, spell check, editor width, raw Markdown Vim mode, frontmatter visibility, collapsible headings, TOC, formatting bar, Zen mode, and people mentions as tags
 - file tree settings: sort mode, folder counts, non-Markdown file visibility, beautiful tags, people mentions
 - database UI settings
 - shortcut bindings
 - onboarding flags
 
-Defaults live in the same file. The loader normalizes older values into current shapes.
+`DURABLE_SETTINGS` defines application settings and `SPACE_SETTINGS` defines settings that belong to a space. `settings.json` stores application values and the `spaceScopedSettings` entry stores a normalized map keyed by space path. The loader applies each definition's default and normalizer, validates paths and enum values, and reads legacy keys when needed. Writers normalize before persistence and emit the relevant change payload. `settingsSearch.ts` checks that every searchable definition has a matching localized search entry.
 
 ## Live Settings Event
 
@@ -68,7 +71,7 @@ settings:updated
 
 Listeners include:
 
-- `UIProvider`: AI, TOC, folio, daily notes, templates
+- `UIProvider`: AI, TOC, folio, daily notes, templates, note peek, and period-note state
 - `FileTreeProvider`: people mentions and beautiful tags
 - `useNoteEditor`: editor feature flags and attachment settings
 - `AppShell`: collapsible headings
@@ -84,6 +87,7 @@ Some settings must be sent to Rust:
 - menu shortcuts: `set_menu_shortcuts`
 - quick note global shortcut: `set_quick_note_global_shortcut`
 - window vibrancy: `set_window_vibrancy_theme`
+- period-note menu state: `set_period_note_menu_enabled`
 
 Keep the Tauri runtime synchronized after settings load and after updates.
 
@@ -116,7 +120,7 @@ The command palette is lazy-loaded:
 
 `AppShell` preloads it after 500ms idle time. Commands come from `useAppCommands()`, which receives current shell state and returns action objects with enablement.
 
-Command search uses the index for note search and the command registry for command results.
+Command search uses the index for note search and the command registry for command results. The palette also exposes registered setting editors. The current registry includes application and space settings such as weekly/monthly/quarterly note cadence, default editor mode, formatting bar, Zen mode, focus mode, note peek, and people mentions as tags. These entries use the same setting definitions and write paths as the settings panes.
 
 When adding a command:
 
@@ -146,6 +150,8 @@ Rust builds the main menu in `src-tauri/src/lib.rs`. Menu events follow one of t
 - editor formatting actions
 
 This lets native menus call the same functions as keyboard shortcuts and command palette commands.
+
+The weekly, monthly, and quarterly note menu items are enabled only when a space is open and the corresponding setting is enabled. Rust keeps these three flags in `MenuState`; the frontend updates them through `set_period_note_menu_enabled`, and menu rebuilds reapply the flags.
 
 ## Window Runtime
 
@@ -246,10 +252,12 @@ Background run:
 5. Upsert managed `.gitignore`.
 6. Fetch remote.
 7. Stage sync inclusions.
-8. Commit local changes as `Glyph sync`.
+8. Commit local changes.
 9. Merge remote branch if it exists.
 10. Push branch, setting upstream when needed.
 11. Record success and emit status.
+
+For a manual run with `prompt_for_commit_message` enabled, the frontend first calls `git_sync_commit_message_prompt`. On macOS this schedules an `NSAlert` with a text field on the main thread. A confirmed, trimmed response becomes `GitSyncRunRequest.commit_message`; an empty response uses `Glyph sync`, and cancellation aborts the run. Auto runs never prompt. The choice is persisted per space as `prompt_for_commit_message` in the Git sync config.
 
 On auto-sync failure, consecutive failures increment. After three auto failures, Git sync pauses itself.
 

--- a/docs/architecture/10-security-and-operational-invariants.md
+++ b/docs/architecture/10-security-and-operational-invariants.md
@@ -180,7 +180,7 @@ User-supplied network features should use `net::validate_url_host()` or a strict
 
 ## Invariant 11: Asset URLs Stay in the Requesting Space
 
-`glyphasset://localhost/<relative-path>` is the only accepted asset form. `space_asset_protocol.rs` rejects other hosts, malformed percent encoding, absolute paths, hidden components, unsupported extensions, and paths that do not resolve under the space root. It resolves the root from the requesting webview label, joins with `paths::join_under()`, canonicalizes the result, checks that the canonical file remains under that root, and serves only allowlisted image MIME types for `png`, `jpg`/`jpeg`, `webp`, `gif`, `svg`, `bmp`, `avif`, `tif`, and `tiff`.
+`glyphasset://localhost/<relative-path>` is the canonical asset form. Hostless forms such as `glyphasset:///image.png` are also accepted because a missing host defaults to `localhost`. `space_asset_protocol.rs` rejects other hosts, invalid hexadecimal percent escapes, absolute paths, hidden components, unsupported extensions, and paths that do not resolve under the space root. Its current percent-decoding behavior accepts an incomplete trailing `%`. It resolves the root from the requesting webview label, joins with `paths::join_under()`, canonicalizes the result, verifies that the canonical path is an existing file under that root, and serves only allowlisted image MIME types for `png`, `jpg`/`jpeg`, `webp`, `gif`, `svg`, `bmp`, `avif`, `tif`, and `tiff`.
 
 Do not turn asset URLs into unrestricted file URLs or resolve them against a global active-space path. The webview-to-space lookup is part of the isolation boundary.
 

--- a/docs/architecture/10-security-and-operational-invariants.md
+++ b/docs/architecture/10-security-and-operational-invariants.md
@@ -13,6 +13,7 @@ Backend safety:
 - `src-tauri/src/ai_rig/helpers.rs`: AI base URL validation and HTTP helpers
 - `src-tauri/src/ai_rig/tools.rs`: AI tool path and size limits
 - `src-tauri/src/ai_rig/local_secrets.rs`: per-space AI secrets store
+- `src-tauri/src/space_asset_protocol.rs`: space-scoped `glyphasset://` image protocol
 - `src-tauri/src/license/`: license storage and Gumroad verification
 - `src-tauri/src/glyph_paths.rs`: controlled `.glyph/` paths
 - `src-tauri/src/space/watcher.rs`: watcher and local-change suppression
@@ -107,7 +108,7 @@ Do not remove `base_mtime_ms` from editor saves.
 
 Markdown writes call `mark_recent_local_change()` before writing. The watcher checks `has_recent_local_change()` and skips external reindex/event handling for recent local writes.
 
-The writer then emits `notes:external_changed` after indexing.
+The mutation boundary emits `space:fs_changed` with a typed content/create payload after indexing.
 
 This prevents duplicate indexing and reload loops while keeping the UI informed.
 
@@ -177,7 +178,13 @@ It resolves DNS for non-literal hosts and rejects any forbidden address. It only
 
 User-supplied network features should use `net::validate_url_host()` or a stricter wrapper.
 
-## Invariant 11: Secrets Stay Out of Logs and Normal File APIs
+## Invariant 11: Asset URLs Stay in the Requesting Space
+
+`glyphasset://localhost/<relative-path>` is the only accepted asset form. `space_asset_protocol.rs` rejects other hosts, malformed percent encoding, absolute paths, hidden components, unsupported extensions, and paths that do not resolve under the space root. It resolves the root from the requesting webview label, joins with `paths::join_under()`, canonicalizes the result, checks that the canonical file remains under that root, and serves only allowlisted image MIME types for `png`, `jpg`/`jpeg`, `webp`, `gif`, `svg`, `bmp`, `avif`, `tif`, and `tiff`.
+
+Do not turn asset URLs into unrestricted file URLs or resolve them against a global active-space path. The webview-to-space lookup is part of the isolation boundary.
+
+## Invariant 12: Secrets Stay Out of Logs and Normal File APIs
 
 Current AI secrets are stored per space by `ai_rig/local_secrets.rs` in:
 
@@ -195,7 +202,7 @@ Rules:
 - Never expose `.glyph/Glyph/ai_secrets.json` through previews or file tree commands.
 - Consider OS keychain migration separately if the product requires encrypted local secret storage.
 
-## Invariant 12: License Keys Are Hashed and Masked
+## Invariant 13: License Keys Are Hashed and Masked
 
 License activation verifies through Gumroad. Local license records live in Tauri app config as `license.json`.
 
@@ -210,7 +217,7 @@ The local record stores:
 
 It does not store the raw license key after activation. Activation failures record error state without storing the submitted raw key.
 
-## Invariant 13: Git Sync Flushes the Editor
+## Invariant 14: Git Sync Flushes the Editor
 
 `useGitSync()` calls `saveCurrentEditor()` before `git_sync_run`.
 
@@ -218,7 +225,7 @@ This keeps the active editor from being left out of a commit. Preserve this call
 
 Git sync also refuses unsupported repository states and pauses auto-sync after repeated failures.
 
-## Invariant 14: Command Types Must Match Rust
+## Invariant 15: Command Types Must Match Rust
 
 The TypeScript command map and Rust command registration must stay aligned.
 
@@ -231,16 +238,17 @@ When adding commands:
 
 When changing payload casing, check Rust command attributes such as `rename_all = "snake_case"`.
 
-## Invariant 15: Events Are Part of State Consistency
+## Invariant 16: Events Are Part of State Consistency
 
 Events keep surfaces synchronized:
 
-- `space:fs_changed`: file tree and removal handling
-- `notes:external_changed`: editor reload and cache invalidation
+- `space:fs_changed`: file tree, editor reload, and cache invalidation
 - `settings:updated`: live settings propagation
 - `git_sync:status`: sync status updates
 - `ai:*`: chat streaming and timeline
 - `menu:*`: native menu actions
+
+Cursor and Grok CLI runtimes also follow the event contract. Their subprocess parsers emit only job-scoped `ai:status`, `ai:chunk`, `ai:tool`, `ai:done`, and `ai:error` events, and cancellation must terminate the child process rather than merely dropping the reader.
 
 If a backend command mutates data that multiple UI areas cache, emit an event or invalidate through the existing event path.
 


### PR DESCRIPTION
Closes


## Description

Updates the architecture and translation documentation to match the current implementation since the previous docs update.

- Documents typed `space:fs_changed` mutation propagation and per-window space sessions.
- Covers Note Peek, Zen mode, Activity Timeline, settings changes, wikilinks, and usage insights.
- Adds Cursor and Grok runtime details, Git commit-message prompts, and `glyphasset://` security rules.
- Refreshes translation-table entries and removes stale references to replaced event and component paths.


## Docs

Updated 10 files under `docs/`, including the architecture guides and translation table.


## Ready?

Did you do any of the following? If not, no worries. If you can, it is
really helpful.

- [x] Documented what's new\n- [ ] Added in-code documentation (wherever needed)\n- [ ] Wrote tests for new components/features\n- [ ] Ran the linter to ensure style guidelines were followed\n- [ ] Created a demo

## Summary by Sourcery

Bring the architecture, security, runtime, settings, and translation documentation into alignment with the current implementation.

Enhancements:
- Refresh the architecture documentation to reflect typed filesystem-change propagation, per-window space sessions, centralized note mutations, current editor and navigation behavior, usage insights, and settings organization.
- Document current AI provider runtimes, Git commit-message prompting, wiki-link handling, and space-scoped asset protocol security rules.

Documentation:
- Update the translation table with current Note Peek, Zen mode, and context-related strings while removing stale event and component references.

Chores:
- Align repository guidance with the single typed `space:fs_changed` event contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the `docs/` architecture guides and translation table so they match the current implementation. Note and filesystem events now use a single typed `space:fs_changed` payload in place of `notes:external_changed`, and Rust tracks per-window space sessions instead of one global active space.

**Docs updates**
- Covers Note Peek, Zen mode, Activity Timeline/All Notes, and space-specific new-note folder settings.
- Documents the shared note-mutation boundary and the renderer's centralized `applySpaceChange()` propagation.
- Adds Cursor and Grok child-process runtimes, including their startup/run limits and CLI path overrides.
- Documents the `glyphasset://` security rules and renumbered security invariants.
- Refreshes translation-table entries and removes stale references to replaced event and component paths.

<sup>Written for commit 2ed97a24179b773a977d6a88ba5545df15f64031. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

