### PR TITLE
feat: add hidden easter eggs

### DIFF
--- a/src/components/app/CommandPalette.tsx
+++ b/src/components/app/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
 import { invoke } from "../../lib/tauri";
 import { listTemplates } from "../../lib/templates";
 import { toast } from "../../lib/toast";
+import { SecretPaletteReveal } from "../easter-eggs/secret-palette/SecretPaletteReveal";
 import { NotePreviewContent } from "../preview/NotePreviewContent";
 import { NOTE_PREVIEW_OPEN_DELAY_MS } from "../preview/notePreviewShared";
 import { useNotePreview } from "../preview/useNotePreview";
@@ -99,6 +100,9 @@ export function CommandPalette({
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const restoreFocusRef = useRef<HTMLElement | null>(null);
 	const parsedQuery = useMemo(() => parsePaletteQuery(query), [query]);
+	const normalizedQuery = query.trim();
+	const normalizedSecretQuery = normalizedQuery.toLowerCase();
+	const isSecretPalettePhrase = normalizedSecretQuery === "glyphglyph";
 	const {
 		settings,
 		valueFor: settingValue,
@@ -122,9 +126,10 @@ export function CommandPalette({
 	}, [onClose]);
 
 	const searchEnabled =
-		parsedQuery.scope === "all" ||
-		parsedQuery.scope === "tags" ||
-		parsedQuery.scope === "people";
+		!isSecretPalettePhrase &&
+		(parsedQuery.scope === "all" ||
+			parsedQuery.scope === "tags" ||
+			parsedQuery.scope === "people");
 	const searchQuery =
 		parsedQuery.scope === "tags" || parsedQuery.scope === "people"
 			? parsedQuery.raw
@@ -215,7 +220,9 @@ export function CommandPalette({
 	}, [results, selectedId]);
 	const selectedResult = results[resolvedSelectedIndex];
 	const selectedPreviewPath =
-		initialMode === "search" ? (selectedResult?.previewPath ?? null) : null;
+		!isSecretPalettePhrase && initialMode === "search"
+			? (selectedResult?.previewPath ?? null)
+			: null;
 	const notePreview = useNotePreview(selectedPreviewPath, {
 		delayMs: NOTE_PREVIEW_OPEN_DELAY_MS,
 	});
@@ -346,6 +353,7 @@ export function CommandPalette({
 			) {
 				return;
 			}
+			if (isSecretPalettePhrase && event.key !== "Escape") return;
 			if (event.key === "ArrowDown" || event.key === "ArrowUp") {
 				event.preventDefault();
 				if (!results.length) return;
@@ -394,7 +402,14 @@ export function CommandPalette({
 				}
 			}
 		},
-		[results, resolvedSelectedIndex, selectResult, query, closeAndRestoreFocus],
+		[
+			results,
+			resolvedSelectedIndex,
+			selectResult,
+			query,
+			closeAndRestoreFocus,
+			isSecretPalettePhrase,
+		],
 	);
 
 	const activeSetting = activeSettingId
@@ -418,11 +433,11 @@ export function CommandPalette({
 			inputRef.current?.focus();
 		}
 	}, [activeSettingId, activeTemplatePath, open]);
-	const normalizedQuery = query.trim();
 	const canSaveSearch =
-		parsedQuery.scope === "all" ||
-		parsedQuery.scope === "tags" ||
-		parsedQuery.scope === "people";
+		!isSecretPalettePhrase &&
+		(parsedQuery.scope === "all" ||
+			parsedQuery.scope === "tags" ||
+			parsedQuery.scope === "people");
 	const isCurrentSearchSaved = databaseSummaries.data?.some(
 		(collection) =>
 			collection.source.kind === "search" &&
@@ -577,14 +592,18 @@ export function CommandPalette({
 										{settingAnnouncement}
 									</output>
 								) : null}
-								<CommandList
-									results={results}
-									selectedIndex={resolvedSelectedIndex}
-									onSetSelectedIndex={(index) =>
-										setSelectedId(results[index]?.id ?? null)
-									}
-									onSelectResult={selectResult}
-								/>
+								{isSecretPalettePhrase ? (
+									<SecretPaletteReveal />
+								) : (
+									<CommandList
+										results={results}
+										selectedIndex={resolvedSelectedIndex}
+										onSetSelectedIndex={(index) =>
+											setSelectedId(results[index]?.id ?? null)
+										}
+										onSelectResult={selectResult}
+									/>
+								)}
 							</div>
 							{selectedPreviewPath ? (
 								<aside

--- a/src/components/app/WelcomeScreen.tsx
+++ b/src/components/app/WelcomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import glyphIconUrl from "../../../src-tauri/icons/icon.png";
+import { GlyphBloom } from "../easter-eggs/glyph-bloom/GlyphBloom";
 
 interface WelcomeScreenProps {
 	onOpenSpace: () => Promise<void> | void;
@@ -26,12 +27,7 @@ export function WelcomeScreen({ onOpenSpace }: WelcomeScreenProps) {
 	return (
 		<div className="welcomeScreen">
 			<div className="welcomeScreenBody">
-				<img
-					className="welcomeScreenIcon"
-					src={glyphIconUrl}
-					alt=""
-					aria-hidden="true"
-				/>
+				<GlyphBloom iconUrl={glyphIconUrl} />
 				<h1 className="welcomeScreenTitle">
 					Glyph
 					<span className="welcomeScreenTitleSub">

--- a/src/components/easter-eggs/glyph-bloom/GlyphBloom.module.css
+++ b/src/components/easter-eggs/glyph-bloom/GlyphBloom.module.css
@@ -11,11 +11,6 @@
 	cursor: pointer;
 }
 
-.trigger:focus-visible {
-	outline: 2px solid var(--text-primary);
-	outline-offset: 4px;
-}
-
 .icon {
 	margin: 0;
 }

--- a/src/components/easter-eggs/glyph-bloom/GlyphBloom.module.css
+++ b/src/components/easter-eggs/glyph-bloom/GlyphBloom.module.css
@@ -1,0 +1,141 @@
+.trigger {
+	position: relative;
+	display: block;
+	width: 48px;
+	height: 48px;
+	margin: 0 auto 16px;
+	padding: 0;
+	border: 0;
+	border-radius: 12px;
+	background: transparent;
+	cursor: pointer;
+}
+
+.trigger:focus-visible {
+	outline: 2px solid var(--text-primary);
+	outline-offset: 4px;
+}
+
+.icon {
+	margin: 0;
+}
+
+.bloom {
+	position: absolute;
+	inset: -14px;
+	pointer-events: none;
+	border-radius: 50%;
+	opacity: 0;
+	animation: bloomPulse 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.bloom::before,
+.bloom::after,
+.spark {
+	position: absolute;
+	display: block;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	content: "";
+	box-shadow: 0 0 12px currentColor;
+}
+
+.bloom::before {
+	top: 12%;
+	left: 18%;
+	color: #3b86f7;
+	animation: sparkBlue 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.bloom::after {
+	right: 14%;
+	bottom: 18%;
+	color: #eb4c46;
+	animation: sparkRed 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.spark {
+	top: 8%;
+	right: 28%;
+	color: #f09343;
+	animation: sparkOrange 720ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes bloomPulse {
+	0% {
+		opacity: 0;
+		box-shadow: 0 0 0 0 rgb(59 134 247 / 0%);
+		transform: scale(0.55);
+	}
+	35% {
+		opacity: 1;
+		box-shadow: 0 0 24px 5px rgb(240 147 67 / 18%);
+	}
+	100% {
+		opacity: 0;
+		box-shadow: 0 0 0 22px rgb(235 76 70 / 0%);
+		transform: scale(1.12);
+	}
+}
+
+@keyframes sparkBlue {
+	0% {
+		opacity: 0;
+		transform: translate(18px, 16px) scale(0.4);
+	}
+	25% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translate(-2px, -5px) scale(1);
+	}
+}
+
+@keyframes sparkRed {
+	0% {
+		opacity: 0;
+		transform: translate(-18px, -14px) scale(0.4);
+	}
+	25% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translate(3px, 4px) scale(1);
+	}
+}
+
+@keyframes sparkOrange {
+	0% {
+		opacity: 0;
+		transform: translate(-5px, 20px) scale(0.4);
+	}
+	25% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+		transform: translate(7px, -5px) scale(1);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.bloom,
+	.bloom::before,
+	.bloom::after,
+	.spark {
+		animation-name: bloomReduced;
+		animation-duration: 1ms;
+	}
+}
+
+@keyframes bloomReduced {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}

--- a/src/components/easter-eggs/glyph-bloom/GlyphBloom.tsx
+++ b/src/components/easter-eggs/glyph-bloom/GlyphBloom.tsx
@@ -1,0 +1,60 @@
+import type { AnimationEvent, KeyboardEvent, MouseEvent } from "react";
+import { useState } from "react";
+import styles from "./GlyphBloom.module.css";
+
+interface GlyphBloomProps {
+	iconUrl: string;
+}
+
+export function GlyphBloom({ iconUrl }: GlyphBloomProps) {
+	const [bloomId, setBloomId] = useState<number | null>(null);
+
+	const triggerBloom = () => {
+		setBloomId((currentId) => (currentId ?? 0) + 1);
+	};
+
+	const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+		if (event.detail === 3) {
+			triggerBloom();
+		}
+	};
+
+	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === "Enter" || event.key === " ") {
+			triggerBloom();
+		}
+	};
+
+	const handleBloomAnimationEnd = (event: AnimationEvent<HTMLSpanElement>) => {
+		if (event.target === event.currentTarget) {
+			setBloomId(null);
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			className={styles.trigger}
+			aria-label="Glyph"
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+		>
+			<img
+				className={`${styles.icon} welcomeScreenIcon`}
+				src={iconUrl}
+				alt=""
+				aria-hidden="true"
+			/>
+			{bloomId !== null ? (
+				<span
+					key={bloomId}
+					className={styles.bloom}
+					aria-hidden="true"
+					onAnimationEnd={handleBloomAnimationEnd}
+				>
+					<span className={styles.spark} />
+				</span>
+			) : null}
+		</button>
+	);
+}

--- a/src/components/easter-eggs/glyph-bloom/GlyphBloom.tsx
+++ b/src/components/easter-eggs/glyph-bloom/GlyphBloom.tsx
@@ -1,4 +1,4 @@
-import type { AnimationEvent, KeyboardEvent, MouseEvent } from "react";
+import type { AnimationEvent, MouseEvent } from "react";
 import { useState } from "react";
 import styles from "./GlyphBloom.module.css";
 
@@ -9,20 +9,9 @@ interface GlyphBloomProps {
 export function GlyphBloom({ iconUrl }: GlyphBloomProps) {
 	const [bloomId, setBloomId] = useState<number | null>(null);
 
-	const triggerBloom = () => {
+	const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+		if (event.detail !== 3) return;
 		setBloomId((currentId) => (currentId ?? 0) + 1);
-	};
-
-	const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
-		if (event.detail === 3) {
-			triggerBloom();
-		}
-	};
-
-	const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-		if (event.key === "Enter" || event.key === " ") {
-			triggerBloom();
-		}
 	};
 
 	const handleBloomAnimationEnd = (event: AnimationEvent<HTMLSpanElement>) => {
@@ -32,13 +21,7 @@ export function GlyphBloom({ iconUrl }: GlyphBloomProps) {
 	};
 
 	return (
-		<button
-			type="button"
-			className={styles.trigger}
-			aria-label="Glyph"
-			onClick={handleClick}
-			onKeyDown={handleKeyDown}
-		>
+		<div className={styles.trigger} onMouseDown={handleMouseDown}>
 			<img
 				className={`${styles.icon} welcomeScreenIcon`}
 				src={iconUrl}
@@ -55,6 +38,6 @@ export function GlyphBloom({ iconUrl }: GlyphBloomProps) {
 					<span className={styles.spark} />
 				</span>
 			) : null}
-		</button>
+		</div>
 	);
 }

--- a/src/components/easter-eggs/secret-palette/SecretPaletteReveal.tsx
+++ b/src/components/easter-eggs/secret-palette/SecretPaletteReveal.tsx
@@ -1,0 +1,27 @@
+import "./secretPaletteReveal.css";
+
+const ASTERISK_COLORS = [
+	"var(--glyph-inline-color-orange)",
+	"var(--glyph-inline-color-blue)",
+	"var(--glyph-inline-color-purple)",
+] as const;
+
+export function SecretPaletteReveal() {
+	return (
+		<div className="secretPaletteReveal" aria-hidden="true">
+			<div className="secretPaletteRevealCard">
+				<div className="secretPaletteRevealStars">
+					{ASTERISK_COLORS.map((color, index) => (
+						<span
+							key={color}
+							className="secretPaletteRevealStar"
+							style={{ color, animationDelay: `${index * 90}ms` }}
+						>
+							✱
+						</span>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/easter-eggs/secret-palette/secretPaletteReveal.css
+++ b/src/components/easter-eggs/secret-palette/secretPaletteReveal.css
@@ -1,0 +1,47 @@
+.secretPaletteReveal {
+	display: grid;
+	place-items: center;
+	min-height: 124px;
+	padding: 12px 16px 20px;
+}
+
+.secretPaletteRevealCard {
+	display: grid;
+	place-items: center;
+	width: min(260px, 100%);
+	height: 92px;
+	border: 1px solid color-mix(in srgb, var(--border-light) 82%, transparent);
+	border-radius: 16px;
+	background: color-mix(in srgb, var(--bg-secondary) 62%, transparent);
+	box-shadow: inset 0 1px color-mix(in srgb, white 8%, transparent);
+}
+
+.secretPaletteRevealStars {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-size: 34px;
+	line-height: 1;
+}
+
+.secretPaletteRevealStar {
+	display: block;
+	animation: secretPaletteRevealStar 900ms ease-in-out infinite alternate;
+}
+
+@keyframes secretPaletteRevealStar {
+	from {
+		opacity: 0.62;
+		transform: translateY(3px) scale(0.92);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(-3px) scale(1.08);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.secretPaletteRevealStar {
+		animation: none;
+	}
+}

--- a/src/components/editor/extensions/asteriskDividerBloom.ts
+++ b/src/components/editor/extensions/asteriskDividerBloom.ts
@@ -21,6 +21,7 @@ type AsteriskBloomMeta =
 
 interface AsteriskBloomState {
 	blooms: Map<string, number>;
+	decorations: DecorationSet;
 }
 
 function isAsteriskDivider(node: ProseMirrorNode): boolean {
@@ -36,6 +37,17 @@ function prefersReducedMotion(): boolean {
 	);
 }
 
+function isBloomPayload(value: unknown): value is { id: string; pos: number } {
+	return (
+		value !== null &&
+		typeof value === "object" &&
+		"id" in value &&
+		typeof value.id === "string" &&
+		"pos" in value &&
+		typeof value.pos === "number"
+	);
+}
+
 function isAsteriskBloomMeta(value: unknown): value is AsteriskBloomMeta {
 	if (!value || typeof value !== "object" || !("kind" in value)) return false;
 	if (value.kind === "finish") {
@@ -48,14 +60,16 @@ function isAsteriskBloomMeta(value: unknown): value is AsteriskBloomMeta {
 	) {
 		return false;
 	}
-	return value.blooms.every(
-		(bloom: unknown) =>
-			Boolean(bloom) &&
-			typeof bloom === "object" &&
-			"id" in bloom &&
-			typeof bloom.id === "string" &&
-			"pos" in bloom &&
-			typeof bloom.pos === "number",
+	return value.blooms.every(isBloomPayload);
+}
+
+function dispatchBloomFinish(view: EditorView, id: string): void {
+	if (view.isDestroyed) return;
+	view.dispatch(
+		view.state.tr.setMeta(ASTERISK_DIVIDER_BLOOM_KEY, {
+			kind: "finish",
+			id,
+		} satisfies AsteriskBloomMeta),
 	);
 }
 
@@ -82,6 +96,12 @@ function createBloomAsterisks(view: EditorView, id: string): HTMLElement {
 		bloom.append(asterisk);
 	}
 
+	let finished = false;
+	const finish = () => {
+		if (finished) return;
+		finished = true;
+		dispatchBloomFinish(view, id);
+	};
 	const animation = bloom.animate(
 		[
 			{ opacity: 0, transform: "translateY(0.18em) scale(0.7)" },
@@ -90,16 +110,8 @@ function createBloomAsterisks(view: EditorView, id: string): HTMLElement {
 		],
 		{ duration: BLOOM_DURATION_MS, easing: "cubic-bezier(0.22, 1, 0.36, 1)" },
 	);
-	animation.onfinish = () => {
-		if (!view.isDestroyed) {
-			view.dispatch(
-				view.state.tr.setMeta(ASTERISK_DIVIDER_BLOOM_KEY, {
-					kind: "finish",
-					id,
-				} satisfies AsteriskBloomMeta),
-			);
-		}
-	};
+	animation.onfinish = finish;
+	animation.oncancel = finish;
 	return bloom;
 }
 
@@ -117,6 +129,7 @@ function buildBloomDecorations(
 			}),
 			Decoration.widget(pos + 1, (view) => createBloomAsterisks(view, id), {
 				side: -1,
+				key: id,
 			}),
 		);
 	}
@@ -132,25 +145,50 @@ const AsteriskDividerBloom = Extension.create({
 			new Plugin<AsteriskBloomState>({
 				key: ASTERISK_DIVIDER_BLOOM_KEY,
 				state: {
-					init: () => ({ blooms: new Map() }),
+					init: () => ({
+						blooms: new Map(),
+						decorations: DecorationSet.empty,
+					}),
 					apply(transaction, previous) {
 						const rawMeta: unknown = transaction.getMeta(
 							ASTERISK_DIVIDER_BLOOM_KEY,
 						);
 						const meta = isAsteriskBloomMeta(rawMeta) ? rawMeta : undefined;
 						const blooms = new Map<string, number>();
+						let bloomsChanged = false;
 						for (const [id, pos] of previous.blooms) {
-							if (meta?.kind === "finish" && meta.id === id) continue;
+							if (meta?.kind === "finish" && meta.id === id) {
+								bloomsChanged = true;
+								continue;
+							}
 							const mappedPos = transaction.docChanged
 								? transaction.mapping.map(pos, -1)
 								: pos;
 							const node = transaction.doc.nodeAt(mappedPos);
-							if (node && isAsteriskDivider(node)) blooms.set(id, mappedPos);
+							if (node && isAsteriskDivider(node)) {
+								blooms.set(id, mappedPos);
+							} else {
+								bloomsChanged = true;
+							}
 						}
 						if (meta?.kind === "activate") {
 							for (const bloom of meta.blooms) blooms.set(bloom.id, bloom.pos);
+							bloomsChanged = true;
 						}
-						return { blooms };
+						if (bloomsChanged) {
+							return {
+								blooms,
+								decorations: buildBloomDecorations(transaction.doc, blooms),
+							};
+						}
+						if (!transaction.docChanged) return previous;
+						return {
+							blooms,
+							decorations: previous.decorations.map(
+								transaction.mapping,
+								transaction.doc,
+							),
+						};
 					},
 				},
 				appendTransaction(transactions, _oldState, newState) {
@@ -160,6 +198,10 @@ const AsteriskDividerBloom = Extension.create({
 					) {
 						return null;
 					}
+					const activePositions = new Set(
+						ASTERISK_DIVIDER_BLOOM_KEY.getState(newState)?.blooms.values() ??
+							[],
+					);
 					const blooms: Array<{ id: string; pos: number }> = [];
 					const ranges = changedRangesFromTransactions(
 						transactions,
@@ -168,6 +210,7 @@ const AsteriskDividerBloom = Extension.create({
 					visitNodesInRanges(newState, ranges, (node, pos) => {
 						if (
 							!isAsteriskDivider(node) ||
+							activePositions.has(pos) ||
 							pos + node.nodeSize - 1 !== newState.selection.from
 						) {
 							return;
@@ -182,10 +225,10 @@ const AsteriskDividerBloom = Extension.create({
 				},
 				props: {
 					decorations(state) {
-						const pluginState = ASTERISK_DIVIDER_BLOOM_KEY.getState(state);
-						return pluginState
-							? buildBloomDecorations(state.doc, pluginState.blooms)
-							: DecorationSet.empty;
+						return (
+							ASTERISK_DIVIDER_BLOOM_KEY.getState(state)?.decorations ??
+							DecorationSet.empty
+						);
 					},
 				},
 			}),

--- a/src/components/editor/extensions/asteriskDividerBloom.ts
+++ b/src/components/editor/extensions/asteriskDividerBloom.ts
@@ -1,0 +1,196 @@
+import { Extension } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet, type EditorView } from "@tiptap/pm/view";
+import {
+	changedRangesFromTransactions,
+	visitNodesInRanges,
+} from "./changedRanges";
+
+const ASTERISK_DIVIDER_BLOOM_KEY = new PluginKey<AsteriskBloomState>(
+	"asterisk-divider-bloom",
+);
+const ASTERISK_DIVIDER = "***";
+const BLOOM_DURATION_MS = 720;
+
+let nextBloomId = 0;
+
+type AsteriskBloomMeta =
+	| { kind: "activate"; blooms: Array<{ id: string; pos: number }> }
+	| { kind: "finish"; id: string };
+
+interface AsteriskBloomState {
+	blooms: Map<string, number>;
+}
+
+function isAsteriskDivider(node: ProseMirrorNode): boolean {
+	return (
+		node.type.name === "paragraph" && node.textContent === ASTERISK_DIVIDER
+	);
+}
+
+function prefersReducedMotion(): boolean {
+	return (
+		typeof window !== "undefined" &&
+		window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
+}
+
+function isAsteriskBloomMeta(value: unknown): value is AsteriskBloomMeta {
+	if (!value || typeof value !== "object" || !("kind" in value)) return false;
+	if (value.kind === "finish") {
+		return "id" in value && typeof value.id === "string";
+	}
+	if (
+		value.kind !== "activate" ||
+		!("blooms" in value) ||
+		!Array.isArray(value.blooms)
+	) {
+		return false;
+	}
+	return value.blooms.every(
+		(bloom: unknown) =>
+			Boolean(bloom) &&
+			typeof bloom === "object" &&
+			"id" in bloom &&
+			typeof bloom.id === "string" &&
+			"pos" in bloom &&
+			typeof bloom.pos === "number",
+	);
+}
+
+function createBloomAsterisks(view: EditorView, id: string): HTMLElement {
+	const bloom = document.createElement("span");
+	bloom.className = "asterisk-divider-bloom";
+	bloom.setAttribute("aria-hidden", "true");
+	bloom.style.display = "inline-flex";
+	bloom.style.width = "3ch";
+	bloom.style.marginRight = "-3ch";
+	bloom.style.pointerEvents = "none";
+
+	const colors = [
+		"var(--glyph-inline-color-orange)",
+		"var(--glyph-inline-color-blue)",
+		"var(--glyph-inline-color-red)",
+	];
+	for (const color of colors) {
+		const asterisk = document.createElement("span");
+		asterisk.textContent = ASTERISK_DIVIDER[0];
+		asterisk.style.color = color;
+		asterisk.style.display = "inline-block";
+		asterisk.style.width = "1ch";
+		bloom.append(asterisk);
+	}
+
+	const animation = bloom.animate(
+		[
+			{ opacity: 0, transform: "translateY(0.18em) scale(0.7)" },
+			{ opacity: 1, transform: "translateY(0) scale(1)", offset: 0.35 },
+			{ opacity: 0, transform: "translateY(-0.08em) scale(1.08)" },
+		],
+		{ duration: BLOOM_DURATION_MS, easing: "cubic-bezier(0.22, 1, 0.36, 1)" },
+	);
+	animation.onfinish = () => {
+		if (!view.isDestroyed) {
+			view.dispatch(
+				view.state.tr.setMeta(ASTERISK_DIVIDER_BLOOM_KEY, {
+					kind: "finish",
+					id,
+				} satisfies AsteriskBloomMeta),
+			);
+		}
+	};
+	return bloom;
+}
+
+function buildBloomDecorations(
+	doc: ProseMirrorNode,
+	blooms: Map<string, number>,
+): DecorationSet {
+	const decorations: Decoration[] = [];
+	for (const [id, pos] of blooms) {
+		const node = doc.nodeAt(pos);
+		if (!node || !isAsteriskDivider(node)) continue;
+		decorations.push(
+			Decoration.inline(pos + 1, pos + 4, {
+				style: "color: transparent",
+			}),
+			Decoration.widget(pos + 1, (view) => createBloomAsterisks(view, id), {
+				side: -1,
+			}),
+		);
+	}
+	return decorations.length
+		? DecorationSet.create(doc, decorations)
+		: DecorationSet.empty;
+}
+
+const AsteriskDividerBloom = Extension.create({
+	name: "asterisk-divider-bloom",
+	addProseMirrorPlugins() {
+		return [
+			new Plugin<AsteriskBloomState>({
+				key: ASTERISK_DIVIDER_BLOOM_KEY,
+				state: {
+					init: () => ({ blooms: new Map() }),
+					apply(transaction, previous) {
+						const rawMeta: unknown = transaction.getMeta(
+							ASTERISK_DIVIDER_BLOOM_KEY,
+						);
+						const meta = isAsteriskBloomMeta(rawMeta) ? rawMeta : undefined;
+						const blooms = new Map<string, number>();
+						for (const [id, pos] of previous.blooms) {
+							if (meta?.kind === "finish" && meta.id === id) continue;
+							const mappedPos = transaction.docChanged
+								? transaction.mapping.map(pos, -1)
+								: pos;
+							const node = transaction.doc.nodeAt(mappedPos);
+							if (node && isAsteriskDivider(node)) blooms.set(id, mappedPos);
+						}
+						if (meta?.kind === "activate") {
+							for (const bloom of meta.blooms) blooms.set(bloom.id, bloom.pos);
+						}
+						return { blooms };
+					},
+				},
+				appendTransaction(transactions, _oldState, newState) {
+					if (
+						prefersReducedMotion() ||
+						!transactions.some((transaction) => transaction.docChanged)
+					) {
+						return null;
+					}
+					const blooms: Array<{ id: string; pos: number }> = [];
+					const ranges = changedRangesFromTransactions(
+						transactions,
+						newState.doc.content.size,
+					);
+					visitNodesInRanges(newState, ranges, (node, pos) => {
+						if (
+							!isAsteriskDivider(node) ||
+							pos + node.nodeSize - 1 !== newState.selection.from
+						) {
+							return;
+						}
+						blooms.push({ id: `bloom-${nextBloomId++}`, pos });
+					});
+					if (!blooms.length) return null;
+					return newState.tr.setMeta(ASTERISK_DIVIDER_BLOOM_KEY, {
+						kind: "activate",
+						blooms,
+					} satisfies AsteriskBloomMeta);
+				},
+				props: {
+					decorations(state) {
+						const pluginState = ASTERISK_DIVIDER_BLOOM_KEY.getState(state);
+						return pluginState
+							? buildBloomDecorations(state.doc, pluginState.blooms)
+							: DecorationSet.empty;
+					},
+				},
+			}),
+		];
+	},
+});
+
+export { AsteriskDividerBloom };

--- a/src/components/editor/extensions/index.ts
+++ b/src/components/editor/extensions/index.ts
@@ -15,6 +15,7 @@ import type { EditorState } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import StarterKit from "@tiptap/starter-kit";
 import { SlashCommand } from "../slashCommands";
+import { AsteriskDividerBloom } from "./asteriskDividerBloom";
 import {
 	type ChangedRange,
 	changedRangesFromTransactions,
@@ -719,6 +720,7 @@ export function createEditorExtensions(
 		CalloutDecorations.configure({
 			enableShortcutTransform: enableEditingExtensions,
 		}),
+		...(enableEditingExtensions ? [AsteriskDividerBloom] : []),
 		TagDecorations.configure({ enablePeopleMentions }),
 		FootnoteDecorations,
 		...(enableFocusMode ? [FocusModeDecorations] : []),


### PR DESCRIPTION
Closes


## Description

Adds four subtle, opt-in easter eggs to make normal app interactions feel more rewarding.

- Triple-click the Glyph icon on the welcome screen for a brief three-color bloom.
- Type `glyphglyph` in the command palette to reveal a playful animated card.
- Type `***` on its own line in the rich editor for a brief colored divider bloom.
- Keeps `three stars` and `***` out of the command-palette trigger so they remain normal searches.

## Screenshots

Screenshots or a screen recording were not included.

## Docs

No documentation changes are needed; these are intentionally undisclosed interactions.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three hidden, opt-in easter eggs that reward otherwise normal app interactions.

**New Features**
- Triple-clicking the Glyph icon on the welcome screen triggers a brief three-color bloom; activation is limited to mouse triple-clicks so the icon stays out of the tab order.
- Typing `glyphglyph` in the command palette shows an animated three-star card and suppresses search results, previews, save-search actions, and keyboard controls other than Escape for that phrase.
- Typing `***` on its own line in the rich editor triggers a transient colored divider bloom when editing extensions are enabled, without remounting the overlay mid-animation.
- All animations respect `prefers-reduced-motion`.

<sup>Written for commit 348ec4651d6841782aaf1a2f6a5e6158d5b7b33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Add opt-in easter eggs that reward common welcome-screen, command-palette, and rich-editor interactions.

New Features:
- Add hidden visual reveals for triple-clicking the welcome-screen Glyph icon, entering `glyphglyph` in the command palette, and typing `***` as an editor divider.

Enhancements:
- Respect reduced-motion preferences across the new easter-egg animations and keep the secret palette phrase from triggering normal search interactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hidden keyboard phrase that reveals a secret command palette animation.
  * Added an interactive glyph icon that produces a colorful bloom effect when activated.
  * Added an animated editor divider effect when entering `***`.
  * Added reduced-motion support for new animations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->