### PR TITLE
Fix TOC preview range crash (#532) [Release]

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.16",
+	"version": "0.8.17-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/components/editor/hooks/useTableOfContents.ts
+++ b/src/components/editor/hooks/useTableOfContents.ts
@@ -1,3 +1,4 @@
+import type { EditorEvents } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
@@ -78,7 +79,13 @@ export function getHeadingPreview(
 	nextHeading: TOCHeading | undefined,
 ): string | null {
 	const chunks: string[] = [];
-	const to = nextHeading?.pos ?? doc.content.size;
+	const docEnd = doc.content.size;
+	if (heading.pos < 0 || heading.pos >= docEnd) return null;
+	const to = Math.min(
+		Math.max(nextHeading?.pos ?? docEnd, heading.pos),
+		docEnd,
+	);
+	if (heading.pos >= to) return null;
 
 	doc.nodesBetween(heading.pos, to, (node) => {
 		if (node.type.name === "heading") return false;
@@ -267,14 +274,19 @@ export function useTableOfContents(
 		publishHeadings();
 		const updateHeadings = ({
 			transaction,
-		}: {
-			transaction: Transaction;
-		}) => {
-			if (!transaction.docChanged) return;
-			headingsRef.current = updateHeadingsFromTransaction(
-				headingsRef.current,
+			appendedTransactions,
+		}: EditorEvents["transaction"]) => {
+			const documentTransactions = [
 				transaction,
-			);
+				...appendedTransactions,
+			].filter((item) => item.docChanged);
+			if (documentTransactions.length === 0) return;
+			for (const documentTransaction of documentTransactions) {
+				headingsRef.current = updateHeadingsFromTransaction(
+					headingsRef.current,
+					documentTransaction,
+				);
+			}
 			publishHeadings();
 		};
 		editor.on("transaction", updateHeadings);


### PR DESCRIPTION
Closes


## Description

Fixes TOC preview crashes when heading positions fall outside the current document or the preview range is invalid. The transaction listener now processes both the original and appended document-changing transactions so the TOC stays in sync with TipTap updates. The app version is bumped to 0.8.17-alpha.1 for the next release.

- Summary of changes: clamp TOC preview ranges and handle appended TipTap transactions.
- Reasoning: stale or out-of-bounds heading positions can make ProseMirror traversal throw.
- Additional context: no issue link was provided.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TOC preview crash when heading positions fall outside the document or the preview range is invalid, and keeps the TOC in sync with appended TipTap transactions. Version bumps to `0.8.17-alpha.1`.

**Bug Fixes**
- Clamps the preview range to valid document positions and returns `null` when a heading position is out of bounds.
- Processes both the original and appended transactions in the transaction listener.

<sup>Written for commit 416e79f8769d2c95710f11d9989d3da147c3610c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved table of contents updates when multiple document changes are applied together.
  - Prevented invalid or empty heading previews from appearing near document boundaries.
  - Enhanced heading detection and preview accuracy during editing.

- **Chores**
  - Updated the application version to `0.8.17-alpha.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->