### PR TITLE
Reveal Folio note folders in the file tree (#536) [Release]

### DIFF
--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -41,6 +41,7 @@ import {
 	nextDatabasesOpenRequest,
 } from "../../lib/database/openDatabasesRequest";
 import { DATABASES_TAB_ID } from "../../lib/databases";
+import { scheduleScrollFileTreePathIntoView } from "../../lib/fileTreeScroll";
 import {
 	prefetchAllDocs,
 	prefetchDatabasesLanding,
@@ -1151,13 +1152,19 @@ export function AppShell() {
 
 			const dirsToLoad = nextPath ? ["", ...ancestorDirs] : [""];
 			void (async () => {
-				for (const dir of dirsToLoad) {
-					await fileTree.loadDir(dir);
+				try {
+					for (const dir of dirsToLoad) {
+						await fileTree.loadDir(dir);
+					}
+					if (nextPath) scheduleScrollFileTreePathIntoView(nextPath);
+				} catch (error) {
+					setError(error instanceof Error ? error.message : String(error));
 				}
 			})();
 		},
 		[
 			fileTree.loadDir,
+			setError,
 			setActiveDirPath,
 			setSidebarCollapsed,
 			updateExpandedDirs,

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1149,8 +1149,12 @@ export function AppShell() {
 				return next;
 			});
 
-			const dirsToLoad = nextPath ? ancestorDirs : [""];
-			void Promise.all(dirsToLoad.map((dir) => fileTree.loadDir(dir)));
+			const dirsToLoad = nextPath ? ["", ...ancestorDirs] : [""];
+			void (async () => {
+				for (const dir of dirsToLoad) {
+					await fileTree.loadDir(dir);
+				}
+			})();
 		},
 		[
 			fileTree.loadDir,

--- a/src/components/app/MainContent.tsx
+++ b/src/components/app/MainContent.tsx
@@ -527,6 +527,7 @@ export const MainContent = memo(function MainContent({
 							activeTabPath={activeTabPath}
 							onOpenFile={onOpenFolioFile}
 							onOpenFileInNewTab={onOpenFolioFileInNewTab}
+							onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
 							onRenameFile={(path, nextName) =>
 								fileTree.onRenameDir(path, nextName, "file")
 							}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -270,7 +270,6 @@ export const SidebarContent = memo(function SidebarContent({
 	} = useFileTreeContext();
 	const {
 		folioMode,
-		folioScope,
 		periodNotesEnabled,
 		sidebarOrder,
 		setFolioScope,
@@ -311,8 +310,6 @@ export const SidebarContent = memo(function SidebarContent({
 	} = useHoverPrefetch(() => {
 		onPrefetchDatabases();
 	});
-	const activeFolioFolder =
-		folioScope.kind === "folder" ? folioScope.folderPrefix : null;
 	const spaceLabel = spacePath ? formatSpaceLabel(spacePath) : "Glyph";
 	const folioSpaceContainerPath = useMemo(() => {
 		if (!folioMode) return null;
@@ -807,7 +804,7 @@ export const SidebarContent = memo(function SidebarContent({
 									childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
 									expandedDirs={expandedDirs}
 									activeFilePath={folioMode ? null : activeFilePath}
-									activeDirPath={folioMode ? activeFolioFolder : activeDirPath}
+									activeDirPath={activeDirPath}
 									onToggleDir={onToggleDir}
 									onLoadDir={onLoadDir}
 									onSelectDir={

--- a/src/components/folio/FolioNoteListItem.tsx
+++ b/src/components/folio/FolioNoteListItem.tsx
@@ -1,6 +1,7 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
 	type CSSProperties,
+	type KeyboardEvent,
 	type MouseEvent,
 	forwardRef,
 	memo,
@@ -9,6 +10,7 @@ import {
 	useMemo,
 	useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useSpace } from "../../contexts";
 import { useHoverPrefetch } from "../../hooks/useHoverPrefetch";
 import { normalizeInlineMarkdown } from "../../lib/markdownUtils";
@@ -34,6 +36,7 @@ interface FolioNoteListItemProps {
 	selected: boolean;
 	onOpen: (path: string) => void;
 	onOpenInNewTab: (path: string) => void;
+	onShowInFolder: (path: string) => void;
 	onPrefetch: (path: string) => void;
 	onRename?: (path: string) => void;
 	onDelete: (path: string) => void;
@@ -339,6 +342,7 @@ export const FolioNoteListItem = memo(
 			selected,
 			onOpen,
 			onOpenInNewTab,
+			onShowInFolder,
 			onPrefetch,
 			onRename,
 			onDelete,
@@ -356,6 +360,7 @@ export const FolioNoteListItem = memo(
 		},
 		ref,
 	) {
+		const { t } = useTranslation("shell");
 		const title = note.title.trim() || titleFromPath(note.note_path);
 		const isMarkdown = note.is_markdown;
 		const { spacePath } = useSpace();
@@ -464,7 +469,24 @@ export const FolioNoteListItem = memo(
 			/>
 		);
 		const noteTitleIcon = (
-			<span className="folioNoteTitleIcon" aria-hidden="true">
+			// biome-ignore lint/a11y/useSemanticElements: nested inside button row
+			<span
+				role="button"
+				tabIndex={0}
+				className="folioNoteTitleIcon"
+				aria-label={t("fileTree.showInFolder")}
+				onClick={(event) => {
+					event.preventDefault();
+					event.stopPropagation();
+					onShowInFolder(note.note_path);
+				}}
+				onKeyDown={(event: KeyboardEvent<HTMLSpanElement>) => {
+					if (event.key !== "Enter" && event.key !== " ") return;
+					event.preventDefault();
+					event.stopPropagation();
+					onShowInFolder(note.note_path);
+				}}
+			>
 				{fileIcon}
 			</span>
 		);
@@ -595,7 +617,8 @@ export const FolioNoteListItem = memo(
 							if (event.button === 1) onOpenInNewTab(note.note_path);
 						}}
 						{...hoverPrefetchProps}
-						onFocus={() => {
+						onFocus={(event) => {
+							if (event.target !== event.currentTarget) return;
 							onFocus();
 							if (isMarkdown) onPrefetch(note.note_path);
 						}}

--- a/src/components/folio/FolioNotesListPane.tsx
+++ b/src/components/folio/FolioNotesListPane.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../lib/tagIcons";
 import type { FileTreeAppearance } from "../../lib/tauri";
 import { isDeleteKey } from "../../utils/keyboard";
-import { basename } from "../../utils/path";
+import { basename, parentDir } from "../../utils/path";
 import { AppearancePicker } from "../AppearancePicker";
 import { EDITOR_TEXT_COLORS, isEditorTextColor } from "../editor/textColors";
 import { FolioNoteListItem } from "./FolioNoteListItem";
@@ -32,6 +32,7 @@ interface FolioNotesListPaneProps {
 	activeTabPath: string | null;
 	onOpenFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onNavigateBreadcrumbPath?: (dirPath: string) => void;
 	onRenameFile?: (relPath: string, nextName: string) => Promise<string | null>;
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
@@ -145,12 +146,18 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 	activeTabPath,
 	onOpenFile,
 	onOpenFileInNewTab,
+	onNavigateBreadcrumbPath,
 	onRenameFile,
 	onDeleteFile,
 }: FolioNotesListPaneProps) {
 	const { folioScope } = useUILayoutContext();
-	const { beautifulTags, itemAppearance, setItemAppearance, tagAppearance } =
-		useFileTreeContext();
+	const {
+		beautifulTags,
+		itemAppearance,
+		setActiveDirPath,
+		setItemAppearance,
+		tagAppearance,
+	} = useFileTreeContext();
 	const { notes, filesTruncated, error, nonMarkdownFileLimit } =
 		useFolioNotes(folioScope);
 	const [searchQuery, setSearchQuery] = useState("");
@@ -255,6 +262,12 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 			void onOpenFileInNewTab(path);
 		},
 		[onOpenFileInNewTab],
+	);
+	const showNoteInFolder = useCallback(
+		(path: string) => {
+			(onNavigateBreadcrumbPath ?? setActiveDirPath)(parentDir(path));
+		},
+		[onNavigateBreadcrumbPath, setActiveDirPath],
 	);
 	const renameNote = useCallback((path: string) => {
 		setRenamingPath(path);
@@ -386,6 +399,7 @@ export const FolioNotesListPane = memo(function FolioNotesListPane({
 								selected={activeTabPath === row.note.note_path}
 								onOpen={openNote}
 								onOpenInNewTab={openNoteInNewTab}
+								onShowInFolder={showNoteInFolder}
 								onPrefetch={prefetchNote}
 								onRename={onRenameFile ? renameNote : undefined}
 								onDelete={deleteNote}

--- a/src/components/folio/FolioWorkspace.tsx
+++ b/src/components/folio/FolioWorkspace.tsx
@@ -13,6 +13,7 @@ interface FolioWorkspaceProps {
 	activeTabPath: string | null;
 	onOpenFile: (relPath: string) => Promise<void>;
 	onOpenFileInNewTab: (relPath: string) => Promise<void>;
+	onNavigateBreadcrumbPath: (dirPath: string) => void;
 	onRenameFile: (relPath: string, nextName: string) => Promise<string | null>;
 	onDeleteFile: (relPath: string) => Promise<boolean>;
 }
@@ -22,6 +23,7 @@ export const FolioWorkspace = memo(function FolioWorkspace({
 	activeTabPath,
 	onOpenFile,
 	onOpenFileInNewTab,
+	onNavigateBreadcrumbPath,
 	onRenameFile,
 	onDeleteFile,
 }: FolioWorkspaceProps) {
@@ -47,6 +49,7 @@ export const FolioWorkspace = memo(function FolioWorkspace({
 				activeTabPath={activeTabPath}
 				onOpenFile={onOpenFile}
 				onOpenFileInNewTab={onOpenFileInNewTab}
+				onNavigateBreadcrumbPath={onNavigateBreadcrumbPath}
 				onRenameFile={onRenameFile}
 				onDeleteFile={onDeleteFile}
 			/>

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "Öffnen",
 		"openInNewWindow": "In neuem Fenster öffnen",
+		"showInFolder": "Im Ordner anzeigen",
 		"showInFinder": "Im Finder anzeigen",
 		"copyRelativePath": "Relativen Pfad kopieren",
 		"copyAbsolutePath": "Absoluten Pfad kopieren",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -65,6 +65,7 @@
 	"fileTree": {
 		"open": "Open",
 		"openInNewWindow": "Open in New Window",
+		"showInFolder": "Show in Folder",
 		"showInFinder": "Show in Finder",
 		"copyRelativePath": "Copy Relative Path",
 		"copyAbsolutePath": "Copy Absolute Path",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "Abrir",
 		"openInNewWindow": "Abrir en una ventana nueva",
+		"showInFolder": "Mostrar en la carpeta",
 		"showInFinder": "Mostrar en el Finder",
 		"copyRelativePath": "Copiar ruta relativa",
 		"copyAbsolutePath": "Copiar ruta absoluta",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -65,6 +65,7 @@
 	"fileTree": {
 		"open": "Ouvrir",
 		"openInNewWindow": "Ouvrir dans une nouvelle fenêtre",
+		"showInFolder": "Afficher dans le dossier",
 		"showInFinder": "Afficher dans le Finder",
 		"copyRelativePath": "Copier le chemin relatif",
 		"copyAbsolutePath": "Copier le chemin absolu",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "開く",
 		"openInNewWindow": "新しいウィンドウで開く",
+		"showInFolder": "フォルダで表示",
 		"showInFinder": "Finder で表示",
 		"copyRelativePath": "相対パスをコピー",
 		"copyAbsolutePath": "絶対パスをコピー",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "열기",
 		"openInNewWindow": "새 창에서 열기",
+		"showInFolder": "폴더에서 보기",
 		"showInFinder": "Finder에서 보기",
 		"copyRelativePath": "상대 경로 복사",
 		"copyAbsolutePath": "절대 경로 복사",

--- a/src/i18n/locales/pl/shell.json
+++ b/src/i18n/locales/pl/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "Otwórz",
 		"openInNewWindow": "Otwórz w nowym oknie",
+		"showInFolder": "Pokaż w folderze",
 		"showInFinder": "Pokaż w programie Finder",
 		"copyRelativePath": "Kopiuj ścieżkę względną",
 		"copyAbsolutePath": "Kopiuj ścieżkę bezwzględną",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -63,6 +63,7 @@
 	"fileTree": {
 		"open": "Abrir",
 		"openInNewWindow": "Abrir em nova janela",
+		"showInFolder": "Mostrar na pasta",
 		"showInFinder": "Mostrar no Finder",
 		"copyRelativePath": "Copiar caminho relativo",
 		"copyAbsolutePath": "Copiar caminho absoluto",

--- a/src/styles/app/49-folio-mode.css
+++ b/src/styles/app/49-folio-mode.css
@@ -279,6 +279,7 @@
 	height: var(--icon-lg);
 	color: var(--folio-file-color, var(--text-tertiary));
 	opacity: 0.72;
+	cursor: pointer;
 }
 
 .folioNoteRenameInput {


### PR DESCRIPTION
Closes


## Description

Adds a Folio note action that reveals the note's folder in the left file tree.

- Makes the existing note icon clickable and keyboard accessible.
- Highlights the matching folder without changing the Folio search scope.
- Expands and loads the root and parent folders in order when needed.
- Removes the previous scope-based folder highlight behavior and keeps icon styling free of hover and transition effects.
- Adds localized accessibility labels.


## Screenshots

No screenshot included. This is a small UI interaction change.


## Docs

No documentation changes are needed. The new icon label is localized in the existing shell translation files.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Enable users to reveal a Folio note’s containing folder in the file tree while preserving their current search scope.

New Features:
- Add an accessible Folio note action that reveals the note’s containing folder in the file tree.

Enhancements:
- Navigate to and highlight the note’s folder without changing the active Folio search scope, loading required folder hierarchy as needed.
- Remove Folio-specific folder highlighting in favor of the regular file-tree selection state and make the note action visually interactive.

Chores:
- Add localized accessibility labels for the new file-tree action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Folio note action that reveals a note's folder in the left file tree without changing the Folio search scope.

**New Features**
- Makes the note icon clickable and keyboard accessible.
- Expands and loads root and parent folders in order, then scrolls the revealed folder into view.
- Highlights the folder with the regular tree highlight and removes the old scope-based highlight.
- Wires breadcrumb navigation through Folio mode so navigation and reveal stay consistent.
- Adds localized accessibility labels for the icon.

<sup>Written for commit 05f08309c8d7faead1748ae229414b710320cfa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a keyboard-accessible action to show a note’s containing folder.
  - Breadcrumb navigation now works consistently from Folio mode and loads nested paths in sequence.
  - Note title icons now clearly appear clickable.

- **Bug Fixes**
  - Improved navigation to the correct parent folder when opening notes from lists.

- **Localization**
  - Added “Show in folder” translations for supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->