### PR TITLE
Default keep-running behavior to on

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1188,7 +1188,7 @@ fn keep_running_on_last_window_close(app: &tauri::AppHandle) -> bool {
         .ok()
         .and_then(|store| store.get(KEEP_RUNNING_ON_LAST_WINDOW_CLOSE_SETTING_KEY))
         .and_then(|value| value.as_bool())
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 fn emit_menu_command_to_main(app: &tauri::AppHandle, command_id: &str) {

--- a/src/components/settings/GeneralSettingsPane.tsx
+++ b/src/components/settings/GeneralSettingsPane.tsx
@@ -42,7 +42,7 @@ export function GeneralSettingsPane() {
 		setError,
 	);
 	const keepRunningOnLastWindowClose = useSettingsBoolean(
-		false,
+		DURABLE_SETTINGS.keepRunningOnLastWindowClose.defaultValue,
 		DURABLE_SETTINGS.keepRunningOnLastWindowClose.write,
 		setError,
 	);

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -576,7 +576,7 @@ export const DURABLE_SETTINGS = {
 	}),
 	keepRunningOnLastWindowClose: booleanSetting({
 		key: "ui.keepRunningOnLastWindowClose",
-		defaultValue: false,
+		defaultValue: true,
 		discovery: searchable("general-keep-running-on-close"),
 		nativeConsumption: {
 			kind: "settings-store",


### PR DESCRIPTION
Closes


## Description

Glyph now keeps running by default after its last window closes.

- Set the frontend setting default to on.
- Match the native close handler fallback to the same default when no stored value exists.
- Preserve an explicit off choice saved by the user.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Glyph now keeps running by default after the last window closes instead of exiting. The frontend setting reads the durable default (on), and the native close handler falls back to on when no saved value exists. Users who explicitly disabled it remain opted out.

<sup>Written for commit 2ca1ec915c735c4897355d1cf554676239175a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Default the keep-running setting to enabled across the frontend and native close behavior.

New Features:
- Default Glyph to keep running after the last window closes.

Enhancements:
- Keep users’ explicit disabled preference unchanged while applying the new default when no value is stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * On macOS, closing the last application window now keeps the app running and hides the window by default.
  * The default setting for keeping the app running after the last window closes is now enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->