### PR TITLE
Add tabbed Files and Tags sidebar views

### DIFF
--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -26,7 +26,6 @@ interface TagsPaneProps {
 	tagAppearance?: Record<string, TagAppearance>;
 	onChangeTagIcon?: (tag: string, iconName: string | null) => Promise<void>;
 	tagsError?: string;
-	onEnsureTagsFresh: () => Promise<void>;
 }
 
 const springTransition = springPresets.bouncy;
@@ -87,7 +86,6 @@ export const TagsPane = memo(function TagsPane({
 	tagAppearance = {},
 	onChangeTagIcon,
 	tagsError = "",
-	onEnsureTagsFresh,
 }: TagsPaneProps) {
 	const { t } = useTranslation("shell");
 	const onClick = useCallback(
@@ -100,14 +98,6 @@ export const TagsPane = memo(function TagsPane({
 		[onSelectPerson],
 	);
 	const [tagsExpanded, setTagsExpanded] = useState(false);
-	const [sectionExpanded, setSectionExpanded] = useState(false);
-	const handleSectionToggle = useCallback(() => {
-		const nextExpanded = !sectionExpanded;
-		setSectionExpanded(nextExpanded);
-		if (nextExpanded) {
-			void onEnsureTagsFresh();
-		}
-	}, [onEnsureTagsFresh, sectionExpanded]);
 	const rows = buildTagTreeRows(tags);
 	const peopleRows = buildPeopleRows(people);
 	const tagIconOverrides = useMemo(
@@ -118,6 +108,33 @@ export const TagsPane = memo(function TagsPane({
 	const TAG_LIMIT = 5;
 	const hasMoreTags = rows.length > TAG_LIMIT;
 	const visibleRows = tagsExpanded ? rows : rows.slice(0, TAG_LIMIT);
+	const peopleSection = peopleRows.length ? (
+		<>
+			<div className="tagsHeader tagsSubheader">
+				<div className="tagsHeaderTitle">{t("tags.people")}</div>
+			</div>
+			<ul className="tagsList">
+				{peopleRows.map((person) => (
+					<li key={person.handle} className="tagsItem">
+						<button
+							type="button"
+							className="tagsButton"
+							data-explicit="true"
+							onClick={() => onPersonClick(person.handle)}
+							title={`@${person.handle} · ${person.count} note${
+								person.count === 1 ? "" : "s"
+							}`}
+						>
+							<span className="tagsNameWrap">
+								<span className="tagsName">@{person.handle}</span>
+							</span>
+							<span className="tagsCount">{person.count}</span>
+						</button>
+					</li>
+				))}
+			</ul>
+		</>
+	) : null;
 
 	return (
 		<m.section
@@ -127,18 +144,7 @@ export const TagsPane = memo(function TagsPane({
 			animate={{ y: 0 }}
 			transition={springTransition}
 		>
-			<div className="tagsHeader">
-				<button
-					type="button"
-					className="tagsHeaderTitle tagsHeaderToggle"
-					onClick={handleSectionToggle}
-					aria-expanded={sectionExpanded}
-					aria-label={sectionExpanded ? t("tags.collapse") : t("tags.expand")}
-				>
-					<span>{t("tags.header")}</span>
-				</button>
-			</div>
-			{!sectionExpanded ? null : tagsError ? (
+			{tagsError ? (
 				<div className="tagsEmpty">{tagsError}</div>
 			) : rows.length ? (
 				<>
@@ -197,60 +203,10 @@ export const TagsPane = memo(function TagsPane({
 								: t("tags.showMore", { count: rows.length - TAG_LIMIT })}
 						</button>
 					) : null}
-					{peopleRows.length ? (
-						<>
-							<div className="tagsHeader tagsSubheader">
-								<div className="tagsHeaderTitle">{t("tags.people")}</div>
-							</div>
-							<ul className="tagsList">
-								{peopleRows.map((person) => (
-									<li key={person.handle} className="tagsItem">
-										<button
-											type="button"
-											className="tagsButton"
-											data-explicit="true"
-											onClick={() => onPersonClick(person.handle)}
-											title={`@${person.handle} · ${person.count} note${
-												person.count === 1 ? "" : "s"
-											}`}
-										>
-											<span className="tagsNameWrap">
-												<span className="tagsName">@{person.handle}</span>
-											</span>
-											<span className="tagsCount">{person.count}</span>
-										</button>
-									</li>
-								))}
-							</ul>
-						</>
-					) : null}
+					{peopleSection}
 				</>
-			) : peopleRows.length ? (
-				<>
-					<div className="tagsHeader tagsSubheader">
-						<div className="tagsHeaderTitle">{t("tags.people")}</div>
-					</div>
-					<ul className="tagsList">
-						{peopleRows.map((person) => (
-							<li key={person.handle} className="tagsItem">
-								<button
-									type="button"
-									className="tagsButton"
-									data-explicit="true"
-									onClick={() => onPersonClick(person.handle)}
-									title={`@${person.handle} · ${person.count} note${
-										person.count === 1 ? "" : "s"
-									}`}
-								>
-									<span className="tagsNameWrap">
-										<span className="tagsName">@{person.handle}</span>
-									</span>
-									<span className="tagsCount">{person.count}</span>
-								</button>
-							</li>
-						))}
-					</ul>
-				</>
+			) : peopleSection ? (
+				peopleSection
 			) : (
 				<div className="tagsEmpty">No tags found.</div>
 			)}

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -427,14 +427,13 @@ export const SidebarContent = memo(function SidebarContent({
 	}, [onOpenAllDocs, showAllFolioDocs]);
 	const handleSidebarViewChange = useCallback(
 		(view: SidebarView) => {
+			if (view === sidebarView) return;
 			setSidebarView(view);
 			if (view === "tags") {
 				void ensureTagsFresh();
-				return;
 			}
-			showAllFolioDocs();
 		},
-		[ensureTagsFresh, showAllFolioDocs],
+		[ensureTagsFresh, sidebarView],
 	);
 
 	const handleSelectFolioFolder = useCallback(
@@ -786,7 +785,7 @@ export const SidebarContent = memo(function SidebarContent({
 					<div className="sidebarViewContent">
 						<Activity mode={sidebarView === "files" ? "visible" : "hidden"}>
 							<section
-								className="sidebarStackItem sidebarStackItemGrow"
+								className="sidebarStackItem sidebarStackItemGrow sidebarViewPanel"
 								data-section="files"
 								id="sidebar-files-panel"
 								role="tabpanel"
@@ -882,7 +881,7 @@ export const SidebarContent = memo(function SidebarContent({
 						</Activity>
 						<Activity mode={sidebarView === "tags" ? "visible" : "hidden"}>
 							<section
-								className="sidebarStackItem sidebarStackItemGrow"
+								className="sidebarStackItem sidebarStackItemGrow sidebarViewPanel"
 								data-section="tags"
 								id="sidebar-tags-panel"
 								role="tabpanel"

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -8,15 +8,18 @@ import {
 	ColorsIcon,
 	CursorAddSelection02Icon,
 	ExpandParagraphIcon,
+	Folder01Icon,
 	LibraryIcon,
 	Link01Icon,
 	NoteIcon,
 	SearchIcon,
 	Sorting01Icon,
 	StarIcon,
+	Tag01Icon,
 } from "@hugeicons/core-free-icons";
 import { useQuery } from "@tanstack/react-query";
 import {
+	Activity,
 	Children,
 	type ComponentProps,
 	type ReactNode,
@@ -105,6 +108,8 @@ interface SidebarContentProps {
 	onCreateFromTemplate: () => void;
 	onGitSyncNow: () => void;
 }
+
+type SidebarView = "files" | "tags";
 
 function formatSpaceLabel(path: string): string {
 	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
@@ -279,7 +284,7 @@ export const SidebarContent = memo(function SidebarContent({
 	const [pendingNewNotePath, setPendingNewNotePath] = useState<string | null>(
 		null,
 	);
-	const [notesExpanded, setNotesExpanded] = useState(true);
+	const [sidebarView, setSidebarView] = useState<SidebarView>("files");
 	const fileTreeSort = useFileTreeSortMode({
 		onError: (message) => {
 			toast.error("Could not update file tree sorting", {
@@ -410,20 +415,27 @@ export const SidebarContent = memo(function SidebarContent({
 		},
 		[onOpenFile, onRenameDir, pendingNewNotePath],
 	);
-
-	const handleOpenAllNotes = useCallback(() => {
-		onOpenAllDocs();
-		if (folioMode) {
-			setFolioScope({ kind: "all" });
-			onPrefetchAllDocs();
-		}
-	}, [folioMode, onOpenAllDocs, onPrefetchAllDocs, setFolioScope]);
-	const handleNotesHeaderClick = useCallback(() => {
-		setNotesExpanded((value) => !value);
+	const showAllFolioDocs = useCallback(() => {
 		if (!folioMode) return;
 		setFolioScope({ kind: "all" });
 		onPrefetchAllDocs();
 	}, [folioMode, onPrefetchAllDocs, setFolioScope]);
+
+	const handleOpenAllNotes = useCallback(() => {
+		onOpenAllDocs();
+		showAllFolioDocs();
+	}, [onOpenAllDocs, showAllFolioDocs]);
+	const handleSidebarViewChange = useCallback(
+		(view: SidebarView) => {
+			setSidebarView(view);
+			if (view === "tags") {
+				void ensureTagsFresh();
+				return;
+			}
+			showAllFolioDocs();
+		},
+		[ensureTagsFresh, showAllFolioDocs],
+	);
 
 	const handleSelectFolioFolder = useCallback(
 		(dirPath: string) => {
@@ -724,25 +736,55 @@ export const SidebarContent = memo(function SidebarContent({
 							</div>
 						) : null}
 					</OrderedSidebarItems>
-					<div className="sidebarStack">
+					<div
+						className="sidebarViewTabs"
+						role="tablist"
+						aria-label={`${t("sidebar.files")} / ${t("tags.header")}`}
+					>
+						<button
+							type="button"
+							className="sidebarViewTab"
+							id="sidebar-files-tab"
+							role="tab"
+							aria-selected={sidebarView === "files"}
+							aria-controls="sidebar-files-panel"
+							onClick={() => handleSidebarViewChange("files")}
+						>
+							<HugeiconsIcon
+								icon={Folder01Icon}
+								size="var(--icon-sm)"
+								className="sidebarViewTabIcon"
+								aria-hidden="true"
+							/>
+							<span className="sidebarViewTabLabel">{t("sidebar.files")}</span>
+						</button>
+						<button
+							type="button"
+							className="sidebarViewTab"
+							id="sidebar-tags-tab"
+							role="tab"
+							aria-selected={sidebarView === "tags"}
+							aria-controls="sidebar-tags-panel"
+							onClick={() => handleSidebarViewChange("tags")}
+						>
+							<HugeiconsIcon
+								icon={Tag01Icon}
+								size="var(--icon-sm)"
+								className="sidebarViewTabIcon"
+								aria-hidden="true"
+							/>
+							<span className="sidebarViewTabLabel">{t("tags.header")}</span>
+						</button>
+					</div>
+					<Activity mode={sidebarView === "files" ? "visible" : "hidden"}>
 						<section
 							className="sidebarStackItem sidebarStackItemGrow"
 							data-section="files"
+							id="sidebar-files-panel"
+							role="tabpanel"
+							aria-labelledby="sidebar-files-tab"
 						>
-							<div className="sidebarStackHeader">
-								<button
-									type="button"
-									className="sidebarStackHeaderToggle"
-									onClick={handleNotesHeaderClick}
-									aria-expanded={notesExpanded}
-									aria-label={
-										notesExpanded
-											? t("sidebar.collapseNotes")
-											: t("sidebar.expandNotes")
-									}
-								>
-									<span>{t("sidebar.notes")}</span>
-								</button>
+							<div className="sidebarStackHeader sidebarFileTreeToolbar">
 								<div className="sidebarStackHeaderActions">
 									<label className="sidebarStackHeaderSortNative">
 										<span className="sr-only">{t("sidebar.sortNotes")}</span>
@@ -798,40 +840,44 @@ export const SidebarContent = memo(function SidebarContent({
 									</button>
 								</div>
 							</div>
-							{notesExpanded ? (
-								<FileTreePane
-									rootEntries={folioMode ? folioRootEntries : rootEntries}
-									childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
-									expandedDirs={expandedDirs}
-									activeFilePath={folioMode ? null : activeFilePath}
-									activeDirPath={activeDirPath}
-									onToggleDir={onToggleDir}
-									onLoadDir={onLoadDir}
-									onSelectDir={
-										folioMode ? handleSelectFolioFolder : onSelectDir
-									}
-									onOpenFile={onOpenFile}
-									onPrefetchFile={onPrefetchFile}
-									onNewFileInDir={onNewFileInDir}
-									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-									onImportFilesInDir={onImportFilesInDir}
-									onImportFolderInDir={onImportFolderInDir}
-									onImportPathsInDir={onImportPathsInDir}
-									onRequestCreateFolder={onRequestCreateFolder}
-									onDuplicateFile={onDuplicateFile}
-									onDeletePath={onDeletePath}
-									renamingPath={renamingPath}
-									onStartRename={handleStartRename}
-									onCancelRename={handleCancelRename}
-									onCommitFileRename={handleCommitFileRename}
-									onCommitDirRename={handleCommitDirRename}
-									onMovePath={onMovePath}
-									pinnedFiles={folioMode ? [] : pinnedFiles}
-									onTogglePinnedFile={togglePinnedFile}
-								/>
-							) : null}
+							<FileTreePane
+								rootEntries={folioMode ? folioRootEntries : rootEntries}
+								childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
+								expandedDirs={expandedDirs}
+								activeFilePath={folioMode ? null : activeFilePath}
+								activeDirPath={activeDirPath}
+								onToggleDir={onToggleDir}
+								onLoadDir={onLoadDir}
+								onSelectDir={folioMode ? handleSelectFolioFolder : onSelectDir}
+								onOpenFile={onOpenFile}
+								onPrefetchFile={onPrefetchFile}
+								onNewFileInDir={onNewFileInDir}
+								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+								onImportFilesInDir={onImportFilesInDir}
+								onImportFolderInDir={onImportFolderInDir}
+								onImportPathsInDir={onImportPathsInDir}
+								onRequestCreateFolder={onRequestCreateFolder}
+								onDuplicateFile={onDuplicateFile}
+								onDeletePath={onDeletePath}
+								renamingPath={renamingPath}
+								onStartRename={handleStartRename}
+								onCancelRename={handleCancelRename}
+								onCommitFileRename={handleCommitFileRename}
+								onCommitDirRename={handleCommitDirRename}
+								onMovePath={onMovePath}
+								pinnedFiles={folioMode ? [] : pinnedFiles}
+								onTogglePinnedFile={togglePinnedFile}
+							/>
 						</section>
-						<section className="sidebarStackItem" data-section="tags">
+					</Activity>
+					<Activity mode={sidebarView === "tags" ? "visible" : "hidden"}>
+						<section
+							className="sidebarStackItem sidebarStackItemGrow"
+							data-section="tags"
+							id="sidebar-tags-panel"
+							role="tabpanel"
+							aria-labelledby="sidebar-tags-tab"
+						>
 							<TagsPane
 								tags={tags}
 								people={people}
@@ -840,11 +886,10 @@ export const SidebarContent = memo(function SidebarContent({
 								beautifulTags={beautifulTags}
 								tagAppearance={tagAppearance}
 								tagsError={tagsError}
-								onEnsureTagsFresh={ensureTagsFresh}
 								onChangeTagIcon={handleChangeTagIcon}
 							/>
 						</section>
-					</div>
+					</Activity>
 				</div>
 			</div>
 		</>

--- a/src/components/app/SidebarContent.tsx
+++ b/src/components/app/SidebarContent.tsx
@@ -483,413 +483,424 @@ export const SidebarContent = memo(function SidebarContent({
 	return (
 		<>
 			<div className="sidebarSection sidebarSectionGrow">
-				<div className="sidebarSectionContent sidebarOrderedContent">
-					<OrderedSidebarItems order={sidebarOrder}>
-						{sidebarVisibility.newNote ? (
-							<button
-								key="newNote"
-								type="button"
-								className="sidebarQuickActionBtn sidebarNavBtn"
-								data-sidebar-key="newNote"
-								data-kind="new-note"
-								aria-label={t("sidebar.newNote")}
-								onClick={onNewNote}
-								title={`${newNoteTitle}${
-									newNoteShortcut
-										? ` (${formatShortcutForPlatform(newNoteShortcut)})`
-										: ""
-								}`}
-							>
-								<HugeiconsIcon
-									icon={CursorAddSelection02Icon}
-									size="var(--icon-lg)"
-								/>
-								<span className="sidebarQuickActionLabel">
-									{t("sidebar.newNote")}
-								</span>
-								{newNoteShortcut ? (
-									<span className="sidebarQuickActionShortcut">
-										{formatShortcutForPlatform(newNoteShortcut)}
+				<div className="sidebarSectionContent">
+					<div className="sidebarTopNavigation">
+						<OrderedSidebarItems order={sidebarOrder}>
+							{sidebarVisibility.newNote ? (
+								<button
+									key="newNote"
+									type="button"
+									className="sidebarQuickActionBtn sidebarNavBtn"
+									data-sidebar-key="newNote"
+									data-kind="new-note"
+									aria-label={t("sidebar.newNote")}
+									onClick={onNewNote}
+									title={`${newNoteTitle}${
+										newNoteShortcut
+											? ` (${formatShortcutForPlatform(newNoteShortcut)})`
+											: ""
+									}`}
+								>
+									<HugeiconsIcon
+										icon={CursorAddSelection02Icon}
+										size="var(--icon-lg)"
+									/>
+									<span className="sidebarQuickActionLabel">
+										{t("sidebar.newNote")}
 									</span>
-								) : null}
-							</button>
-						) : null}
-						{sidebarVisibility.pinned ? (
-							<button
-								key="pinned"
-								type="button"
-								className="sidebarQuickActionBtn sidebarNavBtn"
-								data-sidebar-key="pinned"
-								data-kind="pinned-notes"
-								data-active={
-									activeTopSection === "pinned-notes" ? "true" : "false"
-								}
-								aria-label={t("sidebar.pinned")}
-								aria-pressed={activeTopSection === "pinned-notes"}
-								aria-current={
-									activeTopSection === "pinned-notes" ? "page" : undefined
-								}
-								onClick={onOpenPinnedDocs}
-								title={t("sidebar.pinned")}
-							>
-								<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
-								<span className="sidebarQuickActionLabel">
-									{t("sidebar.pinned")}
-								</span>
-								<PinnedCountBadge noteCount={pinnedFiles.length} />
-							</button>
-						) : null}
-						{sidebarVisibility.allNotes ? (
-							<button
-								key="allNotes"
-								type="button"
-								className="sidebarQuickActionBtn sidebarNavBtn"
-								data-sidebar-key="allNotes"
-								data-kind="all-notes"
-								data-active={
-									activeTopSection === "all-notes" ? "true" : "false"
-								}
-								aria-label={t("sidebar.allNotes")}
-								aria-pressed={activeTopSection === "all-notes"}
-								aria-current={
-									activeTopSection === "all-notes" ? "page" : undefined
-								}
-								onClick={() => {
-									cancelAllDocsHoverPrefetch();
-									handleOpenAllNotes();
-								}}
-								{...allDocsHoverPrefetchProps}
-								onFocus={onPrefetchAllDocs}
-								title={t("sidebar.allNotes")}
-							>
-								<HugeiconsIcon icon={Archive04Icon} size="var(--icon-md)" />
-								<span className="sidebarQuickActionLabel">
-									{t("sidebar.allNotes")}
-								</span>
-								<AllNotesCountBadge />
-							</button>
-						) : null}
-						{sidebarVisibility.databases ? (
-							<button
-								key="databases"
-								type="button"
-								className="sidebarQuickActionBtn sidebarNavBtn"
-								data-sidebar-key="databases"
-								data-kind="databases"
-								data-active={
-									activeTopSection === "databases" ? "true" : "false"
-								}
-								aria-label={t("sidebar.collections")}
-								aria-pressed={activeTopSection === "databases"}
-								aria-current={
-									activeTopSection === "databases" ? "page" : undefined
-								}
-								onClick={() => {
-									cancelDatabasesHoverPrefetch();
-									onOpenDatabases();
-								}}
-								{...databasesHoverPrefetchProps}
-								onFocus={() => onPrefetchDatabases()}
-								title={t("sidebar.collections")}
-							>
-								<HugeiconsIcon icon={LibraryIcon} size="var(--icon-md)" />
-								<span className="sidebarQuickActionLabel">
-									{t("sidebar.collections")}
-								</span>
-							</button>
-						) : null}
-						{sidebarVisibility.connections ? (
-							<button
-								key="connections"
-								type="button"
-								className="sidebarQuickActionBtn sidebarNavBtn"
-								data-sidebar-key="connections"
-								data-kind="connections"
-								data-active={
-									activeTopSection === "connections" ? "true" : "false"
-								}
-								aria-label={t("sidebar.connections")}
-								aria-pressed={activeTopSection === "connections"}
-								aria-current={
-									activeTopSection === "connections" ? "page" : undefined
-								}
-								onClick={onOpenConnections}
-								title={t("sidebar.connections")}
-							>
-								<HugeiconsIcon
-									icon={ChartRelationshipIcon}
-									size="var(--icon-md)"
+									{newNoteShortcut ? (
+										<span className="sidebarQuickActionShortcut">
+											{formatShortcutForPlatform(newNoteShortcut)}
+										</span>
+									) : null}
+								</button>
+							) : null}
+							{sidebarVisibility.pinned ? (
+								<button
+									key="pinned"
+									type="button"
+									className="sidebarQuickActionBtn sidebarNavBtn"
+									data-sidebar-key="pinned"
+									data-kind="pinned-notes"
+									data-active={
+										activeTopSection === "pinned-notes" ? "true" : "false"
+									}
+									aria-label={t("sidebar.pinned")}
+									aria-pressed={activeTopSection === "pinned-notes"}
+									aria-current={
+										activeTopSection === "pinned-notes" ? "page" : undefined
+									}
+									onClick={onOpenPinnedDocs}
+									title={t("sidebar.pinned")}
+								>
+									<HugeiconsIcon icon={StarIcon} size="var(--icon-md)" />
+									<span className="sidebarQuickActionLabel">
+										{t("sidebar.pinned")}
+									</span>
+									<PinnedCountBadge noteCount={pinnedFiles.length} />
+								</button>
+							) : null}
+							{sidebarVisibility.allNotes ? (
+								<button
+									key="allNotes"
+									type="button"
+									className="sidebarQuickActionBtn sidebarNavBtn"
+									data-sidebar-key="allNotes"
+									data-kind="all-notes"
+									data-active={
+										activeTopSection === "all-notes" ? "true" : "false"
+									}
+									aria-label={t("sidebar.allNotes")}
+									aria-pressed={activeTopSection === "all-notes"}
+									aria-current={
+										activeTopSection === "all-notes" ? "page" : undefined
+									}
+									onClick={() => {
+										cancelAllDocsHoverPrefetch();
+										handleOpenAllNotes();
+									}}
+									{...allDocsHoverPrefetchProps}
+									onFocus={onPrefetchAllDocs}
+									title={t("sidebar.allNotes")}
+								>
+									<HugeiconsIcon icon={Archive04Icon} size="var(--icon-md)" />
+									<span className="sidebarQuickActionLabel">
+										{t("sidebar.allNotes")}
+									</span>
+									<AllNotesCountBadge />
+								</button>
+							) : null}
+							{sidebarVisibility.databases ? (
+								<button
+									key="databases"
+									type="button"
+									className="sidebarQuickActionBtn sidebarNavBtn"
+									data-sidebar-key="databases"
+									data-kind="databases"
+									data-active={
+										activeTopSection === "databases" ? "true" : "false"
+									}
+									aria-label={t("sidebar.collections")}
+									aria-pressed={activeTopSection === "databases"}
+									aria-current={
+										activeTopSection === "databases" ? "page" : undefined
+									}
+									onClick={() => {
+										cancelDatabasesHoverPrefetch();
+										onOpenDatabases();
+									}}
+									{...databasesHoverPrefetchProps}
+									onFocus={() => onPrefetchDatabases()}
+									title={t("sidebar.collections")}
+								>
+									<HugeiconsIcon icon={LibraryIcon} size="var(--icon-md)" />
+									<span className="sidebarQuickActionLabel">
+										{t("sidebar.collections")}
+									</span>
+								</button>
+							) : null}
+							{sidebarVisibility.connections ? (
+								<button
+									key="connections"
+									type="button"
+									className="sidebarQuickActionBtn sidebarNavBtn"
+									data-sidebar-key="connections"
+									data-kind="connections"
+									data-active={
+										activeTopSection === "connections" ? "true" : "false"
+									}
+									aria-label={t("sidebar.connections")}
+									aria-pressed={activeTopSection === "connections"}
+									aria-current={
+										activeTopSection === "connections" ? "page" : undefined
+									}
+									onClick={onOpenConnections}
+									title={t("sidebar.connections")}
+								>
+									<HugeiconsIcon
+										icon={ChartRelationshipIcon}
+										size="var(--icon-md)"
+									/>
+									<span className="sidebarQuickActionLabel">
+										{t("sidebar.connections")}
+									</span>
+								</button>
+							) : null}
+							{sidebarVisibility.calendar ? (
+								<SidebarActionButton
+									key="calendar"
+									data-sidebar-key="calendar"
+									kind="calendar"
+									label={t("sidebar.calendar")}
+									icon={Calendar03Icon}
+									onClick={onOpenCalendar}
 								/>
-								<span className="sidebarQuickActionLabel">
-									{t("sidebar.connections")}
-								</span>
-							</button>
-						) : null}
-						{sidebarVisibility.calendar ? (
-							<SidebarActionButton
-								key="calendar"
-								data-sidebar-key="calendar"
-								kind="calendar"
-								label={t("sidebar.calendar")}
-								icon={Calendar03Icon}
-								onClick={onOpenCalendar}
-							/>
-						) : null}
-						{sidebarVisibility.search ? (
+							) : null}
+							{sidebarVisibility.search ? (
+								<button
+									key="search"
+									type="button"
+									className="sidebarSearchBar"
+									data-sidebar-key="search"
+									data-kind="search"
+									aria-label={t("sidebar.search")}
+									title={
+										searchShortcutLabel
+											? `${t("sidebar.search")} (${searchShortcutLabel})`
+											: t("sidebar.search")
+									}
+									onClick={onOpenSearch}
+								>
+									<HugeiconsIcon
+										icon={SearchIcon}
+										size="var(--icon-sm)"
+										className="sidebarSearchBarIcon"
+										aria-hidden="true"
+									/>
+									<span className="sidebarSearchBarLabel">
+										{searchPlaceholder}
+									</span>
+									{searchShortcutLabel ? (
+										<span
+											className="sidebarSearchBarShortcut"
+											aria-hidden="true"
+										>
+											{searchShortcutLabel}
+										</span>
+									) : null}
+								</button>
+							) : null}
+							{sidebarVisibility.quickNote ? (
+								<SidebarActionButton
+									key="quickNote"
+									data-sidebar-key="quickNote"
+									kind="quick-note"
+									label={t("sidebar.quickNote")}
+									icon={NoteIcon}
+									onClick={onOpenQuickNote}
+								/>
+							) : null}
+							{sidebarVisibility.templates ? (
+								<SidebarActionButton
+									key="templates"
+									data-sidebar-key="templates"
+									kind="templates"
+									label={t("sidebar.templates")}
+									icon={ColorsIcon}
+									onClick={onCreateFromTemplate}
+								/>
+							) : null}
+							{sidebarVisibility.gitSync ? (
+								<SidebarActionButton
+									key="gitSync"
+									data-sidebar-key="gitSync"
+									kind="git-sync"
+									label={t("sidebar.gitSync")}
+									icon={Link01Icon}
+									onClick={onGitSyncNow}
+								/>
+							) : null}
+							{sidebarVisibility.periodNotes ? (
+								<div
+									key="periodNotes"
+									className="sidebarNavRow"
+									data-sidebar-key="periodNotes"
+									data-section="period-notes"
+								>
+									<SidebarActionButton
+										kind="daily-note"
+										label={t("sidebar.dailyNote")}
+										icon={CalendarAdd01Icon}
+										onClick={() => onOpenPeriodNote("day")}
+									/>
+									{isPeriodNoteEnabled("week", periodNotesEnabled) ? (
+										<SidebarActionButton
+											kind="weekly-note"
+											label={t("sidebar.weeklyNote")}
+											icon={CalendarAdd01Icon}
+											onClick={() => onOpenPeriodNote("week")}
+										/>
+									) : null}
+									{isPeriodNoteEnabled("month", periodNotesEnabled) ? (
+										<SidebarActionButton
+											kind="monthly-note"
+											label={t("sidebar.monthlyNote")}
+											icon={CalendarAdd01Icon}
+											onClick={() => onOpenPeriodNote("month")}
+										/>
+									) : null}
+									{isPeriodNoteEnabled("quarter", periodNotesEnabled) ? (
+										<SidebarActionButton
+											kind="quarterly-note"
+											label={t("sidebar.quarterlyNote")}
+											icon={CalendarAdd01Icon}
+											onClick={() => onOpenPeriodNote("quarter")}
+										/>
+									) : null}
+								</div>
+							) : null}
+						</OrderedSidebarItems>
+						<div
+							className="sidebarViewTabs"
+							role="tablist"
+							aria-label={`${t("sidebar.files")} / ${t("tags.header")}`}
+						>
 							<button
-								key="search"
 								type="button"
-								className="sidebarSearchBar"
-								data-sidebar-key="search"
-								data-kind="search"
-								aria-label={t("sidebar.search")}
-								title={
-									searchShortcutLabel
-										? `${t("sidebar.search")} (${searchShortcutLabel})`
-										: t("sidebar.search")
-								}
-								onClick={onOpenSearch}
+								className="sidebarViewTab"
+								id="sidebar-files-tab"
+								role="tab"
+								aria-selected={sidebarView === "files"}
+								aria-controls="sidebar-files-panel"
+								onClick={() => handleSidebarViewChange("files")}
 							>
 								<HugeiconsIcon
-									icon={SearchIcon}
+									icon={Folder01Icon}
 									size="var(--icon-sm)"
-									className="sidebarSearchBarIcon"
+									className="sidebarViewTabIcon"
 									aria-hidden="true"
 								/>
-								<span className="sidebarSearchBarLabel">
-									{searchPlaceholder}
+								<span className="sidebarViewTabLabel">
+									{t("sidebar.files")}
 								</span>
-								{searchShortcutLabel ? (
-									<span className="sidebarSearchBarShortcut" aria-hidden="true">
-										{searchShortcutLabel}
-									</span>
-								) : null}
 							</button>
-						) : null}
-						{sidebarVisibility.quickNote ? (
-							<SidebarActionButton
-								key="quickNote"
-								data-sidebar-key="quickNote"
-								kind="quick-note"
-								label={t("sidebar.quickNote")}
-								icon={NoteIcon}
-								onClick={onOpenQuickNote}
-							/>
-						) : null}
-						{sidebarVisibility.templates ? (
-							<SidebarActionButton
-								key="templates"
-								data-sidebar-key="templates"
-								kind="templates"
-								label={t("sidebar.templates")}
-								icon={ColorsIcon}
-								onClick={onCreateFromTemplate}
-							/>
-						) : null}
-						{sidebarVisibility.gitSync ? (
-							<SidebarActionButton
-								key="gitSync"
-								data-sidebar-key="gitSync"
-								kind="git-sync"
-								label={t("sidebar.gitSync")}
-								icon={Link01Icon}
-								onClick={onGitSyncNow}
-							/>
-						) : null}
-						{sidebarVisibility.periodNotes ? (
-							<div
-								key="periodNotes"
-								className="sidebarNavRow"
-								data-sidebar-key="periodNotes"
-								data-section="period-notes"
+							<button
+								type="button"
+								className="sidebarViewTab"
+								id="sidebar-tags-tab"
+								role="tab"
+								aria-selected={sidebarView === "tags"}
+								aria-controls="sidebar-tags-panel"
+								onClick={() => handleSidebarViewChange("tags")}
 							>
-								<SidebarActionButton
-									kind="daily-note"
-									label={t("sidebar.dailyNote")}
-									icon={CalendarAdd01Icon}
-									onClick={() => onOpenPeriodNote("day")}
+								<HugeiconsIcon
+									icon={Tag01Icon}
+									size="var(--icon-sm)"
+									className="sidebarViewTabIcon"
+									aria-hidden="true"
 								/>
-								{isPeriodNoteEnabled("week", periodNotesEnabled) ? (
-									<SidebarActionButton
-										kind="weekly-note"
-										label={t("sidebar.weeklyNote")}
-										icon={CalendarAdd01Icon}
-										onClick={() => onOpenPeriodNote("week")}
-									/>
-								) : null}
-								{isPeriodNoteEnabled("month", periodNotesEnabled) ? (
-									<SidebarActionButton
-										kind="monthly-note"
-										label={t("sidebar.monthlyNote")}
-										icon={CalendarAdd01Icon}
-										onClick={() => onOpenPeriodNote("month")}
-									/>
-								) : null}
-								{isPeriodNoteEnabled("quarter", periodNotesEnabled) ? (
-									<SidebarActionButton
-										kind="quarterly-note"
-										label={t("sidebar.quarterlyNote")}
-										icon={CalendarAdd01Icon}
-										onClick={() => onOpenPeriodNote("quarter")}
-									/>
-								) : null}
-							</div>
-						) : null}
-					</OrderedSidebarItems>
-					<div
-						className="sidebarViewTabs"
-						role="tablist"
-						aria-label={`${t("sidebar.files")} / ${t("tags.header")}`}
-					>
-						<button
-							type="button"
-							className="sidebarViewTab"
-							id="sidebar-files-tab"
-							role="tab"
-							aria-selected={sidebarView === "files"}
-							aria-controls="sidebar-files-panel"
-							onClick={() => handleSidebarViewChange("files")}
-						>
-							<HugeiconsIcon
-								icon={Folder01Icon}
-								size="var(--icon-sm)"
-								className="sidebarViewTabIcon"
-								aria-hidden="true"
-							/>
-							<span className="sidebarViewTabLabel">{t("sidebar.files")}</span>
-						</button>
-						<button
-							type="button"
-							className="sidebarViewTab"
-							id="sidebar-tags-tab"
-							role="tab"
-							aria-selected={sidebarView === "tags"}
-							aria-controls="sidebar-tags-panel"
-							onClick={() => handleSidebarViewChange("tags")}
-						>
-							<HugeiconsIcon
-								icon={Tag01Icon}
-								size="var(--icon-sm)"
-								className="sidebarViewTabIcon"
-								aria-hidden="true"
-							/>
-							<span className="sidebarViewTabLabel">{t("tags.header")}</span>
-						</button>
+								<span className="sidebarViewTabLabel">{t("tags.header")}</span>
+							</button>
+						</div>
 					</div>
-					<Activity mode={sidebarView === "files" ? "visible" : "hidden"}>
-						<section
-							className="sidebarStackItem sidebarStackItemGrow"
-							data-section="files"
-							id="sidebar-files-panel"
-							role="tabpanel"
-							aria-labelledby="sidebar-files-tab"
-						>
-							<div className="sidebarStackHeader sidebarFileTreeToolbar">
-								<div className="sidebarStackHeaderActions">
-									<label className="sidebarStackHeaderSortNative">
-										<span className="sr-only">{t("sidebar.sortNotes")}</span>
-										<HugeiconsIcon
-											icon={Sorting01Icon}
-											size="var(--icon-sm)"
-											className="sidebarStackHeaderSortIcon"
-											aria-hidden="true"
-										/>
-										<select
-											className="sidebarStackHeaderSortSelect"
-											value={fileTreeSort.sortMode}
-											title={`${t("sidebar.sortNotes")}: ${fileTreeSortLabel(fileTreeSort.sortMode)}`}
-											aria-label={t("sidebar.sortNotes")}
-											onChange={(event) => {
-												const nextSortMode = event.currentTarget.value;
-												if (!isFileTreeSortMode(nextSortMode)) return;
-												void fileTreeSort.setSortMode(nextSortMode);
+					<div className="sidebarViewContent">
+						<Activity mode={sidebarView === "files" ? "visible" : "hidden"}>
+							<section
+								className="sidebarStackItem sidebarStackItemGrow"
+								data-section="files"
+								id="sidebar-files-panel"
+								role="tabpanel"
+								aria-labelledby="sidebar-files-tab"
+							>
+								<div className="sidebarStackHeader sidebarFileTreeToolbar">
+									<div className="sidebarStackHeaderActions">
+										<label className="sidebarStackHeaderSortNative">
+											<span className="sr-only">{t("sidebar.sortNotes")}</span>
+											<HugeiconsIcon
+												icon={Sorting01Icon}
+												size="var(--icon-sm)"
+												className="sidebarStackHeaderSortIcon"
+												aria-hidden="true"
+											/>
+											<select
+												className="sidebarStackHeaderSortSelect"
+												value={fileTreeSort.sortMode}
+												title={`${t("sidebar.sortNotes")}: ${fileTreeSortLabel(fileTreeSort.sortMode)}`}
+												aria-label={t("sidebar.sortNotes")}
+												onChange={(event) => {
+													const nextSortMode = event.currentTarget.value;
+													if (!isFileTreeSortMode(nextSortMode)) return;
+													void fileTreeSort.setSortMode(nextSortMode);
+												}}
+											>
+												{FILE_TREE_SORT_MODES.map((mode) => (
+													<option key={mode} value={mode}>
+														{fileTreeSortLabel(mode)}
+													</option>
+												))}
+											</select>
+										</label>
+										<button
+											type="button"
+											className="sidebarStackHeaderAction"
+											title={t("sidebar.expandAllFolders")}
+											aria-label={t("sidebar.expandAllFolders")}
+											onClick={() => {
+												void onExpandAllDirs();
 											}}
 										>
-											{FILE_TREE_SORT_MODES.map((mode) => (
-												<option key={mode} value={mode}>
-													{fileTreeSortLabel(mode)}
-												</option>
-											))}
-										</select>
-									</label>
-									<button
-										type="button"
-										className="sidebarStackHeaderAction"
-										title={t("sidebar.expandAllFolders")}
-										aria-label={t("sidebar.expandAllFolders")}
-										onClick={() => {
-											void onExpandAllDirs();
-										}}
-									>
-										<HugeiconsIcon
-											icon={ExpandParagraphIcon}
-											size="var(--icon-sm)"
-										/>
-									</button>
-									<button
-										type="button"
-										className="sidebarStackHeaderAction"
-										title={t("sidebar.collapseAllFolders")}
-										aria-label={t("sidebar.collapseAllFolders")}
-										onClick={onCollapseAllDirs}
-									>
-										<HugeiconsIcon
-											icon={ArrowShrinkIcon}
-											size="var(--icon-sm)"
-										/>
-									</button>
+											<HugeiconsIcon
+												icon={ExpandParagraphIcon}
+												size="var(--icon-sm)"
+											/>
+										</button>
+										<button
+											type="button"
+											className="sidebarStackHeaderAction"
+											title={t("sidebar.collapseAllFolders")}
+											aria-label={t("sidebar.collapseAllFolders")}
+											onClick={onCollapseAllDirs}
+										>
+											<HugeiconsIcon
+												icon={ArrowShrinkIcon}
+												size="var(--icon-sm)"
+											/>
+										</button>
+									</div>
 								</div>
-							</div>
-							<FileTreePane
-								rootEntries={folioMode ? folioRootEntries : rootEntries}
-								childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
-								expandedDirs={expandedDirs}
-								activeFilePath={folioMode ? null : activeFilePath}
-								activeDirPath={activeDirPath}
-								onToggleDir={onToggleDir}
-								onLoadDir={onLoadDir}
-								onSelectDir={folioMode ? handleSelectFolioFolder : onSelectDir}
-								onOpenFile={onOpenFile}
-								onPrefetchFile={onPrefetchFile}
-								onNewFileInDir={onNewFileInDir}
-								onCreateFromTemplateInDir={onCreateFromTemplateInDir}
-								onImportFilesInDir={onImportFilesInDir}
-								onImportFolderInDir={onImportFolderInDir}
-								onImportPathsInDir={onImportPathsInDir}
-								onRequestCreateFolder={onRequestCreateFolder}
-								onDuplicateFile={onDuplicateFile}
-								onDeletePath={onDeletePath}
-								renamingPath={renamingPath}
-								onStartRename={handleStartRename}
-								onCancelRename={handleCancelRename}
-								onCommitFileRename={handleCommitFileRename}
-								onCommitDirRename={handleCommitDirRename}
-								onMovePath={onMovePath}
-								pinnedFiles={folioMode ? [] : pinnedFiles}
-								onTogglePinnedFile={togglePinnedFile}
-							/>
-						</section>
-					</Activity>
-					<Activity mode={sidebarView === "tags" ? "visible" : "hidden"}>
-						<section
-							className="sidebarStackItem sidebarStackItemGrow"
-							data-section="tags"
-							id="sidebar-tags-panel"
-							role="tabpanel"
-							aria-labelledby="sidebar-tags-tab"
-						>
-							<TagsPane
-								tags={tags}
-								people={people}
-								onSelectTag={handleSelectTag}
-								onSelectPerson={handleSelectPerson}
-								beautifulTags={beautifulTags}
-								tagAppearance={tagAppearance}
-								tagsError={tagsError}
-								onChangeTagIcon={handleChangeTagIcon}
-							/>
-						</section>
-					</Activity>
+								<FileTreePane
+									rootEntries={folioMode ? folioRootEntries : rootEntries}
+									childrenByDir={folioMode ? folioChildrenByDir : childrenByDir}
+									expandedDirs={expandedDirs}
+									activeFilePath={folioMode ? null : activeFilePath}
+									activeDirPath={activeDirPath}
+									onToggleDir={onToggleDir}
+									onLoadDir={onLoadDir}
+									onSelectDir={
+										folioMode ? handleSelectFolioFolder : onSelectDir
+									}
+									onOpenFile={onOpenFile}
+									onPrefetchFile={onPrefetchFile}
+									onNewFileInDir={onNewFileInDir}
+									onCreateFromTemplateInDir={onCreateFromTemplateInDir}
+									onImportFilesInDir={onImportFilesInDir}
+									onImportFolderInDir={onImportFolderInDir}
+									onImportPathsInDir={onImportPathsInDir}
+									onRequestCreateFolder={onRequestCreateFolder}
+									onDuplicateFile={onDuplicateFile}
+									onDeletePath={onDeletePath}
+									renamingPath={renamingPath}
+									onStartRename={handleStartRename}
+									onCancelRename={handleCancelRename}
+									onCommitFileRename={handleCommitFileRename}
+									onCommitDirRename={handleCommitDirRename}
+									onMovePath={onMovePath}
+									pinnedFiles={folioMode ? [] : pinnedFiles}
+									onTogglePinnedFile={togglePinnedFile}
+								/>
+							</section>
+						</Activity>
+						<Activity mode={sidebarView === "tags" ? "visible" : "hidden"}>
+							<section
+								className="sidebarStackItem sidebarStackItemGrow"
+								data-section="tags"
+								id="sidebar-tags-panel"
+								role="tabpanel"
+								aria-labelledby="sidebar-tags-tab"
+							>
+								<TagsPane
+									tags={tags}
+									people={people}
+									onSelectTag={handleSelectTag}
+									onSelectPerson={handleSelectPerson}
+									beautifulTags={beautifulTags}
+									tagAppearance={tagAppearance}
+									tagsError={tagsError}
+									onChangeTagIcon={handleChangeTagIcon}
+								/>
+							</section>
+						</Activity>
+					</div>
 				</div>
 			</div>
 		</>

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -411,7 +411,8 @@ function TreeEntries({
 	const listRef = useCallback((element: HTMLUListElement | null) => {
 		setListElement(element);
 		setScrollElement(
-			element?.closest<HTMLElement>(".sidebarViewContent") ??
+			element?.closest<HTMLElement>(".sidebarViewPanel") ??
+				element?.closest<HTMLElement>(".sidebarViewContent") ??
 				element?.closest<HTMLElement>(".sidebarSectionContent") ??
 				element?.parentElement ??
 				null,
@@ -431,7 +432,10 @@ function TreeEntries({
 		getScrollElement: () => scrollElement,
 		getItemKey: (index) => virtualRows[index]?.id ?? index,
 		overscan: 4,
-		scrollMargin: listElement?.offsetTop ?? 0,
+		scrollMargin:
+			listElement && scrollElement
+				? listElement.offsetTop - scrollElement.offsetTop
+				: (listElement?.offsetTop ?? 0),
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 	const visiblePreviewPathKey = useMemo(() => {

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -411,7 +411,8 @@ function TreeEntries({
 	const listRef = useCallback((element: HTMLUListElement | null) => {
 		setListElement(element);
 		setScrollElement(
-			element?.closest<HTMLElement>(".sidebarSectionContent") ??
+			element?.closest<HTMLElement>(".sidebarViewContent") ??
+				element?.closest<HTMLElement>(".sidebarSectionContent") ??
 				element?.parentElement ??
 				null,
 		);

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "Schnelle Notiz",
 		"templates": "Vorlagen",
 		"gitSync": "Git-Synchronisierung",
-		"notes": "Notizen",
-		"collapseNotes": "Notizen einklappen",
-		"expandNotes": "Notizen ausklappen",
+		"files": "Dateien",
 		"sortNotes": "Notizen sortieren",
 		"sort": "Sortieren",
 		"expandAllFolders": "Alle Ordner ausklappen",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"collapse": "Tags einklappen",
-		"expand": "Tags ausklappen",
 		"people": "Personen",
 		"showLess": "Weniger anzeigen",
 		"showMore": "{{count}} weitere anzeigen"

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -20,9 +20,7 @@
 		"quickNote": "Quick Note",
 		"templates": "Templates",
 		"gitSync": "Git Sync",
-		"notes": "Notes",
-		"collapseNotes": "Collapse Notes",
-		"expandNotes": "Expand Notes",
+		"files": "Files",
 		"sortNotes": "Sort notes",
 		"sort": "Sort",
 		"expandAllFolders": "Expand all folders",
@@ -56,8 +54,6 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"collapse": "Collapse Tags",
-		"expand": "Expand Tags",
 		"people": "People",
 		"showLess": "Show less",
 		"showMore": "Show {{count}} more"

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "Nota rápida",
 		"templates": "Plantillas",
 		"gitSync": "Sincronización con Git",
-		"notes": "Notas",
-		"collapseNotes": "Contraer notas",
-		"expandNotes": "Expandir notas",
+		"files": "Archivos",
 		"sortNotes": "Ordenar notas",
 		"sort": "Ordenar",
 		"expandAllFolders": "Expandir todas las carpetas",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "Etiquetas",
-		"collapse": "Contraer etiquetas",
-		"expand": "Expandir etiquetas",
 		"people": "Personas",
 		"showLess": "Mostrar menos",
 		"showMore": "Mostrar {{count}} más"

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -20,9 +20,7 @@
 		"quickNote": "Note rapide",
 		"templates": "Modèles",
 		"gitSync": "Synchronisation Git",
-		"notes": "Notes",
-		"collapseNotes": "Réduire les notes",
-		"expandNotes": "Développer les notes",
+		"files": "Fichiers",
 		"sortNotes": "Trier les notes",
 		"sort": "Trier",
 		"expandAllFolders": "Développer tous les dossiers",
@@ -56,8 +54,6 @@
 	},
 	"tags": {
 		"header": "Étiquettes",
-		"collapse": "Réduire les étiquettes",
-		"expand": "Développer les étiquettes",
 		"people": "Personnes",
 		"showLess": "Afficher moins",
 		"showMore": "Afficher {{count}} de plus"

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "クイックノート",
 		"templates": "テンプレート",
 		"gitSync": "Git 同期",
-		"notes": "ノート",
-		"collapseNotes": "ノートを折りたたむ",
-		"expandNotes": "ノートを展開",
+		"files": "ファイル",
 		"sortNotes": "ノートを並べ替え",
 		"sort": "並べ替え",
 		"expandAllFolders": "すべてのフォルダを展開",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "タグ",
-		"collapse": "タグを折りたたむ",
-		"expand": "タグを展開",
 		"people": "人物",
 		"showLess": "表示を減らす",
 		"showMore": "あと {{count}} 件表示"

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "빠른 노트",
 		"templates": "템플릿",
 		"gitSync": "Git 동기화",
-		"notes": "노트",
-		"collapseNotes": "노트 접기",
-		"expandNotes": "노트 펼치기",
+		"files": "파일",
 		"sortNotes": "노트 정렬",
 		"sort": "정렬",
 		"expandAllFolders": "모든 폴더 펼치기",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "태그",
-		"collapse": "태그 접기",
-		"expand": "태그 펼치기",
 		"people": "사람",
 		"showLess": "간략히",
 		"showMore": "{{count}}개 더 보기"

--- a/src/i18n/locales/pl/shell.json
+++ b/src/i18n/locales/pl/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "Szybka notatka",
 		"templates": "Szablony",
 		"gitSync": "Synchronizacja Git",
-		"notes": "Notatki",
-		"collapseNotes": "Zwiń notatki",
-		"expandNotes": "Rozwiń notatki",
+		"files": "Pliki",
 		"sortNotes": "Sortuj",
 		"sort": "Sortuj",
 		"expandAllFolders": "Rozwiń wszystkie foldery",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "Tagi",
-		"collapse": "Zwiń tagi",
-		"expand": "Rozwiń tagi",
 		"people": "Ludzie",
 		"showLess": "Pokaż mniej",
 		"showMore": "Pokaż {{count}} więcej"

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -18,9 +18,7 @@
 		"quickNote": "Nota rápida",
 		"templates": "Modelos",
 		"gitSync": "Sincronização Git",
-		"notes": "Notas",
-		"collapseNotes": "Recolher notas",
-		"expandNotes": "Expandir notas",
+		"files": "Arquivos",
 		"sortNotes": "Ordenar notas",
 		"sort": "Ordenar",
 		"expandAllFolders": "Expandir todas as pastas",
@@ -54,8 +52,6 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"collapse": "Recolher tags",
-		"expand": "Expandir tags",
 		"people": "Pessoas",
 		"showLess": "Mostrar menos",
 		"showMore": "Mostrar mais {{count}}"

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -239,13 +239,13 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	gap: 2px;
+	gap: 1px;
 	width: max-content;
 	max-width: calc(100% - 32px);
 	margin: 10px auto 6px;
-	padding: 3px;
-	border-radius: var(--radius-lg);
-	background: color-mix(in srgb, var(--bg-secondary) 62%, transparent);
+	padding: 2px;
+	border-radius: var(--radius-8);
+	background: color-mix(in srgb, var(--bg-secondary) 52%, transparent);
 	flex-shrink: 0;
 }
 
@@ -254,20 +254,20 @@ button.sidebarViewTab {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: 6px;
+	gap: 5px;
 	min-width: 0;
-	height: 28px;
-	padding: 0 10px;
+	height: 26px;
+	padding: 0 9px;
 	border: 0;
-	border-radius: var(--radius-md);
+	border-radius: var(--radius-6);
 	background: transparent;
 	color: var(--text-tertiary);
 	font-size: var(--text-xs);
 	font-weight: var(--font-medium);
-	line-height: 1;
+	line-height: 1.25;
 	cursor: pointer;
-	transition: color var(--transition-fast), background-color
-		var(--transition-fast), box-shadow var(--transition-fast);
+	transition: color 140ms ease, background-color 140ms ease, box-shadow 140ms
+		ease;
 }
 
 .sidebarViewTabIcon {
@@ -305,7 +305,7 @@ button.sidebarViewTab[aria-selected="true"],
 button.sidebarViewTab[aria-selected="true"]:hover,
 button.sidebarViewTab[aria-selected="true"]:active {
 	background: var(--bg-primary);
-	box-shadow: var(--shadow-sm);
+	box-shadow: 0 1px 2px color-mix(in srgb, black 7%, transparent);
 	color: var(--text-primary);
 	font-weight: var(--font-semibold);
 }

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -198,8 +198,7 @@
 .sidebarSectionContent {
 	flex: 1;
 	min-height: 0;
-	overflow-y: auto;
-	overflow-x: hidden;
+	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 	position: relative;
@@ -209,15 +208,30 @@
 	padding-bottom: var(--space-2);
 }
 
-.sidebarOrderedContent {
+.sidebarTopNavigation {
+	flex: 0 0 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
 	gap: 2px;
 	padding-top: 10px;
 }
 
-.sidebarOrderedContent > .sidebarQuickActionBtn,
-.sidebarOrderedContent > .sidebarNavRow .sidebarQuickActionBtn {
+.sidebarTopNavigation > .sidebarQuickActionBtn,
+.sidebarTopNavigation > .sidebarNavRow .sidebarQuickActionBtn {
 	width: calc(100% - 16px);
 	margin-inline: 8px;
+}
+
+.sidebarViewContent {
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 0;
+	overflow-y: auto;
+	overflow-x: hidden;
+	scrollbar-gutter: stable;
+	display: flex;
+	flex-direction: column;
 }
 
 .sidebarSectionContent * {
@@ -320,7 +334,7 @@ button.sidebarViewTab:focus-visible {
 }
 
 .sidebarStackHeader.sidebarFileTreeToolbar {
-	justify-content: center;
+	justify-content: flex-end;
 }
 
 .sidebarStackHeader {

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -235,9 +235,92 @@
 	outline-offset: 2px;
 }
 
-.sidebarStack {
+.sidebarViewTabs {
 	display: flex;
-	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 2px;
+	width: max-content;
+	max-width: calc(100% - 32px);
+	margin: 10px auto 6px;
+	padding: 3px;
+	border-radius: var(--radius-lg);
+	background: color-mix(in srgb, var(--bg-secondary) 62%, transparent);
+	flex-shrink: 0;
+}
+
+button.sidebarViewTab {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	min-width: 0;
+	height: 28px;
+	padding: 0 10px;
+	border: 0;
+	border-radius: var(--radius-md);
+	background: transparent;
+	color: var(--text-tertiary);
+	font-size: var(--text-xs);
+	font-weight: var(--font-medium);
+	line-height: 1;
+	cursor: pointer;
+	transition: color var(--transition-fast), background-color
+		var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.sidebarViewTabIcon {
+	flex: 0 0 var(--icon-sm);
+	opacity: 0.64;
+}
+
+.sidebarViewTabLabel {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	line-height: 1.25;
+}
+
+button.sidebarViewTab:not([aria-selected="true"]) .sidebarViewTabLabel {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+button.sidebarViewTab:hover,
+button.sidebarViewTab:active {
+	background: color-mix(in srgb, var(--bg-hover) 86%, transparent);
+	color: var(--text-primary);
+}
+
+button.sidebarViewTab[aria-selected="true"],
+button.sidebarViewTab[aria-selected="true"]:hover,
+button.sidebarViewTab[aria-selected="true"]:active {
+	background: var(--bg-primary);
+	box-shadow: var(--shadow-sm);
+	color: var(--text-primary);
+	font-weight: var(--font-semibold);
+}
+
+button.sidebarViewTab[aria-selected="true"] .sidebarViewTabIcon {
+	opacity: 1;
+}
+
+button.sidebarViewTab:focus-visible {
+	outline: 2px solid var(--border-focus);
+	outline-offset: 1px;
+}
+
+.sidebarStackHeader.sidebarFileTreeToolbar {
+	justify-content: center;
 }
 
 .sidebarStackHeader {
@@ -255,40 +338,11 @@
 	flex-shrink: 0;
 }
 
-.sidebarStackHeaderToggle,
 .tagsHeaderTitle {
 	font-size: var(--text-sm);
 	font-weight: var(--font-normal);
 	line-height: 1.3;
 	letter-spacing: normal;
-}
-
-.sidebarStackHeaderToggle {
-	appearance: none;
-	background: transparent;
-	border: 0;
-	margin: 0;
-	flex: 1 1 auto;
-	min-width: 0;
-	padding: 0;
-	cursor: pointer;
-	text-align: left;
-	font: inherit;
-	color: var(--text-tertiary);
-	transition: color var(--transition-fast);
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	justify-content: flex-start;
-}
-
-.sidebarStackHeaderToggle:hover,
-.sidebarStackHeaderToggle:focus-visible,
-.sidebarStackHeaderToggle:active {
-	background: transparent;
-	box-shadow: none;
-	color: var(--text-secondary);
-	outline: none;
 }
 
 .sidebarStackHeaderActions {

--- a/src/styles/app/04-sidebar.css
+++ b/src/styles/app/04-sidebar.css
@@ -227,6 +227,15 @@
 	flex: 1 1 auto;
 	min-width: 0;
 	min-height: 0;
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+}
+
+.sidebarViewContent > .sidebarViewPanel {
+	flex: 1 1 auto;
+	min-width: 0;
+	min-height: 0;
 	overflow-y: auto;
 	overflow-x: hidden;
 	scrollbar-gutter: stable;

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -4,15 +4,7 @@
 .tagsPane {
 	display: flex;
 	flex-direction: column;
-	padding: var(--space-2) 12px;
-}
-
-.sidebarSectionContent .tagsPane {
-	border-top: none;
-}
-
-.sidebarStackItem .tagsPane {
-	padding: 0 8px 0;
+	padding: 4px 8px var(--space-2);
 }
 
 .tagsHeader {
@@ -33,38 +25,6 @@
 	align-items: center;
 	gap: 6px;
 	color: var(--text-tertiary);
-}
-
-.tagsHeaderTitle svg {
-	flex-shrink: 0;
-	color: currentcolor;
-}
-
-button.tagsHeaderTitle {
-	appearance: none;
-	background: transparent;
-	border: 0;
-	margin: 0;
-	padding: 0;
-	flex: 1;
-	cursor: pointer;
-	text-align: left;
-	font-family: inherit;
-	color: var(--text-tertiary);
-	transition: color var(--transition-fast);
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	justify-content: flex-start;
-}
-
-button.tagsHeaderTitle:hover,
-button.tagsHeaderTitle:focus-visible,
-button.tagsHeaderTitle:active {
-	background: transparent;
-	box-shadow: none;
-	color: var(--text-secondary);
-	outline: none;
 }
 
 .tagsList {


### PR DESCRIPTION
Closes


## Description

Added a Files/Tags tabbed sidebar layout with stable navigation and independent scrolling.

- Replaced the stacked Files and Tags sections with a compact icon tab toggle.
- Kept only the active tab label visible and preserved accessible labels for inactive tabs.
- Isolated top sidebar navigation from the scrollable Files/Tags content so expanding folders or showing all tags does not move it.
- Removed obsolete collapse state, props, styles, translations, and duplicated People markup.

## Screenshots

No screenshots captured in this environment; the visual changes can be reviewed in the app.

## Docs

No documentation changes are needed; the UI behavior is self-explanatory.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it is really helpful.

- [ ] Documented what is new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Replace the stacked Files and Tags sidebar sections with accessible tabbed views and independently scrolling content.

New Features:
- Add accessible Files and Tags tabs to the sidebar with compact icon-based navigation and active-tab labels.

Bug Fixes:
- Keep sidebar navigation fixed while Files or Tags content scrolls, folders expand, or additional tags are displayed.
- Refresh tags when the Tags view is selected.

Enhancements:
- Remove obsolete Files and Tags collapse behavior and consolidate duplicated People rendering.
- Update file-tree scrolling and virtualization to operate within the active sidebar view.

Chores:
- Remove obsolete sidebar styles, translations, and component properties related to section collapse state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the stacked Files and Tags sidebar sections with tabbed views so the top navigation stays fixed while content scrolls independently.

- The sidebar now shows compact Files/Tags icon tabs; only the active tab's label is visible, and inactive tabs keep accessible labels.
- Expanding folders or showing all tags no longer moves the top navigation.
- Tags refresh now happens when switching to the Tags tab instead of when expanding the section.
- Removed obsolete collapse state, props, styles, translations, and duplicated People markup.

<sup>Written for commit cdf5822649e5cf9611e25ace8e960cfa8f27aff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Files and Tags tab navigation in the sidebar.
  - Files view displays documents, while Tags view provides tag and people browsing.
  - People are now shown directly in the Tags view when available.
  - Tags refresh when switching to the Tags view, and Files returns to the full document scope.

- **Style**
  - Updated sidebar layout, scrolling, tab states, focus, and hover styling for improved navigation.

- **Localization**
  - Updated sidebar labels across supported languages to use “Files” terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->