### PR TITLE
Show all sidebar tags by default

### DIFF
--- a/src/components/TagsPane.tsx
+++ b/src/components/TagsPane.tsx
@@ -1,13 +1,7 @@
 import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { Tag01Icon } from "@hugeicons/core-free-icons";
 import { m } from "motion/react";
-import {
-	type CSSProperties,
-	memo,
-	useCallback,
-	useMemo,
-	useState,
-} from "react";
+import { type CSSProperties, memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
 	type TagIconOverrides,
@@ -97,7 +91,6 @@ export const TagsPane = memo(function TagsPane({
 			onSelectPerson(handle.startsWith("@") ? handle : `@${handle}`),
 		[onSelectPerson],
 	);
-	const [tagsExpanded, setTagsExpanded] = useState(false);
 	const rows = buildTagTreeRows(tags);
 	const peopleRows = buildPeopleRows(people);
 	const tagIconOverrides = useMemo(
@@ -105,9 +98,6 @@ export const TagsPane = memo(function TagsPane({
 		[tagAppearance],
 	);
 
-	const TAG_LIMIT = 5;
-	const hasMoreTags = rows.length > TAG_LIMIT;
-	const visibleRows = tagsExpanded ? rows : rows.slice(0, TAG_LIMIT);
 	const peopleSection = peopleRows.length ? (
 		<>
 			<div className="tagsHeader tagsSubheader">
@@ -157,7 +147,7 @@ export const TagsPane = memo(function TagsPane({
 							hidden: {},
 						}}
 					>
-						{visibleRows.map((tag) => {
+						{rows.map((tag) => {
 							return (
 								<m.li key={tag.tag} className="tagsItem">
 									<m.div
@@ -192,17 +182,6 @@ export const TagsPane = memo(function TagsPane({
 							);
 						})}
 					</m.ul>
-					{hasMoreTags ? (
-						<button
-							type="button"
-							className="tagsToggle"
-							onClick={() => setTagsExpanded((v) => !v)}
-						>
-							{tagsExpanded
-								? t("tags.showLess")
-								: t("tags.showMore", { count: rows.length - TAG_LIMIT })}
-						</button>
-					) : null}
 					{peopleSection}
 				</>
 			) : peopleSection ? (

--- a/src/i18n/locales/de/shell.json
+++ b/src/i18n/locales/de/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"people": "Personen",
-		"showLess": "Weniger anzeigen",
-		"showMore": "{{count}} weitere anzeigen"
+		"people": "Personen"
 	},
 	"fileTree": {
 		"open": "Öffnen",

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -54,9 +54,7 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"people": "People",
-		"showLess": "Show less",
-		"showMore": "Show {{count}} more"
+		"people": "People"
 	},
 	"fileTree": {
 		"open": "Open",

--- a/src/i18n/locales/es/shell.json
+++ b/src/i18n/locales/es/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "Etiquetas",
-		"people": "Personas",
-		"showLess": "Mostrar menos",
-		"showMore": "Mostrar {{count}} más"
+		"people": "Personas"
 	},
 	"fileTree": {
 		"open": "Abrir",

--- a/src/i18n/locales/fr/shell.json
+++ b/src/i18n/locales/fr/shell.json
@@ -54,9 +54,7 @@
 	},
 	"tags": {
 		"header": "Étiquettes",
-		"people": "Personnes",
-		"showLess": "Afficher moins",
-		"showMore": "Afficher {{count}} de plus"
+		"people": "Personnes"
 	},
 	"fileTree": {
 		"open": "Ouvrir",

--- a/src/i18n/locales/ja/shell.json
+++ b/src/i18n/locales/ja/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "タグ",
-		"people": "人物",
-		"showLess": "表示を減らす",
-		"showMore": "あと {{count}} 件表示"
+		"people": "人物"
 	},
 	"fileTree": {
 		"open": "開く",

--- a/src/i18n/locales/ko/shell.json
+++ b/src/i18n/locales/ko/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "태그",
-		"people": "사람",
-		"showLess": "간략히",
-		"showMore": "{{count}}개 더 보기"
+		"people": "사람"
 	},
 	"fileTree": {
 		"open": "열기",

--- a/src/i18n/locales/pl/shell.json
+++ b/src/i18n/locales/pl/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "Tagi",
-		"people": "Ludzie",
-		"showLess": "Pokaż mniej",
-		"showMore": "Pokaż {{count}} więcej"
+		"people": "Ludzie"
 	},
 	"fileTree": {
 		"open": "Otwórz",

--- a/src/i18n/locales/pt-BR/shell.json
+++ b/src/i18n/locales/pt-BR/shell.json
@@ -52,9 +52,7 @@
 	},
 	"tags": {
 		"header": "Tags",
-		"people": "Pessoas",
-		"showLess": "Mostrar menos",
-		"showMore": "Mostrar mais {{count}}"
+		"people": "Pessoas"
 	},
 	"fileTree": {
 		"open": "Abrir",

--- a/src/styles/app/13-tags.css
+++ b/src/styles/app/13-tags.css
@@ -283,14 +283,6 @@ button.tagsIconPicker {
 	white-space: nowrap;
 }
 
-.tagsToggle {
-	padding: 4px 18px;
-	font-size: var(--text-xs);
-	color: var(--text-tertiary);
-	cursor: pointer;
-	background: transparent;
-}
-
 .tagsEmpty {
 	padding: var(--space-2) var(--space-3) var(--space-3);
 	color: var(--text-tertiary);


### PR DESCRIPTION
Closes


## Description

Remove the sidebar tag-list expansion toggle so every tag is visible all the time.

- Remove the five-tag limit and show more/show less control.
- Keep the existing tag list rendering and scrolling behavior.
- Remove the unused toggle styles and translations.


## Screenshots

No screenshot included.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it is really helpful.

- [ ] Documented what is new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Show the complete sidebar tag list without requiring users to expand it.

Enhancements:
- Display all sidebar tags by default while preserving the existing list rendering and scrolling behavior.
- Remove the obsolete tag expansion control, styling, and localized toggle translations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the sidebar tag-list expansion toggle so every tag is visible by default instead of only the first five.

<sup>Written for commit 8b5cdc8dbe222fdb54256e3a13af2f8294c5886e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

