### PR TITLE
Fix initial file tree virtualization offset

### DIFF
--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -434,8 +434,10 @@ function TreeEntries({
 		overscan: 4,
 		scrollMargin:
 			listElement && scrollElement
-				? listElement.offsetTop - scrollElement.offsetTop
-				: (listElement?.offsetTop ?? 0),
+				? listElement.getBoundingClientRect().top -
+					scrollElement.getBoundingClientRect().top +
+					scrollElement.scrollTop
+				: 0,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 	const visiblePreviewPathKey = useMemo(() => {

--- a/src/components/filetree/FileTreePane.tsx
+++ b/src/components/filetree/FileTreePane.tsx
@@ -406,17 +406,22 @@ function TreeEntries({
 			sortMode,
 		],
 	);
-	const [listElement, setListElement] = useState<HTMLUListElement | null>(null);
 	const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+	const scrollMarginRef = useRef(0);
 	const listRef = useCallback((element: HTMLUListElement | null) => {
-		setListElement(element);
-		setScrollElement(
+		const nextScrollElement =
 			element?.closest<HTMLElement>(".sidebarViewPanel") ??
-				element?.closest<HTMLElement>(".sidebarViewContent") ??
-				element?.closest<HTMLElement>(".sidebarSectionContent") ??
-				element?.parentElement ??
-				null,
-		);
+			element?.closest<HTMLElement>(".sidebarViewContent") ??
+			element?.closest<HTMLElement>(".sidebarSectionContent") ??
+			element?.parentElement ??
+			null;
+		scrollMarginRef.current =
+			element && nextScrollElement
+				? element.getBoundingClientRect().top -
+					nextScrollElement.getBoundingClientRect().top +
+					nextScrollElement.scrollTop
+				: 0;
+		setScrollElement(nextScrollElement);
 	}, []);
 	const rowVirtualizer = useVirtualizer<HTMLElement, HTMLLIElement>({
 		count: virtualRows.length,
@@ -432,12 +437,7 @@ function TreeEntries({
 		getScrollElement: () => scrollElement,
 		getItemKey: (index) => virtualRows[index]?.id ?? index,
 		overscan: 4,
-		scrollMargin:
-			listElement && scrollElement
-				? listElement.getBoundingClientRect().top -
-					scrollElement.getBoundingClientRect().top +
-					scrollElement.scrollTop
-				: 0,
+		scrollMargin: scrollMarginRef.current,
 	});
 	const virtualItems = rowVirtualizer.getVirtualItems();
 	const visiblePreviewPathKey = useMemo(() => {


### PR DESCRIPTION
Closes


## Description

Fixes initial file-tree virtualization positioning by calculating the scroll margin from viewport-relative bounds plus the scroll container's scroll position. This keeps virtual rows aligned when the file tree is nested or already scrolled during initial rendering.

- Replaces offsetTop subtraction with a getBoundingClientRect() delta plus scrollTop.
- Keeps the scroll margin at zero until both elements are available.
- No issue link was provided.


## Docs

No documentation changes are needed for this internal positioning fix.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Bug Fixes:
- Fix the initial file-tree virtualization offset so rows remain aligned when the tree is nested or the scroll container is already scrolled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the initial file-tree virtualization offset so virtual rows stay aligned when the tree is nested or already scrolled during first render.

- Calculates the scroll margin from viewport-relative bounds plus the scroll container's scroll position instead of `offsetTop` subtraction.
- Keeps the scroll margin at zero until both the list and scroll elements are available.

<sup>Written for commit 737e67ff95ffe2065f725aa36008a6a3c254eb5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

