### PR TITLE
Fix native File and Help menu entries

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -867,14 +867,6 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
         ],
     )?;
 
-    let help_getting_started = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "help.getting_started",
-        space_open,
-        None,
-    )?;
-    let help_welcome_note = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "help.welcome_note",
-        space_open,
-        None,
-    )?;
     let help_shortcuts = menu_item_with_shortcut(app, menu_labels, menu_shortcuts, "help.shortcuts",
         true,
         None,
@@ -899,9 +891,6 @@ fn build_main_menu<R: tauri::Runtime, M: Manager<R>>(
             .item(&PredefinedMenuItem::about(app, None, None)?)
             .separator();
         let builder = builder
-            .item(&help_getting_started)
-            .item(&help_welcome_note)
-            .separator()
             .item(&help_shortcuts)
             .separator();
         let mut builder = builder;

--- a/src/i18n/locales/en/commands.json
+++ b/src/i18n/locales/en/commands.json
@@ -350,6 +350,10 @@
 			"label": "Previous Tab",
 			"description": "Move to the previous tab."
 		},
+		"print-note": {
+			"label": "Print Note",
+			"description": "Print the current note."
+		},
 		"quick-open": {
 			"label": "Quick Open",
 			"description": "Open the command palette directly in file mode."

--- a/src/shared/appCommandManifest.json
+++ b/src/shared/appCommandManifest.json
@@ -1017,6 +1017,17 @@
 			"allowInEditable": false,
 			"commandPalette": true
 		},
+		"print-note": {
+			"id": "print-note",
+			"label": "Print Note",
+			"description": "Print the current note.",
+			"category": "file",
+			"context": "editor",
+			"defaultBinding": null,
+			"allowInEditable": true,
+			"commandPalette": true,
+			"menuId": "file.print_note"
+		},
 		"quick-open": {
 			"id": "quick-open",
 			"label": "Quick Open",


### PR DESCRIPTION
Closes

## Description

This PR fixes the native macOS menu entries.

- Adds the missing `print-note` command manifest entry and English label so File > Print Note no longer displays `file.print_note`.
- Removes Getting Started and Welcome Note from the Help submenu without removing their command definitions.
- No other command behavior changes.

## Docs

No documentation changes are needed for these native menu adjustments.

## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Bug Fixes:
- Fix native macOS File and Help menu entries by adding the missing Print Note command label and removing Getting Started and Welcome Note from the Help submenu.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native macOS menu entries so File > Print Note shows the correct label and the Help menu no longer lists Getting Started and Welcome Note.

- Adds the missing `print-note` command manifest entry and English label.
- Keeps the Getting Started and Welcome Note command definitions intact.
- No other command behavior changes.

<sup>Written for commit cfd0e2f1ba8048486c88e2e703daa654424362a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

