### PR TITLE
Add row and column move to markdown table menus

### DIFF
--- a/src/components/editor/NoteInlineEditor.test.tsx
+++ b/src/components/editor/NoteInlineEditor.test.tsx
@@ -132,14 +132,21 @@ vi.mock("@tiptap/react", () => ({
 			<p>Outside table</p>
 		</div>
 	),
-	useEditorState: ({
-		selector,
-	}: {
-		selector: (snapshot: {
-			editor: unknown;
-			transactionNumber: number;
-		}) => unknown;
-	}) => selector({ editor: null, transactionNumber: 0 }),
+	useEditorState: () => ({
+		target: {
+			tablePos: 1,
+			rowIndex: 1,
+			columnIndex: 0,
+		},
+		capabilities: {
+			canDeleteRow: true,
+			canDeleteColumn: true,
+			canMoveRowUp: true,
+			canMoveRowDown: true,
+			canMoveColumnLeft: true,
+			canMoveColumnRight: true,
+		},
+	}),
 }));
 
 vi.mock("motion/react", () => ({
@@ -454,7 +461,7 @@ describe("NoteInlineEditor table controls", () => {
 			?.closest('[data-testid="dropdown-menu"]');
 		const addRowBelow = Array.from(
 			rowMenu?.querySelectorAll('[data-slot="dropdown-menu-item"]') ?? [],
-		).find((element) => element.textContent === "Add row below") as
+		).find((element) => element.textContent === "tableControls.addRowBelow") as
 			| HTMLButtonElement
 			| undefined;
 		expect(addRowBelow).toBeTruthy();
@@ -476,9 +483,9 @@ describe("NoteInlineEditor table controls", () => {
 			?.closest('[data-testid="dropdown-menu"]');
 		const addColumnRight = Array.from(
 			columnMenu?.querySelectorAll('[data-slot="dropdown-menu-item"]') ?? [],
-		).find((element) => element.textContent === "Add column right") as
-			| HTMLButtonElement
-			| undefined;
+		).find(
+			(element) => element.textContent === "tableControls.addColumnRight",
+		) as HTMLButtonElement | undefined;
 		expect(addColumnRight).toBeTruthy();
 
 		await act(async () => {

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -17,7 +17,6 @@ import {
 import type {
 	TableActionTarget,
 	TableEditorAction,
-	TableEditorCapabilities,
 	TableEditorCommand,
 	TableInlineControlsProps,
 } from "./noteEditorOverlayTypes";

--- a/src/components/editor/TableInlineControls.tsx
+++ b/src/components/editor/TableInlineControls.tsx
@@ -1,6 +1,7 @@
 import { HugeiconsIcon } from "@/components/HugeiconsIcon";
 import { LocationAdd01Icon } from "@hugeicons/core-free-icons";
-import { type MouseEvent, memo, useCallback, useMemo } from "react";
+import { type MouseEvent, memo, useCallback, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import {
 	type NativeContextMenuItem,
 	isNativeContextMenuAvailable,
@@ -14,6 +15,9 @@ import {
 	DropdownMenuTrigger,
 } from "../ui/shadcn/dropdown-menu";
 import type {
+	TableActionTarget,
+	TableEditorAction,
+	TableEditorCapabilities,
 	TableEditorCommand,
 	TableInlineControlsProps,
 } from "./noteEditorOverlayTypes";
@@ -23,29 +27,64 @@ type TableAxisMenuItem =
 			type: "action";
 			label: string;
 			command: TableEditorCommand;
-			enabled?: boolean;
+			enabled: boolean;
 			destructive?: boolean;
 	  }
-	| { type: "separator" };
+	| { type: "separator"; id: string };
 
 function buildAxisMenuItems(
-	beforeLabel: string,
-	afterLabel: string,
-	deleteLabel: string,
-	beforeCommand: TableEditorCommand,
-	afterCommand: TableEditorCommand,
-	deleteCommand: TableEditorCommand,
-	canDelete: boolean,
+	labels: {
+		addBefore: string;
+		addAfter: string;
+		moveBefore: string;
+		moveAfter: string;
+		deleteItem: string;
+	},
+	commands: {
+		addBefore: TableEditorCommand;
+		addAfter: TableEditorCommand;
+		moveBefore: TableEditorCommand;
+		moveAfter: TableEditorCommand;
+		deleteItem: TableEditorCommand;
+	},
+	enabled: {
+		moveBefore: boolean;
+		moveAfter: boolean;
+		deleteItem: boolean;
+	},
 ): TableAxisMenuItem[] {
 	return [
-		{ type: "action", label: beforeLabel, command: beforeCommand },
-		{ type: "action", label: afterLabel, command: afterCommand },
-		{ type: "separator" },
 		{
 			type: "action",
-			label: deleteLabel,
-			command: deleteCommand,
-			enabled: canDelete,
+			label: labels.addBefore,
+			command: commands.addBefore,
+			enabled: true,
+		},
+		{
+			type: "action",
+			label: labels.addAfter,
+			command: commands.addAfter,
+			enabled: true,
+		},
+		{ type: "separator", id: `${commands.deleteItem}-insert` },
+		{
+			type: "action",
+			label: labels.moveBefore,
+			command: commands.moveBefore,
+			enabled: enabled.moveBefore,
+		},
+		{
+			type: "action",
+			label: labels.moveAfter,
+			command: commands.moveAfter,
+			enabled: enabled.moveAfter,
+		},
+		{ type: "separator", id: `${commands.deleteItem}-move` },
+		{
+			type: "action",
+			label: labels.deleteItem,
+			command: commands.deleteItem,
+			enabled: enabled.deleteItem,
 			destructive: true,
 		},
 	];
@@ -74,7 +113,8 @@ interface TableAxisControlProps {
 	ariaLabel: string;
 	menuItems: TableAxisMenuItem[];
 	onControlMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
-	onCommand: (command: TableEditorCommand) => void;
+	onCommand: (action: TableEditorAction) => void;
+	captureTarget: () => TableActionTarget | null;
 	nativeMenusEnabled: boolean;
 }
 
@@ -86,21 +126,42 @@ const TableAxisControl = memo(function TableAxisControl({
 	menuItems,
 	onControlMouseDown,
 	onCommand,
+	captureTarget,
 	nativeMenusEnabled,
 }: TableAxisControlProps) {
-	const nativeMenuItems = useMemo(
-		() => toNativeMenuItems(menuItems, onCommand),
-		[menuItems, onCommand],
+	const capturedTargetRef = useRef<TableActionTarget | null>(null);
+
+	const runCapturedCommand = useCallback(
+		(command: TableEditorCommand) => {
+			const target = capturedTargetRef.current ?? captureTarget();
+			if (!target) return;
+			onCommand({ kind: command, target });
+		},
+		[captureTarget, onCommand],
 	);
+
 	const handleNativeMenuClick = useCallback(
 		(event: MouseEvent<HTMLButtonElement>) => {
+			const target = captureTarget();
+			capturedTargetRef.current = target;
+			if (!target) return;
+			const nativeMenuItems = toNativeMenuItems(menuItems, runCapturedCommand);
 			void showNativePopupMenu(event, nativeMenuItems).catch(
 				(error: unknown) => {
 					console.error(`Failed to show table ${axis} menu`, error);
 				},
 			);
 		},
-		[axis, nativeMenuItems],
+		[axis, captureTarget, menuItems, runCapturedCommand],
+	);
+
+	const handleOpenChange = useCallback(
+		(open: boolean) => {
+			if (open) {
+				capturedTargetRef.current = captureTarget();
+			}
+		},
+		[captureTarget],
 	);
 
 	const triggerButton = (
@@ -126,19 +187,19 @@ const TableAxisControl = memo(function TableAxisControl({
 	}
 
 	return (
-		<DropdownMenu>
+		<DropdownMenu onOpenChange={handleOpenChange}>
 			<DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
 			<DropdownMenuContent className="tableInlineControlsMenu" align="start">
 				{menuItems.map((item) => {
 					if (item.type === "separator") {
-						return <DropdownMenuSeparator key="separator" />;
+						return <DropdownMenuSeparator key={item.id} />;
 					}
 					return (
 						<DropdownMenuItem
 							key={item.command}
-							disabled={item.enabled === false}
+							disabled={!item.enabled}
 							variant={item.destructive ? "destructive" : "default"}
-							onSelect={() => onCommand(item.command)}
+							onSelect={() => runCapturedCommand(item.command)}
 						>
 							{item.label}
 						</DropdownMenuItem>
@@ -153,35 +214,60 @@ export const TableInlineControls = memo(function TableInlineControls({
 	selected,
 	onControlMouseDown,
 	onCommand,
-	canDeleteRow,
-	canDeleteColumn,
+	captureTarget,
+	capabilities,
 }: TableInlineControlsProps) {
+	const { t } = useTranslation("editor");
 	const nativeMenusEnabled = isNativeContextMenuAvailable();
 	const rowMenuItems = useMemo(
 		() =>
 			buildAxisMenuItems(
-				"Add row above",
-				"Add row below",
-				"Delete row",
-				"addRowBefore",
-				"addRowAfter",
-				"deleteRow",
-				canDeleteRow,
+				{
+					addBefore: t("tableControls.addRowAbove"),
+					addAfter: t("tableControls.addRowBelow"),
+					moveBefore: t("tableControls.moveRowUp"),
+					moveAfter: t("tableControls.moveRowDown"),
+					deleteItem: t("tableControls.deleteRow"),
+				},
+				{
+					addBefore: "addRowBefore",
+					addAfter: "addRowAfter",
+					moveBefore: "moveRowUp",
+					moveAfter: "moveRowDown",
+					deleteItem: "deleteRow",
+				},
+				{
+					moveBefore: capabilities.canMoveRowUp,
+					moveAfter: capabilities.canMoveRowDown,
+					deleteItem: capabilities.canDeleteRow,
+				},
 			),
-		[canDeleteRow],
+		[capabilities, t],
 	);
 	const columnMenuItems = useMemo(
 		() =>
 			buildAxisMenuItems(
-				"Add column left",
-				"Add column right",
-				"Delete column",
-				"addColumnBefore",
-				"addColumnAfter",
-				"deleteColumn",
-				canDeleteColumn,
+				{
+					addBefore: t("tableControls.addColumnLeft"),
+					addAfter: t("tableControls.addColumnRight"),
+					moveBefore: t("tableControls.moveColumnLeft"),
+					moveAfter: t("tableControls.moveColumnRight"),
+					deleteItem: t("tableControls.deleteColumn"),
+				},
+				{
+					addBefore: "addColumnBefore",
+					addAfter: "addColumnAfter",
+					moveBefore: "moveColumnLeft",
+					moveAfter: "moveColumnRight",
+					deleteItem: "deleteColumn",
+				},
+				{
+					moveBefore: capabilities.canMoveColumnLeft,
+					moveAfter: capabilities.canMoveColumnRight,
+					deleteItem: capabilities.canDeleteColumn,
+				},
 			),
-		[canDeleteColumn],
+		[capabilities, t],
 	);
 
 	return (
@@ -190,20 +276,22 @@ export const TableInlineControls = memo(function TableInlineControls({
 				axis="row"
 				left={selected.rowControlLeft}
 				top={selected.rowControlTop}
-				ariaLabel="Row options"
+				ariaLabel={t("tableControls.rowOptions")}
 				menuItems={rowMenuItems}
 				onControlMouseDown={onControlMouseDown}
 				onCommand={onCommand}
+				captureTarget={captureTarget}
 				nativeMenusEnabled={nativeMenusEnabled}
 			/>
 			<TableAxisControl
 				axis="column"
 				left={selected.columnControlLeft}
 				top={selected.columnControlTop}
-				ariaLabel="Column options"
+				ariaLabel={t("tableControls.columnOptions")}
 				menuItems={columnMenuItems}
 				onControlMouseDown={onControlMouseDown}
 				onCommand={onCommand}
+				captureTarget={captureTarget}
 				nativeMenusEnabled={nativeMenusEnabled}
 			/>
 		</>

--- a/src/components/editor/hooks/tableEditorCommands.ts
+++ b/src/components/editor/hooks/tableEditorCommands.ts
@@ -185,8 +185,10 @@ export function runTableEditorAction(
 ): boolean {
 	if (editor.isDestroyed) return false;
 
-	const node = editor.state?.doc?.nodeAt(action.target.tablePos);
+	const doc = editor.state?.doc;
+	const node = doc?.nodeAt(action.target.tablePos);
 	const table = node?.type.name === "table" ? node : null;
+	if (doc && !table) return false;
 	if (table) {
 		if (!canMove(action.kind, table, action.target)) return false;
 		if (!restoreSelection(editor, table, action.target)) return false;

--- a/src/components/editor/hooks/tableEditorCommands.ts
+++ b/src/components/editor/hooks/tableEditorCommands.ts
@@ -1,9 +1,217 @@
 import type { Editor } from "@tiptap/core";
-import type { TableEditorCommand } from "../noteEditorOverlayTypes";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { TextSelection } from "@tiptap/pm/state";
+import {
+	TableMap,
+	isInTable,
+	moveTableColumn,
+	moveTableRow,
+	selectedRect,
+} from "@tiptap/pm/tables";
+import type {
+	TableActionTarget,
+	TableEditorAction,
+	TableEditorCapabilities,
+	TableEditorCommand,
+} from "../noteEditorOverlayTypes";
 
-export function runTableEditorCommand(
+export interface TableEditorSnapshot {
+	target: TableActionTarget;
+	capabilities: TableEditorCapabilities;
+}
+
+export function tableEditorSnapshot(
+	state: EditorState,
+	canDelete: { column: boolean; row: boolean },
+): TableEditorSnapshot | null {
+	if (!isInTable(state)) return null;
+
+	const rect = selectedRect(state);
+	const rowIndex = rect.top;
+	const columnIndex = rect.left;
+	return {
+		target: {
+			tablePos: rect.tableStart - 1,
+			rowIndex,
+			columnIndex,
+		},
+		capabilities: {
+			canDeleteRow: canDelete.row,
+			canDeleteColumn: canDelete.column,
+			canMoveRowUp: rowIndex > 1,
+			canMoveRowDown: rowIndex > 0 && rowIndex < rect.map.height - 1,
+			canMoveColumnLeft: columnIndex > 0,
+			canMoveColumnRight: columnIndex < rect.map.width - 1,
+		},
+	};
+}
+
+export function tableSnapshotsEqual(
+	a: TableEditorSnapshot | null | undefined,
+	b: TableEditorSnapshot | null | undefined,
+): boolean {
+	if (a === b) return true;
+	if (!a || !b) return false;
+	return (
+		a.target.tablePos === b.target.tablePos &&
+		a.target.rowIndex === b.target.rowIndex &&
+		a.target.columnIndex === b.target.columnIndex &&
+		a.capabilities.canDeleteRow === b.capabilities.canDeleteRow &&
+		a.capabilities.canDeleteColumn === b.capabilities.canDeleteColumn &&
+		a.capabilities.canMoveRowUp === b.capabilities.canMoveRowUp &&
+		a.capabilities.canMoveRowDown === b.capabilities.canMoveRowDown &&
+		a.capabilities.canMoveColumnLeft === b.capabilities.canMoveColumnLeft &&
+		a.capabilities.canMoveColumnRight === b.capabilities.canMoveColumnRight
+	);
+}
+
+function cellPosition(
+	table: ProseMirrorNode,
+	tablePos: number,
+	rowIndex: number,
+	columnIndex: number,
+): { cell: ProseMirrorNode; cellPos: number } | null {
+	const map = TableMap.get(table);
+	if (
+		rowIndex < 0 ||
+		columnIndex < 0 ||
+		rowIndex >= map.height ||
+		columnIndex >= map.width
+	) {
+		return null;
+	}
+	const relative = map.positionAt(rowIndex, columnIndex, table);
+	const cell = table.nodeAt(relative);
+	if (!cell) return null;
+	return { cell, cellPos: tablePos + 1 + relative };
+}
+
+function restoreSelection(
 	editor: Editor,
-	command: TableEditorCommand,
-): void {
-	editor.chain().focus(null, { scrollIntoView: false })[command]().run();
+	table: ProseMirrorNode,
+	target: TableActionTarget,
+): boolean {
+	const located = cellPosition(
+		table,
+		target.tablePos,
+		target.rowIndex,
+		target.columnIndex,
+	);
+	if (!located || !editor.view) return false;
+	const { from, to } = editor.state.selection;
+	if (
+		from >= located.cellPos &&
+		to <= located.cellPos + located.cell.nodeSize
+	) {
+		editor.view.focus();
+		return true;
+	}
+
+	const inner = Math.min(
+		located.cellPos + 1,
+		located.cellPos + located.cell.nodeSize - 1,
+	);
+	const selection = TextSelection.near(editor.state.doc.resolve(inner), 1);
+	const tr = editor.state.tr.setSelection(selection);
+	tr.setMeta("addToHistory", false);
+	editor.view.dispatch(tr);
+	editor.view.focus();
+	return true;
+}
+
+function canMove(
+	kind: TableEditorCommand,
+	table: ProseMirrorNode,
+	target: TableActionTarget,
+): boolean {
+	const map = TableMap.get(table);
+	switch (kind) {
+		case "moveRowUp":
+			return target.rowIndex > 1;
+		case "moveRowDown":
+			return target.rowIndex > 0 && target.rowIndex < map.height - 1;
+		case "moveColumnLeft":
+			return target.columnIndex > 0;
+		case "moveColumnRight":
+			return target.columnIndex < map.width - 1;
+		default:
+			return true;
+	}
+}
+
+function runMoveCommand(editor: Editor, action: TableEditorAction): boolean {
+	const pos = editor.state.selection.from;
+	const dispatch = (tr: Transaction) => {
+		editor.view.dispatch(tr);
+	};
+	switch (action.kind) {
+		case "moveRowUp":
+			return moveTableRow({
+				from: action.target.rowIndex,
+				to: action.target.rowIndex - 1,
+				select: true,
+				pos,
+			})(editor.state, dispatch);
+		case "moveRowDown":
+			return moveTableRow({
+				from: action.target.rowIndex,
+				to: action.target.rowIndex + 1,
+				select: true,
+				pos,
+			})(editor.state, dispatch);
+		case "moveColumnLeft":
+			return moveTableColumn({
+				from: action.target.columnIndex,
+				to: action.target.columnIndex - 1,
+				select: true,
+				pos,
+			})(editor.state, dispatch);
+		case "moveColumnRight":
+			return moveTableColumn({
+				from: action.target.columnIndex,
+				to: action.target.columnIndex + 1,
+				select: true,
+				pos,
+			})(editor.state, dispatch);
+		default:
+			return false;
+	}
+}
+
+export function runTableEditorAction(
+	editor: Editor,
+	action: TableEditorAction,
+): boolean {
+	if (editor.isDestroyed) return false;
+
+	const node = editor.state?.doc?.nodeAt(action.target.tablePos);
+	const table = node?.type.name === "table" ? node : null;
+	if (table) {
+		if (!canMove(action.kind, table, action.target)) return false;
+		if (!restoreSelection(editor, table, action.target)) return false;
+	}
+
+	switch (action.kind) {
+		case "addRowBefore":
+		case "addRowAfter":
+		case "deleteRow":
+		case "addColumnBefore":
+		case "addColumnAfter":
+		case "deleteColumn":
+			return editor
+				.chain()
+				.focus(null, { scrollIntoView: false })
+				[action.kind]()
+				.run();
+		case "moveRowUp":
+		case "moveRowDown":
+		case "moveColumnLeft":
+		case "moveColumnRight":
+			return table ? runMoveCommand(editor, action) : false;
+		default: {
+			const _exhaustive: never = action.kind;
+			return _exhaustive;
+		}
+	}
 }

--- a/src/components/editor/hooks/useTableInlineControls.ts
+++ b/src/components/editor/hooks/useTableInlineControls.ts
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/core";
+import { useEditorState } from "@tiptap/react";
 import {
 	type MouseEvent as ReactMouseEvent,
 	type RefObject,
@@ -8,17 +9,25 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "../../../lib/toast";
 import type {
 	SelectedTableState,
-	TableEditorCommand,
+	TableActionTarget,
+	TableEditorAction,
 	TableInlineControlsProps,
 } from "../noteEditorOverlayTypes";
+import { DISABLED_TABLE_CAPABILITIES } from "../noteEditorOverlayTypes";
 import type { NoteInlineEditorMode } from "../types";
 import {
 	getMountedEditorContentRoot,
 	getOffsetWithinAncestor,
 } from "./editorDomUtils";
-import { runTableEditorCommand } from "./tableEditorCommands";
+import {
+	runTableEditorAction,
+	tableEditorSnapshot,
+	tableSnapshotsEqual,
+} from "./tableEditorCommands";
 
 const TABLE_INLINE_CONTROL_OFFSET_PX = 20;
 const TABLE_INLINE_CONTROL_EDGE_PADDING_PX = 10;
@@ -36,12 +45,25 @@ export function useTableInlineControls({
 	hostRef,
 	mode,
 }: UseTableInlineControlsArgs): TableInlineControlsProps | null {
+	const { t } = useTranslation("editor");
 	const syncRafRef = useRef<number | null>(null);
 	const [selectedTable, setSelectedTable] = useState<SelectedTableState | null>(
 		null,
 	);
-	const [canDeleteRow, setCanDeleteRow] = useState(false);
-	const [canDeleteColumn, setCanDeleteColumn] = useState(false);
+
+	const snapshot = useEditorState({
+		editor,
+		selector: ({ editor: instance }) => {
+			if (!instance || instance.isDestroyed || mode !== "rich" || !canEdit) {
+				return null;
+			}
+			return tableEditorSnapshot(instance.state, {
+				column: instance.can().deleteColumn(),
+				row: instance.can().deleteRow(),
+			});
+		},
+		equalityFn: tableSnapshotsEqual,
+	});
 
 	const onControlMouseDown = useCallback(
 		(event: ReactMouseEvent<HTMLElement>) => {
@@ -49,43 +71,18 @@ export function useTableInlineControls({
 		},
 		[],
 	);
+	const captureTarget = useCallback((): TableActionTarget | null => {
+		return snapshot?.target ?? null;
+	}, [snapshot]);
 	const onCommand = useCallback(
-		(command: TableEditorCommand) => {
+		(action: TableEditorAction) => {
 			if (!editor || editor.isDestroyed) return;
-			runTableEditorCommand(editor, command);
-		},
-		[editor],
-	);
-
-	useEffect(() => {
-		const clearDeleteCapabilities = () => {
-			setCanDeleteRow(false);
-			setCanDeleteColumn(false);
-		};
-		if (!editor || editor.isDestroyed || mode !== "rich" || !canEdit) {
-			clearDeleteCapabilities();
-			return;
-		}
-
-		const syncDeleteCapabilities = () => {
-			if (editor.isDestroyed) {
-				clearDeleteCapabilities();
-				return;
+			if (!runTableEditorAction(editor, action)) {
+				toast.error(t("tableControls.unavailable"));
 			}
-			setCanDeleteRow(editor.can().deleteRow());
-			setCanDeleteColumn(editor.can().deleteColumn());
-		};
-
-		syncDeleteCapabilities();
-		editor.on("transaction", syncDeleteCapabilities);
-		editor.on("selectionUpdate", syncDeleteCapabilities);
-		editor.on("destroy", clearDeleteCapabilities);
-		return () => {
-			editor.off("transaction", syncDeleteCapabilities);
-			editor.off("selectionUpdate", syncDeleteCapabilities);
-			editor.off("destroy", clearDeleteCapabilities);
-		};
-	}, [canEdit, editor, mode]);
+		},
+		[editor, t],
+	);
 
 	useEffect(() => {
 		const clearSelectedTable = () => {
@@ -115,14 +112,19 @@ export function useTableInlineControls({
 				return;
 			}
 
-			const activeCell = anchorElement.closest("td, th") as HTMLElement | null;
+			const closestCell = anchorElement.closest("td, th");
+			const activeCell =
+				closestCell instanceof HTMLElement ? closestCell : null;
 			if (!activeCell || !contentRoot.contains(activeCell)) {
 				setSelectedTable(null);
 				return;
 			}
 
-			const activeRow = activeCell.closest("tr") as HTMLElement | null;
-			const activeTable = activeCell.closest("table") as HTMLElement | null;
+			const closestRow = activeCell.closest("tr");
+			const closestTable = activeCell.closest("table");
+			const activeRow = closestRow instanceof HTMLElement ? closestRow : null;
+			const activeTable =
+				closestTable instanceof HTMLElement ? closestTable : null;
 			if (!activeRow || !activeTable || !contentRoot.contains(activeTable)) {
 				setSelectedTable(null);
 				return;
@@ -199,14 +201,8 @@ export function useTableInlineControls({
 			selected: selectedTable,
 			onControlMouseDown,
 			onCommand,
-			canDeleteRow,
-			canDeleteColumn,
+			captureTarget,
+			capabilities: snapshot?.capabilities ?? DISABLED_TABLE_CAPABILITIES,
 		};
-	}, [
-		canDeleteColumn,
-		canDeleteRow,
-		onCommand,
-		onControlMouseDown,
-		selectedTable,
-	]);
+	}, [captureTarget, onCommand, onControlMouseDown, selectedTable, snapshot]);
 }

--- a/src/components/editor/noteEditorOverlayTypes.ts
+++ b/src/components/editor/noteEditorOverlayTypes.ts
@@ -20,12 +20,45 @@ export type TableEditorCommand =
 	| "deleteRow"
 	| "addColumnBefore"
 	| "addColumnAfter"
-	| "deleteColumn";
+	| "deleteColumn"
+	| "moveRowUp"
+	| "moveRowDown"
+	| "moveColumnLeft"
+	| "moveColumnRight";
+
+export interface TableActionTarget {
+	tablePos: number;
+	rowIndex: number;
+	columnIndex: number;
+}
+
+export interface TableEditorAction {
+	kind: TableEditorCommand;
+	target: TableActionTarget;
+}
+
+export interface TableEditorCapabilities {
+	canDeleteRow: boolean;
+	canDeleteColumn: boolean;
+	canMoveRowUp: boolean;
+	canMoveRowDown: boolean;
+	canMoveColumnLeft: boolean;
+	canMoveColumnRight: boolean;
+}
+
+export const DISABLED_TABLE_CAPABILITIES: TableEditorCapabilities = {
+	canDeleteRow: false,
+	canDeleteColumn: false,
+	canMoveRowUp: false,
+	canMoveRowDown: false,
+	canMoveColumnLeft: false,
+	canMoveColumnRight: false,
+};
 
 export interface TableInlineControlsProps {
 	selected: SelectedTableState;
 	onControlMouseDown: (event: React.MouseEvent<HTMLElement>) => void;
-	onCommand: (command: TableEditorCommand) => void;
-	canDeleteRow: boolean;
-	canDeleteColumn: boolean;
+	onCommand: (action: TableEditorAction) => void;
+	captureTarget: () => TableActionTarget | null;
+	capabilities: TableEditorCapabilities;
 }

--- a/src/i18n/locales/en/editor.json
+++ b/src/i18n/locales/en/editor.json
@@ -282,6 +282,21 @@
 			"description": "Remove text highlight"
 		}
 	},
+	"tableControls": {
+		"rowOptions": "Row options",
+		"columnOptions": "Column options",
+		"addRowAbove": "Add row above",
+		"addRowBelow": "Add row below",
+		"deleteRow": "Delete row",
+		"moveRowUp": "Move row up",
+		"moveRowDown": "Move row down",
+		"addColumnLeft": "Add column left",
+		"addColumnRight": "Add column right",
+		"deleteColumn": "Delete column",
+		"moveColumnLeft": "Move column left",
+		"moveColumnRight": "Move column right",
+		"unavailable": "The table changed. Open the menu again and retry."
+	},
 	"sidePeek": {
 		"dialogLabel": "Note peek",
 		"open": "Open note",


### PR DESCRIPTION
Closes 


## Description

Markdown table row/column menus could add and delete, but reordering a row or column meant cutting and pasting cells. This adds move up/down and left/right to those same menus.

- Row menu: add above/below, move up/down, delete. The header row stays at index 0; body rows cannot swap with it.
- Column menu: add left/right, move left/right, delete.
- Native menus can fire after the editor blurs, so the selected cell is captured when the menu opens and restored before the command runs.
- Insert/delete still use the existing TipTap chain. Moves use `moveTableRow` / `moveTableColumn`.
- One toast if the captured table is gone. Menu items disable at the header and at the first/last row or column.

Rich editor only. No new shortcuts, settings, or backend commands. English copy only.


## Screenshots

Screenshots or a screen recording of the visual changes associated with this PR.


## Docs

No doc changes. Menu labels live in `src/i18n/locales/en/editor.json` under `tableControls`.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Enable rich-editor table users to reorder rows and columns directly from the existing menus.

New Features:
- Add row and column reordering actions to rich-editor markdown table menus.
- Disable move actions when the selected row or column is already at its boundary, while keeping the header row fixed.

Bug Fixes:
- Preserve the selected table cell when native menus open after the editor loses focus and report unavailable actions when the target table no longer exists.

Enhancements:
- Centralize table action targets and capabilities so menu commands can restore and operate on the captured selection.

Tests:
- Update table control tests for translated menu labels and expanded table editor state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds move up/down and left/right to the markdown table row and column menus, so reordering no longer requires cutting and pasting cells.

- Row menu: add above/below, move up/down, and delete; the header row stays pinned at index 0.
- Column menu: add left/right, move left/right, and delete.
- The selected cell is captured when the menu opens and restored before the command runs, since native menus can fire after the editor blurs.
- Insert and delete keep using the existing TipTap chain; moves use `moveTableRow` and `moveTableColumn`.
- Move items disable at the header row and at the first or last row or column.
- If the captured table is gone, actions now abort with a single toast instead of running against the current selection.
- Rich editor only; no new shortcuts, settings, or backend commands. Menu labels now live in `en/editor.json` under `tableControls`.

<sup>Written for commit 7b12302885b26b167b6da0a7990995aacd495efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table controls for inserting, deleting, and moving rows and columns.
  * Added capability-based control states to prevent unavailable actions.
  * Localized table control labels and unavailable-action messaging.
  * Preserved table selection when performing table actions.

* **Bug Fixes**
  * Improved table action targeting when opening menus before making a selection.
  * Added error feedback when a table action cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->