### PR TITLE
Fix wikilink updates after renames and unreadable notes (#551) [Release]

### DIFF
--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::Serialize;
 
-use crate::{index, paths, utils};
+use crate::{paths, utils};
 
 #[derive(Debug, Clone)]
 pub struct LinkRewritePlan {
@@ -36,7 +36,17 @@ pub fn rewrite_links_after_rename(
 
     for rel_path in markdown_files {
         let abs = paths::join_under(space_root, Path::new(&rel_path))?;
-        let original = std::fs::read_to_string(&abs).map_err(|e| e.to_string())?;
+        let original = match std::fs::read_to_string(&abs) {
+            Ok(markdown) => markdown,
+            Err(error) => {
+                tracing::warn!(
+                    note_id = %rel_path,
+                    error = %error,
+                    "failed to read note for link rewrite after rename"
+                );
+                continue;
+            }
+        };
         let rewrite = rewrite_markdown_links_for_path(&original, plan, &rel_path);
 
         if rewrite.markdown != original {
@@ -514,11 +524,8 @@ pub fn plan_for_rename(
     } else {
         None
     };
-    let from_title =
-        note_title_for_path(root, from_path).unwrap_or_else(|| title_from_rel_path(from_path));
-    let to_title = note_title_for_path(root, to_path)
-        .or_else(|| note_title_for_path(root, from_path))
-        .unwrap_or_else(|| title_from_rel_path(to_path));
+    let from_title = title_from_rel_path(from_path);
+    let to_title = title_from_rel_path(to_path);
     LinkRewritePlan {
         from_rel_path: if is_dir {
             from_path.trim_end_matches('/').to_string()
@@ -597,16 +604,6 @@ fn collect_markdown_files_and_basename_counts(
     }
     markdown_files.sort();
     Ok((markdown_files, basename_counts))
-}
-
-fn note_title_for_path(root: &Path, rel_path: &str) -> Option<String> {
-    let conn = index::open_db(root).ok()?;
-    conn.query_row(
-        "SELECT title FROM notes WHERE id = ? LIMIT 1",
-        [rel_path],
-        |row| row.get(0),
-    )
-    .ok()
 }
 
 fn is_external_target(target: &str) -> bool {

--- a/src-tauri/src/space_fs/link_rewrite.rs
+++ b/src-tauri/src/space_fs/link_rewrite.rs
@@ -22,6 +22,7 @@ pub struct LinkRewritePlan {
 pub struct LinkRewriteResult {
     pub changed_files: Vec<String>,
     pub changed_links: usize,
+    pub skipped_files: Vec<String>,
 }
 
 pub fn rewrite_links_after_rename(
@@ -33,6 +34,7 @@ pub fn rewrite_links_after_rename(
         None => collect_markdown_files(space_root)?,
     };
     let mut rewrites = Vec::new();
+    let mut result = LinkRewriteResult::default();
 
     for rel_path in markdown_files {
         let abs = paths::join_under(space_root, Path::new(&rel_path))?;
@@ -44,6 +46,7 @@ pub fn rewrite_links_after_rename(
                     error = %error,
                     "failed to read note for link rewrite after rename"
                 );
+                result.skipped_files.push(rel_path);
                 continue;
             }
         };
@@ -54,7 +57,6 @@ pub fn rewrite_links_after_rename(
         }
     }
 
-    let mut result = LinkRewriteResult::default();
     for (rel_path, abs, markdown, changed_links) in rewrites {
         match crate::io_atomic::write_atomic(&abs, markdown.as_bytes()) {
             Ok(()) => {
@@ -67,6 +69,7 @@ pub fn rewrite_links_after_rename(
                     error = %error,
                     "failed to write rewritten links after rename"
                 );
+                result.skipped_files.push(rel_path);
             }
         }
     }
@@ -255,7 +258,11 @@ fn rewrite_target(target: &str, plan: &LinkRewritePlan, markdown_link: bool) -> 
     {
         return Some(plan.to_rel_path.clone());
     }
-    if is_markdown_rename && !markdown_link && target == plan.from_title {
+    if is_markdown_rename
+        && !markdown_link
+        && plan.from_basename_is_unique
+        && target == plan.from_title
+    {
         return Some(plan.to_title.clone());
     }
     None
@@ -504,10 +511,9 @@ pub fn is_supported_attachment_path(path: &Path) -> bool {
 }
 
 fn title_from_rel_path(path: &str) -> String {
-    Path::new(path)
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .unwrap_or(path)
+    basename(path)
+        .trim_end_matches(".md")
+        .trim_end_matches(".MD")
         .to_string()
 }
 
@@ -519,7 +525,7 @@ pub fn plan_for_rename(
 ) -> LinkRewritePlan {
     let is_dir = from_abs.is_dir();
     let is_markdown_rename = is_markdown_rel_path(from_path);
-    let attachment_link_context = if !is_dir && !is_markdown_rename {
+    let link_context = if !is_dir {
         collect_markdown_files_and_basename_counts(root).ok()
     } else {
         None
@@ -540,10 +546,11 @@ pub fn plan_for_rename(
         from_title,
         to_title,
         is_dir,
-        from_basename_is_unique: attachment_link_context.as_ref().is_some_and(
+        from_basename_is_unique: link_context.as_ref().is_some_and(
             |(_markdown_files, basename_counts)| basename_is_unique(basename_counts, from_path),
         ),
-        markdown_files: attachment_link_context
+        markdown_files: link_context
+            .filter(|_| !is_markdown_rename)
             .map(|(markdown_files, _basename_counts)| markdown_files),
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Glyph",
-	"version": "0.8.17",
+	"version": "0.8.18-alpha.1",
 	"identifier": "com.karatsidhu.glyph",
 	"build": {
 		"beforeDevCommand": "pnpm dev",

--- a/src/hooks/useFileTreeCRUD.ts
+++ b/src/hooks/useFileTreeCRUD.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef } from "react";
+import { i18n } from "../i18n";
 import { dispatchFileTreeStartRename } from "../lib/appEvents";
 import { extractErrorMessage } from "../lib/errorUtils";
 import { isMissingFileError } from "../lib/fsErrors";
@@ -50,6 +51,14 @@ export interface CreateMarkdownFileOptions {
 }
 
 function showLinkRewriteToast(result: LinkRewriteResult) {
+	if (result.skipped_files.length > 0) {
+		toast.warning(i18n.t("shell:linkRewrite.incomplete"), {
+			description: i18n.t("shell:linkRewrite.skipped", {
+				paths: result.skipped_files.join("\n"),
+			}),
+		});
+		return;
+	}
 	if (result.changed_files.length === 0) return;
 	const linkLabel = result.changed_links === 1 ? "link" : "links";
 	const fileLabel = result.changed_files.length === 1 ? "file" : "files";

--- a/src/i18n/locales/en/shell.json
+++ b/src/i18n/locales/en/shell.json
@@ -1,4 +1,8 @@
 {
+	"linkRewrite": {
+		"incomplete": "Rename or move completed, but some links could not be updated",
+		"skipped": "Could not read or write these files. Their links may need manual updates:\n{{paths}}"
+	},
 	"sidebar": {
 		"collapse": "Collapse sidebar",
 		"expand": "Expand sidebar",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -48,6 +48,7 @@ export interface FsEntryList {
 export interface LinkRewriteResult {
 	changed_files: string[];
 	changed_links: number;
+	skipped_files: string[];
 }
 
 export interface FileTreeAppearance {


### PR DESCRIPTION
Closes


## Description

Fix two failure cases when rewriting links after a note rename or folder move:

- Build short wikilink replacements from the old and new filenames, matching filesystem link resolution. Previously, an indexed note could reuse its old title as the replacement and leave the link unchanged.
- Log and skip unreadable Markdown files so one read failure does not cancel link updates in every other note. The skipped file remains unchanged.

These are confirmed code issues, but neither has been confirmed as the cause of the original user report. Existing atomic writes, reindexing, and content-change events remain in use.

Validation: `git diff --check` passed. Builds, lint, and tests were not run under the repository instructions.


## Docs

No documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [ ] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [ ] Wrote tests for new components/features
- [ ] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Make link updates after renames resilient to basename ambiguity and individual file access failures.

Bug Fixes:
- Fix wikilink rewriting after note renames and moves by deriving replacements from filesystem basenames and avoiding ambiguous title-based updates.
- Continue rewriting links in readable notes when other Markdown files cannot be read, while reporting skipped files to users.

Enhancements:
- Log unreadable or unwritable files encountered during link rewriting and surface them through an incomplete-update warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes link rewriting after note renames and moves so a renamed note no longer leaves stale wikilinks, and one unreadable file no longer cancels link updates across all notes.

- Only rewrites stale titles when the source basename is unique in the space; ambiguous links are left untouched.
- Shows a warning toast listing skipped files so the user knows their links may need manual updates.
- Bumps the app version to 0.8.18-alpha.1.

<sup>Written for commit e4299eeb9b5958057464a385d16eb3166777012b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/SidhuK/Glyph/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Link rewriting after file renames now continues when an individual Markdown file cannot be read, instead of stopping the entire operation.
  * Rename planning now derives titles directly from file paths, improving reliability when note database information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->