### PR TITLE
Redesign Connections graph with hierarchical edge bundling

### DIFF
--- a/src/components/connections/SpaceConnectionsView.tsx
+++ b/src/components/connections/SpaceConnectionsView.tsx
@@ -11,6 +11,7 @@ import {
 	connectionsLinkOpacity,
 	connectionsLinkThicknessScale,
 	connectionsNodeSizeScale,
+	legacyConnectionsLinkOpacity,
 } from "../../lib/connectionsGraphOptions";
 import { extractErrorMessage } from "../../lib/errorUtils";
 import {
@@ -129,6 +130,8 @@ export function SpaceConnectionsView() {
 	});
 	const options =
 		settingsQuery.data?.connectionsGraph ?? DEFAULT_CONNECTIONS_GRAPH_OPTIONS;
+	const legacyConnections = settingsQuery.data?.ui.legacyConnections ?? false;
+	const layoutMode = legacyConnections ? "legacy" : "bundled";
 
 	const optionsMutation = useMutation({
 		mutationFn: (next: ConnectionsGraphOptions) =>
@@ -192,22 +195,29 @@ export function SpaceConnectionsView() {
 		: "";
 
 	const { filteredPayload, graph, layoutError, layoutLoading, refetchLayout } =
-		useSpaceConnectionsGraph(payload, scopedSpacePath, options);
+		useSpaceConnectionsGraph(payload, scopedSpacePath, options, layoutMode);
 	const loading = dataLoading || layoutLoading;
 	const visibleError = error || layoutError;
 	const display = useMemo(
 		() => ({
 			nodeSizeScale: connectionsNodeSizeScale(options.nodeSize),
-			linkOpacity: connectionsLinkOpacity(options.linkOpacity),
+			linkOpacity: legacyConnections
+				? legacyConnectionsLinkOpacity(options.linkOpacity)
+				: connectionsLinkOpacity(options.linkOpacity),
 			linkThicknessScale: connectionsLinkThicknessScale(options.linkThickness),
 		}),
-		[options.linkOpacity, options.linkThickness, options.nodeSize],
+		[
+			legacyConnections,
+			options.linkOpacity,
+			options.linkThickness,
+			options.nodeSize,
+		],
 	);
 
 	const overlay = useSigmaConnections({
 		graph,
 		containerRef,
-		variant: "space",
+		variant: legacyConnections ? "space-legacy" : "space",
 		enabled: Boolean(graph && !loading && !visibleError),
 		display,
 		labelZoomThreshold: options.labelZoomThreshold,
@@ -257,7 +267,9 @@ export function SpaceConnectionsView() {
 					optionsMutation.mutate(next);
 					overlay.current.setDisplay({
 						nodeSizeScale: connectionsNodeSizeScale(next.nodeSize),
-						linkOpacity: connectionsLinkOpacity(next.linkOpacity),
+						linkOpacity: legacyConnections
+							? legacyConnectionsLinkOpacity(next.linkOpacity)
+							: connectionsLinkOpacity(next.linkOpacity),
 						linkThicknessScale: connectionsLinkThicknessScale(
 							next.linkThickness,
 						),

--- a/src/components/connections/connectionsCanvas.ts
+++ b/src/components/connections/connectionsCanvas.ts
@@ -1,9 +1,12 @@
+import type Sigma from "sigma";
 import type {
 	NodeHoverDrawingFunction,
 	NodeLabelDrawingFunction,
 } from "sigma/rendering";
+import type { Coordinates, EdgeDisplayData } from "sigma/types";
 import type {
 	ConnectionsEdgeAttributes,
+	ConnectionsGraph,
 	ConnectionsGraphVariant,
 	ConnectionsNodeAttributes,
 } from "./connectionsGraph";
@@ -20,6 +23,95 @@ type NodeHoverData = Parameters<
 >[1];
 
 const TRANSPARENT = "rgba(0, 0, 0, 0)";
+
+interface BundledEdgesDrawingOptions {
+	readonly canvas: HTMLCanvasElement;
+	readonly context: CanvasRenderingContext2D;
+	readonly renderer: Sigma<
+		ConnectionsNodeAttributes,
+		ConnectionsEdgeAttributes
+	>;
+	readonly graph: ConnectionsGraph;
+	readonly resolveStyle: (
+		edge: string,
+		data: ConnectionsEdgeAttributes,
+		source: string,
+		target: string,
+	) => Partial<EdgeDisplayData>;
+}
+
+interface BundledNodePoints {
+	readonly node: Coordinates;
+	readonly bundle: Coordinates;
+}
+
+export function drawBundledConnectionsEdges({
+	canvas,
+	context,
+	renderer,
+	graph,
+	resolveStyle,
+}: BundledEdgesDrawingOptions) {
+	const { width, height } = renderer.getDimensions();
+	const { pixelRatio } = renderer.getRenderParams();
+	const renderWidth = Math.max(1, Math.round(width * pixelRatio));
+	const renderHeight = Math.max(1, Math.round(height * pixelRatio));
+	const cssWidth = `${width}px`;
+	const cssHeight = `${height}px`;
+	if (canvas.style.width !== cssWidth) canvas.style.width = cssWidth;
+	if (canvas.style.height !== cssHeight) canvas.style.height = cssHeight;
+	if (canvas.width !== renderWidth || canvas.height !== renderHeight) {
+		canvas.width = renderWidth;
+		canvas.height = renderHeight;
+	}
+
+	context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+	context.clearRect(0, 0, width, height);
+
+	const mouse = renderer.getMouseCaptor();
+	const moving =
+		renderer.getCamera().isAnimated() ||
+		mouse.isMoving ||
+		mouse.draggedEvents > 0 ||
+		mouse.currentWheelDirection !== 0;
+	if (graph.size > 5_000 && moving) return;
+
+	context.lineCap = "round";
+	context.lineJoin = "round";
+	const pointsByNode = new Map<string, BundledNodePoints>();
+	graph.forEachNode((node, data) => {
+		pointsByNode.set(node, {
+			node: renderer.graphToViewport(data),
+			bundle: renderer.graphToViewport({
+				x: data.bundleX,
+				y: data.bundleY,
+			}),
+		});
+	});
+
+	graph.forEachEdge((edge, data, source, target) => {
+		const style = resolveStyle(edge, data, source, target);
+		if (style.hidden) return;
+
+		const sourcePoints = pointsByNode.get(source);
+		const targetPoints = pointsByNode.get(target);
+		if (!sourcePoints || !targetPoints) return;
+
+		context.strokeStyle = style.color ?? data.color;
+		context.lineWidth = Math.max(0.35, style.size ?? data.size);
+		context.beginPath();
+		context.moveTo(sourcePoints.node.x, sourcePoints.node.y);
+		context.bezierCurveTo(
+			sourcePoints.bundle.x,
+			sourcePoints.bundle.y,
+			targetPoints.bundle.x,
+			targetPoints.bundle.y,
+			targetPoints.node.x,
+			targetPoints.node.y,
+		);
+		context.stroke();
+	});
+}
 
 function roundedRectPath(
 	context: CanvasRenderingContext2D,
@@ -94,6 +186,7 @@ export function drawConnectionsNodeLabel(
 	settings: NodeLabelSettings,
 	palette: ConnectionsPalette,
 	variant: ConnectionsGraphVariant,
+	graphCenter?: Coordinates,
 ) {
 	const label = data.label;
 	if (!label) return;
@@ -107,6 +200,26 @@ export function drawConnectionsNodeLabel(
 	context.save();
 	context.font = `${weight} ${fontSize}px ${settings.labelFont}`;
 	context.textBaseline = "alphabetic";
+
+	if (variant === "space" && !emphasized) {
+		const centerX = graphCenter?.x ?? context.canvas.clientWidth / 2;
+		const centerY = graphCenter?.y ?? context.canvas.clientHeight / 2;
+		const angle = Math.atan2(data.y - centerY, data.x - centerX);
+		const onLeft = Math.cos(angle) < 0;
+		const labelOffset = size + 6;
+		context.translate(data.x, data.y);
+		context.rotate(onLeft ? angle + Math.PI : angle);
+		context.textAlign = onLeft ? "right" : "left";
+		context.textBaseline = "middle";
+		context.lineJoin = "round";
+		context.lineWidth = 3;
+		context.strokeStyle = palette.labelBackground;
+		context.strokeText(label, onLeft ? -labelOffset : labelOffset, 0);
+		context.fillStyle = palette.text;
+		context.fillText(label, onLeft ? -labelOffset : labelOffset, 0);
+		context.restore();
+		return;
+	}
 
 	const textWidth = context.measureText(label).width;
 	const offsetX = variant === "local" ? 8 : 6;

--- a/src/components/connections/connectionsCommunities.ts
+++ b/src/components/connections/connectionsCommunities.ts
@@ -31,8 +31,19 @@ export interface ConnectionsLayoutGraph {
 }
 
 export interface ConnectionsCommunity {
+	readonly id: number;
 	readonly members: readonly string[];
 	readonly hubId: string;
+	readonly radius: number;
+}
+
+export interface ConnectionsCommunityModel {
+	readonly communities: readonly ConnectionsCommunity[];
+	readonly communityBridges: ReadonlyMap<string, number>;
+}
+
+export function communityBridgeKey(left: number, right: number) {
+	return left < right ? `${left}:${right}` : `${right}:${left}`;
 }
 
 type CommunityGraph = Graph<
@@ -143,7 +154,7 @@ function internalWeightedDegree(
 
 export function detectConnectionsCommunities(
 	layoutGraph: ConnectionsLayoutGraph,
-): readonly ConnectionsCommunity[] {
+): ConnectionsCommunityModel {
 	const graph = buildWeightedGraph(layoutGraph);
 	const assignments =
 		graph.size > 0
@@ -159,7 +170,8 @@ export function detectConnectionsCommunities(
 		return hashString(left[0] ?? "") - hashString(right[0] ?? "");
 	});
 
-	return components.map((members) => {
+	const nodeCommunity = new Map<string, number>();
+	const communities = components.map((members, id) => {
 		const memberSet = new Set(members);
 		members.sort((left, right) => {
 			const degreeDifference =
@@ -167,9 +179,32 @@ export function detectConnectionsCommunities(
 				internalWeightedDegree(left, memberSet, graph);
 			return degreeDifference || hashString(left) - hashString(right);
 		});
+		for (const member of members) nodeCommunity.set(member, id);
 		return {
+			id,
 			members,
 			hubId: members[0] ?? "",
+			radius: Math.max(18, 18 * Math.sqrt(members.length / Math.PI) * 1.15),
 		};
 	});
+
+	const communityBridges = new Map<string, number>();
+	graph.forEachEdge((_edge, attributes, source, target) => {
+		const sourceCommunity = nodeCommunity.get(source);
+		const targetCommunity = nodeCommunity.get(target);
+		if (
+			sourceCommunity === undefined ||
+			targetCommunity === undefined ||
+			sourceCommunity === targetCommunity
+		) {
+			return;
+		}
+		const key = communityBridgeKey(sourceCommunity, targetCommunity);
+		communityBridges.set(
+			key,
+			(communityBridges.get(key) ?? 0) + attributes.weight,
+		);
+	});
+
+	return { communities, communityBridges };
 }

--- a/src/components/connections/connectionsCommunities.ts
+++ b/src/components/connections/connectionsCommunities.ts
@@ -13,31 +13,26 @@ interface CommunityGraphEdgeAttributes {
 }
 
 export interface ConnectionsLayoutGraph {
-	nodeIds: string[];
-	tags: Array<{ id: string; noteCount: number }>;
-	edges: Array<{
-		source: string;
-		target: string;
-		kind: "link" | "relationship";
-		weight: number;
-	}>;
-	tagEdges: Array<{ tagId: string; noteId: string }>;
+	readonly nodeIds: readonly string[];
+	readonly tags: readonly {
+		readonly id: string;
+		readonly noteCount: number;
+	}[];
+	readonly edges: readonly {
+		readonly source: string;
+		readonly target: string;
+		readonly kind: "link" | "relationship";
+		readonly weight: number;
+	}[];
+	readonly tagEdges: readonly {
+		readonly tagId: string;
+		readonly noteId: string;
+	}[];
 }
 
 export interface ConnectionsCommunity {
-	id: number;
-	members: string[];
-	hubId: string;
-	radius: number;
-}
-
-export interface ConnectionsCommunityModel {
-	communities: ConnectionsCommunity[];
-	communityBridges: ReadonlyMap<string, number>;
-}
-
-export function communityBridgeKey(left: number, right: number) {
-	return left < right ? `${left}:${right}` : `${right}:${left}`;
+	readonly members: readonly string[];
+	readonly hubId: string;
 }
 
 type CommunityGraph = Graph<
@@ -148,7 +143,7 @@ function internalWeightedDegree(
 
 export function detectConnectionsCommunities(
 	layoutGraph: ConnectionsLayoutGraph,
-): ConnectionsCommunityModel {
+): readonly ConnectionsCommunity[] {
 	const graph = buildWeightedGraph(layoutGraph);
 	const assignments =
 		graph.size > 0
@@ -164,8 +159,7 @@ export function detectConnectionsCommunities(
 		return hashString(left[0] ?? "") - hashString(right[0] ?? "");
 	});
 
-	const nodeCommunity = new Map<string, number>();
-	const communities = components.map((members, id) => {
+	return components.map((members) => {
 		const memberSet = new Set(members);
 		members.sort((left, right) => {
 			const degreeDifference =
@@ -173,32 +167,9 @@ export function detectConnectionsCommunities(
 				internalWeightedDegree(left, memberSet, graph);
 			return degreeDifference || hashString(left) - hashString(right);
 		});
-		for (const member of members) nodeCommunity.set(member, id);
 		return {
-			id,
 			members,
 			hubId: members[0] ?? "",
-			radius: Math.max(18, 18 * Math.sqrt(members.length / Math.PI) * 1.15),
 		};
 	});
-
-	const communityBridges = new Map<string, number>();
-	graph.forEachEdge((_edge, attributes, source, target) => {
-		const sourceCommunity = nodeCommunity.get(source);
-		const targetCommunity = nodeCommunity.get(target);
-		if (
-			sourceCommunity === undefined ||
-			targetCommunity === undefined ||
-			sourceCommunity === targetCommunity
-		) {
-			return;
-		}
-		const key = communityBridgeKey(sourceCommunity, targetCommunity);
-		communityBridges.set(
-			key,
-			(communityBridges.get(key) ?? 0) + attributes.weight,
-		);
-	});
-
-	return { communities, communityBridges };
 }

--- a/src/components/connections/connectionsCommunityPlacement.ts
+++ b/src/components/connections/connectionsCommunityPlacement.ts
@@ -1,4 +1,7 @@
-import type { ConnectionsCommunity } from "./connectionsCommunities";
+import type {
+	ConnectionsCommunity,
+	ConnectionsCommunityModel,
+} from "./connectionsCommunities";
 import type { SerializedGraphPosition } from "./connectionsLayout";
 import { hashString } from "./connectionsRandom";
 
@@ -94,9 +97,9 @@ function communityBundlePoints(slots: readonly (RadialMember | undefined)[]) {
 }
 
 export function placeConnectionsCommunities(
-	communities: readonly ConnectionsCommunity[],
+	model: ConnectionsCommunityModel,
 ): SerializedGraphPosition[] {
-	const { connected, disconnected } = partitionMembers(communities);
+	const { connected, disconnected } = partitionMembers(model.communities);
 	const slots = distributeAroundRing(connected, disconnected);
 	if (slots.length === 0) return [];
 

--- a/src/components/connections/connectionsCommunityPlacement.ts
+++ b/src/components/connections/connectionsCommunityPlacement.ts
@@ -1,232 +1,119 @@
-import {
-	type ConnectionsCommunity,
-	type ConnectionsCommunityModel,
-	communityBridgeKey,
-} from "./connectionsCommunities";
-import type {
-	GraphPosition,
-	SerializedGraphPosition,
-} from "./connectionsLayout";
-import { hashString, randomUnit } from "./connectionsRandom";
+import type { ConnectionsCommunity } from "./connectionsCommunities";
+import type { SerializedGraphPosition } from "./connectionsLayout";
+import { hashString } from "./connectionsRandom";
 
-const COMMUNITY_GAP = 22;
-const MEMBER_SPACING = 18;
-const PACK_SLOT_COUNT = 160;
-const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+const FULL_CIRCLE = Math.PI * 2;
+const START_ANGLE = -Math.PI / 2;
+const NODE_RING_RADIUS = 1_000;
+const BUNDLE_RING_RADIUS = 360;
 
-function distance(left: GraphPosition, right: GraphPosition) {
-	return Math.hypot(left.x - right.x, left.y - right.y);
+interface RadialMember {
+	readonly id: string;
+	readonly communityId: string;
 }
 
-interface PackedCircle {
-	id: number;
-	center: GraphPosition;
-	radius: number;
+interface CommunityDirection {
+	x: number;
+	y: number;
 }
 
-function clearanceToPacked(
-	candidate: GraphPosition,
-	radius: number,
-	packed: readonly PackedCircle[],
-) {
-	let clearance = Number.POSITIVE_INFINITY;
-	for (const existing of packed) {
-		clearance = Math.min(
-			clearance,
-			distance(candidate, existing.center) - radius - existing.radius,
-		);
-	}
-	return clearance;
-}
-
-function packFallbackCenter(
-	radius: number,
-	packed: readonly PackedCircle[],
-): GraphPosition {
-	let outer = 0;
-	for (const circle of packed) {
-		outer = Math.max(
-			outer,
-			Math.hypot(circle.center.x, circle.center.y) + circle.radius,
-		);
-	}
-	const ring = outer + radius + COMMUNITY_GAP;
-	const angle = packed.length * GOLDEN_ANGLE;
-	return {
-		x: Math.cos(angle) * ring,
-		y: Math.sin(angle) * ring,
-	};
-}
-
-function placeCommunityCenters(
-	cores: readonly ConnectionsCommunity[],
-	communityBridges: ReadonlyMap<string, number>,
-) {
-	const centers = new Map<number, GraphPosition>();
-	const packed: PackedCircle[] = [];
-
-	for (const community of cores) {
-		if (packed.length === 0) {
-			const origin = { x: 0, y: 0 };
-			centers.set(community.id, origin);
-			packed.push({
-				id: community.id,
-				center: origin,
-				radius: community.radius,
-			});
-			continue;
-		}
-
-		const linked = packed.flatMap((circle) => {
-			const weight =
-				communityBridges.get(communityBridgeKey(community.id, circle.id)) ?? 0;
-			return weight > 0 ? [{ circle, weight }] : [];
-		});
-		const seed = hashString(`community:${community.hubId}`);
-		const step = Math.max(community.radius * 0.38, COMMUNITY_GAP);
-		let bestPosition: GraphPosition | null = null;
-		let bestScore = Number.NEGATIVE_INFINITY;
-		for (let index = 0; index < PACK_SLOT_COUNT; index += 1) {
-			const radius = step * Math.sqrt(index + 1);
-			const angle = index * GOLDEN_ANGLE + randomUnit(seed, 1) * 0.12;
-			const candidate = {
-				x: Math.cos(angle) * radius,
-				y: Math.sin(angle) * radius,
-			};
-			const clearance = clearanceToPacked(candidate, community.radius, packed);
-			if (clearance < COMMUNITY_GAP * 0.2) continue;
-			let bridgeCost = 0;
-			for (const neighbor of linked) {
-				bridgeCost +=
-					neighbor.weight *
-					Math.max(
-						0,
-						distance(candidate, neighbor.circle.center) -
-							community.radius -
-							neighbor.circle.radius,
-					);
-			}
-			const extraGap = Math.max(0, clearance - COMMUNITY_GAP);
-			const score =
-				-Math.hypot(candidate.x, candidate.y) * 0.12 -
-				extraGap * 1.6 -
-				bridgeCost * 0.05;
-			if (score > bestScore) {
-				bestScore = score;
-				bestPosition = candidate;
-			}
-		}
-
-		const center = bestPosition ?? packFallbackCenter(community.radius, packed);
-		centers.set(community.id, center);
-		packed.push({
-			id: community.id,
-			center,
-			radius: community.radius,
-		});
-	}
-
-	return centers;
-}
-
-function placeCommunityMembers(
-	community: ConnectionsCommunity,
-	center: GraphPosition,
-) {
-	const positions = new Map<string, GraphPosition>();
-	positions.set(community.hubId, center);
-	const members = community.members
-		.filter((id) => id !== community.hubId)
-		.sort((left, right) => hashString(left) - hashString(right));
-	if (members.length === 0) return positions;
-
-	const radialStep = Math.min(
-		MEMBER_SPACING,
-		community.radius / Math.sqrt(members.length),
-	);
-	members.forEach((id, index) => {
-		const radius = radialStep * Math.sqrt(index + 1);
-		const angle = index * GOLDEN_ANGLE;
-		positions.set(id, {
-			x: center.x + Math.cos(angle) * radius,
-			y: center.y + Math.sin(angle) * radius,
-		});
+function orderedMembers(community: ConnectionsCommunity) {
+	return [...community.members].sort((left, right) => {
+		if (left === community.hubId) return -1;
+		if (right === community.hubId) return 1;
+		return hashString(left) - hashString(right);
 	});
-	return positions;
 }
 
-function placeDust(
-	ids: readonly string[],
-	cores: readonly PackedCircle[],
-	spacing: number,
-) {
-	const positions = new Map<string, GraphPosition>();
-	const ordered = [...ids].sort(
-		(left, right) => hashString(left) - hashString(right),
-	);
-	let slot = 0;
-	for (const id of ordered) {
-		let placed = false;
-		for (let attempt = 0; attempt < 32; attempt += 1) {
-			const radius = spacing * Math.sqrt(slot + 1);
-			const angle = slot * GOLDEN_ANGLE;
-			slot += 1;
-			const candidate = {
-				x: Math.cos(angle) * radius,
-				y: Math.sin(angle) * radius,
-			};
-			const blocked = cores.some(
-				(core) =>
-					distance(candidate, core.center) < core.radius + spacing * 0.3,
-			);
-			if (!blocked) {
-				positions.set(id, candidate);
-				placed = true;
-				break;
-			}
+function partitionMembers(communities: readonly ConnectionsCommunity[]) {
+	const connected: RadialMember[] = [];
+	const disconnected: RadialMember[] = [];
+	for (const community of communities) {
+		const members = community.members.length > 1 ? connected : disconnected;
+		for (const id of orderedMembers(community)) {
+			members.push({ id, communityId: community.hubId });
 		}
-		if (placed) continue;
-		const radius = spacing * Math.sqrt(slot + 1);
-		const angle = slot * GOLDEN_ANGLE;
-		slot += 1;
-		positions.set(id, {
-			x: Math.cos(angle) * radius,
-			y: Math.sin(angle) * radius,
+	}
+	return { connected, disconnected };
+}
+
+function distributeAroundRing(
+	connected: readonly RadialMember[],
+	disconnected: readonly RadialMember[],
+) {
+	const nodeCount = connected.length + disconnected.length;
+	const slots = new Array<RadialMember | undefined>(nodeCount);
+
+	if (connected.length > 0) {
+		connected.forEach((member, index) => {
+			const slot = Math.floor(((index + 0.5) * nodeCount) / connected.length);
+			slots[slot] = member;
 		});
 	}
-	return positions;
+
+	const remaining = [...disconnected].sort(
+		(left, right) => hashString(left.id) - hashString(right.id),
+	);
+	let remainingIndex = 0;
+	for (let slot = 0; slot < slots.length; slot += 1) {
+		if (slots[slot]) continue;
+		const member = remaining[remainingIndex];
+		if (!member) continue;
+		slots[slot] = member;
+		remainingIndex += 1;
+	}
+
+	return slots;
+}
+
+function communityBundlePoints(slots: readonly (RadialMember | undefined)[]) {
+	const directions = new Map<string, CommunityDirection>();
+	slots.forEach((member, slot) => {
+		if (!member) return;
+		const angle = START_ANGLE + ((slot + 0.5) * FULL_CIRCLE) / slots.length;
+		const direction = directions.get(member.communityId) ?? { x: 0, y: 0 };
+		direction.x += Math.cos(angle);
+		direction.y += Math.sin(angle);
+		directions.set(member.communityId, direction);
+	});
+
+	const bundlePoints = new Map<string, CommunityDirection>();
+	for (const [communityId, direction] of directions) {
+		const magnitude = Math.hypot(direction.x, direction.y);
+		bundlePoints.set(
+			communityId,
+			magnitude < 0.001
+				? { x: 0, y: 0 }
+				: {
+						x: (direction.x / magnitude) * BUNDLE_RING_RADIUS,
+						y: (direction.y / magnitude) * BUNDLE_RING_RADIUS,
+					},
+		);
+	}
+	return bundlePoints;
 }
 
 export function placeConnectionsCommunities(
-	model: ConnectionsCommunityModel,
+	communities: readonly ConnectionsCommunity[],
 ): SerializedGraphPosition[] {
-	const cores = model.communities.filter(
-		(community) => community.members.length >= 2,
-	);
-	const leftover = model.communities
-		.filter((community) => community.members.length < 2)
-		.flatMap((community) => community.members);
-	const toPack = cores.length > 0 ? cores : model.communities;
-	const dust = cores.length > 0 ? leftover : [];
-	const centers = placeCommunityCenters(toPack, model.communityBridges);
-	const packedCores: PackedCircle[] = [];
+	const { connected, disconnected } = partitionMembers(communities);
+	const slots = distributeAroundRing(connected, disconnected);
+	if (slots.length === 0) return [];
+
+	const bundlePoints = communityBundlePoints(slots);
 	const positions: SerializedGraphPosition[] = [];
+	slots.forEach((member, slot) => {
+		if (!member) return;
+		const angle = START_ANGLE + ((slot + 0.5) * FULL_CIRCLE) / slots.length;
+		const bundlePoint = bundlePoints.get(member.communityId) ?? { x: 0, y: 0 };
+		positions.push([
+			member.id,
+			Math.cos(angle) * NODE_RING_RADIUS,
+			Math.sin(angle) * NODE_RING_RADIUS,
+			bundlePoint.x,
+			bundlePoint.y,
+		]);
+	});
 
-	for (const community of toPack) {
-		const center = centers.get(community.id);
-		if (!center) continue;
-		packedCores.push({
-			id: community.id,
-			center,
-			radius: community.radius,
-		});
-		for (const [id, position] of placeCommunityMembers(community, center)) {
-			positions.push([id, position.x, position.y]);
-		}
-	}
-
-	for (const [id, position] of placeDust(dust, packedCores, MEMBER_SPACING)) {
-		positions.push([id, position.x, position.y]);
-	}
 	return positions;
 }

--- a/src/components/connections/connectionsDensity.ts
+++ b/src/components/connections/connectionsDensity.ts
@@ -60,7 +60,6 @@ const SPACE_EDGE_SCALE_TIERS: readonly SpaceEdgeScaleTier[] = [
 interface SpaceSigmaTier {
 	minNodes: number;
 	stagePadding: number;
-	minEdgeThickness: number;
 	minCameraRatio: number;
 }
 
@@ -68,25 +67,21 @@ const SPACE_SIGMA_TIERS: readonly SpaceSigmaTier[] = [
 	{
 		minNodes: 5_000,
 		stagePadding: 36,
-		minEdgeThickness: 0.7,
 		minCameraRatio: 0.05,
 	},
 	{
 		minNodes: 1_000,
 		stagePadding: 40,
-		minEdgeThickness: 0.78,
 		minCameraRatio: 0.18,
 	},
 	{
 		minNodes: 150,
 		stagePadding: 48,
-		minEdgeThickness: 0.85,
 		minCameraRatio: 0.18,
 	},
 	{
 		minNodes: 0,
 		stagePadding: 56,
-		minEdgeThickness: 0.9,
 		minCameraRatio: 0.18,
 	},
 ];
@@ -166,14 +161,12 @@ export function sigmaSettingsForVariant(
 		renderEdgeLabels: false,
 		enableEdgeEvents: false,
 		hideLabelsOnMove: true,
-		hideEdgesOnMove: edgeCount > 5000,
 		defaultNodeType: "circle",
 		defaultEdgeType: "line",
 		minCameraRatio: sigmaTier.minCameraRatio,
 		maxCameraRatio: 2.1,
 		stagePadding: sigmaTier.stagePadding,
 		zoomingRatio: 1.6,
-		minEdgeThickness: sigmaTier.minEdgeThickness,
 		zIndex: true,
 		allowInvalidContainer: false,
 	};

--- a/src/components/connections/connectionsGraph.ts
+++ b/src/components/connections/connectionsGraph.ts
@@ -15,6 +15,8 @@ export type ConnectionsGraphVariant = "space" | "local";
 export interface ConnectionsNodeAttributes {
 	x: number;
 	y: number;
+	bundleX: number;
+	bundleY: number;
 	label: string;
 	size: number;
 	color: string;
@@ -150,11 +152,18 @@ export function buildSpaceConnectionsGraph(
 	const maxConnections = maxConnectionCount(connectionCounts);
 
 	for (const node of payload.nodes) {
-		const position = positions.get(node.id) ?? { x: 1, y: 1 };
+		const position = positions.get(node.id) ?? {
+			x: 1,
+			y: 1,
+			bundleX: 0,
+			bundleY: 0,
+		};
 		const connectionCount = connectionCounts.get(node.id) ?? 0;
 		graph.addNode(node.id, {
 			x: position.x,
 			y: position.y,
+			bundleX: position.bundleX,
+			bundleY: position.bundleY,
 			label: node.title || node.id,
 			size: scaledNodeSize(
 				connectionCount,
@@ -169,11 +178,18 @@ export function buildSpaceConnectionsGraph(
 	}
 
 	for (const tag of payload.tags) {
-		const position = positions.get(tag.id) ?? { x: -1, y: 1 };
+		const position = positions.get(tag.id) ?? {
+			x: -1,
+			y: 1,
+			bundleX: 0,
+			bundleY: 0,
+		};
 		const connectionCount = connectionCounts.get(tag.id) ?? 0;
 		graph.addNode(tag.id, {
 			x: position.x,
 			y: position.y,
+			bundleX: position.bundleX,
+			bundleY: position.bundleY,
 			label: tag.title,
 			size: scaledNodeSize(
 				connectionCount,
@@ -226,6 +242,8 @@ export function buildLocalConnectionsGraph(
 		graph.addNode(node.id, {
 			x: position.x,
 			y: position.y,
+			bundleX: position.x,
+			bundleY: position.y,
 			label: node.title || node.id,
 			size: node.is_center
 				? LOCAL_CENTER_NODE_SIZE
@@ -242,6 +260,8 @@ export function buildLocalConnectionsGraph(
 		graph.addNode(tag.id, {
 			x: position.x,
 			y: position.y,
+			bundleX: position.x,
+			bundleY: position.y,
 			label: tag.title,
 			size: scaledNodeSize(
 				connectionCount,

--- a/src/components/connections/connectionsGraph.ts
+++ b/src/components/connections/connectionsGraph.ts
@@ -10,7 +10,7 @@ import { hashString, randomUnit } from "./connectionsRandom";
 export type ConnectionsNodeKind = "note" | "tag";
 export type ConnectionsEdgeColorRole = "default" | "accent" | "internal";
 
-export type ConnectionsGraphVariant = "space" | "local";
+export type ConnectionsGraphVariant = "space" | "space-legacy" | "local";
 
 export interface ConnectionsNodeAttributes {
 	x: number;

--- a/src/components/connections/connectionsLayout.ts
+++ b/src/components/connections/connectionsLayout.ts
@@ -3,6 +3,14 @@ import {
 	detectConnectionsCommunities,
 } from "./connectionsCommunities";
 import { placeConnectionsCommunities } from "./connectionsCommunityPlacement";
+import { placeLegacyConnectionsCommunities } from "./connectionsLegacyCommunityPlacement";
+
+export type ConnectionsLayoutMode = "bundled" | "legacy";
+
+export interface ConnectionsLayoutRequest {
+	readonly graph: ConnectionsLayoutGraph;
+	readonly mode: ConnectionsLayoutMode;
+}
 
 export interface GraphPosition {
 	readonly x: number;
@@ -27,7 +35,13 @@ export type ConnectionsLayoutResponse =
 			readonly error: string;
 	  };
 
-export function computeSpaceConnectionsLayout(graph: ConnectionsLayoutGraph) {
+export function computeSpaceConnectionsLayout({
+	graph,
+	mode,
+}: ConnectionsLayoutRequest) {
 	if (graph.nodeIds.length + graph.tags.length === 0) return [];
-	return placeConnectionsCommunities(detectConnectionsCommunities(graph));
+	const model = detectConnectionsCommunities(graph);
+	return mode === "legacy"
+		? placeLegacyConnectionsCommunities(model)
+		: placeConnectionsCommunities(model);
 }

--- a/src/components/connections/connectionsLayout.ts
+++ b/src/components/connections/connectionsLayout.ts
@@ -5,22 +5,26 @@ import {
 import { placeConnectionsCommunities } from "./connectionsCommunityPlacement";
 
 export interface GraphPosition {
-	x: number;
-	y: number;
+	readonly x: number;
+	readonly y: number;
+	readonly bundleX: number;
+	readonly bundleY: number;
 }
 
 export type SerializedGraphPosition = readonly [
 	id: string,
 	x: number,
 	y: number,
+	bundleX: number,
+	bundleY: number,
 ];
 
 export type ConnectionsLayoutResponse =
 	| {
-			positions: SerializedGraphPosition[];
+			readonly positions: readonly SerializedGraphPosition[];
 	  }
 	| {
-			error: string;
+			readonly error: string;
 	  };
 
 export function computeSpaceConnectionsLayout(graph: ConnectionsLayoutGraph) {

--- a/src/components/connections/connectionsLayout.worker.ts
+++ b/src/components/connections/connectionsLayout.worker.ts
@@ -1,11 +1,11 @@
-import type { ConnectionsLayoutGraph } from "./connectionsCommunities";
 import {
+	type ConnectionsLayoutRequest,
 	type ConnectionsLayoutResponse,
 	computeSpaceConnectionsLayout,
 } from "./connectionsLayout";
 
 interface ConnectionsWorkerScope {
-	onmessage: ((event: MessageEvent<ConnectionsLayoutGraph>) => void) | null;
+	onmessage: ((event: MessageEvent<ConnectionsLayoutRequest>) => void) | null;
 	postMessage: (response: ConnectionsLayoutResponse) => void;
 }
 

--- a/src/components/connections/connectionsLegacyCommunityPlacement.ts
+++ b/src/components/connections/connectionsLegacyCommunityPlacement.ts
@@ -1,0 +1,234 @@
+import {
+	type ConnectionsCommunity,
+	type ConnectionsCommunityModel,
+	communityBridgeKey,
+} from "./connectionsCommunities";
+import type { SerializedGraphPosition } from "./connectionsLayout";
+import { hashString, randomUnit } from "./connectionsRandom";
+
+const COMMUNITY_GAP = 22;
+const MEMBER_SPACING = 18;
+const PACK_SLOT_COUNT = 160;
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
+
+interface GraphPoint {
+	readonly x: number;
+	readonly y: number;
+}
+
+interface PackedCircle {
+	readonly id: number;
+	readonly center: GraphPoint;
+	readonly radius: number;
+}
+
+function distance(left: GraphPoint, right: GraphPoint) {
+	return Math.hypot(left.x - right.x, left.y - right.y);
+}
+
+function clearanceToPacked(
+	candidate: GraphPoint,
+	radius: number,
+	packed: readonly PackedCircle[],
+) {
+	let clearance = Number.POSITIVE_INFINITY;
+	for (const existing of packed) {
+		clearance = Math.min(
+			clearance,
+			distance(candidate, existing.center) - radius - existing.radius,
+		);
+	}
+	return clearance;
+}
+
+function packFallbackCenter(
+	radius: number,
+	packed: readonly PackedCircle[],
+): GraphPoint {
+	let outer = 0;
+	for (const circle of packed) {
+		outer = Math.max(
+			outer,
+			Math.hypot(circle.center.x, circle.center.y) + circle.radius,
+		);
+	}
+	const ring = outer + radius + COMMUNITY_GAP;
+	const angle = packed.length * GOLDEN_ANGLE;
+	return {
+		x: Math.cos(angle) * ring,
+		y: Math.sin(angle) * ring,
+	};
+}
+
+function placeCommunityCenters(
+	cores: readonly ConnectionsCommunity[],
+	communityBridges: ReadonlyMap<string, number>,
+) {
+	const centers = new Map<number, GraphPoint>();
+	const packed: PackedCircle[] = [];
+
+	for (const community of cores) {
+		if (packed.length === 0) {
+			const origin = { x: 0, y: 0 };
+			centers.set(community.id, origin);
+			packed.push({
+				id: community.id,
+				center: origin,
+				radius: community.radius,
+			});
+			continue;
+		}
+
+		const linked = packed.flatMap((circle) => {
+			const weight =
+				communityBridges.get(communityBridgeKey(community.id, circle.id)) ?? 0;
+			return weight > 0 ? [{ circle, weight }] : [];
+		});
+		const seed = hashString(`community:${community.hubId}`);
+		const step = Math.max(community.radius * 0.38, COMMUNITY_GAP);
+		let bestPosition: GraphPoint | null = null;
+		let bestScore = Number.NEGATIVE_INFINITY;
+		for (let index = 0; index < PACK_SLOT_COUNT; index += 1) {
+			const radius = step * Math.sqrt(index + 1);
+			const angle = index * GOLDEN_ANGLE + randomUnit(seed, 1) * 0.12;
+			const candidate = {
+				x: Math.cos(angle) * radius,
+				y: Math.sin(angle) * radius,
+			};
+			const clearance = clearanceToPacked(candidate, community.radius, packed);
+			if (clearance < COMMUNITY_GAP * 0.2) continue;
+			let bridgeCost = 0;
+			for (const neighbor of linked) {
+				bridgeCost +=
+					neighbor.weight *
+					Math.max(
+						0,
+						distance(candidate, neighbor.circle.center) -
+							community.radius -
+							neighbor.circle.radius,
+					);
+			}
+			const extraGap = Math.max(0, clearance - COMMUNITY_GAP);
+			const score =
+				-Math.hypot(candidate.x, candidate.y) * 0.12 -
+				extraGap * 1.6 -
+				bridgeCost * 0.05;
+			if (score > bestScore) {
+				bestScore = score;
+				bestPosition = candidate;
+			}
+		}
+
+		const center = bestPosition ?? packFallbackCenter(community.radius, packed);
+		centers.set(community.id, center);
+		packed.push({
+			id: community.id,
+			center,
+			radius: community.radius,
+		});
+	}
+
+	return centers;
+}
+
+function placeCommunityMembers(
+	community: ConnectionsCommunity,
+	center: GraphPoint,
+) {
+	const positions = new Map<string, GraphPoint>();
+	positions.set(community.hubId, center);
+	const members = community.members
+		.filter((id) => id !== community.hubId)
+		.sort((left, right) => hashString(left) - hashString(right));
+	if (members.length === 0) return positions;
+
+	const radialStep = Math.min(
+		MEMBER_SPACING,
+		community.radius / Math.sqrt(members.length),
+	);
+	members.forEach((id, index) => {
+		const radius = radialStep * Math.sqrt(index + 1);
+		const angle = index * GOLDEN_ANGLE;
+		positions.set(id, {
+			x: center.x + Math.cos(angle) * radius,
+			y: center.y + Math.sin(angle) * radius,
+		});
+	});
+	return positions;
+}
+
+function placeDust(
+	ids: readonly string[],
+	cores: readonly PackedCircle[],
+	spacing: number,
+) {
+	const positions = new Map<string, GraphPoint>();
+	const ordered = [...ids].sort(
+		(left, right) => hashString(left) - hashString(right),
+	);
+	let slot = 0;
+	for (const id of ordered) {
+		let placed = false;
+		for (let attempt = 0; attempt < 32; attempt += 1) {
+			const radius = spacing * Math.sqrt(slot + 1);
+			const angle = slot * GOLDEN_ANGLE;
+			slot += 1;
+			const candidate = {
+				x: Math.cos(angle) * radius,
+				y: Math.sin(angle) * radius,
+			};
+			const blocked = cores.some(
+				(core) =>
+					distance(candidate, core.center) < core.radius + spacing * 0.3,
+			);
+			if (!blocked) {
+				positions.set(id, candidate);
+				placed = true;
+				break;
+			}
+		}
+		if (placed) continue;
+		const radius = spacing * Math.sqrt(slot + 1);
+		const angle = slot * GOLDEN_ANGLE;
+		slot += 1;
+		positions.set(id, {
+			x: Math.cos(angle) * radius,
+			y: Math.sin(angle) * radius,
+		});
+	}
+	return positions;
+}
+
+export function placeLegacyConnectionsCommunities(
+	model: ConnectionsCommunityModel,
+): SerializedGraphPosition[] {
+	const cores = model.communities.filter(
+		(community) => community.members.length >= 2,
+	);
+	const leftover = model.communities
+		.filter((community) => community.members.length < 2)
+		.flatMap((community) => community.members);
+	const toPack = cores.length > 0 ? cores : model.communities;
+	const dust = cores.length > 0 ? leftover : [];
+	const centers = placeCommunityCenters(toPack, model.communityBridges);
+	const packedCores: PackedCircle[] = [];
+	const positions: SerializedGraphPosition[] = [];
+
+	for (const community of toPack) {
+		const center = centers.get(community.id);
+		if (!center) continue;
+		packedCores.push({
+			id: community.id,
+			center,
+			radius: community.radius,
+		});
+		for (const [id, position] of placeCommunityMembers(community, center)) {
+			positions.push([id, position.x, position.y, position.x, position.y]);
+		}
+	}
+
+	for (const [id, position] of placeDust(dust, packedCores, MEMBER_SPACING)) {
+		positions.push([id, position.x, position.y, position.x, position.y]);
+	}
+	return positions;
+}

--- a/src/components/connections/connectionsLegacyCommunityPlacement.ts
+++ b/src/components/connections/connectionsLegacyCommunityPlacement.ts
@@ -166,6 +166,13 @@ function placeDust(
 	const ordered = [...ids].sort(
 		(left, right) => hashString(left) - hashString(right),
 	);
+	let packedOuterRadius = 0;
+	for (const core of cores) {
+		packedOuterRadius = Math.max(
+			packedOuterRadius,
+			Math.hypot(core.center.x, core.center.y) + core.radius,
+		);
+	}
 	let slot = 0;
 	for (const id of ordered) {
 		let placed = false;
@@ -188,7 +195,7 @@ function placeDust(
 			}
 		}
 		if (placed) continue;
-		const radius = spacing * Math.sqrt(slot + 1);
+		const radius = packedOuterRadius + spacing * Math.sqrt(slot + 1);
 		const angle = slot * GOLDEN_ANGLE;
 		slot += 1;
 		positions.set(id, {
@@ -208,13 +215,11 @@ export function placeLegacyConnectionsCommunities(
 	const leftover = model.communities
 		.filter((community) => community.members.length < 2)
 		.flatMap((community) => community.members);
-	const toPack = cores.length > 0 ? cores : model.communities;
-	const dust = cores.length > 0 ? leftover : [];
-	const centers = placeCommunityCenters(toPack, model.communityBridges);
+	const centers = placeCommunityCenters(cores, model.communityBridges);
 	const packedCores: PackedCircle[] = [];
 	const positions: SerializedGraphPosition[] = [];
 
-	for (const community of toPack) {
+	for (const community of cores) {
 		const center = centers.get(community.id);
 		if (!center) continue;
 		packedCores.push({
@@ -227,7 +232,11 @@ export function placeLegacyConnectionsCommunities(
 		}
 	}
 
-	for (const [id, position] of placeDust(dust, packedCores, MEMBER_SPACING)) {
+	for (const [id, position] of placeDust(
+		leftover,
+		packedCores,
+		MEMBER_SPACING,
+	)) {
 		positions.push([id, position.x, position.y, position.x, position.y]);
 	}
 	return positions;

--- a/src/components/connections/useSigmaConnections.ts
+++ b/src/components/connections/useSigmaConnections.ts
@@ -221,7 +221,7 @@ export function useSigmaConnections({
 				ConnectionsEdgeAttributes
 			>(graph, container, {
 				...sigmaSettings,
-				...(variant !== "local"
+				...(variant === "space"
 					? connectionsLabelVisibility(labelZoomRef.current)
 					: {}),
 				labelColor: { color: palette.text },

--- a/src/components/connections/useSigmaConnections.ts
+++ b/src/components/connections/useSigmaConnections.ts
@@ -2,6 +2,7 @@ import { type RefObject, useEffect, useRef } from "react";
 import Sigma from "sigma";
 import { connectionsLabelVisibility } from "../../lib/connectionsGraphOptions";
 import {
+	drawBundledConnectionsEdges,
 	drawConnectionsNodeHover,
 	drawConnectionsNodeLabel,
 } from "./connectionsCanvas";
@@ -93,6 +94,10 @@ export function useSigmaConnections({
 	labelZoomRef.current = labelZoomThreshold;
 	const searchMatchIdsRef = useRef(searchMatchIds);
 	searchMatchIdsRef.current = searchMatchIds;
+	const onNoteOpenRef = useRef(onNoteOpen);
+	onNoteOpenRef.current = onNoteOpen;
+	const onTagActivateRef = useRef(onTagActivate);
+	onTagActivateRef.current = onTagActivate;
 	const paletteRef = useRef<ConnectionsPalette | null>(null);
 	const refreshScheduledRef = useRef(false);
 	const overlayRef = useRef<ConnectionsOverlayApi>({
@@ -204,6 +209,12 @@ export function useSigmaConnections({
 						target,
 					),
 			);
+			const resolveEdgeStyle = (
+				edge: string,
+				data: ConnectionsEdgeAttributes,
+				source: string,
+				target: string,
+			) => edgeReducer(edge, data, source, target);
 
 			const activeRenderer = new Sigma<
 				ConnectionsNodeAttributes,
@@ -224,6 +235,7 @@ export function useSigmaConnections({
 						labelSettings,
 						paletteRef.current ?? palette,
 						variant,
+						renderer?.graphToViewport({ x: 0, y: 0 }),
 					),
 				defaultDrawNodeHover: (context, data) =>
 					drawConnectionsNodeHover(
@@ -239,12 +251,36 @@ export function useSigmaConnections({
 						y: graph.getNodeAttribute(node, "y"),
 					}),
 				edgeReducer: (edge, data) => {
+					if (variant === "space") return { hidden: true };
 					const source = graph.source(edge);
 					const target = graph.target(edge);
-					return edgeReducer(edge, data, source, target);
+					return resolveEdgeStyle(edge, data, source, target);
 				},
 			});
 			renderer = activeRenderer;
+
+			if (variant === "space") {
+				const bundledEdgesCanvas = activeRenderer.createCanvas("bundledEdges", {
+					afterLayer: "edges",
+					style: {
+						left: "0",
+						pointerEvents: "none",
+						top: "0",
+					},
+				});
+				const bundledEdgesContext = bundledEdgesCanvas.getContext("2d");
+				if (bundledEdgesContext) {
+					activeRenderer.on("afterRender", () => {
+						drawBundledConnectionsEdges({
+							canvas: bundledEdgesCanvas,
+							context: bundledEdgesContext,
+							renderer: activeRenderer,
+							graph,
+							resolveStyle: resolveEdgeStyle,
+						});
+					});
+				}
+			}
 
 			const fitToView = () => {
 				if (disposed) return;
@@ -281,22 +317,28 @@ export function useSigmaConnections({
 			});
 			activeRenderer.on("clickNode", ({ node }) => {
 				if (didDrag) return;
+				const shouldOpen = focusState.selectedNodeId === node;
 				setFocus(activeRenderer, {
 					selectedNodeId: node,
 					hoveredNode: node,
 				});
+				if (!shouldOpen) return;
 				const kind = graph.getNodeAttribute(node, "kind");
 				if (kind === "tag") {
-					onTagActivate?.(node, graph.getNodeAttribute(node, "label"));
+					onTagActivateRef.current?.(
+						node,
+						graph.getNodeAttribute(node, "label"),
+					);
 					return;
 				}
-				onNoteOpen?.(node);
+				onNoteOpenRef.current?.(node);
 			});
 			activeRenderer.on("clickStage", () => {
 				setFocus(activeRenderer, { hoveredNode: null, selectedNodeId: null });
 			});
 
 			activeRenderer.on("downNode", ({ node }) => {
+				if (variant === "space") return;
 				if (graph.getNodeAttribute(node, "isCenter")) return;
 				draggedNode = node;
 				didDrag = false;
@@ -349,7 +391,7 @@ export function useSigmaConnections({
 		setup();
 
 		return cleanup;
-	}, [containerRef, enabled, graph, onNoteOpen, onTagActivate, variant]);
+	}, [containerRef, enabled, graph, variant]);
 
 	return overlayRef;
 }

--- a/src/components/connections/useSigmaConnections.ts
+++ b/src/components/connections/useSigmaConnections.ts
@@ -221,7 +221,7 @@ export function useSigmaConnections({
 				ConnectionsEdgeAttributes
 			>(graph, container, {
 				...sigmaSettings,
-				...(variant === "space"
+				...(variant !== "local"
 					? connectionsLabelVisibility(labelZoomRef.current)
 					: {}),
 				labelColor: { color: palette.text },

--- a/src/components/connections/useSpaceConnectionsGraph.ts
+++ b/src/components/connections/useSpaceConnectionsGraph.ts
@@ -61,7 +61,14 @@ function layoutSpaceConnections(
 				reject(new Error(response.error));
 				return;
 			}
-			resolve(new Map(response.positions.map(([id, x, y]) => [id, { x, y }])));
+			resolve(
+				new Map(
+					response.positions.map(([id, x, y, bundleX, bundleY]) => [
+						id,
+						{ x, y, bundleX, bundleY },
+					]),
+				),
+			);
 		};
 		worker.onerror = (event) => {
 			signal.removeEventListener("abort", abort);

--- a/src/components/connections/useSpaceConnectionsGraph.ts
+++ b/src/components/connections/useSpaceConnectionsGraph.ts
@@ -11,6 +11,8 @@ import {
 	buildSpaceConnectionsGraph,
 } from "./connectionsGraph";
 import type {
+	ConnectionsLayoutMode,
+	ConnectionsLayoutRequest,
 	ConnectionsLayoutResponse,
 	GraphPosition,
 } from "./connectionsLayout";
@@ -18,6 +20,7 @@ import { hashString } from "./connectionsRandom";
 
 function layoutSpaceConnections(
 	payload: SpaceConnections,
+	mode: ConnectionsLayoutMode,
 	signal: AbortSignal,
 ) {
 	return new Promise<ReadonlyMap<string, GraphPosition>>((resolve, reject) => {
@@ -25,7 +28,7 @@ function layoutSpaceConnections(
 			new URL("./connectionsLayout.worker.ts", import.meta.url),
 			{ type: "module" },
 		);
-		const request: ConnectionsLayoutGraph = {
+		const graph: ConnectionsLayoutGraph = {
 			nodeIds: payload.nodes.map((node) => node.id),
 			tags: payload.tags.map((tag) => ({
 				id: tag.id,
@@ -42,6 +45,7 @@ function layoutSpaceConnections(
 				noteId: edge.note_id,
 			})),
 		};
+		const request: ConnectionsLayoutRequest = { graph, mode };
 
 		const abort = () => {
 			worker.terminate();
@@ -140,6 +144,7 @@ export function useSpaceConnectionsGraph(
 	payload: SpaceConnections | null,
 	spacePath: string,
 	options: ConnectionsGraphOptions,
+	mode: ConnectionsLayoutMode,
 ) {
 	const filteredPayload = useMemo(
 		() => (payload ? filterSpaceConnections(payload, options) : null),
@@ -152,7 +157,7 @@ export function useSpaceConnectionsGraph(
 	);
 
 	const layoutQuery = useQuery({
-		queryKey: ["space-connections-layout", spacePath, layoutFingerprint],
+		queryKey: ["space-connections-layout", spacePath, layoutFingerprint, mode],
 		enabled: Boolean(filteredPayload && filteredPayload.nodes.length > 0),
 		staleTime: Number.POSITIVE_INFINITY,
 		gcTime: 0,
@@ -161,7 +166,7 @@ export function useSpaceConnectionsGraph(
 			if (!filteredPayload) {
 				return Promise.reject(new Error("Missing connections payload"));
 			}
-			return layoutSpaceConnections(filteredPayload, signal);
+			return layoutSpaceConnections(filteredPayload, mode, signal);
 		},
 	});
 

--- a/src/components/settings/ExperimentalSettingsPane.tsx
+++ b/src/components/settings/ExperimentalSettingsPane.tsx
@@ -51,6 +51,11 @@ export function ExperimentalSettingsPane() {
 		DURABLE_SETTINGS.noteSidePeek.write,
 		setError,
 	);
+	const legacyConnections = useSettingsBoolean(
+		false,
+		DURABLE_SETTINGS.legacyConnections.write,
+		setError,
+	);
 	const externalLinkPreviews = useSettingsBoolean(
 		false,
 		DURABLE_SETTINGS.editorShowExternalLinkPreviews.write,
@@ -84,6 +89,7 @@ export function ExperimentalSettingsPane() {
 
 	const setInitialFolioMode = folioMode.setInitialChecked;
 	const setInitialNoteSidePeek = noteSidePeek.setInitialChecked;
+	const setInitialLegacyConnections = legacyConnections.setInitialChecked;
 	const setInitialExternalLinkPreviews = externalLinkPreviews.setInitialChecked;
 	const setInitialFormatBar = formatBar.setInitialChecked;
 	const setInitialZenMode = zenMode.setInitialChecked;
@@ -96,6 +102,7 @@ export function ExperimentalSettingsPane() {
 		if (!settings) return;
 		setInitialFolioMode(settings.ui.folioMode);
 		setInitialNoteSidePeek(settings.ui.noteSidePeek);
+		setInitialLegacyConnections(settings.ui.legacyConnections);
 		setInitialExternalLinkPreviews(settings.editor.showExternalLinkPreviews);
 		setInitialFormatBar(settings.editor.showFormatBar);
 		setInitialZenMode(settings.editor.zenMode);
@@ -109,6 +116,7 @@ export function ExperimentalSettingsPane() {
 		setInitialFormatBar,
 		setInitialZenMode,
 		setInitialNoteSidePeek,
+		setInitialLegacyConnections,
 		setInitialFocusMode,
 		setInitialNonMarkdownFiles,
 		setInitialRawMarkdownVimMode,
@@ -141,6 +149,18 @@ export function ExperimentalSettingsPane() {
 							disabled={folioMode.isSaving}
 							ariaLabel={tAppearance("layout.folioMode.ariaLabel")}
 							onCheckedChange={folioMode.onCheckedChange}
+						/>
+					</SettingsRow>
+					<SettingsRow
+						label={t("experimental.legacyConnections.label")}
+						description={t("experimental.legacyConnections.description")}
+						searchId="experimental-legacy-connections"
+					>
+						<SettingsToggle
+							checked={legacyConnections.checked}
+							disabled={legacyConnections.isSaving}
+							ariaLabel={t("experimental.legacyConnections.ariaLabel")}
+							onCheckedChange={legacyConnections.onCheckedChange}
 						/>
 					</SettingsRow>
 					<SettingsRow

--- a/src/components/settings/settingsSearch.ts
+++ b/src/components/settings/settingsSearch.ts
@@ -115,6 +115,7 @@ const SETTINGS_SEARCH_DEFS: readonly SettingsSearchDef[] = [
 	{ id: "ai-assistant-behavior-tools", tab: "ai" },
 	{ id: "appearance-layout-folio-mode", tab: "experimental" },
 	{ id: "appearance-layout-note-side-peek", tab: "experimental" },
+	{ id: "experimental-legacy-connections", tab: "experimental" },
 	{ id: "general-file-tree-folder-counts", tab: "general" },
 	{ id: "general-file-tree-folder-tabs", tab: "general" },
 	{ id: "general-file-tree-non-markdown-files", tab: "experimental" },

--- a/src/i18n/locales/de/settings.general.json
+++ b/src/i18n/locales/de/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "Experimentell",
 		"sectionDescription": "Experimentelle Funktionen, die noch nicht ausgereift sind. Eine spätere Glyph-Version kann sie ändern oder entfernen.",
+		"legacyConnections": {
+			"label": "Klassische Verbindungen",
+			"description": "Verwendet die vorherige freie Verbindungsansicht mit geraden Kanten und verschiebbaren Knoten.",
+			"ariaLabel": "Klassische Verbindungen"
+		},
 		"noteSidePeek": {
 			"label": "Notiz-Peek",
 			"description": "Wiki-Links und Alle Notizen öffnen als Peek über dem aktuellen Tab, statt ihn zu ersetzen. Erweitere den Peek, um zur Notiz zu wechseln, oder schließe ihn, um zu bleiben. Dateibaum und Befehlspalette öffnen weiter Tabs.",

--- a/src/i18n/locales/de/settings.search.json
+++ b/src/i18n/locales/de/settings.search.json
@@ -609,6 +609,11 @@
 			"section": "Experimentell",
 			"keywords": ["peek", "vorschau", "wiki", "alle notizen", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Klassische Verbindungen",
+			"section": "Experimentell",
+			"keywords": ["verbindungen", "graph", "klassisch", "layout"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Dateianzahl in Ordnern anzeigen",
 			"section": "Dateibaum",

--- a/src/i18n/locales/en/settings.general.json
+++ b/src/i18n/locales/en/settings.general.json
@@ -89,6 +89,11 @@
 	"experimental": {
 		"sectionTitle": "Experimental",
 		"sectionDescription": "Experimental features that are not fully fleshed out. A later version of Glyph may change or remove them.",
+		"legacyConnections": {
+			"label": "Legacy Connections",
+			"description": "Use the previous freeform Connections layout with straight edges and draggable nodes.",
+			"ariaLabel": "Legacy Connections"
+		},
 		"noteSidePeek": {
 			"label": "Note peek",
 			"description": "Wiki links and All Notes open as a Peek over the current tab instead of replacing it. Expand the Peek to go to that note, or close it to stay where you were. The file tree and command palette still open tabs.",

--- a/src/i18n/locales/en/settings.search.json
+++ b/src/i18n/locales/en/settings.search.json
@@ -609,6 +609,11 @@
 			"section": "Experimental",
 			"keywords": ["peek", "preview", "wiki", "all notes", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Legacy Connections",
+			"section": "Experimental",
+			"keywords": ["connections", "graph", "legacy", "classic", "layout"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Show folder file counts",
 			"section": "File tree",

--- a/src/i18n/locales/es/settings.general.json
+++ b/src/i18n/locales/es/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "Experimental",
 		"sectionDescription": "Funciones experimentales que aún no están del todo definidas. Una versión posterior de Glyph puede cambiarlas o quitarlas.",
+		"legacyConnections": {
+			"label": "Conexiones clásicas",
+			"description": "Usa el diseño libre anterior de Conexiones, con enlaces rectos y nodos que se pueden arrastrar.",
+			"ariaLabel": "Conexiones clásicas"
+		},
 		"noteSidePeek": {
 			"label": "Peek de nota",
 			"description": "Los wiki-enlaces y Todas las notas se abren como un Peek sobre la pestaña actual en lugar de reemplazarla. Amplía el Peek para ir a esa nota, o ciérralo para quedarte. El árbol de archivos y la paleta de comandos siguen abriendo pestañas.",

--- a/src/i18n/locales/es/settings.search.json
+++ b/src/i18n/locales/es/settings.search.json
@@ -617,6 +617,11 @@
 			"section": "Experimental",
 			"keywords": ["peek", "vista", "wiki", "todas las notas", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Conexiones clásicas",
+			"section": "Experimental",
+			"keywords": ["conexiones", "grafo", "clásico", "diseño"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Mostrar recuento de archivos por carpeta",
 			"section": "Árbol de archivos",

--- a/src/i18n/locales/fr/settings.general.json
+++ b/src/i18n/locales/fr/settings.general.json
@@ -89,6 +89,11 @@
 	"experimental": {
 		"sectionTitle": "Expérimental",
 		"sectionDescription": "Fonctionnalités expérimentales encore inachevées. Une version ultérieure de Glyph peut les modifier ou les retirer.",
+		"legacyConnections": {
+			"label": "Connexions classiques",
+			"description": "Utilise l’ancienne disposition libre des connexions, avec des arêtes droites et des nœuds déplaçables.",
+			"ariaLabel": "Connexions classiques"
+		},
 		"noteSidePeek": {
 			"label": "Peek de note",
 			"description": "Les wiki-liens et Toutes les notes s’ouvrent en Peek au-dessus de l’onglet actuel au lieu de le remplacer. Agrandissez le Peek pour aller à cette note, ou fermez-le pour rester. L’arborescence et la palette de commandes ouvrent toujours des onglets.",

--- a/src/i18n/locales/fr/settings.search.json
+++ b/src/i18n/locales/fr/settings.search.json
@@ -615,6 +615,11 @@
 			"section": "Expérimental",
 			"keywords": ["peek", "aperçu", "wiki", "toutes les notes", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Connexions classiques",
+			"section": "Expérimental",
+			"keywords": ["connexions", "graphe", "classique", "disposition"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Afficher le nombre de fichiers par dossier",
 			"section": "Arborescence des fichiers",

--- a/src/i18n/locales/ja/settings.general.json
+++ b/src/i18n/locales/ja/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "実験的",
 		"sectionDescription": "まだ作り込みが足りない実験的な機能です。今後の Glyph のバージョンで変更または削除されることがあります。",
+		"legacyConnections": {
+			"label": "従来の接続グラフ",
+			"description": "直線のエッジとドラッグ可能なノードを使う、以前の自由配置の接続グラフを使用します。",
+			"ariaLabel": "従来の接続グラフ"
+		},
 		"noteSidePeek": {
 			"label": "ノートプレビュー",
 			"description": "Wiki リンクやすべてのノートは、現在のタブを置き換えず Peek として重ねて開きます。Peek を広げるとそのノートへ移動し、閉じると今の場所に残ります。ファイルツリーとコマンドパレットはこれまでどおりタブで開きます。",

--- a/src/i18n/locales/ja/settings.search.json
+++ b/src/i18n/locales/ja/settings.search.json
@@ -598,6 +598,11 @@
 			"section": "実験的",
 			"keywords": ["peek", "プレビュー", "wiki", "すべてのノート", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "従来の接続グラフ",
+			"section": "実験的",
+			"keywords": ["接続", "グラフ", "従来", "配置"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "フォルダのファイル数を表示",
 			"section": "ファイルツリー",

--- a/src/i18n/locales/ko/settings.general.json
+++ b/src/i18n/locales/ko/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "실험적",
 		"sectionDescription": "아직 다듬어지지 않은 실험적 기능입니다. 이후 Glyph 버전에서 바뀌거나 제거될 수 있습니다.",
+		"legacyConnections": {
+			"label": "기존 연결 그래프",
+			"description": "직선 연결선과 드래그 가능한 노드를 사용하는 이전 자유 배치 연결 그래프를 사용합니다.",
+			"ariaLabel": "기존 연결 그래프"
+		},
 		"noteSidePeek": {
 			"label": "노트 피크",
 			"description": "위키 링크와 모든 노트는 현재 탭을 바꾸지 않고 Peek으로 겹쳐 엽니다. Peek을 펼치면 그 노트로 가고, 닫으면 지금 자리에 남습니다. 파일 트리와 명령 팔레트는 여전히 탭으로 엽니다.",

--- a/src/i18n/locales/ko/settings.search.json
+++ b/src/i18n/locales/ko/settings.search.json
@@ -584,6 +584,11 @@
 			"section": "실험적",
 			"keywords": ["peek", "미리보기", "wiki", "모든 노트", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "기존 연결 그래프",
+			"section": "실험적",
+			"keywords": ["연결", "그래프", "기존", "레이아웃"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "폴더 파일 수 표시",
 			"section": "파일 트리",

--- a/src/i18n/locales/pl/settings.general.json
+++ b/src/i18n/locales/pl/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "Eksperymentalne",
 		"sectionDescription": "Funkcje eksperymentalne, które nie są jeszcze dopracowane. Późniejsza wersja Glyph może je zmienić lub usunąć.",
+		"legacyConnections": {
+			"label": "Klasyczne połączenia",
+			"description": "Używa poprzedniego swobodnego układu połączeń z prostymi krawędziami i przeciąganymi węzłami.",
+			"ariaLabel": "Klasyczne połączenia"
+		},
 		"noteSidePeek": {
 			"label": "Peek notatki",
 			"description": "Wiki-linki i Wszystkie notatki otwierają się jako Peek nad bieżącą kartą zamiast ją zastępować. Rozwiń Peek, aby przejść do notatki, albo zamknij, aby zostać. Drzewo plików i paleta poleceń nadal otwierają karty.",

--- a/src/i18n/locales/pl/settings.search.json
+++ b/src/i18n/locales/pl/settings.search.json
@@ -579,6 +579,11 @@
 			"section": "Eksperymentalne",
 			"keywords": ["peek", "podgląd", "wiki", "wszystkie notatki", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Klasyczne połączenia",
+			"section": "Eksperymentalne",
+			"keywords": ["połączenia", "graf", "klasyczne", "układ"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Pokaż liczbę plików w folderach",
 			"section": "Drzewo plików",

--- a/src/i18n/locales/pt-BR/settings.general.json
+++ b/src/i18n/locales/pt-BR/settings.general.json
@@ -78,6 +78,11 @@
 	"experimental": {
 		"sectionTitle": "Experimental",
 		"sectionDescription": "Recursos experimentais ainda incompletos. Uma versão posterior do Glyph pode alterá-los ou removê-los.",
+		"legacyConnections": {
+			"label": "Conexões clássicas",
+			"description": "Usa o layout livre anterior de Conexões, com arestas retas e nós que podem ser arrastados.",
+			"ariaLabel": "Conexões clássicas"
+		},
 		"noteSidePeek": {
 			"label": "Peek de nota",
 			"description": "Wiki-links e Todas as notas abrem como um Peek sobre a aba atual em vez de substituí-la. Amplie o Peek para ir até essa nota, ou feche para ficar onde está. A árvore de arquivos e a paleta de comandos ainda abrem abas.",

--- a/src/i18n/locales/pt-BR/settings.search.json
+++ b/src/i18n/locales/pt-BR/settings.search.json
@@ -598,6 +598,11 @@
 			"section": "Experimental",
 			"keywords": ["peek", "pré-visualização", "wiki", "todas as notas", "arc"]
 		},
+		"experimental-legacy-connections": {
+			"title": "Conexões clássicas",
+			"section": "Experimental",
+			"keywords": ["conexões", "grafo", "clássico", "layout"]
+		},
 		"general-file-tree-folder-counts": {
 			"title": "Mostrar contagem de arquivos por pasta",
 			"section": "Árvore de arquivos",

--- a/src/lib/connectionsGraphOptions.ts
+++ b/src/lib/connectionsGraphOptions.ts
@@ -89,6 +89,10 @@ export function connectionsLinkOpacity(value: number) {
 	return unitScale(value, 0.07, 0.55);
 }
 
+export function legacyConnectionsLinkOpacity(value: number) {
+	return unitScale(value, 0.55, 1);
+}
+
 export function connectionsLinkThicknessScale(value: number) {
 	return unitScale(value, 0.5, 1.8);
 }

--- a/src/lib/connectionsGraphOptions.ts
+++ b/src/lib/connectionsGraphOptions.ts
@@ -86,7 +86,7 @@ export function connectionsNodeSizeScale(value: number) {
 }
 
 export function connectionsLinkOpacity(value: number) {
-	return unitScale(value, 0.55, 1);
+	return unitScale(value, 0.07, 0.55);
 }
 
 export function connectionsLinkThicknessScale(value: number) {

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -116,6 +116,16 @@ const DURABLE_SETTING_CASES = [
 		writes: [{ value: true, payload: { ui: { folioMode: true } } }],
 	},
 	{
+		name: "legacy connections",
+		storeKey: "ui.legacyConnections",
+		read: (settings: AppSettings) => settings.ui.legacyConnections,
+		defaultValue: false,
+		storedValue: true,
+		invalidStoredValue: "yes",
+		writeKey: "legacyConnections",
+		writes: [{ value: true, payload: { ui: { legacyConnections: true } } }],
+	},
+	{
 		name: "resume last session",
 		storeKey: "ui.resumeLastSession",
 		read: (settings: AppSettings) => settings.ui.resumeLastSession,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -526,6 +526,7 @@ export async function loadSettings(
 	const fileTreeSortMode = DURABLE_SETTINGS.fileTreeSortMode.load(entries);
 	const folioMode = DURABLE_SETTINGS.folioMode.load(entries);
 	const noteSidePeek = DURABLE_SETTINGS.noteSidePeek.load(entries);
+	const legacyConnections = DURABLE_SETTINGS.legacyConnections.load(entries);
 	const resumeLastSession = DURABLE_SETTINGS.resumeLastSession.load(entries);
 	const keepRunningOnLastWindowClose =
 		DURABLE_SETTINGS.keepRunningOnLastWindowClose.load(entries);
@@ -687,6 +688,7 @@ export async function loadSettings(
 			sidebarFolderTabs,
 			folioMode,
 			noteSidePeek,
+			legacyConnections,
 			resumeLastSession,
 			keepRunningOnLastWindowClose,
 			aiAssistantMode,

--- a/src/lib/settings/definitions.ts
+++ b/src/lib/settings/definitions.ts
@@ -612,6 +612,13 @@ export const DURABLE_SETTINGS = {
 		read: (settings) => settings.ui.noteSidePeek,
 		change: (value) => ({ ui: { noteSidePeek: value } }),
 	}),
+	legacyConnections: booleanSetting({
+		key: "ui.legacyConnections",
+		defaultValue: false,
+		discovery: searchable("experimental-legacy-connections"),
+		read: (settings) => settings.ui.legacyConnections,
+		change: (value) => ({ ui: { legacyConnections: value } }),
+	}),
 	resumeLastSession: booleanSetting({
 		key: "ui.resumeLastSession",
 		defaultValue: false,

--- a/src/lib/settings/model.ts
+++ b/src/lib/settings/model.ts
@@ -213,6 +213,7 @@ export interface AppSettings {
 		sidebarFolderTabs: string[];
 		folioMode: boolean;
 		noteSidePeek: boolean;
+		legacyConnections: boolean;
 		resumeLastSession: boolean;
 		keepRunningOnLastWindowClose: boolean;
 		aiAssistantMode: AiAssistantMode;


### PR DESCRIPTION
Closes


## Description

Replaces the full-space Connections graph with a circular hierarchical edge-bundling layout while keeping the previous graph available during the transition.

- Places notes and tags around the complete ring and mixes unconnected nodes into the available positions.
- Routes connections through community bundle points on a dedicated canvas.
- Uses one click to select a note or tag, then a second click on the selected node to open it.
- Adds an Experimental "Legacy Connections" setting, off by default.
- Restores the previous packed layout, straight edges, label treatment, link opacity, and node dragging when the legacy setting is on.
- Keeps the local-note Connections graph unchanged.

Validation:

- `pnpm check`
- `pnpm build`
- `pnpm test` with 52 files and 350 tests passing
- `cargo check`


## Screenshots

Screenshots in the task show the circular layout with nodes distributed around the full ring.


## Docs

The localized Experimental setting description documents how to return to the previous Connections graph. No separate documentation changes are needed.


## Ready?

Did you do any of the following? If not, no worries, but if you can
it's really helpful.

- [x] Documented what's new
- [ ] Added in-code documentation (wherever needed)
- [x] Wrote tests for new components/features
- [x] Ran the linter to ensure style guidelines were followed
- [ ] Created a demo

## Summary by Sourcery

Redesign the space Connections graph around a circular hierarchical edge-bundling view while retaining the previous layout as an experimental fallback.

New Features:
- Replace the space Connections graph with a circular hierarchical edge-bundling layout that distributes connected and unconnected notes and tags around a ring.
- Add two-step node interaction so the first click selects a note or tag and the second click opens or activates it.

Enhancements:
- Preserve the former packed Connections layout as an optional legacy mode, including its prior interaction, labeling, dragging, and link-visibility behavior.
- Improve bundled graph rendering with community-based connection routing, radial labels, and large-graph rendering safeguards.

Documentation:
- Add localized Experimental setting text explaining how to restore the legacy Connections graph.

Tests:
- Add coverage for the persisted legacy Connections setting and its default behavior.

Chores:
- Add the Experimental Legacy Connections preference, disabled by default, and include it in settings search and persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bundled connection rendering for clearer graph visualization.
  - Added an experimental **Legacy Connections** setting to restore the previous layout and interaction style.
  - Added support for switching between bundled and legacy layouts.
  - Improved space-graph labels to orient around the graph and added performance safeguards for very large graphs.
- **Localization**
  - Added translations and settings search entries for Legacy Connections across supported languages.
- **Bug Fixes**
  - Improved node selection behavior so notes and tags open only when activating the selected node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->